### PR TITLE
Querier: rename shouldStopQueryFunc into shouldRetry

### DIFF
--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -3320,7 +3320,7 @@ func TestShouldStopQueryFunc(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			assert.Equal(t, testData.expected, shouldStopQueryFunc(testData.err))
+			assert.Equal(t, testData.expected, shouldRetry(testData.err))
 		})
 	}
 }

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -3243,78 +3243,90 @@ func TestStoreConsistencyCheckFailedErr(t *testing.T) {
 	})
 }
 
-func TestShouldStopQueryFunc(t *testing.T) {
+func TestShouldRetry(t *testing.T) {
 	tests := map[string]struct {
 		err      error
 		expected bool
 	}{
-		"should return true on context canceled": {
+		"should not retry on context canceled": {
 			err:      context.Canceled,
-			expected: true,
+			expected: false,
 		},
-		"should return true on wrapped context canceled": {
+		"should not retry on wrapped context canceled": {
 			err:      errors.Wrap(context.Canceled, "test"),
-			expected: true,
+			expected: false,
 		},
-		"should return true on deadline exceeded": {
+		"should not retry on deadline exceeded": {
 			err:      context.DeadlineExceeded,
-			expected: true,
+			expected: false,
 		},
-		"should return true on wrapped deadline exceeded": {
+		"should not retry on wrapped deadline exceeded": {
 			err:      errors.Wrap(context.DeadlineExceeded, "test"),
-			expected: true,
+			expected: false,
 		},
-		"should return true on gRPC error with status code = 422": {
+		"should not retry on gRPC error with status code = 422": {
 			err:      status.Error(http.StatusUnprocessableEntity, "test"),
-			expected: true,
+			expected: false,
 		},
-		"should return true on wrapped gRPC error with status code = 422": {
+		"should not retry on wrapped gRPC error with status code = 422": {
 			err:      errors.Wrap(status.Error(http.StatusUnprocessableEntity, "test"), "test"),
-			expected: true,
+			expected: false,
 		},
-		"should return true on gogo error with status code = 422": {
+		"should not retry on gogo error with status code = 422": {
 			err:      gogoStatus.Error(http.StatusUnprocessableEntity, "test"),
-			expected: true,
+			expected: false,
 		},
-		"should return true on wrapped gogo error with status code = 422": {
+		"should not retry on wrapped gogo error with status code = 422": {
 			err:      errors.Wrap(gogoStatus.Error(http.StatusUnprocessableEntity, "test"), "test"),
+			expected: false,
+		},
+		"should retry on gRPC error with status code != 422": {
+			err:      status.Error(http.StatusInternalServerError, "test"),
 			expected: true,
 		},
-		"should return false on gRPC error with status code != 422": {
-			err:      status.Error(http.StatusInternalServerError, "test"),
-			expected: false,
+		"should retry on grpc.ErrClientConnClosing": {
+			// Ignore deprecation warning for now
+			// nolint:staticcheck
+			err:      grpc.ErrClientConnClosing,
+			expected: true,
 		},
-		"should return false on generic error": {
+		"should retry on wrapped grpc.ErrClientConnClosing": {
+			// Ignore deprecation warning for now
+			// nolint:staticcheck
+			err:      globalerror.WrapGRPCErrorWithContextError(grpc.ErrClientConnClosing),
+			expected: true,
+		},
+		"should retry on generic error": {
 			err:      errors.New("test"),
-			expected: false,
+			expected: true,
 		},
-		"should not stop query on store-gateway instance limit": {
+		"should retry stop query on store-gateway instance limit": {
 			err:      globalerror.WrapErrorWithGRPCStatus(errors.New("instance limit"), codes.Aborted, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT}).Err(),
-			expected: false,
+			expected: true,
 		},
-		"should not stop query on store-gateway instance limit; shouldn't look at the gRPC code, only Mimir error cause": {
+		"should retry on store-gateway instance limit; shouldn't look at the gRPC code, only Mimir error cause": {
 			err:      globalerror.WrapErrorWithGRPCStatus(errors.New("instance limit"), codes.Internal, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT}).Err(),
-			expected: false,
+			expected: true,
 		},
-		"should not stop query on any other mimirpb error": {
+		"should retry on any other mimirpb error": {
 			err:      globalerror.WrapErrorWithGRPCStatus(errors.New("instance limit"), codes.Internal, &mimirpb.ErrorDetails{Cause: mimirpb.TOO_BUSY}).Err(),
-			expected: false,
+			expected: true,
 		},
-		"should not stop query on any unknown error detail": {
+		"should retry on any unknown error detail": {
 			err: func() error {
 				st, createErr := status.New(codes.Internal, "test").WithDetails(&hintspb.Block{Id: "123"})
 				require.NoError(t, createErr)
 				return st.Err()
 			}(),
-			expected: false,
+			expected: true,
 		},
-		"should not stop query on multiple error details": {
+		"should retry on multiple error details": {
 			err: func() error {
 				st, createErr := status.New(codes.Internal, "test").WithDetails(&hintspb.Block{Id: "123"}, &mimirpb.ErrorDetails{Cause: mimirpb.INSTANCE_LIMIT})
 				require.NoError(t, createErr)
 				return st.Err()
 			}(),
-			expected: false,
+			expected: true,
 		},
 	}
 

--- a/pkg/util/globalerror/grpc_test.go
+++ b/pkg/util/globalerror/grpc_test.go
@@ -84,7 +84,9 @@ func TestWrapContextError(t *testing.T) {
 				expectedContextErr: context.DeadlineExceeded,
 			},
 			"grpc.ErrClientConnClosing": {
-				origErr:            status.Error(codes.Canceled, "grpc: the client connection is closing"),
+				// Ignore deprecation warning for now
+				// nolint:staticcheck
+				origErr:            grpc.ErrClientConnClosing,
 				expectedGrpcCode:   codes.Canceled,
 				expectedContextErr: nil,
 			},


### PR DESCRIPTION
#### What this PR does

This PR is a simple no-op refactoring that renames `querier.shouldStopQueryFunc()` into `querier.shouldRetry()`.
The main reason for that is to make the code more intuitive.

More precisely, these usages:
```
  err := ...
  if shouldStopQueryFunc(err) {
    return err
  }
  // log the positive outcome 
  return nil
```
have been replaced with these usages:
```
  err := ...
  if shouldRetry(err) {
    // log the positive outcome
    return nil
  }
  return err
```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
