### PR TITLE
Vendor kadm from upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.24.7
 	github.com/thanos-io/objstore v0.0.0-20240722162417-19b0c0f0ffd8
 	github.com/twmb/franz-go v1.17.1
-	github.com/twmb/franz-go/pkg/kadm v1.12.0
+	github.com/twmb/franz-go/pkg/kadm v1.13.0
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20240730205842-6b61d17383b1
 	github.com/twmb/franz-go/pkg/kmsg v1.8.0
 	github.com/twmb/franz-go/plugin/kotel v1.4.1
@@ -304,6 +304,3 @@ replace github.com/opentracing-contrib/go-grpc => github.com/charleskorn/go-grpc
 
 // Replacing prometheus/alertmanager with our fork.
 replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20240625192351-66ec17e3aa45
-
-// Replace kadm with a fork until https://github.com/twmb/franz-go/pull/775 is merged
-replace github.com/twmb/franz-go/pkg/kadm => github.com/pracucci/franz-go/pkg/kadm v0.0.0-20240711165048-831cca07c9a4

--- a/go.sum
+++ b/go.sum
@@ -808,8 +808,6 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/pracucci/franz-go/pkg/kadm v0.0.0-20240711165048-831cca07c9a4 h1:cE4BEK/+rL8LlaKDidhBDSlMR9nTSSR6wgHnc/+5WRo=
-github.com/pracucci/franz-go/pkg/kadm v0.0.0-20240711165048-831cca07c9a4/go.mod h1:VMvpfjz/szpH9WB+vGM+rteTzVv0djyHFimci9qm2C0=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
@@ -934,6 +932,8 @@ github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9f
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/twmb/franz-go v1.17.1 h1:0LwPsbbJeJ9R91DPUHSEd4su82WJWcTY1Zzbgbg4CeQ=
 github.com/twmb/franz-go v1.17.1/go.mod h1:NreRdJ2F7dziDY/m6VyspWd6sNxHKXdMZI42UfQ3GXM=
+github.com/twmb/franz-go/pkg/kadm v1.13.0 h1:bJq4C2ZikUE2jh/wl9MtMTQ/kpmnBgVFh8XMQBEC+60=
+github.com/twmb/franz-go/pkg/kadm v1.13.0/go.mod h1:VMvpfjz/szpH9WB+vGM+rteTzVv0djyHFimci9qm2C0=
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20240730205842-6b61d17383b1 h1:Vo6jYkEuHJugUPS52xmcu1LJgDcC4AXUMVwo8Ct0kfQ=
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20240730205842-6b61d17383b1/go.mod h1:nkBI/wGFp7t1NJnnCeJdS4sX5atPAqwCPpDXKuI7SC8=
 github.com/twmb/franz-go/pkg/kmsg v1.8.0 h1:lAQB9Z3aMrIP9qF9288XcFf/ccaSxEitNA1CDTEIeTA=

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/acls.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/acls.go
@@ -663,7 +663,8 @@ type CreateACLsResult struct {
 	Operation  ACLOperation           // Operation is the operation allowed / denied.
 	Permission kmsg.ACLPermissionType // Permission is whether this is allowed / denied.
 
-	Err error // Err is the error for this ACL creation.
+	Err        error  // Err is the error for this ACL creation.
+	ErrMessage string // ErrMessage a potential extra message describing any error.
 }
 
 // CreateACLsResults contains all results to created ACLs.
@@ -752,7 +753,8 @@ func (cl *Client) CreateACLs(ctx context.Context, b *ACLBuilder) (CreateACLsResu
 			Operation:  c.Operation,
 			Permission: c.PermissionType,
 
-			Err: kerr.ErrorForCode(r.ErrorCode),
+			Err:        kerr.ErrorForCode(r.ErrorCode),
+			ErrMessage: unptrStr(r.ErrorMessage),
 		})
 	}
 
@@ -770,7 +772,8 @@ type DeletedACL struct {
 	Operation  ACLOperation           // Operation is this deleted ACL's operation.
 	Permission kmsg.ACLPermissionType // Permission this deleted ACLs permission.
 
-	Err error // Err is non-nil if this match has an error.
+	Err        error  // Err is non-nil if this match has an error.
+	ErrMessage string // ErrMessage a potential extra message describing any error.
 }
 
 // DeletedACLs contains ACLs that were deleted from a single delete filter.
@@ -794,7 +797,8 @@ type DeleteACLsResult struct {
 
 	Deleted DeletedACLs // Deleted contains all ACLs this delete filter matched.
 
-	Err error // Err is non-nil if this filter has an error.
+	Err        error  // Err is non-nil if this filter has an error.
+	ErrMessage string // ErrMessage a potential extra message describing any error.
 }
 
 // DeleteACLsResults contains all results to deleted ACLs.
