### PR TITLE
Fix missing error for no usable configuration

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2974,7 +2974,7 @@ func TestSyncStates(t *testing.T) {
 				usingGrafanaConfig: true,
 			},
 			parts:  map[string][]byte{"notifications": grafanaNflog},
-			expErr: fmt.Sprintf("error creating new Alertmanager for user %[1]s: no usable Alertmanager configuration for %[1]s", user),
+			expErr: fmt.Sprintf("error creating new Alertmanager for user %[1]s: no usable Alertmanager configuration for %[1]s: invalid Alertmanager configuration: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `invalid` into definition.plain", user),
 		},
 		{
 			name: "invalid part key",


### PR DESCRIPTION
#### What this PR does

This commit fixes the error `no usable Alertmanager configuration` as it was missing context explaining why the configuration was missing. In most cases, this is due to an invalid Alertmanager configuration. However, without an error message, it was very hard to find out why the configuration was invalid.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
