### PR TITLE
Convert `Mimir / Config` dashboard to grafonnet

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -6244,25 +6244,9 @@ metadata:
 data:
   mimir-config.json: |-
     {
-          "__requires": [
-             {
-                "id": "grafana",
-                "name": "Grafana",
-                "type": "grafana",
-                "version": "8.0.0"
-             }
-          ],
-          "annotations": {
-             "list": [ ]
-          },
-          "editable": true,
-          "gnetId": null,
-          "graphTooltip": 1,
-          "hideControls": false,
           "links": [
              {
                 "asDropdown": true,
-                "icon": "external link",
                 "includeVars": true,
                 "keepTime": true,
                 "tags": [
@@ -6273,131 +6257,125 @@ data:
                 "type": "dashboards"
              }
           ],
-          "refresh": "5m",
-          "rows": [
+          "panels": [
              {
-                "collapse": false,
-                "height": "250px",
-                "panels": [
-                   {
-                      "datasource": "$datasource",
-                      "fieldConfig": {
-                         "defaults": {
-                            "custom": {
-                               "drawStyle": "line",
-                               "fillOpacity": 100,
-                               "lineWidth": 0,
-                               "pointSize": 5,
-                               "showPoints": "never",
-                               "spanNulls": false,
-                               "stacking": {
-                                  "group": "A",
-                                  "mode": "normal"
-                               }
-                            },
-                            "min": 0,
-                            "thresholds": {
-                               "mode": "absolute",
-                               "steps": [ ]
-                            },
-                            "unit": "instances"
-                         },
-                         "overrides": [ ]
-                      },
-                      "id": 1,
-                      "links": [ ],
-                      "options": {
-                         "legend": {
-                            "showLegend": true
-                         },
-                         "tooltip": {
-                            "mode": "multi",
-                            "sort": "none"
-                         }
-                      },
-                      "span": 12,
-                      "targets": [
-                         {
-                            "expr": "count(cortex_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
-                            "format": "time_series",
-                            "legendFormat": "sha256:{{sha256}}",
-                            "legendLink": null
-                         }
-                      ],
-                      "title": "Startup config file hashes",
-                      "type": "timeseries"
-                   }
-                ],
-                "repeat": null,
-                "repeatIteration": null,
-                "repeatRowId": null,
-                "showTitle": true,
+                "collapsed": false,
+                "gridPos": {
+                   "h": 1,
+                   "w": 24,
+                   "x": 0
+                },
+                "id": 1,
                 "title": "Startup config file",
-                "titleSize": "h6"
+                "type": "row"
              },
              {
-                "collapse": false,
-                "height": "250px",
-                "panels": [
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "$datasource"
+                },
+                "fieldConfig": {
+                   "defaults": {
+                      "custom": {
+                         "fillOpacity": 100,
+                         "lineWidth": 0,
+                         "stacking": {
+                            "mode": "normal"
+                         }
+                      }
+                   }
+                },
+                "gridPos": {
+                   "h": "7",
+                   "w": "24"
+                },
+                "id": 2,
+                "options": {
+                   "legend": {
+                      "showLegend": true
+                   },
+                   "tooltip": {
+                      "mode": "multi",
+                      "sort": "none"
+                   }
+                },
+                "pluginVersion": "v11.0.0",
+                "targets": [
                    {
-                      "datasource": "$datasource",
-                      "fieldConfig": {
-                         "defaults": {
-                            "custom": {
-                               "drawStyle": "line",
-                               "fillOpacity": 100,
-                               "lineWidth": 0,
-                               "pointSize": 5,
-                               "showPoints": "never",
-                               "spanNulls": false,
-                               "stacking": {
-                                  "group": "A",
-                                  "mode": "normal"
-                               }
-                            },
-                            "min": 0,
-                            "thresholds": {
-                               "mode": "absolute",
-                               "steps": [ ]
-                            },
-                            "unit": "instances"
-                         },
-                         "overrides": [ ]
+                      "datasource": {
+                         "type": "prometheus",
+                         "uid": "$datasource"
                       },
-                      "id": 2,
-                      "links": [ ],
-                      "options": {
-                         "legend": {
-                            "showLegend": true
-                         },
-                         "tooltip": {
-                            "mode": "multi",
-                            "sort": "none"
-                         }
-                      },
-                      "span": 12,
-                      "targets": [
-                         {
-                            "expr": "count(cortex_runtime_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
-                            "format": "time_series",
-                            "legendFormat": "sha256:{{sha256}}",
-                            "legendLink": null
-                         }
-                      ],
-                      "title": "Runtime config file hashes",
-                      "type": "timeseries"
+                      "expr": "count(cortex_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
+                      "legendFormat": "sha256:{{sha256}}"
                    }
                 ],
-                "repeat": null,
-                "repeatIteration": null,
-                "repeatRowId": null,
-                "showTitle": true,
+                "title": "Startup config file hashes",
+                "type": "timeseries"
+             },
+             {
+                "collapsed": false,
+                "gridPos": {
+                   "h": 1,
+                   "w": 24,
+                   "x": 0
+                },
+                "id": 3,
                 "title": "Runtime config file",
-                "titleSize": "h6"
+                "type": "row"
+             },
+             {
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "$datasource"
+                },
+                "fieldConfig": {
+                   "defaults": {
+                      "custom": {
+                         "fillOpacity": 100,
+                         "lineWidth": 0,
+                         "stacking": {
+                            "mode": "normal"
+                         }
+                      }
+                   }
+                },
+                "gridPos": {
+                   "h": "7",
+                   "w": "24"
+                },
+                "id": 4,
+                "options": {
+                   "legend": {
+                      "showLegend": true
+                   },
+                   "tooltip": {
+                      "mode": "multi",
+                      "sort": "none"
+                   }
+                },
+                "pluginVersion": "v11.0.0",
+                "targets": [
+                   {
+                      "datasource": {
+                         "type": "prometheus",
+                         "uid": "$datasource"
+                      },
+                      "expr": "count(cortex_runtime_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
+                      "fieldConfig": {
+                         "defaults": {
+                            "unit": "instances"
+                         }
+                      },
+                      "legendFormat": "sha256:{{sha256}}"
+                   }
+                ],
+                "title": "Runtime config file hashes",
+                "type": "timeseries"
              }
           ],
-          "schemaVersion": 14,
-          "style": "dark",
+          "refresh": "5m",
+          "schemaVersion": 39,
           "tags": [
              "mimir"
           ],
@@ -6405,65 +6383,61 @@ data:
              "list": [
                 {
                    "current": {
+                      "selected": false,
                       "text": "default",
                       "value": "default"
                    },
-                   "hide": 0,
                    "label": "Data source",
                    "name": "datasource",
-                   "options": [ ],
                    "query": "prometheus",
-                   "refresh": 1,
                    "regex": "",
                    "type": "datasource"
                 },
                 {
                    "allValue": ".+",
                    "current": {
-                      "selected": true,
-                      "text": "All",
-                      "value": "$__all"
+                      "selected": false,
+                      "text": [
+                         "All"
+                      ],
+                      "value": [
+                         "$__all"
+                      ]
                    },
-                   "datasource": "$datasource",
-                   "hide": 0,
+                   "datasource": {
+                      "type": "query",
+                      "uid": "$datasource"
+                   },
                    "includeAll": true,
                    "label": "cluster",
                    "multi": true,
                    "name": "cluster",
-                   "options": [ ],
                    "query": "label_values(cortex_build_info, cluster)",
-                   "refresh": 1,
-                   "regex": "",
                    "sort": 1,
-                   "tagValuesQuery": "",
-                   "tags": [ ],
-                   "tagsQuery": "",
-                   "type": "query",
-                   "useTags": false
+                   "type": "query"
                 },
                 {
                    "allValue": ".+",
                    "current": {
-                      "selected": true,
-                      "text": "All",
-                      "value": "$__all"
+                      "selected": false,
+                      "text": [
+                         "All"
+                      ],
+                      "value": [
+                         "$__all"
+                      ]
                    },
-                   "datasource": "$datasource",
-                   "hide": 0,
+                   "datasource": {
+                      "type": "query",
+                      "uid": "$datasource"
+                   },
                    "includeAll": false,
                    "label": "namespace",
                    "multi": true,
                    "name": "namespace",
-                   "options": [ ],
                    "query": "label_values(cortex_build_info{cluster=~\"$cluster\"}, namespace)",
-                   "refresh": 1,
-                   "regex": "",
                    "sort": 1,
-                   "tagValuesQuery": "",
-                   "tags": [ ],
-                   "tagsQuery": "",
-                   "type": "query",
-                   "useTags": false
+                   "type": "query"
                 }
              ]
           },
@@ -6498,8 +6472,7 @@ data:
           },
           "timezone": "utc",
           "title": "Mimir / Config",
-          "uid": "5d9d0b4724c0f80d68467088ec61e003",
-          "version": 0
+          "uid": "5d9d0b4724c0f80d68467088ec61e003"
        }
 ---
 # Source: mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-config.json
