### PR TITLE
Dashboards: add Kafka end-to-end latency outliers panel in the "Mimir / Writes" dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 * [ENHANCEMENT] Dashboards: added "Kafka produced records / sec" panel to "Mimir / Writes" dashboard. #8763
 * [ENHANCEMENT] Alerts: added `MimirStrongConsistencyOffsetNotPropagatedToIngesters` alert, and rename `MimirIngesterFailsEnforceStrongConsistencyOnReadPath` alert to `MimirStrongConsistencyEnforcementFailed`. #8831
 * [ENHANCEMENT] Dashboards: remove "All" option for namespace dropdown in dashboards. #8829
+* [ENHANCEMENT] Dashboards: add Kafka end-to-end latency outliers panel in the "Mimir / Writes" dashboard. #8948
 * [BUGFIX] Dashboards: fix "current replicas" in autoscaling panels when HPA is not active. #8566
 * [BUGFIX] Alerts: do not fire `MimirRingMembersMismatch` during the migration to experimental ingest storage. #8727
 

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -1732,9 +1732,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ],
 
   ingestStorageIngesterEndToEndLatencyWhenStartingPanel()::
-    $.timeseriesPanel('Kafka record end-to-end latency when starting') +
+    $.timeseriesPanel('Kafka end-to-end latency when starting') +
     $.panelDescription(
-      'Kafka record end-to-end latency when starting',
+      'Kafka end-to-end latency when starting',
       |||
         Time between writing request by distributor to Kafka and reading the record by ingester during catch-up phase, when ingesters are starting.
         If ingesters are not starting and catching up in the selected time range, this panel will be empty.
@@ -1760,9 +1760,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
     },
 
   ingestStorageIngesterEndToEndLatencyWhenRunningPanel()::
-    $.timeseriesPanel('Kafka record end-to-end latency when ingesters are running') +
+    $.timeseriesPanel('Kafka end-to-end latency when ingesters are running') +
     $.panelDescription(
-      'Kafka record end-to-end latency when ingesters are running',
+      'Kafka end-to-end latency when ingesters are running',
       |||
         Time between writing request by distributor to Kafka and reading the record by ingester, when ingesters are running.
       |||
@@ -1780,6 +1780,41 @@ local utils = import 'mixin-utils/utils.libsonnet';
         '99.9th percentile',
         '100th percentile',
       ],
+    ) + {
+      fieldConfig+: {
+        defaults+: { unit: 's' },
+      },
+    },
+
+  ingestStorageIngesterEndToEndLatencyOutliersWhenRunningPanel()::
+    $.timeseriesPanel('Kafka 100th percentile end-to-end latency when ingesters are running (outliers)') +
+    $.panelDescription(
+      'Kafka 100th percentile end-to-end latency when ingesters are running (outliers only)',
+      |||
+        The 100th percentile of the time between writing request by distributor to Kafka and reading the record by ingester,
+        when ingesters are running. This panel only shows ingester outliers, to easily spot if the high end-to-end latency
+        may be caused by few ingesters.
+      |||
+    ) +
+    $.hiddenLegendQueryPanel(
+      |||
+        histogram_quantile(1.0, sum by(pod) (rate(cortex_ingest_storage_reader_receive_delay_seconds{%(job_matcher)s, phase="running"}[$__rate_interval])))
+
+        # Add a filter to show only the outliers. We consider an ingester an outlier if its
+        # 100th percentile latency is greater than the 200%% of the average 100th of the 10
+        # worst ingesters (if there are less than 10 ingesters, then all ingesters will be took
+        # in account).
+        > scalar(
+          avg(
+            topk(10,
+                histogram_quantile(1.0, sum by(pod) (rate(cortex_ingest_storage_reader_receive_delay_seconds{%(job_matcher)s, phase="running"}[$__rate_interval])))
+                > 0
+            )
+          )
+          * 2
+        )
+      ||| % { job_matcher: $.jobMatcher($._config.job_names.ingester) },
+      '{{pod}}',
     ) + {
       fieldConfig+: {
         defaults+: { unit: 's' },

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -297,6 +297,8 @@ local filename = 'mimir-writes.json';
       $.row('Ingester – end-to-end latency (ingest storage)')
       .addPanel(
         $.ingestStorageIngesterEndToEndLatencyWhenRunningPanel(),
+      ).addPanel(
+        $.ingestStorageIngesterEndToEndLatencyOutliersWhenRunningPanel(),
       )
       .addPanel(
         $.ingestStorageIngesterEndToEndLatencyWhenStartingPanel(),


### PR DESCRIPTION
#### What this PR does

Yesterday I spent few hours investigating high end-to-end latency in a dev cell and it took me a while to figure out that the high reported latency was actually caused by 1 outlier ingester. In this PR I propose to add a panel to show outliers. It's not perfect, but it gives an hint. I also tried to compute outliers using a more complex approach (using stddev and z-score but I couldn't get better results, so I'm proposing the simple approach).

![Screenshot 2024-08-09 at 12 50 58](https://github.com/user-attachments/assets/0fa11753-259c-4c3a-be25-14ad25a50294)


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
