### PR TITLE
Alertmanager: Update fork to use Adaptive Cards in MS Teams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -305,4 +305,4 @@ replace github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentraci
 replace github.com/opentracing-contrib/go-grpc => github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f
 
 // Replacing prometheus/alertmanager with our fork.
-replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20240625192351-66ec17e3aa45
+replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20240830135110-ca3d9add3996

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/grafana/mimir-prometheus v0.0.0-20240826084742-bf5bf35a1b4d h1:wnVWb4
 github.com/grafana/mimir-prometheus v0.0.0-20240826084742-bf5bf35a1b4d/go.mod h1:cNDAD0ooSyLfNtakmnGbChNg7JPYmKsRn7CQ01Rpu2E=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20240625192351-66ec17e3aa45 h1:AJKOtDKAOg8XNFnIZSmqqqutoTSxVlRs6vekL2p2KEY=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20240625192351-66ec17e3aa45/go.mod h1:01sXtHoRwI8W324IPAzuxDFOmALqYLCOhvSC2fUHWXc=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20240830135110-ca3d9add3996 h1:uc40ltiat42f8QbBgxgs/NTqBYYNij6jB9oPcFawAtQ=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20240830135110-ca3d9add3996/go.mod h1:01sXtHoRwI8W324IPAzuxDFOmALqYLCOhvSC2fUHWXc=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8 h1:iwOtYXeeVSAeYefJNaxDytgjKtUuKQbJqgAIjlnicKg=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.8/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b h1:oMAq12GxTpwo9jxbnG/M4F/HdpwbibTaVoxNA0NZprY=

--- a/vendor/github.com/prometheus/alertmanager/notify/msteams/adaptive_cards.go
+++ b/vendor/github.com/prometheus/alertmanager/notify/msteams/adaptive_cards.go
@@ -1,0 +1,155 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package msteams
+
+import "encoding/json"
+
+// AdaptiveCardsMessage represents a message for adaptive cards.
+type AdaptiveCardsMessage struct {
+	Attachments []AdaptiveCardsAttachment `json:"attachments"`
+	Summary     string                    `json:"summary,omitempty"` // Summary is the text shown in notifications
+	Type        string                    `json:"type"`
+}
+
+// NewAdaptiveCardsMessage returns a message prepared for adaptive cards.
+// https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#send-adaptive-cards-using-an-incoming-webhook
+// more info https://learn.microsoft.com/en-us/connectors/teams/?tabs=text1#microsoft-teams-webhook
+func NewAdaptiveCardsMessage(card AdaptiveCard) AdaptiveCardsMessage {
+	return AdaptiveCardsMessage{
+		Attachments: []AdaptiveCardsAttachment{{
+			ContentType: "application/vnd.microsoft.card.adaptive",
+			Content:     card,
+		}},
+		Type: "message",
+	}
+}
+
+// AdaptiveCardsAttachment contains an adaptive card.
+type AdaptiveCardsAttachment struct {
+	Content     AdaptiveCard `json:"content"`
+	ContentType string       `json:"contentType"`
+	ContentURL  string       `json:"contentUrl,omitempty"`
+}
+
+// AdaptiveCard repesents an Adaptive Card.
+// https://adaptivecards.io/explorer/AdaptiveCard.html
+type AdaptiveCard struct {
+	Body    []AdaptiveCardItem
+	Schema  string
+	Type    string
+	Version string
+}
+
+// NewAdaptiveCard returns a prepared Adaptive Card.
+func NewAdaptiveCard() AdaptiveCard {
+	return AdaptiveCard{
+		Body:    make([]AdaptiveCardItem, 0),
+		Schema:  "http://adaptivecards.io/schemas/adaptive-card.json",
+		Type:    "AdaptiveCard",
+		Version: "1.4",
+	}
+}
+
+func (c *AdaptiveCard) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Body    []AdaptiveCardItem     `json:"body"`
+		Schema  string                 `json:"$schema"`
+		Type    string                 `json:"type"`
+		Version string                 `json:"version"`
+		MsTeams map[string]interface{} `json:"msTeams,omitempty"`
+	}{
+		Body:    c.Body,
+		Schema:  c.Schema,
+		Type:    c.Type,
+		Version: c.Version,
+		MsTeams: map[string]interface{}{"width": "Full"},
+	})
+}
+
+// AppendItem appends an item, such as text or an image, to the Adaptive Card.
+func (c *AdaptiveCard) AppendItem(i AdaptiveCardItem) {
+	c.Body = append(c.Body, i)
+}
+
+// AdaptiveCardItem is an interface for adaptive card items such as containers, elements and inputs.
+type AdaptiveCardItem interface {
+	MarshalJSON() ([]byte, error)
+}
+
+// AdaptiveCardTextBlockItem is a TextBlock.
+type AdaptiveCardTextBlockItem struct {
+	Color  string
+	Size   string
+	Text   string
+	Weight string
+	Wrap   bool
+}
+
+func (i AdaptiveCardTextBlockItem) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type   string `json:"type"`
+		Text   string `json:"text"`
+		Color  string `json:"color,omitempty"`
+		Size   string `json:"size,omitempty"`
+		Weight string `json:"weight,omitempty"`
+		Wrap   bool   `json:"wrap,omitempty"`
+	}{
+		Type:   "TextBlock",
+		Text:   i.Text,
+		Color:  i.Color,
+		Size:   i.Size,
+		Weight: i.Weight,
+		Wrap:   i.Wrap,
+	})
+}
+
+// AdaptiveCardActionSetItem is an ActionSet.
+type AdaptiveCardActionSetItem struct {
+	Actions []AdaptiveCardActionItem
+}
+
+func (i AdaptiveCardActionSetItem) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type    string                   `json:"type"`
+		Actions []AdaptiveCardActionItem `json:"actions"`
+	}{
+		Type:    "ActionSet",
+		Actions: i.Actions,
+	})
+}
+
+type AdaptiveCardActionItem interface {
+	MarshalJSON() ([]byte, error)
+}
+
+// AdaptiveCardOpenURLActionItem is an Action.OpenUrl action.
+type AdaptiveCardOpenURLActionItem struct {
+	IconURL string
+	Title   string
+	URL     string
+}
+
+func (i AdaptiveCardOpenURLActionItem) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type    string `json:"type"`
+		Title   string `json:"title"`
+		URL     string `json:"url"`
+		IconURL string `json:"iconUrl,omitempty"`
+	}{
+		Type:    "Action.OpenUrl",
+		Title:   i.Title,
+		URL:     i.URL,
+		IconURL: i.IconURL,
+	})
+}

