### PR TITLE
Mimir query engine: improve performance of `TestBothEnginesReturnSameResultsForBenchmarkQueries` and `TestBenchmarkSetup`

### DIFF
--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -127,7 +127,7 @@ func TestBenchmarkSetup(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := user.InjectOrgID(context.Background(), UserID)
-	query, err := mimirEngine.NewRangeQuery(ctx, q, nil, "a_1", time.Unix(0, 0), time.Unix(int64(15*intervalSeconds), 0), interval)
+	query, err := mimirEngine.NewRangeQuery(ctx, q, nil, "a_1", time.Unix(0, 0), time.Unix(int64((NumIntervals-1)*intervalSeconds), 0), interval)
 	require.NoError(t, err)
 
 	t.Cleanup(query.Close)
@@ -143,23 +143,11 @@ func TestBenchmarkSetup(t *testing.T) {
 	require.Len(t, series.Histograms, 0)
 
 	intervalMilliseconds := interval.Milliseconds()
-	expectedPoints := []promql.FPoint{
-		{T: 0, F: 0},
-		{T: 1 * intervalMilliseconds, F: 1},
-		{T: 2 * intervalMilliseconds, F: 2},
-		{T: 3 * intervalMilliseconds, F: 3},
-		{T: 4 * intervalMilliseconds, F: 4},
-		{T: 5 * intervalMilliseconds, F: 5},
-		{T: 6 * intervalMilliseconds, F: 6},
-		{T: 7 * intervalMilliseconds, F: 7},
-		{T: 8 * intervalMilliseconds, F: 8},
-		{T: 9 * intervalMilliseconds, F: 9},
-		{T: 10 * intervalMilliseconds, F: 10},
-		{T: 11 * intervalMilliseconds, F: 11},
-		{T: 12 * intervalMilliseconds, F: 12},
-		{T: 13 * intervalMilliseconds, F: 13},
-		{T: 14 * intervalMilliseconds, F: 14},
-		{T: 15 * intervalMilliseconds, F: 15},
+	expectedPoints := make([]promql.FPoint, NumIntervals)
+
+	for i := range expectedPoints {
+		expectedPoints[i].T = int64(i) * intervalMilliseconds
+		expectedPoints[i].F = float64(i)
 	}
 
 	require.Equal(t, expectedPoints, series.Floats)

--- a/pkg/streamingpromql/benchmarks/ingester.go
+++ b/pkg/streamingpromql/benchmarks/ingester.go
@@ -224,16 +224,22 @@ func pushTestData(ing *ingester.Ingester, metricSizes []int) error {
 			end = NumIntervals
 		}
 
+		sampleCount := end - start
+
 		req := &mimirpb.WriteRequest{
 			Timeseries: make([]mimirpb.PreallocTimeseries, len(metrics)),
 		}
 
 		for metricIdx, m := range metrics {
+			series := mimirpb.PreallocTimeseries{TimeSeries: mimirpb.TimeseriesFromPool()}
+			series.Labels = mimirpb.FromLabelsToLabelAdapters(m.Copy())
+
 			if strings.HasPrefix(m.Get("__name__"), "nh_") {
-				series := mimirpb.PreallocTimeseries{TimeSeries: &mimirpb.TimeSeries{
-					Labels:     mimirpb.FromLabelsToLabelAdapters(m.Copy()),
-					Histograms: make([]mimirpb.Histogram, end-start),
-				}}
+				if cap(series.Histograms) < sampleCount {
+					series.Histograms = make([]mimirpb.Histogram, sampleCount)
+				}
+
+				series.Histograms = series.Histograms[:sampleCount]
 
 				for ts := start; ts < end; ts++ {
 					// TODO(jhesketh): Fix this with some better data
@@ -248,21 +254,20 @@ func pushTestData(ing *ingester.Ingester, metricSizes []int) error {
 					series.Histograms[ts-start].PositiveSpans = histogramSpans
 					series.Histograms[ts-start].PositiveDeltas = histogramDeltas
 				}
-
-				req.Timeseries[metricIdx] = series
 			} else {
-				series := mimirpb.PreallocTimeseries{TimeSeries: &mimirpb.TimeSeries{
-					Labels:  mimirpb.FromLabelsToLabelAdapters(m.Copy()),
-					Samples: make([]mimirpb.Sample, end-start),
-				}}
+				if cap(series.Samples) < sampleCount {
+					series.Samples = make([]mimirpb.Sample, sampleCount)
+				}
+
+				series.Samples = series.Samples[:sampleCount]
 
 				for ts := start; ts < end; ts++ {
 					series.Samples[ts-start].TimestampMs = int64(ts) * interval.Milliseconds()
 					series.Samples[ts-start].Value = float64(ts) + float64(metricIdx)/float64(len(metrics))
 				}
-
-				req.Timeseries[metricIdx] = series
 			}
+
+			req.Timeseries[metricIdx] = series
 		}
 		if _, err := ing.Push(ctx, req); err != nil {
 			return fmt.Errorf("failed to push samples to ingester: %w", err)

--- a/pkg/streamingpromql/benchmarks/ingester.go
+++ b/pkg/streamingpromql/benchmarks/ingester.go
@@ -211,10 +211,9 @@ func pushTestData(ing *ingester.Ingester, metricSizes []int) error {
 	ctx := user.InjectOrgID(context.Background(), UserID)
 
 	// Batch samples into separate requests
-	// There is no precise science behind this number currently.
-	// A quick run locally found batching by 100 did not increase the loading time by any noticeable amount.
-	// Additionally memory usage maxed about 4GB for the whole process.
-	batchSize := 100
+	// There is no precise science behind this number: based on a few experiments,
+	// batching by 1000 gives a good balance between peak memory consumption and run time.
+	batchSize := 1000
 	histogramSpans := []mimirpb.BucketSpan{{Offset: 0, Length: 2}, {Offset: 1, Length: 2}}
 	histogramDeltas := []int64{1, 1, -1, 0}
 
@@ -272,9 +271,9 @@ func pushTestData(ing *ingester.Ingester, metricSizes []int) error {
 		if _, err := ing.Push(ctx, req); err != nil {
 			return fmt.Errorf("failed to push samples to ingester: %w", err)
 		}
-	}
 
-	ing.Flush()
+		ing.Flush()
+	}
 
 	return nil
 }

--- a/pkg/streamingpromql/benchmarks/ingester.go
+++ b/pkg/streamingpromql/benchmarks/ingester.go
@@ -267,8 +267,9 @@ func pushTestData(ing *ingester.Ingester, metricSizes []int) error {
 		if _, err := ing.Push(ctx, req); err != nil {
 			return fmt.Errorf("failed to push samples to ingester: %w", err)
 		}
-		ing.Flush()
 	}
+
+	ing.Flush()
 
 	return nil
 }


### PR DESCRIPTION
#### What this PR does

This PR improves the performance of two MQE tests, `TestBothEnginesReturnSameResultsForBenchmarkQueries` and `TestBenchmarkSetup`.

It does this by only flushing the ingester used during these tests once, rather than after loading each batch of data.

On my machine, this cuts ~30s off the time taken to run each of these tests:
* `TestBothEnginesReturnSameResultsForBenchmarkQueries`: was 50.1, now 20.2s
* `TestBenchmarkSetup`: was 36.1s, now 6.0s

This does not have a dramatic effect on the performance of setting up the test data used during benchmarks, as this is dominated by the time taken to ingest the data.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
