### PR TITLE
Mimir query engine: don't include `cpu: ...` line before every benchmark run in `tools/benchmark-query-engine`

### DIFF
--- a/tools/benchmark-query-engine/main.go
+++ b/tools/benchmark-query-engine/main.go
@@ -329,7 +329,7 @@ func (a *app) runTestCase(name string, printBenchmarkHeader bool) error {
 	outputLines := strings.Split(strings.TrimSpace(buf.String()), "\n")
 
 	for _, l := range outputLines {
-		isBenchmarkHeaderLine := strings.HasPrefix(l, "goos") || strings.HasPrefix(l, "goarch") || strings.HasPrefix(l, "pkg")
+		isBenchmarkHeaderLine := strings.HasPrefix(l, "goos") || strings.HasPrefix(l, "goarch") || strings.HasPrefix(l, "pkg") || strings.HasPrefix(l, "cpu")
 		isBenchmarkLine := strings.HasPrefix(l, benchmarkName)
 		isPassLine := l == "PASS"
 


### PR DESCRIPTION
#### What this PR does

Go 1.23 added printing the CPU name to benchmarks on macOS, which clutters the output from `tools/benchmark-query-engine`.

This PR fixes the behaviour of `tools/benchmark-query-engine` to print the CPU name just once per run.

Given this is just an internal tooling change I haven't added a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
