### PR TITLE
development: Remove version field from docker-compose.yml

### DIFF
--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -229,8 +229,5 @@ std.manifestYamlDoc({
     volumes: ['./config:/mimir/config', './activity:/activity'] + options.extraVolumes,
   },
 
-  // docker-compose YAML output version.
-  version: '3.4',
-
   // "true" option for std.manifestYamlDoc indents arrays in objects.
 }, true)

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -309,4 +309,3 @@
       - "8080:8080"
     "volumes":
       - "../common/config:/etc/nginx/templates"
-"version": "3.4"

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -408,8 +408,5 @@ std.manifestYamlDoc({
     },
   },
 
-  // docker-compose YAML output version.
-  version: '3.4',
-
   // "true" option for std.manifestYamlDoc indents arrays in objects.
 }, true)

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -496,4 +496,3 @@
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
-"version": "3.4"

--- a/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
+++ b/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
 
   consul:

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
 
   consul:

--- a/development/mimir-read-write-mode/docker-compose.jsonnet
+++ b/development/mimir-read-write-mode/docker-compose.jsonnet
@@ -173,8 +173,5 @@ std.manifestYamlDoc({
     volumes: ['./config:/mimir/config', './activity:/activity'] + options.extraVolumes,
   },
 
-  // docker-compose YAML output version.
-  version: '3.4',
-
   // "true" option for std.manifestYamlDoc indents arrays in objects.
 }, true)

--- a/development/mimir-read-write-mode/docker-compose.yml
+++ b/development/mimir-read-write-mode/docker-compose.yml
@@ -195,4 +195,3 @@
       - "9090:9090"
     "volumes":
       - "./config:/etc/prometheus"
-"version": "3.4"


### PR DESCRIPTION
#### What this PR does
Remove version field from development/*/docker-compose.yml files, as it's [deprecated](https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313).

Currently the following type of warning is produced:

```console
WARN[0000] /Users/arve/Projects/grafana/mimir/development/mimir-monolithic-mode/docker-compose.yml: `version` is obsolete
```

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [na] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
