### PR TITLE
query-tee: log all samples for matrix series when a mismatch occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@
 * [ENHANCEMENT] Check annotations emitted by both backends are the same when comparing responses from two backends. #8660
 * [ENHANCEMENT] Compare native histograms in query results when comparing results between two backends. #8724
 * [ENHANCEMENT] Don't consider responses to be different during response comparison if both backends' responses contain different series, but all samples are within the recent sample window. #8749 #8894
+* [ENHANCEMENT] When the expected and actual response for a matrix series is different, the full set of samples for that series from both backends will now be logged. #8947
 * [BUGFIX] Ensure any errors encountered while forwarding a request to a backend (eg. DNS resolution failures) are logged. #8419
 * [BUGFIX] The comparison of the results should not fail when either side contains extra samples from within SkipRecentSamples duration. #8920
 

--- a/tools/querytee/response_comparator.go
+++ b/tools/querytee/response_comparator.go
@@ -179,7 +179,7 @@ func compareMatrix(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 
 		err := compareMatrixSamples(expectedMetric, actualMetric, opts)
 		if err != nil {
-			return err
+			return fmt.Errorf("%w\nFull expected result:\n%v\n\nFull actual result:\n%v", err, expectedMetric, actualMetric)
 		}
 	}
 

--- a/tools/querytee/response_comparator.go
+++ b/tools/querytee/response_comparator.go
@@ -179,7 +179,7 @@ func compareMatrix(expectedRaw, actualRaw json.RawMessage, opts SampleComparison
 
 		err := compareMatrixSamples(expectedMetric, actualMetric, opts)
 		if err != nil {
-			return fmt.Errorf("%w\nFull expected result:\n%v\n\nFull actual result:\n%v", err, expectedMetric, actualMetric)
+			return fmt.Errorf("%w\nExpected result for series:\n%v\n\nActual result for series:\n%v", err, expectedMetric, actualMetric)
 		}
 	}
 

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -66,7 +66,15 @@ func TestCompareMatrix(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"values":[[1,"1"]]}
 						]`),
-			err: `expected 2 float sample(s) and 0 histogram sample(s) for metric {foo="bar"} but got 1 float sample(s) and 0 histogram sample(s)`,
+			err: `expected 2 float sample(s) and 0 histogram sample(s) for metric {foo="bar"} but got 1 float sample(s) and 0 histogram sample(s)
+Expected result for series:
+{foo="bar"} =>
+1 @[1]
+2 @[2]
+
+Actual result for series:
+{foo="bar"} =>
+1 @[1]`,
 		},
 		{
 			name: "difference in float sample timestamp",
@@ -76,7 +84,16 @@ func TestCompareMatrix(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"values":[[1,"1"],[3,"2"]]}
 						]`),
-			err: `float sample pair does not match for metric {foo="bar"}: expected timestamp 2 but got 3`,
+			err: `float sample pair does not match for metric {foo="bar"}: expected timestamp 2 but got 3
+Expected result for series:
+{foo="bar"} =>
+1 @[1]
+2 @[2]
+
+Actual result for series:
+{foo="bar"} =>
+1 @[1]
+2 @[3]`,
 		},
 		{
 			name: "difference in float sample value",
@@ -86,7 +103,16 @@ func TestCompareMatrix(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"values":[[1,"1"],[2,"3"]]}
 						]`),
-			err: `float sample pair does not match for metric {foo="bar"}: expected value 2 for timestamp 2 but got 3`,
+			err: `float sample pair does not match for metric {foo="bar"}: expected value 2 for timestamp 2 but got 3
+Expected result for series:
+{foo="bar"} =>
+1 @[1]
+2 @[2]
+
+Actual result for series:
+{foo="bar"} =>
+1 @[1]
+3 @[2]`,
 		},
 		{
 			name: "actual float samples match expected",
@@ -107,7 +133,16 @@ func TestCompareMatrix(t *testing.T) {
 							{"metric":{"foo":"bar"},"values":[[1,"1"],[2,"2"]]},
 							{"metric":{"oops":"bar"},"values":[[1,"1"],[2,"3"]]}
 						]`),
