### PR TITLE
Add query pruning middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
     * `-ingester.partition-ring.*`: configures partitions ring backend.
 * [FEATURE] Querier: added support for `limitk()` and `limit_ratio()` experimental PromQL functions. Experimental functions are disabled by default, but can be enabled setting `-querier.promql-experimental-functions-enabled=true` in the query-frontend and querier. #8632
 * [FEATURE] Querier: experimental support for `X-Mimir-Chunk-Info-Logger` header that triggers logging information about TSDB chunks loaded from ingesters and store-gateways in the querier. The header should contain the comma separated list of labels for which their value will be included in the logs. #8599
+* [FEATURE] Query frontend: added new query pruning middleware to enable pruning dead code (eg. expressions that cannot produce any results) and simplifying expressions (eg. expressions that can be evaluated immediately) in queries. #9086
 * [FEATURE] Ruler: added experimental configuration, `-ruler.rule-evaluation-write-enabled`, to disable writing the result of rule evaluation to ingesters. This feature can be used for testing purposes. #9060
 * [FEATURE] Ingester: added experimental configuration `ingester.ignore-ooo-exemplars`. When set to `true` out of order exemplars are no longer reported to the remote write client. #9151
 * [ENHANCEMENT] Compactor: Add `cortex_compactor_compaction_job_duration_seconds` and `cortex_compactor_compaction_job_blocks` histogram metrics to track duration of individual compaction jobs and number of blocks per job. #8371

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -6369,6 +6369,16 @@
         },
         {
           "kind": "field",
+          "name": "prune_queries",
+          "required": false,
+          "desc": "True to enable query pruning.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-frontend.prune-queries",
+          "fieldType": "boolean"
+        },
+        {
+          "kind": "field",
           "name": "query_sharding_target_series_per_shard",
           "required": false,
           "desc": "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -6371,11 +6371,12 @@
           "kind": "field",
           "name": "prune_queries",
           "required": false,
-          "desc": "True to enable query pruning.",
+          "desc": "True to enable pruning dead code (eg. expressions that cannot produce any results) and simplifying expressions (eg. expressions that can be evaluated immediately) in queries.",
           "fieldValue": null,
           "fieldDefaultValue": false,
           "fieldFlag": "query-frontend.prune-queries",
-          "fieldType": "boolean"
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         },
         {
           "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2083,6 +2083,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum time to wait for the query-frontend to become ready before rejecting requests received before the frontend was ready. 0 to disable (i.e. fail immediately if a request is received while the frontend is still starting up) (default 2s)
   -query-frontend.parallelize-shardable-queries
     	True to enable query sharding.
+  -query-frontend.prune-queries
+    	True to enable query pruning.
   -query-frontend.querier-forget-delay duration
     	[experimental] If a querier disconnects without sending notification about graceful shutdown, the query-frontend will keep the querier in the tenant's shard until the forget delay has passed. This feature is useful to reduce the blast radius when shuffle-sharding is enabled.
   -query-frontend.query-result-response-format string

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2084,7 +2084,7 @@ Usage of ./cmd/mimir/mimir:
   -query-frontend.parallelize-shardable-queries
     	True to enable query sharding.
   -query-frontend.prune-queries
-    	True to enable query pruning.
+    	[experimental] True to enable pruning dead code (eg. expressions that cannot produce any results) and simplifying expressions (eg. expressions that can be evaluated immediately) in queries.
   -query-frontend.querier-forget-delay duration
     	[experimental] If a querier disconnects without sending notification about graceful shutdown, the query-frontend will keep the querier in the tenant's shard until the forget delay has passed. This feature is useful to reduce the blast radius when shuffle-sharding is enabled.
   -query-frontend.query-result-response-format string

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -555,6 +555,8 @@ Usage of ./cmd/mimir/mimir:
     	Limit the total query time range (end - start time). This limit is enforced in the query-frontend on the received instant, range or remote read query.
   -query-frontend.parallelize-shardable-queries
     	True to enable query sharding.
+  -query-frontend.prune-queries
+    	True to enable query pruning.
   -query-frontend.query-result-response-format string
     	Format to use when retrieving query results from queriers. Supported values: json, protobuf (default "protobuf")
   -query-frontend.query-sharding-max-regexp-size-bytes int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -555,8 +555,6 @@ Usage of ./cmd/mimir/mimir:
     	Limit the total query time range (end - start time). This limit is enforced in the query-frontend on the received instant, range or remote read query.
   -query-frontend.parallelize-shardable-queries
     	True to enable query sharding.
-  -query-frontend.prune-queries
-    	True to enable query pruning.
   -query-frontend.query-result-response-format string
     	Format to use when retrieving query results from queriers. Supported values: json, protobuf (default "protobuf")
   -query-frontend.query-sharding-max-regexp-size-bytes int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1674,7 +1674,9 @@ results_cache:
 # CLI flag: -query-frontend.parallelize-shardable-queries
 [parallelize_shardable_queries: <boolean> | default = false]
 
-# True to enable query pruning.
+# (experimental) True to enable pruning dead code (eg. expressions that cannot
+# produce any results) and simplifying expressions (eg. expressions that can be
+# evaluated immediately) in queries.
 # CLI flag: -query-frontend.prune-queries
 [prune_queries: <boolean> | default = false]
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1674,6 +1674,10 @@ results_cache:
 # CLI flag: -query-frontend.parallelize-shardable-queries
 [parallelize_shardable_queries: <boolean> | default = false]
 
+# True to enable query pruning.
+# CLI flag: -query-frontend.prune-queries
+[prune_queries: <boolean> | default = false]
+
 # (advanced) How many series a single sharded partial query should load at most.
 # This is not a strict requirement guaranteed to be honoured by query sharding,
 # but a hint given to the query sharding when the query execution is initially

--- a/pkg/frontend/querymiddleware/astmapper/pruning.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning.go
@@ -13,9 +13,9 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
-func NewQueryPruner(ctx context.Context, logger log.Logger) (ASTMapper, error) {
+func NewQueryPruner(ctx context.Context, logger log.Logger) ASTMapper {
 	pruner := newQueryPruner(ctx, logger)
-	return NewASTExprMapper(pruner), nil
+	return NewASTExprMapper(pruner)
 }
 
 type queryPruner struct {

--- a/pkg/frontend/querymiddleware/astmapper/pruning.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning.go
@@ -34,6 +34,12 @@ func (pruner *queryPruner) MapExpr(expr parser.Expr) (mapped parser.Expr, finish
 	}
 
 	switch e := expr.(type) {
+	case *parser.ParenExpr:
+		mapped, finished, err = pruner.MapExpr(e.Expr)
+		if err != nil {
+			return e, false, err
+		}
+		return &parser.ParenExpr{Expr: mapped, PosRange: e.PosRange}, finished, nil
 	case *parser.BinaryExpr:
 		return pruner.pruneBinOp(e)
 	default:

--- a/pkg/frontend/querymiddleware/astmapper/pruning.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning.go
@@ -109,12 +109,12 @@ func (pruner *queryPruner) handleCompOp(expr *parser.BinaryExpr) parser.Expr {
 				Args: []parser.Expr{&parser.NumberLiteral{Val: 0}},
 			},
 			Op:         parser.LSS,
-			RHS:        refNeg,
+			RHS:        &parser.NumberLiteral{Val: math.Inf(-1)},
 			ReturnBool: false,
 		}
 	}
 
-	// foo > +Inf or +Inf < foo => vector(0) > +Inf
+	// foo > +Inf or +Inf < foo => vector(0) > +Inf => vector(0) < -Inf
 	isInf, sign = pruner.isInfinite(refPos)
 	if isInf && sign {
 		return &parser.BinaryExpr{
@@ -122,8 +122,8 @@ func (pruner *queryPruner) handleCompOp(expr *parser.BinaryExpr) parser.Expr {
 				Func: parser.Functions["vector"],
 				Args: []parser.Expr{&parser.NumberLiteral{Val: 0}},
 			},
-			Op:         parser.GTR,
-			RHS:        refPos,
+			Op:         parser.LSS,
+			RHS:        &parser.NumberLiteral{Val: math.Inf(-1)},
 			ReturnBool: false,
 		}
 	}

--- a/pkg/frontend/querymiddleware/astmapper/pruning.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/querier/astmapper/shard_summer.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+package astmapper
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+func NewQueryPruner(ctx context.Context, logger log.Logger, stats *MapperStats) (ASTMapper, error) {
+	pruner := newQueryPruner(ctx, logger, stats)
+	return NewASTExprMapper(pruner), nil
+}
+
+type queryPruner struct {
+	ctx context.Context
+
+	logger log.Logger
+	stats  *MapperStats
+
+	canShardAllVectorSelectorsCache map[string]bool
+}
+
+func newQueryPruner(ctx context.Context, logger log.Logger, stats *MapperStats) *queryPruner {
+	return &queryPruner{
+		ctx: ctx,
+
+		logger: logger,
+		stats:  stats,
+
+		canShardAllVectorSelectorsCache: make(map[string]bool),
+	}
+}
+
+func (pruner *queryPruner) Clone() *queryPruner {
+	s := *pruner
+	s.stats = NewMapperStats()
+	return &s
+}
+
+func (pruner *queryPruner) Copy() *queryPruner {
+	s := *pruner
+	return &s
+}
+
+func (pruner *queryPruner) MapExpr(expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
+	if err := pruner.ctx.Err(); err != nil {
+		return nil, false, err
+	}
+
+	switch e := expr.(type) {
+	case *parser.AggregateExpr:
+		return e, true, nil
+
+	case *parser.VectorSelector:
+		return e, true, nil
+
+	case *parser.Call:
+		return e, true, nil
+
+	case *parser.BinaryExpr:
+		return pruner.pruneBinOp(e)
+
+	case *parser.SubqueryExpr:
+		return e, true, nil
+
+	default:
+		return e, false, nil
+	}
+}
+
+func (pruner *queryPruner) pruneBinOp(expr *parser.BinaryExpr) (mapped parser.Expr, finished bool, err error) {
+	switch expr.Op {
+	case parser.MUL:
+		return pruner.handleMultiplyOp(expr), true, nil
+	case parser.DIV:
+		return pruner.handleDivideOp(expr), true, nil
+	case parser.SUB:
+		return pruner.handleSubtractOp(expr), true, nil
+	default:
+		return expr, false, nil
+	}
+}
+
+func (pruner *queryPruner) handleMultiplyOp(expr *parser.BinaryExpr) parser.Expr {
+	if expr.LHS.String() == "0" {
+		return expr.LHS
+	}
+	if expr.RHS.String() == "0" {
+		return expr.RHS
+	}
+	return expr
+}
+
+func (pruner *queryPruner) handleDivideOp(expr *parser.BinaryExpr) parser.Expr {
+	if expr.LHS.String() == "0" {
+		return expr.LHS
+	}
+	return expr
+}
+
+func (pruner *queryPruner) handleSubtractOp(expr *parser.BinaryExpr) parser.Expr {
+	if expr.LHS.String() == expr.RHS.String() {
+		return &parser.NumberLiteral{Val: 0}
+	}
+	return expr
+}

--- a/pkg/frontend/querymiddleware/astmapper/pruning.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning.go
@@ -58,6 +58,8 @@ func (pruner *queryPruner) pruneBinOp(expr *parser.BinaryExpr) (mapped parser.Ex
 	}
 }
 
+// The bool signifies if the number evaluates to infinity, and if it does
+// we return the infinity of the correct sign.
 func calcInf(isPositive bool, num string) (*parser.NumberLiteral, bool) {
 	coeff, err := strconv.Atoi(num)
 	if err != nil || coeff == 0 {
@@ -139,6 +141,8 @@ func (pruner *queryPruner) handleCompOp(expr *parser.BinaryExpr) parser.Expr {
 	return expr
 }
 
+// 1st bool is true if the number is infinite.
+// 2nd bool is true if the number is positive infinity.
 func (pruner *queryPruner) isInfinite(expr parser.Expr) (bool, bool) {
 	mapped, _, err := pruner.MapExpr(expr)
 	if err == nil {

--- a/pkg/frontend/querymiddleware/astmapper/pruning_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning_test.go
@@ -113,6 +113,22 @@ func TestQueryPruner(t *testing.T) {
 			`(-1 * -Inf) < avg(rate(foo[1m]))`,
 			`vector(0) < -Inf`,
 		},
+		{
+			`vector(0) < -Inf or avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`avg(rate(foo[1m])) or vector(0) < -Inf`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`avg(rate(foo[1m])) or (vector(0) < -Inf)`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`((-1 * -Inf) < avg(rate(foo[1m]))) or avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
 	} {
 		tt := tt
 

--- a/pkg/frontend/querymiddleware/astmapper/pruning_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning_test.go
@@ -51,11 +51,11 @@ func TestQueryPruner(t *testing.T) {
 		},
 		{
 			`up > +Inf`,
-			`vector(0) > +Inf`,
+			`vector(0) < -Inf`,
 		},
 		{
 			`+Inf < up`,
-			`vector(0) > +Inf`,
+			`vector(0) < -Inf`,
 		},
 		{
 			`up < +Inf`,
@@ -75,7 +75,7 @@ func TestQueryPruner(t *testing.T) {
 		},
 		{
 			`avg(rate(foo[1m])) < (-Inf)`,
-			`vector(0) < (-Inf)`,
+			`vector(0) < -Inf`,
 		},
 		{
 			`Inf * -1`,
@@ -95,7 +95,7 @@ func TestQueryPruner(t *testing.T) {
 		},
 		{
 			`avg(rate(foo[1m])) < (-1 * +Inf)`,
-			`vector(0) < (-Inf)`,
+			`vector(0) < -Inf`,
 		},
 		{
 			`avg(rate(foo[1m])) < (+1 * +Inf)`,
@@ -107,11 +107,11 @@ func TestQueryPruner(t *testing.T) {
 		},
 		{
 			`avg(rate(foo[1m])) < (+1 * -Inf)`,
-			`vector(0) < (-Inf)`,
+			`vector(0) < -Inf`,
 		},
 		{
 			`(-1 * -Inf) < avg(rate(foo[1m]))`,
-			`vector(0) > (+Inf)`,
+			`vector(0) < -Inf`,
 		},
 	} {
 		tt := tt

--- a/pkg/frontend/querymiddleware/astmapper/pruning_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestQueryPruner(t *testing.T) {
-	stats := NewMapperStats()
-	mapper, err := NewQueryPruner(context.Background(), log.NewNopLogger(), stats)
+	mapper, err := NewQueryPruner(context.Background(), log.NewNopLogger())
 	require.NoError(t, err)
 
 	for _, tt := range []struct {

--- a/pkg/frontend/querymiddleware/astmapper/pruning_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestQueryPruner(t *testing.T) {
-	mapper, err := NewQueryPruner(context.Background(), log.NewNopLogger())
-	require.NoError(t, err)
+	pruner := NewQueryPruner(context.Background(), log.NewNopLogger())
 
 	for _, tt := range []struct {
 		in  string
@@ -123,7 +122,7 @@ func TestQueryPruner(t *testing.T) {
 			out, err := parser.ParseExpr(tt.out)
 			require.NoError(t, err)
 
-			mapped, err := mapper.Map(expr)
+			mapped, err := pruner.Map(expr)
 			require.NoError(t, err)
 			require.Equal(t, out.String(), mapped.String())
 		})

--- a/pkg/frontend/querymiddleware/astmapper/pruning_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/querier/astmapper/shard_summer_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+package astmapper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryPruner(t *testing.T) {
+	for _, tt := range []struct {
+		in  string
+		out string
+	}{
+		{
+			`quantile(0.9,foo)`,
+			`quantile(0.9,foo)`,
+		},
+		{
+			`histogram_quantile(0.5, rate(bar1{baz="blip"}[30s]))`,
+			`histogram_quantile(0.5, rate(bar1{baz="blip"}[30s]))`,
+		},
+		{
+			`count(up)`,
+			`count(up)`,
+		},
+		{
+			`avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`avg(rate(foo[1m])) * 0`,
+			`0`,
+		},
+		{
+			`0 * avg(rate(foo[1m]))`,
+			`0`,
+		},
+		{
+			`0 * avg(1 + rate(foo[1m]))`,
+			`0`,
+		},
+		{
+			`avg(rate(foo[1m])) * 0 + 1`,
+			`0 + 1`,
+		},
+		{
+			`1 + avg(rate(foo[1m])) * 0`,
+			`1 + 0`,
+		},
+		{
+			`0 / avg(rate(foo[1m]))`,
+			`0`,
+		},
+		{
+			`avg(rate(foo[1m])) - avg(rate(foo[1m]))`,
+			`0`,
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.in, func(t *testing.T) {
+			stats := NewMapperStats()
+			mapper, err := NewQueryPruner(context.Background(), log.NewNopLogger(), stats)
+			require.NoError(t, err)
+			expr, err := parser.ParseExpr(tt.in)
+			require.NoError(t, err)
+			out, err := parser.ParseExpr(tt.out)
+			require.NoError(t, err)
+
+			mapped, err := mapper.Map(expr)
+			require.NoError(t, err)
+			require.Equal(t, out.String(), mapped.String())
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/astmapper/pruning_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning_test.go
@@ -182,6 +182,14 @@ func TestQueryPruner(t *testing.T) {
 			`((((-1 * -Inf) < avg(rate(foo[4m]))) unless avg(rate(foo[3m]))) and avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
 			`avg(rate(foo[1m]))`,
 		},
+		{
+			`(((-1 * -Inf) < avg(rate(foo[4m]))) unless (avg(rate(foo[3m])) and avg(rate(foo[2m])))) or avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`(((-1 * -Inf) < avg(rate(foo[4m]))) unless avg(rate(foo[3m])) and avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
 	} {
 		tt := tt
 

--- a/pkg/frontend/querymiddleware/astmapper/pruning_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning_test.go
@@ -1,7 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/querier/astmapper/shard_summer_test.go
-// Provenance-includes-license: Apache-2.0
-// Provenance-includes-copyright: The Cortex Authors.
 
 package astmapper
 
@@ -126,7 +123,63 @@ func TestQueryPruner(t *testing.T) {
 			`avg(rate(foo[1m]))`,
 		},
 		{
-			`((-1 * -Inf) < avg(rate(foo[1m]))) or avg(rate(foo[1m]))`,
+			`((-1 * -Inf) < avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`((-1 * -Inf) <= avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`((+Inf) <= avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+		},
+		{
+			`((-1 * -Inf) >= avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`((+Inf) >= avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+		},
+		{
+			`((-1 * -Inf) > avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`((+Inf) > avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+		},
+		{
+			`((-1 * +Inf) > avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`((+1 * -Inf) > avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`(avg(rate(foo[2m])) < (+1 * -Inf)) or avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`((-1 * -Inf) == avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`((+Inf) == avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+		},
+		{
+			`((-1 * -Inf) != avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`((+Inf) != avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+		},
+		{
+			`((-1 * -Inf) < avg(rate(foo[2m]))) and avg(rate(foo[1m]))`,
+			`(vector(0) < -Inf)`,
+		},
+		{
+			`((-1 * -Inf) < avg(rate(foo[2m]))) unless avg(rate(foo[1m]))`,
+			`(vector(0) < -Inf)`,
+		},
+		{
+			`avg(rate(foo[1m])) unless ((-1 * -Inf) < avg(rate(foo[2m])))`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`((2 * +Inf) < avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`(((-1 * -Inf) < avg(rate(foo[3m]))) unless avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
+			`avg(rate(foo[1m]))`,
+		},
+		{
+			`((((-1 * -Inf) < avg(rate(foo[4m]))) unless avg(rate(foo[3m]))) and avg(rate(foo[2m]))) or avg(rate(foo[1m]))`,
 			`avg(rate(foo[1m]))`,
 		},
 	} {

--- a/pkg/frontend/querymiddleware/prune.go
+++ b/pkg/frontend/querymiddleware/prune.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/querier/queryrange/step_align.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+package querymiddleware
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	apierror "github.com/grafana/mimir/pkg/api/error"
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+)
+
+type pruneMiddleware struct {
+	next   MetricsQueryHandler
+	logger log.Logger
+}
+
+// newPruneMiddleware creates a middleware that optimises queries by rewriting them to prune away
+// unnecessary computations.
+func newPruneMiddleware(logger log.Logger) MetricsQueryMiddleware {
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
+		return &pruneMiddleware{
+			next:   next,
+			logger: logger,
+		}
+	})
+}
+
+func (p *pruneMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Response, error) {
+	log := spanlogger.FromContext(ctx, p.logger)
+
+	prunedQuery, err := p.pruneQuery(ctx, r.GetQuery())
+	if err != nil {
+		level.Warn(log).Log("msg", "failed to prune the input query, falling back to the original query", "query", r.GetQuery(), "err", err)
+
+		return p.next.Do(ctx, r)
+	}
+
+	level.Debug(log).Log("msg", "query has been purged", "original", r.GetQuery(), "rewritten", prunedQuery)
+
+	updatedReq, err := r.WithQuery(prunedQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.next.Do(ctx, updatedReq)
+}
+
+func (p *pruneMiddleware) pruneQuery(ctx context.Context, query string) (string, error) {
+	mapper := astmapper.NewQueryPruner(ctx, p.logger)
+
+	// The mapper can modify the input expression in-place, so we must re-parse the original query
+	// each time before passing it to the mapper.
+	expr, err := parser.ParseExpr(query)
+	if err != nil {
+		return "", apierror.New(apierror.TypeBadData, decorateWithParamName(err, "query").Error())
+	}
+
+	prunedQuery, err := mapper.Map(expr)
+	if err != nil {
+		return "", err
+	}
+
+	return prunedQuery.String(), nil
+}

--- a/pkg/frontend/querymiddleware/prune_test.go
+++ b/pkg/frontend/querymiddleware/prune_test.go
@@ -41,9 +41,7 @@ func TestQueryPruning(t *testing.T) {
 	}
 	queryable := storageSeriesQueryable(storageSeries)
 
-	const numShards = 8
 	const step = 20 * time.Second
-	const splitInterval = 15 * time.Second
 
 	engine := newEngine()
 	pruningware := newPruneMiddleware(

--- a/pkg/frontend/querymiddleware/prune_test.go
+++ b/pkg/frontend/querymiddleware/prune_test.go
@@ -65,6 +65,7 @@ func TestQueryPruning(t *testing.T) {
 		{`avg(rate(%s[1m])) < (-1 * -Inf)`, false},
 		{`avg(rate(%s[1m])) < (+1 * -Inf)`, true},
 		{`(-1 * -Inf) < avg(rate(%s[1m]))`, true},
+		{`((-1 * -Inf) < avg(rate(foo[1m]))) or avg(rate(%s[1m]))`, false},
 	}
 	for _, template := range templates {
 		t.Run(template.query, func(t *testing.T) {

--- a/pkg/frontend/querymiddleware/prune_test.go
+++ b/pkg/frontend/querymiddleware/prune_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/querier/queryrange/step_align_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
+package querymiddleware
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryPruning(t *testing.T) {
+	numSeries := 10
+	endTime := 100
+	storageSeries := make([]*promql.StorageSeries, 0, numSeries)
+	floats := make([]promql.FPoint, 0, endTime)
+	for i := 0; i < endTime; i++ {
+		floats = append(floats, promql.FPoint{
+			T: int64(i * 1000),
+			F: float64(i),
+		})
+	}
+	histograms := make([]promql.HPoint, 0)
+	seriesName := `test_float`
+	for i := 0; i < numSeries; i++ {
+		nss := promql.NewStorageSeries(promql.Series{
+			Metric:     labels.FromStrings("__name__", seriesName, "series", fmt.Sprint(i)),
+			Floats:     floats,
+			Histograms: histograms,
+		})
+		storageSeries = append(storageSeries, nss)
+	}
+	queryable := storageSeriesQueryable(storageSeries)
+
+	const numShards = 8
+	const step = 20 * time.Second
+	const splitInterval = 15 * time.Second
+
+	engine := newEngine()
+	pruningware := newPruneMiddleware(
+		log.NewNopLogger(),
+	)
+	downstream := &downstreamHandler{
+		engine:    engine,
+		queryable: queryable,
+	}
+
+	type template struct {
+		query   string
+		IsEmpty bool
+	}
+
+	templates := []template{
+		{`avg(rate(%s[1m])) < (-1 * +Inf)`, true},
+		{`avg(rate(%s[1m])) < (+1 * +Inf)`, false},
+		{`avg(rate(%s[1m])) < (-1 * -Inf)`, false},
+		{`avg(rate(%s[1m])) < (+1 * -Inf)`, true},
+		{`(-1 * -Inf) < avg(rate(%s[1m]))`, true},
+	}
+	for _, template := range templates {
+		t.Run(template.query, func(t *testing.T) {
+			query := fmt.Sprintf(template.query, seriesName)
+			req := &PrometheusRangeQueryRequest{
+				path:      "/query_range",
+				start:     0,
+				end:       int64(endTime * 1000),
+				step:      step.Milliseconds(),
+				queryExpr: parseQuery(t, query),
+			}
+
+			injectedContext := user.InjectOrgID(context.Background(), "test")
+
+			// Run the query without pruning.
+			expectedRes, err := downstream.Do(injectedContext, req)
+			require.Nil(t, err)
+
+			if !template.IsEmpty {
+				// Ensure the query produces some results.
+				require.NotEmpty(t, expectedRes.(*PrometheusResponse).Data.Result)
+				requireValidSamples(t, expectedRes.(*PrometheusResponse).Data.Result)
+			}
+
+			// Run the query with pruning.
+			shardedRes, err := pruningware.Wrap(downstream).Do(injectedContext, req)
+			require.Nil(t, err)
+
+			if !template.IsEmpty {
+				// Ensure the query produces some results.
+				require.NotEmpty(t, shardedRes.(*PrometheusResponse).Data.Result)
+				requireValidSamples(t, shardedRes.(*PrometheusResponse).Data.Result)
+			}
+
+			// Ensure the results are approximately equal.
+			approximatelyEquals(t, expectedRes.(*PrometheusResponse), shardedRes.(*PrometheusResponse))
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -68,8 +68,9 @@ func sampleStreamsStrings(ss []SampleStream) []string {
 	return strs
 }
 
-// approximatelyEquals ensures two responses are approximately equal, up to 6 decimals precision per sample
-func approximatelyEquals(t *testing.T, a, b *PrometheusResponse) {
+// approximatelyEqualsSamples ensures two responses are approximately equal, up to 6 decimals precision per sample,
+// but only checks the samples and not the warning/info annotations.
+func approximatelyEqualsSamples(t *testing.T, a, b *PrometheusResponse) {
 	// Ensure both queries succeeded.
 	require.Equal(t, statusSuccess, a.Status)
 	require.Equal(t, statusSuccess, b.Status)
@@ -101,7 +102,11 @@ func approximatelyEquals(t *testing.T, a, b *PrometheusResponse) {
 			compareExpectedAndActual(t, expected.TimestampMs, actual.TimestampMs, expected.Histogram.Sum, actual.Histogram.Sum, j, a.Labels, "histogram", 1e-12)
 		}
 	}
+}
 
+// approximatelyEquals ensures two responses are approximately equal, up to 6 decimals precision per sample
+func approximatelyEquals(t *testing.T, a, b *PrometheusResponse) {
+	approximatelyEqualsSamples(t, a, b)
 	require.ElementsMatch(t, a.Infos, b.Infos, "expected same info annotations")
 	require.ElementsMatch(t, a.Warnings, b.Warnings, "expected same info annotations")
 }

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -61,6 +61,7 @@ type Config struct {
 	MaxRetries               int           `yaml:"max_retries" category:"advanced"`
 	NotRunningTimeout        time.Duration `yaml:"not_running_timeout" category:"advanced"`
 	ShardedQueries           bool          `yaml:"parallelize_shardable_queries"`
+	PrunedQueries            bool          `yaml:"prune_queries"`
 	TargetSeriesPerShard     uint64        `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
 	ShardActiveSeriesQueries bool          `yaml:"shard_active_series_queries" category:"experimental"`
 	UseActiveSeriesDecoder   bool          `yaml:"use_active_series_decoder" category:"experimental"`
@@ -87,6 +88,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.SplitQueriesByInterval, "query-frontend.split-queries-by-interval", 24*time.Hour, "Split range queries by an interval and execute in parallel. You should use a multiple of 24 hours to optimize querying blocks. 0 to disable it.")
 	f.BoolVar(&cfg.CacheResults, "query-frontend.cache-results", false, "Cache query results.")
 	f.BoolVar(&cfg.ShardedQueries, "query-frontend.parallelize-shardable-queries", false, "True to enable query sharding.")
+	f.BoolVar(&cfg.PrunedQueries, "query-frontend.prune-queries", false, "True to enable query pruning.")
 	f.Uint64Var(&cfg.TargetSeriesPerShard, "query-frontend.query-sharding-target-series-per-shard", 0, "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.")
 	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatProtobuf, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
 	f.BoolVar(&cfg.ShardActiveSeriesQueries, "query-frontend.shard-active-series-queries", false, "True to enable sharding of active series queries.")
@@ -360,13 +362,29 @@ func newQueryMiddlewares(
 		queryBlockerMiddleware,
 	)
 
-	// Inject the extra middlewares provided by the user before the query sharding middleware.
+	// Inject the extra middlewares provided by the user before the query pruning and query sharding middleware.
 	if len(cfg.ExtraInstantQueryMiddlewares) > 0 {
 		queryInstantMiddleware = append(queryInstantMiddleware, cfg.ExtraInstantQueryMiddlewares...)
 	}
-	// Inject the extra middlewares provided by the user before the query sharding middleware.
+	// Inject the extra middlewares provided by the user before the query pruning and query sharding middleware.
 	if len(cfg.ExtraRangeQueryMiddlewares) > 0 {
 		queryRangeMiddleware = append(queryRangeMiddleware, cfg.ExtraRangeQueryMiddlewares...)
+	}
+
+	if cfg.PrunedQueries {
+		pruneMiddleware := newPruneMiddleware(
+			log,
+		)
+		queryRangeMiddleware = append(
+			queryRangeMiddleware,
+			newInstrumentMiddleware("pruning", metrics),
+			pruneMiddleware,
+		)
+		queryInstantMiddleware = append(
+			queryInstantMiddleware,
+			newInstrumentMiddleware("pruning", metrics),
+			pruneMiddleware,
+		)
 	}
 
 	if cfg.ShardedQueries {

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -61,7 +61,7 @@ type Config struct {
 	MaxRetries               int           `yaml:"max_retries" category:"advanced"`
 	NotRunningTimeout        time.Duration `yaml:"not_running_timeout" category:"advanced"`
 	ShardedQueries           bool          `yaml:"parallelize_shardable_queries"`
-	PrunedQueries            bool          `yaml:"prune_queries"`
+	PrunedQueries            bool          `yaml:"prune_queries" category:"experimental"`
 	TargetSeriesPerShard     uint64        `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
 	ShardActiveSeriesQueries bool          `yaml:"shard_active_series_queries" category:"experimental"`
 	UseActiveSeriesDecoder   bool          `yaml:"use_active_series_decoder" category:"experimental"`
@@ -88,7 +88,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.SplitQueriesByInterval, "query-frontend.split-queries-by-interval", 24*time.Hour, "Split range queries by an interval and execute in parallel. You should use a multiple of 24 hours to optimize querying blocks. 0 to disable it.")
 	f.BoolVar(&cfg.CacheResults, "query-frontend.cache-results", false, "Cache query results.")
 	f.BoolVar(&cfg.ShardedQueries, "query-frontend.parallelize-shardable-queries", false, "True to enable query sharding.")
-	f.BoolVar(&cfg.PrunedQueries, "query-frontend.prune-queries", false, "True to enable query pruning.")
+	f.BoolVar(&cfg.PrunedQueries, "query-frontend.prune-queries", false, "True to enable pruning dead code (eg. expressions that cannot produce any results) and simplifying expressions (eg. expressions that can be evaluated immediately) in queries.")
 	f.Uint64Var(&cfg.TargetSeriesPerShard, "query-frontend.query-sharding-target-series-per-shard", 0, "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.")
 	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatProtobuf, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
 	f.BoolVar(&cfg.ShardActiveSeriesQueries, "query-frontend.shard-active-series-queries", false, "True to enable sharding of active series queries.")
@@ -372,9 +372,7 @@ func newQueryMiddlewares(
 	}
 
 	if cfg.PrunedQueries {
-		pruneMiddleware := newPruneMiddleware(
-			log,
-		)
+		pruneMiddleware := newPruneMiddleware(log)
 		queryRangeMiddleware = append(
 			queryRangeMiddleware,
 			newInstrumentMiddleware("pruning", metrics),

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -540,10 +540,12 @@ func TestMiddlewaresConsistency(t *testing.T) {
 	cfg := makeTestConfig()
 	cfg.CacheResults = true
 	cfg.ShardedQueries = true
+	cfg.PrunedQueries = true
 
 	// Ensure all features are enabled, so that we assert on all middlewares.
 	require.NotZero(t, cfg.CacheResults)
 	require.NotZero(t, cfg.ShardedQueries)
+	require.NotZero(t, cfg.PrunedQueries)
 	require.NotZero(t, cfg.SplitQueriesByInterval)
 	require.NotZero(t, cfg.MaxRetries)
 
@@ -582,6 +584,7 @@ func TestMiddlewaresConsistency(t *testing.T) {
 				"splitAndCacheMiddleware",               // No time splitting and results cache support.
 				"splitInstantQueryByIntervalMiddleware", // Not applicable because specific to instant queries.
 				"stepAlignMiddleware",                   // Not applicable because remote read requests don't take step in account when running in Mimir.
+				"pruneMiddleware",                       // No query pruning support.
 			},
 		},
 	}


### PR DESCRIPTION
#### What this PR does

(Hackathon project) Query pruning optimises PromQL queries by rewriting them to avoid evaluating expressions that can't produce a result, which is particularly useful in [dashboards with toggles between native and classic histograms](https://github.com/grafana/jsonnet-libs/pull/1164/files#diff-040bce91f6d46ff86f067fe7e11934183b2ea095ff6d4c62c5e798f24b6d9269R86).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
