### PR TITLE
Use grafana URL to test receivers

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -192,7 +192,7 @@ type Replicator interface {
 }
 
 // New creates a new Alertmanager.
-func New(cfg *Config, reg *prometheus.Registry, tmplExternalURL *url.URL) (*Alertmanager, error) {
+func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 	if cfg.TenantDataDir == "" {
 		return nil, fmt.Errorf("directory for tenant-specific AlertManager is not configured")
 	}
@@ -210,8 +210,6 @@ func New(cfg *Config, reg *prometheus.Registry, tmplExternalURL *url.URL) (*Aler
 			Name: "alertmanager_notification_rate_limited_total",
 			Help: "Number of rate-limited notifications per integration.",
 		}, []string{"integration"}), // "integration" is consistent with other alertmanager metrics.
-
-		tmplExternalURL: tmplExternalURL,
 	}
 
 	am.registry = reg

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -92,6 +92,7 @@ type Config struct {
 	Retention                         time.Duration
 	MaxConcurrentGetRequestsPerTenant int
 	ExternalURL                       *url.URL
+	TmplExternalURL                   *url.URL
 	Limits                            Limits
 	Features                          featurecontrol.Flagger
 
@@ -399,7 +400,7 @@ func (am *Alertmanager) TestReceiversHandler(w http.ResponseWriter, r *http.Requ
 	}
 	am.templatesMtx.RUnlock()
 
-	response, status, err := alertingNotify.TestReceivers(r.Context(), c, tmpls, am.buildGrafanaReceiverIntegrations, am.cfg.ExternalURL.String())
+	response, status, err := alertingNotify.TestReceivers(r.Context(), c, tmpls, am.buildGrafanaReceiverIntegrations, am.cfg.TmplExternalURL.String())
 	if err != nil {
 		http.Error(w,
 			fmt.Sprintf("error testing receivers: %s", err.Error()),

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -519,6 +519,7 @@ func (am *Alertmanager) ApplyConfig(conf *definition.PostableApiAlertingConfig, 
 
 	am.templatesMtx.Lock()
 	am.templates = tmpls
+	am.tmplExternalURL = tmplExternalURL
 	am.templatesMtx.Unlock()
 
 	pipeline := am.pipelineBuilder.New(

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -56,9 +56,11 @@ type stubReplicator struct{}
 func (*stubReplicator) ReplicateStateForUser(context.Context, string, *clusterpb.Part) error {
 	return nil
 }
+
 func (*stubReplicator) GetPositionForUser(string) int {
 	return 0
 }
+
 func (*stubReplicator) ReadFullStateForUser(context.Context, string) ([]*clusterpb.FullState, error) {
 	return nil, nil
 }
@@ -80,7 +82,7 @@ func createAlertmanagerAndSendAlerts(t *testing.T, alertGroups, groupsLimit, exp
 		ReplicationFactor: 1,
 		// We have to set this interval non-zero, though we don't need the persister to do anything.
 		PersisterConfig: PersisterConfig{Interval: time.Hour},
-	}, reg)
+	}, reg, &url.URL{Path: "/am"})
 	require.NoError(t, err)
 	defer am.StopAndWait()
 
@@ -165,7 +167,7 @@ func TestDispatcherLoggerInsightKey(t *testing.T) {
 		Replicator:        &stubReplicator{},
 		ReplicationFactor: 1,
 		PersisterConfig:   PersisterConfig{Interval: time.Hour},
-	}, reg)
+	}, reg, &url.URL{Path: "/am"})
 	require.NoError(t, err)
 	defer am.StopAndWait()
 
@@ -371,7 +373,7 @@ func TestSilenceLimits(t *testing.T) {
 		// We have set this to 1 hour, but we don't use it in this
 		// test as we override the broadcast function with SetBroadcast.
 		PersisterConfig: PersisterConfig{Interval: time.Hour},
-	}, r)
+	}, r, &url.URL{Path: "/am"})
 	require.NoError(t, err)
 	defer am.StopAndWait()
 