--- a/vendor/github.com/prometheus/alertmanager/notify/msteams/msteams.go
+++ b/vendor/github.com/prometheus/alertmanager/notify/msteams/msteams.go
@@ -35,9 +35,15 @@ import (
 )
 
 const (
-	colorRed   = "8C1A1A"
-	colorGreen = "2DC72D"
-	colorGrey  = "808080"
+	ColorAlertFiring   = "#D63232"
+	ColorAlertResolved = "#36a64f"
+
+	TextColorAttention = "attention"
+	TextColorGood      = "good"
+
+	TextSizeLarge = "large"
+
+	TextWeightBolder = "bolder"
 )
 
 type Notifier struct {
@@ -48,16 +54,6 @@ type Notifier struct {
 	retrier      *notify.Retrier
 	webhookURL   *config.SecretURL
 	postJSONFunc func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error)
-}
-
-// Message card reference can be found at https://learn.microsoft.com/en-us/outlook/actionable-messages/message-card-reference.
-type teamsMessage struct {
-	Context    string `json:"@context"`
-	Type       string `json:"type"`
-	Title      string `json:"title"`
-	Summary    string `json:"summary"`
-	Text       string `json:"text"`
-	ThemeColor string `json:"themeColor"`
 }
 
 // New returns a new notifier that uses the Microsoft Teams Webhook API.
@@ -107,14 +103,30 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		return false, err
 	}
 
-	alerts := types.Alerts(as...)
-	color := colorGrey
-	switch alerts.Status() {
-	case model.AlertFiring:
-		color = colorRed
-	case model.AlertResolved:
-		color = colorGreen
-	}
+	card := NewAdaptiveCard()
+	card.AppendItem(AdaptiveCardTextBlockItem{
+		Color:  getTeamsTextColor(types.Alerts(as...)),
+		Text:   title,
+		Size:   TextSizeLarge,
+		Weight: TextWeightBolder,
+		Wrap:   true,
+	})
+	card.AppendItem(AdaptiveCardTextBlockItem{
+		Text: text,
+		Wrap: true,
+	})
+
+	card.AppendItem(AdaptiveCardActionSetItem{
+		Actions: []AdaptiveCardActionItem{
+			AdaptiveCardOpenURLActionItem{
+				Title: "View URL",
+				URL:   n.tmpl.ExternalURL.String(),
+			},
+		},
+	})
+
+	msg := NewAdaptiveCardsMessage(card)
+	msg.Summary = summary
 
 	var url string
 	if n.conf.WebhookURL != nil {
@@ -127,17 +139,8 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		url = strings.TrimSpace(string(content))
 	}
 
-	t := teamsMessage{
-		Context:    "http://schema.org/extensions",
-		Type:       "MessageCard",
-		Title:      title,
-		Summary:    summary,
-		Text:       text,
-		ThemeColor: color,
-	}
-
 	var payload bytes.Buffer
-	if err = json.NewEncoder(&payload).Encode(t); err != nil {
+	if err = json.NewEncoder(&payload).Encode(msg); err != nil {
 		return false, err
 	}
 
@@ -153,4 +156,12 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		return shouldRetry, notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
 	}
 	return shouldRetry, err
+}
+
+// getTeamsTextColor returns the text color for the message title.
+func getTeamsTextColor(alerts model.Alerts) string {
+	if alerts.Status() == model.AlertFiring {
+		return TextColorAttention
+	}
+	return TextColorGood
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -914,7 +914,7 @@ github.com/pmezard/go-difflib/difflib
 # github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c
 ## explicit; go 1.14
 github.com/power-devops/perfstat
-# github.com/prometheus/alertmanager v0.27.0 => github.com/grafana/prometheus-alertmanager v0.25.1-0.20240625192351-66ec17e3aa45
+# github.com/prometheus/alertmanager v0.27.0 => github.com/grafana/prometheus-alertmanager v0.25.1-0.20240830135110-ca3d9add3996
 ## explicit; go 1.21
 github.com/prometheus/alertmanager/api
 github.com/prometheus/alertmanager/api/metrics
@@ -1655,4 +1655,4 @@ sigs.k8s.io/yaml/goyaml.v3
 # github.com/munnerz/goautoneg => github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce
 # github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
 # github.com/opentracing-contrib/go-grpc => github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f
-# github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20240625192351-66ec17e3aa45
+# github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20240830135110-ca3d9add3996


### PR DESCRIPTION
This PR updates the [AM fork](https://github.com/grafana/prometheus-alertmanager/commits/main/) dependency to include https://github.com/grafana/prometheus-alertmanager/pull/90

TODO: update once the AM fork PR is merged.