-			err: `float sample pair does not match for metric {oops="bar"}: expected value 2 for timestamp 2 but got 3`,
+			err: `float sample pair does not match for metric {oops="bar"}: expected value 2 for timestamp 2 but got 3
+Expected result for series:
+{oops="bar"} =>
+1 @[1]
+2 @[2]
+
+Actual result for series:
+{oops="bar"} =>
+1 @[1]
+3 @[2]`,
 		},
 		{
 			name: "single expected sample has histogram but actual sample has float value",
@@ -131,7 +166,14 @@ func TestCompareMatrix(t *testing.T) {
 								"values": [[1,"1"]]
 							}
 						]`),
-			err: `expected 0 float sample(s) and 1 histogram sample(s) for metric {foo="bar"} but got 1 float sample(s) and 0 histogram sample(s)`,
+			err: `expected 0 float sample(s) and 1 histogram sample(s) for metric {foo="bar"} but got 1 float sample(s) and 0 histogram sample(s)
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+
+Actual result for series:
+{foo="bar"} =>
+1 @[1]`,
 		},
 		{
 			name: "single expected sample has float value but actual sample has histogram",
@@ -155,7 +197,14 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `expected 1 float sample(s) and 0 histogram sample(s) for metric {foo="bar"} but got 0 float sample(s) and 1 histogram sample(s)`,
+			err: `expected 1 float sample(s) and 0 histogram sample(s) for metric {foo="bar"} but got 0 float sample(s) and 1 histogram sample(s)
+Expected result for series:
+{foo="bar"} =>
+1 @[1]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[2]`,
 		},
 		{
 			name: "difference in histogram sample timestamp",
@@ -187,7 +236,14 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `histogram sample pair does not match for metric {foo="bar"}: expected timestamp 1 but got 2`,
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected timestamp 1 but got 2
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[2]`,
 		},
 		{
 			name: "difference in histogram sample count",
@@ -219,7 +275,14 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `histogram sample pair does not match for metric {foo="bar"}: expected count 2 for timestamp 1 but got 5`,
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected count 2 for timestamp 1 but got 5
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 5.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]`,
 		},
 		{
 			name: "difference in histogram sample sum",
@@ -251,7 +314,14 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `histogram sample pair does not match for metric {foo="bar"}: expected sum 3 for timestamp 1 but got 5`,
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected sum 3 for timestamp 1 but got 5
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 5.000000, Buckets: [[0,2):2] @[1]`,
 		},
 		{
 			name: "difference in histogram sample buckets length",
@@ -284,7 +354,14 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):2 [2,4):2]`,
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):2 [2,4):2]
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2 [2,4):2] @[1]`,
 		},
 		{
 			name: "difference in histogram sample buckets boundaries",
@@ -316,7 +393,14 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [(0,2):2]`,
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [(0,2):2]
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [(0,2):2] @[1]`,
 		},
 		{
 			name: "difference in histogram sample buckets lower boundary",
@@ -348,7 +432,14 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[1,2):2]`,
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[1,2):2]
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[1,2):2] @[1]`,
 		},
 		{
 			name: "difference in histogram sample buckets upper boundary",
@@ -380,7 +471,14 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,3):2]`,
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,3):2]
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,3):2] @[1]`,
 		},
 		{
 			name: "difference in histogram sample buckets count",
@@ -412,7 +510,14 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):3]`,
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):3]
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):3] @[1]`,
 		},
 		{
 			name: "single actual histogram value matches expected",
@@ -534,7 +639,16 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `histogram sample pair does not match for metric {foo="bar"}: expected sum 5 for timestamp 2 but got 6`,
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected sum 5 for timestamp 2 but got 6
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+Count: 4.000000, Sum: 5.000000, Buckets: [[0,2):4] @[2]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+Count: 4.000000, Sum: 6.000000, Buckets: [[0,2):4] @[2]`,
 		},
 		{
 			name: "actual result has different number of histogram samples to expected result",
@@ -573,7 +687,15 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: `expected 0 float sample(s) and 2 histogram sample(s) for metric {foo="bar"} but got 0 float sample(s) and 1 histogram sample(s)`,
+			err: `expected 0 float sample(s) and 2 histogram sample(s) for metric {foo="bar"} but got 0 float sample(s) and 1 histogram sample(s)
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]
+Count: 4.000000, Sum: 5.000000, Buckets: [[0,2):4] @[2]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -583,7 +705,7 @@ func TestCompareMatrix(t *testing.T) {
 				return
 			}
 			require.Error(t, err)