@@ -508,7 +510,7 @@ func TestExperimentalReceiversAPI(t *testing.T) {
 		Replicator:        &stubReplicator{},
 		ReplicationFactor: 1,
 		PersisterConfig:   PersisterConfig{Interval: time.Hour},
-	}, reg)
+	}, reg, &url.URL{Path: "/am"})
 	require.NoError(t, err)
 	defer am.StopAndWait()
 

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -82,7 +82,7 @@ func createAlertmanagerAndSendAlerts(t *testing.T, alertGroups, groupsLimit, exp
 		ReplicationFactor: 1,
 		// We have to set this interval non-zero, though we don't need the persister to do anything.
 		PersisterConfig: PersisterConfig{Interval: time.Hour},
-	}, reg, &url.URL{Path: "/am"})
+	}, reg)
 	require.NoError(t, err)
 	defer am.StopAndWait()
 
@@ -167,7 +167,7 @@ func TestDispatcherLoggerInsightKey(t *testing.T) {
 		Replicator:        &stubReplicator{},
 		ReplicationFactor: 1,
 		PersisterConfig:   PersisterConfig{Interval: time.Hour},
-	}, reg, &url.URL{Path: "/am"})
+	}, reg)
 	require.NoError(t, err)
 	defer am.StopAndWait()
 
@@ -373,7 +373,7 @@ func TestSilenceLimits(t *testing.T) {
 		// We have set this to 1 hour, but we don't use it in this
 		// test as we override the broadcast function with SetBroadcast.
 		PersisterConfig: PersisterConfig{Interval: time.Hour},
-	}, r, &url.URL{Path: "/am"})
+	}, r)
 	require.NoError(t, err)
 	defer am.StopAndWait()
 
@@ -510,7 +510,7 @@ func TestExperimentalReceiversAPI(t *testing.T) {
 		Replicator:        &stubReplicator{},
 		ReplicationFactor: 1,
 		PersisterConfig:   PersisterConfig{Interval: time.Hour},
-	}, reg, &url.URL{Path: "/am"})
+	}, reg)
 	require.NoError(t, err)
 	defer am.StopAndWait()
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -912,6 +912,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *defi
 		Retention:                         am.cfg.Retention,
 		MaxConcurrentGetRequestsPerTenant: am.cfg.MaxConcurrentGetRequestsPerTenant,
 		ExternalURL:                       am.cfg.ExternalURL.URL,
+		TmplExternalURL:                   tmplExternalURL,
 		Replicator:                        am,
 		ReplicationFactor:                 am.cfg.ShardingRing.ReplicationFactor,
 		Store:                             am.store,

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -919,7 +919,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *defi
 		Limits:                            am.limits,
 		Features:                          am.features,
 		GrafanaAlertmanagerCompatibility:  am.cfg.GrafanaAlertmanagerCompatibilityEnabled,
-	}, reg, tmplExternalURL)
+	}, reg)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start Alertmanager for user %v: %v", userID, err)
 	}

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -912,7 +912,6 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *defi
 		Retention:                         am.cfg.Retention,
 		MaxConcurrentGetRequestsPerTenant: am.cfg.MaxConcurrentGetRequestsPerTenant,
 		ExternalURL:                       am.cfg.ExternalURL.URL,
-		TmplExternalURL:                   tmplExternalURL,
 		Replicator:                        am,
 		ReplicationFactor:                 am.cfg.ShardingRing.ReplicationFactor,
 		Store:                             am.store,
@@ -920,7 +919,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *defi
 		Limits:                            am.limits,
 		Features:                          am.features,
 		GrafanaAlertmanagerCompatibility:  am.cfg.GrafanaAlertmanagerCompatibilityEnabled,
-	}, reg)
+	}, reg, tmplExternalURL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to start Alertmanager for user %v: %v", userID, err)
 	}
@@ -1189,7 +1188,6 @@ func (am *MultitenantAlertmanager) UpdateState(ctx context.Context, part *cluste
 
 // deleteUnusedRemoteUserState deletes state objects in remote storage for users that are no longer configured.
 func (am *MultitenantAlertmanager) deleteUnusedRemoteUserState(ctx context.Context, allUsers []string) {
-
 	users := make(map[string]struct{}, len(allUsers))
 	for _, userID := range allUsers {
 		users[userID] = struct{}{}


### PR DESCRIPTION
Fixes https://github.com/grafana/alerting-squad/issues/872

As described, alerts should use the Grafana URL instead of the remote AM's. For regular alert notifications this was already done, this PR fixes for tests