### PR TITLE
api: clean up outdated chunk from earlier block-builder prototyping

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -484,13 +484,6 @@ func (a *API) RegisterOverridesExporter(oe *exporter.OverridesExporter) {
 	a.RegisterRoute("/overrides-exporter/ring", http.HandlerFunc(oe.RingHandler), false, true, "GET", "POST")
 }
 
-func (a *API) RegisterBlockBuilderRing(r http.Handler) {
-	a.indexPage.AddLinks(defaultWeight, "BlockBuilder", []IndexPageLink{
-		{Desc: "Ring status", Path: "/blockbuilder/ring"},
-	})
-	a.RegisterRoute("/blockbuilder/ring", r, false, true, "GET", "POST")
-}
-
 // RegisterServiceMapHandler registers the Mimir structs service handler
 // TODO: Refactor this code to be accomplished using the services.ServiceManager
 // or a future module manager #2291


### PR DESCRIPTION
This one cleans up an outdated piece of code from the earlier prototype. Block-builder doesn't create its own hash-ring (for now). We may revisit that in the future.