### PR TITLE
querier: set minimum concurrency to 4 for query-scheduler's new querier-worker queue prioritization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [CHANGE] Store-gateway / querier: enable streaming chunks from store-gateways to queriers by default. #6646
 * [CHANGE] Querier: honor the start/end time range specified in the read hints when executing a remote read request. #8431
 * [CHANGE] Querier: return only samples within the queried start/end time range when executing a remote read request using "SAMPLES" mode. Previously, samples outside of the range could have been returned. Samples outside of the queried time range may still be returned when executing a remote read request using "STREAMED_XOR_CHUNKS" mode. #8463
-* [CHANGE] Querier: Set minimum for `-querier.max-concurrent` to 4 to prevent queue starvation with querier-worker queue prioritization algorithm; values below the minimum 4 will be ignored and set to the minimum. #9054
+* [CHANGE] Querier: Set minimum for `-querier.max-concurrent` to four to prevent queue starvation with querier-worker queue prioritization algorithm; values below the minimum four are ignored and set to the minimum. #9054
 * [CHANGE] Store-gateway: enabled `-blocks-storage.bucket-store.max-concurrent-queue-timeout` by default with a timeout of 5 seconds. #8496
 * [CHANGE] Store-gateway: enabled `-blocks-storage.bucket-store.index-header.lazy-loading-concurrency-queue-timeout` by default with a timeout of 5 seconds . #8667
 * [CHANGE] Distributor: Incoming OTLP requests were previously size-limited by using limit from `-distributor.max-recv-msg-size` option. We have added option `-distributor.max-otlp-request-size` for limiting OTLP requests, with default value of 100 MiB. #8574

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGE] Store-gateway / querier: enable streaming chunks from store-gateways to queriers by default. #6646
 * [CHANGE] Querier: honor the start/end time range specified in the read hints when executing a remote read request. #8431
 * [CHANGE] Querier: return only samples within the queried start/end time range when executing a remote read request using "SAMPLES" mode. Previously, samples outside of the range could have been returned. Samples outside of the queried time range may still be returned when executing a remote read request using "STREAMED_XOR_CHUNKS" mode. #8463
+* [CHANGE] Querier: Set minimum for `-querier.max-concurrent` to 4 to prevent queue starvation with querier-worker queue prioritization algorithm; values below the minimum 4 will be ignored and set to the minimum. #9054
 * [CHANGE] Store-gateway: enabled `-blocks-storage.bucket-store.max-concurrent-queue-timeout` by default with a timeout of 5 seconds. #8496
 * [CHANGE] Store-gateway: enabled `-blocks-storage.bucket-store.index-header.lazy-loading-concurrency-queue-timeout` by default with a timeout of 5 seconds . #8667
 * [CHANGE] Distributor: Incoming OTLP requests were previously size-limited by using limit from `-distributor.max-recv-msg-size` option. We have added option `-distributor.max-otlp-request-size` for limiting OTLP requests, with default value of 100 MiB. #8574

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1935,7 +1935,7 @@
           "kind": "field",
           "name": "max_concurrent",
           "required": false,
-          "desc": "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier.",
+          "desc": "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. Minimum 4; lower values will be ignored and set to the minimum.",
           "fieldValue": null,
           "fieldDefaultValue": 20,
           "fieldFlag": "querier.max-concurrent",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1935,7 +1935,7 @@
           "kind": "field",
           "name": "max_concurrent",
           "required": false,
-          "desc": "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. Minimum 4; lower values will be ignored and set to the minimum.",
+          "desc": "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum",
           "fieldValue": null,
           "fieldDefaultValue": 20,
           "fieldFlag": "querier.max-concurrent",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1876,7 +1876,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.lookback-delta duration
     	Time since the last sample after which a time series is considered stale and ignored by expression evaluations. This config option should be set on query-frontend too when query sharding is enabled. (default 5m0s)
   -querier.max-concurrent int
-    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. Minimum 4; lower values will be ignored and set to the minimum. (default 20)
+    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum (default 20)
   -querier.max-estimated-fetched-chunks-per-query-multiplier float
     	[experimental] Maximum number of chunks estimated to be fetched in a single query from ingesters and store-gateways, as a multiple of -querier.max-fetched-chunks-per-query. This limit is enforced in the querier. Must be greater than or equal to 1, or 0 to disable.
   -querier.max-estimated-memory-consumption-per-query uint

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1876,7 +1876,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.lookback-delta duration
     	Time since the last sample after which a time series is considered stale and ignored by expression evaluations. This config option should be set on query-frontend too when query sharding is enabled. (default 5m0s)
   -querier.max-concurrent int
