### PR TITLE
Jsonnet: change min/max ingester replicas setting to per-zone when ingest storage is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,9 @@
 
 ### Jsonnet
 
+* [CHANGE] Changed the following config options when the experimental ingest storage is enabled: #8874
+  * `ingest_storage_ingester_autoscaling_min_replicas` changed to `ingest_storage_ingester_autoscaling_min_replicas_per_zone`
+  * `ingest_storage_ingester_autoscaling_max_replicas` changed to `ingest_storage_ingester_autoscaling_max_replicas_per_zone`
 * [FEATURE] Add support for automatically deleting compactor, store-gateway and read-write mode backend PVCs when the corresponding StatefulSet is scaled down. #8382
 * [ENHANCEMENT] Added the following config options to set the number of partition ingester replicas when migrating to experimental ingest storage. #8517
   * `ingest_storage_migration_partition_ingester_zone_a_replicas`

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10.jsonnet
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10.jsonnet
@@ -4,8 +4,8 @@
   _config+:: {
     // This builds on previous step.
     ingest_storage_ingester_autoscaling_enabled: true,
-    ingest_storage_ingester_autoscaling_min_replicas: 3,
-    ingest_storage_ingester_autoscaling_max_replicas: 30,
+    ingest_storage_ingester_autoscaling_min_replicas_per_zone: 2,
+    ingest_storage_ingester_autoscaling_max_replicas_per_zone: 15,
 
     // Do not configure ingesters to scale based on HPA yet.
     ingest_storage_ingester_autoscaling_ingester_annotations_enabled: false,

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -2954,8 +2954,8 @@ spec:
             value: 100
           selectPolicy: Min
           stabilizationWindowSeconds: 1800
-  maxReplicaCount: 10
-  minReplicaCount: 1
+  maxReplicaCount: 15
+  minReplicaCount: 2
   pollingInterval: 10
   scaleTargetRef:
     apiVersion: rollout-operator.grafana.com/v1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final.jsonnet
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final.jsonnet
@@ -9,8 +9,8 @@
     ingest_storage_ingester_instance_ring_dedicated_prefix_enabled: true,
 
     ingest_storage_ingester_autoscaling_enabled: true,
-    ingest_storage_ingester_autoscaling_min_replicas: 3,
-    ingest_storage_ingester_autoscaling_max_replicas: 30,
+    ingest_storage_ingester_autoscaling_min_replicas_per_zone: 2,
+    ingest_storage_ingester_autoscaling_max_replicas_per_zone: 15,
 
     multi_zone_ingester_replicas: 0,
     ingester_automated_downscale_enabled: false,

--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -7,8 +7,8 @@
     ingest_storage_ingester_autoscaling_primary_zone: 'ingester-zone-a',
 
     // Total number of min/max replicas across all zones.
-    ingest_storage_ingester_autoscaling_min_replicas: error 'you must set ingest_storage_ingester_autoscaling_min_replicas in the _config in namespace %s' % $._config.namespace,
-    ingest_storage_ingester_autoscaling_max_replicas: error 'you must set ingest_storage_ingester_autoscaling_max_replicas in the _config in namespace %s' % $._config.namespace,
+    ingest_storage_ingester_autoscaling_min_replicas_per_zone: error 'you must set ingest_storage_ingester_autoscaling_min_replicas_per_zone in the _config in namespace %s' % $._config.namespace,
+    ingest_storage_ingester_autoscaling_max_replicas_per_zone: error 'you must set ingest_storage_ingester_autoscaling_max_replicas_per_zone in the _config in namespace %s' % $._config.namespace,
 
     // The target number of active series per ingester.
     ingest_storage_ingester_autoscaling_active_series_threshold: 1500000,
@@ -172,8 +172,8 @@
   ingest_storage_ingester_primary_zone_scaling: if !$._config.ingest_storage_ingester_autoscaling_enabled then null else
     $.newPartitionsPrimaryIngesterZoneScaledObject(
       $._config.ingest_storage_ingester_autoscaling_primary_zone,
-      std.ceil($._config.ingest_storage_ingester_autoscaling_min_replicas / $._config.ingest_storage_ingester_zones),
-      std.ceil($._config.ingest_storage_ingester_autoscaling_max_replicas / $._config.ingest_storage_ingester_zones),
+      $._config.ingest_storage_ingester_autoscaling_min_replicas_per_zone,
+      $._config.ingest_storage_ingester_autoscaling_max_replicas_per_zone,
       $._config.ingest_storage_ingester_autoscaling_active_series_threshold,
       $.ingester_primary_zone_replica_template
     ),


### PR DESCRIPTION
#### What this PR does

In this PR I'm changing the min/max ingester replicas setting to be per-zone when ingest storage is enabled. It makes it easier to reason, given in the ingest storage zones can be added and removed.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
