### PR TITLE
Fix mergeIterator.Seek()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * [BUGFIX] Compactor: fix a race condition between different compactor replicas that may cause a deleted block to be still referenced as non-deleted in the bucket index. #8905
 * [BUGFIX] Querier: fix issue where some native histogram-related warnings were not emitted when `rate()` was used over native histograms. #8918
 * [BUGFIX] Ruler: map invalid org-id errors to 400 status code. #8935
+* [BUGFIX] Querier: Fix invalid query results when multiple chunks are being merged. #8992
 
 ### Mixin
 

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -38,7 +38,7 @@ func (c GenericChunk) Iterator(reuse chunk.Iterator) chunk.Iterator {
 
 // iterator iterates over batches.
 type iterator interface {
-	// Seek to the batch at (or after) time t.
+	// Seek to the batch with sample at (or after) time t.
 	Seek(t int64, size int) chunkenc.ValueType
 
 	// Next moves to the next batch.

--- a/pkg/querier/batch/chunk.go
+++ b/pkg/querier/batch/chunk.go
@@ -43,7 +43,7 @@ func (i *chunkIterator) Seek(t int64, size int) chunkenc.ValueType {
 
 	// If the seek is to the middle of the current batch, and size fits, we can
 	// shortcut.
-	if i.batch.Length > 0 && t >= i.batch.Timestamps[0] && t <= i.batch.Timestamps[i.batch.Length-1] {
+	if i.batch.Length > 0 && t <= i.batch.Timestamps[i.batch.Length-1] {
 		i.batch.Index = 0
 		for i.batch.Index < i.batch.Length && t > i.batch.Timestamps[i.batch.Index] {
 			i.batch.Index++

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -78,7 +78,7 @@ func (c *mergeIterator) Seek(t int64, size int) chunkenc.ValueType {
 found:
 	for c.batches.len() > 0 {
 		batch := c.batches.curr()
-		if t >= batch.Timestamps[0] && t <= batch.Timestamps[batch.Length-1] {
+		if t <= batch.Timestamps[batch.Length-1] {
 			batch.Index = 0
 			for batch.Index < batch.Length && t > batch.Timestamps[batch.Index] {
 				batch.Index++

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -78,6 +78,7 @@ func (c *mergeIterator) Seek(t int64, size int) chunkenc.ValueType {
 found:
 	for c.batches.len() > 0 {
 		batch := c.batches.curr()
+		// The first sample in the batch can be after the seek time.
 		if t <= batch.Timestamps[batch.Length-1] {
 			batch.Index = 0
 			for batch.Index < batch.Length && t > batch.Timestamps[batch.Index] {

--- a/pkg/querier/batch/merge.go
+++ b/pkg/querier/batch/merge.go
@@ -79,9 +79,9 @@ found:
 	for c.batches.len() > 0 {
 		batch := c.batches.curr()
 		// The first sample in the batch can be after the seek time.
-		if t <= batch.Timestamps[batch.Length-1] {
+		if batch.Timestamps[batch.Length-1] >= t {
 			batch.Index = 0
-			for batch.Index < batch.Length && t > batch.Timestamps[batch.Index] {
+			for batch.Index < batch.Length && batch.Timestamps[batch.Index] < t {
 				batch.Index++
 			}
 			break found

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -64,8 +64,8 @@ func TestMergeHarder(t *testing.T) {
 	}
 }
 
-// TestBugInMergeIterator tests a bug while calling Seek() on mergeIterator.
-func TestBugInMergeIteratorSeek(t *testing.T) {
+// TestMergeIteratorSeek tests a bug while calling Seek() on mergeIterator.
+func TestMergeIteratorSeek(t *testing.T) {
 	// Samples for 3 chunks.
 	chunkSamples := [][]int64{
 		{10, 20, 30, 40},

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -6,13 +6,13 @@
 package batch
 
 import (
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/chunk"
 )

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -6,6 +6,11 @@
 package batch
 
 import (
+	"fmt"
+	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -60,4 +65,95 @@ func TestMergeHarder(t *testing.T) {
 			testSeek(t, offset*numChunks+samples-offset, newIteratorAdapter(nil, iter, labels.EmptyLabels()), enc)
 		})
 	}
+}
+
+// TestBugInMergeIterator tests a bug while calling Seek() on mergeIterator.
+// The samples used for testing is from a live Mimir cluster where the bug was first observed.
+func TestBugInMergeIteratorSeek(t *testing.T) {
+	// Samples for 3 chunks.
+	chunkSamples := [][]int64{
+		{1723419966795, 1723420626795, 1723420686795, 1723420746795},
+		{1723420806795, 1723420866795, 1723420926795, 1723427346795, 1723427406795, 1723427946795},
+		{1723428006795, 1723428546795},
+	}
+
+	var genericChunks []GenericChunk
+	for _, samples := range chunkSamples {
+		ch := chunkenc.NewXORChunk()
+		app, err := ch.Appender()
+		require.NoError(t, err)
+		for _, ts := range samples {
+			app.Append(ts, 1)
+		}
+
+		genericChunks = append(genericChunks, NewGenericChunk(samples[0], samples[len(samples)-1], func(reuse chunk.Iterator) chunk.Iterator {
+			chk, err := chunk.NewForEncoding(chunk.PrometheusXorChunk)
+			require.NoError(t, err)
+			require.NoError(t, chk.UnmarshalFromBuf(ch.Bytes()))
+			return chk.NewIterator(reuse)
+		}))
+	}
+
+	c3It := NewGenericChunkMergeIterator(nil, labels.EmptyLabels(), genericChunks)
+
+	c3It.Seek(1723420500000)
+	// These Next() calls are necessary to reproduce the bug.
+	c3It.Next()
+	c3It.Next()
+	c3It.Next()
+	c3It.Seek(1723421700000)
+	// Without the bug fix, this Seek() call skips an additional sample than desired.
+	// Instead of stopping at 1723427946795, which is the last sample of chunk 2,
+	// it would go to 1723428006795, which is the first sample of chunk 3.
+	// This was happening because in the Seek() method we were discarding the current
+	// batch from mergeIterator if the batch's first sample was after the seek time.
+	c3It.Seek(1723427700000)
+
+	require.Equal(t, int64(1723427946795), c3It.AtT())
+}
+
+func readFloats(t *testing.T, chunks ...storepb.AggrChunk) []promql.FPoint {
+	fmt.Println("READ FLOATS")
+	it := newBlockQuerierSeriesIterator(nil, labels.EmptyLabels(), chunks)
+	var firstIteratorPoints []promql.FPoint
+	for it.Next() != chunkenc.ValNone {
+		ts, value := it.At()
+		firstIteratorPoints = append(firstIteratorPoints, promql.FPoint{T: ts, F: value})
+		fmt.Println(ts)
+
+		require.Equal(t, ts, it.AtT())
+	}
+
+	require.NoError(t, it.Err())
+	return firstIteratorPoints
+}
+
+func newBlockQuerierSeriesIterator(reuse chunkenc.Iterator, lbls labels.Labels, chunks []storepb.AggrChunk) chunkenc.Iterator {
+	genericChunks := make([]GenericChunk, 0, len(chunks))
+
+	for _, c := range chunks {
+		c := c
+
+		genericChunk := NewGenericChunk(c.MinTime, c.MaxTime, func(reuse chunk.Iterator) chunk.Iterator {
+			encoding, ok := c.GetChunkEncoding()
+			if !ok {
+				return chunk.ErrorIterator(fmt.Sprintf("cannot create new chunk for series %s: unknown encoded raw data type %v", lbls, c.Raw.Type))
+			}
+
+			ch, err := chunk.NewForEncoding(encoding)
+			if err != nil {
+				return chunk.ErrorIterator(fmt.Sprintf("cannot create new chunk for series %s: %s", lbls.String(), err.Error()))
+			}
+
+			if err := ch.UnmarshalFromBuf(c.Raw.Data); err != nil {
+				return chunk.ErrorIterator(fmt.Sprintf("cannot unmarshal chunk for series %s: %s", lbls.String(), err.Error()))
+			}
+
+			return ch.NewIterator(reuse)
+		})
+
+		genericChunks = append(genericChunks, genericChunk)
+	}
+
+	return NewGenericChunkMergeIterator(reuse, lbls, genericChunks)
 }


### PR DESCRIPTION
#### What this PR does

mergeIterator.Seek() was skipping samples in some cases. This was happening because in the Seek() method we were discarding the current batch from mergeIterator if the batch's first sample was after the seek time.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
