### PR TITLE
Disable logging of migration data when UTF-8 Strict Mode is enabled

### DIFF
--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -881,6 +881,7 @@ alertmanager_config: |
 
 	limits := &mockAlertManagerLimits{}
 	am := &MultitenantAlertmanager{
+		cfg:    &MultitenantAlertmanagerConfig{},
 		store:  prepareInMemoryAlertStore(),
 		logger: test.NewTestingLogger(t),
 		limits: limits,

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -806,12 +806,14 @@ type amConfig struct {
 // setConfig applies the given configuration to the alertmanager for `userID`,
 // creating an alertmanager if it doesn't already exist.
 func (am *MultitenantAlertmanager) setConfig(cfg amConfig) error {
-	// Instead of using "config" as the origin, as in Prometheus Alertmanager, we use "tenant".
-	// The reason for this that the config.Load function uses the origin "config",
-	// which is correct, but Mimir uses config.Load to validate both API requests and tenant
-	// configurations. This means metrics from API requests are confused with metrics from
-	// tenant configurations. To avoid this confusion, we use a different origin.
-	validateMatchersInConfigDesc(am.logger, "tenant", cfg.AlertConfigDesc)
+	if !am.cfg.UTF8StrictMode {
+		// Instead of using "config" as the origin, as in Prometheus Alertmanager, we use "tenant".
+		// The reason for this that the config.Load function uses the origin "config",
+		// which is correct, but Mimir uses config.Load to validate both API requests and tenant
+		// configurations. This means metrics from API requests are confused with metrics from
+		// tenant configurations. To avoid this confusion, we use a different origin.
+		validateMatchersInConfigDesc(am.logger, "tenant", cfg.AlertConfigDesc)
+	}
 
 	level.Debug(am.logger).Log("msg", "setting config", "user", cfg.User)
 


### PR DESCRIPTION
#### What this PR does

This commit disables logging of the migration code that assists users to enable UTF-8 Strict Mode. When UTF-8 strict mode is enabled, these logs are no longer needed, and should be disabled to reduce log volume.

`validateMatchersInConfigDesc` is a special function added to Mimir to log Alertmanager configurations that are incompatible with UTF-8. It does this by unmarshalling each configuration a second time, but with different options and a specialized logger than injects the Tenant ID. It is intended to provide the data to Mimir server operators that helps them identify incompatible tenant configurations before enabling the `utf8-strict-mode` flag. It's purpose is nothing else but to log this data. Once UTF-8 strict mode is enabled, there is no need to call this function anymore.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
