### PR TITLE
Introduce leaf nodes and "unknown" query component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## main / unreleased
+* [ENHANCEMENT] Query-scheduler: Improve CPU/memory performance of experimental query-scheduler. #8871
 
 ### Grafana Mimir
 

--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue.go
@@ -140,15 +140,16 @@ func newNode(name string, height int, da QueuingAlgorithm) (*Node, error) {
 		name:             name,
 		localQueue:       nil,
 		queuePosition:    localQueueIndex,
-		queueOrder:       make([]string, 0),
-		queueMap:         make(map[string]*Node, 1),
 		height:           height,
 		queuingAlgorithm: da,
 	}
-	// if the node is a leaf node, it gets memory allocated towards a local queue and cannot have child nodes
+	// if the node is a leaf node, it gets memory allocated towards a local queue and cannot have child queues
 	if height == 0 {
 		n.localQueue = list.New()
-		n.queueMap = nil
+	} else {
+		// any other kind of node is allowed to have children, but not a local queue
+		n.queueMap = make(map[string]*Node, 1)
+		n.queueOrder = make([]string, 0)
 	}
 	return n, nil
 }

--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue.go
@@ -170,7 +170,6 @@ func (n *Node) IsEmpty() bool {
 	if n.isLeaf() {
 		return n.localQueue.Len() == 0
 	}
-
 	return len(n.queueMap) == 0
 }
 
