### PR TITLE
Renovate: Pin Go to v1.22.5

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,6 +26,13 @@
           "github.com/charleskorn/go-grpc"
         ],
         "enabled": false
+      },
+      // Pin Go at the current version, since we want to upgrade it manually.
+      // Remember to keep this in sync when upgrading our Go version!
+      {
+        "matchDatasources": ["docker", "golang-version"],
+        "matchPackageNames": ["go", "golang"],
+        "allowedVersions": "<=1.22.5"
       }
     ],
     "branchPrefix": "deps-update/",


### PR DESCRIPTION
#### What this PR does
Try to configure Renovate to Pin the Go version at 1.22.5. Following a solution provided in a [Renovate discussion](https://github.com/renovatebot/renovate/discussions/16922).

Also rename renovate.json to renovate.json5, so we can add a comment (supported in [JSON5](https://json5.org/)). [Renovate supports JSON5](https://docs.renovatebot.com/configuration-options/).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
