### PR TITLE
Jsonnet: Improve min-time-between-zones-downscale setting during ingest storage migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@
 * [ENHANCEMENT] Memcached: Update to Memcached 1.6.28 and memcached-exporter 0.14.4. #8557
 * [ENHANCEMENT] Rollout-operator: Allow the rollout-operator to be used as Kubernetes statefulset webhook to enable `no-downscale` and `prepare-downscale` annotations to be used on ingesters or store-gateways. #8743
 * [ENHANCEMENT] Do not deploy ingester-zone-c when experimental ingest storage is enabled and `ingest_storage_ingester_zones` is configured to `2`. #8776
-* [ENHANCEMENT] Added the config option `ingest_storage_migration_classic_ingesters_no_scale_down_delay` to disable the downscale delay on classic ingesters when migrating to experimental ingest storage. #8775
+* [ENHANCEMENT] Added the config option `ingest_storage_migration_classic_ingesters_no_scale_down_delay` to disable the downscale delay on classic ingesters when migrating to experimental ingest storage. #8775 #8873
 * [ENHANCEMENT] Configure experimental ingest storage on query-frontend too when enabled. #8843
 
 ### Mimirtool

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -1798,7 +1798,7 @@ metadata:
     grafana.com/prepare-downscale-http-port: "80"
     rollout-max-unavailable: "50"
   labels:
-    grafana.com/min-time-between-zones-downscale: 12h
+    grafana.com/min-time-between-zones-downscale: "0"
     grafana.com/prepare-downscale: "true"
     rollout-group: ingester
   name: ingester-zone-a
@@ -1943,7 +1943,7 @@ metadata:
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
-    grafana.com/min-time-between-zones-downscale: 12h
+    grafana.com/min-time-between-zones-downscale: "0"
     grafana.com/prepare-downscale: "true"
     rollout-group: ingester
   name: ingester-zone-b

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11.jsonnet
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11.jsonnet
@@ -6,5 +6,8 @@
     ingest_storage_ingester_autoscaling_ingester_annotations_enabled: true,
     multi_zone_ingester_replicas: 0,
     ingester_automated_downscale_enabled: false,
+
+    // The following config is not required anymore.
+    ingest_storage_migration_classic_ingesters_no_scale_down_delay: false,
   },
 }

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -1815,7 +1815,7 @@ metadata:
     grafana.com/prepare-downscale-http-port: "80"
     rollout-max-unavailable: "50"
   labels:
-    grafana.com/min-time-between-zones-downscale: 0s
+    grafana.com/min-time-between-zones-downscale: "0"
     grafana.com/prepare-downscale: "true"
     rollout-group: ingester
   name: ingester-zone-a
@@ -2096,7 +2096,7 @@ metadata:
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
-    grafana.com/min-time-between-zones-downscale: 0s
+    grafana.com/min-time-between-zones-downscale: "0"
     grafana.com/prepare-downscale: "true"
     rollout-group: ingester
   name: ingester-zone-b
@@ -2364,7 +2364,7 @@ metadata:
     grafana.com/rollout-downscale-leader: ingester-zone-b
     rollout-max-unavailable: "50"
   labels:
-    grafana.com/min-time-between-zones-downscale: 0s
+    grafana.com/min-time-between-zones-downscale: "0"
     grafana.com/prepare-downscale: "true"
     rollout-group: ingester
   name: ingester-zone-c

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -1815,7 +1815,7 @@ metadata:
     grafana.com/prepare-downscale-http-port: "80"
     rollout-max-unavailable: "50"
   labels:
-    grafana.com/min-time-between-zones-downscale: 0s
+    grafana.com/min-time-between-zones-downscale: "0"
     grafana.com/prepare-downscale: "true"
     rollout-group: ingester
   name: ingester-zone-a
@@ -2096,7 +2096,7 @@ metadata:
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
-    grafana.com/min-time-between-zones-downscale: 0s
+    grafana.com/min-time-between-zones-downscale: "0"
     grafana.com/prepare-downscale: "true"
     rollout-group: ingester
   name: ingester-zone-b