@@ -1,23 +1,7 @@
 {
-      "__requires": [
-         {
-            "id": "grafana",
-            "name": "Grafana",
-            "type": "grafana",
-            "version": "8.0.0"
-         }
-      ],
-      "annotations": {
-         "list": [ ]
-      },
-      "editable": true,
-      "gnetId": null,
-      "graphTooltip": 1,
-      "hideControls": false,
       "links": [
          {
             "asDropdown": true,
-            "icon": "external link",
             "includeVars": true,
             "keepTime": true,
             "tags": [
@@ -28,131 +12,125 @@
             "type": "dashboards"
          }
       ],
-      "refresh": "5m",
-      "rows": [
+      "panels": [
          {
-            "collapse": false,
-            "height": "250px",
-            "panels": [
-               {
-                  "datasource": "$datasource",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 100,
-                           "lineWidth": 0,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "normal"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "instances"
-                     },
-                     "overrides": [ ]
-                  },
-                  "id": 1,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "multi",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 12,
-                  "targets": [
-                     {
-                        "expr": "count(cortex_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
-                        "format": "time_series",
-                        "legendFormat": "sha256:{{sha256}}",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Startup config file hashes",
-                  "type": "timeseries"
-               }
-            ],
-            "repeat": null,
-            "repeatIteration": null,
-            "repeatRowId": null,
-            "showTitle": true,
+            "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0
+            },
+            "id": 1,
             "title": "Startup config file",
-            "titleSize": "h6"
+            "type": "row"
          },
          {
-            "collapse": false,
-            "height": "250px",
-            "panels": [
+            "datasource": {
+               "type": "prometheus",
+               "uid": "$datasource"
+            },
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 100,
+                     "lineWidth": 0,
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  }
+               }
+            },
+            "gridPos": {
+               "h": "7",
+               "w": "24"
+            },
+            "id": 2,
+            "options": {
+               "legend": {
+                  "showLegend": true
+               },
+               "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+               }
+            },
+            "pluginVersion": "v11.0.0",
+            "targets": [
                {
-                  "datasource": "$datasource",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 100,
-                           "lineWidth": 0,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "normal"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "instances"
-                     },
-                     "overrides": [ ]
+                  "datasource": {
+                     "type": "prometheus",
+                     "uid": "$datasource"
                   },
-                  "id": 2,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "multi",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 12,
-                  "targets": [
-                     {
-                        "expr": "count(cortex_runtime_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
-                        "format": "time_series",
-                        "legendFormat": "sha256:{{sha256}}",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Runtime config file hashes",
-                  "type": "timeseries"
+                  "expr": "count(cortex_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
+                  "legendFormat": "sha256:{{sha256}}"
                }
             ],
-            "repeat": null,
-            "repeatIteration": null,
-            "repeatRowId": null,
-            "showTitle": true,
+            "title": "Startup config file hashes",
+            "type": "timeseries"
+         },
+         {
+            "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0
+            },
+            "id": 3,
             "title": "Runtime config file",
-            "titleSize": "h6"
+            "type": "row"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "$datasource"
+            },
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 100,
+                     "lineWidth": 0,
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  }
+               }
+            },
+            "gridPos": {
+               "h": "7",
+               "w": "24"
+            },
+            "id": 4,
+            "options": {
+               "legend": {
+                  "showLegend": true
+               },
+               "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+               }
+            },
+            "pluginVersion": "v11.0.0",
+            "targets": [
+               {
+                  "datasource": {
+                     "type": "prometheus",
+                     "uid": "$datasource"
+                  },
+                  "expr": "count(cortex_runtime_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
+                  "fieldConfig": {
+                     "defaults": {
+                        "unit": "instances"
+                     }
+                  },
+                  "legendFormat": "sha256:{{sha256}}"
+               }
+            ],
+            "title": "Runtime config file hashes",
+            "type": "timeseries"
          }
       ],
