### PR TITLE
change the pod anti affinity when setting zone aware replication

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -47,7 +47,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Add missing container security context to run `continuous-test` under the restricted security policy. #8653
 * [BUGFIX] Add `global.extraVolumeMounts` to the exporter container on memcached statefulsets #8787
 * [BUGFIX] Fix helm releases failing when `querier.kedaAutoscaling.predictiveScalingEnabled=true`. #8731
-* [BUGFIX] change the pod anti affinity when setting zone aware replication. #8955
+* [BUGFIX] change the pod anti affinity when setting zone aware replication. #8972
 
 ## 5.4.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -47,6 +47,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Add missing container security context to run `continuous-test` under the restricted security policy. #8653
 * [BUGFIX] Add `global.extraVolumeMounts` to the exporter container on memcached statefulsets #8787
 * [BUGFIX] Fix helm releases failing when `querier.kedaAutoscaling.predictiveScalingEnabled=true`. #8731
+* [BUGFIX] change the pod anti affinity when setting zone aware replication. #8955
 
 ## 5.4.0
 

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -607,7 +607,7 @@ podAntiAffinity:
             values:
               - {{ .component }}
           - key: zone
-            operator: NotIn
+            operator: In
             values:
               - {{ .rolloutZoneName }}
       topologyKey: {{ .topologyKey | quote }}

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -72,7 +72,7 @@ spec:
                 values:
                 - ingester
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-a
             topologyKey: kubernetes.io/hostname
@@ -221,7 +221,7 @@ spec:
                 values:
                 - ingester
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-b
             topologyKey: kubernetes.io/hostname
@@ -370,7 +370,7 @@ spec:
                 values:
                 - ingester
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-c
             topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -72,7 +72,7 @@ spec:
                 values:
                 - store-gateway
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-a
             topologyKey: kubernetes.io/hostname
@@ -225,7 +225,7 @@ spec:
                 values:
                 - store-gateway
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-b
             topologyKey: kubernetes.io/hostname
@@ -378,7 +378,7 @@ spec:
                 values:
                 - store-gateway
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-c
             topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -72,7 +72,7 @@ spec:
                 values:
                 - ingester
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-a
             topologyKey: kubernetes.io/hostname
@@ -221,7 +221,7 @@ spec:
                 values:
                 - ingester
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-b
             topologyKey: kubernetes.io/hostname
@@ -370,7 +370,7 @@ spec:
                 values:
                 - ingester
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-c
             topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -72,7 +72,7 @@ spec:
                 values:
                 - store-gateway
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-a
             topologyKey: kubernetes.io/hostname
@@ -225,7 +225,7 @@ spec:
                 values:
                 - store-gateway
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-b
             topologyKey: kubernetes.io/hostname
@@ -378,7 +378,7 @@ spec:
                 values:
                 - store-gateway
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-c
             topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
                 values:
                 - alertmanager
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-a
             topologyKey: kubernetes.io/hostname
@@ -219,7 +219,7 @@ spec:
                 values:
                 - alertmanager
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-b
             topologyKey: kubernetes.io/hostname
@@ -369,7 +369,7 @@ spec:
                 values:
                 - alertmanager
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-c
             topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
                 values:
                 - ingester
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-a
             topologyKey: kubernetes.io/hostname
@@ -237,7 +237,7 @@ spec:
                 values:
                 - ingester
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-b
             topologyKey: kubernetes.io/hostname
@@ -393,7 +393,7 @@ spec:
                 values:
                 - ingester
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-c
             topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
                 values:
                 - store-gateway
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-a
             topologyKey: kubernetes.io/hostname
@@ -227,7 +227,7 @@ spec:
                 values:
                 - store-gateway
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-b
             topologyKey: kubernetes.io/hostname
@@ -380,7 +380,7 @@ spec:
                 values:
                 - store-gateway
               - key: zone
-                operator: NotIn
+                operator: In
                 values:
                 - zone-c
             topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
this PR changes the second element of the zone aware replication pod anti affinity map from using the NotIn operator to In operator, the reason is that this causes it to sometimes pod the same ingester pod on the same node in the same zone 
#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
