### PR TITLE
indexheader: abort writing index-header when data transfer from bucket is slow

### DIFF
--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -22,7 +22,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/index"
-	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 )
@@ -69,7 +68,7 @@ type BinaryTOC struct {
 }
 
 // WriteBinary build index-header file from the pieces of index in object storage.
-func WriteBinary(ctx context.Context, bkt objstore.BucketReader, id ulid.ULID, filename string) (err error) {
+func WriteBinary(ctx context.Context, bkt bucketRangeReader, id ulid.ULID, filename string) (err error) {
 	ir, indexVersion, err := newChunkedIndexReader(ctx, bkt, id)
 	if err != nil {
 		return errors.Wrap(err, "new index reader")
@@ -129,11 +128,11 @@ type chunkedIndexReader struct {
 	ctx  context.Context
 	path string
 	size uint64
-	bkt  objstore.BucketReader
+	bkt  bucketRangeReader
 	toc  *index.TOC
 }
 
-func newChunkedIndexReader(ctx context.Context, bkt objstore.BucketReader, id ulid.ULID) (*chunkedIndexReader, int, error) {
+func newChunkedIndexReader(ctx context.Context, bkt bucketRangeReader, id ulid.ULID) (*chunkedIndexReader, int, error) {
 	indexFilepath := filepath.Join(id.String(), block.IndexFilename)
 	attrs, err := bkt.Attributes(ctx, indexFilepath)
 	if err != nil {

--- a/pkg/storegateway/indexheader/bucket_reader.go
+++ b/pkg/storegateway/indexheader/bucket_reader.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package indexheader
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math"
+	"time"
+
+	"github.com/thanos-io/objstore"
+)
+
+var errLowThroughput = errors.New("throughput is lower than expected minimum")
+
+type bucketRangeReader interface {
+	// GetRange returns a new range reader for the given object name and range.
+	GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error)
+	// Attributes returns information about the specified object.
+	Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error)
+}
+
+type minThroughputBucketRangeReader struct {
+	bucketRangeReader
+	// Minimum expected throughput in bytes/s.
+	throughput int
+}
+
+func bucketRangeReaderWithEnforcedThroughput(bkt bucketRangeReader, throughput int) bucketRangeReader {
+	return &minThroughputBucketRangeReader{
+		bucketRangeReader: bkt,
+		throughput:        throughput,
+	}
+}
+
+func (m *minThroughputBucketRangeReader) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, m.expectedTime(length), errLowThroughput)
+	defer cancel()
+	return m.bucketRangeReader.GetRange(ctx, name, off, length)
+}
+
+func (m *minThroughputBucketRangeReader) expectedTime(n int64) time.Duration {
+	if m.throughput == 0 {
+		return time.Duration(math.MaxInt)
+	}
+	return time.Duration(n) * time.Second / time.Duration(m.throughput)
+}

--- a/pkg/storegateway/indexheader/header.go
+++ b/pkg/storegateway/indexheader/header.go
@@ -70,12 +70,12 @@ type Config struct {
 	// Controls whether index-header lazy loading is enabled.
 	LazyLoadingEnabled     bool          `yaml:"lazy_loading_enabled" category:"advanced"`
 	LazyLoadingIdleTimeout time.Duration `yaml:"lazy_loading_idle_timeout" category:"advanced"`
-
 	// Maximum index-headers loaded into store-gateway concurrently
 	LazyLoadingConcurrency             int           `yaml:"lazy_loading_concurrency" category:"advanced"`
 	LazyLoadingConcurrencyQueueTimeout time.Duration `yaml:"lazy_loading_concurrency_queue_timeout" category:"advanced"`
 
-	VerifyOnLoad bool `yaml:"verify_on_load" category:"advanced"`
+	MinDownloadThroughput int  `yaml:"min_download_throughput" category:"experimental"`
+	VerifyOnLoad          bool `yaml:"verify_on_load" category:"advanced"`
 
 	// EagerLoadingPersistInterval is injected for testing purposes only.
 	EagerLoadingPersistInterval time.Duration `yaml:"-" doc:"hidden"`
@@ -89,6 +89,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
 	f.DurationVar(&cfg.LazyLoadingConcurrencyQueueTimeout, prefix+"lazy-loading-concurrency-queue-timeout", 5*time.Second, "Timeout for the queue of index header loads. If the queue is full and the timeout is reached, the load will return an error. 0 means no timeout and the load will wait indefinitely.")
 	f.BoolVar(&cfg.EagerLoadingStartupEnabled, prefix+"eager-loading-startup-enabled", true, "If enabled, store-gateway will periodically persist block IDs of lazy loaded index-headers and load them eagerly during startup. Ignored if index-header lazy loading is disabled.")
 	f.DurationVar(&cfg.EagerLoadingPersistInterval, prefix+"eager-loading-persist-interval", time.Minute, "Interval at which the store-gateway persists block IDs of lazy loaded index-headers. Ignored if index-header eager loading is disabled.")
+	f.IntVar(&cfg.MinDownloadThroughput, prefix+"min-download-throughput", 256*1024, "The floor of the throughput, in bytes/sec, with which store-gateway expected to download index-header.")
 	f.BoolVar(&cfg.VerifyOnLoad, prefix+"verify-on-load", false, "If true, verify the checksum of index headers upon loading them (either on startup or lazily when lazy loading is enabled). Setting to true helps detect disk corruption at the cost of slowing down index header loading.")
 }
 

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -48,8 +48,7 @@ var implementations = []struct {
 			readerFactory := func() (Reader, error) {
 				return NewStreamBinaryReader(ctx, log.NewNopLogger(), nil, dir, id, 32, NewStreamBinaryReaderMetrics(nil), Config{})
 			}
-
-			br, err := NewLazyBinaryReader(ctx, readerFactory, log.NewNopLogger(), nil, dir, id, NewLazyBinaryReaderMetrics(nil), nil, gate.NewNoop())
+			br, err := NewLazyBinaryReader(ctx, log.NewNopLogger(), readerFactory, id, NewLazyBinaryReaderMetrics(nil), nil, gate.NewNoop())
 			require.NoError(t, err)
 			requireCleanup(t, br.Close)
 			return br

--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -53,7 +53,6 @@ func TestReaderPool_NewBinaryReader(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-
 			metrics := NewReaderPoolMetrics(nil)
 			indexHeaderConfig := Config{
 				LazyLoadingEnabled:     testData.lazyReaderEnabled,

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -22,7 +22,6 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/tsdb/index"
-	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	streamencoding "github.com/grafana/mimir/pkg/storegateway/indexheader/encoding"
@@ -70,7 +69,7 @@ type StreamBinaryReader struct {
 }
 
 // NewStreamBinaryReader loads or builds new index-header if not present on disk.
-func NewStreamBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, metrics *StreamBinaryReaderMetrics, cfg Config) (*StreamBinaryReader, error) {
+func NewStreamBinaryReader(ctx context.Context, logger log.Logger, bkt bucketRangeReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, metrics *StreamBinaryReaderMetrics, cfg Config) (*StreamBinaryReader, error) {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, logger, "indexheader.NewStreamBinaryReader")
 	defer spanLog.Finish()
 


### PR DESCRIPTION
#### What this PR does

_This one is still a draft, as I wanted to get some feedback on the approach. I'm not too fancy about how this ended up, but it seems the simplest way to solve what we outlined in #8364. Note, I'll be looking at which tests to add here, after we agree on the direction._

Here we update the internals of `indexheader` with the support for estimating how much time the download of an index-header's chunks should take, base on the configured `min-download-throughput`.

cc @dimitarvdimitrov @pracucci 

#### Which issue(s) this PR fixes or relates to

Fixes #8364

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
