### PR TITLE
Update dskit to support gzip-compressed runtime configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
 * [ENHANCEMENT] Make `-query-frontend.additional-query-queue-dimensions-enabled` and `-query-scheduler.additional-query-queue-dimensions-enabled` non-operational flags in preparation for removal. #8984
 * [ENHANCEMENT] Add a new ingester endpoint to prepare instances to downscale. #8956
 * [ENHANCEMENT] Query-scheduler: Add `query-scheduler.prioritize-query-components` which, when enabled, will primarily prioritize dequeuing fairly across queue components, and secondarily prioritize dequeuing fairly across tenants. When disabled, tenant fairness is primarily prioritized. `query-scheduler.use-multi-algorithm-query-queue` must be enabled in order to use this flag. #9016 #9071
-* [ENHANCEMENT] Runtime configuration can now read gzip-compressed files with `.gz` extension.
+* [ENHANCEMENT] Runtime configuration can now read gzip-compressed files with `.gz` extension. #9074
 * [BUGFIX] Ruler: add support for draining any outstanding alert notifications before shutting down. This can be enabled with the `-ruler.drain-notification-queue-on-shutdown=true` CLI flag. #8346
 * [BUGFIX] Query-frontend: fix `-querier.max-query-lookback` enforcement when `-compactor.blocks-retention-period` is not set, and viceversa. #8388
 * [BUGFIX] Ingester: fix sporadic `not found` error causing an internal server error if label names are queried with matchers during head compaction. #8391

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * [ENHANCEMENT] Make `-query-frontend.additional-query-queue-dimensions-enabled` and `-query-scheduler.additional-query-queue-dimensions-enabled` non-operational flags in preparation for removal. #8984
 * [ENHANCEMENT] Add a new ingester endpoint to prepare instances to downscale. #8956
 * [ENHANCEMENT] Query-scheduler: Add `query-scheduler.prioritize-query-components` which, when enabled, will primarily prioritize dequeuing fairly across queue components, and secondarily prioritize dequeuing fairly across tenants. When disabled, tenant fairness is primarily prioritized. `query-scheduler.use-multi-algorithm-query-queue` must be enabled in order to use this flag. #9016 #9071
+* [ENHANCEMENT] Runtime configuration can now read gzip-compressed files with `.gz` extension.
 * [BUGFIX] Ruler: add support for draining any outstanding alert notifications before shutting down. This can be enabled with the `-ruler.drain-notification-queue-on-shutdown=true` CLI flag. #8346
 * [BUGFIX] Query-frontend: fix `-querier.max-query-lookback` enforcement when `-compactor.blocks-retention-period` is not set, and viceversa. #8388
 * [BUGFIX] Ingester: fix sporadic `not found` error causing an internal server error if label names are queried with matchers during head compaction. #8391

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
 * [ENHANCEMENT] Make `-query-frontend.additional-query-queue-dimensions-enabled` and `-query-scheduler.additional-query-queue-dimensions-enabled` non-operational flags in preparation for removal. #8984
 * [ENHANCEMENT] Add a new ingester endpoint to prepare instances to downscale. #8956
 * [ENHANCEMENT] Query-scheduler: Add `query-scheduler.prioritize-query-components` which, when enabled, will primarily prioritize dequeuing fairly across queue components, and secondarily prioritize dequeuing fairly across tenants. When disabled, tenant fairness is primarily prioritized. `query-scheduler.use-multi-algorithm-query-queue` must be enabled in order to use this flag. #9016 #9071
-* [ENHANCEMENT] Runtime configuration can now read gzip-compressed files with `.gz` extension. #9074
+* [ENHANCEMENT] Update runtime configuration to read gzip-compressed files with `.gz` extension. #9074
 * [BUGFIX] Ruler: add support for draining any outstanding alert notifications before shutting down. This can be enabled with the `-ruler.drain-notification-queue-on-shutdown=true` CLI flag. #8346
 * [BUGFIX] Query-frontend: fix `-querier.max-query-lookback` enforcement when `-compactor.blocks-retention-period` is not set, and viceversa. #8388
 * [BUGFIX] Ingester: fix sporadic `not found` error causing an internal server error if label names are queried with matchers during head compaction. #8391

--- a/docs/sources/mimir/configure/about-runtime-configuration.md
+++ b/docs/sources/mimir/configure/about-runtime-configuration.md
@@ -23,7 +23,7 @@ Runtime configuration values take precedence over command-line options.
 
 If multiple runtime configuration files are specified the runtime configuration files will be merged in a left to right order.
 
-If a runtime configuration file has the `.gz` extension, it will be decompressed before being read.
+Add a `.gz` extension to the configuration files that should be decompressed before parsing YAML.
 
 ## Enable runtime configuration
 