-    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. (default 20)
+    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. Minimum 4; lower values will be ignored and set to the minimum. (default 20)
   -querier.max-estimated-fetched-chunks-per-query-multiplier float
     	[experimental] Maximum number of chunks estimated to be fetched in a single query from ingesters and store-gateways, as a multiple of -querier.max-fetched-chunks-per-query. This limit is enforced in the querier. Must be greater than or equal to 1, or 0 to disable.
   -querier.max-estimated-memory-consumption-per-query uint

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -522,7 +522,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.label-values-max-cardinality-label-names-per-request int
     	Maximum number of label names allowed to be queried in a single /api/v1/cardinality/label_values API call. (default 100)
   -querier.max-concurrent int
-    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. (default 20)
+    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. Minimum 4; lower values will be ignored and set to the minimum. (default 20)
   -querier.max-fetched-chunk-bytes-per-query int
     	The maximum size of all chunks in bytes that a query can fetch from ingesters and store-gateways. This limit is enforced in the querier and ruler. 0 to disable.
   -querier.max-fetched-chunks-per-query int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -522,7 +522,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.label-values-max-cardinality-label-names-per-request int
     	Maximum number of label names allowed to be queried in a single /api/v1/cardinality/label_values API call. (default 100)
   -querier.max-concurrent int
-    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. Minimum 4; lower values will be ignored and set to the minimum. (default 20)
+    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum (default 20)
   -querier.max-fetched-chunk-bytes-per-query int
     	The maximum size of all chunks in bytes that a query can fetch from ingesters and store-gateways. This limit is enforced in the querier and ruler. 0 to disable.
   -querier.max-fetched-chunks-per-query int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1484,8 +1484,8 @@ store_gateway_client:
 [enable_query_engine_fallback: <boolean> | default = true]
 
 # The number of workers running in each querier process. This setting limits the
-# maximum number of concurrent queries in each querier. Minimum 4; lower values
-# will be ignored and set to the minimum.
+# maximum number of concurrent queries in each querier. The minimum value is four; lower values
+# are ignored and set to the minimum.
 # CLI flag: -querier.max-concurrent
 [max_concurrent: <int> | default = 20]
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1484,7 +1484,8 @@ store_gateway_client:
 [enable_query_engine_fallback: <boolean> | default = true]
 
 # The number of workers running in each querier process. This setting limits the
-# maximum number of concurrent queries in each querier.
+# maximum number of concurrent queries in each querier. Minimum 4; lower values
+# will be ignored and set to the minimum.
 # CLI flag: -querier.max-concurrent
 [max_concurrent: <int> | default = 20]
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1484,8 +1484,8 @@ store_gateway_client:
 [enable_query_engine_fallback: <boolean> | default = true]
 
 # The number of workers running in each querier process. This setting limits the
