### PR TITLE
globalerror: get rid of deprecated gprc.ErrClientConnClosing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@
 * [BUGFIX] Query-frontend: Ensure that internal errors result in an HTTP 500 response code instead of 422. #8595 #8666
 * [BUGFIX] Configuration: Multi line envs variables are flatten during injection to be compatible with YAML syntax
 * [BUGFIX] Querier: fix issue where queries can return incorrect results if a single store-gateway returns overlapping chunks for a series. #8827
-* [BUGFIX] Querier: do not return `grpc: the client connection is closing` errors as HTTP `499`. #8865
+* [BUGFIX] Querier: do not return `grpc: the client connection is closing` errors as HTTP `499`. #8865 #8888
 
 ### Mixin
 

--- a/pkg/util/globalerror/grpc.go
+++ b/pkg/util/globalerror/grpc.go
@@ -7,22 +7,15 @@ import (
 
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/grpcutil"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
-var grpcClientConnectionIsClosingErr string
-
-func init() {
-	// Ignore deprecation warning for now
-	//nolint:staticcheck
-	if stat, ok := grpcutil.ErrorToStatus(grpc.ErrClientConnClosing); ok && stat.Code() == codes.Canceled {
-		grpcClientConnectionIsClosingErr = stat.Message()
-	}
-}
+var (
+	grpcClientConnectionIsClosingErr = "grpc: the client connection is closing"
+)
 
 // WrapGRPCErrorWithContextError checks if the given error is a gRPC error corresponding
 // to a standard golang context error, and if it is, wraps the former with the latter.

--- a/pkg/util/globalerror/grpc_test.go
+++ b/pkg/util/globalerror/grpc_test.go
@@ -83,10 +83,8 @@ func TestWrapContextError(t *testing.T) {
 				expectedGrpcCode:   codes.DeadlineExceeded,
 				expectedContextErr: context.DeadlineExceeded,
 			},
-			"grpc.ErrClientConnClosing": {
-				// Ignore deprecation warning for now
-				// nolint:staticcheck
-				origErr:            grpc.ErrClientConnClosing,
+			"grpc: the client connection is closing": {
+				origErr:            status.Error(codes.Canceled, grpcClientConnectionIsClosingErr),
 				expectedGrpcCode:   codes.Canceled,
 				expectedContextErr: nil,
 			},
@@ -367,7 +365,7 @@ func checkGRPCConnectionIsClosingError(t *testing.T, err error) {
 	stat, ok := grpcutil.ErrorToStatus(err)
 	require.True(t, ok)
 	require.Equal(t, codes.Canceled, stat.Code())
-	require.Equal(t, "grpc: the client connection is closing", stat.Message())
+	require.Equal(t, grpcClientConnectionIsClosingErr, stat.Message())
 }
 
 type mockServer struct {


### PR DESCRIPTION
#### What this PR does
This PR gets rid of usages of the deprecated `grpc.ErrClientConnClosing` error introduced in #8865.

#### Which issue(s) this PR fixes or relates to

Related to #8815 

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
