### PR TITLE
store-gateway: gracefully shut down BucketStores

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -330,6 +330,9 @@ func (s *BucketStore) syncBlocks(ctx context.Context) error {
 		}
 		select {
 		case <-ctx.Done():
+			close(blockc)
+			wg.Wait()
+			return nil
 		case blockc <- meta:
 		}
 	}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -330,9 +330,6 @@ func (s *BucketStore) syncBlocks(ctx context.Context) error {
 		}
 		select {
 		case <-ctx.Done():
-			close(blockc)
-			wg.Wait()
-			return nil
 		case blockc <- meta:
 		}
 	}

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -253,6 +253,7 @@ func (g *StoreGateway) starting(ctx context.Context) (err error) {
 	// At this point, the instance is registered with some tokens
 	// and we can start the bucket stores.
 	g.bucketSync.WithLabelValues(syncReasonInitial).Inc()
+	// We pass context.Background() because we want to control the shutdown of stores ourselves instead of stopping it immediately after when ctx is cancelled.
 	if err = services.StartAndAwaitRunning(context.Background(), g.stores); err != nil {
 		return errors.Wrap(err, "starting bucket stores")
 	}

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -253,7 +253,7 @@ func (g *StoreGateway) starting(ctx context.Context) (err error) {
 	// At this point, the instance is registered with some tokens
 	// and we can start the bucket stores.
 	g.bucketSync.WithLabelValues(syncReasonInitial).Inc()
-	if err = services.StartAndAwaitRunning(ctx, g.stores); err != nil {
+	if err = services.StartAndAwaitRunning(context.Background(), g.stores); err != nil {
 		return errors.Wrap(err, "starting bucket stores")
 	}
 


### PR DESCRIPTION
### What this PR does

This PR fixes a bug which resulted in a flaky test. 
#### BucketStores graceful shutdown

BucketStores would get shut down immediately when we receive SIGTERM instead of waiting for ongoing bucket syncs to finish first. This sometimes results in leaving index header readers open before shutting down.

This made some tests flaky. It could possibly mean that `BucketStores` stop `BucketStore` instances before waiting for ongoing queries to finish, but I am not certain of this and couldn't find proof in 2 weeks worth of store-gateway and querier logs. Still this is a bug and we should fix it.

By using `context.Background()` we rely on the shutdown here to take effect instead of detecting the parent context being cancelled

https://github.com/grafana/mimir/blob/fcef902e727c603411614d41bdb5d95223ac539f/pkg/storegateway/gateway.go#L326-L328

This is also the pattern I used for starting and stopping the index reader pool here

https://github.com/grafana/mimir/blob/b3a8b39b5fcf7b327239160229bbb1c13a97240f/pkg/storegateway/bucket.go#L265-L266


### Flaky test

Previously the test from https://github.com/grafana/mimir/issues/9009 failed 3 out of 70 runs (once every ~23 runs). With this fix I ran it 100 times and it didn't fail.

### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/9009

### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
