### PR TITLE
store-gateway: make concurrency gate logs debug

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -742,7 +742,7 @@ func (s *BucketStore) limitConcurrentQueries(ctx context.Context, stats *safeQue
 	waited := time.Since(waitStart)
 
 	stats.update(func(stats *queryStats) { stats.streamingSeriesConcurrencyLimitWaitDuration = waited })
-	level.Info(spanlogger.FromContext(ctx, s.logger)).Log("msg", "waited for turn on query concurrency gate", "duration", waited)
+	level.Debug(spanlogger.FromContext(ctx, s.logger)).Log("msg", "waited for turn on query concurrency gate", "duration", waited)
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to wait for turn")


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

I noticed that logs are now filled with lines like this one

```
ts=2024-08-19T14:44:32.753385487Z caller=spanlogger.go:111 user=10428 caller=log.go:168 level=info msg="waited for turn on query concurrency gate" duration=6.289µs
```

I don't think we need this as an info log.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