-			require.ErrorContains(t, err, tc.err)
+			require.EqualError(t, err, tc.err)
 		})
 	}
 }

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -583,7 +583,7 @@ func TestCompareMatrix(t *testing.T) {
 				return
 			}
 			require.Error(t, err)
-			require.EqualError(t, err, tc.err)
+			require.ErrorContains(t, err, tc.err)
 		})
 	}
 }

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -22,7 +22,7 @@ func TestCompareMatrix(t *testing.T) {
 		name     string
 		expected json.RawMessage
 		actual   json.RawMessage
-		err      error
+		err      string
 	}{
 		{
 			name:     "no metrics",
@@ -35,7 +35,7 @@ func TestCompareMatrix(t *testing.T) {
 							{"metric":{"foo":"bar"},"values":[[1,"1"]]}
 						]`),
 			actual: json.RawMessage(`[]`),
-			err:    errors.New("expected 1 metrics but got 0"),
+			err:    "expected 1 metrics but got 0",
 		},
 		{
 			name: "extra metric in actual response",
@@ -46,7 +46,7 @@ func TestCompareMatrix(t *testing.T) {
 							{"metric":{"foo":"bar"},"values":[[1,"1"]]},
 							{"metric":{"foo1":"bar1"},"values":[[1,"1"]]}
 						]`),
-			err: errors.New("expected 1 metrics but got 2"),
+			err: "expected 1 metrics but got 2",
 		},
 		{
 			name: "same number of metrics but with different labels",
@@ -56,7 +56,7 @@ func TestCompareMatrix(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo1":"bar1"},"values":[[1,"1"]]}
 						]`),
-			err: errors.New(`expected metric {foo="bar"} missing from actual response`),
+			err: `expected metric {foo="bar"} missing from actual response`,
 		},
 		{
 			name: "difference in number of float samples",
@@ -66,7 +66,7 @@ func TestCompareMatrix(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"values":[[1,"1"]]}
 						]`),
-			err: errors.New(`expected 2 float sample(s) and 0 histogram sample(s) for metric {foo="bar"} but got 1 float sample(s) and 0 histogram sample(s)`),
+			err: `expected 2 float sample(s) and 0 histogram sample(s) for metric {foo="bar"} but got 1 float sample(s) and 0 histogram sample(s)`,
 		},
 		{
 			name: "difference in float sample timestamp",
@@ -76,7 +76,7 @@ func TestCompareMatrix(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"values":[[1,"1"],[3,"2"]]}
 						]`),
-			err: errors.New(`float sample pair does not match for metric {foo="bar"}: expected timestamp 2 but got 3`),
+			err: `float sample pair does not match for metric {foo="bar"}: expected timestamp 2 but got 3`,
 		},
 		{
 			name: "difference in float sample value",
@@ -86,7 +86,7 @@ func TestCompareMatrix(t *testing.T) {
 			actual: json.RawMessage(`[
 							{"metric":{"foo":"bar"},"values":[[1,"1"],[2,"3"]]}
 						]`),
-			err: errors.New(`float sample pair does not match for metric {foo="bar"}: expected value 2 for timestamp 2 but got 3`),
+			err: `float sample pair does not match for metric {foo="bar"}: expected value 2 for timestamp 2 but got 3`,
 		},
 		{
 			name: "actual float samples match expected",
@@ -107,7 +107,7 @@ func TestCompareMatrix(t *testing.T) {
 							{"metric":{"foo":"bar"},"values":[[1,"1"],[2,"2"]]},
 							{"metric":{"oops":"bar"},"values":[[1,"1"],[2,"3"]]}
 						]`),