-      "schemaVersion": 14,
-      "style": "dark",
+      "refresh": "5m",
+      "schemaVersion": 39,
       "tags": [
          "mimir"
       ],
@@ -160,65 +138,61 @@
          "list": [
             {
                "current": {
+                  "selected": false,
                   "text": "default",
                   "value": "default"
                },
-               "hide": 0,
                "label": "Data source",
                "name": "datasource",
-               "options": [ ],
                "query": "prometheus",
-               "refresh": 1,
                "regex": "",
                "type": "datasource"
             },
             {
                "allValue": ".+",
                "current": {
-                  "selected": true,
-                  "text": "All",
-                  "value": "$__all"
+                  "selected": false,
+                  "text": [
+                     "All"
+                  ],
+                  "value": [
+                     "$__all"
+                  ]
                },
-               "datasource": "$datasource",
-               "hide": 0,
+               "datasource": {
+                  "type": "query",
+                  "uid": "$datasource"
+               },
                "includeAll": true,
                "label": "cluster",
                "multi": true,
                "name": "cluster",
-               "options": [ ],
                "query": "label_values(cortex_build_info, cluster)",
-               "refresh": 1,
-               "regex": "",
                "sort": 1,
-               "tagValuesQuery": "",
-               "tags": [ ],
-               "tagsQuery": "",
-               "type": "query",
-               "useTags": false
+               "type": "query"
             },
             {
                "allValue": ".+",
                "current": {
-                  "selected": true,
-                  "text": "All",
-                  "value": "$__all"
+                  "selected": false,
+                  "text": [
+                     "All"
+                  ],
+                  "value": [
+                     "$__all"
+                  ]
                },
-               "datasource": "$datasource",
-               "hide": 0,
+               "datasource": {
+                  "type": "query",
+                  "uid": "$datasource"
+               },
                "includeAll": false,
                "label": "namespace",
                "multi": true,
                "name": "namespace",
-               "options": [ ],
                "query": "label_values(cortex_build_info{cluster=~\"$cluster\"}, namespace)",
-               "refresh": 1,
-               "regex": "",
                "sort": 1,
-               "tagValuesQuery": "",
-               "tags": [ ],
-               "tagsQuery": "",
-               "type": "query",
-               "useTags": false
+               "type": "query"
             }
          ]
       },
