### PR TITLE
development mode: use alloy instead of agent for flow mode

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -33,7 +33,7 @@ Available profiles:
 
 1. grafana-agent-static (started by default)
 1. prometheus (started by default)
-1. grafana-agent-flow
+1. grafana-alloy
 1. otel-collector-remote-write (don't use with the other otel collector, both use the default ports for clients)
 1. otel-collector-otlp-push (don't use with the other otel collector, both use the default ports for clients)
 

--- a/development/mimir-monolithic-mode/config/config.alloy
+++ b/development/mimir-monolithic-mode/config/config.alloy
@@ -12,7 +12,7 @@ prometheus.scrape "mimir" {
 
   scrape_interval = "5s"
   scrape_timeout = "4s"
-  enable_protobuf_negotiation = true
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
   scrape_classic_histograms = true
 }
 
@@ -21,7 +21,7 @@ prometheus.relabel "mimir" {
 
   rule {
     action       = "replace"
-    replacement  = "grafana-agent-flow"
+    replacement  = "grafana-alloy"
     target_label = "scraped_by"
   }
   rule {

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -51,15 +51,13 @@ services:
     ports:
       - 9091:9091
 
-  grafana-agent-flow:
+  grafana-alloy:
     profiles:
-      - grafana-agent-flow
-    image: grafana/agent:v0.41.1
-    environment:
-      - AGENT_MODE=flow
-    command: ["run", "--server.http.listen-addr=0.0.0.0:9092", "/etc/agent/config.river"]
+      - grafana-alloy
+    image: grafana/alloy:v1.2.1
+    command: ["run", "--server.http.listen-addr=0.0.0.0:9092", "--storage.path=/var/lib/alloy/data", "/etc/alloy/config.alloy"]
     volumes:
-      - ./config/grafana-agent.river:/etc/agent/config.river
+      - ./config/config.alloy:/etc/alloy/config.alloy
     ports:
       - 9092:9092
 


### PR DESCRIPTION
#### What this PR does

Prepare to update https://grafana.com/docs/mimir/next/send/native-histograms/ .

Also fix deprecated use of enable_protobuf_negotiation = true scrape option.

#### Which issue(s) this PR fixes or relates to

Related to #8814 
Related to https://github.com/grafana/mimir-squad/issues/1334

#### Checklist

- N/A Tests updated.
- N/A Documentation added.
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