-			err: errors.New(`float sample pair does not match for metric {oops="bar"}: expected value 2 for timestamp 2 but got 3`),
+			err: `float sample pair does not match for metric {oops="bar"}: expected value 2 for timestamp 2 but got 3`,
 		},
 		{
 			name: "single expected sample has histogram but actual sample has float value",
@@ -131,7 +131,7 @@ func TestCompareMatrix(t *testing.T) {
 								"values": [[1,"1"]]
 							}
 						]`),
-			err: errors.New(`expected 0 float sample(s) and 1 histogram sample(s) for metric {foo="bar"} but got 1 float sample(s) and 0 histogram sample(s)`),
+			err: `expected 0 float sample(s) and 1 histogram sample(s) for metric {foo="bar"} but got 1 float sample(s) and 0 histogram sample(s)`,
 		},
 		{
 			name: "single expected sample has float value but actual sample has histogram",
@@ -155,7 +155,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`expected 1 float sample(s) and 0 histogram sample(s) for metric {foo="bar"} but got 0 float sample(s) and 1 histogram sample(s)`),
+			err: `expected 1 float sample(s) and 0 histogram sample(s) for metric {foo="bar"} but got 0 float sample(s) and 1 histogram sample(s)`,
 		},
 		{
 			name: "difference in histogram sample timestamp",
@@ -187,7 +187,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected timestamp 1 but got 2`),
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected timestamp 1 but got 2`,
 		},
 		{
 			name: "difference in histogram sample count",
@@ -219,7 +219,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected count 2 for timestamp 1 but got 5`),
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected count 2 for timestamp 1 but got 5`,
 		},
 		{
 			name: "difference in histogram sample sum",
@@ -251,7 +251,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected sum 3 for timestamp 1 but got 5`),
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected sum 3 for timestamp 1 but got 5`,
 		},
 		{
 			name: "difference in histogram sample buckets length",
@@ -284,7 +284,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):2 [2,4):2]`),
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):2 [2,4):2]`,
 		},
 		{
 			name: "difference in histogram sample buckets boundaries",
@@ -316,7 +316,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [(0,2):2]`),
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [(0,2):2]`,
 		},
 		{
 			name: "difference in histogram sample buckets lower boundary",
@@ -348,7 +348,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[1,2):2]`),
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[1,2):2]`,
 		},
 		{
 			name: "difference in histogram sample buckets upper boundary",
@@ -380,7 +380,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,3):2]`),
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,3):2]`,
 		},
 		{
 			name: "difference in histogram sample buckets count",
@@ -412,7 +412,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):3]`),
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected buckets [[0,2):2] for timestamp 1 but got [[0,2):3]`,
 		},
 		{
 			name: "single actual histogram value matches expected",
@@ -534,7 +534,7 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected sum 5 for timestamp 2 but got 6`),
+			err: `histogram sample pair does not match for metric {foo="bar"}: expected sum 5 for timestamp 2 but got 6`,
 		},
 		{
 			name: "actual result has different number of histogram samples to expected result",
@@ -573,17 +573,17 @@ func TestCompareMatrix(t *testing.T) {
 								]
 							}
 						]`),
-			err: errors.New(`expected 0 float sample(s) and 2 histogram sample(s) for metric {foo="bar"} but got 0 float sample(s) and 1 histogram sample(s)`),
+			err: `expected 0 float sample(s) and 2 histogram sample(s) for metric {foo="bar"} but got 0 float sample(s) and 1 histogram sample(s)`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := compareMatrix(tc.expected, tc.actual, SampleComparisonOptions{})
-			if tc.err == nil {
+			if tc.err == "" {
 				require.NoError(t, err)
 				return
 			}
 			require.Error(t, err)
-			require.Equal(t, tc.err.Error(), err.Error())
+			require.EqualError(t, err, tc.err)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR adds more information to the error messages produced by query-tee when comparing series from a matrix. 

Specifically, it will now include all samples for a series when a mismatch occurs.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
