### PR TITLE
Revert "chore(deps): update dependency go to v1.23.0 (#9043)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/mimir
 
 go 1.21.0
 
-toolchain go1.22.6
+toolchain go1.22.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/mimir
 
 go 1.21.0
 
-toolchain go1.23.0
+toolchain go1.22.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2


### PR DESCRIPTION
#### What this PR does

This reverts commit 86b8d6d41e3157dd6d8b9ad248fa152b33cd00c7.

Revert, as we don't want to require a newer Go toolchain than is in the build image. Also downgrading the toolchain version to v1.22.5 rather than v1.22.6, since the build image has the former.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
