### PR TITLE
Mimir / Tenants dashboard: add "Out-of-order samples appended"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 * [ENHANCEMENT] Dashboards: added "Kafka produced records / sec" panel to "Mimir / Writes" dashboard. #8763
 * [ENHANCEMENT] Alerts: added `MimirStrongConsistencyOffsetNotPropagatedToIngesters` alert, and rename `MimirIngesterFailsEnforceStrongConsistencyOnReadPath` alert to `MimirStrongConsistencyEnforcementFailed`. #8831
 * [ENHANCEMENT] Dashboards: remove "All" option for namespace dropdown in dashboards. #8829
+* [ENHANCEMENT] Dashboards: add "Out-of-order samples appended" panel to "Mimir / Tenants" dashboard. #8939
 * [BUGFIX] Dashboards: fix "current replicas" in autoscaling panels when HPA is not active. #8566
 * [BUGFIX] Alerts: do not fire `MimirRingMembersMismatch` during the migration to experimental ingest storage. #8727
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -33404,7 +33404,7 @@ data:
                             "sort": "none"
                          }
                       },
-                      "span": 2,
+                      "span": 3,
                       "targets": [
                          {
                             "expr": "sum(rate(cortex_distributor_samples_in_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -33472,7 +33472,7 @@ data:
                             "sort": "none"
                          }
                       },
-                      "span": 2,
+                      "span": 3,
                       "targets": [
                          {
                             "expr": "sum(rate(cortex_distributor_received_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -33810,7 +33810,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
-                      "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\nThis doesn't account for the replication factor\n\n",
+                      "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\nThis doesn't account for the replication factor.\n\n",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -33404,7 +33404,7 @@ data:
                             "sort": "none"
                          }
                       },
-                      "span": 3,
+                      "span": 2,
                       "targets": [
                          {
                             "expr": "sum(rate(cortex_distributor_samples_in_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -33472,7 +33472,7 @@ data:
                             "sort": "none"
                          }
                       },
-                      "span": 3,
+                      "span": 2,
                       "targets": [
                          {
                             "expr": "sum(rate(cortex_distributor_received_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -33527,7 +33527,7 @@ data:
                             "sort": "none"
                          }
                       },
-                      "span": 3,
+                      "span": 2,
                       "targets": [
                          {
                             "expr": "sum(rate(cortex_distributor_deduped_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -33547,7 +33547,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
-                      "description": "### Distributor and ingester discarded samples rate\nThe rate of each sample's discarding reason.\n\n",
+                      "description": "### Distributor and ingester discarded samples rate\nThe rate of each sample's discarding reason.\nThis doesn't account for the replication factor.\n\n",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {
@@ -33582,7 +33582,7 @@ data:
                             "sort": "none"
                          }
                       },
-                      "span": 3,
+                      "span": 2,
                       "targets": [
                          {
                             "expr": "sum by (reason) (rate(cortex_discarded_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -33593,11 +33593,60 @@ data:
                          {
                             "expr": "sum by (reason) (rate(cortex_discarded_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
                             "format": "time_series",
-                            "legendFormat": "{{ reason }} (ingester)",
+                            "legendFormat": "{{ reason }} (ingester, replicated)",
                             "legendLink": null
                          }
                       ],
                       "title": "Distributor and ingester discarded samples rate",
+                      "type": "timeseries"
+                   },
+                   {
+                      "datasource": "$datasource",
+                      "description": "### Out-of-order samples appended\nThe rate of OOO samples that have been appended.\nThis doesn't account for the replication factor.\n\n",
+                      "fieldConfig": {
+                         "defaults": {
+                            "custom": {
+                               "drawStyle": "line",
+                               "fillOpacity": 1,
+                               "lineWidth": 1,
+                               "pointSize": 5,
+                               "showPoints": "never",
+                               "spanNulls": false,
+                               "stacking": {
+                                  "group": "A",
+                                  "mode": "none"
+                               }
+                            },
+                            "min": 0,
+                            "thresholds": {
+                               "mode": "absolute",
+                               "steps": [ ]
+                            },
+                            "unit": "short"
+                         },
+                         "overrides": [ ]
+                      },
+                      "id": 17,
+                      "links": [ ],
+                      "options": {
+                         "legend": {
+                            "showLegend": false
+                         },
+                         "tooltip": {
+                            "mode": "multi",
+                            "sort": "none"
+                         }
+                      },
+                      "span": 2,
+                      "targets": [
+                         {
+                            "expr": "sum(rate(cortex_ingester_tsdb_out_of_order_samples_appended_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
+                            "format": "time_series",
+                            "legendFormat": "rate",
+                            "legendLink": null
+                         }
+                      ],
+                      "title": "Out-of-order samples appended",
                       "type": "timeseries"
                    }
                 ],
