### PR TITLE
mimir-build-image: Upgrade Go version to 1.23.0-bookworm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr9070-3b4c4993ed
+LATEST_BUILD_IMAGE_TAG ?= pr9070-5347ec889b
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr9082-d0a22a8a96
+LATEST_BUILD_IMAGE_TAG ?= pr9070-2850516d73
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr9070-2850516d73
+LATEST_BUILD_IMAGE_TAG ?= pr9070-3b4c4993ed
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM registry.k8s.io/kustomize/kustomize:v5.4.3 as kustomize
 FROM alpine/helm:3.14.4 as helm
-FROM golang:1.22.5-bookworm
+FROM golang:1.23.0-bookworm
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -39,7 +39,7 @@ RUN GOARCH=$(go env GOARCH) && \
     curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
     chmod a+x /usr/bin/tk
 
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.59.1
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.60.2
 
 ENV SKOPEO_VERSION=v1.15.1
 RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -98,7 +98,7 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 				// Non-retryable error.
 				1: testkafka.CreateProduceResponseError(0, kafkaTopic, 1, kerr.InvalidTopicException),
 			},
-			expectedErr: fmt.Errorf("%s %d", failedPushingToPartitionMessage, 1),
+			expectedErr: fmt.Errorf("%s 1", failedPushingToPartitionMessage),
 			expectedSeriesByPartition: map[int32][]string{
 				// Partition 1 is missing because it failed.
 				0: {"series_four", "series_one", "series_three"},

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -98,7 +98,7 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 				// Non-retryable error.
 				1: testkafka.CreateProduceResponseError(0, kafkaTopic, 1, kerr.InvalidTopicException),
 			},
-			expectedErr: fmt.Errorf(fmt.Sprintf("%s %d", failedPushingToPartitionMessage, 1)),
+			expectedErr: fmt.Errorf("%s %d", failedPushingToPartitionMessage, 1),
 			expectedSeriesByPartition: map[int32][]string{
 				// Partition 1 is missing because it failed.
 				0: {"series_four", "series_one", "series_three"},

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -90,10 +90,10 @@ func OTLPHandler(
 				protoBodySize, err := util.ParseProtoReader(ctx, reader, int(r.ContentLength), maxRecvMsgSize, buffers, unmarshaler, compression)
 				var tooLargeErr util.MsgSizeTooLargeErr
 				if errors.As(err, &tooLargeErr) {
-					return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, distributorMaxOTLPRequestSizeErr{
+					return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%w", distributorMaxOTLPRequestSizeErr{
 						actual: tooLargeErr.Actual,
 						limit:  tooLargeErr.Limit,
-					}.Error())
+					})
 				}
 				return exportReq, protoBodySize, err
 			}
@@ -118,10 +118,10 @@ func OTLPHandler(
 				reader = http.MaxBytesReader(nil, reader, int64(maxRecvMsgSize))
 				if _, err := buf.ReadFrom(reader); err != nil {
 					if util.IsRequestBodyTooLarge(err) {
-						return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, distributorMaxOTLPRequestSizeErr{
+						return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%w", distributorMaxOTLPRequestSizeErr{
 							actual: -1,
 							limit:  maxRecvMsgSize,
-						}.Error())
+						})
 					}
 
 					return exportReq, 0, errors.Wrap(err, "read write request")