-# maximum number of concurrent queries in each querier. The minimum value is four; lower values
-# are ignored and set to the minimum.
+# maximum number of concurrent queries in each querier. The minimum value is
+# four; lower values are ignored and set to the minimum
 # CLI flag: -querier.max-concurrent
 [max_concurrent: <int> | default = 20]
 

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -202,7 +202,7 @@ var (
 			"-querier.frontend-client.backoff-min-period": "100ms",
 			"-querier.frontend-client.backoff-max-period": "100ms",
 			"-querier.frontend-client.backoff-retries":    "1",
-			"-querier.max-concurrent":                     "1",
+			"-querier.max-concurrent":                     "4",
 			// Distributor.
 			"-distributor.ring.store": "memberlist",
 			// Ingester.

--- a/integration/e2emimir/services.go
+++ b/integration/e2emimir/services.go
@@ -123,7 +123,7 @@ func NewQuerier(name string, consulAddress string, flags map[string]string, opti
 			"-querier.frontend-client.backoff-min-period": "100ms",
 			"-querier.frontend-client.backoff-max-period": "100ms",
 			"-querier.frontend-client.backoff-retries":    "1",
-			"-querier.max-concurrent":                     "1",
+			"-querier.max-concurrent":                     "4",
 			// Quickly detect query-frontend and query-scheduler when running it.
 			"-querier.dns-lookup-period": "1s",
 			// Store-gateway ring backend.

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -142,11 +142,11 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 		require.NoError(t, err)
 	}
 
-	// Wait until both workers connect to the query-frontend or query-scheduler
+	// Wait until both workers connect to the query-frontend or query-scheduler, each with the minimum 4 connections.
 	if cfg.querySchedulerEnabled {
-		require.NoError(t, queryScheduler.WaitSumMetrics(e2e.Equals(2), "cortex_query_scheduler_connected_querier_clients"))
+		require.NoError(t, queryScheduler.WaitSumMetrics(e2e.Equals(8), "cortex_query_scheduler_connected_querier_clients"))
 	} else {
-		require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(2), "cortex_query_frontend_connected_clients"))
+		require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(8), "cortex_query_frontend_connected_clients"))
 	}
 
 	wg := sync.WaitGroup{}

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -39,7 +39,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 			"-query-scheduler.service-discovery-mode": "ring",
 			"-query-scheduler.ring.store":             "consul",
 			"-query-scheduler.max-used-instances":     "1",
-			"-querier.max-concurrent":                 "4",
+			"-querier.max-concurrent":                 "12",
 		},
 	)
 
@@ -86,9 +86,9 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	inUseScheduler := schedulers[0]
 	notInUseScheduler := schedulers[1]
 
-	// We expect the querier to open 4 connections to the in-use scheduler, and 1 connection to the not-in-use one.
-	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
-	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_query_scheduler_connected_querier_clients"}))
+	// We expect the querier to open 8 connections to the in-use scheduler, and 4 connection to the not-in-use one.
+	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(8), []string{"cortex_query_scheduler_connected_querier_clients"}))
+	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
 
 	// We expect the query-frontend to only open connections to the in-use scheduler.
 	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_query_scheduler_connected_frontend_clients"}))

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -39,7 +39,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 			"-query-scheduler.service-discovery-mode": "ring",
 			"-query-scheduler.ring.store":             "consul",
 			"-query-scheduler.max-used-instances":     "1",
-			"-querier.max-concurrent":                 "4",
+			"-querier.max-concurrent":                 "6",
 		},
 	)
 
@@ -115,7 +115,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	require.NoError(t, s.Stop(inUseScheduler))
 
 	// We expect the querier to open 4 connections to the previously not-in-use scheduler.
-	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
+	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(6), []string{"cortex_query_scheduler_connected_querier_clients"}))
 
 	// We expect the query-frontend to open connections to the previously not-in-use scheduler.
 	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_query_scheduler_connected_frontend_clients"}))

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -89,7 +89,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	// The minimum number of connections per scheduler is 4 in order to avoid queue starvation
 	// when the RequestQueue utilizes the querier-worker queue prioritization algorithm.
 	// Although the max-concurrent is set to 8, the querier will create an extra 4 connections
-	// per not-in-use scheduler meet the minimum requirements per connected RequestQueue instance.
+	// per not-in-use to scheduler meet the minimum requirements per connected RequestQueue instance.
 	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(8), []string{"cortex_query_scheduler_connected_querier_clients"}))
 	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
 

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -89,7 +89,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	// The minimum number of connections per scheduler is 4 in order to avoid queue starvation
 	// when the RequestQueue utilizes the querier-worker queue prioritization algorithm.
 	// Although the max-concurrent is set to 8, the querier will create an extra 4 connections
-	// per not-in-use to scheduler meet the minimum requirements per connected RequestQueue instance.
+	// per not-in-use scheduler to meet the minimum requirements per connected RequestQueue instance.
 	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(8), []string{"cortex_query_scheduler_connected_querier_clients"}))
 	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
 

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -39,7 +39,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 			"-query-scheduler.service-discovery-mode": "ring",
 			"-query-scheduler.ring.store":             "consul",
 			"-query-scheduler.max-used-instances":     "1",
-			"-querier.max-concurrent":                 "6",
+			"-querier.max-concurrent":                 "12",
 		},
 	)
 
@@ -86,16 +86,9 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	inUseScheduler := schedulers[0]
 	notInUseScheduler := schedulers[1]
 