--- a/docs/sources/mimir/configure/about-runtime-configuration.md
+++ b/docs/sources/mimir/configure/about-runtime-configuration.md
@@ -23,6 +23,8 @@ Runtime configuration values take precedence over command-line options.
 
 If multiple runtime configuration files are specified the runtime configuration files will be merged in a left to right order.
 
+If a runtime configuration file has the `.gz` extension, it will be decompressed before being read.
+
 ## Enable runtime configuration
 
 To enable runtime configuration, specify a comma-separated list of file paths upon startup by using the `-runtime-config.file=<filepath>,<filepath>` CLI flag or from within your YAML configuration file in the `runtime_config` block.

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20240816175624-cbfe0ab4f4c2
+	github.com/grafana/dskit v0.0.0-20240822084815-f25f20668f96
 	github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20240812131556-611a23ff0f7f h1:c8QAFXkilBiF29xc7oKO2IkbGE3bp9NIKgiNLazdooY=
 github.com/grafana/alerting v0.0.0-20240812131556-611a23ff0f7f/go.mod h1:DLj8frbtCaITljC2jc0L85JQViPF3mPfOSiYhm1osso=
-github.com/grafana/dskit v0.0.0-20240816175624-cbfe0ab4f4c2 h1:nNhzI/mjA2Hw/M2tlyS+OL7tOVRBpfryX9eQJpvv5XQ=
-github.com/grafana/dskit v0.0.0-20240816175624-cbfe0ab4f4c2/go.mod h1:c4ASJAo1QFmXGydDzNed2o0+Fncx+x4YmQ1r9HfYU3c=
+github.com/grafana/dskit v0.0.0-20240822084815-f25f20668f96 h1:8WSVfqXC2S1bQLu30TsKfW7e+1ArAr4j5TQEFaVcB74=
+github.com/grafana/dskit v0.0.0-20240822084815-f25f20668f96/go.mod h1:c4ASJAo1QFmXGydDzNed2o0+Fncx+x4YmQ1r9HfYU3c=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc h1:BW+LjKJDz0So5LI8UZfW5neWeKpSkWqhmGjQFzcFfLM=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/vendor/github.com/grafana/dskit/httpgrpc/httpgrpc.go
+++ b/vendor/github.com/grafana/dskit/httpgrpc/httpgrpc.go
@@ -106,14 +106,21 @@ func FromHeader(hs http.Header) []*Header {
 	return result
 }
 
-// Errorf returns a HTTP gRPC error than is correctly forwarded over
+// Error returns a HTTP gRPC error that is correctly forwarded over
+// gRPC, and can eventually be converted back to a HTTP response with
+// HTTPResponseFromError.
+func Error(code int, msg string) error {
+	return ErrorFromHTTPResponse(&HTTPResponse{
+		Code: int32(code),
+		Body: []byte(msg),
+	})
+}
+
+// Errorf returns a HTTP gRPC error that is correctly forwarded over
 // gRPC, and can eventually be converted back to a HTTP response with
 // HTTPResponseFromError.
 func Errorf(code int, tmpl string, args ...interface{}) error {
-	return ErrorFromHTTPResponse(&HTTPResponse{
-		Code: int32(code),
-		Body: []byte(fmt.Sprintf(tmpl, args...)),
-	})
+	return Error(code, fmt.Sprintf(tmpl, args...))
 }
 
 // ErrorFromHTTPResponse converts an HTTP response into a grpc error, and uses HTTP response body as an error message.

--- a/vendor/github.com/grafana/dskit/ring/replication_set.go
+++ b/vendor/github.com/grafana/dskit/ring/replication_set.go
@@ -316,7 +316,7 @@ func DoUntilQuorumWithoutSuccessfulContextCancellation[T any](ctx context.Contex
 			ext.Error.Set(cfg.Logger.Span, true)
 		}
 
-		contextTracker.cancelAllContexts(cancellation.NewErrorf(cause))
+		contextTracker.cancelAllContexts(cancellation.NewError(errors.New(cause)))
 		cleanupResultsAlreadyReceived()
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -610,7 +610,7 @@ github.com/grafana/alerting/receivers/webex
 github.com/grafana/alerting/receivers/webhook
 github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
-# github.com/grafana/dskit v0.0.0-20240816175624-cbfe0ab4f4c2
+# github.com/grafana/dskit v0.0.0-20240822084815-f25f20668f96
 ## explicit; go 1.21
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This allows larger runtime configuration files without hitting the Kubernetes ConfigMap size limit.

Implemented in dskit in https://github.com/grafana/dskit/pull/571

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated (tested in dskit).
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