@@ -33638,7 +33687,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 17,
+                      "id": 18,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -33687,7 +33736,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 18,
+                      "id": 19,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -33736,7 +33785,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 19,
+                      "id": 20,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -33761,7 +33810,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
-                      "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\n\n",
+                      "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\nThis doesn't account for the replication factor\n\n",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {
@@ -33785,7 +33834,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 20,
+                      "id": 21,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -33846,7 +33895,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 21,
+                      "id": 22,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -33895,7 +33944,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 22,
+                      "id": 23,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -33975,7 +34024,7 @@ data:
                             }
                          ]
                       },
-                      "id": 23,
+                      "id": 24,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34030,7 +34079,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 24,
+                      "id": 25,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34078,7 +34127,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 25,
+                      "id": 26,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34126,7 +34175,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 26,
+                      "id": 27,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34208,7 +34257,7 @@ data:
                          ]
                       },
                       "fill": 1,
-                      "id": 27,
+                      "id": 28,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -34328,7 +34377,7 @@ data:
                          ]
                       },
                       "fill": 1,
-                      "id": 28,
+                      "id": 29,
                       "legend": {
                          "avg": false,
                          "current": false,
@@ -34438,7 +34487,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 29,
+                      "id": 30,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34502,7 +34551,7 @@ data:
                             }
                          ]
                       },
-                      "id": 30,
+                      "id": 31,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34562,7 +34611,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 31,
+                      "id": 32,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34647,7 +34696,7 @@ data:
                             }
                          ]
                       },
-                      "id": 32,
+                      "id": 33,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34701,7 +34750,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 33,
+                      "id": 34,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34767,7 +34816,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 34,
+                      "id": 35,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34815,7 +34864,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 35,
+                      "id": 36,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34875,7 +34924,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 36,
+                      "id": 37,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34923,7 +34972,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 37,
+                      "id": 38,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -34984,7 +35033,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 38,
+                      "id": 39,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -35033,7 +35082,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 39,
+                      "id": 40,
                       "links": [ ],
                       "options": {
                          "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -1041,7 +1041,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### OOO Samples appended\nThe rate of OOO samples that have been appended.\nThis doesn't account for the replication factor.\n\n",
+                  "description": "### Out-of-order samples appended\nThe rate of OOO samples that have been appended.\nThis doesn't account for the replication factor.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1085,7 +1085,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "OOO Samples appended",
+                  "title": "Out-of-order samples appended",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -843,7 +843,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 3,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_distributor_samples_in_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -911,7 +911,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 3,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_distributor_received_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -843,7 +843,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 2,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_distributor_samples_in_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -911,7 +911,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 2,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_distributor_received_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -966,7 +966,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 2,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_distributor_deduped_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -986,7 +986,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Distributor and ingester discarded samples rate\nThe rate of each sample's discarding reason.\n\n",
+                  "description": "### Distributor and ingester discarded samples rate\nThe rate of each sample's discarding reason.\nThis doesn't account for the replication factor.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1021,7 +1021,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 2,
                   "targets": [
                      {
                         "expr": "sum by (reason) (rate(cortex_discarded_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -1032,11 +1032,60 @@
                      {
                         "expr": "sum by (reason) (rate(cortex_discarded_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
                         "format": "time_series",
-                        "legendFormat": "{{ reason }} (ingester)",
+                        "legendFormat": "{{ reason }} (ingester, replicated)",
                         "legendLink": null
                      }
                   ],
                   "title": "Distributor and ingester discarded samples rate",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### OOO Samples appended\nThe rate of OOO samples that have been appended.\nThis doesn't account for the replication factor.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 17,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": false
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 2,
+                  "targets": [
+                     {
+                        "expr": "sum(rate(cortex_ingester_tsdb_out_of_order_samples_appended_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "legendFormat": "rate",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOO Samples appended",
                   "type": "timeseries"
                }
             ],
@@ -1077,7 +1126,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 17,
+                  "id": 18,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1126,7 +1175,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 18,
+                  "id": 19,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1175,7 +1224,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 19,
+                  "id": 20,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1200,7 +1249,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\n\n",
+                  "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\nThis doesn't account for the replication factor\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1224,7 +1273,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 20,
+                  "id": 21,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1285,7 +1334,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 21,
+                  "id": 22,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1334,7 +1383,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1414,7 +1463,7 @@
                         }
                      ]
                   },
