### PR TITLE
querier: clamp start time for Series, LabelValues, LabelNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@
 * [BUGFIX] Ruler: map invalid org-id errors to 400 status code. #8935
 * [BUGFIX] Querier: Fix invalid query results when multiple chunks are being merged. #8992
 * [BUGFIX] Query-frontend: return annotations generated during evaluation of sharded queries. #9138
-* [BUGFIX] Querier: Support optional start and end times on `/prometheus/api/v1/labels`, `/prometheus/api/v1/label/\<label\>/values`, and `/prometheus/api/v1/series` when `max_query_into_future: 0`. #9129
+* [BUGFIX] Querier: Support optional start and end times on `/prometheus/api/v1/labels`, `/prometheus/api/v1/label/<label>/values`, and `/prometheus/api/v1/series` when `max_query_into_future: 0`. #9129
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 * [BUGFIX] Ruler: map invalid org-id errors to 400 status code. #8935
 * [BUGFIX] Querier: Fix invalid query results when multiple chunks are being merged. #8992
 * [BUGFIX] Query-frontend: return annotations generated during evaluation of sharded queries. #9138
+* [BUGFIX] Querier: Support optional start and end times on `/prometheus/api/v1/labels`, `/prometheus/api/v1/label/\<label\>/values`, and `/prometheus/api/v1/series` when `max_query_into_future: 0`. #9129
 
 ### Mixin
 

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -355,7 +355,7 @@ func (q *blocksStoreQuerier) LabelNames(ctx context.Context, _ *storage.LabelHin
 	// Clamp minT; we cannot push this down into queryWithConsistencyCheck as not all its callers need to clamp minT
 	maxQueryLength := q.limits.MaxLabelsQueryLength(tenantID)
 	if maxQueryLength != 0 {
-		minT = clampLabelsMinTime(spanLog, minT, maxT, time.Now().UnixMilli(), maxQueryLength.Milliseconds())
+		minT = clampToMaxLabelQueryLength(spanLog, minT, maxT, time.Now().UnixMilli(), maxQueryLength.Milliseconds())
 	}
 
 	var (
@@ -400,7 +400,7 @@ func (q *blocksStoreQuerier) LabelValues(ctx context.Context, name string, _ *st
 	// Clamp minT; we cannot push this down into queryWithConsistencyCheck as not all its callers need to clamp minT
 	maxQueryLength := q.limits.MaxLabelsQueryLength(tenantID)
 	if maxQueryLength != 0 {
-		minT = clampLabelsMinTime(spanLog, minT, maxT, time.Now().UnixMilli(), maxQueryLength.Milliseconds())
+		minT = clampToMaxLabelQueryLength(spanLog, minT, maxT, time.Now().UnixMilli(), maxQueryLength.Milliseconds())
 	}
 
 	var (

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -355,7 +355,7 @@ func (q *blocksStoreQuerier) LabelNames(ctx context.Context, _ *storage.LabelHin
 	// Clamp minT; we cannot push this down into queryWithConsistencyCheck as not all its callers need to clamp minT
 	maxQueryLength := q.limits.MaxLabelsQueryLength(tenantID)
 	if maxQueryLength != 0 {
-		minT = clampMinTime(spanLog, minT, maxT, -maxQueryLength, "max label query length")
+		minT = clampLabelsMinTime(spanLog, minT, maxT, time.Now().UnixMilli(), maxQueryLength.Milliseconds())
 	}
 
 	var (
@@ -400,7 +400,7 @@ func (q *blocksStoreQuerier) LabelValues(ctx context.Context, name string, _ *st
 	// Clamp minT; we cannot push this down into queryWithConsistencyCheck as not all its callers need to clamp minT
 	maxQueryLength := q.limits.MaxLabelsQueryLength(tenantID)
 	if maxQueryLength != 0 {
-		minT = clampMinTime(spanLog, minT, maxT, -maxQueryLength, "max label query length")
+		minT = clampLabelsMinTime(spanLog, minT, maxT, time.Now().UnixMilli(), maxQueryLength.Milliseconds())
 	}
 
 	var (

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -2640,6 +2641,35 @@ func TestBlocksStoreQuerier_MaxLabelsQueryRange(t *testing.T) {
 			expectedMinT:         util.TimeToMillis(now.Add(-sevenDays)),
 			expectedMaxT:         util.TimeToMillis(now),
 		},
+
+		"should manipulate query on large time range over the limit": {
+			maxLabelsQueryLength: thirtyDays,
+			queryMinT:            util.TimeToMillis(now.Add(-thirtyDays).Add(-100 * time.Hour)),
+			queryMaxT:            util.TimeToMillis(now),
+			expectedMinT:         util.TimeToMillis(now.Add(-thirtyDays)),
+			expectedMaxT:         util.TimeToMillis(now),
+		},
+		"should manipulate the start of a query without start time": {
+			maxLabelsQueryLength: thirtyDays,
+			queryMinT:            util.TimeToMillis(v1.MinTime),
+			queryMaxT:            util.TimeToMillis(now),
+			expectedMinT:         util.TimeToMillis(now.Add(-thirtyDays)),
+			expectedMaxT:         util.TimeToMillis(now),
+		},
+		"should not manipulate query without end time, we allow querying arbitrarily into the future": {
+			maxLabelsQueryLength: thirtyDays,
+			queryMinT:            util.TimeToMillis(now.Add(-time.Hour)),
+			queryMaxT:            util.TimeToMillis(v1.MaxTime),
+			expectedMinT:         util.TimeToMillis(now.Add(-time.Hour)),
+			expectedMaxT:         util.TimeToMillis(v1.MaxTime),
+		},
+		"should manipulate the start of a query without start or end time, we allow querying arbitrarily into the future, but not the past": {
+			maxLabelsQueryLength: thirtyDays,
+			queryMinT:            util.TimeToMillis(v1.MinTime),
+			queryMaxT:            util.TimeToMillis(v1.MaxTime),
+			expectedMinT:         util.TimeToMillis(now.Add(-thirtyDays)),
+			expectedMaxT:         util.TimeToMillis(v1.MaxTime),
+		},
 	}
 
 	for testName, testData := range tests {
@@ -2661,17 +2691,28 @@ func TestBlocksStoreQuerier_MaxLabelsQueryRange(t *testing.T) {
 				},
 			}
 
-			_, _, err := q.LabelNames(ctx, &storage.LabelHints{})
-			require.NoError(t, err)
-			require.Len(t, finder.Calls, 1)
-			assert.Equal(t, testData.expectedMinT, finder.Calls[0].Arguments.Get(2))
-			assert.Equal(t, testData.expectedMaxT, finder.Calls[0].Arguments.Get(3))
+			assertCalledWithMinMaxTime := func() {
+				const delta = float64(5000)
+				require.Len(t, finder.Calls, 1)
+				gotStartMillis := finder.Calls[0].Arguments.Get(2).(int64)
+				assert.InDeltaf(t, testData.expectedMinT, gotStartMillis, delta, "expected start %s, got %s", util.TimeFromMillis(testData.expectedMinT).UTC(), util.TimeFromMillis(gotStartMillis).UTC())
+				gotEndMillis := finder.Calls[0].Arguments.Get(3).(int64)
+				assert.InDeltaf(t, testData.expectedMaxT, gotEndMillis, delta, "expected end %s, got %s", util.TimeFromMillis(testData.expectedMinT).UTC(), util.TimeFromMillis(gotEndMillis).UTC())
+				finder.Calls = finder.Calls[1:]
+			}
 
-			_, _, err = q.LabelValues(ctx, "foo", &storage.LabelHints{})
-			require.Len(t, finder.Calls, 2)
-			require.NoError(t, err)
-			assert.Equal(t, testData.expectedMinT, finder.Calls[1].Arguments.Get(2))
-			assert.Equal(t, testData.expectedMaxT, finder.Calls[1].Arguments.Get(3))
+			// Assert on the time range of the actual executed query (5s delta).
+			t.Run("LabelNames", func(t *testing.T) {
+				_, _, err := q.LabelNames(ctx, &storage.LabelHints{})
+				require.NoError(t, err)
+				assertCalledWithMinMaxTime()
+			})
+
+			t.Run("LabelValues", func(t *testing.T) {
+				_, _, err := q.LabelValues(ctx, "foo", &storage.LabelHints{})
+				require.NoError(t, err)
+				assertCalledWithMinMaxTime()
+			})
 		})
 	}
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/mimir/pkg/querier/engine"
@@ -338,8 +339,7 @@ func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHin
 		return storage.ErrSeriesSet(err)
 	}
 	if sp.Func == "series" { // Clamp max time range for series-only queries, before we check max length.
-		maxQueryLength := mq.limits.MaxLabelsQueryLength(userID)
-		startMs = clampMinTime(spanLog, startMs, endMs, -maxQueryLength, "max label query length")
+		startMs = clampSeriesMinTime(spanLog, startMs, endMs, now.UnixMilli(), mq.limits.MaxLabelsQueryLength(userID).Milliseconds())
 	}
 
 	// The time range may have been manipulated during the validation,
@@ -380,6 +380,51 @@ func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHin
 	// time series from store and time series from ingesters).
 	// mergeSeriesSets will return sorted set.
 	return mq.mergeSeriesSets(result)
+}
+
+func clampLabelsMinTime(spanLog *spanlogger.SpanLogger, startMs, endMs, nowMs, maxLabelQueryLengthMs int64) int64 {
+	return clampSeriesMinTime(spanLog, startMs, endMs, nowMs, maxLabelQueryLengthMs)
+}
+
+func clampSeriesMinTime(spanLog *spanlogger.SpanLogger, startMs, endMs, nowMs, maxLabelQueryLengthMs int64) int64 {
+	if maxLabelQueryLengthMs == 0 {
+		// It's unlimited.
+		return startMs
+	}
+	unsetStartTime := startMs == v1.MinTime.UnixMilli()
+	unsetEndTime := endMs == v1.MaxTime.UnixMilli()
+
+	switch {
+	case unsetStartTime && unsetEndTime:
+		// The user asked for "everything", but that's too expensive.
+		// We clamp the start, since the past likely has more data.
+		// Allow querying into the future because that will likely have much less data.
+		// Leaving end unchanged also allows to query the future for samples with timestamps in the future.
+		earliestAllowedStart := nowMs - maxLabelQueryLengthMs
+		logClampEvent(spanLog, startMs, earliestAllowedStart, "min", "max label query length")
+		startMs = earliestAllowedStart
+	case unsetStartTime:
+		// We can't provide all data since the beginning of time.
+		// But end was provided, so we use the end as the anchor.
+		earliestAllowedStart := endMs - maxLabelQueryLengthMs
+		logClampEvent(spanLog, startMs, earliestAllowedStart, "min", "max label query length")
+		startMs = earliestAllowedStart
+	case unsetEndTime:
+		// Start was provided, but not end.
+		// We clamp the start relative to now so that we don't query a lot of data.
+		if earliestAllowedStart := nowMs - maxLabelQueryLengthMs; earliestAllowedStart > startMs {
+			logClampEvent(spanLog, startMs, earliestAllowedStart, "min", "max label query length")
+			startMs = earliestAllowedStart
+		}
+	default:
+		// Both start and end were provided. We clamp the start.
+		// There's no strong reason to do this vs clamping end.
+		if earliestAllowedStart := endMs - maxLabelQueryLengthMs; earliestAllowedStart > startMs {
+			logClampEvent(spanLog, startMs, earliestAllowedStart, "min", "max label query length")
+			startMs = earliestAllowedStart
+		}
+	}
+	return startMs
 }
 
 // LabelValues implements storage.Querier.

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -339,7 +339,7 @@ func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHin
 		return storage.ErrSeriesSet(err)
 	}
 	if sp.Func == "series" { // Clamp max time range for series-only queries, before we check max length.
-		startMs = clampSeriesMinTime(spanLog, startMs, endMs, now.UnixMilli(), mq.limits.MaxLabelsQueryLength(userID).Milliseconds())
+		startMs = clampToMaxLabelQueryLength(spanLog, startMs, endMs, now.UnixMilli(), mq.limits.MaxLabelsQueryLength(userID).Milliseconds())
 	}
 
 	// The time range may have been manipulated during the validation,
@@ -382,11 +382,7 @@ func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHin
 	return mq.mergeSeriesSets(result)
 }
 