@@ -253,6 +227,5 @@
       },
       "timezone": "utc",
       "title": "Mimir / Config",
-      "uid": "5d9d0b4724c0f80d68467088ec61e003",
-      "version": 0
+      "uid": "5d9d0b4724c0f80d68467088ec61e003"
    }

--- a/operations/mimir-mixin-compiled/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-config.json
@@ -1,23 +1,7 @@
 {
-      "__requires": [
-         {
-            "id": "grafana",
-            "name": "Grafana",
-            "type": "grafana",
-            "version": "8.0.0"
-         }
-      ],
-      "annotations": {
-         "list": [ ]
-      },
-      "editable": true,
-      "gnetId": null,
-      "graphTooltip": 1,
-      "hideControls": false,
       "links": [
          {
             "asDropdown": true,
-            "icon": "external link",
             "includeVars": true,
             "keepTime": true,
             "tags": [
@@ -28,131 +12,125 @@
             "type": "dashboards"
          }
       ],
-      "refresh": "5m",
-      "rows": [
+      "panels": [
          {
-            "collapse": false,
-            "height": "250px",
-            "panels": [
-               {
-                  "datasource": "$datasource",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 100,
-                           "lineWidth": 0,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "normal"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "instances"
-                     },
-                     "overrides": [ ]
-                  },
-                  "id": 1,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "multi",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 12,
-                  "targets": [
-                     {
-                        "expr": "count(cortex_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
-                        "format": "time_series",
-                        "legendFormat": "sha256:{{sha256}}",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Startup config file hashes",
-                  "type": "timeseries"
-               }
-            ],
-            "repeat": null,
-            "repeatIteration": null,
-            "repeatRowId": null,
-            "showTitle": true,
+            "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0
+            },
+            "id": 1,
             "title": "Startup config file",
-            "titleSize": "h6"
+            "type": "row"
          },
          {
-            "collapse": false,
-            "height": "250px",
-            "panels": [
+            "datasource": {
+               "type": "prometheus",
+               "uid": "$datasource"
+            },
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 100,
+                     "lineWidth": 0,
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  }
+               }
+            },
+            "gridPos": {
+               "h": "7",
+               "w": "24"
+            },
+            "id": 2,
+            "options": {
+               "legend": {
+                  "showLegend": true
+               },
+               "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+               }
+            },
+            "pluginVersion": "v11.0.0",
+            "targets": [
                {
-                  "datasource": "$datasource",
-                  "fieldConfig": {
-                     "defaults": {
-                        "custom": {
-                           "drawStyle": "line",
-                           "fillOpacity": 100,
-                           "lineWidth": 0,
-                           "pointSize": 5,
-                           "showPoints": "never",
-                           "spanNulls": false,
-                           "stacking": {
-                              "group": "A",
-                              "mode": "normal"
-                           }
-                        },
-                        "min": 0,
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [ ]
-                        },
-                        "unit": "instances"
-                     },
-                     "overrides": [ ]
+                  "datasource": {
+                     "type": "prometheus",
+                     "uid": "$datasource"
                   },
-                  "id": 2,
-                  "links": [ ],
-                  "options": {
-                     "legend": {
-                        "showLegend": true
-                     },
-                     "tooltip": {
-                        "mode": "multi",
-                        "sort": "none"
-                     }
-                  },
-                  "span": 12,
-                  "targets": [
-                     {
-                        "expr": "count(cortex_runtime_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
-                        "format": "time_series",
-                        "legendFormat": "sha256:{{sha256}}",
-                        "legendLink": null
-                     }
-                  ],
-                  "title": "Runtime config file hashes",
-                  "type": "timeseries"
+                  "expr": "count(cortex_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
+                  "legendFormat": "sha256:{{sha256}}"
                }
             ],
-            "repeat": null,
-            "repeatIteration": null,
-            "repeatRowId": null,
-            "showTitle": true,
+            "title": "Startup config file hashes",
+            "type": "timeseries"
+         },
+         {
+            "collapsed": false,
+            "gridPos": {
+               "h": 1,
+               "w": 24,
+               "x": 0
+            },
+            "id": 3,
             "title": "Runtime config file",
-            "titleSize": "h6"
+            "type": "row"
+         },
+         {
+            "datasource": {
+               "type": "prometheus",
+               "uid": "$datasource"
+            },
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                     "fillOpacity": 100,
+                     "lineWidth": 0,
+                     "stacking": {
+                        "mode": "normal"
+                     }
+                  }
+               }
+            },
+            "gridPos": {
+               "h": "7",
+               "w": "24"
+            },
+            "id": 4,
+            "options": {
+               "legend": {
+                  "showLegend": true
+               },
+               "tooltip": {
+                  "mode": "multi",
+                  "sort": "none"
+               }
+            },
+            "pluginVersion": "v11.0.0",
+            "targets": [
+               {
+                  "datasource": {
+                     "type": "prometheus",
+                     "uid": "$datasource"
+                  },
+                  "expr": "count(cortex_runtime_config_hash{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (sha256)",
+                  "fieldConfig": {
+                     "defaults": {
+                        "unit": "instances"
+                     }
+                  },
+                  "legendFormat": "sha256:{{sha256}}"
+               }
+            ],
+            "title": "Runtime config file hashes",
+            "type": "timeseries"
          }
       ],
