### PR TITLE
mimir-mixin: get rid of unused functions and variables

### DIFF
--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -183,8 +183,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
       overviewRoutesPerSecondSelector: '%(queryFrontendMatcher)s,route=~"%(overviewRoutesRegex)s"' % (variables { overviewRoutesRegex: overviewRoutesRegex }),
       nonOverviewRoutesPerSecondSelector: '%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)_api_v1_.*",route!~"%(overviewRoutesRegex)s"' % (variables { overviewRoutesRegex: overviewRoutesRegex }),
 
-      local queryPerSecond(name) = 'sum(rate(cortex_request_duration_seconds_count{%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)%(route)s"}[$__rate_interval]))' %
-                                   (variables { route: std.filter(function(r) r.name == name, overviewRoutes)[0].routeLabel }),
       local ncQueryPerSecond(name) = utils.ncHistogramSumBy(utils.ncHistogramCountRate(p.requestsPerSecondMetric, '%(queryFrontendMatcher)s,route=~"(prometheus|api_prom)%(route)s"' %
                                                                                                                   (variables { route: std.filter(function(r) r.name == name, overviewRoutes)[0].routeLabel }))),
       ncInstantQueriesPerSecond: ncQueryPerSecond('instantQuery'),
@@ -192,12 +190,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ncLabelNamesQueriesPerSecond: ncQueryPerSecond('labelNames'),
       ncLabelValuesQueriesPerSecond: ncQueryPerSecond('labelValues'),
       ncSeriesQueriesPerSecond: ncQueryPerSecond('series'),
-      remoteReadQueriesPerSecond: queryPerSecond('remoteRead'),
-      metadataQueriesPerSecond: queryPerSecond('metadata'),
-      exemplarsQueriesPerSecond: queryPerSecond('exemplars'),
-      activeSeriesQueriesPerSecond: queryPerSecond('activeSeries'),
-      labelNamesCardinalityQueriesPerSecond: queryPerSecond('labelNamesCardinality'),
-      labelValuesCardinalityQueriesPerSecond: queryPerSecond('labelValuesCardinality'),
 
       // Read failures rate as percentage of total requests.
       readFailuresRate: $.ncHistogramFailureRate(p.requestsPerSecondMetric, p.readRequestsPerSecondSelector),


### PR DESCRIPTION
#### What this PR does

This PR gets rid of the `queryPerSecond()` function and the unused variables that call that function.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
