### PR TITLE
(PoC) Use only Grafana MSTeams integration

### DIFF
--- a/development/mimir-read-write-mode/config/mimir.yaml
+++ b/development/mimir-read-write-mode/config/mimir.yaml
@@ -56,6 +56,7 @@ alertmanager:
   data_dir: /data/alertmanager
   fallback_config_file: ./config/alertmanager-fallback-config.yaml
   external_url: http://localhost:8006/alertmanager
+  grafana_alertmanager_compatibility_enabled: true
 
 alertmanager_storage:
   s3:

--- a/development/mimir-read-write-mode/docker-compose.jsonnet
+++ b/development/mimir-read-write-mode/docker-compose.jsonnet
@@ -6,8 +6,8 @@ std.manifestYamlDoc({
     self.backend +
     self.nginx +
     self.minio +
-    self.grafana +
-    self.grafana_agent +
+    // self.grafana +
+    // self.grafana_agent +
     self.memcached +
     self.prometheus +
     {},
@@ -159,6 +159,7 @@ std.manifestYamlDoc({
       './mimir',
       '-config.file=./config/mimir.yaml' % options,
       '-target=%(target)s' % options,
+      '-log.level=debug' % options,
       '-activity-tracker.filepath=/activity/%(name)s' % options,
     ],
     environment: [

--- a/development/mimir-read-write-mode/docker-compose.yml
+++ b/development/mimir-read-write-mode/docker-compose.yml
@@ -1,23 +1,4 @@
 "services":
-  "grafana":
-    "environment":
-      - "GF_AUTH_ANONYMOUS_ENABLED=true"
-      - "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin"
-    "image": "grafana/grafana:10.4.3"
-    "ports":
-      - "3000:3000"
-    "volumes":
-      - "./config/datasource-mimir.yaml:/etc/grafana/provisioning/datasources/mimir.yaml"
-  "grafana-agent":
-    "command":
-      - "-config.file=/etc/agent-config/grafana-agent.yaml"
-      - "-metrics.wal-directory=/tmp"
-      - "-server.http.address=127.0.0.1:9091"
-    "image": "grafana/agent:v0.37.3"
-    "ports":
-      - "9091:9091"
-    "volumes":
-      - "./config:/etc/agent-config"
   "memcached":
     "image": "memcached:1.6.19-alpine"
   "mimir-backend-1":
@@ -28,6 +9,7 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=backend"
+      - "-log.level=debug"
       - "-activity-tracker.filepath=/activity/mimir-backend-1"
     "depends_on":
       - "minio"
@@ -47,6 +29,7 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=backend"
+      - "-log.level=debug"
       - "-activity-tracker.filepath=/activity/mimir-backend-2"
     "depends_on":
       - "minio"
@@ -66,6 +49,7 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=read"
+      - "-log.level=debug"
       - "-activity-tracker.filepath=/activity/mimir-read-1"
     "depends_on":
       - "minio"
@@ -85,6 +69,7 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=read"
+      - "-log.level=debug"
       - "-activity-tracker.filepath=/activity/mimir-read-2"
     "depends_on":
       - "minio"
@@ -104,6 +89,7 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=write"
+      - "-log.level=debug"
       - "-activity-tracker.filepath=/activity/mimir-write-1"
     "depends_on":
       - "minio"
@@ -124,6 +110,7 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=write"
+      - "-log.level=debug"
       - "-activity-tracker.filepath=/activity/mimir-write-2"
     "depends_on":
       - "minio"
@@ -144,6 +131,7 @@
       - "./mimir"
       - "-config.file=./config/mimir.yaml"
       - "-target=write"
+      - "-log.level=debug"
       - "-activity-tracker.filepath=/activity/mimir-write-3"
     "depends_on":
       - "minio"


### PR DESCRIPTION
This is a PoC for creating Grafana MSTeams integrations from upstream MSTeams configurations.

The upstream configuration is used to create a Grafana MSTeams integration. The configuration is then set to `nil` to avoid creating an upstream integration.

To test this, I'd recommend spinning up a Grafana instance in _remote primary_ or _remote only_ mode. An example can be found in the `defaults.ini` file of [this other PoC](https://github.com/grafana/grafana/pull/82021/files#diff-3f8a56cf48f018d19dd5378a288ed6b9180d60ef82649c98339f93b3523bd7ce).