### PR TITLE
Mimir query engine: improve benchmark setup time by ~10% by reusing slices for histograms

### DIFF
--- a/pkg/streamingpromql/benchmarks/ingester.go
+++ b/pkg/streamingpromql/benchmarks/ingester.go
@@ -215,6 +215,9 @@ func pushTestData(ing *ingester.Ingester, metricSizes []int) error {
 	// A quick run locally found batching by 100 did not increase the loading time by any noticeable amount.
 	// Additionally memory usage maxed about 4GB for the whole process.
 	batchSize := 100
+	histogramSpans := []mimirpb.BucketSpan{{Offset: 0, Length: 2}, {Offset: 1, Length: 2}}
+	histogramDeltas := []int64{1, 1, -1, 0}
+
 	for start := 0; start < NumIntervals; start += batchSize {
 		end := start + batchSize
 		if end > NumIntervals {
@@ -240,10 +243,10 @@ func pushTestData(ing *ingester.Ingester, metricSizes []int) error {
 					series.Histograms[ts-start].ZeroThreshold = 0.001
 					series.Histograms[ts-start].Sum = 18.4
 					series.Histograms[ts-start].Schema = 0
-					series.Histograms[ts-start].NegativeSpans = []mimirpb.BucketSpan{{Offset: 0, Length: 2}, {Offset: 1, Length: 2}}
-					series.Histograms[ts-start].NegativeDeltas = []int64{1, 1, -1, 0}
-					series.Histograms[ts-start].PositiveSpans = []mimirpb.BucketSpan{{Offset: 0, Length: 2}, {Offset: 1, Length: 2}}
-					series.Histograms[ts-start].PositiveDeltas = []int64{1, 1, -1, 0}
+					series.Histograms[ts-start].NegativeSpans = histogramSpans
+					series.Histograms[ts-start].NegativeDeltas = histogramDeltas
+					series.Histograms[ts-start].PositiveSpans = histogramSpans
+					series.Histograms[ts-start].PositiveDeltas = histogramDeltas
 				}
 
 				req.Timeseries[metricIdx] = series


### PR DESCRIPTION
#### What this PR does

This PR reduces the time taken to load data into a test ingester during the MQE benchmarks.

It does this by reusing the same slices for spans and deltas for all samples, rather than allocating a new one for each sample.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
