### PR TITLE
querytee: update compareMatrix to handle difference in series with recent samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@
 * [ENHANCEMENT] Compare native histograms in query results when comparing results between two backends. #8724
 * [ENHANCEMENT] Don't consider responses to be different during response comparison if both backends' responses contain different series, but all samples are within the recent sample window. #8749 #8894
 * [BUGFIX] Ensure any errors encountered while forwarding a request to a backend (eg. DNS resolution failures) are logged. #8419
+* [BUGFIX] The comparison of the results should not fail when either side contains extra samples from within SkipRecentSamples duration. #8920
 
 ### Documentation
 

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -98,6 +98,18 @@ func TestCompareMatrix(t *testing.T) {
 						]`),
 		},
 		{
+			name: "first series match but later series has difference in sample value",
+			expected: json.RawMessage(`[
+							{"metric":{"foo":"bar"},"values":[[1,"1"],[2,"2"]]},
+							{"metric":{"oops":"bar"},"values":[[1,"1"],[2,"2"]]}
+						]`),
+			actual: json.RawMessage(`[
+							{"metric":{"foo":"bar"},"values":[[1,"1"],[2,"2"]]},
+							{"metric":{"oops":"bar"},"values":[[1,"1"],[2,"3"]]}
+						]`),
+			err: errors.New(`float sample pair does not match for metric {oops="bar"}: expected value 2 for timestamp 2 but got 3`),
+		},
+		{
 			name: "single expected sample has histogram but actual sample has float value",
 			expected: json.RawMessage(`[
 							{

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -76,7 +76,6 @@ func TestCompareMatrix(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"values":[[1,"1"],[3,"2"]]}
 						]`),
-			// timestamps are parsed from seconds to ms which are then added to errors as is so adding 3 0s to expected error.
 			err: errors.New(`float sample pair does not match for metric {foo="bar"}: expected timestamp 2 but got 3`),
 		},
 		{
@@ -1735,6 +1734,19 @@ func TestCompareSamplesResponse(t *testing.T) {
 						}`),
 			skipRecentSamples: time.Hour,
 			err:               errors.New("expected 1 metrics but got 2"),
+		},
+		{
+			name: "should not fail when there is a different number of samples in a series in a matrix, where some float samples are more recent than the configured skip recent samples interval",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[` + overAnHourAgo + `,"10"],[` + now + `,"20"]]}]}
+						}`),
+
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[` + overAnHourAgo + `,"10"]]}]}
+						}`),
+			skipRecentSamples: time.Hour,
 		},
 		{
 			name: "should not fail if both results have an empty set of warnings",

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -1748,7 +1748,7 @@ func TestCompareSamplesResponse(t *testing.T) {
 			err:               errors.New("expected 1 metrics but got 2"),
 		},
 		{
-			name: "should not fail when there is a different number of samples in a series in a matrix, where some float samples are more recent than the configured skip recent samples interval",
+			name: "should not fail when there is different number of samples in a series, but non-matching float samples are more recent than configured skip recent samples interval",
 			expected: json.RawMessage(`{
 							"status": "success",
 							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[` + overAnHourAgo + `,"10"],[` + now + `,"20"]]}]}
@@ -1757,6 +1757,67 @@ func TestCompareSamplesResponse(t *testing.T) {
 			actual: json.RawMessage(`{
 							"status": "success",
 							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[` + overAnHourAgo + `,"10"]]}]}
+						}`),
+			skipRecentSamples: time.Hour,
+		},
+		{
+			name: "should not fail when there is different number of samples in a series, but non-matching histogram samples are more recent than configured skip recent samples interval",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {
+								"resultType": "matrix",
+								"result": [
+									{
+										"metric": {"foo":"bar"},
+										"histograms": [
+											[
+												` + overAnHourAgo + `,
+												{
+													"count": "2",
+													"sum": "3",
+													"buckets": [
+														[1,"0","2","2"]
+													]
+												}
+											],
+											[
+												` + now + `,
+												{
+													"count": "2",
+													"sum": "3",
+													"buckets": [
+														[1,"0","2","2"]
+													]
+												}
+											]
+										]
+									}
+								]
+							}
+						}`),
+
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {
+								"resultType": "matrix",
+								"result": [
+									{
+										"metric": {"foo":"bar"},
+										"histograms": [
+											[
+												` + overAnHourAgo + `,
+												{
+													"count": "2",
+													"sum": "3",
+													"buckets": [
+														[1,"0","2","2"]
+													]
+												}
+											]
+										]
+									}
+								]
+							}
 						}`),
 			skipRecentSamples: time.Hour,
 		},


### PR DESCRIPTION
#### What this PR does

We've noticed a corner case that is currently failing in `querytee`. The comparison should not fail, when 

1. "expected" and "actual" series has a different number of samples AND
2. the difference is within the `SkipRecentSamples` duration

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