-      "schemaVersion": 14,
-      "style": "dark",
+      "refresh": "5m",
+      "schemaVersion": 39,
       "tags": [
          "mimir"
       ],
@@ -160,65 +138,61 @@
          "list": [
             {
                "current": {
+                  "selected": false,
                   "text": "default",
                   "value": "default"
                },
-               "hide": 0,
                "label": "Data source",
                "name": "datasource",
-               "options": [ ],
                "query": "prometheus",
-               "refresh": 1,
                "regex": "",
                "type": "datasource"
             },
             {
                "allValue": ".+",
                "current": {
-                  "selected": true,
-                  "text": "All",
-                  "value": "$__all"
+                  "selected": false,
+                  "text": [
+                     "All"
+                  ],
+                  "value": [
+                     "$__all"
+                  ]
                },
-               "datasource": "$datasource",
-               "hide": 0,
+               "datasource": {
+                  "type": "query",
+                  "uid": "$datasource"
+               },
                "includeAll": true,
                "label": "cluster",
                "multi": true,
                "name": "cluster",
-               "options": [ ],
                "query": "label_values(cortex_build_info, cluster)",
-               "refresh": 1,
-               "regex": "",
                "sort": 1,
-               "tagValuesQuery": "",
-               "tags": [ ],
-               "tagsQuery": "",
-               "type": "query",
-               "useTags": false
+               "type": "query"
             },
             {
                "allValue": ".+",
                "current": {
-                  "selected": true,
-                  "text": "All",
-                  "value": "$__all"
+                  "selected": false,
+                  "text": [
+                     "All"
+                  ],
+                  "value": [
+                     "$__all"
+                  ]
                },
-               "datasource": "$datasource",
-               "hide": 0,
+               "datasource": {
+                  "type": "query",
+                  "uid": "$datasource"
+               },
                "includeAll": false,
                "label": "namespace",
                "multi": true,
                "name": "namespace",
-               "options": [ ],
                "query": "label_values(cortex_build_info{cluster=~\"$cluster\"}, namespace)",
-               "refresh": 1,
-               "regex": "",
                "sort": 1,
-               "tagValuesQuery": "",
-               "tags": [ ],
-               "tagsQuery": "",
-               "type": "query",
-               "useTags": false
+               "type": "query"
             }
          ]
       },