@@ -137,10 +137,10 @@ func OTLPHandler(
 		// Check the request size against the message size limit, regardless of whether the request is compressed.
 		// If the request is compressed and its compressed length already exceeds the size limit, there's no need to decompress it.
 		if r.ContentLength > int64(maxRecvMsgSize) {
-			return httpgrpc.Errorf(http.StatusRequestEntityTooLarge, distributorMaxOTLPRequestSizeErr{
+			return httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%w", distributorMaxOTLPRequestSizeErr{
 				actual: int(r.ContentLength),
 				limit:  maxRecvMsgSize,
-			}.Error())
+			})
 		}
 
 		spanLogger, ctx := spanlogger.NewWithLogger(ctx, logger, "Distributor.OTLPHandler.decodeAndConvert")

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -118,7 +118,7 @@ func OTLPHandler(
 				reader = http.MaxBytesReader(nil, reader, int64(maxRecvMsgSize))
 				if _, err := buf.ReadFrom(reader); err != nil {
 					if util.IsRequestBodyTooLarge(err) {
-						return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, distributorMaxOTLPRequestSizeErr{
+						return exportReq, 0, httpgrpc.Error(http.StatusRequestEntityTooLarge, distributorMaxOTLPRequestSizeErr{
 							actual: -1,
 							limit:  maxRecvMsgSize,
 						}.Error())
@@ -137,7 +137,7 @@ func OTLPHandler(
 		// Check the request size against the message size limit, regardless of whether the request is compressed.
 		// If the request is compressed and its compressed length already exceeds the size limit, there's no need to decompress it.
 		if r.ContentLength > int64(maxRecvMsgSize) {
-			return httpgrpc.Errorf(http.StatusRequestEntityTooLarge, distributorMaxOTLPRequestSizeErr{
+			return httpgrpc.Error(http.StatusRequestEntityTooLarge, distributorMaxOTLPRequestSizeErr{
 				actual: int(r.ContentLength),
 				limit:  maxRecvMsgSize,
 			}.Error())

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -229,7 +229,7 @@ func otlpHandler(
 			if err := parser(ctx, r, maxRecvMsgSize, rb, &req, logger); err != nil {
 				// Check for httpgrpc error, default to client error if parsing failed
 				if _, ok := httpgrpc.HTTPResponseFromError(err); !ok {
-					err = httpgrpc.Errorf(http.StatusBadRequest, err.Error())
+					err = httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error())
 				}
 
 				rb.CleanUp()

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -90,10 +90,10 @@ func OTLPHandler(
 				protoBodySize, err := util.ParseProtoReader(ctx, reader, int(r.ContentLength), maxRecvMsgSize, buffers, unmarshaler, compression)
 				var tooLargeErr util.MsgSizeTooLargeErr
 				if errors.As(err, &tooLargeErr) {
-					return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%w", distributorMaxOTLPRequestSizeErr{
+					return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", distributorMaxOTLPRequestSizeErr{
 						actual: tooLargeErr.Actual,
 						limit:  tooLargeErr.Limit,
-					})
+					}.Error())
 				}
 				return exportReq, protoBodySize, err
 			}
@@ -118,10 +118,10 @@ func OTLPHandler(
 				reader = http.MaxBytesReader(nil, reader, int64(maxRecvMsgSize))
 				if _, err := buf.ReadFrom(reader); err != nil {
 					if util.IsRequestBodyTooLarge(err) {
-						return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%w", distributorMaxOTLPRequestSizeErr{
+						return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", distributorMaxOTLPRequestSizeErr{
 							actual: -1,
 							limit:  maxRecvMsgSize,
-						})
+						}.Error())
 					}
 
 					return exportReq, 0, errors.Wrap(err, "read write request")
@@ -137,10 +137,10 @@ func OTLPHandler(
 		// Check the request size against the message size limit, regardless of whether the request is compressed.
 		// If the request is compressed and its compressed length already exceeds the size limit, there's no need to decompress it.
 		if r.ContentLength > int64(maxRecvMsgSize) {
-			return httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%w", distributorMaxOTLPRequestSizeErr{
+			return httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", distributorMaxOTLPRequestSizeErr{
 				actual: int(r.ContentLength),
 				limit:  maxRecvMsgSize,
-			})
+			}.Error())
 		}
 
 		spanLogger, ctx := spanlogger.NewWithLogger(ctx, logger, "Distributor.OTLPHandler.decodeAndConvert")

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -90,7 +90,7 @@ func OTLPHandler(
 				protoBodySize, err := util.ParseProtoReader(ctx, reader, int(r.ContentLength), maxRecvMsgSize, buffers, unmarshaler, compression)
 				var tooLargeErr util.MsgSizeTooLargeErr
 				if errors.As(err, &tooLargeErr) {
-					return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", distributorMaxOTLPRequestSizeErr{
+					return exportReq, 0, httpgrpc.Error(http.StatusRequestEntityTooLarge, distributorMaxOTLPRequestSizeErr{
 						actual: tooLargeErr.Actual,
 						limit:  tooLargeErr.Limit,
 					}.Error())
@@ -118,7 +118,7 @@ func OTLPHandler(
 				reader = http.MaxBytesReader(nil, reader, int64(maxRecvMsgSize))
 				if _, err := buf.ReadFrom(reader); err != nil {
 					if util.IsRequestBodyTooLarge(err) {
-						return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", distributorMaxOTLPRequestSizeErr{
+						return exportReq, 0, httpgrpc.Errorf(http.StatusRequestEntityTooLarge, distributorMaxOTLPRequestSizeErr{
 							actual: -1,
 							limit:  maxRecvMsgSize,
 						}.Error())
@@ -137,7 +137,7 @@ func OTLPHandler(
 		// Check the request size against the message size limit, regardless of whether the request is compressed.
 		// If the request is compressed and its compressed length already exceeds the size limit, there's no need to decompress it.
 		if r.ContentLength > int64(maxRecvMsgSize) {
-			return httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", distributorMaxOTLPRequestSizeErr{
+			return httpgrpc.Errorf(http.StatusRequestEntityTooLarge, distributorMaxOTLPRequestSizeErr{
 				actual: int(r.ContentLength),
 				limit:  maxRecvMsgSize,
 			}.Error())
@@ -229,7 +229,7 @@ func otlpHandler(
 			if err := parser(ctx, r, maxRecvMsgSize, rb, &req, logger); err != nil {
 				// Check for httpgrpc error, default to client error if parsing failed
 				if _, ok := httpgrpc.HTTPResponseFromError(err); !ok {
-					err = httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error())
+					err = httpgrpc.Error(http.StatusBadRequest, err.Error())
 				}
 
 				rb.CleanUp()

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -164,7 +164,7 @@ func handler(
 			if err := parser(ctx, r, maxRecvMsgSize, rb, &req, logger); err != nil {
 				// Check for httpgrpc error, default to client error if parsing failed
 				if _, ok := httpgrpc.HTTPResponseFromError(err); !ok {
-					err = httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error())
+					err = httpgrpc.Error(http.StatusBadRequest, err.Error())
 				}
 
 				rb.CleanUp()

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -164,7 +164,7 @@ func handler(
 			if err := parser(ctx, r, maxRecvMsgSize, rb, &req, logger); err != nil {
 				// Check for httpgrpc error, default to client error if parsing failed
 				if _, ok := httpgrpc.HTTPResponseFromError(err); !ok {
-					err = httpgrpc.Errorf(http.StatusBadRequest, err.Error())
+					err = httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error())
 				}
 
 				rb.CleanUp()

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -534,14 +534,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 	}{
 		{
 			name:                 "a generic error during request parsing gets an HTTP 400",
-			err:                  fmt.Errorf("%s", errMsg),
+			err:                  errors.New(errMsg),
 			expectedHTTPStatus:   http.StatusBadRequest,
 			expectedErrorMessage: errMsg,
 			expectedLogs:         []string{`level=error user=testuser msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" httpCode=400 err="rpc error: code = Code(400) desc = this is an error" insight=true`},
 		},
 		{
 			name:                 "a gRPC error with a status during request parsing gets translated into HTTP error without DoNotLogError header",
-			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", errMsg),
+			err:                  httpgrpc.Error(http.StatusRequestEntityTooLarge, errMsg),
 			expectedHTTPStatus:   http.StatusRequestEntityTooLarge,
 			expectedErrorMessage: errMsg,
 			expectedLogs:         []string{`level=error user=testuser msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
@@ -590,14 +590,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 		},
 		{
 			name:                 "a generic error during push gets a HTTP 500 without DoNotLogError header",
-			err:                  fmt.Errorf("%s", errMsg),
+			err:                  errors.New(errMsg),
 			expectedHTTPStatus:   http.StatusInternalServerError,
 			expectedErrorMessage: errMsg,
 			expectedLogs:         []string{`level=error user=testuser msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" httpCode=500 err="this is an error"`},
 		},
 		{
 			name:                        "a DoNotLogError of a generic error during push gets a HTTP 500 with DoNotLogError header",
-			err:                         middleware.DoNotLogError{Err: fmt.Errorf("%s", errMsg)},
+			err:                         middleware.DoNotLogError{Err: errors.New(errMsg)},
 			expectedHTTPStatus:          http.StatusInternalServerError,
 			expectedErrorMessage:        errMsg,
 			expectedDoNotLogErrorHeader: true,

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -605,14 +605,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 		},
 		{
 			name:                 "a gRPC error with a status during push gets translated into HTTP error without DoNotLogError header",
-			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", errMsg),
+			err:                  httpgrpc.Error(http.StatusRequestEntityTooLarge, errMsg),
 			expectedHTTPStatus:   http.StatusRequestEntityTooLarge,
 			expectedErrorMessage: errMsg,
 			expectedLogs:         []string{`level=error user=testuser msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
 		},
 		{
 			name:                        "a DoNotLogError of a gRPC error with a status during push gets translated into HTTP error without DoNotLogError header",
-			err:                         middleware.DoNotLogError{Err: httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", errMsg)},
+			err:                         middleware.DoNotLogError{Err: httpgrpc.Error(http.StatusRequestEntityTooLarge, errMsg)},
 			expectedHTTPStatus:          http.StatusRequestEntityTooLarge,
 			expectedErrorMessage:        errMsg,
 			expectedDoNotLogErrorHeader: true,
@@ -627,7 +627,7 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 		},
 		{
 			name:                 "StatusBadRequest is logged with insight=true",
-			err:                  httpgrpc.Errorf(http.StatusBadRequest, "limits reached"),
+			err:                  httpgrpc.Error(http.StatusBadRequest, "limits reached"),
 			expectedHTTPStatus:   http.StatusBadRequest,
 			expectedErrorMessage: "limits reached",
 			expectedLogs:         []string{`level=error user=testuser msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" httpCode=400 err="rpc error: code = Code(400) desc = limits reached" insight=true`},

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -534,14 +534,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 	}{
 		{
 			name:                 "a generic error during request parsing gets an HTTP 400",
-			err:                  fmt.Errorf(errMsg),
+			err:                  fmt.Errorf("%s", errMsg),
 			expectedHTTPStatus:   http.StatusBadRequest,
 			expectedErrorMessage: errMsg,
 			expectedLogs:         []string{`level=error user=testuser msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" httpCode=400 err="rpc error: code = Code(400) desc = this is an error" insight=true`},
 		},
 		{
 			name:                 "a gRPC error with a status during request parsing gets translated into HTTP error without DoNotLogError header",
-			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, errMsg),
+			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", errMsg),
 			expectedHTTPStatus:   http.StatusRequestEntityTooLarge,
 			expectedErrorMessage: errMsg,
 			expectedLogs:         []string{`level=error user=testuser msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
@@ -590,14 +590,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 		},
 		{
 			name:                 "a generic error during push gets a HTTP 500 without DoNotLogError header",
-			err:                  fmt.Errorf(errMsg),
+			err:                  fmt.Errorf("%s", errMsg),
 			expectedHTTPStatus:   http.StatusInternalServerError,
 			expectedErrorMessage: errMsg,
 			expectedLogs:         []string{`level=error user=testuser msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" httpCode=500 err="this is an error"`},
 		},
 		{
 			name:                        "a DoNotLogError of a generic error during push gets a HTTP 500 with DoNotLogError header",
-			err:                         middleware.DoNotLogError{Err: fmt.Errorf(errMsg)},
+			err:                         middleware.DoNotLogError{Err: fmt.Errorf("%s", errMsg)},
 			expectedHTTPStatus:          http.StatusInternalServerError,
 			expectedErrorMessage:        errMsg,
 			expectedDoNotLogErrorHeader: true,
@@ -605,14 +605,14 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 		},
 		{
 			name:                 "a gRPC error with a status during push gets translated into HTTP error without DoNotLogError header",
-			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, errMsg),
+			err:                  httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", errMsg),
 			expectedHTTPStatus:   http.StatusRequestEntityTooLarge,
 			expectedErrorMessage: errMsg,
 			expectedLogs:         []string{`level=error user=testuser msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" httpCode=413 err="rpc error: code = Code(413) desc = this is an error" insight=true`},
 		},
 		{
 			name:                        "a DoNotLogError of a gRPC error with a status during push gets translated into HTTP error without DoNotLogError header",
-			err:                         middleware.DoNotLogError{Err: httpgrpc.Errorf(http.StatusRequestEntityTooLarge, errMsg)},
+			err:                         middleware.DoNotLogError{Err: httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "%s", errMsg)},
 			expectedHTTPStatus:          http.StatusRequestEntityTooLarge,
 			expectedErrorMessage:        errMsg,
 			expectedDoNotLogErrorHeader: true,

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -703,7 +703,7 @@ func TestPrometheusCodec_EncodeMetricsQueryRequest_AcceptHeader(t *testing.T) {
 			case formatProtobuf:
 				require.Equal(t, "application/vnd.mimir.queryresponse+protobuf,application/json", encodedRequest.Header.Get("Accept"))
 			default:
-				t.Fatalf(fmt.Sprintf("unknown query result payload format: %v", queryResultPayloadFormat))
+				t.Fatalf("unknown query result payload format: %v", queryResultPayloadFormat)
 			}
 		})
 	}

--- a/pkg/frontend/querymiddleware/shard_active_native_histogram_metrics_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_native_histogram_metrics_test.go
@@ -721,7 +721,7 @@ func TestShardActiveNativeHistogramMetricsMiddlewareMergeResponseContextCancella
 	}()
 
 	cancelCause := "request canceled while streaming response"
-	cancel(fmt.Errorf("%s", cancelCause))
+	cancel(errors.New(cancelCause))
 
 	g.Wait()
 

--- a/pkg/frontend/querymiddleware/shard_active_native_histogram_metrics_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_native_histogram_metrics_test.go
@@ -721,7 +721,7 @@ func TestShardActiveNativeHistogramMetricsMiddlewareMergeResponseContextCancella
 	}()
 
 	cancelCause := "request canceled while streaming response"
-	cancel(fmt.Errorf(cancelCause))
+	cancel(fmt.Errorf("%s", cancelCause))
 
 	g.Wait()
 

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -486,7 +486,7 @@ func runTestShardActiveSeriesMiddlewareMergeResponseContextCancellation(t *testi
 	require.NoError(t, err)
 
 	cancelCause := "request canceled while streaming response"
-	cancel(fmt.Errorf("%s", cancelCause))
+	cancel(errors.New(cancelCause))
 
 	_, err = io.Copy(&buf, resp.Body)
 	require.NoError(t, err)

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -486,7 +486,7 @@ func runTestShardActiveSeriesMiddlewareMergeResponseContextCancellation(t *testi
 	require.NoError(t, err)
 
 	cancelCause := "request canceled while streaming response"
-	cancel(fmt.Errorf(cancelCause))
+	cancel(fmt.Errorf("%s", cancelCause))
 
 	_, err = io.Copy(&buf, resp.Body)
 	require.NoError(t, err)

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -46,8 +46,8 @@ const (
 )
 
 var (
-	errCanceled              = httpgrpc.Errorf(StatusClientClosedRequest, context.Canceled.Error())
-	errDeadlineExceeded      = httpgrpc.Errorf(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
+	errCanceled              = httpgrpc.Errorf(StatusClientClosedRequest, "%s", context.Canceled.Error())
+	errDeadlineExceeded      = httpgrpc.Errorf(http.StatusGatewayTimeout, "%s", context.DeadlineExceeded.Error())
 	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
 )
 

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -46,8 +46,8 @@ const (
 )
 
 var (
-	errCanceled              = httpgrpc.Errorf(StatusClientClosedRequest, "%s", context.Canceled.Error())
-	errDeadlineExceeded      = httpgrpc.Errorf(http.StatusGatewayTimeout, "%s", context.DeadlineExceeded.Error())
+	errCanceled              = httpgrpc.Error(StatusClientClosedRequest, context.Canceled.Error())
+	errDeadlineExceeded      = httpgrpc.Error(http.StatusGatewayTimeout, context.DeadlineExceeded.Error())
 	errRequestEntityTooLarge = httpgrpc.Errorf(http.StatusRequestEntityTooLarge, "http: request body too large")
 )
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -405,7 +405,7 @@ func (s *Scheduler) cancelRequestAndRemoveFromPending(key queue.RequestKey, reas
 
 	req := s.schedulerInflightRequests[key]
 	if req != nil {
-		req.CancelFunc(cancellation.NewErrorf("%s", reason))
+		req.CancelFunc(cancellation.NewError(errors.New(reason)))
 	}
 
 	delete(s.schedulerInflightRequests, key)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -405,7 +405,7 @@ func (s *Scheduler) cancelRequestAndRemoveFromPending(key queue.RequestKey, reas
 
 	req := s.schedulerInflightRequests[key]
 	if req != nil {
-		req.CancelFunc(cancellation.NewErrorf("%s", reason))
+		req.CancelFunc(cancellation.NewError(reason))
 	}
 
 	delete(s.schedulerInflightRequests, key)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -405,7 +405,7 @@ func (s *Scheduler) cancelRequestAndRemoveFromPending(key queue.RequestKey, reas
 
 	req := s.schedulerInflightRequests[key]
 	if req != nil {
-		req.CancelFunc(cancellation.NewError(reason))
+		req.CancelFunc(cancellation.NewErrorf("%s", reason))
 	}
 
 	delete(s.schedulerInflightRequests, key)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -405,7 +405,7 @@ func (s *Scheduler) cancelRequestAndRemoveFromPending(key queue.RequestKey, reas
 
 	req := s.schedulerInflightRequests[key]
 	if req != nil {
-		req.CancelFunc(cancellation.NewErrorf(reason))
+		req.CancelFunc(cancellation.NewErrorf("%s", reason))
 	}
 
 	delete(s.schedulerInflightRequests, key)

--- a/pkg/storegateway/limiter.go
+++ b/pkg/storegateway/limiter.go
@@ -67,7 +67,7 @@ func (l *Limiter) Reserve(num uint64) error {
 		// We need to protect from the counter being incremented twice due to concurrency
 		// while calling Reserve().
 		l.failedOnce.Do(l.failedCounter.Inc)
-		return httpgrpc.Errorf(http.StatusUnprocessableEntity, l.limitErrorMsg)
+		return httpgrpc.Error(http.StatusUnprocessableEntity, l.limitErrorMsg)
 	}
 	return nil
 }

--- a/pkg/util/objtools/bucket.go
+++ b/pkg/util/objtools/bucket.go
@@ -138,7 +138,7 @@ func (c *BucketConfig) Validate() error {
 func (c *BucketConfig) validate(descriptor string) error {
 	descriptorFlagPrefix := ifNotEmptySuffix(descriptor, ".")
 	if c.backend == "" {
-		return fmt.Errorf("--" + descriptorFlagPrefix + "backend is missing")
+		return fmt.Errorf("--%sbackend is missing", descriptorFlagPrefix)
 	}
 	switch c.backend {
 	case bucket.Azure:
@@ -148,7 +148,7 @@ func (c *BucketConfig) validate(descriptor string) error {
 	case bucket.S3:
 		return c.s3.Validate(bucket.S3 + "." + descriptorFlagPrefix)
 	default:
-		return fmt.Errorf("unknown backend provided in --" + descriptorFlagPrefix + "backend")
+		return fmt.Errorf("unknown backend provided in --%sbackend", descriptorFlagPrefix)
 	}
 }
 

--- a/tools/tsdb-index-toc/main.go
+++ b/tools/tsdb-index-toc/main.go
@@ -33,18 +33,18 @@ func main() {
 
 	finfo, err := os.Stat(filepath)
 	if err != nil {
-		log.Fatalf("%w", err)
+		log.Fatalf("%s", err.Error())
 	}
 	indexSize := finfo.Size()
 
 	f, err := fileutil.OpenMmapFile(filepath)
 	if err != nil {
-		log.Fatalf("%w", err)
+		log.Fatalf("%s", err.Error())
 	}
 
 	toc, err := index.NewTOCFromByteSlice(realByteSlice(f.Bytes()))
 	if err != nil {
-		log.Fatalf("%w", err)
+		log.Fatalf("%s", err.Error())
 	}
 
 	// See https://github.com/prometheus/prometheus/blob/main/tsdb/docs/format/index.md on the index format.

--- a/tools/tsdb-index-toc/main.go
+++ b/tools/tsdb-index-toc/main.go
@@ -33,18 +33,18 @@ func main() {
 
 	finfo, err := os.Stat(filepath)
 	if err != nil {
-		log.Fatalf("%s", err.Error())
+		log.Fatal(err.Error())
 	}
 	indexSize := finfo.Size()
 
 	f, err := fileutil.OpenMmapFile(filepath)
 	if err != nil {
-		log.Fatalf("%s", err.Error())
+		log.Fatal(err.Error())
 	}
 
 	toc, err := index.NewTOCFromByteSlice(realByteSlice(f.Bytes()))
 	if err != nil {
-		log.Fatalf("%s", err.Error())
+		log.Fatal(err.Error())
 	}
 
 	// See https://github.com/prometheus/prometheus/blob/main/tsdb/docs/format/index.md on the index format.

--- a/tools/tsdb-index-toc/main.go
+++ b/tools/tsdb-index-toc/main.go
@@ -33,18 +33,18 @@ func main() {
 
 	finfo, err := os.Stat(filepath)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%w", err)
 	}
 	indexSize := finfo.Size()
 
 	f, err := fileutil.OpenMmapFile(filepath)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%w", err)
 	}
 
 	toc, err := index.NewTOCFromByteSlice(realByteSlice(f.Bytes()))
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%w", err)
 	}
 
 	// See https://github.com/prometheus/prometheus/blob/main/tsdb/docs/format/index.md on the index format.


### PR DESCRIPTION
#### What this PR does

Upgrades Go version in mimir-build-image.

This required an upgrade to `golangci-lint`. In turn, the upgrade of this introduced a new linter rule for constant format strings (which in rare cases can be a security thing). Fixed all violations of this new linter rule.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