-	// The querier initially sees both query-schedulers as in-use,
-	// and increases the number of connections to give each scheduler the minimum 4 connections each, for a total of 8
-	//We expect the querier to initially open the minimum 4 connections to each scheduler, including the not-in-use-instance.
 	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
 
-	// When the querier detects that one scheduler is not in use,
-	// it will recalculate its max connections to distribute all connections to the in-use scheduler.
-	// With only one scheduler connected and a minimum of 4 connections per scheduler,
-	// all 6 connections are allocated to a single scheduler and the total reduces from 8 to 6.
-	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(6), []string{"cortex_query_scheduler_connected_querier_clients"}))
+	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(8), []string{"cortex_query_scheduler_connected_querier_clients"}))
 
 	// We expect the query-frontend to only open connections to the in-use scheduler.
 	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_query_scheduler_connected_frontend_clients"}))

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -39,7 +39,9 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 			"-query-scheduler.service-discovery-mode": "ring",
 			"-query-scheduler.ring.store":             "consul",
 			"-query-scheduler.max-used-instances":     "1",
-			"-querier.max-concurrent":                 "6",
+			// -querier.max-concurrent is chosen < 8 (where 8 == 2 * worker.MinConcurrencyPerRequestQueue)
+			// to require adjustment when 2 schedulers are connected and re-adjustment when one is terminated.
+			"-querier.max-concurrent": "6",
 		},
 	)
 
@@ -86,9 +88,12 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	inUseScheduler := schedulers[0]
 	notInUseScheduler := schedulers[1]
 
-	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
-
+	// The minimum number of connections per scheduler is 4 in order to avoid queue starvation
+	// when the RequestQueue utilizes the querier-worker queue prioritization algorithm.
+	// We expect the querier to open 4 connections to each scheduler; although the max-concurrent
+	// is set to 6, the querier will override to meet the minimum requirements per scheduler.
 	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
+	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
 
 	// We expect the query-frontend to only open connections to the in-use scheduler.
 	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_query_scheduler_connected_frontend_clients"}))
@@ -114,7 +119,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	// Terminate the in-use query-scheduler.
 	require.NoError(t, s.Stop(inUseScheduler))
 
-	// We expect the querier to open 4 connections to the previously not-in-use scheduler.
+	// We expect the querier to transfer all connections up to the configured max to the previously not-in-use scheduler.
 	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(6), []string{"cortex_query_scheduler_connected_querier_clients"}))
 
 	// We expect the query-frontend to open connections to the previously not-in-use scheduler.

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -39,7 +39,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 			"-query-scheduler.service-discovery-mode": "ring",
 			"-query-scheduler.ring.store":             "consul",
 			"-query-scheduler.max-used-instances":     "1",
-			"-querier.max-concurrent":                 "12",
+			"-querier.max-concurrent":                 "4",
 		},
 	)
 
@@ -88,7 +88,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 
 	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
 
-	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(8), []string{"cortex_query_scheduler_connected_querier_clients"}))
+	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Equals(4), []string{"cortex_query_scheduler_connected_querier_clients"}))
 
 	// We expect the query-frontend to only open connections to the in-use scheduler.
 	require.NoError(t, inUseScheduler.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_query_scheduler_connected_frontend_clients"}))

--- a/pkg/querier/engine/config.go
+++ b/pkg/querier/engine/config.go
@@ -44,7 +44,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 		return help + "This config option should be set on query-frontend too when query sharding is enabled."
 	}
 
-	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 20, "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier.")
+	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 20, "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. Minimum 4; lower values will be ignored and set to the minimum.")
 	f.DurationVar(&cfg.Timeout, "querier.timeout", 2*time.Minute, sharedWithQueryFrontend("The timeout for a query.")+" This also applies to queries evaluated by the ruler (internally or remotely).")
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, sharedWithQueryFrontend("Maximum number of samples a single query can load into memory."))
 	f.DurationVar(&cfg.DefaultEvaluationInterval, "querier.default-evaluation-interval", time.Minute, sharedWithQueryFrontend("The default evaluation interval or step size for subqueries."))

--- a/pkg/querier/engine/config.go
+++ b/pkg/querier/engine/config.go
@@ -44,7 +44,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 		return help + "This config option should be set on query-frontend too when query sharding is enabled."
 	}
 
