### PR TITLE
makefile: Run `mixtool` in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr9070-5347ec889b
+LATEST_BUILD_IMAGE_TAG ?= pr9117-daf8649bf3
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -54,7 +54,7 @@ RUN GO111MODULE=on \
 	go install github.com/fatih/faillint@v1.12.0 && \
 	go install github.com/campoy/embedmd@v1.0.0 && \
 	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0 && \
-	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@b97ae11 && \
+	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@1aace356d01747eea16a2677ed13bdcbbd4bb082 && \
 	go install github.com/mikefarah/yq/v4@v4.13.4 && \
 	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.19.1 && \
 	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.19.1 && \


### PR DESCRIPTION
Also updates mixtool to latest version which closes https://github.com/grafana/mimir/issues/1617 
Mixtool was actually updated two months ago, so the dashboards are already all compliant!

**Makefile changes:**
I was looking at the issue above and I wanted to test it using the build image. I noticed that it wasn't actually running in the container. This makes the `check-mixin-*` steps run in the build image for local uses and should make it easier to test in the future.