### PR TITLE
Jsonnet: allow to easily override Kafka client ID on a per-component basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 * [ENHANCEMENT] Do not deploy ingester-zone-c when experimental ingest storage is enabled and `ingest_storage_ingester_zones` is configured to `2`. #8776
 * [ENHANCEMENT] Added the config option `ingest_storage_migration_classic_ingesters_no_scale_down_delay` to disable the downscale delay on classic ingesters when migrating to experimental ingest storage. #8775 #8873
 * [ENHANCEMENT] Configure experimental ingest storage on query-frontend too when enabled. #8843
+* [ENHANCEMENT] Allow to override Kafka client ID on a per-component basis. #9026
 * [BUGFIX] Added missing node affinity matchers to write component. #8910
 
 ### Mimirtool

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -65,13 +65,13 @@
   // The configuration that should be applied to all Mimir components producing to Kafka.
   ingest_storage_kafka_producer_args:: {
     'ingest-storage.kafka.address': $.ingest_storage_kafka_producer_address,
-    'ingest-storage.kafka.client-id': buildKafkaClientID($.ingest_storage_kafka_producer_client_id_default_settings),
+    'ingest-storage.kafka.client-id': $.mimirKafkaClientID($.ingest_storage_kafka_producer_client_id_default_settings),
   },
 
   // The configuration that should be applied to all Mimir components consuming from Kafka.
   ingest_storage_kafka_consumer_args:: {
     'ingest-storage.kafka.address': $.ingest_storage_kafka_consumer_address,
-    'ingest-storage.kafka.client-id': buildKafkaClientID($.ingest_storage_kafka_consumer_client_id_default_settings),
+    'ingest-storage.kafka.client-id': $.mimirKafkaClientID($.ingest_storage_kafka_consumer_client_id_default_settings),
   },
 
   //
