### PR TITLE
Mimir query engine: add support for some annotations emitted by `rate()`

### DIFF
--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -189,15 +189,14 @@ func TestBenchmarkSetup(t *testing.T) {
 
 // Why do we do this rather than require.Equal(t, expected, actual)?
 // It's possible that floating point values are slightly different due to imprecision, but require.Equal doesn't allow us to set an allowable difference.
-func requireEqualResults(t testing.TB, expr string, expected, actual *promql.Result) { //nolint:revive // We'll begin using 'expr' again soon.
+func requireEqualResults(t testing.TB, expr string, expected, actual *promql.Result) {
 	require.Equal(t, expected.Err, actual.Err)
 	require.Equal(t, expected.Value.Type(), actual.Value.Type())
 
-	// FIXME: re-enable this once we've added support for warnings in rate()
-	// expectedWarnings, expectedInfos := expected.Warnings.AsStrings(expr, 0, 0)
-	// actualWarnings, actualInfos := actual.Warnings.AsStrings(expr, 0, 0)
-	// require.ElementsMatch(t, expectedWarnings, actualWarnings)
-	// require.ElementsMatch(t, expectedInfos, actualInfos)
+	expectedWarnings, expectedInfos := expected.Warnings.AsStrings(expr, 0, 0)
+	actualWarnings, actualInfos := actual.Warnings.AsStrings(expr, 0, 0)
+	require.ElementsMatch(t, expectedWarnings, actualWarnings)
+	require.ElementsMatch(t, expectedInfos, actualInfos)
 
 	switch expected.Value.Type() {
 	case parser.ValueTypeVector:

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1290,6 +1290,60 @@ func TestAnnotations(t *testing.T) {
 			data: mixedFloatHistogramData,
 			expr: `sum(metric{type="histogram"})`,
 		},
+
+		"rate() over metric without counter suffix containing only floats": {
+			data:                    mixedFloatHistogramData,
+			expr:                    `rate(metric{type="float"}[1m])`,
+			expectedInfoAnnotations: []string{`PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "metric" (1:6)`},
+		},
+		"rate() over metric without counter suffix containing only native histograms": {
+			data: mixedFloatHistogramData,
+			expr: `rate(metric{type="histogram"}[1m])`,
+		},
+		"rate() over metric ending in _total": {
+			data: `some_metric_total 0+1x3`,
+			expr: `rate(some_metric_total[1m])`,
+		},
+		"rate() over metric ending in _sum": {
+			data: `some_metric_sum 0+1x3`,
+			expr: `rate(some_metric_sum[1m])`,
+		},
+		"rate() over metric ending in _count": {
+			data: `some_metric_count 0+1x3`,
+			expr: `rate(some_metric_count[1m])`,
+		},
+		"rate() over metric ending in _bucket": {
+			data: `some_metric_bucket 0+1x3`,
+			expr: `rate(some_metric_bucket[1m])`,
+		},
+		"rate() over multiple metric names": {
+			data: `
+				not_a_counter{env="prod", series="1"}      0+1x3
+				a_total{series="2"}                        1+1x3
+				a_sum{series="3"}                          2+1x3
+				a_count{series="4"}                        3+1x3
+				a_bucket{series="5"}                       4+1x3
+				not_a_counter{env="test", series="6"}      5+1x3
+				also_not_a_counter{env="test", series="7"} 6+1x3
+			`,
+			expr: `rate({__name__!=""}[1m])`,
+			expectedInfoAnnotations: []string{
+				`PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "not_a_counter" (1:6)`,
+				`PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "also_not_a_counter" (1:6)`,
+			},
+		},
+		"rate() over series with both floats and histograms": {
+			data:                       `some_metric_count 10 {{schema:0 sum:1 count:1 buckets:[1]}}`,
+			expr:                       `rate(some_metric_count[1m])`,
+			expectedWarningAnnotations: []string{`PromQL warning: encountered a mix of histograms and floats for metric name "some_metric_count" (1:6)`},
+		},
+
+		// Blocked until https://github.com/prometheus/prometheus/pull/14537 is merged
+		// "rate() over series with histograms that are not counters": {
+		// 	data:                       `some_metric {{schema:0 sum:1 count:1 buckets:[1] counter_reset_hint:gauge}} {{schema:0 sum:2 count:2 buckets:[2] counter_reset_hint:gauge}}`,
+		// 	expr:                       `rate(some_metric[1m])`,
+		// 	expectedWarningAnnotations: []string{`PromQL warning: this native histogram metric is not a counter: some_metric (1:6)`},
+		// },
 	}
 
 	opts := NewTestEngineOpts()
@@ -1304,15 +1358,6 @@ func TestAnnotations(t *testing.T) {
 		"Prometheus' engine": prometheusEngine,
 	}
 
-	queryTypes := map[string]func(expr string, engine promql.QueryEngine, storage storage.Queryable) (promql.Query, error){
-		"range": func(expr string, engine promql.QueryEngine, storage storage.Queryable) (promql.Query, error) {
-			return engine.NewRangeQuery(context.Background(), storage, nil, expr, startT, endT, step)
-		},
-		"instant": func(expr string, engine promql.QueryEngine, storage storage.Queryable) (promql.Query, error) {
-			return engine.NewInstantQuery(context.Background(), storage, nil, expr, startT)
-		},
-	}
-
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			store := promqltest.LoadedStorage(t, "load 1m\n"+strings.TrimSpace(testCase.data))
@@ -1320,9 +1365,19 @@ func TestAnnotations(t *testing.T) {
 
 			for engineName, engine := range engines {
 				t.Run(engineName, func(t *testing.T) {
+
+					queryTypes := map[string]func() (promql.Query, error){
+						"range": func() (promql.Query, error) {
+							return engine.NewRangeQuery(context.Background(), store, nil, testCase.expr, startT, endT, step)
+						},
+						"instant": func() (promql.Query, error) {
+							return engine.NewInstantQuery(context.Background(), store, nil, testCase.expr, startT)
+						},
+					}
+
 					for queryType, generator := range queryTypes {
 						t.Run(queryType, func(t *testing.T) {
-							query, err := generator(testCase.expr, engine, store)
+							query, err := generator()
 							require.NoError(t, err)
 							t.Cleanup(query.Close)
 

--- a/pkg/streamingpromql/functions.go
+++ b/pkg/streamingpromql/functions.go
@@ -20,7 +20,7 @@ type InstantVectorFunctionOperatorFactory func(args []types.Operator, memoryCons
 // that have exactly 1 argument (v instant-vector).
 //
 // Parameters:
-//   - name: The name of the function.
+//   - name: The name of the function
 //   - metadataFunc: The function for handling metadata
 //   - seriesDataFunc: The function to handle series data
 func SingleInputVectorFunctionOperatorFactory(name string, metadataFunc functions.SeriesMetadataFunction, seriesDataFunc functions.InstantVectorFunction) InstantVectorFunctionOperatorFactory {
@@ -44,7 +44,7 @@ func SingleInputVectorFunctionOperatorFactory(name string, metadataFunc function
 // that have exactly 1 argument (v instant-vector), and drop the series __name__ label.
 //
 // Parameters:
-//   - name: The name of the function.
+//   - name: The name of the function
 //   - seriesDataFunc: The function to handle series data
 func InstantVectorTransformationFunctionOperatorFactory(name string, seriesDataFunc functions.InstantVectorFunction) InstantVectorFunctionOperatorFactory {
 	return SingleInputVectorFunctionOperatorFactory(name, functions.DropSeriesName, seriesDataFunc)
@@ -56,12 +56,8 @@ func InstantVectorTransformationFunctionOperatorFactory(name string, seriesDataF
 // The values of v are passed through.
 //
 // Parameters:
-//   - name: The name of the function.
+//   - name: The name of the function
 //   - metadataFunc: The function for handling metadata
-//
-// Returns:
-//
-//	An InstantVectorFunctionOperator.
 func InstantVectorLabelManipulationFunctionOperatorFactory(name string, metadataFunc functions.SeriesMetadataFunction) InstantVectorFunctionOperatorFactory {
 	return SingleInputVectorFunctionOperatorFactory(name, metadataFunc, functions.Passthrough)
 }
@@ -70,10 +66,11 @@ func InstantVectorLabelManipulationFunctionOperatorFactory(name string, metadata
 // that have exactly 1 argument (v range-vector).
 //
 // Parameters:
-//   - name: The name of the function.
+//   - name: The name of the function
 //   - metadataFunc: The function for handling metadata
 //   - stepFunc: The function to handle a range vector step
-func SingleRangeVectorFunctionOperatorFactory(name string, metadataFunc functions.SeriesMetadataFunction, stepFunc functions.RangeVectorStepFunction) InstantVectorFunctionOperatorFactory {
+//   - needMetricNames: If true, stepFunc emits annotations that contain the metric names for each series
+func SingleRangeVectorFunctionOperatorFactory(name string, metadataFunc functions.SeriesMetadataFunction, stepFunc functions.RangeVectorStepFunction, needMetricNames bool) InstantVectorFunctionOperatorFactory {
 	return func(args []types.Operator, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, annotations *annotations.Annotations, expressionPosition posrange.PositionRange) (types.InstantVectorOperator, error) {
 		if len(args) != 1 {
 			// Should be caught by the PromQL parser, but we check here for safety.
@@ -86,19 +83,19 @@ func SingleRangeVectorFunctionOperatorFactory(name string, metadataFunc function
 			return nil, fmt.Errorf("expected a range vector argument for %s, got %T", name, args[0])
 		}
 
-		return operators.NewFunctionOverRangeVector(inner, memoryConsumptionTracker, metadataFunc, stepFunc, annotations, expressionPosition), nil
+		return operators.NewFunctionOverRangeVector(inner, memoryConsumptionTracker, metadataFunc, stepFunc, needMetricNames, annotations, expressionPosition), nil
 	}
 }
 
-// SingleRangeVectorTransformationFunctionOperatorFactory creates an InstantVectorFunctionOperatorFactory for functions
+// RangeVectorTransformationFunctionOperatorFactory creates an InstantVectorFunctionOperatorFactory for functions
 // that have exactly 1 argument (v range-vector), and drop the series __name__ label.
 //
 // Parameters:
-//   - name: The name of the function.
-//   - rangeStepFunc: The function to handle a range vector step
-
-func RangeVectorTransformationFunctionOperatorFactory(name string, rangeStepFunc functions.RangeVectorStepFunction) InstantVectorFunctionOperatorFactory {
-	return SingleRangeVectorFunctionOperatorFactory(name, functions.DropSeriesName, rangeStepFunc)
+//   - name: The name of the function
+//   - stepFunc: The function to handle a range vector step
+//   - needMetricNames: If true, stepFunc emits annotations that contain the metric names for each series
+func RangeVectorTransformationFunctionOperatorFactory(name string, stepFunc functions.RangeVectorStepFunction, needMetricNames bool) InstantVectorFunctionOperatorFactory {
+	return SingleRangeVectorFunctionOperatorFactory(name, functions.DropSeriesName, stepFunc, needMetricNames)
 }
 
 // These functions return an instant-vector.
@@ -122,7 +119,7 @@ var instantVectorFunctionOperatorFactories = map[string]InstantVectorFunctionOpe
 	"log10":           InstantVectorTransformationFunctionOperatorFactory("log10", functions.Log10),
 	"log2":            InstantVectorTransformationFunctionOperatorFactory("log2", functions.Log2),
 	"rad":             InstantVectorTransformationFunctionOperatorFactory("rad", functions.Rad),
-	"rate":            RangeVectorTransformationFunctionOperatorFactory("rate", functions.Rate),
+	"rate":            RangeVectorTransformationFunctionOperatorFactory("rate", functions.Rate, true),
 	"sgn":             InstantVectorTransformationFunctionOperatorFactory("sgn", functions.Sgn),
 	"sin":             InstantVectorTransformationFunctionOperatorFactory("sin", functions.Sin),
 	"sinh":            InstantVectorTransformationFunctionOperatorFactory("sinh", functions.Sinh),

--- a/pkg/streamingpromql/functions.go
+++ b/pkg/streamingpromql/functions.go
@@ -70,7 +70,7 @@ func InstantVectorLabelManipulationFunctionOperatorFactory(name string, metadata
 //   - metadataFunc: The function for handling metadata
 //   - stepFunc: The function to handle a range vector step
 //   - needMetricNames: If true, stepFunc emits annotations that contain the metric names for each series
-func SingleRangeVectorFunctionOperatorFactory(name string, metadataFunc functions.SeriesMetadataFunction, stepFunc functions.RangeVectorStepFunction, needMetricNames bool) InstantVectorFunctionOperatorFactory {
+func SingleRangeVectorFunctionOperatorFactory(name string, metadataFunc functions.SeriesMetadataFunction, stepFunc functions.RangeVectorStepFunction, seriesValidationFunc functions.RangeVectorSeriesValidationFunction, needMetricNames bool) InstantVectorFunctionOperatorFactory {
 	return func(args []types.Operator, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, annotations *annotations.Annotations, expressionPosition posrange.PositionRange) (types.InstantVectorOperator, error) {
 		if len(args) != 1 {
 			// Should be caught by the PromQL parser, but we check here for safety.
@@ -83,19 +83,19 @@ func SingleRangeVectorFunctionOperatorFactory(name string, metadataFunc function
 			return nil, fmt.Errorf("expected a range vector argument for %s, got %T", name, args[0])
 		}
 
-		return operators.NewFunctionOverRangeVector(inner, memoryConsumptionTracker, metadataFunc, stepFunc, needMetricNames, annotations, expressionPosition), nil
+		return operators.NewFunctionOverRangeVector(inner, memoryConsumptionTracker, metadataFunc, stepFunc, seriesValidationFunc, needMetricNames, annotations, expressionPosition), nil
 	}
 }
 
 // RangeVectorTransformationFunctionOperatorFactory creates an InstantVectorFunctionOperatorFactory for functions
-// that have exactly 1 argument (v range-vector), and drop the series __name__ label.
+// that have exactly 1 argument (v range-vector), drop the series __name__ label, and do no per-series validation.
 //
 // Parameters:
 //   - name: The name of the function
 //   - stepFunc: The function to handle a range vector step
 //   - needMetricNames: If true, stepFunc emits annotations that contain the metric names for each series
 func RangeVectorTransformationFunctionOperatorFactory(name string, stepFunc functions.RangeVectorStepFunction, needMetricNames bool) InstantVectorFunctionOperatorFactory {
-	return SingleRangeVectorFunctionOperatorFactory(name, functions.DropSeriesName, stepFunc, needMetricNames)
+	return SingleRangeVectorFunctionOperatorFactory(name, functions.DropSeriesName, stepFunc, nil, needMetricNames)
 }
 
 // These functions return an instant-vector.

--- a/pkg/streamingpromql/functions.go
+++ b/pkg/streamingpromql/functions.go
@@ -62,15 +62,16 @@ func InstantVectorLabelManipulationFunctionOperatorFactory(name string, metadata
 	return SingleInputVectorFunctionOperatorFactory(name, metadataFunc, functions.Passthrough)
 }
 
-// SingleRangeVectorFunctionOperatorFactory creates an InstantVectorFunctionOperatorFactory for functions
+// FunctionOverRangeVectorOperatorFactory creates an InstantVectorFunctionOperatorFactory for functions
 // that have exactly 1 argument (v range-vector).
 //
 // Parameters:
 //   - name: The name of the function
-//   - metadataFunc: The function for handling metadata
-//   - stepFunc: The function to handle a range vector step
-//   - needMetricNames: If true, stepFunc emits annotations that contain the metric names for each series
-func SingleRangeVectorFunctionOperatorFactory(name string, metadataFunc functions.SeriesMetadataFunction, stepFunc functions.RangeVectorStepFunction, seriesValidationFunc functions.RangeVectorSeriesValidationFunction, needMetricNames bool) InstantVectorFunctionOperatorFactory {
+//   - f: The function implementation
+func FunctionOverRangeVectorOperatorFactory(
+	name string,
+	f functions.FunctionOverRangeVector,
+) InstantVectorFunctionOperatorFactory {
 	return func(args []types.Operator, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, annotations *annotations.Annotations, expressionPosition posrange.PositionRange) (types.InstantVectorOperator, error) {
 		if len(args) != 1 {
 			// Should be caught by the PromQL parser, but we check here for safety.
@@ -83,19 +84,8 @@ func SingleRangeVectorFunctionOperatorFactory(name string, metadataFunc function
 			return nil, fmt.Errorf("expected a range vector argument for %s, got %T", name, args[0])
 		}
 
-		return operators.NewFunctionOverRangeVector(inner, memoryConsumptionTracker, metadataFunc, stepFunc, seriesValidationFunc, needMetricNames, annotations, expressionPosition), nil
+		return operators.NewFunctionOverRangeVector(inner, memoryConsumptionTracker, f, annotations, expressionPosition), nil
 	}
-}
-
-// RangeVectorTransformationFunctionOperatorFactory creates an InstantVectorFunctionOperatorFactory for functions
-// that have exactly 1 argument (v range-vector), drop the series __name__ label, and do no per-series validation.
-//
-// Parameters:
-//   - name: The name of the function
-//   - stepFunc: The function to handle a range vector step
-//   - needMetricNames: If true, stepFunc emits annotations that contain the metric names for each series
-func RangeVectorTransformationFunctionOperatorFactory(name string, stepFunc functions.RangeVectorStepFunction, needMetricNames bool) InstantVectorFunctionOperatorFactory {
-	return SingleRangeVectorFunctionOperatorFactory(name, functions.DropSeriesName, stepFunc, nil, needMetricNames)
 }
 
 // These functions return an instant-vector.
@@ -119,7 +109,7 @@ var instantVectorFunctionOperatorFactories = map[string]InstantVectorFunctionOpe
 	"log10":           InstantVectorTransformationFunctionOperatorFactory("log10", functions.Log10),
 	"log2":            InstantVectorTransformationFunctionOperatorFactory("log2", functions.Log2),
 	"rad":             InstantVectorTransformationFunctionOperatorFactory("rad", functions.Rad),
-	"rate":            RangeVectorTransformationFunctionOperatorFactory("rate", functions.Rate, true),
+	"rate":            FunctionOverRangeVectorOperatorFactory("rate", functions.Rate),
 	"sgn":             InstantVectorTransformationFunctionOperatorFactory("sgn", functions.Sgn),
 	"sin":             InstantVectorTransformationFunctionOperatorFactory("sin", functions.Sin),
 	"sinh":            InstantVectorTransformationFunctionOperatorFactory("sinh", functions.Sinh),

--- a/pkg/streamingpromql/functions/common.go
+++ b/pkg/streamingpromql/functions/common.go
@@ -105,7 +105,5 @@ type FunctionOverRangeVector struct {
 	SeriesMetadataFunc SeriesMetadataFunction
 
 	// NeedsSeriesNamesForAnnotations indicates that this function uses the names of input series when emitting annotations.
-	//
-	// NeedsSeriesNamesForAnnotations is implied if SeriesValidationFunc is non-nil.
 	NeedsSeriesNamesForAnnotations bool
 }

--- a/pkg/streamingpromql/functions/common.go
+++ b/pkg/streamingpromql/functions/common.go
@@ -4,6 +4,7 @@ package functions
 
 import (
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
@@ -58,10 +59,20 @@ func Passthrough(seriesData types.InstantVectorSeriesData, _ *limiting.MemoryCon
 //   - rangeSeconds: the duration of the range in seconds.
 //   - floatBuffer: a ring buffer containing float values for the step range.
 //   - histogramBuffer: a ring buffer containing histogram values for the step range.
+//   - emitAnnotation: a callback function to emit an annotation for the current series.
 //
 // Returns:
 //   - hasFloat bool: a boolean indicating if a float value is present.
 //   - f float64: the float value.
 //   - h *histogram.FloatHistogram: nil if no histogram is present.
 //   - err error.
-type RangeVectorStepFunction func(step types.RangeVectorStepData, rangeSeconds float64, floatBuffer *types.FPointRingBuffer, histogramBuffer *types.HPointRingBuffer) (f float64, hasFloat bool, h *histogram.FloatHistogram, err error)
+type RangeVectorStepFunction func(
+	step types.RangeVectorStepData,
+	rangeSeconds float64,
+	floatBuffer *types.FPointRingBuffer,
+	histogramBuffer *types.HPointRingBuffer,
+	emitAnnotation EmitAnnotationFunc,
+) (f float64, hasFloat bool, h *histogram.FloatHistogram, err error)
+
+type EmitAnnotationFunc func(generator AnnotationGenerator)
+type AnnotationGenerator func(metricName string, expressionPosition posrange.PositionRange) error

--- a/pkg/streamingpromql/functions/common.go
+++ b/pkg/streamingpromql/functions/common.go
@@ -76,3 +76,5 @@ type RangeVectorStepFunction func(
 
 type EmitAnnotationFunc func(generator AnnotationGenerator)
 type AnnotationGenerator func(metricName string, expressionPosition posrange.PositionRange) error
+
+type RangeVectorSeriesValidationFunction func(seriesData types.InstantVectorSeriesData, metricName string, emitAnnotation EmitAnnotationFunc)

--- a/pkg/streamingpromql/functions/common.go
+++ b/pkg/streamingpromql/functions/common.go
@@ -74,7 +74,29 @@ type RangeVectorStepFunction func(
 	emitAnnotation EmitAnnotationFunc,
 ) (f float64, hasFloat bool, h *histogram.FloatHistogram, err error)
 
+// EmitAnnotationFunc is a function that emits the annotation created by generator.
 type EmitAnnotationFunc func(generator AnnotationGenerator)
+
+// AnnotationGenerator is a function that returns an annotation for the given metric name and expression position.
 type AnnotationGenerator func(metricName string, expressionPosition posrange.PositionRange) error
 
+// RangeVectorSeriesValidationFunction is a function that is called after a series is completed for a function over a range vector.
 type RangeVectorSeriesValidationFunction func(seriesData types.InstantVectorSeriesData, metricName string, emitAnnotation EmitAnnotationFunc)
+
+type FunctionOverRangeVector struct {
+	// StepFunc is the function that computes an output sample for a single step.
+	StepFunc RangeVectorStepFunction
+
+	// SeriesValidationFunc is the function that validates a complete series, emitting any annotations for that series.
+	//
+	// SeriesValidationFunc can be nil, in which case no validation is performed.
+	SeriesValidationFunc RangeVectorSeriesValidationFunction
+
+	// SeriesMetadataFunc is the function that computes the output series for this function based on the given input series.
+	SeriesMetadataFunc SeriesMetadataFunction
+
+	// NeedsSeriesNamesForAnnotations indicates that this function uses the names of input series when emitting annotations.
+	//
+	// NeedsSeriesNamesForAnnotations is implied if SeriesValidationFunc is non-nil.
+	NeedsSeriesNamesForAnnotations bool
+}

--- a/pkg/streamingpromql/functions/common.go
+++ b/pkg/streamingpromql/functions/common.go
@@ -83,14 +83,23 @@ type AnnotationGenerator func(metricName string, expressionPosition posrange.Pos
 // RangeVectorSeriesValidationFunction is a function that is called after a series is completed for a function over a range vector.
 type RangeVectorSeriesValidationFunction func(seriesData types.InstantVectorSeriesData, metricName string, emitAnnotation EmitAnnotationFunc)
 
+// RangeVectorSeriesValidationFunctionFactory is a factory function that returns a RangeVectorSeriesValidationFunction
+type RangeVectorSeriesValidationFunctionFactory func() RangeVectorSeriesValidationFunction
+
 type FunctionOverRangeVector struct {
 	// StepFunc is the function that computes an output sample for a single step.
 	StepFunc RangeVectorStepFunction
 
-	// SeriesValidationFunc is the function that validates a complete series, emitting any annotations for that series.
+	// SeriesValidationFuncFactory is the function that creates a validator for a complete series, emitting any annotations
+	// for that series.
 	//
-	// SeriesValidationFunc can be nil, in which case no validation is performed.
-	SeriesValidationFunc RangeVectorSeriesValidationFunction
+	// A new validator instance is created for each instance of this range vector function (ie. a validator is not shared
+	// between queries or between different invocations of the same range vector function in a single query). A single
+	// instance of a range vector function can then implement optimisations such as skipping checks for repeated metric
+	// names.
+	//
+	// SeriesValidationFuncFactory can be nil, in which case no validation is performed.
+	SeriesValidationFuncFactory RangeVectorSeriesValidationFunctionFactory
 
 	// SeriesMetadataFunc is the function that computes the output series for this function based on the given input series.
 	SeriesMetadataFunc SeriesMetadataFunction

--- a/pkg/streamingpromql/functions/rate.go
+++ b/pkg/streamingpromql/functions/rate.go
@@ -54,7 +54,13 @@ func rate(step types.RangeVectorStepData, rangeSeconds float64, floatBuffer *typ
 
 func histogramRate(histogramBuffer *types.HPointRingBuffer, step types.RangeVectorStepData, hHead []promql.HPoint, hTail []promql.HPoint, rangeSeconds float64, hCount int, emitAnnotation EmitAnnotationFunc) (*histogram.FloatHistogram, error) {
 	firstPoint := histogramBuffer.First()
-	lastPoint, _ := histogramBuffer.LastAtOrBefore(step.RangeEnd) // We already know there is a point at or before this time, no need to check.
+
+	var lastPoint promql.HPoint
+	if len(hTail) > 0 {
+		lastPoint = hTail[len(hTail)-1]
+	} else {
+		lastPoint = hHead[len(hHead)-1]
+	}
 
 	if firstPoint.H.CounterResetHint == histogram.GaugeType || lastPoint.H.CounterResetHint == histogram.GaugeType {
 		emitAnnotation(annotations.NewNativeHistogramNotCounterWarning)
@@ -111,7 +117,14 @@ func histogramRate(histogramBuffer *types.HPointRingBuffer, step types.RangeVect
 
 func floatRate(fCount int, floatBuffer *types.FPointRingBuffer, step types.RangeVectorStepData, fHead []promql.FPoint, fTail []promql.FPoint, rangeSeconds float64) float64 {
 	firstPoint := floatBuffer.First()
-	lastPoint, _ := floatBuffer.LastAtOrBefore(step.RangeEnd) // We already know there is a point at or before this time, no need to check.
+
+	var lastPoint promql.FPoint
+	if len(fTail) > 0 {
+		lastPoint = fTail[len(fTail)-1]
+	} else {
+		lastPoint = fHead[len(fHead)-1]
+	}
+
 	delta := lastPoint.F - firstPoint.F
 	previousValue := firstPoint.F
 

--- a/pkg/streamingpromql/functions/rate.go
+++ b/pkg/streamingpromql/functions/rate.go
@@ -6,6 +6,8 @@
 package functions
 
 import (
+	"strings"
+
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/util/annotations"
@@ -187,4 +189,18 @@ func calculateFloatRate(rangeStart, rangeEnd int64, rangeSeconds float64, firstP
 	factor := extrapolateToInterval / sampledInterval
 	factor /= rangeSeconds
 	return delta * factor
+}
+
+func RateSeriesValidator(data types.InstantVectorSeriesData, metricName string, emitAnnotation EmitAnnotationFunc) {
+	if len(data.Floats) == 0 {
+		return
+	}
+
+	if metricName == "" {
+		return
+	}
+
+	if !strings.HasSuffix(metricName, "_total") && !strings.HasSuffix(metricName, "_count") && !strings.HasSuffix(metricName, "_sum") && !strings.HasSuffix(metricName, "_bucket") {
+		emitAnnotation(annotations.NewPossibleNonCounterInfo)
+	}
 }

--- a/pkg/streamingpromql/operators/function_over_instant_vector.go
+++ b/pkg/streamingpromql/operators/function_over_instant_vector.go
@@ -24,8 +24,8 @@ type FunctionOverInstantVector struct {
 	Inner                    types.InstantVectorOperator
 	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
 
-	MetadataFunc   functions.SeriesMetadataFunction
-	SeriesDataFunc functions.InstantVectorFunction
+	SeriesMetadataFunc functions.SeriesMetadataFunction
+	SeriesDataFunc     functions.InstantVectorFunction
 
 	expressionPosition posrange.PositionRange
 }
@@ -43,8 +43,8 @@ func NewFunctionOverInstantVector(
 		Inner:                    inner,
 		MemoryConsumptionTracker: memoryConsumptionTracker,
 
-		MetadataFunc:   metadataFunc,
-		SeriesDataFunc: seriesDataFunc,
+		SeriesMetadataFunc: metadataFunc,
+		SeriesDataFunc:     seriesDataFunc,
 
 		expressionPosition: expressionPosition,
 	}
@@ -60,7 +60,7 @@ func (m *FunctionOverInstantVector) SeriesMetadata(ctx context.Context) ([]types
 		return nil, err
 	}
 
-	return m.MetadataFunc(metadata, m.MemoryConsumptionTracker)
+	return m.SeriesMetadataFunc(metadata, m.MemoryConsumptionTracker)
 }
 
 func (m *FunctionOverInstantVector) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {

--- a/pkg/streamingpromql/operators/function_over_instant_vector_test.go
+++ b/pkg/streamingpromql/operators/function_over_instant_vector_test.go
@@ -45,8 +45,8 @@ func TestFunctionOverInstantVector(t *testing.T) {
 		Inner:                    inner,
 		MemoryConsumptionTracker: limiting.NewMemoryConsumptionTracker(0, nil),
 
-		MetadataFunc:   mustBeCalledMetadata,
-		SeriesDataFunc: mustBeCalledSeriesData,
+		SeriesMetadataFunc: mustBeCalledMetadata,
+		SeriesDataFunc:     mustBeCalledSeriesData,
 	}
 
 	ctx := context.TODO()

--- a/pkg/streamingpromql/operators/function_over_range_vector.go
+++ b/pkg/streamingpromql/operators/function_over_range_vector.go
@@ -60,7 +60,7 @@ func NewFunctionOverRangeVector(
 		o.seriesValidationFunc = f.SeriesValidationFuncFactory()
 	}
 
-	if f.NeedsSeriesNamesForAnnotations || o.seriesValidationFunc != nil {
+	if f.NeedsSeriesNamesForAnnotations {
 		o.metricNames = &MetricNames{}
 	}
 

--- a/pkg/streamingpromql/operators/function_over_range_vector.go
+++ b/pkg/streamingpromql/operators/function_over_range_vector.go
@@ -23,7 +23,7 @@ type FunctionOverRangeVector struct {
 	Inner                    types.RangeVectorOperator
 	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
 
-	MetadataFunc         functions.SeriesMetadataFunction
+	SeriesMetadataFunc   functions.SeriesMetadataFunction
 	StepFunc             functions.RangeVectorStepFunction
 	SeriesValidationFunc functions.RangeVectorSeriesValidationFunction
 
@@ -55,9 +55,9 @@ func NewFunctionOverRangeVector(
 	o := &FunctionOverRangeVector{
 		Inner:                    inner,
 		MemoryConsumptionTracker: memoryConsumptionTracker,
-		MetadataFunc:             metadataFunc,
-		SeriesValidationFunc:     seriesValidationFunc,
+		SeriesMetadataFunc:       metadataFunc,
 		StepFunc:                 stepFunc,
+		SeriesValidationFunc:     seriesValidationFunc,
 		Annotations:              annotations,
 		expressionPosition:       expressionPosition,
 	}
@@ -86,7 +86,7 @@ func (m *FunctionOverRangeVector) SeriesMetadata(ctx context.Context) ([]types.S
 	m.numSteps = m.Inner.StepCount()
 	m.rangeSeconds = m.Inner.Range().Seconds()
 
-	return m.MetadataFunc(metadata, m.MemoryConsumptionTracker)
+	return m.SeriesMetadataFunc(metadata, m.MemoryConsumptionTracker)
 }
 
 func (m *FunctionOverRangeVector) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {

--- a/pkg/streamingpromql/operators/metric_names.go
+++ b/pkg/streamingpromql/operators/metric_names.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package operators
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+// MetricNames captures and stores the metric names of each series for later use in an operator.
+//
+// For example, it can be used to retrieve the metric name of a series for use in an annotation
+// that can only be generated once the series data has been examined.
+type MetricNames struct {
+	names []string
+}
+
+func (n *MetricNames) CaptureMetricNames(metadata []types.SeriesMetadata) {
+	n.names = make([]string, len(metadata))
+
+	for i, series := range metadata {
+		n.names[i] = series.Labels.Get(labels.MetricName)
+	}
+}
+
+func (n *MetricNames) GetMetricNameForSeries(seriesIndex int) string {
+	return n.names[seriesIndex]
+}

--- a/pkg/streamingpromql/testdata/upstream/native_histograms.test
+++ b/pkg/streamingpromql/testdata/upstream/native_histograms.test
@@ -926,11 +926,9 @@ load 30s
     some_metric {{schema:0 sum:1 count:1 buckets:[1] counter_reset_hint:gauge}} {{schema:0 sum:2 count:2 buckets:[2] counter_reset_hint:gauge}} {{schema:0 sum:3 count:3 buckets:[3] counter_reset_hint:gauge}}
 
 # Test the case where we only have two points for rate
-# Unsupported by streaming engine.
-# eval_warn instant at 30s rate(some_metric[30s])
-#     {} {{count:0.03333333333333333 sum:0.03333333333333333 buckets:[0.03333333333333333]}}
+eval_warn instant at 30s rate(some_metric[30s])
+    {} {{count:0.03333333333333333 sum:0.03333333333333333 buckets:[0.03333333333333333]}}
 
 # Test the case where we have more than two points for rate
-# Unsupported by streaming engine.
-# eval_warn instant at 1m rate(some_metric[1m])
-#     {} {{count:0.03333333333333333 sum:0.03333333333333333 buckets:[0.03333333333333333]}}
+eval_warn instant at 1m rate(some_metric[1m])
+    {} {{count:0.03333333333333333 sum:0.03333333333333333 buckets:[0.03333333333333333]}}


### PR DESCRIPTION
#### What this PR does

This PR builds on #8660, adding annotations for the following cases for `rate`:

* `rate` is called over a range with both floats and histograms
* `rate` is called over a series containing floats with a metric name that does not look like a counter
* `rate` is called over a range with gauge-type histograms

Performance is generally on par or better than `main`, with the exception of `rate` over native histograms which has regressed somewhat due to all the extra checks:

<details>
<summary>Benchmark results</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/streamingpromql/benchmarks
                                                                                │   main.txt   │  step-3-without-lastatorbefore.txt  │
                                                                                │    sec/op    │    sec/op     vs base               │
Query/rate(a_1[1m]),_instant_query/Mimir-10                                       143.0µ ± 15%   144.9µ ±  4%        ~ (p=0.818 n=6)
Query/rate(a_1[1m]),_range_query_with_100_steps/Mimir-10                          159.6µ ±  3%   159.7µ ±  3%        ~ (p=0.937 n=6)
Query/rate(a_1[1m]),_range_query_with_1000_steps/Mimir-10                         277.4µ ±  6%   245.6µ ±  1%  -11.49% (p=0.002 n=6)
Query/rate(a_100[1m]),_instant_query/Mimir-10                                     444.7µ ±  4%   409.6µ ±  1%   -7.88% (p=0.002 n=6)
Query/rate(a_100[1m]),_range_query_with_100_steps/Mimir-10                        1.292m ±  5%   1.176m ±  1%   -8.98% (p=0.002 n=6)
Query/rate(a_100[1m]),_range_query_with_1000_steps/Mimir-10                       8.002m ±  1%   7.541m ±  1%   -5.76% (p=0.002 n=6)
Query/rate(a_2000[1m]),_instant_query/Mimir-10                                    4.406m ±  1%   4.119m ±  3%   -6.50% (p=0.002 n=6)
Query/rate(a_2000[1m]),_range_query_with_100_steps/Mimir-10                       17.98m ±  2%   17.45m ±  1%   -2.92% (p=0.002 n=6)
Query/rate(a_2000[1m]),_range_query_with_1000_steps/Mimir-10                      138.0m ±  1%   134.7m ±  2%   -2.34% (p=0.004 n=6)
Query/rate(a_1[1m]),_range_query_with_10000_steps/Mimir-10                        1.121m ±  5%   1.072m ±  1%   -4.36% (p=0.002 n=6)
Query/rate(a_100[1m]),_range_query_with_10000_steps/Mimir-10                      71.25m ±  2%   69.46m ±  3%   -2.52% (p=0.015 n=6)
Query/rate(a_2000[1m]),_range_query_with_10000_steps/Mimir-10                      1.421 ±  9%    1.368 ±  2%   -3.67% (p=0.002 n=6)
Query/rate(nh_1[1m]),_instant_query/Mimir-10                                      140.2µ ±  7%   134.6µ ±  2%   -4.00% (p=0.002 n=6)
Query/rate(nh_1[1m]),_range_query_with_100_steps/Mimir-10                         203.6µ ±  0%   197.0µ ±  1%   -3.23% (p=0.002 n=6)
Query/rate(nh_1[1m]),_range_query_with_1000_steps/Mimir-10                        716.2µ ±  4%   696.3µ ±  2%   -2.79% (p=0.004 n=6)
Query/rate(nh_100[1m]),_instant_query/Mimir-10                                    583.0µ ±  3%   567.8µ ±  1%   -2.61% (p=0.002 n=6)
Query/rate(nh_100[1m]),_range_query_with_100_steps/Mimir-10                       5.419m ±  2%   5.283m ±  2%   -2.50% (p=0.009 n=6)
Query/rate(nh_100[1m]),_range_query_with_1000_steps/Mimir-10                      46.00m ±  0%   45.60m ±  0%   -0.88% (p=0.002 n=6)
Query/rate(nh_2000[1m]),_instant_query/Mimir-10                                   6.382m ±  0%   6.312m ±  0%   -1.09% (p=0.002 n=6)
Query/rate(nh_2000[1m]),_range_query_with_100_steps/Mimir-10                      94.88m ±  0%   94.87m ±  1%        ~ (p=0.818 n=6)
Query/rate(nh_2000[1m]),_range_query_with_1000_steps/Mimir-10                     873.7m ±  1%   880.6m ±  1%   +0.79% (p=0.015 n=6)
Query/rate(nh_1[1m]),_range_query_with_10000_steps/Mimir-10                       5.118m ±  1%   5.018m ±  3%   -1.95% (p=0.041 n=6)
Query/rate(nh_100[1m]),_range_query_with_10000_steps/Mimir-10                     433.5m ±  1%   437.6m ±  2%   +0.94% (p=0.002 n=6)
Query/rate(nh_2000[1m]),_range_query_with_10000_steps/Mimir-10                     9.112 ±  2%    9.155 ±  2%        ~ (p=0.310 n=6)
Query/rate(a_1[1d]),_instant_query/Mimir-10                                       819.9µ ±  9%   791.7µ ±  2%   -3.44% (p=0.004 n=6)
Query/rate(a_1[1d]),_range_query_with_100_steps/Mimir-10                          1.182m ±  5%   1.127m ±  2%   -4.68% (p=0.002 n=6)
Query/rate(a_1[1d]),_range_query_with_1000_steps/Mimir-10                         4.264m ±  2%   4.068m ±  1%   -4.60% (p=0.002 n=6)
Query/rate(a_100[1d]),_instant_query/Mimir-10                                     47.33m ±  1%   46.31m ±  1%   -2.15% (p=0.002 n=6)
Query/rate(a_100[1d]),_range_query_with_100_steps/Mimir-10                        80.56m ±  1%   79.23m ±  1%   -1.66% (p=0.002 n=6)
Query/rate(a_100[1d]),_range_query_with_1000_steps/Mimir-10                       379.4m ±  1%   373.8m ±  1%   -1.46% (p=0.004 n=6)
Query/rate(a_2000[1d]),_instant_query/Mimir-10                                    842.0m ±  1%   832.4m ±  0%   -1.14% (p=0.002 n=6)
Query/rate(a_2000[1d]),_range_query_with_100_steps/Mimir-10                        1.529 ±  0%    1.507 ±  0%   -1.41% (p=0.002 n=6)
Query/rate(a_2000[1d]),_range_query_with_1000_steps/Mimir-10                       7.445 ±  0%    7.398 ±  1%   -0.62% (p=0.009 n=6)
Query/rate(nh_1[1h]),_instant_query/Mimir-10                                      276.5µ ± 11%   266.8µ ±  2%   -3.52% (p=0.009 n=6)
Query/rate(nh_1[1h]),_range_query_with_100_steps/Mimir-10                         489.3µ ±  3%   490.1µ ±  2%        ~ (p=0.937 n=6)
Query/rate(nh_1[1h]),_range_query_with_1000_steps/Mimir-10                        2.221m ±  1%   2.324m ±  1%   +4.67% (p=0.002 n=6)
Query/rate(nh_100[1h]),_instant_query/Mimir-10                                    6.753m ±  1%   6.744m ± 11%        ~ (p=0.937 n=6)
Query/rate(nh_100[1h]),_range_query_with_100_steps/Mimir-10                       24.80m ±  1%   26.23m ±  1%   +5.79% (p=0.002 n=6)
Query/rate(nh_100[1h]),_range_query_with_1000_steps/Mimir-10                      190.0m ±  1%   202.8m ±  1%   +6.74% (p=0.002 n=6)
Query/rate(nh_2000[1h]),_instant_query/Mimir-10                                   122.1m ±  3%   122.2m ±  0%        ~ (p=0.818 n=6)
Query/rate(nh_2000[1h]),_range_query_with_100_steps/Mimir-10                      468.8m ±  2%   501.4m ±  1%   +6.97% (p=0.002 n=6)
Query/rate(nh_2000[1h]),_range_query_with_1000_steps/Mimir-10                      3.749 ±  1%    4.055 ±  1%   +8.17% (p=0.002 n=6)
Query/rate(a_1[1m])_+_rate(b_1[1m]),_instant_query/Mimir-10                       243.8µ ±  2%   243.0µ ±  1%        ~ (p=0.699 n=6)
Query/rate(a_1[1m])_+_rate(b_1[1m]),_range_query_with_100_steps/Mimir-10          279.6µ ±  4%   271.6µ ±  2%        ~ (p=0.180 n=6)
Query/rate(a_1[1m])_+_rate(b_1[1m]),_range_query_with_1000_steps/Mimir-10         448.0µ ±  1%   429.4µ ±  2%   -4.17% (p=0.002 n=6)
Query/rate(a_100[1m])_+_rate(b_100[1m]),_instant_query/Mimir-10                   893.0µ ±  3%   866.2µ ±  4%   -2.99% (p=0.009 n=6)
Query/rate(a_100[1m])_+_rate(b_100[1m]),_range_query_with_100_steps/Mimir-10      2.351m ±  2%   2.292m ±  1%   -2.51% (p=0.002 n=6)
Query/rate(a_100[1m])_+_rate(b_100[1m]),_range_query_with_1000_steps/Mimir-10     15.30m ±  1%   14.95m ±  0%   -2.29% (p=0.002 n=6)
Query/rate(a_2000[1m])_+_rate(b_2000[1m]),_instant_query/Mimir-10                 9.955m ±  2%   9.752m ±  1%   -2.05% (p=0.002 n=6)
Query/rate(a_2000[1m])_+_rate(b_2000[1m]),_range_query_with_100_steps/Mimir-10    37.75m ±  3%   37.36m ±  1%   -1.05% (p=0.009 n=6)
Query/rate(a_2000[1m])_+_rate(b_2000[1m]),_range_query_with_1000_steps/Mimir-10   281.0m ±  1%   279.9m ±  1%   -0.39% (p=0.002 n=6)
geomean                                                                           12.06m         11.85m         -1.69%
```

</details>

Peak memory consumption is unchanged.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
