### PR TITLE
Fix issue where annotations would not be returned for sharded queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
 * [BUGFIX] Querier: fix issue where some native histogram-related warnings were not emitted when `rate()` was used over native histograms. #8918
 * [BUGFIX] Ruler: map invalid org-id errors to 400 status code. #8935
 * [BUGFIX] Querier: Fix invalid query results when multiple chunks are being merged. #8992
+* [BUGFIX] Query-frontend: return annotations generated during evaluation of sharded queries. #9138
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -8,6 +8,8 @@ package querymiddleware
 import (
 	"context"
 	"fmt"
+	"slices"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -148,7 +150,9 @@ func (s *querySharding) Do(ctx context.Context, r MetricsQueryRequest) (Response
 	if err != nil {
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
-	shardedQueryable := newShardedQueryable(r, s.next)
+
+	annotationAccumulator := newAnnotationAccumulator()
+	shardedQueryable := newShardedQueryable(r, annotationAccumulator, s.next)
 
 	qry, err := newQuery(ctx, r, s.engine, lazyquery.NewLazyQueryable(shardedQueryable))
 	if err != nil {
@@ -160,17 +164,25 @@ func (s *querySharding) Do(ctx context.Context, r MetricsQueryRequest) (Response
 	if err != nil {
 		return nil, mapEngineError(err)
 	}
+	// Note that the positions based on the original query may be wrong as the rewritten
+	// query which is actually used is different, but the user does not see the rewritten
+	// query, so we pass in an empty string as the query so the positions will be hidden.
 	warn, info := res.Warnings.AsStrings("", 0, 0)
+
+	// Add any annotations returned by the sharded queries, and remove any duplicates.
+	accumulatedWarnings, accumulatedInfos := annotationAccumulator.getAll()
+	warn = append(warn, accumulatedWarnings...)
+	info = append(info, accumulatedInfos...)
+	warn = removeDuplicates(warn)
+	info = removeDuplicates(info)
+
 	return &PrometheusResponse{
 		Status: statusSuccess,
 		Data: &PrometheusData{
 			ResultType: string(res.Value.Type()),
 			Result:     extracted,
 		},
-		Headers: shardedQueryable.getResponseHeaders(),
-		// Note that the positions based on the original query may be wrong as the rewritten
-		// query which is actually used is different, but the user does not see the rewritten
-		// query, so we pass in an empty string as the query so the positions will be hidden.
+		Headers:  shardedQueryable.getResponseHeaders(),
 		Warnings: warn,
 		Infos:    info,
 	}, nil
@@ -476,4 +488,77 @@ func longestRegexpMatcherBytes(expr parser.Expr) int {
 	}
 
 	return longest
+}
+
+// annotationAccumulator collects annotations returned by sharded queries.
+type annotationAccumulator struct {
+	warnings *sync.Map
+	infos    *sync.Map
+}
+
+func newAnnotationAccumulator() *annotationAccumulator {
+	return &annotationAccumulator{
+		warnings: &sync.Map{},
+		infos:    &sync.Map{},
+	}
+}
+
+// addWarning collects the warning annotation w.
+//
+// addWarning is safe to call from multiple goroutines.
+func (a *annotationAccumulator) addWarning(w string) {
+	// We use LoadOrStore here to add the annotation if it doesn't already exist or otherwise do nothing.
+	a.warnings.LoadOrStore(w, struct{}{})
+}
+
+// addWarnings collects all of the warning annotations in warnings.
+//
+// addWarnings is safe to call from multiple goroutines.
+func (a *annotationAccumulator) addWarnings(warnings []string) {
+	for _, w := range warnings {
+		a.addWarning(w)
+	}
+}
+
+// addInfo collects the info annotation i.
+//
+// addInfo is safe to call from multiple goroutines.
+func (a *annotationAccumulator) addInfo(i string) {
+	// We use LoadOrStore here to add the annotation if it doesn't already exist or otherwise do nothing.
+	a.infos.LoadOrStore(i, struct{}{})
+}
+
+// addInfos collects all of the info annotations in infos.
+//
+// addInfo is safe to call from multiple goroutines.
+func (a *annotationAccumulator) addInfos(infos []string) {
+	for _, i := range infos {
+		a.addInfo(i)
+	}
+}
+
+// getAll returns all annotations collected by this accumulator.
+//
+// getAll may return inconsistent or unexpected results if it is called concurrently with addInfo or addWarning.
+func (a *annotationAccumulator) getAll() (warnings, infos []string) {
+	return getAllKeys(a.warnings), getAllKeys(a.infos)
+}
+
+func getAllKeys(m *sync.Map) []string {
+	var keys []string
+
+	m.Range(func(k, _ interface{}) bool {
+		keys = append(keys, k.(string))
+		return true
+	})
+
+	return keys
+}
+
+// removeDuplicates removes duplicate entries from s.
+//
+// s may be modified and should not be used after removeDuplicates returns.
+func removeDuplicates(s []string) []string {
+	slices.Sort(s)
+	return slices.Compact(s)
 }

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -101,6 +101,9 @@ func approximatelyEquals(t *testing.T, a, b *PrometheusResponse) {
 			compareExpectedAndActual(t, expected.TimestampMs, actual.TimestampMs, expected.Histogram.Sum, actual.Histogram.Sum, j, a.Labels, "histogram", 1e-12)
 		}
 	}
+
+	require.ElementsMatch(t, a.Infos, b.Infos, "expected same info annotations")
+	require.ElementsMatch(t, a.Warnings, b.Warnings, "expected same info annotations")
 }
 
 func compareExpectedAndActual(t *testing.T, expectedTs, actualTs int64, expectedVal, actualVal float64, j int, labels []mimirpb.LabelAdapter, sampleType string, tolerance float64) {

--- a/pkg/frontend/querymiddleware/sharded_queryable_test.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable_test.go
@@ -257,7 +257,7 @@ func TestShardedQuerier_Select_ShouldConcurrentlyRunEmbeddedQueries(t *testing.T
 }
 
 func TestShardedQueryable_GetResponseHeaders(t *testing.T) {
-	queryable := newShardedQueryable(&PrometheusRangeQueryRequest{}, nil)
+	queryable := newShardedQueryable(&PrometheusRangeQueryRequest{}, nil, nil)
 	assert.Empty(t, queryable.getResponseHeaders())
 
 	// Merge some response headers from the 1st querier.


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where some annotations would not be returned for sharded queries.

This would occur if the annotation was generated during the evaluation of one of the shards. 

For example, the query `sum(rate(foo[5m]))` should return a `metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "foo"` info annotation. When this query is sharded, the annotation is generated during the evaluation of one of the `sum(rate(foo{__query_shard__="x_of_y"}[5m]))` shards on queriers, but the query-frontend would not combine annotations from individual shards into the final result.

This PR changes the behaviour of query-frontends to accumulate and return annotations from each sharded query.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
