### PR TITLE
WIP: PromQL: Add info function MVP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -282,7 +282,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240925112120-6046bf43c9b2
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240927154309-4f2b10421e39
 
 // client_golang v1.20.3 has some data races in histogram exemplars.
 // Stick to v1.19.1 until they are fixed.

--- a/go.sum
+++ b/go.sum
@@ -1262,8 +1262,8 @@ github.com/grafana/gomemcache v0.0.0-20240229205252-cd6a66d6fb56 h1:X8IKQ0wu40wp
 github.com/grafana/gomemcache v0.0.0-20240229205252-cd6a66d6fb56/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20240925112120-6046bf43c9b2 h1:440vf/oyTq3xubH0iMHveDfEM8p+t/lzLMHiJNQRfY0=
-github.com/grafana/mimir-prometheus v0.0.0-20240925112120-6046bf43c9b2/go.mod h1:oyDm7JaLUh+QGuGkC7iXC8IyTUq5rlh1ba2CRm9DlVg=
+github.com/grafana/mimir-prometheus v0.0.0-20240927154309-4f2b10421e39 h1:5Z/cEOspXtTkeL1oFgGczEJCGM5lKqLPQP4BLeF4/sQ=
+github.com/grafana/mimir-prometheus v0.0.0-20240927154309-4f2b10421e39/go.mod h1:WL0W43+vQuDqtqczi+jWoIntQVlJDFr0kiHtcoXUrGQ=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20240924175849-b8b7c2c74eb6 h1:nT8QXdJo6wHMBcF0xEoXxEWkoUZOyzV/jyi/u9l7YEk=

