### PR TITLE
Code cleanup for `pusherConsumer`

### DIFF
--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -46,9 +46,6 @@ type pusherConsumer struct {
 	metrics                  *pusherConsumerMetrics
 	logger                   log.Logger
 
-	shards    int
-	batchSize int
-
 	pusher PusherCloser
 }
 

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -28,16 +28,6 @@ type Pusher interface {
 	PushToStorage(context.Context, *mimirpb.WriteRequest) error
 }
 
-type pusherConsumerPrototype struct {
-	processingTimeSeconds prometheus.Observer
-	clientErrRequests     prometheus.Counter
-	serverErrRequests     prometheus.Counter
-	totalRequests         prometheus.Counter
-
-	fallbackClientErrSampler *util_log.Sampler // Fallback log message sampler client errors that are not sampled yet.
-	logger                   log.Logger
-}
-
 type parsedRecord struct {
 	*mimirpb.WriteRequest
 	// Context holds the tracing and cancellation data for this record/request.
@@ -52,41 +42,36 @@ type PusherCloser interface {
 }
 
 type pusherConsumer struct {
-	pusherConsumerPrototype
+	fallbackClientErrSampler *util_log.Sampler
+	metrics                  *pusherConsumerMetrics
+	logger                   log.Logger
+
+	shards    int
+	batchSize int
+
 	pusher PusherCloser
 }
 
-func (c pusherConsumer) Close(ctx context.Context) error {
-	spanLog := spanlogger.FromContext(ctx, log.NewNopLogger())
-	errs := c.pusher.Close()
-	for eIdx := 0; eIdx < len(errs); eIdx++ {
-		err := errs[eIdx]
-		isServerErr := c.handlePushErr(ctx, "TODO", err, spanLog)
-		if !isServerErr {
-			errs[len(errs)-1], errs[eIdx] = errs[eIdx], errs[len(errs)-1]
-			errs = errs[:len(errs)-1]
-			eIdx--
-		}
-	}
-	return multierror.New(errs...).Err()
+type pusherConsumerMetrics struct {
+	numTimeSeriesPerFlush prometheus.Histogram
+	processingTimeSeconds prometheus.Observer
+	clientErrRequests     prometheus.Counter
+	serverErrRequests     prometheus.Counter
+	totalRequests         prometheus.Counter
 }
 
-func newPusherConsumer(p PusherCloser, proto pusherConsumerPrototype) *pusherConsumer {
-	return &pusherConsumer{
-		pusher:                  p,
-		pusherConsumerPrototype: proto,
-	}
-}
-
-func newPusherConsumerPrototype(fallbackClientErrSampler *util_log.Sampler, reg prometheus.Registerer, l log.Logger) pusherConsumerPrototype {
+func newPusherConsumerMetrics(reg prometheus.Registerer) *pusherConsumerMetrics {
 	errRequestsCounter := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_ingest_storage_reader_records_failed_total",
 		Help: "Number of records (write requests) which caused errors while processing. Client errors are errors such as tenant limits and samples out of bounds. Server errors indicate internal recoverable errors.",
 	}, []string{"cause"})
 
-	return pusherConsumerPrototype{
-		logger:                   l,
-		fallbackClientErrSampler: fallbackClientErrSampler,
+	return &pusherConsumerMetrics{
+		numTimeSeriesPerFlush: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:                        "cortex_ingester_pusher_num_timeseries_per_flush",
+			Help:                        "Number of time series per flush",
+			NativeHistogramBucketFactor: 1.1,
+		}),
 		processingTimeSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:                            "cortex_ingest_storage_reader_processing_time_seconds",
 			Help:                            "Time taken to process a single record (write request).",
@@ -104,6 +89,25 @@ func newPusherConsumerPrototype(fallbackClientErrSampler *util_log.Sampler, reg 
 	}
 }
 
+func newPusherConsumer(pusher Pusher, kafkaCfg KafkaConfig, reg prometheus.Registerer, logger log.Logger) *pusherConsumer {
+	metrics := newPusherConsumerMetrics(reg)
+
+	var p PusherCloser
+	if kafkaCfg.ReplayShards == 0 {
+		p = newNoopPusherCloser(metrics, pusher)
+	} else {
+		p = newMultiTenantPusher(metrics, pusher, kafkaCfg.ReplayShards, kafkaCfg.BatchSize)
+	}
+
+	return &pusherConsumer{
+		metrics:                  metrics,
+		logger:                   logger,
+		fallbackClientErrSampler: util_log.NewSampler(kafkaCfg.FallbackClientErrorSampleRate),
+
+		pusher: p,
+	}
+}
+
 func (c pusherConsumer) consume(ctx context.Context, records []record) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(cancellation.NewErrorf("done consuming records"))
@@ -113,6 +117,21 @@ func (c pusherConsumer) consume(ctx context.Context, records []record) error {
 	// Speed up consumption by unmarhsalling the next request while the previous one is being pushed.
 	go c.unmarshalRequests(ctx, records, recC)
 	return c.pushRequests(recC)
+}
+
+func (c pusherConsumer) Close(ctx context.Context) error {
+	spanLog := spanlogger.FromContext(ctx, log.NewNopLogger())
+	errs := c.pusher.Close()
+	for eIdx := 0; eIdx < len(errs); eIdx++ {
+		err := errs[eIdx]
+		isServerErr := c.handlePushErr(ctx, "TODO", err, spanLog)
+		if !isServerErr {
+			errs[len(errs)-1], errs[eIdx] = errs[eIdx], errs[len(errs)-1]
+			errs = errs[:len(errs)-1]
+			eIdx--
+		}
+	}
+	return multierror.New(errs...).Err()
 }
 
 func (c pusherConsumer) pushRequests(reqC <-chan parsedRecord) error {
@@ -143,8 +162,8 @@ func (c pusherConsumer) pushToStorage(ctx context.Context, tenantID string, req 
 	err := c.pusher.PushToStorage(ctx, req)
 
 	// TODO dimitarvdimitrov processing time is flawed because it's only counting enqueuing time, not processing time.
-	c.processingTimeSeconds.Observe(time.Since(processingStart).Seconds())
-	c.totalRequests.Inc()
+	c.metrics.processingTimeSeconds.Observe(time.Since(processingStart).Seconds())
+	c.metrics.totalRequests.Inc()
 
 	isServerErr := c.handlePushErr(ctx, tenantID, err, spanLog)
 	if isServerErr {
@@ -159,12 +178,12 @@ func (c pusherConsumer) handlePushErr(ctx context.Context, tenantID string, err 
 	}
 	// Only return non-client errors; these will stop the processing of the current Kafka fetches and retry (possibly).
 	if !mimirpb.IsClientError(err) {
-		c.serverErrRequests.Inc()
+		c.metrics.serverErrRequests.Inc()
 		_ = spanLog.Error(err)
 		return true
 	}
 
-	c.clientErrRequests.Inc()
+	c.metrics.clientErrRequests.Inc()
 
 	// The error could be sampled or marked to be skipped in logs, so we check whether it should be
 	// logged before doing it.
@@ -226,11 +245,12 @@ func (c pusherConsumer) unmarshalRequests(ctx context.Context, records []record,
 }
 
 type multiTenantPusher struct {
-	pushers               map[string]*shardingPusher
-	upstreamPusher        Pusher
-	numShards             int
-	batchSize             int
-	numTimeSeriesPerFlush prometheus.Histogram
+	metrics *pusherConsumerMetrics
+
+	pushers        map[string]*shardingPusher
+	upstreamPusher Pusher
+	numShards      int
+	batchSize      int
 }
 
 func (c multiTenantPusher) PushToStorage(ctx context.Context, request *mimirpb.WriteRequest) error {
@@ -239,13 +259,13 @@ func (c multiTenantPusher) PushToStorage(ctx context.Context, request *mimirpb.W
 }
 
 // TODO dimitarvdimitrov rename because this is multi-tenant sharding pusher
-func newMultiTenantPusher(numTimeSeriesPerFlush prometheus.Histogram, upstream Pusher, numShards int, batchSize int) *multiTenantPusher {
+func newMultiTenantPusher(metrics *pusherConsumerMetrics, upstream Pusher, numShards int, batchSize int) *multiTenantPusher {
 	return &multiTenantPusher{
-		pushers:               make(map[string]*shardingPusher),
-		upstreamPusher:        upstream,
-		numShards:             numShards,
-		batchSize:             batchSize,
-		numTimeSeriesPerFlush: numTimeSeriesPerFlush,
+		pushers:        make(map[string]*shardingPusher),
+		upstreamPusher: upstream,
+		numShards:      numShards,
+		batchSize:      batchSize,
+		metrics:        metrics,
 	}
 }
 
@@ -253,7 +273,7 @@ func (c multiTenantPusher) pusher(userID string) *shardingPusher {
 	if p := c.pushers[userID]; p != nil {
 		return p
 	}
-	p := newShardingPusher(c.numTimeSeriesPerFlush, c.numShards, c.batchSize, c.upstreamPusher) // TODO dimitarvdimitrov this ok or do we need to inject a factory here too?
+	p := newShardingPusher(c.metrics.numTimeSeriesPerFlush, c.numShards, c.batchSize, c.upstreamPusher) // TODO dimitarvdimitrov this ok or do we need to inject a factory here too?
 	c.pushers[userID] = p
 	return p
 }
@@ -265,11 +285,6 @@ func (c multiTenantPusher) Close() []error {
 	}
 	clear(c.pushers)
 	return errs
-}
-
-type shardedPush struct {
-	mimirpb.PreallocTimeseries
-	context.Context
 }
 
 type shardingPusher struct {

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -424,7 +424,7 @@ type mockPusher struct {
 	mock.Mock
 }
 
-func (m mockPusher) PushToStorage(ctx context.Context, request *mimirpb.WriteRequest) error {
+func (m *mockPusher) PushToStorage(ctx context.Context, request *mimirpb.WriteRequest) error {
 	args := m.Called(ctx, request)
 	return args.Error(0)
 }

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -208,7 +208,7 @@ func TestPusherConsumer(t *testing.T) {
 			})
 
 			logs := &concurrency.SyncBuffer{}
-			c := newPusherConsumer(pusher, newPusherConsumerPrototype(nil, prometheus.NewPedanticRegistry(), log.NewLogfmtLogger(logs)))
+			c := newPusherConsumer(pusher, KafkaConfig{}, prometheus.NewPedanticRegistry(), log.NewLogfmtLogger(logs))
 			err := c.consume(context.Background(), tc.records)
 			if tc.expErr == "" {
 				assert.NoError(t, err)
@@ -278,7 +278,8 @@ func TestPusherConsumer_clientErrorSampling(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			c := newPusherConsumer(nil, newPusherConsumerPrototype(tc.sampler, prometheus.NewPedanticRegistry(), log.NewNopLogger()))
+			c := newPusherConsumer(nil, KafkaConfig{}, prometheus.NewPedanticRegistry(), log.NewNopLogger())
+			c.fallbackClientErrSampler = tc.sampler
 
 			sampled, reason := c.shouldLogClientError(context.Background(), tc.err)
 			assert.Equal(t, tc.expectedSampled, sampled)
@@ -307,7 +308,7 @@ func TestPusherConsumer_consume_ShouldLogErrorsHonoringOptionalLogging(t *testin
 
 		reg := prometheus.NewPedanticRegistry()
 		logs := &concurrency.SyncBuffer{}
-		consumer := newPusherConsumer(pusher, newPusherConsumerPrototype(nil, reg, log.NewLogfmtLogger(logs)))
+		consumer := newPusherConsumer(pusher, KafkaConfig{}, reg, log.NewLogfmtLogger(logs))
 
 		return consumer, logs, reg
 	}
@@ -393,7 +394,7 @@ func TestPusherConsumer_consume_ShouldHonorContextCancellation(t *testing.T) {
 		<-ctx.Done()
 		return context.Cause(ctx)
 	})
-	consumer := newPusherConsumer(pusher, newPusherConsumerPrototype(nil, prometheus.NewPedanticRegistry(), log.NewNopLogger()))
+	consumer := newPusherConsumer(pusher, KafkaConfig{}, prometheus.NewPedanticRegistry(), log.NewNopLogger())
 
 	wantCancelErr := cancellation.NewErrorf("stop")
 

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -494,7 +494,7 @@ func (r *PartitionReader) consumeFetches(ctx context.Context, fetches kgo.Fetche
 		consumeCtx := context.WithoutCancel(ctx)
 		err := consumer.consume(consumeCtx, records)
 		if err == nil {
-			err = consumer.Close(consumeCtx)
+			_ = consumer.Close(consumeCtx)
 			break
 		}
 		level.Error(r.logger).Log(
@@ -744,10 +744,6 @@ func (r *PartitionReader) pollFetches(ctx context.Context) (result kgo.Fetches) 
 	return f
 }
 
-func (r *PartitionReader) setPollingStartOffset(offset int64) {
-	r.consumedOffsetWatcher.Notify(offset)
-}
-
 type fetchWant struct {
 	startOffset int64 // inclusive
 	endOffset   int64 // exclusive
@@ -846,7 +842,7 @@ func (r *concurrentFetchers) pollFetches(ctx context.Context) (result kgo.Fetche
 	}
 }
 
-func (r *concurrentFetchers) fetchSingle(ctx context.Context, w fetchWant, logger log.Logger) (_ kgo.FetchPartition, fetchedBytes int) {
+func (r *concurrentFetchers) fetchSingle(ctx context.Context, w fetchWant, _ log.Logger) (_ kgo.FetchPartition, fetchedBytes int) {
 	req := kmsg.NewFetchRequest()
 	req.Topics = []kmsg.FetchRequestTopic{{
 		Topic:   r.topicName,
@@ -1167,9 +1163,9 @@ func processRespPartition(rp *kmsg.FetchResponseTopicPartition, topic string) kg
 
 		switch t := r.(type) {
 		case *kmsg.MessageV0:
-			panic("unkown message type")
+			panic("unknown message type")
 		case *kmsg.MessageV1:
-			panic("unkown message type")
+			panic("unknown message type")
 		case *kmsg.RecordBatch:
 			_, _ = processRecordBatch(topic, &fp, t)
 		}

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -65,12 +65,6 @@ type recordConsumer interface {
 	consume(context.Context, []record) error
 }
 
-type noopConsumer struct{}
-
-func (noopConsumer) consume(ctx context.Context, records []record) error {
-	return nil
-}
-
 type PartitionReader struct {
 	services.Service
 	dependencies *services.Manager
@@ -337,9 +331,6 @@ func (r *PartitionReader) processNextFetchesUntilLagHonored(ctx context.Context,
 	} else {
 		fetcher = r
 	}
-	// defer func() {
-	//	r.setPollingStartOffset(r.consumedOffsetWatcher.LastConsumedOffset())
-	// }()
 
 	for boff.Ongoing() {
 		// Send a direct request to the Kafka backend to fetch the partition start offset.


### PR DESCRIPTION
#### What this PR does

This small refactor cleans up a bit the code within pusherConsumer to address some dependency inversion of some of the components.

Some of the things I've done are:

- Move functions around to comply with Go code's standards e.g. Functions that are part of the public interface go after the struct definition
- Avoid passing individual metrics around and instead have a single metrics struct that is passed around to the different structs
- Simplify the `consumerFactory` definition  to push the construction of the `pusherCloser` to itself.

There are other things I want to do such as: Remove the "multitenant pusher" abstraction but I think this is a enough for a first PR.

NB: This does not the change the behaviour of the code at all.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
