### PR TITLE
kafka replay speed: Improve fetch request size byte estimations

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -744,12 +744,60 @@ func (r *PartitionReader) pollFetches(ctx context.Context) (result kgo.Fetches) 
 	return f
 }
 
+// fetchWant is a range of offsets we want to fetch.
+// It knows how many records it needs to fetch and roughly how many bytes they will be.
+// It's also used to communicate the result of fetching the fetchWant.
 type fetchWant struct {
-	startOffset int64 // inclusive
-	endOffset   int64 // exclusive
+	startOffset    int64 // inclusive
+	endOffset      int64 // exclusive
+	bytesPerRecord int
+
 	// result should be closed when there are no more fetches for this partition. It is ok to send multiple times on the channel.
-	result   chan fetchResult
-	maxBytes int32
+	result chan fetchResult
+}
+
+// next returns the fetchWant for the next numRecords starting from endOffset.
+func (w fetchWant) next(numRecords int) fetchWant {
+	n := fetchWantFrom(w.endOffset, numRecords)
+	n.bytesPerRecord = w.bytesPerRecord
+	return n.trimIfTooBig()
+}
+
+func fetchWantFrom(offset int64, recordsPerFetch int) fetchWant {
+	return fetchWant{
+		startOffset: offset,
+		endOffset:   offset + int64(recordsPerFetch),
+		result:      make(chan fetchResult, 1), // buffer of 1 so we can do secondary attempt requests in the background
+	}
+}
+
+func (w fetchWant) expectedBytes() int {
+	// We over-fetch bytes to reduce the likelihood of under-fetching and having to run another request.
+	// Based on some testing 65% of under-estimations are by less than 5%. So we account for that.
+	const overFetchBytesFactor = 1.05
+	return int(overFetchBytesFactor * float64(w.bytesPerRecord*int(w.endOffset-w.startOffset)))
+}
+
+func (w fetchWant) maxBytes() int32 {
+	fetchBytes := w.expectedBytes()
+	if fetchBytes > math.MaxInt32 {
+		// This shouldn't happen because w should have been trimmed before sending the request.
+		// But we definitely don't want to request negative bytes by casting to int32, so add this safeguard.
+		return math.MaxInt32
+	}
+	fetchBytes = max(1_000_000, fetchBytes) // when we're fetching few records, we can afford to over-fetch to avoid more requests.
+	return int32(fetchBytes)
+}
+
+// trimIfTooBig returns the same fetchWant, but with potentially lower endOffset if the total size of records exceeds 4GiB.
+func (w fetchWant) trimIfTooBig() fetchWant {
+	if w.expectedBytes() <= math.MaxInt32 {
+		return w
+	}
+	// We are overflowing, so we need to trim the end offset.
+	// We do this by calculating how many records we can fetch with the max bytes, and then setting the end offset to that.
+	w.endOffset = w.startOffset + int64(math.MaxInt32/w.bytesPerRecord)
+	return w
 }
 
 type fetchResult struct {
@@ -844,6 +892,10 @@ func (r *concurrentFetchers) pollFetches(ctx context.Context) (result kgo.Fetche
 
 func (r *concurrentFetchers) fetchSingle(ctx context.Context, w fetchWant, _ log.Logger) (_ kgo.FetchPartition, fetchedBytes int) {
 	req := kmsg.NewFetchRequest()
+	req.MinBytes = 1
+	req.Version = 13
+	req.MaxWaitMillis = 10000
+	req.MaxBytes = w.maxBytes()
 	req.Topics = []kmsg.FetchRequestTopic{{
 		Topic:   r.topicName,
 		TopicID: r.topicID,
@@ -853,14 +905,9 @@ func (r *concurrentFetchers) fetchSingle(ctx context.Context, w fetchWant, _ log
 			LastFetchedEpoch:   -1,
 			CurrentLeaderEpoch: -1,
 			LogStartOffset:     -1,
-			PartitionMaxBytes:  w.maxBytes,
+			PartitionMaxBytes:  req.MaxBytes,
 		}},
 	}}
-	req.MinBytes = 1
-	req.Version = 13
-	req.MaxWaitMillis = 10000
-	req.MaxBytes = w.maxBytes
-	req.SessionEpoch = -1
 
 	resp, err := req.RequestWith(ctx, r.client)
 	if err != nil {
@@ -964,8 +1011,6 @@ func (r *concurrentFetchers) runFetchers(ctx context.Context, startOffset int64)
 						"remaining_records", w.endOffset-lastOffset,
 					)
 					w.startOffset = lastOffset + 1
-					bytesPerRecord := fetchedBytes / len(f.Records)
-					w.maxBytes = max(1_000_000, int32(float64(bytesPerRecord))*int32(w.endOffset-w.startOffset)) // when we have only a few records to fetch we can afford to overfetch in order to not do more requests.
 
 					select {
 					case w.result <- fetchResult{FetchPartition: f, fetchedBytes: fetchedBytes}:
@@ -978,14 +1023,15 @@ func (r *concurrentFetchers) runFetchers(ctx context.Context, startOffset int64)
 	}
 
 	var (
-		bytesPerRecord = 10_000 // start with an estimation, we will update it as we consume
-		nextFetch      = fetchWantFrom(bytesPerRecord, startOffset, r.recordsPerFetch)
+		nextFetch      = fetchWantFrom(startOffset, r.recordsPerFetch)
 		nextResult     chan fetchResult
 		pendingResults = list.New()
 
 		bufferedResult       fetchResult
 		readyBufferedResults chan kgo.FetchPartition // this is non-nil when bufferedResult is non-empty
 	)
+	nextFetch.bytesPerRecord = 10_000 // start with an estimation, we will update it as we consume
+
 	for {
 		refillBufferedResult := nextResult
 		if len(bufferedResult.Records) > 0 {
@@ -1004,7 +1050,7 @@ func (r *concurrentFetchers) runFetchers(ctx context.Context, startOffset int64)
 				nextResult = pendingResults.Front().Value.(chan fetchResult)
 				pendingResults.Remove(pendingResults.Front())
 			}
-			nextFetch = nextFetchWant(bytesPerRecord, nextFetch, r.recordsPerFetch)
+			nextFetch = nextFetch.next(r.recordsPerFetch)
 
 		case result, moreLeft := <-refillBufferedResult:
 			if !moreLeft {
@@ -1016,7 +1062,8 @@ func (r *concurrentFetchers) runFetchers(ctx context.Context, startOffset int64)
 				}
 				continue
 			}
-			bytesPerRecord = estimateBytesPerRecord(bytesPerRecord, result.fetchedBytes, len(result.Records))
+			nextFetch.bytesPerRecord = estimateBytesPerRecord(nextFetch.bytesPerRecord, result.fetchedBytes, len(result.Records))
+			nextFetch = nextFetch.trimIfTooBig()
 			bufferedResult = result
 			readyBufferedResults = r.orderedFetches
 
@@ -1027,25 +1074,17 @@ func (r *concurrentFetchers) runFetchers(ctx context.Context, startOffset int64)
 	}
 }
 
