### PR TITLE
 blockbuilder: consume from lookback when partition doesn't have commit

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -176,11 +176,6 @@ func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 	return nil
 }
 
-const (
-	// kafkaOffsetStart is a special offset value that means the beginning of the partition.
-	kafkaOffsetStart = int64(-2)
-)
-
 func (b *BlockBuilder) findOffsetsToStartAt(ctx context.Context, metrics *kprom.Metrics) (map[int32]kgo.Offset, int64, error) {
 	// We use an ephemeral client to fetch the offset and then create a new client with this offset.
 	// The reason for this is that changing the offset of an existing client requires to have used this client for fetching at least once.

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -131,6 +131,9 @@ func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 		return fmt.Errorf("creating tsdb dir: %w", err)
 	}
 
+	// TODO: add a test to test the case where the consumption on startup happens
+	// after the LookbackOnNoCommit with records before the after the consumption
+	// start point.
 	startAtOffsets, fallbackOffset, err := b.findOffsetsToStartAt(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("find offsets to start at: %w", err)

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -40,8 +41,12 @@ type BlockBuilder struct {
 	register    prometheus.Registerer
 	limits      *validation.Overrides
 	kafkaClient *kgo.Client
-	parts       []int32
 	bucket      objstore.Bucket
+
+	parts []int32
+	// fallbackOffset is the low watermark from where a partition which doesn't have a commit will be consumed.
+	// TODO(v): to support for setting it to kafkaStartOffset we need to rework how a lagging cycle is chopped into time frames.
+	fallbackOffset int64
 
 	metrics blockBuilderMetrics
 
@@ -125,10 +130,12 @@ func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 		return fmt.Errorf("creating tsdb dir: %w", err)
 	}
 
-	startAtOffsets, err := b.findOffsetsToStartAt(ctx, nil)
+	startAtOffsets, fallbackOffset, err := b.findOffsetsToStartAt(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("find offsets to start at: %w", err)
 	}
+	b.fallbackOffset = fallbackOffset
+
 	opts := []kgo.Opt{
 		kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{
 			b.cfg.Kafka.Topic: startAtOffsets,
@@ -172,22 +179,29 @@ func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 const (
 	// kafkaOffsetStart is a special offset value that means the beginning of the partition.
 	kafkaOffsetStart = int64(-2)
-
-	// kafkaOffsetEnd is a special offset value that means the end of the partition.
-	//kafkaOffsetEnd = int64(-1)
 )
 
-func (b *BlockBuilder) findOffsetsToStartAt(ctx context.Context, metrics *kprom.Metrics) (map[int32]kgo.Offset, error) {
+func (b *BlockBuilder) findOffsetsToStartAt(ctx context.Context, metrics *kprom.Metrics) (map[int32]kgo.Offset, int64, error) {
 	// We use an ephemeral client to fetch the offset and then create a new client with this offset.
 	// The reason for this is that changing the offset of an existing client requires to have used this client for fetching at least once.
 	// We don't want to do noop fetches just to warm up the client, so we create a new client instead.
 	cl, err := kgo.NewClient(commonKafkaClientOptions(b.cfg.Kafka, b.logger, metrics)...)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create bootstrap client: %w", err)
+		return nil, -1, fmt.Errorf("unable to create bootstrap client: %w", err)
 	}
 	defer cl.Close()
 
 	admClient := kadm.NewClient(cl)
+
+	fallbackOffset := int64(b.cfg.LookbackOnNoCommit)
+	defaultKOffset := kgo.NewOffset()
+	if fallbackOffset < 0 {
+		defaultKOffset = defaultKOffset.At(fallbackOffset)
+	} else {
+		ts := time.Now().Add(-b.cfg.LookbackOnNoCommit)
+		fallbackOffset = ts.UnixMilli()
+		defaultKOffset = defaultKOffset.AfterMilli(fallbackOffset)
+	}
 
 	fetchOffsets := func(ctx context.Context) (offsets map[int32]kgo.Offset, err error) {
 		resp, err := admClient.FetchOffsets(ctx, b.cfg.Kafka.ConsumerGroup)
@@ -195,12 +209,12 @@ func (b *BlockBuilder) findOffsetsToStartAt(ctx context.Context, metrics *kprom.
 			err = resp.Error()
 		}
 		// Either success or the requested group does not exist.
-		if err == nil {
-			offsets = resp.KOffsets()[b.cfg.Kafka.Topic]
-		} else if errors.Is(err, kerr.GroupIDNotFound) || errors.Is(err, kerr.UnknownTopicOrPartition) {
+		if errors.Is(err, kerr.GroupIDNotFound) || errors.Is(err, kerr.UnknownTopicOrPartition) {
 			offsets = make(map[int32]kgo.Offset)
 		} else if err != nil {
 			return nil, fmt.Errorf("unable to fetch group offsets: %w", err)
+		} else {
+			offsets = resp.KOffsets()[b.cfg.Kafka.Topic]
 		}
 
 		// Look over the assigned partitions and fallback to the ConsumerResetOffset if a partition doesn't have any commit for the configured group.
@@ -208,8 +222,8 @@ func (b *BlockBuilder) findOffsetsToStartAt(ctx context.Context, metrics *kprom.
 			if _, ok := offsets[part]; ok {
 				level.Info(b.logger).Log("msg", "consuming from last consumed offset", "consumer_group", b.cfg.Kafka.ConsumerGroup, "part", part, "offset", offsets[part].String())
 			} else {
-				offsets[part] = kgo.NewOffset().At(kafkaOffsetStart)
-				level.Info(b.logger).Log("msg", "consuming from partition start because no offset has been found", "consumer_group", b.cfg.Kafka.ConsumerGroup, "part", part, "offset", offsets[part].String())
+				offsets[part] = defaultKOffset
+				level.Info(b.logger).Log("msg", "consuming from partition look back because no offset has been found", "consumer_group", b.cfg.Kafka.ConsumerGroup, "part", part, "offset", offsets[part].String())
 			}
 		}
 		return offsets, nil
@@ -224,7 +238,7 @@ func (b *BlockBuilder) findOffsetsToStartAt(ctx context.Context, metrics *kprom.
 		var offsets map[int32]kgo.Offset
 		offsets, err = fetchOffsets(ctx)
 		if err == nil {
-			return offsets, nil
+			return offsets, fallbackOffset, nil
 		}
 		level.Warn(b.logger).Log("msg", "failed to fetch startup offsets", "err", err)
 		boff.Wait()
@@ -233,7 +247,7 @@ func (b *BlockBuilder) findOffsetsToStartAt(ctx context.Context, metrics *kprom.
 	if err == nil {
 		err = boff.Err()
 	}
-	return nil, err
+	return nil, -1, err
 }
 
 func commonKafkaClientOptions(cfg KafkaConfig, logger log.Logger, metrics *kprom.Metrics) []kgo.Opt {
@@ -346,6 +360,8 @@ func (b *BlockBuilder) NextConsumeCycle(ctx context.Context, cycleEnd time.Time)
 
 		level.Debug(b.logger).Log("msg", "next consume cycle", "part", part)
 
+		// TODO(v): calculating lag for each individual partition is redundant, as it requests the data for the whole group all the time.
+		// Since we don't have a rebalance in the middle of the cycle now, can we do it once in the beginning of the cycle?
 		lag, err := b.getLagForPartition(ctx, kadm.NewClient(b.kafkaClient), part)
 		if err != nil {
 			level.Error(b.logger).Log("msg", "failed to get partition lag", "err", err, "part", part)
@@ -405,7 +421,7 @@ func (b *BlockBuilder) getLagForPartition(ctx context.Context, admClient *kadm.C
 		if lastErr != nil {
 			level.Error(b.logger).Log("msg", "failed to get consumer group lag", "err", lastErr, "part", part)
 		}
-		groupLag, err := getGroupLag(ctx, admClient, b.cfg.Kafka.Topic, b.cfg.Kafka.ConsumerGroup)
+		groupLag, err := getGroupLag(ctx, admClient, b.cfg.Kafka.Topic, b.cfg.Kafka.ConsumerGroup, b.fallbackOffset)
 		if err != nil {
 			lastErr = fmt.Errorf("get consumer group lag: %w", err)
 			continue
@@ -425,13 +441,17 @@ func (b *BlockBuilder) getLagForPartition(ctx context.Context, admClient *kadm.C
 // getGroupLag is the inlined version of `kadm.Client.Lag` but updated to work with when the group
 // doesn't have live participants.
 // Similar to `kadm.CalculateGroupLagWithStartOffsets`, it takes into account that the group may not have any commits.
-func getGroupLag(ctx context.Context, admClient *kadm.Client, topic, group string) (kadm.GroupLag, error) {
-	offsets, err := admClient.FetchOffsetsForTopics(ctx, group, topic)
+func getGroupLag(ctx context.Context, admClient *kadm.Client, topic, group string, fallbackOffset int64) (kadm.GroupLag, error) {
+	offsets, err := admClient.FetchOffsets(ctx, group)
 	if err != nil {
 		if !errors.Is(err, kerr.GroupIDNotFound) {
 			return nil, fmt.Errorf("fetch offsets: %w", err)
 		}
 	}
+	if err := offsets.Error(); err != nil {
+		return nil, fmt.Errorf("fetch offsets got error in response: %w", err)
+	}
+
 	startOffsets, err := admClient.ListStartOffsets(ctx, topic)
 	if err != nil {
 		return nil, err
@@ -441,17 +461,35 @@ func getGroupLag(ctx context.Context, admClient *kadm.Client, topic, group strin
 		return nil, err
 	}
 
-	// For now, if the group doesn't have any commits, we use startOffsets as the starting point.
-	if len(offsets) == 0 {
-		offsets = make(kadm.OffsetResponses)
-		for t, pt := range startOffsets.Offsets() {
-			resp := make(map[int32]kadm.OffsetResponse)
-			for _, o := range pt {
-				resp[o.Partition] = kadm.OffsetResponse{
-					Offset: o,
-				}
+	listOffsetsAfterMilli := sync.OnceValues(func() (kadm.ListedOffsets, error) {
+		return admClient.ListOffsetsAfterMilli(ctx, fallbackOffset, topic)
+	})
+	// If the group-partition in offsets doesn't have a commit, fall back depending on where fallbackOffset points at.
+	for topic, pt := range startOffsets.Offsets() {
+		for part, o := range pt {
+			if _, ok := offsets.Lookup(topic, part); ok {
+				continue
 			}
-			offsets[t] = resp
+			// If fallback is not a timestamp, it's the kafkaOffsetStart value.
+			if fallbackOffset < 0 {
+				offsets.Add(kadm.OffsetResponse{Offset: o})
+				continue
+			}
+			fallbackOffsets, err := listOffsetsAfterMilli()
+			if err != nil {
+				return nil, err
+			}
+			o, ok := fallbackOffsets.Lookup(topic, part)
+			if !ok {
+				// This should not happen.
+				return nil, fmt.Errorf("partition %d not found in fallback offsets for topic %s", part, topic)
+			}
+			offsets.Add(kadm.OffsetResponse{Offset: kadm.Offset{
+				Topic:       o.Topic,
+				Partition:   o.Partition,
+				At:          o.Offset,
+				LeaderEpoch: o.LeaderEpoch,
+			}})
 		}
 	}
 
@@ -602,20 +640,17 @@ type partitionInfo struct {
 }
 
 func (b *BlockBuilder) nextConsumeCycle(ctx context.Context, client *kgo.Client, pl partitionInfo, cycleEnd time.Time) error {
-	// TODO(codesome): Add an option to block builder to start consuming from the end for the first rollout.
 	var commitRecTime time.Time
-	var skipRecordsBefore time.Time
 	if pl.CommitRecTs > 0 {
 		commitRecTime = time.UnixMilli(pl.CommitRecTs)
 	}
-	if commitRecTime.IsZero() {
+	if commitRecTime.IsZero() && b.fallbackOffset > 0 {
 		// If there is no commit metadata, we use the lookback config to replay a set amount of
 		// records because it is non-trivial to peek at the first record in a partition to determine
 		// the range of replay required. Without knowing the range, we might end up trying to consume
 		// a lot of records in a single partition consumption call and end up in an OOM loop.
 		// TODO(codesome): add a test for this.
-		commitRecTime = time.Now().Add(-b.cfg.LookbackOnNoCommit).Truncate(b.cfg.ConsumeInterval)
-		skipRecordsBefore = commitRecTime
+		commitRecTime = time.UnixMilli(b.fallbackOffset).Truncate(b.cfg.ConsumeInterval)
 	}
 
 	lagging := cycleEnd.Sub(commitRecTime) > 3*b.cfg.ConsumeInterval/2
@@ -624,7 +659,7 @@ func (b *BlockBuilder) nextConsumeCycle(ctx context.Context, client *kgo.Client,
 		// more than 1.5 times the consume interval.
 		// When there is no kafka commit, we play safe and assume seenTillOffset and
 		// lastBlockEnd was 0 to not discard any samples unnecessarily.
-		_, err := b.consumePartition(ctx, client, pl, cycleEnd, skipRecordsBefore)
+		_, err := b.consumePartition(ctx, client, pl, cycleEnd)
 		if err != nil {
 			return fmt.Errorf("consume partition %d: %w", pl.Partition, err)
 		}
@@ -640,7 +675,7 @@ func (b *BlockBuilder) nextConsumeCycle(ctx context.Context, client *kgo.Client,
 		// Instead of looking for the commit metadata for each iteration, we use the data returned by consumePartition
 		// in the next iteration.
 		var err error
-		pl, err = b.consumePartition(ctx, client, pl, ce, skipRecordsBefore)
+		pl, err = b.consumePartition(ctx, client, pl, ce)
 		if err != nil {
 			return fmt.Errorf("consume partition %d: %w", pl.Partition, err)
 		}
@@ -665,7 +700,6 @@ func (b *BlockBuilder) consumePartition(
 	client *kgo.Client,
 	pl partitionInfo,
 	cycleEnd time.Time,
-	skipRecordsBefore time.Time,
 ) (retPl partitionInfo, retErr error) {
 	var (
 		part           = pl.Partition
@@ -715,7 +749,6 @@ func (b *BlockBuilder) consumePartition(
 	var (
 		done                         bool
 		commitRec, firstRec, lastRec *kgo.Record
-		lastDiscardedBeforeFirstRec  *kgo.Record // Record that is discarded to be before the lookback, and right before firstRec.
 	)
 	for !done {
 		if err := context.Cause(ctx); err != nil {
@@ -750,13 +783,6 @@ func (b *BlockBuilder) consumePartition(
 		recIter := fetches.RecordIter()
 		for !recIter.Done() {
 			rec := recIter.Next()
-			if rec.Timestamp.Before(skipRecordsBefore) {
-				lag--
-				if firstRec == nil {
-					lastDiscardedBeforeFirstRec = rec
-				}
-				continue
-			}
 
 			if firstRec == nil {
 				firstRec = rec
@@ -811,29 +837,23 @@ func (b *BlockBuilder) consumePartition(
 	b.metrics.compactAndUploadDuration.WithLabelValues(fmt.Sprintf("%d", part)).Observe(compactionDur.Seconds())
 
 	// Nothing was processed, including that there was not discarded record.
-	if lastRec == nil && firstRec == nil && lastDiscardedBeforeFirstRec == nil {
+	if lastRec == nil && firstRec == nil {
 		level.Info(b.logger).Log("msg", "no records were processed in consumePartition", "part", part)
 		return pl, nil
 	}
 
 	// No records were for this cycle.
 	if lastRec == nil {
-		if lastDiscardedBeforeFirstRec != nil {
-			// We have a record that was beyond the lookback and was discarded.
-			// We must commit the last discarded.
-			commitRec = lastDiscardedBeforeFirstRec
-		} else {
-			// First record fetched was from the next cycle.
-			// Rewind partition's offset and re-consume this record again on the next cycle.
-			// No need to re-commit since the commit point did not change.
-			level.Info(b.logger).Log("msg", "skip commit record due to first record fetched is from next cycle", "part", part, "first_rec_offset", firstRec.Offset)
-			rec := kgo.EpochOffset{
-				Epoch:  firstRec.LeaderEpoch,
-				Offset: firstRec.Offset,
-			}
-			b.seekPartition(client, part, rec)
-			return pl, nil
+		// The first record fetched was from the next cycle.
+		// Rewind partition's offset and re-consume this record again on the next cycle.
+		// No need to re-commit since the commit point did not change.
+		level.Info(b.logger).Log("msg", "skip commit record due to first record fetched is from next cycle", "part", part, "first_rec_offset", firstRec.Offset)
+		rec := kgo.EpochOffset{
+			Epoch:  firstRec.LeaderEpoch,
+			Offset: firstRec.Offset,
 		}
+		b.seekPartition(client, part, rec)
+		return pl, nil
 	}
 
 	// All samples in all records were processed. We can commit the last record's offset.

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -604,6 +604,89 @@ func TestKafkaCommitMetaMarshalling(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestKafkaGetGroupLag(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	_, addr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, 3, testTopic)
+	writeClient := newKafkaProduceClient(t, addr)
+	admClient := kadm.NewClient(writeClient)
+
+	const numRecords = 5
+
+	var producedRecords []kgo.Record
+	kafkaTime := time.Now().Add(-12 * time.Hour)
+	for i := int64(0); i < numRecords; i++ {
+		kafkaTime = kafkaTime.Add(time.Minute)
+
+		// Produce and keep records to partition 0.
+		res := produceRecords(ctx, t, writeClient, kafkaTime, "1", testTopic, 0, []byte(`test value`))
+		rec, err := res.First()
+		require.NoError(t, err)
+		require.NotNil(t, rec)
+
+		producedRecords = append(producedRecords, *rec)
+
+		// Produce same records to partition 1 (this partition won't have any commits).
+		produceRecords(ctx, t, writeClient, kafkaTime, "1", testTopic, 1, []byte(`test value`))
+
+	}
+	require.Len(t, producedRecords, numRecords)
+
+	// Commit last produced record from partition 0.
+	rec := producedRecords[len(producedRecords)-1]
+	offset := kadm.Offset{
+		Topic:       rec.Topic,
+		Partition:   rec.Partition,
+		At:          rec.Offset + 1,
+		LeaderEpoch: rec.LeaderEpoch,
+	}
+	err := commitOffset(ctx, log.NewNopLogger(), writeClient, testGroup, offset)
+	require.NoError(t, err)
+
+	getTopicPartitionLag := func(t *testing.T, lag kadm.GroupLag, topic string, part int32) int64 {
+		l, ok := lag.Lookup(topic, part)
+		require.True(t, ok)
+		return l.Lag
+	}
+
+	t.Run("fallbackOffset=milliseconds", func(t *testing.T) {
+		// get the timestamp of second to last produced record
+		rec := producedRecords[len(producedRecords)-2]
+		fallbackOffset := rec.Timestamp.Add(-time.Millisecond).UnixMilli()
+		groupLag, err := getGroupLag(ctx, admClient, testTopic, testGroup, fallbackOffset)
+		require.NoError(t, err)
+
+		require.EqualValues(t, 0, getTopicPartitionLag(t, groupLag, testTopic, 0), "partition 0 must have no lag")
+		require.EqualValues(t, 2, getTopicPartitionLag(t, groupLag, testTopic, 1), "partition 1 must fall back to known record and get its lag from there")
+		require.EqualValues(t, 0, getTopicPartitionLag(t, groupLag, testTopic, 2), "partition 2 has no data and must have no lag")
+	})
+
+	t.Run("fallbackOffset=start", func(t *testing.T) {
+		groupLag, err := getGroupLag(ctx, admClient, testTopic, testGroup, kafkaOffsetStart)
+		require.NoError(t, err)
+
+		require.EqualValues(t, 0, getTopicPartitionLag(t, groupLag, testTopic, 0), "partition 0 must have no lag")
+		require.EqualValues(t, numRecords, getTopicPartitionLag(t, groupLag, testTopic, 1), "partition 1 must fall back to start and get its lag from there")
+		require.EqualValues(t, 0, getTopicPartitionLag(t, groupLag, testTopic, 2), "partition 2 has no data and must have no lag")
+	})
+
+	t.Run("fallbackOffset=end", func(t *testing.T) {
+		_, err := getGroupLag(ctx, admClient, testTopic, testGroup, -1)
+		require.Error(t, err, "fallback to partition end isn't supported")
+	})
+
+	t.Run("group=unknown", func(t *testing.T) {
+		groupLag, err := getGroupLag(ctx, admClient, testTopic, "unknown", kafkaOffsetStart)
+		require.NoError(t, err)
+
+		// This group doesn't have any commits so it must calc its lag from the fallback.
+		require.EqualValues(t, numRecords, getTopicPartitionLag(t, groupLag, testTopic, 0))
+		require.EqualValues(t, numRecords, getTopicPartitionLag(t, groupLag, testTopic, 1))
+		require.EqualValues(t, 0, getTopicPartitionLag(t, groupLag, testTopic, 2), "partition 2 has no data and must have no lag")
+	})
+}
+
 func TestBlockBuilderMultiTenancy(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -34,21 +35,18 @@ const (
 )
 
 func blockBuilderConfig(t *testing.T, addr string) (Config, *validation.Overrides) {
-	cfg := Config{
-		InstanceID:            "block-builder-0",
-		ConsumeInterval:       time.Hour,
-		ConsumeIntervalBuffer: 15 * time.Minute,
-		Kafka: KafkaConfig{
-			Address:       addr,
-			Topic:         testTopic,
-			ClientID:      "1",
-			DialTimeout:   10 * time.Second,
-			PollTimeout:   500 * time.Millisecond,
-			ConsumerGroup: testGroup,
-		},
-		LookbackOnNoCommit: 12 * time.Hour,
-	}
+	cfg := Config{}
+	flagext.DefaultValues(&cfg)
 
+	cfg.InstanceID = "block-builder-0"
+
+	// Kafka related options.
+	cfg.Kafka.Address = addr
+	cfg.Kafka.Topic = testTopic
+	cfg.Kafka.ConsumerGroup = testGroup
+	cfg.Kafka.PollTimeout = 500 * time.Millisecond // reduced for testing
+
+	// Block storage related options.
 	cfg.BlocksStorageConfig.TSDB.Dir = t.TempDir()
 	cfg.BlocksStorageConfig.Bucket.StorageBackendConfig.Backend = bucket.Filesystem
 	cfg.BlocksStorageConfig.Bucket.Filesystem.Directory = t.TempDir()

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"os"
 	"path"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/storage/bucket"
@@ -710,7 +710,7 @@ func TestBlockBuilder_LongCatchupWithNoRecordsProcessed(t *testing.T) {
 
 	bb, err := New(cfg, logger, prometheus.NewPedanticRegistry(), overrides)
 	require.NoError(t, err)
-	var compactCalled atomic.Int32
+	compactCalled := atomic.NewInt64(0)
 	bb.tsdbBuilder = func() builder {
 		testBuilder := newTestTSDBBuilder(cfg, overrides)
 		testBuilder.compactFunc = func() {


### PR DESCRIPTION
~_This one seats atop the #8982 for now_~

These changes update block-builder making it to start consuming from a point, after the `-block-builder.lookback-on-no-commit` time, when there is no commit for a partition. That is, on the first deploy, instead of starting from the partition's earliest offset, the block-builder consume from the nearest offset after the `lookback-on-no-commit` from its start.

Note: in the future, I want to extend the `-block-builder.lookback-on-no-commit` to handle the value of `-1`, as a way to start from the partition's start. This may be useful when a user doesn't want to lose any historical data.