-                  "id": 23,
+                  "id": 24,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1469,7 +1518,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1517,7 +1566,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 25,
+                  "id": 26,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1565,7 +1614,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 26,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1647,7 +1696,7 @@
                      ]
                   },
                   "fill": 1,
-                  "id": 27,
+                  "id": 28,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1767,7 +1816,7 @@
                      ]
                   },
                   "fill": 1,
-                  "id": 28,
+                  "id": 29,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1877,7 +1926,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 29,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1941,7 +1990,7 @@
                         }
                      ]
                   },
-                  "id": 30,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2001,7 +2050,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 31,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2086,7 +2135,7 @@
                         }
                      ]
                   },
-                  "id": 32,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2140,7 +2189,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2206,7 +2255,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 34,
+                  "id": 35,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2254,7 +2303,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 36,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2314,7 +2363,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 37,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2362,7 +2411,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2423,7 +2472,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 38,
+                  "id": 39,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2472,7 +2521,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 39,
+                  "id": 40,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -1249,7 +1249,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\nThis doesn't account for the replication factor\n\n",
+                  "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\nThis doesn't account for the replication factor.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -1041,7 +1041,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### OOO Samples appended\nThe rate of OOO samples that have been appended.\nThis doesn't account for the replication factor.\n\n",
+                  "description": "### Out-of-order samples appended\nThe rate of OOO samples that have been appended.\nThis doesn't account for the replication factor.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1085,7 +1085,7 @@
                         "legendLink": null
                      }
                   ],
-                  "title": "OOO Samples appended",
+                  "title": "Out-of-order samples appended",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -843,7 +843,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 3,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_distributor_samples_in_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -911,7 +911,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 2,
+                  "span": 3,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_distributor_received_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -843,7 +843,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 2,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_distributor_samples_in_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -911,7 +911,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 2,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_distributor_received_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -966,7 +966,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 2,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_distributor_deduped_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -986,7 +986,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Distributor and ingester discarded samples rate\nThe rate of each sample's discarding reason.\n\n",
+                  "description": "### Distributor and ingester discarded samples rate\nThe rate of each sample's discarding reason.\nThis doesn't account for the replication factor.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1021,7 +1021,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 2,
                   "targets": [
                      {
                         "expr": "sum by (reason) (rate(cortex_discarded_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
@@ -1032,11 +1032,60 @@
                      {
                         "expr": "sum by (reason) (rate(cortex_discarded_samples_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
                         "format": "time_series",
-                        "legendFormat": "{{ reason }} (ingester)",
+                        "legendFormat": "{{ reason }} (ingester, replicated)",
                         "legendLink": null
                      }
                   ],
                   "title": "Distributor and ingester discarded samples rate",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### OOO Samples appended\nThe rate of OOO samples that have been appended.\nThis doesn't account for the replication factor.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 17,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": false
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 2,
+                  "targets": [
+                     {
+                        "expr": "sum(rate(cortex_ingester_tsdb_out_of_order_samples_appended_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "legendFormat": "rate",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "OOO Samples appended",
                   "type": "timeseries"
                }
             ],
@@ -1077,7 +1126,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 17,
+                  "id": 18,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1126,7 +1175,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 18,
+                  "id": 19,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1175,7 +1224,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 19,
+                  "id": 20,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1200,7 +1249,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\n\n",
+                  "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\nThis doesn't account for the replication factor\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1224,7 +1273,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 20,
+                  "id": 21,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1285,7 +1334,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 21,
+                  "id": 22,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1334,7 +1383,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1414,7 +1463,7 @@
                         }
                      ]
                   },