@@ -841,6 +845,7 @@ func (cl *Client) DeleteACLs(ctx context.Context, b *ACLBuilder) (DeleteACLsResu
 				Operation:  m.Operation,
 				Permission: m.PermissionType,
 				Err:        kerr.ErrorForCode(m.ErrorCode),
+				ErrMessage: unptrStr(m.ErrorMessage),
 			})
 		}
 		rs = append(rs, DeleteACLsResult{
@@ -853,6 +858,7 @@ func (cl *Client) DeleteACLs(ctx context.Context, b *ACLBuilder) (DeleteACLsResu
 			Permission: f.PermissionType,
 			Deleted:    ms,
 			Err:        kerr.ErrorForCode(r.ErrorCode),
+			ErrMessage: unptrStr(r.ErrorMessage),
 		})
 	}
 	return rs, nil
@@ -892,7 +898,8 @@ type DescribeACLsResult struct {
 
 	Described DescribedACLs // Described contains all ACLs this describe filter matched.
 
-	Err error // Err is non-nil if this filter has an error.
+	Err        error  // Err is non-nil if this filter has an error.
+	ErrMessage string // ErrMessage a potential extra message describing any error.
 }
 
 // DescribeACLsResults contains all results to described ACLs.
@@ -974,6 +981,7 @@ func (cl *Client) DescribeACLs(ctx context.Context, b *ACLBuilder) (DescribeACLs
 			Permission: f.PermissionType,
 			Described:  ds,
 			Err:        kerr.ErrorForCode(r.ErrorCode),
+			ErrMessage: unptrStr(r.ErrorMessage),
 		})
 	}
 	return rs, nil

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/configs.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/configs.go
@@ -42,9 +42,10 @@ func (c *Config) MaybeValue() string {
 // ResourceConfig contains the configuration values for a resource (topic,
 // broker, broker logger).
 type ResourceConfig struct {
-	Name    string   // Name is the name of this resource.
-	Configs []Config // Configs are the configs for this topic.
-	Err     error    // Err is any error preventing configs from loading (likely, an unknown topic).
+	Name       string   // Name is the name of this resource.
+	Configs    []Config // Configs are the configs for this topic.
+	Err        error    // Err is any error preventing configs from loading (likely, an unknown topic).
+	ErrMessage string   // ErrMessage a potential extra message describing any error.
 }
 
 // ResourceConfigs contains the configuration values for many resources.
@@ -124,8 +125,9 @@ func (cl *Client) describeConfigs(
 				return err
 			}
 			rc := ResourceConfig{
-				Name: r.ResourceName,
-				Err:  kerr.ErrorForCode(r.ErrorCode),
+				Name:       r.ResourceName,
+				Err:        kerr.ErrorForCode(r.ErrorCode),
+				ErrMessage: unptrStr(r.ErrorMessage),
 			}
 			for _, c := range r.Configs {
 				rcv := Config{
@@ -183,8 +185,9 @@ type AlterConfig struct {
 
 // AlteredConfigsResponse contains the response for an individual alteration.
 type AlterConfigsResponse struct {
-	Name string // Name is the name of this resource (topic name or broker number).
-	Err  error  // Err is non-nil if the config could not be altered.
+	Name       string // Name is the name of this resource (topic name or broker number).
+	Err        error  // Err is non-nil if the config could not be altered.
+	ErrMessage string // ErrMessage a potential extra message describing any error.
 }
 
 // AlterConfigsResponses contains responses for many alterations.
@@ -314,8 +317,9 @@ func (cl *Client) alterConfigs(
 		resp := kr.(*kmsg.IncrementalAlterConfigsResponse)
 		for _, r := range resp.Resources {
 			rs = append(rs, AlterConfigsResponse{ // we are not storing in a map, no existence check possible
-				Name: r.ResourceName,
-				Err:  kerr.ErrorForCode(r.ErrorCode),
+				Name:       r.ResourceName,
+				Err:        kerr.ErrorForCode(r.ErrorCode),
+				ErrMessage: unptrStr(r.ErrorMessage),
 			})
 		}
 		return nil
@@ -403,8 +407,9 @@ func (cl *Client) alterConfigsState(
 		resp := kr.(*kmsg.AlterConfigsResponse)
 		for _, r := range resp.Resources {
 			rs = append(rs, AlterConfigsResponse{ // we are not storing in a map, no existence check possible
-				Name: r.ResourceName,
-				Err:  kerr.ErrorForCode(r.ErrorCode),
+				Name:       r.ResourceName,
+				Err:        kerr.ErrorForCode(r.ErrorCode),
+				ErrMessage: unptrStr(r.ErrorMessage),
 			})
 		}
 		return nil

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/partas.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/partas.go
@@ -108,7 +108,7 @@ func (cl *Client) AlterPartitionAssignments(ctx context.Context, req AlterPartit
 		return nil, err
 	}
 	if err = kerr.ErrorForCode(kresp.ErrorCode); err != nil {
-		return nil, err
+		return nil, &ErrAndMessage{err, unptrStr(kresp.ErrorMessage)}
 	}
 
 	a := make(AlterPartitionAssignmentsResponses)
@@ -187,7 +187,7 @@ func (cl *Client) ListPartitionReassignments(ctx context.Context, s TopicsSet) (
 		return nil, err
 	}
 	if err = kerr.ErrorForCode(kresp.ErrorCode); err != nil {
-		return nil, err
+		return nil, &ErrAndMessage{err, unptrStr(kresp.ErrorMessage)}
 	}
 
 	a := make(ListPartitionReassignmentsResponses)

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/topics.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/topics.go
@@ -46,6 +46,7 @@ type CreateTopicResponse struct {
 	Topic             string            // Topic is the topic that was created.
 	ID                TopicID           // ID is the topic ID for this topic, if talking to Kafka v2.8+.
 	Err               error             // Err is any error preventing this topic from being created.
+	ErrMessage        string            // ErrMessage a potential extra message describing any error.
 	NumPartitions     int32             // NumPartitions is the number of partitions in the response, if talking to Kafka v2.4+.
 	ReplicationFactor int16             // ReplicationFactor is how many replicas every partition has for this topic, if talking to Kafka 2.4+.
 	Configs           map[string]Config // Configs contains the topic configuration (minus config synonyms), if talking to Kafka 2.4+.
@@ -209,6 +210,7 @@ func (cl *Client) createTopics(ctx context.Context, dry bool, p int32, rf int16,
 			Topic:             t.Topic,
 			ID:                t.TopicID,
 			Err:               kerr.ErrorForCode(t.ErrorCode),
+			ErrMessage:        unptrStr(t.ErrorMessage),
 			NumPartitions:     t.NumPartitions,
 			ReplicationFactor: t.ReplicationFactor,
 			Configs:           make(map[string]Config),

--- a/vendor/github.com/twmb/franz-go/pkg/kadm/txn.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kadm/txn.go
@@ -97,6 +97,7 @@ type DescribedProducersPartition struct {
 	Partition       int32              // Partition is the partition whose producer's were described.
 	ActiveProducers DescribedProducers // ActiveProducers are producer's actively transactionally producing to this partition.
 	Err             error              // Err is non-nil if describing this partition failed.
+	ErrMessage      string             // ErrMessage a potential extra message describing any error.
 }
 
 // DescribedProducersPartitions contains partitions whose producer's were described.
@@ -274,6 +275,7 @@ func (cl *Client) DescribeProducers(ctx context.Context, s TopicsSet) (Described
 					Partition:       rp.Partition,
 					ActiveProducers: drs,
 					Err:             kerr.ErrorForCode(rp.ErrorCode),
+					ErrMessage:      unptrStr(rp.ErrorMessage),
 				}
 				dps[rp.Partition] = dp // one partition globally, no need to exist-check
 				for _, rr := range rp.ActiveProducers {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1149,7 +1149,7 @@ github.com/twmb/franz-go/pkg/kgo
 github.com/twmb/franz-go/pkg/kgo/internal/sticky
 github.com/twmb/franz-go/pkg/kversion
 github.com/twmb/franz-go/pkg/sasl
-# github.com/twmb/franz-go/pkg/kadm v1.12.0 => github.com/pracucci/franz-go/pkg/kadm v0.0.0-20240711165048-831cca07c9a4
+# github.com/twmb/franz-go/pkg/kadm v1.13.0
 ## explicit; go 1.21
 github.com/twmb/franz-go/pkg/kadm
 # github.com/twmb/franz-go/pkg/kfake v0.0.0-20240730205842-6b61d17383b1
@@ -1656,4 +1656,3 @@ sigs.k8s.io/yaml/goyaml.v3
 # github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
 # github.com/opentracing-contrib/go-grpc => github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f
 # github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20240625192351-66ec17e3aa45
-# github.com/twmb/franz-go/pkg/kadm => github.com/pracucci/franz-go/pkg/kadm v0.0.0-20240711165048-831cca07c9a4


### PR DESCRIPTION
#### What this PR does

The PR https://github.com/twmb/franz-go/pull/775 has been merged and included in kadm v1.13.0. We can remove the import override and vendor kadm from upstream again.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
