### PR TITLE
Refactor `pusherConsumer.Consume`

### DIFF
--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -141,8 +141,7 @@ func (c pusherConsumer) Consume(ctx context.Context, records []record) error {
 			select {
 			case <-unmarshalCtx.Done():
 				return
-			default:
-				ch <- parsed
+			case ch <- parsed:
 			}
 		}
 	}(ctx, records, recordsChannel)

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -156,7 +156,7 @@ func (c pusherConsumer) Consume(ctx context.Context, records []record) error {
 		// If we get an error at any point, we need to stop processing the records. They will be retried at some point.
 		err := c.pushToStorage(r.ctx, r.tenantID, r.WriteRequest)
 		if err != nil {
-			cancel()
+			cancel() // Stop the unmarshalling goroutine.
 			return fmt.Errorf("consuming record at index %d for tenant %s: %w", r.index, r.tenantID, err)
 		}
 	}

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -209,7 +209,7 @@ func TestPusherConsumer(t *testing.T) {
 
 			logs := &concurrency.SyncBuffer{}
 			c := newPusherConsumer(pusher, KafkaConfig{}, newPusherConsumerMetrics(prometheus.NewPedanticRegistry()), log.NewLogfmtLogger(logs))
-			err := c.consume(context.Background(), tc.records)
+			err := c.Consume(context.Background(), tc.records)
 			if tc.expErr == "" {
 				assert.NoError(t, err)
 			} else {
@@ -318,7 +318,7 @@ func TestPusherConsumer_consume_ShouldLogErrorsHonoringOptionalLogging(t *testin
 		consumer, logs, reg := setupTest(pusherErr)
 
 		// Should return no error on client errors.
-		require.NoError(t, consumer.consume(context.Background(), []record{reqRecord}))
+		require.NoError(t, consumer.Consume(context.Background(), []record{reqRecord}))
 
 		assert.Contains(t, logs.String(), pusherErr.Error())
 		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
@@ -340,7 +340,7 @@ func TestPusherConsumer_consume_ShouldLogErrorsHonoringOptionalLogging(t *testin
 		consumer, logs, reg := setupTest(pusherErr)
 
 		// Should return no error on client errors.
-		require.NoError(t, consumer.consume(context.Background(), []record{reqRecord}))
+		require.NoError(t, consumer.Consume(context.Background(), []record{reqRecord}))
 
 		assert.Contains(t, logs.String(), fmt.Sprintf("%s (sampled 1/100)", pusherErr.Error()))
 		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
@@ -361,7 +361,7 @@ func TestPusherConsumer_consume_ShouldLogErrorsHonoringOptionalLogging(t *testin
 		consumer, logs, reg := setupTest(pusherErr)
 
 		// Should return no error on client errors.
-		require.NoError(t, consumer.consume(context.Background(), []record{reqRecord}))
+		require.NoError(t, consumer.Consume(context.Background(), []record{reqRecord}))
 
 		assert.Empty(t, logs.String())
 		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
@@ -406,7 +406,7 @@ func TestPusherConsumer_consume_ShouldHonorContextCancellation(t *testing.T) {
 		cancel(wantCancelErr)
 	}()
 
-	err = consumer.consume(canceledCtx, []record{reqRecord})
+	err = consumer.Consume(canceledCtx, []record{reqRecord})
 	require.ErrorIs(t, err, wantCancelErr)
 }
 

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -120,7 +120,7 @@ func TestPartitionReader_ConsumerError(t *testing.T) {
 	consumer := consumerFunc(func(ctx context.Context, records []record) error {
 		invocations.Inc()
 		if !returnErrors.Load() {
-			return trackingConsumer.consume(ctx, records)
+			return trackingConsumer.Consume(ctx, records)
 		}
 		// There may be more records, but we only care that the one we failed to consume in the first place is still there.
 		assert.Equal(t, "1", string(records[0].content))
@@ -159,7 +159,7 @@ func TestPartitionReader_ConsumerStopping(t *testing.T) {
 	blockingConsumer := newTestConsumer(0)
 	consumer := consumerFunc(func(ctx context.Context, records []record) error {
 		invocations.Inc()
-		return blockingConsumer.consume(ctx, records)
+		return blockingConsumer.Consume(ctx, records)
 	})
 	reader := createReader(t, clusterAddr, topicName, partitionID, consumer)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
@@ -1980,7 +1980,7 @@ func (t testConsumer) Close(context.Context) error {
 	return nil
 }
 
-func (t testConsumer) consume(ctx context.Context, records []record) error {
+func (t testConsumer) Consume(ctx context.Context, records []record) error {
 	for _, r := range records {
 		select {
 		case <-ctx.Done():
@@ -2025,7 +2025,7 @@ func (consumerFunc) Close(context.Context) error {
 	return nil
 }
 
-func (c consumerFunc) consume(ctx context.Context, records []record) error {
+func (c consumerFunc) Consume(ctx context.Context, records []record) error {
 	return c(ctx, records)
 }
 


### PR DESCRIPTION
#### What this PR does

There's a couple of things going on here:

- Make `Consume` part of the public interface, it's a private struct so having a public method is OK in this package.
- Make the unmarshalling and pushing to storage process a bit easier to understand and document it.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