-                  "id": 23,
+                  "id": 24,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1469,7 +1518,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1517,7 +1566,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 25,
+                  "id": 26,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1565,7 +1614,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 26,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1647,7 +1696,7 @@
                      ]
                   },
                   "fill": 1,
-                  "id": 27,
+                  "id": 28,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1767,7 +1816,7 @@
                      ]
                   },
                   "fill": 1,
-                  "id": 28,
+                  "id": 29,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -1877,7 +1926,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 29,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1941,7 +1990,7 @@
                         }
                      ]
                   },
-                  "id": 30,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2001,7 +2050,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 31,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2086,7 +2135,7 @@
                         }
                      ]
                   },
-                  "id": 32,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2140,7 +2189,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2206,7 +2255,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 34,
+                  "id": 35,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2254,7 +2303,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 36,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2314,7 +2363,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 37,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2362,7 +2411,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2423,7 +2472,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 38,
+                  "id": 39,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2472,7 +2521,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 39,
+                  "id": 40,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -1249,7 +1249,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\nThis doesn't account for the replication factor\n\n",
+                  "description": "### Ingester appended exemplars rate\nTotal number of exemplars appended in the ingesters.\nThis can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.\nThis doesn't account for the replication factor.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -34,6 +34,18 @@ local utils = import 'mixin-utils/utils.libsonnet';
         if condition
         then self.addPanel(panel)
         else self,
+
+      // justifyPanels make sure that the panels span the whole row.
+      // It is useful when the number of panels is not a divisor of 12.
+      justifyPanels()::
+        self + {
+          local n = std.length(super.panels),
+          local span = std.floor(12 / n),
+          panels: [
+            super.panels[i] { span: span + if i < (12 % n) then 1 else 0 }
+            for i in std.range(0, n - 1)
+          ],
+        },
     },
 
   // Override the dashboard constructor to add:

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -405,13 +405,31 @@ local filename = 'mimir-tenants.json';
           ],
           [
             '{{ reason }} (distributor)',
-            '{{ reason }} (ingester)',
+            '{{ reason }} (ingester, replicated)',
           ]
         ) +
         $.panelDescription(
           title,
           |||
             The rate of each sample's discarding reason.
+            This doesn't account for the replication factor.
+          |||
+        ),
+      )
+      .addPanel(
+        local title = 'OOO Samples appended';
+        $.timeseriesPanel(title) +
+        $.queryPanel(
+          'sum(rate(cortex_ingester_tsdb_out_of_order_samples_appended_total{%(job)s, user="$user"}[$__rate_interval]))'
+          % { job: $.jobMatcher($._config.job_names.ingester) },
+          'rate',
+        ) +
+        { options+: { legend+: { showLegend: false } } } +
+        $.panelDescription(
+          title,
+          |||
+            The rate of OOO samples that have been appended.
+            This doesn't account for the replication factor.
           |||
         ),
       ),
@@ -481,6 +499,7 @@ local filename = 'mimir-tenants.json';
           |||
             Total number of exemplars appended in the ingesters.
             This can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.
+            This doesn't account for the replication factor
           |||
         ),
       ),

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -500,7 +500,7 @@ local filename = 'mimir-tenants.json';
           |||
             Total number of exemplars appended in the ingesters.
             This can be lower than ingested exemplars rate since TSDB does not append the same exemplar twice, and those can be frequent.
-            This doesn't account for the replication factor
+            This doesn't account for the replication factor.
           |||
         ),
       ),

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -417,7 +417,7 @@ local filename = 'mimir-tenants.json';
         ),
       )
       .addPanel(
-        local title = 'OOO Samples appended';
+        local title = 'Out-of-order samples appended';
         $.timeseriesPanel(title) +
         $.queryPanel(
           'sum(rate(cortex_ingester_tsdb_out_of_order_samples_appended_total{%(job)s, user="$user"}[$__rate_interval]))'

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -333,6 +333,7 @@ local filename = 'mimir-tenants.json';
 
     .addRow(
       $.row('Samples ingestion funnel')
+      .justifyPanels()  // Make sure panels use all width even if 12 columns are not divisible by the number of panels.
       .addPanel(
         local title = 'Distributor samples incoming rate';
         $.timeseriesPanel(title) +


### PR DESCRIPTION
#### What this PR does

Adds a "Out-of-order samples appended" panel to "Mimir / Tenants" dashboard.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
