### PR TITLE
blockbuilder: fix calculation of the next cycle time

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -656,7 +656,7 @@ func (b *BlockBuilder) nextConsumeCycle(ctx context.Context, client *kgo.Client,
 	// We are lagging behind. We need to consume the partition in parts.
 	// We iterate through all the cycleEnds starting from the first one after commit until the cycleEnd.
 	cycleEndStartAt := commitRecTime.Truncate(b.cfg.ConsumeInterval).Add(b.cfg.ConsumeInterval + b.cfg.ConsumeIntervalBuffer)
-	level.Info(b.logger).Log("msg", "partition is lagging behind", "part", pl.Partition, "lag", pl.Lag, "cycle_end_start", cycleEndStartAt, "cycle_end", cycleEnd, "last_commit_rec_raw", pl.CommitRecTs, "last_commit_rec_time", commitRecTime)
+	level.Info(b.logger).Log("msg", "partition is lagging behind", "part", pl.Partition, "lag", pl.Lag, "cycle_end_start", cycleEndStartAt, "cycle_end", cycleEnd, "last_commit_rec_time", commitRecTime, "last_commit_rec_ts", pl.CommitRecTs)
 	for ce := cycleEndStartAt; cycleEnd.Sub(ce) >= 0; ce = ce.Add(b.cfg.ConsumeInterval) {
 		// Instead of looking for the commit metadata for each iteration, we use the data returned by consumePartition
 		// in the next iteration.


### PR DESCRIPTION
This one fixes a corner case, when the block-builder app starts at around the time of the `nextCycle`. 

Right now the calculation causes a couple of problems:

1. block-builder delays its first cycle (after the startup cycle) by one hour causing the app to lag
1. because we add a `-1 second`, to the `cycleEnd`, the cycles splitting in `partition is lagging behind` skips the last hour, causing it to keep lagging.

I didn't manage to add any tests 'cause the logic in `running` is, currently, bound to wall-clock (`time.Now`). I suggest we reconsider it to be more tests friendly after we get the confidence that the current version works.