### PR TITLE
Move ruler configuration validation to unit test

### DIFF
--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1505,13 +1505,6 @@ func TestRulerPerRuleConcurrency(t *testing.T) {
 		"-ruler.independent-rule-evaluation-concurrency-min-duration-percentage": "0", // This makes sure no matter the ratio, we will attempt concurrency.
 	})
 
-	// Test with an invalid -ruler.independent-rule-evaluation-concurrency-min-duration-percentage.
-	invalidRulerFlags := e2e.MergeFlags(rulerFlags, map[string]string{
-		"-ruler.independent-rule-evaluation-concurrency-min-duration-percentage": "-10",
-	})
-	invalidRuler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), invalidRulerFlags)
-	require.Error(t, s.Start(invalidRuler))
-
 	// Start Mimir components.
 	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags)
 	require.NoError(t, s.StartAndWaitReady(ruler))

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -1964,3 +1964,41 @@ func createRuleGroup(name, user string, rules ...*rulespb.RuleDesc) *rulespb.Rul
 		User:      user,
 	}
 }
+
+func TestConfig_Validate(t *testing.T) {
+	t.Run("invalid tenant shard size", func(t *testing.T) {
+		cfg := defaultRulerConfig(t)
+		limits := validation.MockDefaultLimits()
+		limits.RulerTenantShardSize = -1
+
+		err := cfg.Validate(*limits)
+		require.ErrorIs(t, err, errInvalidTenantShardSize)
+	})
+
+	t.Run("invalid client TLS config", func(t *testing.T) {
+		cfg := defaultRulerConfig(t)
+		cfg.ClientTLSConfig.GRPCCompression = "bogus"
+		limits := validation.MockDefaultLimits()
+
+		err := cfg.Validate(*limits)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid query frontend config", func(t *testing.T) {
+		cfg := defaultRulerConfig(t)
+		cfg.QueryFrontend.QueryResultResponseFormat = "bogus"
+		limits := validation.MockDefaultLimits()
+
+		err := cfg.Validate(*limits)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid concurrency evaluation percentage", func(t *testing.T) {
+		cfg := defaultRulerConfig(t)
+		cfg.IndependentRuleEvaluationConcurrencyMinDurationPercentage = -1.0
+		limits := validation.MockDefaultLimits()
+
+		err := cfg.Validate(*limits)
+		require.ErrorIs(t, err, errInnvalidRuleEvaluationConcurrencyMinDurationPercentage)
+	})
+}


### PR DESCRIPTION
#### What this PR does

This removes assertions made during an integration test that validated configuration and instead tests this functionality in a unit test. This is faster and more reliable than starting a docker container to validate configuration.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
