### PR TITLE
kafka replay speed: Handle errors from closing the pusherConsumer & simplify interface

### DIFF
--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -56,7 +56,7 @@ type pusherConsumer struct {
 	pusher PusherCloser
 }
 
-func (c pusherConsumer) Close(ctx context.Context) []error {
+func (c pusherConsumer) Close(ctx context.Context) error {
 	spanLog := spanlogger.FromContext(ctx, log.NewNopLogger())
 	errs := c.pusher.Close()
 	for eIdx := 0; eIdx < len(errs); eIdx++ {
@@ -68,7 +68,7 @@ func (c pusherConsumer) Close(ctx context.Context) []error {
 			eIdx--
 		}
 	}
-	return errs
+	return multierror.New(errs...).Err()
 }
 
 func newPusherConsumer(p PusherCloser, proto pusherConsumerPrototype) *pusherConsumer {


### PR DESCRIPTION
This address two TODOs 
* handle errors when closing the consumer to make sure we've handled all errors from ingestion
  * here we create a new consumer and retry the whole ingestion on each retry; the reason for that is that currently we can't use a consumer after closing it.
  * This also changes how we record `cortex_ingest_storage_reader_records_batch_process_duration_seconds` - now it includes retries. IMO this is more informative because you'd see an increase in processing time as you start retrying to process; plus this currently isn't used in any alerts or dashboards, so changing semantics is ok
* remove redundant interfaces and add `Close(context.Context) error` to `recordConsumer`

