### PR TITLE
build: add support for docker `healthcheck` to `grafana/mimir` image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * [ENHANCEMENT] Make `-query-frontend.additional-query-queue-dimensions-enabled` and `-query-scheduler.additional-query-queue-dimensions-enabled` non-operational flags in preparation for removal. #8984
 * [ENHANCEMENT] Add a new ingester endpoint to prepare instances to downscale. #8956
 * [ENHANCEMENT] Query-scheduler: Add `query-scheduler.prioritize-query-components` which, when enabled, will primarily prioritize dequeuing fairly across queue components, and secondarily prioritize dequeuing fairly across tenants. When disabled, tenant fairness is primarily prioritized. `query-scheduler.use-multi-algorithm-query-queue` must be enabled in order to use this flag. #9016
+* [ENHANCEMENT] Build: `grafana/mimir` docker image is now support docker `healthcheck`. #9034
 * [BUGFIX] Ruler: add support for draining any outstanding alert notifications before shutting down. This can be enabled with the `-ruler.drain-notification-queue-on-shutdown=true` CLI flag. #8346
 * [BUGFIX] Query-frontend: fix `-querier.max-query-lookback` enforcement when `-compactor.blocks-retention-period` is not set, and viceversa. #8388
 * [BUGFIX] Ingester: fix sporadic `not found` error causing an internal server error if label names are queried with matchers during head compaction. #8391

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -2,7 +2,7 @@
 # We use different base images for mimir and mimir race images since race-detector needs glibc packages.
 # See difference between distroless static and base-nossl at https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md.
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
+ARG        BASEIMG=gcr.io/distroless/static-debian12:debug
 FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
@@ -11,6 +11,7 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying mimir binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       mimir${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /bin/mimir
+RUN        [ "/busybox/sh", "-c", "ln -s /busybox/sh /bin/sh" ]
 EXPOSE     8080
 ENTRYPOINT [ "/bin/mimir" ]
 

--- a/docs/sources/mimir/get-started/play-with-grafana-mimir/docker-compose.yml
+++ b/docs/sources/mimir/get-started/play-with-grafana-mimir/docker-compose.yml
@@ -70,6 +70,11 @@ services:
     hostname: mimir-1
     depends_on:
       - minio
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:8080/ready || exit 1
+      interval: 1m
+      timeout: 5s
+      retries: 5
     volumes:
       - ./config/mimir.yaml:/etc/mimir.yaml
       - ./config/alertmanager-fallback-config.yaml:/etc/alertmanager-fallback-config.yaml
@@ -81,6 +86,11 @@ services:
     hostname: mimir-2
     depends_on:
       - minio
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:8080/ready || exit 1
+      interval: 1m
+      timeout: 5s
+      retries: 5
     volumes:
       - ./config/mimir.yaml:/etc/mimir.yaml
       - ./config/alertmanager-fallback-config.yaml:/etc/alertmanager-fallback-config.yaml
@@ -92,6 +102,11 @@ services:
     hostname: mimir-3
     depends_on:
       - minio
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:8080/ready || exit 1
+      interval: 1m
+      timeout: 5s
+      retries: 5
     volumes:
       - ./config/mimir.yaml:/etc/mimir.yaml
       - ./config/alertmanager-fallback-config.yaml:/etc/alertmanager-fallback-config.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Add support for docker `healthcheck` to `grafana/mimir` image.

Like [loki](https://github.com/grafana/loki/blob/811f5f015cd5da4e25d800307b905c3385406be3/cmd/loki/Dockerfile#L8-L20) does:

```Dockerfile
FROM gcr.io/distroless/base-nossl:debug

COPY --from=build /src/loki/cmd/loki/loki /usr/bin/loki
COPY cmd/loki/loki-docker-config.yaml /etc/loki/local-config.yaml

SHELL [ "/busybox/sh", "-c" ]

RUN addgroup -g 10001 -S loki && \
    adduser -u 10001 -S loki -G loki
RUN mkdir -p /loki/rules && \
    mkdir -p /loki/rules-temp && \
    chown -R loki:loki /etc/loki /loki && \
    ln -s /busybox/sh /bin/sh
```

`debug` tag is used to have `busybox` [available](https://github.com/GoogleContainerTools/distroless/issues/419#issuecomment-542708073) in the image.


#### Which issue(s) this PR fixes or relates to

Fixes #9034

#### Checklist

- [n/a] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
