### PR TITLE
kafka replay speed: make error handling more explicit

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -1072,7 +1072,7 @@ func (r *concurrentFetchers) runFetchers(ctx context.Context, startOffset int64)
 
 // handleKafkaFetchErr handles all the errors listed in the franz-go documentation as possible errors when fetching records.
 // For most of them we just apply a backoff. They are listed here so we can be explicit in what we're handling and how.
-// handleKafkaFetchErr returns an adjusted fetchWant in case the error indicated we were consuming not yet produced records or records already deleted due to retention.
+// It may also return an adjusted fetchWant in case the error indicated, we were consuming not yet produced records or records already deleted due to retention.
 func handleKafkaFetchErr(fr fetchResult, fw fetchWant, shortBackoff, longBackoff *backoff.Backoff, logger log.Logger) fetchWant {
 	err := fr.Err
 	switch {

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -986,7 +986,8 @@ func (r *concurrentFetchers) runFetcher(ctx context.Context, fetchersWg *sync.Wa
 				w = handleKafkaFetchErr(f, w, errBackoff, newRecordsProducedBackoff, attemptLogger)
 			}
 			if len(f.Records) == 0 {
-				// TODO proper handling of NotLeaderForPartition ReplicaNotAvailable UnknownLeaderEpoch FencedLeaderEpoch; we need to be able to select the right broker to handle those
+				// Typically if we had an error, then there wouldn't eb any records.
+				// But it's hard to verify this from the Kafka API docs, so just to be sure, we process any records we might have received.
 				continue
 			}
 			// We reset the backoff if we received any records whatsoever. A received record means _some_ success.

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -987,9 +987,12 @@ func (r *concurrentFetchers) runFetcher(ctx context.Context, fetchersWg *sync.Wa
 			}
 			if len(f.Records) == 0 {
 				// Typically if we had an error, then there wouldn't eb any records.
-				// But it's hard to verify this from the Kafka API docs, so just to be sure, we process any records we might have received.
+				// But it's hard to verify this for all errors from the Kafka API docs, so just to be sure, we process any records we might have received.
 				continue
 			}
+			// Next attempt will be from the last record onwards.
+			w.startOffset = f.Records[len(f.Records)-1].Offset + 1
+
 			// We reset the backoff if we received any records whatsoever. A received record means _some_ success.
 			// We don't want to slow down until we hit a larger error.
 			errBackoff.Reset()


### PR DESCRIPTION
### What this PR does

This is a small cleanup to make error handling a bit more explicit. The basic idea is that we take different actions based on the response:

1. Back off and wait a bit
2. Adjust the range of records we want to fetch
3. (TODO) refresh broker metadata

In each action we look at the error we received and decide.


#### Errors to handle

This is what is listed in the [franz-go package](https://github.com/grafana/mimir/blob/04df05d32320cd19281591a57c19cceba63ceabf/vendor/github.com/twmb/franz-go/pkg/kmsg/generated.go#L4705-L4745) for fetch responses. Next to each is how I think we should handle each. franz-go has more explanations for what each error means _I couldn't find official kafka docs which list this_.

 
<details> <summary>All errors we have to handle </summary>

```
// OffsetOutOfRange - already handled - modify fetchWant and backoff if we're requesting after end; or abort fetchWant if we're fetching before the LSO - no log
// TopicAuthorizationFailed - log error and backoff
// UnknownTopicOrPartition - log error and backoff
// UnsupportedCompressionType - this shouldn't happen - only happens when the request version was under 10, but we always use 13 - log error and backoff - we can't afford to lose records
// UnsupportedVersion - in this case our client is too old - log error and backoff - can't afford to lose records
// KafkaStorageError - it's a server error, log warning and backoff
// UnknownTopicID - log error and backoff
// OffsetMovedToTieredStorage - this should be only intra-broker error and we shouldn't get it. log error and backoff
// NotLeaderForPartition - log warning and backoff; our metadata is likely outdated, so we can retry
// ReplicaNotAvailable - happens when the replica hasn't had the time to catch up with the topic - log warning and backoff
// UnknownLeaderEpoch - our metadata is out of date, we should refresh and try again with a leader who is up to date - log error and backoff // TODO this current doesn't happen
// FencedLeaderEpoch - our metadata is out of date, we should refresh and try again with a leader who is up to date - log error and backoff // TODO this current doesn't happen
```

</details>


### Alternative

 I wasn't sure if that's the best approach or whether it's not something like this which shows all the actions we take for a given error in one place. Open to feedback, but also don't want to bikeshed :smile: I spent way too long trying out different ways and neither looked perfect.

```go
func handleError(f fetchResult) {
  switch f.Err {
  case OffsetOutOfRange:
    w = adjustWant()
    if consumingAfterEnd() {
      waitBackoff()
    }
  case TopicAuthorizationFailed:
    waitBackoff()
  case UnsupportedCompressionType:
    waitBackoff()
  case ... // list all the possible errors, so we're very explicit what happens on each
  default:
     panic("") // or a very loud error
  }
}
```