-func estimateBytesPerRecord(currentBytesPerRecord, recordsSizeBytes, numRecords int) int {
-	const currentFetchFactor = 0.8
+func estimateBytesPerRecord(currentBytesPerRecord int, recordsSizeBytes, numRecords int) int {
+	// Smooth over the estimation to avoid having outlier fetches from throwing off the estimation.
+	// We don't want a fetch of 5 records to determine how we fetch the next fetch of 6000 records.
+	// Ideally we weigh the estimation on the number of records observed, but it's simpler to smooth it over with a constant factor.
+	const currentEstimateWeight = 0.8
+
+	actualBytesPerRecord := float64(recordsSizeBytes) / float64(numRecords)
 	return int(
-		(1-currentFetchFactor)*float64(currentBytesPerRecord) +
-			currentFetchFactor*float64(recordsSizeBytes/numRecords),
+		currentEstimateWeight*float64(currentBytesPerRecord) +
+			(1-currentEstimateWeight)*actualBytesPerRecord,
 	)
-}
-
-func nextFetchWant(bytesPerRecord int, fetch fetchWant, recordsPerFetch int) fetchWant {
-	return fetchWantFrom(bytesPerRecord, fetch.endOffset, recordsPerFetch)
-}
-
-func fetchWantFrom(bytesPerRecord int, offset int64, recordsPerFetch int) fetchWant {
-	return fetchWant{
-		startOffset: offset,
-		endOffset:   offset + int64(recordsPerFetch),
-		result:      make(chan fetchResult, 1), // buffer of 1 to reduce impact of refetches
-		maxBytes:    int32(recordsPerFetch * bytesPerRecord),
-	}
 }
 
 type readerFrom interface {


### PR DESCRIPTION
#### What this PR does

Improve maxBytes estimations - now we make sure to not overflow int32 (it happened during testing) and generally keep the logic closer together in `fetchWant`.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