@@ -2364,7 +2364,7 @@ metadata:
     grafana.com/rollout-downscale-leader: ingester-zone-b
     rollout-max-unavailable: "50"
   labels:
-    grafana.com/min-time-between-zones-downscale: 0s
+    grafana.com/min-time-between-zones-downscale: "0"
     grafana.com/prepare-downscale: "true"
     rollout-group: ingester
   name: ingester-zone-c

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6.jsonnet
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6.jsonnet
@@ -3,7 +3,6 @@
 (import 'test-ingest-storage-migration-step-5b.jsonnet') {
   _config+:: {
     // This builds on previous step.
-    ingest_storage_migration_classic_ingesters_no_scale_down_delay: false,
     ingest_storage_migration_classic_ingesters_scale_down: false,
     ingest_storage_migration_classic_ingesters_zone_a_decommission: true,
     ingest_storage_migration_classic_ingesters_zone_b_decommission: true,

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -1739,7 +1739,7 @@ metadata:
     grafana.com/prepare-downscale-http-port: "80"
     rollout-max-unavailable: "50"
   labels:
-    grafana.com/min-time-between-zones-downscale: 12h
+    grafana.com/min-time-between-zones-downscale: "0"
     grafana.com/prepare-downscale: "true"
     rollout-group: ingester
   name: ingester-zone-a
@@ -1884,7 +1884,7 @@ metadata:
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
-    grafana.com/min-time-between-zones-downscale: 12h
+    grafana.com/min-time-between-zones-downscale: "0"
     grafana.com/prepare-downscale: "true"
     rollout-group: ingester
   name: ingester-zone-b

--- a/operations/mimir/ingest-storage-migration.libsonnet
+++ b/operations/mimir/ingest-storage-migration.libsonnet
@@ -188,7 +188,7 @@
       (
         if !$._config.ingest_storage_migration_classic_ingesters_no_scale_down_delay && !$._config.ingest_storage_migration_classic_ingesters_scale_down then {} else
           statefulSet.mixin.metadata.withLabelsMixin({
-            'grafana.com/min-time-between-zones-downscale': '0s',
+            'grafana.com/min-time-between-zones-downscale': '0',
           })
       ) + (
         if !$._config.ingest_storage_migration_classic_ingesters_scale_down then {} else
@@ -203,7 +203,7 @@
       null
     else if $._config.ingest_storage_migration_classic_ingesters_no_scale_down_delay || $._config.ingest_storage_migration_classic_ingesters_scale_down then
       statefulSet.mixin.metadata.withLabelsMixin({
-        'grafana.com/min-time-between-zones-downscale': '0s',
+        'grafana.com/min-time-between-zones-downscale': '0',
       })
     else
       {},
@@ -215,7 +215,7 @@
       null
     else if $._config.ingest_storage_migration_classic_ingesters_no_scale_down_delay || $._config.ingest_storage_migration_classic_ingesters_scale_down then
       statefulSet.mixin.metadata.withLabelsMixin({
-        'grafana.com/min-time-between-zones-downscale': '0s',
+        'grafana.com/min-time-between-zones-downscale': '0',
       })
     else
       {},


### PR DESCRIPTION
#### What this PR does

We recently migrated a Mimir cluster to the new experimental ingest storage architecture and we noticed a couple of things to improve in the jsonnet-coded migration process:

- [change 'grafana.com/min-time-between-zones-downscale' value from '0s' to '0' to keep it consistent with the setting used when ingest storage ingesters autoscaling is enabled](https://github.com/grafana/mimir/commit/566f3d4704f34b1d625c41054c6f706b25c57b17) 
- [keep ingest_storage_migration_classic_ingesters_no_scale_down_delay:false until ingesters autoscaling is enabled](https://github.com/grafana/mimir/commit/97d132ca625d05d3aee5c591fe1eee4f2022578c) 

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
