### PR TITLE
development/*/compose-up.sh: Execute Make in root directory

### DIFF
--- a/development/mimir-ingest-storage/compose-up.sh
+++ b/development/mimir-ingest-storage/compose-up.sh
@@ -13,7 +13,7 @@ docker_compose() {
 }
 
 SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
-BUILD_IMAGE=$(make -s -f "${SCRIPT_DIR}"/../../Makefile print-build-image)
+BUILD_IMAGE=$(make -s -C "${SCRIPT_DIR}"/../.. print-build-image)
 
 # Make sure docker-compose.yml is up-to-date.
 cd "$SCRIPT_DIR" && make

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -16,7 +16,7 @@ docker_compose() {
 }
 
 SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
-BUILD_IMAGE=$(make -s -f "${SCRIPT_DIR}"/../../Makefile print-build-image)
+BUILD_IMAGE=$(make -s -C "${SCRIPT_DIR}"/../.. print-build-image)
 # Make sure docker-compose.yml is up-to-date.
 cd "$SCRIPT_DIR" && make
 

--- a/development/mimir-read-write-mode/compose-up.sh
+++ b/development/mimir-read-write-mode/compose-up.sh
@@ -13,7 +13,7 @@ docker_compose() {
 }
 
 SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
-BUILD_IMAGE=$(make -s -f "${SCRIPT_DIR}"/../../Makefile print-build-image)
+BUILD_IMAGE=$(make -s -C "${SCRIPT_DIR}"/../.. print-build-image)
 
 # Make sure docker-compose.yml is up-to-date.
 cd "$SCRIPT_DIR" && make


### PR DESCRIPTION
#### What this PR does

In development/*/compose-up.sh files, execute Make in a certain directory instead of with a certain Makefile. This is because parts of Makefile depend on executing in the right directory when issuing e.g. find commands.

Prior to this fix, you'll see an error when executing the following:

```console
$ cd development/mimir-microservices-mode
$ ./compose-up.sh
find: ./pkg/distributor/otlp/: No such file or directory
[...]
```

The reason for the error (`find: ./pkg/distributor/otlp/: No such file or directory`) is the following variable definition in Makefile:

```Makefile
OTLP_GOS := $(shell find ./pkg/distributor/otlp/ -type f -name '*_generated.go' -print)
```

Since executing Make with a certain Makefile (via the `-f` flag) causes Make to execute with a particular Makefile, but in the same directory (development/mimir-microservices-mode), the `find` command fails. The solution is to specify the directory (via the `-C` flag) instead.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
