### PR TITLE
Refactor the `PusherConsumer` interactions

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2161,11 +2161,6 @@ func newTestConsumer(capacity int) testConsumer {
 	}
 }
 
-func (t testConsumer) Close(context.Context) error {
-	// We don't close the channel because the same consumer can be reused to consume multiple fetches.
-	return nil
-}
-
 func (t testConsumer) Consume(ctx context.Context, records []record) error {
 	for _, r := range records {
 		select {
@@ -2206,10 +2201,6 @@ func (t testConsumer) waitRecords(numRecords int, waitTimeout, drainPeriod time.
 }
 
 type consumerFunc func(ctx context.Context, records []record) error
-
-func (consumerFunc) Close(context.Context) error {
-	return nil
-}
 
 func (c consumerFunc) Consume(ctx context.Context, records []record) error {
 	return c(ctx, records)


### PR DESCRIPTION
#### What this PR does

- Introduce a new `BatchingQueue` to reveal the intentions of a queue per shard.
- Removed the need to call `Close` as we pushed data into TSDB from the main loop. This was really confusing given we were using close as a semantic to "no more items are coming" and ensure any incomplete batches were done.
- Renamed and moved the `noopPusherCloser` which is more of an alternative way to push data without any sort of concurrency.
- Inlined a few methods to get rid of certain level of indirection that made the code harder to understand.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
