### PR TITLE
Stop using deprecated config options for golangci-lint

### DIFF
--- a/.errcheck-exclude
+++ b/.errcheck-exclude
@@ -1,8 +1,0 @@
-(*github.com/grafana/dskit/spanlogger.SpanLogger).Error
-(github.com/go-kit/kit/log.Logger).Log
-(github.com/go-kit/log.Logger).Log
-(github.com/mitchellh/colorstring).Println
-(github.com/opentracing/opentracing-go.Tracer).Inject
-io.Copy
-io/ioutil.ReadFile
-io/ioutil.WriteFile

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 output:
-  format: line-number
+  formats:
+    - format: line-number
 
 linters:
   enable:
@@ -15,7 +16,15 @@ linters-settings:
   errcheck:
     # path to a file containing a list of functions to exclude from checking
     # see https://github.com/kisielk/errcheck#excluding-functions for details
-    exclude: ./.errcheck-exclude
+    exclude-functions:
+      - (*github.com/grafana/dskit/spanlogger.SpanLogger).Error
+      - (github.com/go-kit/kit/log.Logger).Log
+      - (github.com/go-kit/log.Logger).Log
+      - (github.com/mitchellh/colorstring).Println
+      - (github.com/opentracing/opentracing-go.Tracer).Inject
+      - io.Copy
+      - io/ioutil.ReadFile
+      - io/ioutil.WriteFile
 
   gci:
     # Section configuration to compare against.


### PR DESCRIPTION
#### What this PR does

This PR fixes the use of two deprecated config options for `golangci-lint`:

```
WARN [config_reader] The configuration option `output.format` is deprecated, please use `output.formats`
WARN [config_reader] The configuration option `linters.errcheck.exclude` is deprecated, please use `linters.errcheck.exclude-functions`.
```

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