--- a/pkg/frontend/querymiddleware/astmapper/parallel.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel.go
@@ -27,6 +27,8 @@ var NonParallelFuncs = []string{
 	// The following functions are not safe to parallelize.
 	"absent",
 	"absent_over_time",
+	// TODO: Find out whether should be parallelizable.
+	"info",
 	"histogram_quantile",
 	"limitk",
 	"limit_ratio",

--- a/pkg/frontend/querymiddleware/astmapper/parallel_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel_test.go
@@ -231,6 +231,10 @@ func TestFunctionsWithDefaultsIsUpToDate(t *testing.T) {
 				// sort by label functions are variadic but no parameter is a timestamp, so they're not relevant for sharding purposes.
 				return
 			}
+			if f.Name == "info" {
+				// the info function is variadic but no parameter is a timestamp, so it's not relevant for sharding purposes.
+				return
+			}
 
 			// Rest of the functions with known defaults are functions with a default time() argument.
 			require.Containsf(t, FuncsWithDefaultTimeArg, name, "Function %q has variable arguments, and it's not in the list of functions with default time() argument.", f.Name)

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -71,6 +71,8 @@ func sampleStreamsStrings(ss []SampleStream) []string {
 // approximatelyEqualsSamples ensures two responses are approximately equal, up to 6 decimals precision per sample,
 // but only checks the samples and not the warning/info annotations.
 func approximatelyEqualsSamples(t *testing.T, a, b *PrometheusResponse) {
+	t.Helper()
+
 	// Ensure both queries succeeded.
 	require.Equal(t, statusSuccess, a.Status)
 	require.Equal(t, statusSuccess, b.Status)
@@ -304,7 +306,7 @@ func TestQuerySharding_Correctness(t *testing.T) {
 			query: `
 				sum by(unique) (metric_counter)
 				*
-				on (unique) group_left (group_1) 
+				on (unique) group_left (group_1)
 				avg by (unique, group_1) (metric_counter)`,
 			expectedShardedQueries: 3,
 		},

--- a/vendor/github.com/prometheus/prometheus/promql/functions.go
+++ b/vendor/github.com/prometheus/prometheus/promql/functions.go
@@ -1572,7 +1572,7 @@ func (ev *evaluator) evalLabelJoin(ctx context.Context, args parser.Expressions)
 
 // === label_join(vector model.ValVector, dest_labelname, separator, src_labelname...) (Vector, Annotations) ===
 func funcLabelJoin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper) (Vector, annotations.Annotations) {
-	panic("funcLabelReplace wrong implementation called")
+	panic("funcLabelJoin wrong implementation called")
 }
 
 // Common code for date related functions.
@@ -1695,6 +1695,7 @@ var FunctionCalls = map[string]FunctionCall{
 	"hour":               funcHour,
 	"idelta":             funcIdelta,
 	"increase":           funcIncrease,
+	"info":               nil,
 	"irate":              funcIrate,
 	"label_replace":      funcLabelReplace,
 	"label_join":         funcLabelJoin,

--- a/vendor/github.com/prometheus/prometheus/promql/info.go
+++ b/vendor/github.com/prometheus/prometheus/promql/info.go
@@ -1,0 +1,468 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/grafana/regexp"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+const targetInfo = "target_info"
+
+// identifyingLabels are the labels we consider as identifying for info metrics.
+// Currently hard coded, so we don't need knowledge of individual info metrics.
+var identifyingLabels = []string{"instance", "job"}
+
+// evalInfo implements the info PromQL function.
+func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (parser.Value, annotations.Annotations) {
+	val, annots := ev.eval(ctx, args[0])
+	mat := val.(Matrix)
+	// Map from data label name to matchers.
+	dataLabelMatchers := map[string][]*labels.Matcher{}
+	var infoNameMatchers []*labels.Matcher
+	if len(args) > 1 {
+		// TODO: Introduce a dedicated LabelSelector type.
+		labelSelector := args[1].(*parser.VectorSelector)
+		for _, m := range labelSelector.LabelMatchers {
+			dataLabelMatchers[m.Name] = append(dataLabelMatchers[m.Name], m)
+			if m.Name == labels.MetricName {
+				infoNameMatchers = append(infoNameMatchers, m)
+			}
+		}
+	} else {
+		infoNameMatchers = []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, targetInfo)}
+	}
+
+	// Don't try to enrich info series.
+	ignoreSeries := map[int]struct{}{}
+loop:
+	for i, s := range mat {
+		lblMap := s.Metric.Map()
+		name := lblMap[labels.MetricName]
+		for _, m := range infoNameMatchers {
+			if m.Matches(name) {
+				ignoreSeries[i] = struct{}{}
+				continue loop
+			}
+		}
+	}
+
+	infoSeries, ws, err := ev.fetchInfoSeries(ctx, mat, ignoreSeries, dataLabelMatchers)
+	annots.Merge(ws)
+	if err != nil {
+		annots.Add(err)
+		return nil, annots
+	}
+
+	res, ws := ev.combineWithInfoSeries(ctx, mat, infoSeries, ignoreSeries, dataLabelMatchers)
+	annots.Merge(ws)
+	return res, annots
+}
+
+// fetchInfoSeries fetches info series given ev.selectHints and matching identifying labels in mat.
+// Series in ignoreSeries are not fetched.
+func (ev *evaluator) fetchInfoSeries(ctx context.Context, mat Matrix, ignoreSeries map[int]struct{}, dataLabelMatchers map[string][]*labels.Matcher) (Matrix, annotations.Annotations, error) {
+	if ev.selectHints == nil {
+		// ev.selectHints should have been set.
+		var annots annotations.Annotations
+		annots.Add(fmt.Errorf("ev.selectHints not set"))
+		return nil, annots, nil
+	}
+
+	// A map of values for all identifying labels we are interested in.
+	idLblValues := map[string]map[string]struct{}{}
+	for i, s := range mat {
+		if _, exists := ignoreSeries[i]; exists {
+			continue
+		}
+
+		// Register relevant values per identifying label for this series.
+		lblMap := s.Metric.Map()
+		for _, l := range identifyingLabels {
+			val := lblMap[l]
+			if val == "" {
+				continue
+			}
+
+			if idLblValues[l] == nil {
+				idLblValues[l] = map[string]struct{}{}
+			}
+			idLblValues[l][val] = struct{}{}
+		}
+	}
+	if len(idLblValues) == 0 {
+		return nil, nil, nil
+	}
+
+	// Generate regexps for every interesting value per identifying label.
+	var sb strings.Builder
+	idLblRegexps := make(map[string]string, len(idLblValues))
+	for name, vals := range idLblValues {
+		sb.Reset()
+		i := 0
+		for v := range vals {
+			if i > 0 {
+				sb.WriteRune('|')
+			}
+			sb.WriteString(regexp.QuoteMeta(v))
+			i++
+		}
+		idLblRegexps[name] = sb.String()
+	}
+
+	var infoLabelMatchers []*labels.Matcher
+	for name, re := range idLblRegexps {
+		infoLabelMatchers = append(infoLabelMatchers, labels.MustNewMatcher(labels.MatchRegexp, name, re))
+	}
+	var nameMatcher *labels.Matcher
+	for name, ms := range dataLabelMatchers {
+		for i, m := range ms {
+			if m.Name == labels.MetricName {
+				nameMatcher = m
+				ms = slices.Delete(ms, i, i+1)
+			}
+			infoLabelMatchers = append(infoLabelMatchers, m)
+		}
+		if len(ms) > 0 {
+			dataLabelMatchers[name] = ms
+		} else {
+			delete(dataLabelMatchers, name)
+		}
+	}
+	if nameMatcher == nil {
+		// Default to using the target_info metric.
+		infoLabelMatchers = append([]*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, targetInfo)}, infoLabelMatchers...)
+	}
+
+	infoIt := ev.querier.Select(ctx, false, ev.selectHints, infoLabelMatchers...)
+	annots := infoIt.Warnings()
+	if infoIt.Err() != nil {
+		return nil, annots, infoIt.Err()
+	}
+	var infoSeries []storage.Series
+	for infoIt.Next() {
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		default:
+		}
+		infoSeries = append(infoSeries, infoIt.At())
+	}
+	infoMat := ev.expandSeriesToMatrix(ctx, infoSeries, 0, true)
+	return infoMat, annots, infoIt.Err()
+}
+
+// combineWithInfoSeries combines mat with select data labels from infoMat.
+func (ev *evaluator) combineWithInfoSeries(ctx context.Context, mat, infoMat Matrix, ignoreSeries map[int]struct{}, dataLabelMatchers map[string][]*labels.Matcher) (Matrix, annotations.Annotations) {
+	buf := make([]byte, 0, 1024)
+	lb := labels.NewScratchBuilder(0)
+	sigFunction := func(name string) func(labels.Labels) string {
+		return func(lset labels.Labels) string {
+			lb.Reset()
+			lb.Add(labels.MetricName, name)
+			lset.MatchLabels(true, identifyingLabels...).Range(func(l labels.Label) {
+				lb.Add(l.Name, l.Value)
+			})
+			lb.Sort()
+			return string(lb.Labels().Bytes(buf))
+		}
+	}
+
+	infoMetrics := map[string]struct{}{}
+	for _, is := range infoMat {
+		lblMap := is.Metric.Map()
+		infoMetrics[lblMap[labels.MetricName]] = struct{}{}
+	}
+	sigfs := make(map[string]func(labels.Labels) string, len(infoMetrics))
+	for name := range infoMetrics {
+		sigfs[name] = sigFunction(name)
+	}
+
+	// Keep a copy of the original point slices so they can be returned to the pool.
+	origMatrices := []Matrix{
+		make(Matrix, len(mat)),
+		make(Matrix, len(infoMat)),
+	}
+	copy(origMatrices[0], mat)
+	copy(origMatrices[1], infoMat)
+
+	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
+	originalNumSamples := ev.currentSamples
+
+	// Create an output vector that is as big as the input matrix with
+	// the most time series.
+	biggestLen := max(len(mat), len(infoMat))
+	baseVector := make(Vector, 0, len(mat))
+	infoVector := make(Vector, 0, len(infoMat))
+	enh := &EvalNodeHelper{
+		Out:          make(Vector, 0, biggestLen),
+		labelBuilder: &lb,
+	}
+	type seriesAndTimestamp struct {
+		Series
+		ts int64
+	}
+	seriess := make(map[uint64]seriesAndTimestamp, biggestLen) // Output series by series hash.
+	tempNumSamples := ev.currentSamples
+
+	// For every base series, compute signature per info metric.
+	baseSigs := make([]map[string]string, 0, len(mat))
+	for _, s := range mat {
+		sigs := make(map[string]string, len(infoMetrics))
+		for infoName := range infoMetrics {
+			sigs[infoName] = sigfs[infoName](s.Metric)
+		}
+		baseSigs = append(baseSigs, sigs)
+	}
+
+	infoSigs := make([]string, 0, len(infoMat))
+	for _, s := range infoMat {
+		name := s.Metric.Map()[labels.MetricName]
+		infoSigs = append(infoSigs, sigfs[name](s.Metric))
+	}
+
+	var warnings annotations.Annotations
+	for ts := ev.startTimestamp; ts <= ev.endTimestamp; ts += ev.interval {
+		if err := contextDone(ctx, "expression evaluation"); err != nil {
+			ev.error(err)
+		}
+
+		// Reset number of samples in memory after each timestamp.
+		ev.currentSamples = tempNumSamples
+		// Gather input vectors for this timestamp.
+		baseVector = ev.gatherVector(ts, mat, baseVector)
+		infoVector = ev.gatherVector(ts, infoMat, infoVector)
+
+		enh.Ts = ts
+		result, err := ev.combineWithInfoVector(baseVector, infoVector, ignoreSeries, baseSigs, infoSigs, enh, dataLabelMatchers)
+		if err != nil {
+			warnings.Add(err)
+		}
+		enh.Out = result[:0] // Reuse result vector.
+
+		vecNumSamples := result.TotalSamples()
+		ev.currentSamples += vecNumSamples
+		// When we reset currentSamples to tempNumSamples during the next iteration of the loop it also
+		// needs to include the samples from the result here, as they're still in memory.
+		tempNumSamples += vecNumSamples
+		ev.samplesStats.UpdatePeak(ev.currentSamples)
+		if ev.currentSamples > ev.maxSamples {
+			ev.error(ErrTooManySamples(env))
+		}
+
+		// Add samples in result vector to output series.
+		for _, sample := range result {
+			h := sample.Metric.Hash()
+			ss, exists := seriess[h]
+			if exists {
+				if ss.ts == ts { // If we've seen this output series before at this timestamp, it's a duplicate.
+					ev.errorf("vector cannot contain metrics with the same labelset")
+				}
+				ss.ts = ts
+			} else {
+				ss = seriesAndTimestamp{Series{Metric: sample.Metric}, ts}
+			}
+			addToSeries(&ss.Series, enh.Ts, sample.F, sample.H, numSteps)
+			seriess[h] = ss
+		}
+	}
+
+	// Reuse the original point slices.
+	for _, m := range origMatrices {
+		for _, s := range m {
+			putFPointSlice(s.Floats)
+			putHPointSlice(s.Histograms)
+		}
+	}
+	// Assemble the output matrix. By the time we get here we know we don't have too many samples.
+	numSamples := 0
+	output := make(Matrix, 0, len(seriess))
+	for _, ss := range seriess {
+		numSamples += len(ss.Floats) + totalHPointSize(ss.Histograms)
+		output = append(output, ss.Series)
+	}
+	ev.currentSamples = originalNumSamples + numSamples
+	ev.samplesStats.UpdatePeak(ev.currentSamples)
+	return output, warnings
+}
+
+// gatherVector gathers a Vector for ts from the series in input.
+// output is used as a buffer.
+func (ev *evaluator) gatherVector(ts int64, input Matrix, output Vector) Vector {
+	output = output[:0]
+	for i, series := range input {
+		switch {
+		case len(series.Floats) > 0 && series.Floats[0].T == ts:
+			s := series.Floats[0]
+			output = append(output, Sample{Metric: series.Metric, F: s.F})
+			// Move input vectors forward so we don't have to re-scan the same
+			// past points at the next step.
+			input[i].Floats = series.Floats[1:]
+		case len(series.Histograms) > 0 && series.Histograms[0].T == ts:
+			s := series.Histograms[0]
+			output = append(output, Sample{Metric: series.Metric, H: s.H, T: ts})
+			input[i].Histograms = series.Histograms[1:]
+		default:
+			continue
+		}
+
+		// Don't add histogram size here because we only
+		// copy the pointer above, not the whole
+		// histogram.
+		ev.currentSamples++
+		if ev.currentSamples > ev.maxSamples {
+			ev.error(ErrTooManySamples(env))
+		}
+	}
+	ev.samplesStats.UpdatePeak(ev.currentSamples)
+
+	return output
+}
+
+// combineWithInfoVector combines base and info Vectors.
+// Base series in ignoreSeries are not combined.
+func (ev *evaluator) combineWithInfoVector(base, info Vector, ignoreSeries map[int]struct{}, baseSigs []map[string]string, infoSigs []string, enh *EvalNodeHelper, dataLabelMatchers map[string][]*labels.Matcher) (Vector, error) {
+	if len(base) == 0 {
+		return nil, nil // Short-circuit: nothing is going to match.
+	}
+
+	// All samples from the info Vector hashed by the matching label/values.
+	if enh.infoSamplesBySig == nil {
+		enh.infoSamplesBySig = make(map[string]Sample, len(enh.Out))
+	} else {
+		clear(enh.infoSamplesBySig)
+	}
+
+	for i, s := range info {
+		if s.H != nil {
+			panic("info sample should be float")
+		}
+		// We encode original info sample timestamps via the float value.
+		origT := int64(s.F)
+
+		sig := infoSigs[i]
+		if existing, exists := enh.infoSamplesBySig[sig]; exists {
+			// We encode original info sample timestamps via the float value.
+			existingOrigT := int64(existing.F)
+			switch {
+			case existingOrigT > origT:
+				// Keep the other info sample, since it's newer.
+			case existingOrigT < origT:
+				// Keep this info sample, since it's newer.
+				enh.infoSamplesBySig[sig] = s
+			default:
+				// The two info samples have the same timestamp - conflict.
+				name := s.Metric.Map()[labels.MetricName]
+				ev.errorf("found duplicate series for info metric %s", name)
+			}
+		} else {
+			enh.infoSamplesBySig[sig] = s
+		}
+	}
+
+	lb := enh.labelBuilder
+	for i, bs := range base {
+		if _, exists := ignoreSeries[i]; exists {
+			// This series should not be enriched with info metric data labels.
+			enh.Out = append(enh.Out, Sample{
+				Metric: bs.Metric,
+				F:      bs.F,
+				H:      bs.H,
+			})
+			continue
+		}
+
+		baseLabels := bs.Metric.Map()
+		infoLblMap := map[string]string{}
+
+		// For every info metric name, try to find an info series with the same signature.
+		seenInfoMetrics := map[string]struct{}{}
+		for infoName, sig := range baseSigs[i] {
+			is, exists := enh.infoSamplesBySig[sig]
+			if !exists {
+				continue
+			}
+			if _, exists := seenInfoMetrics[infoName]; exists {
+				continue
+			}
+
+			err := is.Metric.Validate(func(l labels.Label) error {
+				if l.Name == labels.MetricName {
+					return nil
+				}
+				if _, exists := dataLabelMatchers[l.Name]; len(dataLabelMatchers) > 0 && !exists {
+					// Not among the specified data label matchers.
+					return nil
+				}
+
+				if v, exists := infoLblMap[l.Name]; exists && v != l.Value {
+					return fmt.Errorf("conflicting label: %s", l.Name)
+				}
+				if _, exists := baseLabels[l.Name]; exists {
+					// Skip labels already on the base metric.
+					return nil
+				}
+
+				infoLblMap[l.Name] = l.Value
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			seenInfoMetrics[infoName] = struct{}{}
+		}
+
+		if len(infoLblMap) == 0 {
+			// If there's at least one data label matcher not matching the empty string,
+			// we have to ignore this series as there are no matching info series.
+			allMatchersMatchEmpty := true
+			for _, ms := range dataLabelMatchers {
+				for _, m := range ms {
+					if !m.Matches("") {
+						allMatchersMatchEmpty = false
+						break
+					}
+				}
+			}
+			if !allMatchersMatchEmpty {
+				continue
+			}
+		}
+
+		lb.Reset()
+		bs.Metric.Range(func(l labels.Label) {
+			lb.Add(l.Name, l.Value)
+		})
+		for n, v := range infoLblMap {
+			lb.Add(n, v)
+		}
+		lb.Sort()
+
+		enh.Out = append(enh.Out, Sample{
+			Metric: lb.Labels(),
+			F:      bs.F,
+			H:      bs.H,
+		})
+	}
+	return enh.Out, nil
+}

--- a/vendor/github.com/prometheus/prometheus/promql/parser/ast.go
+++ b/vendor/github.com/prometheus/prometheus/promql/parser/ast.go
@@ -208,6 +208,12 @@ type VectorSelector struct {
 	UnexpandedSeriesSet storage.SeriesSet
 	Series              []storage.Series
 
+	// SelectHints are the SelectHints to use when selecting corresponding info series, if enabled.
+	SelectHints *storage.SelectHints
+	// BypassEmptyMatcherCheck is true when the VectorSelector isn't required to have at least one matcher matching the empty string.
+	// This is the case when VectorSelector is used to represent the info function's second argument.
+	BypassEmptyMatcherCheck bool
+
 	PosRange posrange.PositionRange
 }
 

--- a/vendor/github.com/prometheus/prometheus/promql/parser/functions.go
+++ b/vendor/github.com/prometheus/prometheus/promql/parser/functions.go
@@ -223,6 +223,13 @@ var Functions = map[string]*Function{
 		ArgTypes:   []ValueType{ValueTypeMatrix},
 		ReturnType: ValueTypeVector,
 	},
+	"info": {
+		Name:         "info",
+		ArgTypes:     []ValueType{ValueTypeVector, ValueTypeVector},
+		ReturnType:   ValueTypeVector,
+		Experimental: true,
+		Variadic:     1,
+	},
 	"irate": {
 		Name:       "irate",
 		ArgTypes:   []ValueType{ValueTypeMatrix},

--- a/vendor/github.com/prometheus/prometheus/promql/parser/parse.go
+++ b/vendor/github.com/prometheus/prometheus/promql/parser/parse.go
@@ -786,6 +786,19 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 			}
 		}
 
+		if n.Func.Name == "info" && len(n.Args) > 1 {
+			// Check the type is correct first
+			if n.Args[1].Type() != ValueTypeVector {
+				p.addParseErrf(node.PositionRange(), "expected type %s in %s, got %s", DocumentedType(ValueTypeVector), fmt.Sprintf("call to function %q", n.Func.Name), DocumentedType(n.Args[1].Type()))
+			}
+			// Check the vector selector in the input doesn't contain a metric name
+			if n.Args[1].(*VectorSelector).Name != "" {
+				p.addParseErrf(n.Args[1].PositionRange(), "expected label selectors only, got vector selector instead")
+			}
+			// Set Vector Selector flag to bypass empty matcher check
+			n.Args[1].(*VectorSelector).BypassEmptyMatcherCheck = true
+		}
+
 		for i, arg := range n.Args {
 			if i >= len(n.Func.ArgTypes) {
 				if n.Func.Variadic == 0 {
@@ -832,17 +845,19 @@ func (p *parser) checkAST(node Node) (typ ValueType) {
 			// metric name is a non-empty matcher.
 			break
 		}
-		// A Vector selector must contain at least one non-empty matcher to prevent
-		// implicit selection of all metrics (e.g. by a typo).
-		notEmpty := false
-		for _, lm := range n.LabelMatchers {
-			if lm != nil && !lm.Matches("") {
-				notEmpty = true
-				break
+		if !n.BypassEmptyMatcherCheck {
+			// A Vector selector must contain at least one non-empty matcher to prevent
+			// implicit selection of all metrics (e.g. by a typo).
+			notEmpty := false
+			for _, lm := range n.LabelMatchers {
+				if lm != nil && !lm.Matches("") {
+					notEmpty = true
+					break
+				}
 			}
-		}
-		if !notEmpty {
-			p.addParseErrf(n.PositionRange(), "vector selector must contain at least one non-empty matcher")
+			if !notEmpty {
+				p.addParseErrf(n.PositionRange(), "vector selector must contain at least one non-empty matcher")
+			}
 		}
 
 	case *NumberLiteral, *StringLiteral:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -999,7 +999,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20240925112120-6046bf43c9b2
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20240927154309-4f2b10421e39
 ## explicit; go 1.22.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1663,7 +1663,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240925112120-6046bf43c9b2
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20240927154309-4f2b10421e39
 # github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.19.1
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094


### PR DESCRIPTION
#### What this PR does

Add _experimental_ MVP of the PromQL `info` function, which offers a user friendly way of adding back OTel resource attributes (encoded as `target_info` metric labels) to query results. It's a simpler alternative to the current solution of joining against `target_info`. See corresponding [Prometheus PR](https://github.com/prometheus/prometheus/pull/14495) for all the details.

#### How to test

1. Add the following to development/mimir-monolithic-mode/config/mimir.yaml:
   ```yaml
   querier:
     promql_experimental_functions_enabled: true
   ```
2. Start the mimir-monolithic-mode stack:
   ```console
   cd mimir/development/mimir-monolithic-mode
   ./compose-up.sh -d
   ```
3. Write metric(s) to Mimir over OTLP:
   ```
   git clone git@github.com:grafana/otel-demos.git
   cd otel-demos/otel-exporter
   git switch arve/local-mimir
   go run . 
   ```
4. Open Grafana on http://localhost:3000
5. Go to Grafana's Explore page
6. With Mimir as data source, execute the following query:
   ```promql
   rate(test_counter[$__rate_interval])
   ```
7. Execute the following query:
   ```promql
   info(rate(test_counter[$__rate_interval]))
   ```
8. Verify that `test_counter` is now enriched with (all) `target_info` labels.
9. Execute the following query:
   ```promql
   info(rate(test_counter[$__rate_interval]), {k8s_cluster_name=~".+", k8s_namespace_name=~".+", k8s_container_name=~".+"})
   ```
10. Verify that `test_counter` is now enriched with only the following `target_info` labels:
   * `k8s_cluster_name`
   * `k8s_namespace_name`
   * `k8s_container_name`
11. Try other query combinations.
12. Thoughts on alternative PromQL syntax (even non-function syntax)?

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