@@ -253,6 +227,5 @@
       },
       "timezone": "utc",
       "title": "Mimir / Config",
-      "uid": "5d9d0b4724c0f80d68467088ec61e003",
-      "version": 0
+      "uid": "5d9d0b4724c0f80d68467088ec61e003"
    }

--- a/operations/mimir-mixin/dashboards/config.libsonnet
+++ b/operations/mimir-mixin/dashboards/config.libsonnet
@@ -1,27 +1,38 @@
-local utils = import 'mixin-utils/utils.libsonnet';
 local filename = 'mimir-config.json';
+local uid = std.md5(filename);
+assert uid == '5d9d0b4724c0f80d68467088ec61e003' : 'UID of the dashboard has changed, please update references to dashboard.';
 
-(import 'dashboard-utils.libsonnet') {
+{
+  local g = (import 'grafonnet.libsonnet')($._config),
+  local dashboard = g.dashboard,
+  local panel = g.panel,
+  local promQuery = g.query.prometheus,
+  local timeSeries = panel.timeSeries,
+
   [filename]:
-    assert std.md5(filename) == '5d9d0b4724c0f80d68467088ec61e003' : 'UID of the dashboard has changed, please update references to dashboard.';
-    ($.dashboard('Config') + { uid: std.md5(filename) })
-    .addClusterSelectorTemplates()
-    .addRow(
-      $.row('Startup config file')
-      .addPanel(
-        $.timeseriesPanel('Startup config file hashes') +
-        $.queryPanel('count(cortex_config_hash{%s}) by (sha256)' % $.namespaceMatcher(), 'sha256:{{sha256}}') +
-        $.stack +
-        { fieldConfig+: { defaults+: { unit: 'instances' } } },
-      )
-    )
-    .addRow(
-      $.row('Runtime config file')
-      .addPanel(
-        $.timeseriesPanel('Runtime config file hashes') +
-        $.queryPanel('count(cortex_runtime_config_hash{%s}) by (sha256)' % $.namespaceMatcher(), 'sha256:{{sha256}}') +
-        $.stack +
-        { fieldConfig+: { defaults+: { unit: 'instances' } } },
-      )
-    ),
+    dashboard.new('Config')
+    + dashboard.withUid(std.md5(filename))
+    + g.mimir.addClusterSelectorTemplates()
+    + dashboard.withPanels([
+      panel.row.new('Startup config file'),
+      timeSeries.new('Startup config file hashes')
+      + timeSeries.queryOptions.withDatasource('prometheus', '$datasource')
+      + g.mimir.stack
+      + timeSeries.queryOptions.withTargets(
+        [
+          promQuery.new('$datasource', 'count(cortex_config_hash{%s}) by (sha256)' % g.mimir.namespaceMatcher())
+          + promQuery.withLegendFormat('sha256:{{sha256}}'),
+        ]
+      ),
+
+      panel.row.new('Runtime config file'),
+      timeSeries.new('Runtime config file hashes')
+      + timeSeries.queryOptions.withDatasource('prometheus', '$datasource')
+      + g.mimir.stack
+      + timeSeries.queryOptions.withTargets([
+        promQuery.new('$datasource', 'count(cortex_runtime_config_hash{%s}) by (sha256)' % g.mimir.namespaceMatcher())
+        + promQuery.withLegendFormat('sha256:{{sha256}}')
+        + timeSeries.standardOptions.withUnit('instances'),
+      ]),
+    ]),
 }

--- a/operations/mimir-mixin/dashboards/grafonnet.libsonnet
+++ b/operations/mimir-mixin/dashboards/grafonnet.libsonnet
@@ -1,0 +1,90 @@
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local sortAscending = 1;
+
+
+function(config) g {
+  // Overrides of grafonnet functions
+  dashboard+:: {
+    new(title)::
+      g.dashboard.new('%(prefix)s%(title)s' % { prefix: config.dashboard_prefix, title: title })
+      + g.dashboard.withVariables(
+        g.dashboard.variable.datasource.new('datasource', 'prometheus')
+        + g.dashboard.variable.datasource.generalOptions.withLabel('Data source')
+        + g.dashboard.variable.datasource.generalOptions.withCurrent(config.dashboard_datasource, config.dashboard_datasource)
+        + g.dashboard.variable.datasource.withRegex(config.datasource_regex)
+      )
+      + g.dashboard.time.withFrom('now-1h')
+      + g.dashboard.timepicker.withRefreshIntervals(['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'])
+      + g.dashboard.timepicker.withTimeOptions(['5m', '15m', '1h', '6h', '12h', '24h', '2d', '7d', '30d'])
+      + g.dashboard.withRefresh('5m'),
+  },
+  panel+:: {
+    row+:: {
+      new(title)::
+        g.panel.row.new(title)
+        + g.panel.row.withCollapsed(false),
+    },
+
+    timeSeries+:: {
+      new(title)::
+        g.panel.timeSeries.new(title)
+        + g.panel.timeSeries.gridPos.withH('7')
+        + g.panel.timeSeries.gridPos.withW('24')
+        + g.panel.timeSeries.options.legend.withShowLegend(true)
+        + g.panel.timeSeries.options.tooltip.withMode('multi')
+        + g.panel.timeSeries.options.tooltip.withSort('none'),
+    },
+  },
+
+  // Mimir extensions
+  mimir: {
+    addClusterSelectorTemplates(multi=true)::
+      local variable(name, query, label) =
+        g.dashboard.variable.query.new(name, 'label_values(%s, %s)' % [query, label])
+        + g.dashboard.variable.query.withDatasource('query', '$datasource')
+        + g.dashboard.variable.query.generalOptions.withLabel(label)
+        + g.dashboard.variable.query.withSort(sortAscending)
+        + (
+          if multi
+          then
+            g.dashboard.variable.query.selectionOptions.withMulti(true)
+            + g.dashboard.variable.query.selectionOptions.withIncludeAll(true, '.+')
+            + g.dashboard.variable.query.generalOptions.withCurrent('All', '$__all')
+          else {}
+        );
+
+      local selectors = if config.singleBinary then [
+        variable('job', config.dashboard_variables.job_query, config.per_job_label),
+      ] else if multi then [
+        variable('cluster', config.dashboard_variables.cluster_query, config.per_cluster_label),
+
+        variable('namespace', config.dashboard_variables.namespace_query, config.per_namespace_label)
+        + g.dashboard.variable.query.selectionOptions.withIncludeAll(false),
+      ] else [
+        variable('cluster', config.dashboard_variables.cluster_query, config.per_cluster_label)
+        + g.dashboard.variable.query.selectionOptions.withIncludeAll(true, '.*'),
+
+        variable('namespace', config.dashboard_variables.namespace_query, config.per_namespace_label),
+      ];
+
+      g.dashboard.withTags(config.tags)
+      + g.dashboard.withLinks([
+        g.dashboard.link.dashboards.new(title='%(product)s dashboards' % config, tags=config.tags)
+        + g.dashboard.link.dashboards.options.withAsDropdown(true)
+        + g.dashboard.link.dashboards.options.withIncludeVars(true)
+        + g.dashboard.link.dashboards.options.withKeepTime(true)
+        + g.dashboard.link.dashboards.options.withTargetBlank(false),
+      ])
+      + g.dashboard.withVariablesMixin(selectors),
+
+    namespaceMatcher()::
+      if config.singleBinary
+      then '%s=~"$job"' % config.per_job_label
+      else '%s=~"$cluster", %s=~"$namespace"' % [config.per_cluster_label, config.per_namespace_label],
+
+    stack::
+      g.panel.timeSeries.fieldConfig.defaults.custom.withLineWidth(0)
+      + g.panel.timeSeries.fieldConfig.defaults.custom.withFillOpacity(100)
+      + g.panel.timeSeries.fieldConfig.defaults.custom.stacking.withMode('normal'),
+  },
+}

--- a/operations/mimir-mixin/jsonnetfile.json
+++ b/operations/mimir-mixin/jsonnetfile.json
@@ -4,6 +4,15 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-latest"
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "grafana-builder"
         }

