### PR TITLE
Add session_token to s3 config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
     * `cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total`
     * `cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total`
     * `cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total`
+* [ENHANCEMENT] Expose a new `s3.session-token` configuration option to enable using temporary security credentials. #8952
 * [BUGFIX] Ruler: add support for draining any outstanding alert notifications before shutting down. This can be enabled with the `-ruler.drain-notification-queue-on-shutdown=true` CLI flag. #8346
 * [BUGFIX] Query-frontend: fix `-querier.max-query-lookback` enforcement when `-compactor.blocks-retention-period` is not set, and viceversa. #8388
 * [BUGFIX] Ingester: fix sporadic `not found` error causing an internal server error if label names are queried with matchers during head compaction. #8391

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -6695,6 +6695,16 @@
             },
             {
               "kind": "field",
+              "name": "session_token",
+              "required": false,
+              "desc": "S3 session token",
+              "fieldValue": null,
+              "fieldDefaultValue": "",
+              "fieldFlag": "blocks-storage.s3.session-token",
+              "fieldType": "string"
+            },
+            {
+              "kind": "field",
               "name": "insecure",
               "required": false,
               "desc": "If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.",
@@ -12689,6 +12699,16 @@
             },
             {
               "kind": "field",
+              "name": "session_token",
+              "required": false,
+              "desc": "S3 session token",
+              "fieldValue": null,
+              "fieldDefaultValue": "",
+              "fieldFlag": "ruler-storage.s3.session-token",
+              "fieldType": "string"
+            },
+            {
+              "kind": "field",
               "name": "insecure",
               "required": false,
               "desc": "If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.",
@@ -14846,6 +14866,16 @@
               "fieldValue": null,
               "fieldDefaultValue": "",
               "fieldFlag": "alertmanager-storage.s3.access-key-id",
+              "fieldType": "string"
+            },
+            {
+              "kind": "field",
+              "name": "session_token",
+              "required": false,
+              "desc": "S3 session token",
+              "fieldValue": null,
+              "fieldDefaultValue": "",
+              "fieldFlag": "alertmanager-storage.s3.session-token",
               "fieldType": "string"
             },
             {
@@ -17262,6 +17292,16 @@
                   "fieldValue": null,
                   "fieldDefaultValue": "",
                   "fieldFlag": "common.storage.s3.access-key-id",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "session_token",
+                  "required": false,
+                  "desc": "S3 session token",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "common.storage.s3.session-token",
                   "fieldType": "string"
                 },
                 {

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -73,6 +73,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -alertmanager-storage.s3.send-content-md5
     	[experimental] If enabled, a Content-MD5 header is sent with S3 Put Object requests. Consumes more resources to compute the MD5, but may improve compatibility with object storage services that do not support checksums.
+  -alertmanager-storage.s3.session-token string
+    	S3 session token
   -alertmanager-storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
   -alertmanager-storage.s3.sse.kms-encryption-context string
@@ -733,6 +735,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -blocks-storage.s3.send-content-md5
     	[experimental] If enabled, a Content-MD5 header is sent with S3 Put Object requests. Consumes more resources to compute the MD5, but may improve compatibility with object storage services that do not support checksums.
+  -blocks-storage.s3.session-token string
+    	S3 session token
   -blocks-storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
   -blocks-storage.s3.sse.kms-encryption-context string
@@ -915,6 +919,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -common.storage.s3.send-content-md5
     	[experimental] If enabled, a Content-MD5 header is sent with S3 Put Object requests. Consumes more resources to compute the MD5, but may improve compatibility with object storage services that do not support checksums.
+  -common.storage.s3.session-token string
+    	S3 session token
   -common.storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
   -common.storage.s3.sse.kms-encryption-context string
@@ -2483,6 +2489,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 secret access key
   -ruler-storage.s3.send-content-md5
     	[experimental] If enabled, a Content-MD5 header is sent with S3 Put Object requests. Consumes more resources to compute the MD5, but may improve compatibility with object storage services that do not support checksums.
+  -ruler-storage.s3.session-token string
+    	S3 session token
   -ruler-storage.s3.signature-version string
     	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
   -ruler-storage.s3.sse.kms-encryption-context string

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -31,6 +31,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -alertmanager-storage.s3.secret-access-key string
     	S3 secret access key
+  -alertmanager-storage.s3.session-token string
+    	S3 session token
   -alertmanager-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -alertmanager-storage.s3.sse.kms-key-id string
@@ -195,6 +197,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -blocks-storage.s3.secret-access-key string
     	S3 secret access key
+  -blocks-storage.s3.session-token string
+    	S3 session token
   -blocks-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -blocks-storage.s3.sse.kms-key-id string
@@ -267,6 +271,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -common.storage.s3.secret-access-key string
     	S3 secret access key
+  -common.storage.s3.session-token string
+    	S3 session token
   -common.storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -common.storage.s3.sse.kms-key-id string
@@ -647,6 +653,8 @@ Usage of ./cmd/mimir/mimir:
     	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
   -ruler-storage.s3.secret-access-key string
     	S3 secret access key
+  -ruler-storage.s3.session-token string
+    	S3 session token
   -ruler-storage.s3.sse.kms-encryption-context string
     	KMS Encryption Context used for object encryption. It expects JSON formatted string.
   -ruler-storage.s3.sse.kms-key-id string

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4998,6 +4998,10 @@ The s3_backend block configures the connection to Amazon S3 object storage backe
 # CLI flag: -<prefix>.s3.access-key-id
 [access_key_id: <string> | default = ""]
 
+# S3 session token
+# CLI flag: -<prefix>.s3.session-token
+[session_token: <string> | default = ""]
+
 # (advanced) If enabled, use http:// for the S3 endpoint instead of https://.
 # This could be useful in local dev/test environments while using an
 # S3-compatible backend storage, like Minio.

--- a/pkg/storage/bucket/client_test.go
+++ b/pkg/storage/bucket/client_test.go
@@ -31,6 +31,7 @@ s3:
   bucket_name:       test
   access_key_id:     xxx
   secret_access_key: yyy
+  session_token:     zzz
   insecure:          true
 `
 

--- a/pkg/storage/bucket/s3/bucket_client.go
+++ b/pkg/storage/bucket/s3/bucket_client.go
@@ -56,6 +56,7 @@ func newS3Config(cfg Config) (s3.Config, error) {
 		Region:             cfg.Region,
 		AccessKey:          cfg.AccessKeyID,
 		SecretKey:          cfg.SecretAccessKey.String(),
+		SessionToken:       cfg.SessionToken.String(),
 		Insecure:           cfg.Insecure,
 		PutUserMetadata:    putUserMetadata,
 		SendContentMd5:     cfg.SendContentMd5,

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -118,6 +118,7 @@ type Config struct {
 	BucketName           string              `yaml:"bucket_name"`
 	SecretAccessKey      flagext.Secret      `yaml:"secret_access_key"`
 	AccessKeyID          string              `yaml:"access_key_id"`
+	SessionToken         flagext.Secret      `yaml:"session_token"`
 	Insecure             bool                `yaml:"insecure" category:"advanced"`
 	SignatureVersion     string              `yaml:"signature_version" category:"advanced"`
 	ListObjectsVersion   string              `yaml:"list_objects_version" category:"advanced"`
@@ -143,6 +144,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.AccessKeyID, prefix+"s3.access-key-id", "", "S3 access key ID")
 	f.Var(&cfg.SecretAccessKey, prefix+"s3.secret-access-key", "S3 secret access key")
+	f.Var(&cfg.SessionToken, prefix+"s3.session-token", "S3 session token")
 	f.StringVar(&cfg.BucketName, prefix+"s3.bucket-name", "", "S3 bucket name")
 	f.StringVar(&cfg.Region, prefix+"s3.region", "", "S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.")
 	f.StringVar(&cfg.Endpoint, prefix+"s3.endpoint", "", "The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.")

--- a/pkg/storage/bucket/s3/config_test.go
+++ b/pkg/storage/bucket/s3/config_test.go
@@ -6,6 +6,7 @@
 package s3
 
 import (
+	"bytes"
 	"encoding/base64"
 	"net/http"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestSSEConfig_Validate(t *testing.T) {
@@ -209,4 +211,34 @@ func TestParseKMSEncryptionContext(t *testing.T) {
 	actual, err = parseKMSEncryptionContext(`{"department": "10103.0"}`)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
+}
+
+func TestConfigParsesCredentialsInlineWithSessionToken(t *testing.T) {
+	var cfg = Config{}
+	yamlCfg := `
+access_key_id: access key id
+secret_access_key: secret access key
+session_token: session token
+`
+	err := yaml.Unmarshal([]byte(yamlCfg), &cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, cfg.AccessKeyID, "access key id")
+	require.Equal(t, cfg.SecretAccessKey.String(), "secret access key")
+	require.Equal(t, cfg.SessionToken.String(), "session token")
+}
+
+func TestConfigRedactsCredentials(t *testing.T) {
+	cfg := Config{
+		AccessKeyID:     "access key id",
+		SecretAccessKey: flagext.SecretWithValue("secret access key"),
+		SessionToken:    flagext.SecretWithValue("session token"),
+	}
+
+	output, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+
+	require.True(t, bytes.Contains(output, []byte("access key id")))
+	require.False(t, bytes.Contains(output, []byte("secret access id")))
+	require.False(t, bytes.Contains(output, []byte("session token")))
 }


### PR DESCRIPTION
#### What this PR does
This PR exposes a new `s3.session-token` configuration option to enable using temporary security credentials.

#### Which issue(s) this PR fixes or relates to

Fixes #8832

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