-	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 20, "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. Minimum 4; lower values will be ignored and set to the minimum.")
+	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 20, "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum")
 	f.DurationVar(&cfg.Timeout, "querier.timeout", 2*time.Minute, sharedWithQueryFrontend("The timeout for a query.")+" This also applies to queries evaluated by the ruler (internally or remotely).")
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, sharedWithQueryFrontend("Maximum number of samples a single query can load into memory."))
 	f.DurationVar(&cfg.DefaultEvaluationInterval, "querier.default-evaluation-interval", time.Minute, sharedWithQueryFrontend("The default evaluation interval or step size for subqueries."))

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -349,10 +349,12 @@ func (w *querierWorker) getDesiredConcurrency() map[string]int {
 		inUseIndex = 0
 	)
 
+	level.Warn(w.log).Log("msg", "instances", "instances", fmt.Sprintf("%#v", w.instances))
 	// new adjusted minimum to ensure that each instance has at least minConcurrencyPerRequestQueue connections.
 	maxConcurrentWithMinPerInstance := math.Max(
 		w.maxConcurrentRequests, minConcurrencyPerRequestQueue*len(w.instances),
 	)
+	level.Warn(w.log).Log("msg", "max concurrency with minimum per instance", "max_concurrent_with_min_per_instance", maxConcurrentWithMinPerInstance)
 	if maxConcurrentWithMinPerInstance > w.maxConcurrentRequests {
 		level.Warn(w.log).Log("msg", "max concurrency does not meet the minimum required per request queue instance, increasing to minimum")
 	}
@@ -360,6 +362,7 @@ func (w *querierWorker) getDesiredConcurrency() map[string]int {
 	// not-in-use instances wil only receive minConcurrencyPerRequestQueue;
 	// determine size of remaining pool to be divided across the in-use instances
 	maxConcurrentForInUseInstances := maxConcurrentWithMinPerInstance - minConcurrencyPerRequestQueue*(len(w.instances)-numInUse)
+	level.Warn(w.log).Log("msg", "max concurrency for in use instances", "max_concurrent_for_in_use_instances", maxConcurrentForInUseInstances)
 
 	// Compute the number of desired connections for each discovered instance.
 	for address, instance := range w.instances {
@@ -372,6 +375,7 @@ func (w *querierWorker) getDesiredConcurrency() map[string]int {
 		}
 
 		concurrency := maxConcurrentForInUseInstances / numInUse
+		level.Warn(w.log).Log("msg", "desired concurrency", "addr", address, "concurrency", concurrency)
 
 		// If max concurrency does not evenly divide into in-use instances, then a subset will be chosen
 		// to receive an extra connection. Since we're iterating a map (whose iteration order is not guaranteed),

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -232,10 +232,10 @@ func TestQuerierWorker_getDesiredConcurrency(t *testing.T) {
 			},
 			maxConcurrent: 0,
 			expected: map[string]int{
-				"1.1.1.1": minConcurrencyPerRequestQueue,
-				"2.2.2.2": minConcurrencyPerRequestQueue,
-				"3.3.3.3": minConcurrencyPerRequestQueue,
-				"4.4.4.4": minConcurrencyPerRequestQueue,
+				"1.1.1.1": MinConcurrencyPerRequestQueue,
+				"2.2.2.2": MinConcurrencyPerRequestQueue,
+				"3.3.3.3": MinConcurrencyPerRequestQueue,
+				"4.4.4.4": MinConcurrencyPerRequestQueue,
 			},
 		},
 		"should create the minimum connections for each instance if max concurrency is less than the minimum": {
@@ -247,10 +247,10 @@ func TestQuerierWorker_getDesiredConcurrency(t *testing.T) {
 			},
 			maxConcurrent: 2,
 			expected: map[string]int{
-				"1.1.1.1": minConcurrencyPerRequestQueue,
-				"2.2.2.2": minConcurrencyPerRequestQueue,
-				"3.3.3.3": minConcurrencyPerRequestQueue,
-				"4.4.4.4": minConcurrencyPerRequestQueue,
+				"1.1.1.1": MinConcurrencyPerRequestQueue,
+				"2.2.2.2": MinConcurrencyPerRequestQueue,
+				"3.3.3.3": MinConcurrencyPerRequestQueue,
+				"4.4.4.4": MinConcurrencyPerRequestQueue,
 			},
 		},
 		"should create the minimum connections for each instance if max concurrency is greater than the minimum but less than the min times the number of instances": {
@@ -262,10 +262,10 @@ func TestQuerierWorker_getDesiredConcurrency(t *testing.T) {
 			},
 			maxConcurrent: 12,
 			expected: map[string]int{
-				"1.1.1.1": minConcurrencyPerRequestQueue,
-				"2.2.2.2": minConcurrencyPerRequestQueue,
-				"3.3.3.3": minConcurrencyPerRequestQueue,
-				"4.4.4.4": minConcurrencyPerRequestQueue,
+				"1.1.1.1": MinConcurrencyPerRequestQueue,
+				"2.2.2.2": MinConcurrencyPerRequestQueue,
+				"3.3.3.3": MinConcurrencyPerRequestQueue,
+				"4.4.4.4": MinConcurrencyPerRequestQueue,
 			},
 		},
 	}

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -147,10 +147,10 @@ func TestResetConcurrency(t *testing.T) {
 		},
 		{
 			name:            "Max concurrent dividing with a remainder, with some targets in use",
-			maxConcurrent:   19,
+			maxConcurrent:   9,
 			numTargets:      4,
 			numInUseTargets: 2,
-			expectedConcurrency:/* in use:  */ 8 + /* not in use : */ 11,
+			expectedConcurrency:/* in use:  */ 9 + /* not in use : */ 8,
 		},
 		{
 			name:                "Max concurrent dividing evenly, with all targets in use",
@@ -161,10 +161,10 @@ func TestResetConcurrency(t *testing.T) {
 		},
 		{
 			name:            "Max concurrent dividing evenly, with some targets in use",
-			maxConcurrent:   20,
+			maxConcurrent:   12,
 			numTargets:      4,
 			numInUseTargets: 2,
-			expectedConcurrency:/* in use:  */ 8 + /* not in use : */ 12,
+			expectedConcurrency:/* in use:  */ 12 + /* not in use : */ 8,
 		},
 	}
 
