### PR TITLE
doc-generator: include default values for config options decorated with `nocli`, fix formatting of slices, and export Markdown generation package

### DIFF
--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -18,11 +18,7 @@ import (
 	"github.com/grafana/mimir/pkg/mimir"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/tools/doc-generator/parse"
-)
-
-const (
-	maxLineWidth = 80
-	tabWidth     = 2
+	"github.com/grafana/mimir/tools/doc-generator/write"
 )
 
 func removeFlagPrefix(block *parse.ConfigBlock, prefix string) {
@@ -93,9 +89,9 @@ func annotateFlagPrefix(blocks []*parse.ConfigBlock) {
 }
 
 func generateBlocksMarkdown(blocks []*parse.ConfigBlock) string {
-	md := &markdownWriter{}
-	md.writeConfigDoc(blocks)
-	return md.string()
+	md := &write.MarkdownWriter{}
+	md.WriteConfigDoc(blocks, parse.RootBlocks)
+	return md.String()
 }
 
 func generateBlockMarkdown(blocks []*parse.ConfigBlock, blockName, fieldName string) string {
@@ -105,11 +101,11 @@ func generateBlockMarkdown(blocks []*parse.ConfigBlock, blockName, fieldName str
 			continue
 		}
 
-		md := &markdownWriter{}
+		md := &write.MarkdownWriter{}
 
 		// Wrap the root block with another block, so that we can show the name of the
 		// root field containing the block specs.
-		md.writeConfigBlock(&parse.ConfigBlock{
+		md.WriteConfigBlock(&parse.ConfigBlock{
 			Name: blockName,
 			Desc: block.Desc,
 			Entries: []*parse.ConfigEntry{
@@ -124,7 +120,7 @@ func generateBlockMarkdown(blocks []*parse.ConfigBlock, blockName, fieldName str
 			},
 		})
 
-		return md.string()
+		return md.String()
 	}
 
 	// If the block has not been found, we return an empty string.

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -280,6 +280,11 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 			return nil, errors.Wrapf(err, "config=%s.%s", t.PkgPath(), t.Name())
 		}
 		if fieldFlag == nil {
+			var def string
+			if kind == KindField {
+				def = getFieldDefault(field, "")
+			}
+
 			block.Add(&ConfigEntry{
 				Kind:          kind,
 				Name:          fieldName,
@@ -288,6 +293,7 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 				FieldType:     fieldType,
 				FieldExample:  getFieldExample(fieldName, field.Type),
 				FieldCategory: getFieldCategory(field, ""),
+				FieldDefault:  def,
 				Element:       element,
 			})
 			continue

--- a/tools/doc-generator/write/writer.go
+++ b/tools/doc-generator/write/writer.go
@@ -44,7 +44,8 @@ func (w *specWriter) writeConfigBlock(b *parse.ConfigBlock, indent int) {
 }
 
 func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
-	if e.Kind == parse.KindBlock {
+	switch e.Kind {
+	case parse.KindBlock:
 		// If the block is a root block it will have its dedicated section in the doc,
 		// so here we've just to write down the reference without re-iterating on it.
 		if e.Root {
@@ -66,9 +67,8 @@ func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 			// Entries
 			w.writeConfigBlock(e.Block, indent+tabWidth)
 		}
-	}
 
-	if e.Kind == parse.KindField || e.Kind == parse.KindMap {
+	case parse.KindField, parse.KindMap:
 		// Description
 		w.writeComment(w.modifyDescriptions(e.Description()), indent, 0)
 		w.writeExample(e.FieldExample, indent)
@@ -87,9 +87,8 @@ func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 		} else {
 			w.out.WriteString(pad(indent) + "[" + e.Name + ": <" + e.FieldType + "> | default = " + fieldDefault + "]\n")
 		}
-	}
 
-	if e.Kind == parse.KindSlice {
+	case parse.KindSlice:
 		// Description
 		w.writeComment(w.modifyDescriptions(e.Description()), indent, 0)
 

--- a/tools/doc-generator/write/writer_test.go
+++ b/tools/doc-generator/write/writer_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package write
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/tools/doc-generator/parse"
+)
+
+func TestMarkdownWriter(t *testing.T) {
+	rootBlocks := []parse.RootBlock{
+		{
+			Name:       "the_root",
+			Desc:       "Top-level of all configuration.",
+			StructType: reflect.TypeOf(Root{}),
+		},
+	}
+
+	blocks, err := parse.Config(&Root{}, nil, rootBlocks)
+	require.NoError(t, err)
+
+	md := &MarkdownWriter{}
+	md.WriteConfigDoc(blocks, rootBlocks)
+	threeBackticks := "```"
+	expected := threeBackticks + `yaml
+# The string
+[some_string: <string> | default = ""]
+
+# The nested config
+nested_struct:
+  # The other string
+  [some_other_string: <string> | default = ""]
+
+  # The timeout
+  [timeout: <duration> | default = 30s]
+
+# The nested list
+nested_slice:
+  -
+    # The username
+    [username: <string> | default = ""]
+
+    # The password
+    [password: <string> | default = ""]
+` + threeBackticks
+
+	require.Equal(t, expected, md.String())
+}
+
+type Root struct {
+	SomeString       string               `yaml:"some_string" doc:"description=The string"`
+	SomeNestedStruct NestedStruct         `yaml:"nested_struct" doc:"description=The nested config"`
+	SomeNestedSlice  []NestedSliceElement `yaml:"nested_slice" doc:"description=The nested list"`
+}
+
+type NestedStruct struct {
+	SomeOtherString string        `yaml:"some_other_string" doc:"description=The other string"`
+	Timeout         time.Duration `yaml:"timeout" doc:"description=The timeout|default=30s"`
+}
+
+type NestedSliceElement struct {
+	Username string `yaml:"username" doc:"description=The username"`
+	Password string `yaml:"password" doc:"description=The password"`
+}

--- a/tools/doc-generator/writer.go
+++ b/tools/doc-generator/writer.go
@@ -62,7 +62,7 @@ func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 		}
 	}
 
-	if e.Kind == parse.KindField || e.Kind == parse.KindSlice || e.Kind == parse.KindMap {
+	if e.Kind == parse.KindField || e.Kind == parse.KindMap {
 		// Description
 		w.writeComment(e.Description(), indent, 0)
 		w.writeExample(e.FieldExample, indent)
@@ -81,6 +81,18 @@ func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 		} else {
 			w.out.WriteString(pad(indent) + "[" + e.Name + ": <" + e.FieldType + "> | default = " + fieldDefault + "]\n")
 		}
+	}
+
+	if e.Kind == parse.KindSlice {
+		// Description
+		w.writeComment(replaceProductName(e.Description()), indent, 0)
+
+		// Name
+		w.out.WriteString(pad(indent) + e.Name + ":\n")
+
+		// Element
+		w.out.WriteString(pad(indent+tabWidth) + "-\n")
+		w.writeConfigBlock(e.Element, indent+(2*tabWidth))
 	}
 }
 


### PR DESCRIPTION
#### What this PR does

This PR fixes two issues in `tools/doc-generator`:

* config options that have `nocli` set do not have their default values included in the generated text
* config options that take slices do not include details of the slice elements in the generated text

It also exports the Markdown generation code so that it can be used in other repositories (eg. our enterprise product).

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