-func clampLabelsMinTime(spanLog *spanlogger.SpanLogger, startMs, endMs, nowMs, maxLabelQueryLengthMs int64) int64 {
-	return clampSeriesMinTime(spanLog, startMs, endMs, nowMs, maxLabelQueryLengthMs)
-}
-
-func clampSeriesMinTime(spanLog *spanlogger.SpanLogger, startMs, endMs, nowMs, maxLabelQueryLengthMs int64) int64 {
+func clampToMaxLabelQueryLength(spanLog *spanlogger.SpanLogger, startMs, endMs, nowMs, maxLabelQueryLengthMs int64) int64 {
 	if maxLabelQueryLengthMs == 0 {
 		// It's unlimited.
 		return startMs


### PR DESCRIPTION
#### Background

Start and End times in Series, LabelNames, LabelValues calls are optional. When they're unset Prometheus defaults them to MinTime (effectively MinInt) and MaxTime (MaxInt).

Currently MaxQueryIntoFuture clamps the start time relative to now. After that the start time is clamped relative to the end because of the max_label_query_length limit.

However with PR #7496 we're preparing to remove that option, so we'll no longer be clamping max time relative to now. Without clamping the end time we end up clamping start to MaxTime, so the whole query is for some (e.g.) 30 days in the year 292277025, which usually returns no data.


#### What this PR does

In this PR we're only clamping start time when start, end, or both aren't provided. It's clamped to end time if that was provided or to now, otherwise.

We don't clamp end time because there's likely no data to query and we don't have to think about ignoring samples with a future timestamp that have been ingested. Not clamping end time is potentially a problem if there's large clock skew between clients sending data and the query-frontend. I think this is very unlikely to cause problems.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
