### PR TITLE
Give option to disable IPv6 in nginx config in helm chart

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,7 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [ENHANCEMENT] Add support for turning off IPv6 listener in nginx.
+* [ENHANCEMENT] Add support for turning off IPv6 listener in nginx. #9144
 * [ENHANCEMENT] Dashboards: allow switching between using classic or native histograms in dashboards.
   * Overview dashboard: status, read/write latency and queries/ingestion per sec panels, `cortex_request_duration_seconds` metric. #7674
   * Writes dashboard: `cortex_request_duration_seconds` metric. #8757

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Add support for turning off IPv6 listener in nginx.
 * [ENHANCEMENT] Dashboards: allow switching between using classic or native histograms in dashboards.
   * Overview dashboard: status, read/write latency and queries/ingestion per sec panels, `cortex_request_duration_seconds` metric. #7674
   * Writes dashboard: `cortex_request_duration_seconds` metric. #8757

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2971,6 +2971,8 @@ nginx:
     httpSnippet: ""
     # -- Allows to set a custom resolver
     resolver: null
+    # -- Configures whether or not NGINX bind IPv6
+    enableIPv6: true
     # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating
     # @default -- See values.yaml
     file: |
@@ -3032,7 +3034,9 @@ nginx:
         proxy_read_timeout 300;
         server {
           listen 8080;
+          {{- if .Values.nginx.nginxConfig.enableIPv6 }}
           listen [::]:8080;
+          {{- end }}
 
           {{- if .Values.nginx.basicAuth.enabled }}
           auth_basic           "Mimir";


### PR DESCRIPTION
#### What this PR does

The helm chart value section `nginx.nginxConfig` has no way of turning off IPv6 listener unless modifying the whole `nginx.nginxConfig.file` multi line value.

This PR would make it an value that can easily be turned true or false.

#### Which issue(s) this PR fixes or relates to

I haven't created an issue for this.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