@@ -94,7 +94,7 @@
 
   ingest_storage_distributor_args+:: {
     // Custom Kafka client ID.
-    'ingest-storage.kafka.client-id': buildKafkaClientID(
+    'ingest-storage.kafka.client-id': $.mimirKafkaClientID(
       $.ingest_storage_kafka_producer_client_id_default_settings +
       $.ingest_storage_distributor_kafka_client_id_settings
     ),
@@ -106,7 +106,7 @@
 
   ingest_storage_ruler_args+:: {
     // Custom Kafka client ID.
-    'ingest-storage.kafka.client-id': buildKafkaClientID(
+    'ingest-storage.kafka.client-id': $.mimirKafkaClientID(
       $.ingest_storage_kafka_producer_client_id_default_settings +
       $.ingest_storage_ruler_kafka_client_id_settings
     ),
@@ -126,7 +126,7 @@
     'ingest-storage.kafka.consumer-group-offset-commit-interval': '5s',
 
     // Custom Kafka client ID.
-    'ingest-storage.kafka.client-id': buildKafkaClientID(
+    'ingest-storage.kafka.client-id': $.mimirKafkaClientID(
       $.ingest_storage_kafka_consumer_client_id_default_settings +
       $.ingest_storage_ingester_kafka_client_id_settings
     ),
@@ -150,7 +150,7 @@
     $.ingest_storage_partition_ring_client_args
     {
       // Custom Kafka client ID.
-      'ingest-storage.kafka.client-id': buildKafkaClientID(
+      'ingest-storage.kafka.client-id': $.mimirKafkaClientID(
         $.ingest_storage_kafka_consumer_client_id_default_settings +
         $.ingest_storage_query_frontend_kafka_client_id_settings
       ),
@@ -179,7 +179,7 @@
   // Utilities.
   //
 
-  local buildKafkaClientID(settings) =
+  mimirKafkaClientID(settings)::
     // Remove all null values from the settings. There could be null values because we use null as override
     // value to remove a setting from the map.
     local cleanSettings = {

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -51,10 +51,11 @@
   ingest_storage_kafka_consumer_client_id_default_settings:: {},
 
   // The per-component Kafka client ID settings overrides.
-  ingest_storage_distributor_kafka_client_id_settings:: {},
-  ingest_storage_ingester_kafka_client_id_settings:: {},
-  ingest_storage_query_frontend_kafka_client_id_settings:: {},
-  ingest_storage_ruler_kafka_client_id_settings:: {},
+  ingest_storage_distributor_kafka_client_id_settings:: $.ingest_storage_kafka_producer_client_id_default_settings,
+  ingest_storage_ruler_kafka_client_id_settings:: $.ingest_storage_kafka_producer_client_id_default_settings,
+
+  ingest_storage_ingester_kafka_client_id_settings:: $.ingest_storage_kafka_consumer_client_id_default_settings,
+  ingest_storage_query_frontend_kafka_client_id_settings:: $.ingest_storage_kafka_consumer_client_id_default_settings,
 
   // The configuration that should be applied to Mimir components either producing to or consuming from Kafka.
   ingest_storage_kafka_client_args:: {
@@ -93,11 +94,8 @@
     $.ingest_storage_query_frontend_args,
 
   ingest_storage_distributor_args+:: {
-    // Custom Kafka client ID.
-    'ingest-storage.kafka.client-id': $.mimirKafkaClientID(
-      $.ingest_storage_kafka_producer_client_id_default_settings +
-      $.ingest_storage_distributor_kafka_client_id_settings
-    ),
+    // Apply per-component overrides to Kafka client ID.
+    'ingest-storage.kafka.client-id': $.mimirKafkaClientID($.ingest_storage_distributor_kafka_client_id_settings),
 
     // Increase the default remote write timeout (applied to writing to Kafka too) because writing
     // to Kafka-compatible backend may be slower than writing to ingesters.
@@ -105,11 +103,8 @@
   },
 
   ingest_storage_ruler_args+:: {
-    // Custom Kafka client ID.
-    'ingest-storage.kafka.client-id': $.mimirKafkaClientID(
-      $.ingest_storage_kafka_producer_client_id_default_settings +
-      $.ingest_storage_ruler_kafka_client_id_settings
-    ),
+    // Apply per-component overrides to Kafka client ID.
+    'ingest-storage.kafka.client-id': $.mimirKafkaClientID($.ingest_storage_ruler_kafka_client_id_settings),
 
     // No need to increase -distributor.remote-timeout because the ruler's default is higher.
   },
@@ -125,11 +120,8 @@
     // (in case of a graceful shutdown, the ingester will commit the offset at shutdown too).
     'ingest-storage.kafka.consumer-group-offset-commit-interval': '5s',
 
-    // Custom Kafka client ID.
-    'ingest-storage.kafka.client-id': $.mimirKafkaClientID(
-      $.ingest_storage_kafka_consumer_client_id_default_settings +
-      $.ingest_storage_ingester_kafka_client_id_settings
-    ),
+    // Apply per-component overrides to Kafka client ID.
+    'ingest-storage.kafka.client-id': $.mimirKafkaClientID($.ingest_storage_ingester_kafka_client_id_settings),
   },
 
   ingest_storage_partition_ring_client_args+:: {
@@ -149,11 +141,8 @@
     // the logic to fetch the last produced offsets.
     $.ingest_storage_partition_ring_client_args
     {
-      // Custom Kafka client ID.
-      'ingest-storage.kafka.client-id': $.mimirKafkaClientID(
-        $.ingest_storage_kafka_consumer_client_id_default_settings +
-        $.ingest_storage_query_frontend_kafka_client_id_settings
-      ),
+      // Apply per-component overrides to Kafka client ID.
+      'ingest-storage.kafka.client-id': $.mimirKafkaClientID($.ingest_storage_query_frontend_kafka_client_id_settings),
 
       // Reduce the LPO polling interval to improve latency of strong consistency reads.
       'ingest-storage.kafka.last-produced-offset-poll-interval': '500ms',

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -45,8 +45,16 @@
   ingest_storage_kafka_producer_address:: 'kafka.%(namespace)s.svc.%(cluster_domain)s:9092' % $._config,
   ingest_storage_kafka_consumer_address:: 'kafka.%(namespace)s.svc.%(cluster_domain)s:9092' % $._config,
 
-  ingest_storage_kafka_producer_client_id:: null,
-  ingest_storage_kafka_consumer_client_id:: null,
+  // The default Kafka client ID settings to use for producers and consumers.
+  // These key-value settings get serialised into a comma-separated string.
+  ingest_storage_kafka_producer_client_id_default_settings:: {},
+  ingest_storage_kafka_consumer_client_id_default_settings:: {},
+
+  // The per-component Kafka client ID settings overrides.
+  ingest_storage_distributor_kafka_client_id_settings:: {},
+  ingest_storage_ingester_kafka_client_id_settings:: {},
+  ingest_storage_query_frontend_kafka_client_id_settings:: {},
+  ingest_storage_ruler_kafka_client_id_settings:: {},
 
   // The configuration that should be applied to Mimir components either producing to or consuming from Kafka.
   ingest_storage_kafka_client_args:: {
@@ -54,16 +62,16 @@
     'ingest-storage.kafka.auto-create-topic-default-partitions': 1000,
   },
 
-  // The configuration that should be applied to Mimir components producing to Kafka.
+  // The configuration that should be applied to all Mimir components producing to Kafka.
   ingest_storage_kafka_producer_args:: {
     'ingest-storage.kafka.address': $.ingest_storage_kafka_producer_address,
-    'ingest-storage.kafka.client-id': $.ingest_storage_kafka_producer_client_id,
+    'ingest-storage.kafka.client-id': buildKafkaClientID($.ingest_storage_kafka_producer_client_id_default_settings),
   },
 
-  // The configuration that should be applied to Mimir components consuming from Kafka.
+  // The configuration that should be applied to all Mimir components consuming from Kafka.
   ingest_storage_kafka_consumer_args:: {
     'ingest-storage.kafka.address': $.ingest_storage_kafka_consumer_address,
-    'ingest-storage.kafka.client-id': $.ingest_storage_kafka_consumer_client_id,
+    'ingest-storage.kafka.client-id': buildKafkaClientID($.ingest_storage_kafka_consumer_client_id_default_settings),
   },
 
   //
@@ -85,12 +93,24 @@
     $.ingest_storage_query_frontend_args,
 
   ingest_storage_distributor_args+:: {
+    // Custom Kafka client ID.
+    'ingest-storage.kafka.client-id': buildKafkaClientID(
+      $.ingest_storage_kafka_producer_client_id_default_settings +
+      $.ingest_storage_distributor_kafka_client_id_settings
+    ),
+
     // Increase the default remote write timeout (applied to writing to Kafka too) because writing
     // to Kafka-compatible backend may be slower than writing to ingesters.
     'distributor.remote-timeout': '5s',
   },
 
   ingest_storage_ruler_args+:: {
+    // Custom Kafka client ID.
+    'ingest-storage.kafka.client-id': buildKafkaClientID(
+      $.ingest_storage_kafka_producer_client_id_default_settings +
+      $.ingest_storage_ruler_kafka_client_id_settings
+    ),
+
     // No need to increase -distributor.remote-timeout because the ruler's default is higher.
   },
 
@@ -104,6 +124,12 @@
     // Reduce the OffsetCommit pressure, at the cost of replaying few seconds of already-ingested data in case an ingester abruptly terminates
     // (in case of a graceful shutdown, the ingester will commit the offset at shutdown too).
     'ingest-storage.kafka.consumer-group-offset-commit-interval': '5s',
+
+    // Custom Kafka client ID.
+    'ingest-storage.kafka.client-id': buildKafkaClientID(
+      $.ingest_storage_kafka_consumer_client_id_default_settings +
+      $.ingest_storage_ingester_kafka_client_id_settings
+    ),
   },
 
   ingest_storage_partition_ring_client_args+:: {
@@ -123,6 +149,12 @@
     // the logic to fetch the last produced offsets.
     $.ingest_storage_partition_ring_client_args
     {
+      // Custom Kafka client ID.
+      'ingest-storage.kafka.client-id': buildKafkaClientID(
+        $.ingest_storage_kafka_consumer_client_id_default_settings +
+        $.ingest_storage_query_frontend_kafka_client_id_settings
+      ),
+
       // Reduce the LPO polling interval to improve latency of strong consistency reads.
       'ingest-storage.kafka.last-produced-offset-poll-interval': '500ms',
     },
@@ -142,4 +174,29 @@
     if $._config.ingest_storage_enabled && $._config.ingest_storage_ingester_zones < 3
     then null
     else super.ingester_zone_c_service,
+
+  //
+  // Utilities.
+  //
+
+  local buildKafkaClientID(settings) =
+    // Remove all null values from the settings. There could be null values because we use null as override
+    // value to remove a setting from the map.
+    local cleanSettings = {
+      [key]: settings[key]
+      for key in std.objectFields(settings)
+      if settings[key] != null
+    };
+
+    if std.length(cleanSettings) > 0 then
+      // Build the Kafka client ID from settings. Sort the key-value pairs to get a stable output.
+      std.join(',', std.sort(
+        [
+          key + '=' + cleanSettings[key]
+          for key in std.objectFields(cleanSettings)
+        ]
+      ))
+    else
+      // Explicitly use null so that the CLI flag will not be set at all (instead of getting set to an empty string).
+      null,
 }

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -47,15 +47,15 @@
 
   // The default Kafka client ID settings to use for producers and consumers.
   // These key-value settings get serialised into a comma-separated string.
-  ingest_storage_kafka_producer_client_id_default_settings:: {},
-  ingest_storage_kafka_consumer_client_id_default_settings:: {},
+  ingest_storage_kafka_producer_client_id_settings:: {},
+  ingest_storage_kafka_consumer_client_id_settings:: {},
 
   // The per-component Kafka client ID settings overrides.
-  ingest_storage_distributor_kafka_client_id_settings:: $.ingest_storage_kafka_producer_client_id_default_settings,
-  ingest_storage_ruler_kafka_client_id_settings:: $.ingest_storage_kafka_producer_client_id_default_settings,
+  ingest_storage_distributor_kafka_client_id_settings:: $.ingest_storage_kafka_producer_client_id_settings,
+  ingest_storage_ruler_kafka_client_id_settings:: $.ingest_storage_kafka_producer_client_id_settings,
 
-  ingest_storage_ingester_kafka_client_id_settings:: $.ingest_storage_kafka_consumer_client_id_default_settings,
-  ingest_storage_query_frontend_kafka_client_id_settings:: $.ingest_storage_kafka_consumer_client_id_default_settings,
+  ingest_storage_ingester_kafka_client_id_settings:: $.ingest_storage_kafka_consumer_client_id_settings,
+  ingest_storage_query_frontend_kafka_client_id_settings:: $.ingest_storage_kafka_consumer_client_id_settings,
 
   // The configuration that should be applied to Mimir components either producing to or consuming from Kafka.
   ingest_storage_kafka_client_args:: {
@@ -66,13 +66,13 @@
   // The configuration that should be applied to all Mimir components producing to Kafka.
   ingest_storage_kafka_producer_args:: {
     'ingest-storage.kafka.address': $.ingest_storage_kafka_producer_address,
-    'ingest-storage.kafka.client-id': $.mimirKafkaClientID($.ingest_storage_kafka_producer_client_id_default_settings),
+    'ingest-storage.kafka.client-id': $.mimirKafkaClientID($.ingest_storage_kafka_producer_client_id_settings),
   },
 
   // The configuration that should be applied to all Mimir components consuming from Kafka.
   ingest_storage_kafka_consumer_args:: {
     'ingest-storage.kafka.address': $.ingest_storage_kafka_consumer_address,
-    'ingest-storage.kafka.client-id': $.mimirKafkaClientID($.ingest_storage_kafka_consumer_client_id_default_settings),
+    'ingest-storage.kafka.client-id': $.mimirKafkaClientID($.ingest_storage_kafka_consumer_client_id_settings),
   },
 
   //


### PR DESCRIPTION
#### What this PR does

In this PR I propose a jsonnet refactoring to allow to easily override the Kafka client ID on a per-component basis. The idea is to configure the client ID as key-value pairs, which then gets serialised in a comma-separated string (e.g. `{keyA: 'valueA', keyB: 'valueB'}` gets serialised to `keyA=valueA,keyB=valueB`).

I've introduce config fields to set the Kafka client ID for specific Mimir components (distributor, ingester, query-frontend, ruler). By default, they inherit the default producer or consumer settings, but client ID values can be overriden in the per-component config field. Similarly to CLI args, a `null` value in the override removes that setting from the client ID.

The config fields are suffixed with `_settings`. They work similarly to `_args` ones, but since they're not CLI flags I preferred to name them differently.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