--- a/operations/mimir-mixin/jsonnetfile.lock.json
+++ b/operations/mimir-mixin/jsonnetfile.lock.json
@@ -4,6 +4,26 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-latest"
+        }
+      },
+      "version": "733beadbc8dab55c5fe1bcdcf0d8a2d215759a55",
+      "sum": "eyuJ0jOXeA4MrobbNgU4/v5a7ASDHslHZ0eS6hDdWoI="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-v11.0.0"
+        }
+      },
+      "version": "733beadbc8dab55c5fe1bcdcf0d8a2d215759a55",
+      "sum": "0BvzR0i4bS4hc2O3xDv6i9m52z7mPrjvqxtcPrGhynA="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "grafana-builder"
         }
@@ -20,6 +40,26 @@
       },
       "version": "33fd33f2cd59a045ce4580f0b5a7e06a620e8d37",
       "sum": "mzLmCv9n3ldLChVGPfyRJOVKoBw+dfK40vU9792aHIM="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/docsonnet.git",
+          "subdir": "doc-util"
+        }
+      },
+      "version": "6ac6c69685b8c29c54515448eaca583da2d88150",
+      "sum": "BrAL/k23jq+xy9oA7TWIhUx07dsA/QLm3g7ktCwe//U="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/xtd.git",
+          "subdir": ""
+        }
+      },
+      "version": "63d430b69a95741061c2f7fc9d84b1a778511d9c",
+      "sum": "qiZi3axUSXCVzKUF83zSAxklwrnitMmrDK4XAfjPMdE="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
POC on a single dashboard to show what a conversion to grafonnet would look like

Benefits:
- Maintained library (new features, easier to upgrade, etc)
- Auto-complete and go-to definition with the language server

![image](https://github.com/user-attachments/assets/07e0aa22-aef4-4dab-8b84-e2beefb9499e)

**I've tested the dashboard. Looks the same and seems to work the same as the current one, but this is a pretty simple case**