@@ -222,14 +221,14 @@ func (n *Node) dequeue() (QueuePath, any) {
 
 	path := QueuePath{n.name}
 
-	if n.IsEmpty() {
-		return path, nil
-	}
-
 	var checkedAllNodes bool
 	var dequeueNode *Node
 	// continue until we've found a value or checked all nodes that need checking
 	for v == nil && !checkedAllNodes {
+		if n.IsEmpty() {
+			// we can't dequeue a value from an empty node; return early
+			return path, nil
+		}
 		dequeueNode, checkedAllNodes = n.queuingAlgorithm.dequeueSelectNode(n)
 		switch dequeueNode {
 		case n:

--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_test.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_test.go
@@ -92,18 +92,19 @@ func Test_EnqueueBackByPath(t *testing.T) {
 			childPathsToEnqueue: []QueuePath{{"child-1"}},
 		},
 		{
-			name: "enqueue grandchildren to a tree with max-depth of 2",
+			name: "fail to enqueue to a node at depth 1 in tree with max-depth of 2",
 			treeAlgosByDepth: []QueuingAlgorithm{
 				newTenantQuerierAssignments(),
 				&roundRobinState{},
 				newTenantQuerierAssignments(),
 			},
-			childPathsToEnqueue: []QueuePath{{"child"}, {"grandchild"}},
+			childPathsToEnqueue: []QueuePath{{"child"}},
+			expectErr:           true,
 		},
 		{
-			name:                "enqueue beyond max-depth",
+			name:                "fail to enqueue beyond max-depth",
 			treeAlgosByDepth:    []QueuingAlgorithm{&roundRobinState{}},
-			childPathsToEnqueue: []QueuePath{{"child"}, {"child, grandchild"}},
+			childPathsToEnqueue: []QueuePath{{"child, grandchild"}},
 			expectErr:           true,
 		},
 	}
@@ -231,7 +232,8 @@ func Test_Dequeue_RootNode(t *testing.T) {
 func Test_RoundRobinDequeue(t *testing.T) {
 	tests := []struct {
 		name                      string
-		selfQueueObjects          []string
+		treeDepth                 int
+		enqueueObjs               []enqueueObj
 		children                  []string
 		childQueueObjects         map[string][]any
 		grandchildren             []string
@@ -242,62 +244,42 @@ func Test_RoundRobinDequeue(t *testing.T) {
 		expected []string
 	}{
 		{
-			name:              "dequeue from round-robin child when local queue empty",
-			children:          []string{"child-1"},
-			childQueueObjects: map[string][]any{"child-1": {"child-1:some-object"}},
-			expected:          []string{"child-1:some-object"},
+			name:        "dequeue from round-robin child",
+			treeDepth:   2,
+			enqueueObjs: []enqueueObj{{"child-1:some-object", QueuePath{"child-1"}}},
+			expected:    []string{"child-1:some-object"},
 		},
 		{
-			name:              "dequeue from round-robin root when on node's turn",
-			selfQueueObjects:  []string{"root:object-1", "root:object-2"},
-			children:          []string{"child-1"},
-			childQueueObjects: map[string][]any{"child-1": {"child-1:object-1"}},
-			expected:          []string{"root:object-1", "child-1:object-1"},
+			name:        "dequeue from second round-robin child when first child is empty",
+			treeDepth:   2,
+			enqueueObjs: []enqueueObj{{nil, QueuePath{"child-1"}}, {"child-2:some-object", QueuePath{"cihld-2"}}},
+			expected:    []string{"child-2:some-object"},
 		},
 		{
-			name:              "dequeue from second round-robin child when first child is empty",
-			children:          []string{"child-1", "child-2"},
-			childQueueObjects: map[string][]any{"child-1": {nil}, "child-2": {"child-2:some-object"}},
-			expected:          []string{"child-2:some-object"},
-		},
-		{
-			name:              "dequeue from round-robin grandchild when non-empty",
-			children:          []string{"child-1", "child-2"},
-			childQueueObjects: map[string][]any{"child-1": {"child-1:object-1", "child-1:object-2"}, "child-2": {"child-2:object-1"}},
-			expected:          []string{"child-1:object-1", "child-2:object-1", "grandchild-1:object-1"},
-			grandchildren:     []string{"grandchild-1"},
-			grandchildrenQueueObjects: map[string]struct {
-				path QueuePath
-				objs []any
-			}{"grandchild-1": {
-				path: QueuePath{"child-1", "grandchild-1"},
-				objs: []any{"grandchild-1:object-1"},
-			}},
+			name:      "dequeue from round-robin grandchild",
+			treeDepth: 3,
+			enqueueObjs: []enqueueObj{
+				{"grandchild-1:object-1", QueuePath{"child-1", "grandchild-1"}},
+				{"grandchild-1:object-2", QueuePath{"child-1", "grandchild-1"}},
+				{"grandchild-2:object-1", QueuePath{"child-2", "grandchild-2"}},
+			},
+			expected:      []string{"grandchild-1:object-1", "grandchild-2:object-1", "grandchild-1:object-2"},
+			grandchildren: []string{"grandchild-1"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tree, err := NewTree(&roundRobinState{}, &roundRobinState{}, &roundRobinState{})
+			args := make([]QueuingAlgorithm, 0)
+			for i := 0; i < tt.treeDepth; i++ {
+				args = append(args, &roundRobinState{})
+			}
+			tree, err := NewTree(args...)
 			require.NoError(t, err)
 
-			for _, sqo := range tt.selfQueueObjects {
-				err = tree.EnqueueBackByPath(QueuePath{}, sqo)
+			for _, eo := range tt.enqueueObjs {
+				err = tree.EnqueueBackByPath(eo.path, eo.obj)
 				require.NoError(t, err)
-			}
-
-			for _, child := range tt.children {
-				for _, obj := range tt.childQueueObjects[child] {
-					_ = tree.EnqueueBackByPath(QueuePath{child}, obj)
-				}
-			}
-
-			for _, grandchild := range tt.grandchildren {
-				gqo := tt.grandchildrenQueueObjects[grandchild]
-				for _, obj := range gqo.objs {
-					err = tree.EnqueueBackByPath(gqo.path, obj)
-					require.NoError(t, err)
-				}
 			}
 
 			for _, expected := range tt.expected {
@@ -653,16 +635,54 @@ func Test_ChangeTenantQuerierAssignments(t *testing.T) {
 // Dequeuing from a balanced tree allows the test to have a simple looped structures
 // while running checks to ensure that round-robin order is respected.
 func Test_DequeueBalancedRoundRobinTree(t *testing.T) {
+	/* balanced tree structure:
+		root
+		├── 0
+		│   ├── a
+		│	│	├── 0:a:val0
+	    │   │   ├── 0:a:val1
+	    │   │   ├── 0:a:val2
+		│   │   ├── 0:a:val3
+		│   │   └── 0:a:val4
+		│   ├── b
+		│	│	├── 0:b:val0
+	    │   │   ├── 0:b:val1
+	    │   │   ├── 0:b:val2
+		│   │   ├── 0:b:val3
+		│   │   └── 0:b:val4
+		│   └── c
+		│	 	├── 0:c:val0
+	    │       ├── 0:c:val1
+	    │       ├── 0:c:val2
+		│       ├── 0:c:val3
+		│       └── 0:c:val4
+		├── 1
+		│   ├── a
+		│	│	...
+		│   ├── b
+		│	│	...
+		│   └── c
+		│		...
+		└── 2
+		    ├── a
+		 	│	...
+		    ├── b
+		 	│	...
+		    └── c
+		 		...
+	*/
 	firstDimensions := []string{"0", "1", "2"}
 	secondDimensions := []string{"a", "b", "c"}
 	itemsPerDimension := 5
+
 	tree := makeBalancedRoundRobinTree(t, firstDimensions, secondDimensions, itemsPerDimension)
 	require.NotNil(t, tree)
 
 	count := 0
 
-	// MultiQueuingAlgorithmTreeQueue will fairly dequeue from all levels of the tree
-	rotationsBeforeRepeat := len(firstDimensions) * len(secondDimensions)
+	// MultiQueuingAlgorithmTreeQueue will fairly dequeue from each child node; subtract one to avoid counting
+	// the local queue of first-dimension node.
+	rotationsBeforeRepeat := len(firstDimensions)*len(secondDimensions) - 1
 	// track dequeued paths to ensure round-robin dequeuing does not repeat before expected
 	dequeuedPathCache := make([]QueuePath, rotationsBeforeRepeat)
 
@@ -676,12 +696,10 @@ func Test_DequeueBalancedRoundRobinTree(t *testing.T) {
 		count++
 	}
 
-	// count items enqueued to nodes at depth 1
-	expectedFirstDimensionCount := len(firstDimensions) * itemsPerDimension
-	// count items enqueued to nodes at depth 2
+	// count items enqueued; there should be size(firstDim) * size(secondDim) * itemsPerDim
 	expectedSecondDimensionCount := len(firstDimensions) * len(secondDimensions) * itemsPerDimension
 
-	require.Equal(t, expectedFirstDimensionCount+expectedSecondDimensionCount, count)
+	require.Equal(t, expectedSecondDimensionCount, count)
 
 }
 
@@ -693,36 +711,21 @@ func Test_DequeueBalancedRoundRobinTree(t *testing.T) {
 func Test_DequeueUnbalancedRoundRobinTree(t *testing.T) {
 	tree := makeUnbalancedRoundRobinTree(t)
 
-	// dequeue from root until exhausted
-	_, v := tree.Dequeue()
-	require.Equal(t, "root:0:val0", v)
+	expectedVals := []string{
+		"root:0:a:val0",
+		"root:1:a:val0",
+		"root:2:a:val0",
+		"root:1:a:val1",
+		"root:2:b:val0",
+		"root:2:a:val1",
+		"root:2:b:val1",
+		"root:2:b:val2",
+	}
 
-	_, v = tree.Dequeue()
-	require.Equal(t, "root:1:val0", v)
-
-	_, v = tree.Dequeue()
-	require.Equal(t, "root:2:0:val0", v)
-
-	_, v = tree.Dequeue()
-	require.Equal(t, "root:1:0:val0", v)
-
-	_, v = tree.Dequeue()
-	require.Equal(t, "root:2:1:val0", v)
-
-	_, v = tree.Dequeue()
-	require.Equal(t, "root:1:val1", v)
-
-	_, v = tree.Dequeue()
-	require.Equal(t, "root:2:0:val1", v)
-
-	_, v = tree.Dequeue()
-	require.Equal(t, "root:1:0:val1", v)
-
-	_, v = tree.Dequeue()
-	require.Equal(t, "root:2:1:val1", v)
-
-	_, v = tree.Dequeue()
-	require.Equal(t, "root:2:1:val2", v)
+	for _, expected := range expectedVals {
+		_, v := tree.Dequeue()
+		require.Equal(t, expected, v)
+	}
 
 	// all items have been dequeued
 	require.Equal(t, 0, tree.rootNode.ItemCount())
@@ -733,7 +736,7 @@ func Test_DequeueUnbalancedRoundRobinTree(t *testing.T) {
 }
 
 func Test_EnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
-	tree, err := NewTree(&roundRobinState{}, &roundRobinState{}, &roundRobinState{})
+	tree, err := NewTree(&roundRobinState{}, &roundRobinState{})
 	require.NoError(t, err)
 	require.NotNil(t, tree)
 
@@ -840,11 +843,6 @@ func makeBalancedRoundRobinTree(t *testing.T, firstDimensions, secondDimensions 
 	cache := map[string]struct{}{}
 
 	for _, firstDimName := range firstDimensions {
-		for k := 0; k < itemsPerDimension; k++ {
-			childPath := QueuePath{firstDimName}
-			item := makeItemForChildQueue(tree.rootNode, childPath, cache)
-			require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-		}
 		for _, secondDimName := range secondDimensions {
 			for k := 0; k < itemsPerDimension; k++ {
 				childPath := QueuePath{firstDimName, secondDimName}
@@ -859,29 +857,26 @@ func makeBalancedRoundRobinTree(t *testing.T, firstDimensions, secondDimensions 
 func makeUnbalancedRoundRobinTree(t *testing.T) *MultiQueuingAlgorithmTreeQueue {
 	/*
 	   root
-	   ├── child0
-	   │		 └── localQueue
-	   │		     └── val0
-	   ├── child1
-	   │		 ├── child0
-	   │		 │		 └── localQueue
-	   │		 │		     ├── val0
-	   │		 │		     └── val1
-	   │		 └── localQueue
-	   │		     ├── val0
-	   │		     └── val1
-	   ├── child2
-	   │		 ├── child0
-	   │		 │		 └── localQueue
-	   │		 │		     ├── val0
-	   │		 │		     └── val1
-	   │		 ├── child1
-	   │		 │		 └── localQueue
-	   │		 │		     ├── val0
-	   │		 │		     ├── val1
-	   │		 │		     └── val2
-	   │		 └── localQueue
-	   └── localQueue
+	   ├── 0
+	   │   └── a
+	   │	   └── localQueue
+	   │           └──val0
+	   ├── 1
+	   │   └── a
+	   │	   └── localQueue
+	   │		   ├── val0
+	   │		   └── val1
+	   └── 2
+	       ├── a
+	       │   └── localQueue
+	       │	   ├── val0
+	       │	   └── val1
+	       └── b
+	           └── localQueue
+	        	   ├── val0
+	        	   ├── val1
+	        	   └── val2
+
 	*/
 	tree, err := NewTree(&roundRobinState{}, &roundRobinState{}, &roundRobinState{})
 	require.NoError(t, err)
@@ -890,65 +885,65 @@ func makeUnbalancedRoundRobinTree(t *testing.T) *MultiQueuingAlgorithmTreeQueue 
 
 	cache := map[string]struct{}{}
 
-	// enqueue one item to root:0
-	childPath := QueuePath{"0"}
+	// enqueue one item to root:0:a
+	childPath := QueuePath{"0", "a"}
 	item := makeItemForChildQueue(tree.rootNode, childPath, cache)
 	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-	require.Equal(t, 2, tree.rootNode.nodeCount())
+	require.Equal(t, 3, tree.rootNode.nodeCount())
 	require.Equal(t, 1, tree.rootNode.ItemCount())
 
-	// enqueue two items to root:1
-	childPath = QueuePath{"1"}
+	//// enqueue two items to root:1
+	//childPath = QueuePath{"1"}
+	//item = makeItemForChildQueue(tree.rootNode, childPath, cache)
+	//require.NoError(t, tree.EnqueueBackByPath(childPath, item))
+	//require.Equal(t, 3, tree.rootNode.nodeCount())
+	//require.Equal(t, 2, tree.rootNode.ItemCount())
+	//
+	//item = makeItemForChildQueue(tree.rootNode, childPath, cache)
+	//require.NoError(t, tree.EnqueueBackByPath(childPath, item))
+	//require.Equal(t, 3, tree.rootNode.nodeCount())
+	//require.Equal(t, 3, tree.rootNode.ItemCount())
+
+	// enqueue two items to root:1:a
+	childPath = QueuePath{"1", "a"}
 	item = makeItemForChildQueue(tree.rootNode, childPath, cache)
 	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-	require.Equal(t, 3, tree.rootNode.nodeCount())
+	require.Equal(t, 5, tree.rootNode.nodeCount())
 	require.Equal(t, 2, tree.rootNode.ItemCount())
 
 	item = makeItemForChildQueue(tree.rootNode, childPath, cache)
 	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-	require.Equal(t, 3, tree.rootNode.nodeCount())
+	require.Equal(t, 5, tree.rootNode.nodeCount())
 	require.Equal(t, 3, tree.rootNode.ItemCount())
 
-	// enqueue two items to root:1:0
-	childPath = QueuePath{"1", "0"}
+	// enqueue two items to root:2:a
+	childPath = QueuePath{"2", "a"}
 	item = makeItemForChildQueue(tree.rootNode, childPath, cache)
 	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-	require.Equal(t, 4, tree.rootNode.nodeCount())
+	require.Equal(t, 7, tree.rootNode.nodeCount())
 	require.Equal(t, 4, tree.rootNode.ItemCount())
 
 	item = makeItemForChildQueue(tree.rootNode, childPath, cache)
 	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-	require.Equal(t, 4, tree.rootNode.nodeCount())
+	require.Equal(t, 7, tree.rootNode.nodeCount())
 	require.Equal(t, 5, tree.rootNode.ItemCount())
 
-	// enqueue two items to root:2:0
-	childPath = QueuePath{"2", "0"}
+	// enqueue three items to root:2:b
+	childPath = QueuePath{"2", "b"}
 	item = makeItemForChildQueue(tree.rootNode, childPath, cache)
 	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-	require.Equal(t, 6, tree.rootNode.nodeCount())
+	require.Equal(t, 8, tree.rootNode.nodeCount())
 	require.Equal(t, 6, tree.rootNode.ItemCount())
 
 	item = makeItemForChildQueue(tree.rootNode, childPath, cache)
 	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-	require.Equal(t, 6, tree.rootNode.nodeCount())
+	require.Equal(t, 8, tree.rootNode.nodeCount())
 	require.Equal(t, 7, tree.rootNode.ItemCount())
 
-	// enqueue three items to root:2:1
-	childPath = QueuePath{"2", "1"}
 	item = makeItemForChildQueue(tree.rootNode, childPath, cache)
 	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-	require.Equal(t, 7, tree.rootNode.nodeCount())
+	require.Equal(t, 8, tree.rootNode.nodeCount())
 	require.Equal(t, 8, tree.rootNode.ItemCount())
-
-	item = makeItemForChildQueue(tree.rootNode, childPath, cache)
-	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-	require.Equal(t, 7, tree.rootNode.nodeCount())
-	require.Equal(t, 9, tree.rootNode.ItemCount())
-
-	item = makeItemForChildQueue(tree.rootNode, childPath, cache)
-	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
-	require.Equal(t, 7, tree.rootNode.nodeCount())
-	require.Equal(t, 10, tree.rootNode.ItemCount())
 
 	return tree
 }

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -74,7 +74,7 @@ func (sr *SchedulerRequest) ExpectedQueryComponentName() string {
 	if len(sr.AdditionalQueueDimensions) > 0 {
 		return sr.AdditionalQueueDimensions[0]
 	}
-	return ""
+	return unknownQueueDimension
 }
 
 // TenantIndex is opaque type that allows to resume iteration over tenants

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -136,7 +136,6 @@ func TestMultiDimensionalQueueFairnessSlowConsumerEffects(t *testing.T) {
 			}
 
 			for _, additionalQueueDimensionsEnabled := range additionalQueueDimensionsEnabledCases {
-
 				// Scheduler code uses a histogram for queue duration, but a counter is a more direct metric
 				// for this test, as we are concerned with the total or average wait time for all queue items.
 				// Prometheus histograms also lack support for test assertions via prometheus/testutil.

--- a/pkg/scheduler/queue/tenant_queues_test.go
+++ b/pkg/scheduler/queue/tenant_queues_test.go
@@ -260,13 +260,11 @@ func TestQueuesRespectMaxTenantQueueSizeWithSubQueues(t *testing.T) {
 			// assert equal distribution of queue items between tenant node and 3 subnodes
 			for _, v := range additionalQueueDimensions {
 				var checkPath QueuePath
-				// TODO (casie): After deprecating legacy tree queue, clean this up
-				if _, ok := qb.tree.(*MultiQueuingAlgorithmTreeQueue); ok && v == nil {
+				if v == nil {
 					checkPath = append(QueuePath{"tenant-1"}, unknownQueueDimension)
 				} else {
 					checkPath = append(QueuePath{"tenant-1"}, v...)
 				}
-
 				// TODO (casie): After deprecating legacy tree queue, clean this up
 				var itemCount int
 				if tq, ok := qb.tree.(*TreeQueue); ok {
@@ -854,7 +852,8 @@ func isConsistent(qb *queueBroker) error {
 	var tenantQueueCount int
 	// TODO (casie): After deprecating legacy tree queue, clean this up
 	if tq, ok := qb.tree.(*TreeQueue); ok {
-		tenantQueueCount = tq.NodeCount() - 1
+		// tenants may have child nodes, only count the tenant queue
+		tenantQueueCount = len(tq.childQueueMap)
 	} else if itq, ok := qb.tree.(*MultiQueuingAlgorithmTreeQueue); ok {
 		if qb.additionalQueueDimensionsEnabled {
 			if !qb.prioritizeQueryComponents {

--- a/pkg/scheduler/queue/tree_queueing_algorithms.go
+++ b/pkg/scheduler/queue/tree_queueing_algorithms.go
@@ -32,10 +32,10 @@ type QueuingAlgorithm interface {
 }
 
 // roundRobinState is the simplest type of QueuingAlgorithm; nodes which use this QueuingAlgorithm and are at
-// the same depth in a MultiQueuingAlgorithmTreeQueue do not share any state. When children are added to these nodes, they are placed at
-// the "end" of the order from the perspective of the node's current queuePosition (e.g., if queuePosition is 3,
-// a new child will be placed at index 2). Children are dequeued from using a simple round-robin ordering;
-// queuePosition is incremented on every dequeue.
+// the same depth in a MultiQueuingAlgorithmTreeQueue do not share any state. When children are added to these nodes,
+// they are placed at the "end" of the order from the perspective of the node's current queuePosition (e.g., if
+// queuePosition is 3, a new child will be placed at index 2). Children are dequeued from using a simple round-robin
+// ordering; queuePosition is incremented on every dequeue.
 type roundRobinState struct {
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR introduces the concept of "leaf nodes" to the experimental `MultiQueuingAlgorithmTreeQueue`, and enforces a couple of rules:
* Leaf nodes may only exist at a tree's maximum depth (`len(queuingAlgorithms)` at tree creation)
* Non-leaf nodes may not contain a local queue
* Leaf nodes may not have children (this is already enforced by tree's max-depth)

This lets us efficiently skip memory allocation for non-leaf nodes, saving memory and CPU cycles.

#### Changes to structure/behavior
One structural change is required to enable this: previously, if `query-frontend.additional-query-queue-dimensions-enabled` was set and scheduler requests `AdditionalQueueDimensions` ([code](https://github.com/grafana/mimir/blob/035a8c44bfeb8fd376aa01f534b50064a8ceb235/pkg/scheduler/queue/queue.go#L54)) was _empty_, said requests would be enqueued to the parent node's local queue, e.g.:
```
root
└─ tenant-1 --> local queue: [queries with no additional queue dimensions]
   ├─ ingester
   ├─ store-gateway
   └─ ingester-and-store-gateway
```

With this change, such queries will instead be nested under a new node in the tree:
```
root
└─ tenant-1
   ├─ unknown
   │  └─ queries with no additional queue dimensions
   ├─ ingester
   ├─ store-gateway
   └─ ingester-and-store-gateway
```

The overall behavior is roughly the same, since tenant nodes round-robin between dequeuing from their children and their local queue. There is one fairly non-impactful edge case which will be removed: previously, a query with "unknown" queue dimensions may have jumped the queue in the following example scenario:
1. the tenant node is created by enqueuing queries _with_ queue dimensions (e.g., `ingester-and-store-gateway`)
2. queries with unknown queue dimensions are queued to the tenant's local queue
3. the first dequeue for the tenant will dequeue from the tenant's local queue, skipping all the `ingester-and-store-gateway` queries which were enqueued _first_.

With this change, because "unknown" queue dimensions become their own nodes, they will be queued and dequeued from in the expected FIFO order.

There is a possible unexpected behavior change -- if anyone is using `unknown` as a queue dimension, scheduler requests with empty `AdditionalQueueDimensions` and requests with `unknown` `AdditionalQueueDimensions` will be mixed.

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
