### PR TITLE
blockbuilder: pass partition assignment via flag

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -184,7 +184,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.Frontend.RegisterFlags(f, logger)
 	c.IngestStorage.RegisterFlags(f)
 	c.BlocksStorage.RegisterFlags(f)
-	c.BlockBuilder.RegisterFlags(f)
+	c.BlockBuilder.RegisterFlags(f, logger)
 	c.Compactor.RegisterFlags(f, logger)
 	c.StoreGateway.RegisterFlags(f, logger)
 	c.TenantFederation.RegisterFlags(f)


### PR DESCRIPTION
These changes are the follow-up to #8823

Instead of configuring the number of instances and kafka partitions, as long as asking for a `POD_NAME` env, here we add two new flags

- `-block-builder.instance-id`, which defaults to the hostname;
- `-block-builder.kafka.partition-assignment`, which must be a mapping from the instance-id to a static list of partitions, assigned to the instance.

Example of usage (with docker-compose):

```yaml
mimir-block-builder-0:
  command:
  - /mimir
  - -block-builder.instance-id=instance-0
  - -block-builder.kafka.partition-assignment={"0":[0,1,2]}

mimir-block-builder-1:
  hostname: mimir-block-builder-1
  command:
  - /mimir
  - -block-builder.kafka.partition-assignment={"1":[3,4,5]}
```

When using in Kubernetes, we will generate the full assignment via jsonnet, and pass the assignment to the block builder's stateful set.