### PR TITLE
store-gateway: fix flaky TestBucketStore_PersistsLazyLoadedBlocks

### DIFF
--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -795,6 +795,11 @@ func TestBucketStore_PersistsLazyLoadedBlocks(t *testing.T) {
 	cfg.bucketStoreConfig.IndexHeader.EagerLoadingStartupEnabled = true
 	cfg.bucketStoreConfig.IndexHeader.LazyLoadingIdleTimeout = persistInterval * 3
 	ctx := context.Background()
+	readBlocksInSnapshot := func() map[ulid.ULID]int64 {
+		blocks, err := indexheader.RestoreLoadedBlocks(cfg.tempDir)
+		assert.NoError(t, err)
+		return blocks
+	}
 
 	// Start the store so we generate some blocks and can use them in the mock snapshot.
 	store := prepareStoreWithTestBlocks(t, bkt, cfg)
@@ -802,30 +807,23 @@ func TestBucketStore_PersistsLazyLoadedBlocks(t *testing.T) {
 	time.Sleep(persistInterval * 2)
 
 	// The snapshot should be empty.
-	blocks, err := indexheader.RestoreLoadedBlocks(cfg.tempDir)
-	assert.NoError(t, err)
-	assert.Empty(t, blocks)
+	assert.Empty(t, readBlocksInSnapshot())
 
 	// Run a simple request to trigger loading the blocks
 	resp, err := store.store.LabelNames(ctx, &storepb.LabelNamesRequest{End: math.MaxInt64})
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp.Names)
 
-	// Wait for the snapshot to be persisted.
-	time.Sleep(persistInterval * 2)
+	// The snapshot should now contain the blocks we queried.
+	assert.Eventually(t, func() bool {
+		return len(readBlocksInSnapshot()) == cfg.numBlocks
+	}, persistInterval*5, persistInterval/2)
 
-	blocks, err = indexheader.RestoreLoadedBlocks(cfg.tempDir)
-	assert.NoError(t, err)
-	assert.Len(t, blocks, cfg.numBlocks)
-
-	// Wait for the blocks to be unloaded.
-	// Technically we need to wait for 3x persistInterval, and we've already waited 2x since last using the blocks.
-	// But we give some more time to avoid races.
-	time.Sleep(persistInterval * 2)
+	// Wait for the blocks to be unloaded due to the lazy loading idle timeout.
 	// The snapshot should be empty.
-	blocks, err = indexheader.RestoreLoadedBlocks(cfg.tempDir)
-	assert.NoError(t, err)
-	assert.Empty(t, blocks)
+	assert.Eventually(t, func() bool {
+		return len(readBlocksInSnapshot()) == 0
+	}, persistInterval*5, persistInterval/2)
 }
 
 type staticLoadedBlocks map[ulid.ULID]int64


### PR DESCRIPTION
This test used to use `time.Sleep()` which is flaky. I changed it to use assert.Eventually(), which is less flaky (but still has the potential :()

I'm debating whether we should use fsnotify, but that adds an extra dependency (it's currently only an indirect dep), and we'll be leaking the name of the lazy-loaded.json outside the `indexheader` package. If reviewers think it's a good idea, I can make the change.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/8875

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
