### PR TITLE
mimir-build-image: Explicitly set GOTOOLCHAIN=local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr8600-8a8fd767c7
+LATEST_BUILD_IMAGE_TAG ?= pr9082-d0a22a8a96
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/mimir
 
 go 1.21.0
 
+// Please note that this directive is ignored when building with the Mimir build image,
+// that will always use its bundled toolchain.
 toolchain go1.22.5
 
 require (

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -9,6 +9,10 @@ FROM golang:1.22.5-bookworm
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"
+# Override toolchain directive in go.mod, to ensure the image's Go version is used.
+# Be aware that the official Go Dockerfiles already do this, but let's be explicit.
+# https://github.com/docker-library/golang/issues/472
+RUN go env -w GOTOOLCHAIN=local
 RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev $SKOPEO_DEPS && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -12,7 +12,7 @@ ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-co
 # Override toolchain directive in go.mod, to ensure the image's Go version is used.
 # Be aware that the official Go Dockerfiles already do this, but let's be explicit.
 # https://github.com/docker-library/golang/issues/472
-RUN go env -w GOTOOLCHAIN=local
+ENV GOTOOLCHAIN=local
 RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev $SKOPEO_DEPS && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e


### PR DESCRIPTION
#### What this PR does
In mimir-build-image/Dockerfile, explicitly override environment variable `GOTOOLCHAIN` to be `local`, to make sure that the Docker image's bundled Go toolchain is used, rather than the one specified via the `toolchain` directive in go.mod. The same is already done in [official Go images](https://github.com/docker-library/golang/issues/472), but being explicit helps also to document.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