@@ -215,7 +215,7 @@ func TestQuerierWorker_getDesiredConcurrency(t *testing.T) {
 				{Address: "3.3.3.3", InUse: true},
 				{Address: "4.4.4.4", InUse: false},
 			},
-			maxConcurrent: 20,
+			maxConcurrent: 12,
 			expected: map[string]int{
 				"1.1.1.1": 6,
 				"2.2.2.2": 4,
@@ -238,7 +238,7 @@ func TestQuerierWorker_getDesiredConcurrency(t *testing.T) {
 				"4.4.4.4": MinConcurrencyPerRequestQueue,
 			},
 		},
-		"should create the minimum connections for each instance if max concurrency is less than the minimum": {
+		"should create the minimum connections for each instance if max concurrency is less than the minimum min times the number of in-use instances": {
 			instances: []servicediscovery.Instance{
 				{Address: "1.1.1.1", InUse: true},
 				{Address: "2.2.2.2", InUse: false},
@@ -246,21 +246,6 @@ func TestQuerierWorker_getDesiredConcurrency(t *testing.T) {
 				{Address: "4.4.4.4", InUse: false},
 			},
 			maxConcurrent: 2,
-			expected: map[string]int{
-				"1.1.1.1": MinConcurrencyPerRequestQueue,
-				"2.2.2.2": MinConcurrencyPerRequestQueue,
-				"3.3.3.3": MinConcurrencyPerRequestQueue,
-				"4.4.4.4": MinConcurrencyPerRequestQueue,
-			},
-		},
-		"should create the minimum connections for each instance if max concurrency is greater than the minimum but less than the min times the number of instances": {
-			instances: []servicediscovery.Instance{
-				{Address: "1.1.1.1", InUse: true},
-				{Address: "2.2.2.2", InUse: false},
-				{Address: "3.3.3.3", InUse: true},
-				{Address: "4.4.4.4", InUse: false},
-			},
-			maxConcurrent: 12,
 			expected: map[string]int{
 				"1.1.1.1": MinConcurrencyPerRequestQueue,
 				"2.2.2.2": MinConcurrencyPerRequestQueue,

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -218,9 +218,9 @@ func TestQuerierWorker_getDesiredConcurrency(t *testing.T) {
 			maxConcurrent: 12,
 			expected: map[string]int{
 				"1.1.1.1": 6,
-				"2.2.2.2": 4,
+				"2.2.2.2": MinConcurrencyPerRequestQueue,
 				"3.3.3.3": 6,
-				"4.4.4.4": 4,
+				"4.4.4.4": MinConcurrencyPerRequestQueue,
 			},
 		},
 		"should create the minimum connections for each instance if max concurrency is set to 0": {

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -238,7 +238,7 @@ func TestQuerierWorker_getDesiredConcurrency(t *testing.T) {
 				"4.4.4.4": MinConcurrencyPerRequestQueue,
 			},
 		},
-		"should create the minimum connections for each instance if max concurrency is less than the minimum min times the number of in-use instances": {
+		"should create the minimum connections for each instance if max concurrency is less than (instances * minimum connections per instance)": {
 			instances: []servicediscovery.Instance{
 				{Address: "1.1.1.1", InUse: true},
 				{Address: "2.2.2.2", InUse: false},

--- a/pkg/querier/worker/worker_test.go
+++ b/pkg/querier/worker/worker_test.go
@@ -125,46 +125,46 @@ func TestResetConcurrency(t *testing.T) {
 		expectedConcurrency int
 	}{
 		{
-			name:                "Create at least one processor per target if max concurrent = 0, with all targets in use",
+			name:                "Create at least the minimum processors per target if max concurrent = 0, with all targets in use",
 			maxConcurrent:       0,
 			numTargets:          2,
 			numInUseTargets:     2,
-			expectedConcurrency: 2,
+			expectedConcurrency: 8,
 		},
 		{
-			name:                "Create at least one processor per target if max concurrent = 0, with some targets in use",
+			name:                "Create at least the minimum processors per target if max concurrent = 0, with some targets in use",
 			maxConcurrent:       0,
 			numTargets:          2,
 			numInUseTargets:     1,
-			expectedConcurrency: 2,
+			expectedConcurrency: 8,
 		},
 		{
 			name:                "Max concurrent dividing with a remainder, with all targets in use",
-			maxConcurrent:       7,
+			maxConcurrent:       19,
 			numTargets:          4,
 			numInUseTargets:     4,
-			expectedConcurrency: 7,
+			expectedConcurrency: 19,
 		},
 		{
 			name:            "Max concurrent dividing with a remainder, with some targets in use",
-			maxConcurrent:   7,
+			maxConcurrent:   19,
 			numTargets:      4,
 			numInUseTargets: 2,
-			expectedConcurrency:/* in use:  */ 7 + /* not in use : */ 2,
+			expectedConcurrency:/* in use:  */ 8 + /* not in use : */ 11,
 		},
 		{
 			name:                "Max concurrent dividing evenly, with all targets in use",
-			maxConcurrent:       6,
+			maxConcurrent:       12,
 			numTargets:          2,
 			numInUseTargets:     2,
-			expectedConcurrency: 6,
+			expectedConcurrency: 12,
 		},
 		{
 			name:            "Max concurrent dividing evenly, with some targets in use",
-			maxConcurrent:   6,
+			maxConcurrent:   20,
 			numTargets:      4,
 			numInUseTargets: 2,
-			expectedConcurrency:/* in use:  */ 6 + /* not in use : */ 2,
+			expectedConcurrency:/* in use:  */ 8 + /* not in use : */ 12,
 		},
 	}
 


### PR DESCRIPTION
Docstring for constant should be a sufficient description, but will expand a bit here:

When we move to a new RequestQueue dequeuing algorithm, we will modulo querier-worker IDs to distribute them across 4 request queue dimensions, one each for the "expected query component" which is assigned to the query request: ingester, store-gateway, both, or unknown.
Having querier-worker connections < num queue dimensions will result in queue starvation unless not all 4 queue dimensions are active. In any minimally utilized cluster, we expect all 4 dimensions will exist at almost all times.

Because the queriers have no centralized knowledge or coordination of how many queriers exist in the cluster, we must set a minimum of 4 for each querier<->request queue instance connection, where a "request queue instance" is a query-frontend or a query-scheduler.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [X] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
