### PR TITLE
Improve download-chunks-from-ingesters.sh to query ingesters concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,7 @@
 * [ENHANCEMENT] `tsdb-series`: added `-stats` option to print min/max time of chunks, total number of samples and DPM for each series. #8420
 * [ENHANCEMENT] `tsdb-print-chunk`: print counter reset information for native histograms. #8812
 * [ENHANCEMENT] `grpcurl-query-ingesters`: print counter reset information for native histograms. #8820
+* [ENHANCEMENT] `grpcurl-query-ingesters`: concurrently query ingesters. #9102
 * [ENHANCEMENT] `tsdb-series`: Added `-json` option to generate JSON output for easier post-processing. #8844
 * [ENHANCEMENT] `tsdb-series`: Added `-min-time` and `-max-time` options to filter samples that are used for computing data-points per minute. #8844
 

--- a/tools/grpcurl-query-ingesters/.gitignore
+++ b/tools/grpcurl-query-ingesters/.gitignore
@@ -1,1 +1,2 @@
+chunks-dump/
 grpcurl-query-ingesters

--- a/tools/grpcurl-query-ingesters/download-chunks-from-ingesters-query.json
+++ b/tools/grpcurl-query-ingesters/download-chunks-from-ingesters-query.json
@@ -1,11 +1,11 @@
 {
-  "start_timestamp_ms": 1698746364317,
-  "end_timestamp_ms": 1698748164317,
+  "start_timestamp_ms": 1724657563000,
+  "end_timestamp_ms": 1724659363000,
   "matchers": [
     {
       "type": 0,
       "name": "__name__",
-      "value": "test_series"
+      "value": "mimir_continuous_test_sine_wave_v2"
     }
   ]
 }

--- a/tools/grpcurl-query-ingesters/download-chunks-from-ingesters.sh
+++ b/tools/grpcurl-query-ingesters/download-chunks-from-ingesters.sh
@@ -89,8 +89,6 @@ done
 # Wait for all background jobs to finish
 wait
 
-# Check if a
-
 # Print final report.
 echo ""
 echo ""

--- a/tools/grpcurl-query-ingesters/download-chunks-from-ingesters.sh
+++ b/tools/grpcurl-query-ingesters/download-chunks-from-ingesters.sh
@@ -9,17 +9,38 @@ MIMIR_TENANT_ID=""
 
 SCRIPT_DIR=$(realpath "$(dirname "${0}")")
 OUTPUT_DIR="chunks-dump"
+NEXT_PORT=9010
+
+# File used to keep track of the list of ingesters failed to be queried.
+# Reset it each time this script is called.
+FAILURES_TRACKING_FILE="${SCRIPT_DIR}/${OUTPUT_DIR}/.failures"
+echo -n "" > "${FAILURES_TRACKING_FILE}"
 
 mkdir -p "$OUTPUT_DIR"
 
-# Get list of pods.
-PODS=$(kubectl --context "$K8S_CONTEXT" -n "$K8S_NAMESPACE" get pods --no-headers | grep ingester | awk '{print $1}')
+# Print a message in green.
+print_success() {
+  echo -e "\033[0;32m${1}\033[0m"
+}
 
-for POD in $PODS; do
+# Print a message in red.
+print_failure() {
+  echo -e "\033[0;31m${1}\033[0m"
+}
+
+# Utility function to query a single ingester.
+#
+# Parameters:
+# - $1: The pod ID
+# - $2: The local port to use
+query_ingester() {
+  POD=$1
+  LOCAL_PORT=$2
+
   echo "Querying $POD"
 
   # Open port-forward
-  kubectl port-forward --context "$K8S_CONTEXT" -n "$K8S_NAMESPACE" "$POD" 9095:9095 &
+  kubectl port-forward --context "$K8S_CONTEXT" -n "$K8S_NAMESPACE" "$POD" ${LOCAL_PORT}:9095 > /dev/null &
   KUBECTL_PID=$!
 
   # Wait some time
@@ -36,8 +57,55 @@ for POD in $PODS; do
     -import-path "$SCRIPT_DIR/../.." \
     -import-path "$SCRIPT_DIR/../../vendor" \
     -plaintext \
-    localhost:9095 "cortex.Ingester/QueryStream" > "$OUTPUT_DIR/$POD"
+    localhost:${LOCAL_PORT} "cortex.Ingester/QueryStream" > "$OUTPUT_DIR/$POD"
+  STATUS_CODE=$?
 
-  kill $KUBECTL_PID
-  wait $KUBECTL_PID
+  kill $KUBECTL_PID > /dev/null
+  wait $KUBECTL_PID > /dev/null 2> /dev/null
+
+  if [ $STATUS_CODE -eq 0 ]; then
+    print_success "Successfully queried $POD"
+  else
+    print_failure "Failed to query $POD"
+
+    # Keep track of the failure.
+    echo "$POD" >> "${FAILURES_TRACKING_FILE}"
+  fi
+}
+
+# Get list of pods.
+PODS=$(kubectl --context "$K8S_CONTEXT" -n "$K8S_NAMESPACE" get pods --no-headers | grep ingester | awk '{print $1}')
+
+# Concurrently query ingesters.
+for POD in $PODS; do
+  query_ingester "${POD}" "${NEXT_PORT}" &
+
+  NEXT_PORT=$((NEXT_PORT+1))
+
+  # Throttle to reduce the likelihood of networking issues and K8S rate limiting.
+  sleep 0.25
 done
+
+# Wait for all background jobs to finish
+wait
+
+# Check if a
+
+# Print final report.
+echo ""
+echo ""
+
+if [ ! -s "${FAILURES_TRACKING_FILE}" ]; then
+  print_success "Successfully queried all ingesters"
+  exit 0
+else
+  # Count the number of failed ingesters.
+  FAILURES_COUNT=$(wc -l "${FAILURES_TRACKING_FILE}" | awk '{print $1}')
+
+  print_failure "Failed to query $FAILURES_COUNT ingesters:"
+
+  # Print the list of failed ingesters.
+  sort < "${FAILURES_TRACKING_FILE}" | sed 's/^/- /g'
+
+  exit 1
+fi


### PR DESCRIPTION
#### What this PR does

In this PR I'm upstreaming some changes I did to `download-chunks-from-ingesters.sh ` over the weekend in order to query ingesters concurrently and significantly speed it up when there are many ingesters to query.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
