### PR TITLE
Add unit test for `chunkIterator.Seek()` when the current batch can satisfy the sought timestamp

### DIFF
--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -38,7 +38,10 @@ func (c GenericChunk) Iterator(reuse chunk.Iterator) chunk.Iterator {
 
 // iterator iterates over batches.
 type iterator interface {
-	// Seek advances the iterator forward to the sample at or after the given timestamp.
+	// Seek advances the iterator forward to batch containing the sample at or after the given timestamp.
+	// If the current batch contains a sample at or after the given timestamp, then Seek retains the current batch.
+	//
+	// The batch's Index is advanced to point to the sample at or after the given timestamp.
 	Seek(t int64, size int) chunkenc.ValueType
 
 	// Next moves to the next batch.

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -38,7 +38,7 @@ func (c GenericChunk) Iterator(reuse chunk.Iterator) chunk.Iterator {
 
 // iterator iterates over batches.
 type iterator interface {
-	// Seek to the batch with sample at (or after) time t.
+	// Seek advances the iterator forward to the sample at or after the given timestamp.
 	Seek(t int64, size int) chunkenc.ValueType
 
 	// Next moves to the next batch.

--- a/pkg/querier/batch/chunk.go
+++ b/pkg/querier/batch/chunk.go
@@ -32,8 +32,6 @@ func (i *chunkIterator) reset(chunk GenericChunk) {
 	i.batch.Index = 0
 }
 
-// Seek advances the iterator forward to the value at or after
-// the given timestamp.
 func (i *chunkIterator) Seek(t int64, size int) chunkenc.ValueType {
 	// We assume seeks only care about a specific window; if this chunk doesn't
 	// contain samples in that window, we can shortcut.

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -238,7 +238,7 @@ func TestChunkIterator_SeekBeforeCurrentBatch(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, chk.UnmarshalFromBuf(ch.Bytes()))
 
-		// We should never need to reset this iterator, as the Seek call below should be able to be satisfied by the initial batch.
+		// We should never need to reset this iterator, as the Seek call below should be satisfiable by the initial batch.
 		return &chunkIteratorThatForbidsFindAtOrAfter{chk.NewIterator(reuse)}
 	})
 

--- a/pkg/querier/batch/stream.go
+++ b/pkg/querier/batch/stream.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/chunk"
 )
 
-// batchStream deals with iteratoring through multiple, non-overlapping batches,
+// batchStream deals with iterating through multiple, non-overlapping batches,
 // and building new slices of non-overlapping batches.  Designed to be used
 // without allocations.
 type batchStream struct {


### PR DESCRIPTION
#### What this PR does

This PR is a follow up to https://github.com/grafana/mimir/pull/8992.

In that PR, we noticed that `chunkIterator` had similar logic to `mergeIterator`, but decided to merge the change without adding a test for `chunkIterator`. In this PR, I'm adding a test for that case.

This revealed that while `chunkIterator` would have behaved correctly without the change in #8992, it would unnecessarily skip the optimisation to satisfy the `Seek` from the current batch if the sought timestamp was before the first sample of the current batch.

Note that `Seek` is expected to only move forwards, and I've clarified the docstring for the interface to reflect this.

I haven't added a changelog entry given this PR only adds a test.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/pull/8992.

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
