### PR TITLE
Add proposal for reducing the cost of multitenancy

### DIFF
--- a/docs/proposals/reduce-multitenancy-cost.md
+++ b/docs/proposals/reduce-multitenancy-cost.md
@@ -1,0 +1,221 @@
+---
+title: "XXXX: Tenancy multiplexing"
+description: "Tenancy multiplexing"
+draft: true
+---
+
+# XXXX: Tenancy multiplexing
+
+**Authors:** @wilfriedroset @vaxvms @bubu11e
+
+**Date:** 09/2024
+
+**Sponsor(s):** @username of maintainer(s) willing to shepherd this MID
+
+**Type:** Feature
+
+**Status:** Draft
+
+**Related issues/PRs:**
+
+---
+
+## Background
+
+The `compactor` is a component that improves query performance by compacting multiple blocks for a given tenant in larger optimized ones.
+The `ingester` is a component that is responsible for the persistency of the data of each tenant in a TSDB.
+The `store-gateway` is a component that is responsible for providing access to the object storage where the blocks are stored.
+
+## Problem statement
+
+For each new tenant hosted on a given ingester, a new TSDB is created/opened. With this new TSDB to manage, Mimir consumes more resources (e.g: CPU, RAM, files on disk, objects in the bucket). With the load balancing, replication factor and shuffle sharding the overhead resources consumed by Mimir can be multiplied by the number of replicas of each component. Example: - For each new tenant, the `ingester` consumes ~6MB of ram - Mimir is currently running with 3 ingesters and a replication factor of 3 - The per-tenant RAM overhead is 18MB (3 ingesters _ 1 tenant _ 6MB/tenant)
+
+Given an increasing number of tenants and the horizontal scaling of Mimir, this overhead becomes bigger.
+The problem affects all components that are sensible to the tenant count and their associated TSDB.
+
+## Goals
+
+- From an end-user's point of view, the feature set offered by Mimir works the same as today and there is no breaking changes.
+- Reduce the impact on performance of a high number of Mimir tenants, and therefore enable Mimir to support a large number of tenants.
+
+## Non-Goals
+
+- Provide a migration path from the regular multitenancy to the tenancy multiplexing.
+
+## Proposals
+
+### Proposal 0: Do nothing
+
+In this proposal, it is the operator's responsibility to implement a Mimir gateway to expose tenancy multiplexing using a unique Mimir tenant as the backend.
+This gateway would modify and proxy requests to the Mimir cluster.
+
+The challenge doing so is to re-implement all the tenant limits and isolation built into Mimir.
+Moreover, given the label convention used to enable tenancy multiplexing, the proxy should be implemented in such a way that this private label is not returned in the response to a given Prometheus query.
+
+Note: the gateway of this proposal must not be confused with the GEM gateway.
+
+#### Write path
+
+All the limits enforced by the distributor should be straightforward to implement in another frontend, as the distributor is a stateless process. If the gateway is coded in Go, the code could even be partially reused.
+
+The limits enforced [by the ingester](https://github.com/grafana/mimir/blob/main/pkg/ingester/ingester.go#L102-L109) could be more complex.
+
+#### per_user_series_limit
+
+Gateway could keep in memory a representation of the series already owned by the tenant. This representation should: - be fast to access (as we need to access it for every serie of every write request) - have a small footprint (those information will be exchanged between members of the gateway cluster) - be mergeable (to aggregate information from various members of the gateway cluster) - serializable (for exchange purposes)
+
+A naive approach would be to store in memory all the metadata associated with all the series of every tenants, but this would waste hundreds of gigabytes of memory and would be hard to exchange between frontend cluster members.
+
+A better approach would be to use [HyperLogLog++ estimators](https://research.google/pubs/hyperloglog-in-practice-algorithmic-engineering-of-a-state-of-the-art-cardinality-estimation-algorithm/). Such an estimator is able to keep a representation of the cardinality of a data set using a limited footprint (a few kilobytes per estimator), and is serializable and mergeable with a limited error margin (depends of the precision of the estimator).
+
+Sharing those estimators between members of the gateway would ensure us all members share an up-to-date and sufficiently accurate representation of each tenant's cardinality. Communication between the horizontally scaled gateway could be done via memberlist and gRPC or a pub/sub service like Kafka.
+However, the amount of data to be exchanged between members could be rather large, as we need one estimator per meta-tenant. A way to mitigate this issue could be to propagate only recently updated estimators.
+For example exchange occurs every 15 seconds, for all estimators updated within the last minute.
+
+#### per_metric_series_limit
+
+We could implement this limit in the same way as for `per_user_series_limit`, but this would lead to significant memory consumption as the cardinality of the series is proportional to the cardinality of the tenants.
+
+#### sample-out-of-order
+
+This is not tenant-related, it could be forwarded from the backend.
+
+#### sample-too-old
+
+This is not tenant-related, it could be forwarded from the backend.
+
+#### sample-too-far-in-future
+
+This is not tenant-related, it could be forwarded from the backend.
+
+#### new-value-for-timestamp
+
+This is not tenant-related, it could be forwarded from the backend.
+
+#### sample-out-of-bounds
+
+This is not tenant-related, it could be forwarded from the backend.
+
+#### invalid-native-histogram
+
+This is not tenant-related, it could be forwarded from the backend.
+
+After checking the limits, the gateway adds a dedicated label to each metric containing the name of the meta tenant.
+
+### Read path
+
+The gateway should modify queries on the fly and add the correct label/value to all nodes of the query.
+
+**Pros:**
+
+- Nothing to be done on Mimir side and all the logic is kept apart
+- Operators are free to build any custom made solution
+
+**Cons:**
+
+- The gateway adds an extra hop and therefore latency
+- The limits validation are computed several times
+- All distinct operators faced with the same situation have to solve it themselves
+
+### Proposal 1: Implement tenancy multiplexing through label
+
+In this proposal, we add the possibility for Mimir to host multiples tenants in a single TSDB instead of having one TSDB per tenant. The distinction is done via a label.
+The tenancy multiplexing can be switched on via a configuration file that goes along with the regular multitenancy one.
+
+Example:
+
+```yaml
+# When set to true, incoming HTTP requests must specify tenant ID in HTTP
+# X-Scope-OrgId header. When set to false, tenant ID from -auth.no-auth-tenant
+# is used instead.
+# CLI flag: -auth.multitenancy-enabled
+[multitenancy_enabled: <boolean> | default = true]
+
+# The mode of multitenancy to use. Either "standard" or "multiplexing".
+# When using the "multiplexing" multitenancy several tenants share the same TSDB.
+# CLI flag: -auth.multitenancy-mode
+[multitenancy_mode: <string> | default = "standard"]
+```
+
+All components responsible for manipulating the blocks and/or the TSDB must by adjusted to take into account the tenancy multiplexing.
+
+#### Write path
+
+On the write path we should create a middleware that is responsible for taking the tenant ID and adding the value as a label on each series.
+This middleware is only used when "multiplexing" multitenancy mode is selected.
+
+Option: in order to avoid having a single large TSDB we could distribute the tenants over a fixed numbers of TSDBs. Doing so would reduce the number of tenants per TSDB.
+
+Neither the distributor nor the compactor needs to be modified as their current behavior is not impacted by the multiplexing tenancy.
+
+#### Read path
+
+Ingester and store-gateway use the tenant ID as a matcher when querying storage instead of opening the tenant's TSDB
+
+Ruler still work as-is (see <https://grafana.com/docs/mimir/latest/references/architecture/components/ruler/>): - In internal mode it runs its own distributor. Given the following proposal, we must ensure that we apply the same relabeling as in the rest of the write path - In remote mode, only the read path is changed. Indeed, filtering is performed by the ingester and store-gateway using the tenant ID.
+
+Alertmanager multitenancy still working as-is
+
+    - Ruler call the alertmanager with the tenant ID
+
+The tenants federation still works as-is.
+
+#### Limits
+
+Depending on the component in charge of enforcing the limits, we might have to adapt them:
+
+- distributor: no change expected
+- ingester: max_series_per_user and max_series_per_metrics have to be computed differently
+- querier/query-frontend/query-scheduler: no change expected
+- compactor: retention is per TSDB. It can be enforced in the read path by clamping the "start" of the query. Depending on the compute cost vs the storage cost, this might be more cost-efficient to keep the block for longer instead of processing them to discard the data that have exceeded their retention.
+- ruler: no change expected
+- alertmanager: no change expected
+
+#### Metrics
+
+Depending on the component in charge of metrics exposition, we might have to adapt them:
+
+- ingester: TSDB metrics aren't per user anymore.
+- compactor: metrics are per TSDB.
+- store-gateway: no change expected
+- distributor: no change expected
+- querier/query-frontend/query-scheduler: no change expected
+- ruler: no change expected
+- alertmanager: no change expected
+
+**Pros:**
+
+- The per-tenant overhead is greatly limited and can be considered negligible.
+
+**Cons:**
+
+- Unless modifications, all tenants within the same TSDB share some of the limits. This might be a blocker especially for the retention.
+- There is no easy migration back and forth between regular tenancy and tenancy multiplexing.
+- It is all or nothing as there is no way to define the mapping between the tenant ID and the TSDB.
+- Compactor blocks upload (<https://grafana.com/docs/mimir/latest/configure/configure-tsdb-block-upload/>) will not work properly as block are uploaded to LTS storage as-is. There is no way to add the metatenancy label without rewriting the block.
+- Compactor tenant deletion will not work as it relies on mapping the tenant to a dedicated TSDB.
+- Migrating a metatenant from one TSDB/cluster to another is not straightforward nor easy.
+
+### Proposal 2: Reduce the overhead by at least an order of magnitude
+
+Disclaimer: We list this proposal for the sake of completeness but our knowledge is limited and we don't know how realistic it is.
+
+As Mimir reuses Prometheus TSDB and code, one could investigate how to improve the resources efficiency in both how Mimir uses the TSDB code and the TSDB code itself.
+
+**Pros:**
+
+- No need to modify Mimir's multitenancy
+- The whole Prometheus ecosystem benefits from theses improvements
+
+**Cons:**
+
+- Could be hard to achieve
+- Could be out of Mimir's scope
+
+## Other Notes
+
+- Some backend managed to address this concern, for example [VictoriaMetrics' Multi-tenancy](https://docs.victoriametrics.com/cluster-victoriametrics/#multitenancy) isn't impacted.
+
+### References
+
+- <https://grafana.com/docs/mimir/latest/manage/secure/authentication-and-authorization/>


### PR DESCRIPTION
#### What this PR does

This PR adds a new proposal that aims to reducing the cost of multitenancy

#### Additional context

'm currently working on a usecase where I would like to store the metrics across several thousand of small tenants. The number of tenants to store in a given cluster is 400k and each tenant is expected to have from 50 to 200 actives series at a scrape interval of 15sec, this would make 80M actives series with a replication factor=3 (aka RF).

Mimir is known to efficiently scale for both active series and sample/sec, 80M is expected to be within Mimir working range. However the number of tenants come with an overhead which impact the performance/resources consumption which makes this scenario hard to run in production.

I've run the following proof-of-concept:
* Mimir 2.13.0 is deployed on k8s with [small.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/small.yaml) recommendation
  * see `values.yaml` after.
  * The resources limits of the ingester have been removed. 
```yaml
global:
  podAnnotations:
    profiles.grafana.com/cpu.port_name: http-metrics
    profiles.grafana.com/cpu.scrape: "true"
    profiles.grafana.com/goroutine.port_name: "http-metrics"
    profiles.grafana.com/goroutine.scrape: "true"
    profiles.grafana.com/memory.port_name: "http-metrics"
    profiles.grafana.com/memory.scrape: "true"

alertmanager:
  persistentVolume:
    enabled: true
  replicas: 1
  resources:
    limits:
      memory: 1.4Gi
    requests:
      cpu: 1
      memory: 1Gi
  statefulSet:
    enabled: true

compactor:
  persistentVolume:
    size: 20Gi
  resources:
    limits:
      memory: 2.1Gi
    requests:
      cpu: 1
      memory: 1.5Gi

distributor:
  replicas: 2
  resources:
    limits:
      memory: 5.7Gi
    requests:
      cpu: 2
      memory: 4Gi

ingester:
  persistentVolume:
    size: 50Gi
  replicas: 3
  resources:
    # limits:
    #   memory: 12Gi
    requests:
      cpu: 3.5
      memory: 8Gi
  topologySpreadConstraints: {}
  affinity:
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        - labelSelector:
            matchExpressions:
              - key: target # support for enterprise.legacyLabels
                operator: In
                values:
                  - ingester
          topologyKey: "kubernetes.io/hostname"

        - labelSelector:
            matchExpressions:
              - key: app.kubernetes.io/component
                operator: In
                values:
                  - ingester
          topologyKey: "kubernetes.io/hostname"

  zoneAwareReplication:
    enabled: false
    topologyKey: "kubernetes.io/hostname"

admin-cache:
  enabled: true
  replicas: 2

chunks-cache:
  enabled: true
  replicas: 2

index-cache:
  enabled: true
  replicas: 3

metadata-cache:
  enabled: true

results-cache:
  enabled: true
  replicas: 2

minio:
  enabled: true

overrides_exporter:
  replicas: 0
  resources:
    limits:
      memory: 128Mi
    requests:
      cpu: 100m
      memory: 128Mi

querier:
  replicas: 1
  resources:
    limits:
      memory: 5.6Gi
    requests:
      cpu: 2
      memory: 4Gi

query_frontend:
  replicas: 1
  resources:
    limits:
      memory: 2.8Gi
    requests:
      cpu: 2
      memory: 2Gi

ruler:
  replicas: 0
  resources:
    limits:
      memory: 2.8Gi
    requests:
      cpu: 1
      memory: 2Gi

store_gateway:
  persistentVolume:
    size: 10Gi
  replicas: 3
  resources:
    limits:
      memory: 2.1Gi
    requests:
      cpu: 1
      memory: 1.5Gi
  topologySpreadConstraints: {}
  affinity:
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        - labelSelector:
            matchExpressions:
              - key: target # support for enterprise.legacyLabels
                operator: In
                values:
                  - store-gateway
          topologyKey: "kubernetes.io/hostname"

        - labelSelector:
            matchExpressions:
              - key: app.kubernetes.io/component
                operator: In
                values:
                  - store-gateway
          topologyKey: "kubernetes.io/hostname"
  zoneAwareReplication:
    enabled: false
    topologyKey: "kubernetes.io/hostname"

nginx:
  replicas: 1
  resources:
    # limits:
    #   memory: 731Mi
    requests:
      cpu: 1
      memory: 512Mi

# Grafana Enterprise Metrics feature related
admin_api:
  replicas: 1
  resources:
    limits:
      memory: 128Mi
    requests:
      cpu: 100m
      memory: 64Mi

gateway:
  replicas: 1
  resources:
    limits:
      memory: 731Mi
    requests:
      cpu: 1
      memory: 512Mi

metaMonitoring:
  dashboards:
    enabled: true
  serviceMonitor:
    enabled: true
    interval: 5s
  grafanaAgent:
    enabled: false
    installOperator: false
```
* Every 5 min one sample per tenant is sent to Mimir, the number tenant is gradually increased from 1 to 5k
  * see the go sample after. (note: the sample is far from being perfect 😅)
```go
package main

import (
	"bytes"
	"encoding/json"
	"fmt"
	"net/http"
	"sync"
	"time"

	"github.com/golang/snappy"
	"github.com/prometheus/prometheus/prompb"
)

func generateSample() ([]byte, error) {
	// Create the WriteRequest object with metric data populated.
	wr := prompb.WriteRequest{
		Timeseries: []prompb.TimeSeries{
			{
				Labels: []prompb.Label{
					{
						Name:  "__name__",
						Value: "foo",
					},
				},
				Samples: []prompb.Sample{
					{
						Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
						Value:     100.0,
					},
				},
			},
		},
	}
	// Marshal the data into a byte slice using the protobuf library.
	data, err := wr.Marshal()
	if err != nil {
		return nil, err
	}
	encoded := snappy.Encode(nil, data)
	return encoded, nil
}

func remoteWrite(endpoint string, encodedSample []byte, tenantID int) error {
	body := bytes.NewReader(encodedSample)
	req, err := http.NewRequest("POST", endpoint, body)
	if err != nil {
		return err
	}

	req.Header.Set("Content-Type", "application/x-protobuf")
	req.Header.Set("Content-Encoding", "snappy")
	req.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
	req.Header.Set("X-Scope-OrgID", fmt.Sprintf("tenant_%d", tenantID))

	resp, err := http.DefaultClient.Do(req)
	defer resp.Body.Close()
	if err != nil {
		return err
	}
	return nil
}

type Annotation struct {
	Text string   `json:"text"`
	Time int64    `json:"time"`
	Tags []string `json:"tags"`
}

func addAnnotation(endpoint, username, password string, tenantsCount int) error {
	annotation := Annotation{
		Text: fmt.Sprintf("running with %d", tenantsCount),
		Tags: []string{"tenant"},
		Time: time.Now().UTC().UnixMilli(),
	}
	marsheldAnnotation, err := json.Marshal(annotation)
	if err != nil {
		return err
	}
	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(marsheldAnnotation))
	if err != nil {
		return err
	}

	req.Header.Set("Content-Type", "application/json")
	req.SetBasicAuth(username, password)

	resp, err := http.DefaultClient.Do(req)
	defer resp.Body.Close()
	if err != nil {
		return err
	}
	return nil
}

func main() {
	concurrentGoroutines := make(chan struct{}, 10)

	tenantsCount := []int{1, 5, 10, 20, 50, 75, 100, 150, 200, 250, 300, 500, 600, 700, 800, 900, 1000, 2000, 3000, 4000, 5000}
	for _, tenantCount := range tenantsCount {
		fmt.Printf("== Starting batch with %d tenants\n", tenantCount)

		err := addAnnotation("http://localhost:3000/api/annotations", "admin", "prom-operator", tenantCount)
		if err != nil {
			fmt.Printf("failed to create an annotation: %v\n", err)
		}

		encodedSample, err := generateSample()
		if err != nil {
			panic(err) // we can't do anything without a sample
		}

		var wg sync.WaitGroup

		tenantID := 0
		for tenantID < tenantCount {
			wg.Add(1)
			go func(t int) {
				defer wg.Done()
				// Throttle the number of request to send and avoid slaming the distributor
				concurrentGoroutines <- struct{}{}
				defer func() { <-concurrentGoroutines }()

				fmt.Printf("(batch with %d tenants) Remote write for tenant %d\n", tenantCount, t)
				err = remoteWrite("http://localhost:8080/api/v1/push", encodedSample, t)
				if err != nil {
					fmt.Printf("(batch with %d tenants) failed to push sample for tenantID: %d\n", tenantCount, t)
				}
			}(tenantID)
			tenantID = tenantID + 1
		}
		fmt.Printf("Batch with %d tenants complete, waiting for goroutine\n", tenantCount)
		wg.Wait()
		time.Sleep(5 * time.Minute)
	}
}
```

Here is a screenshot of the resources consumption evolution during the benchmark that can be read as follow:
* The blue annotations shows each time the number of tenants is increased
* The first panel "CPU" query is
```
sum(
    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster="", namespace="mimir-test"}
  * on(namespace,pod)
    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster="", namespace="mimir-test", workload="mimir-test-ingester", workload_type="statefulset"}
) by (pod)
```
* The second panel "Memory" query is
```
sum(
    container_memory_working_set_bytes{cluster="", namespace="mimir-test", container!="", image!=""}
  * on(namespace,pod)
    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster="", namespace="mimir-test", workload="mimir-test-ingester", workload_type="statefulset"}
) by (pod)
```
* The last panel "In-memory series per ingester"query is
```
sum by (pod) (cortex_ingester_memory_series_created_total{cluster=~"mimir-test", job=~"(mimir-test)/((ingester.*|cortex|mimir|mimir-write.*))"})
- sum by (pod) (cortex_ingester_memory_series_removed_total{cluster=~"mimir-test", job=~"(mimir-test)/((ingester.*|cortex|mimir|mimir-write.*))"})
```

![Capture d’écran 2024-08-20 à 16 34 24](https://github.com/user-attachments/assets/b2bde109-75a9-41a4-8096-055871413e40)

Here are a couple of flamgraph during the benchmark:
* **memory:inuse_space**: https://flamegraph.com/share/ce24e81a-5f04-11ef-ab1b-b6898751f631
* **memory:inuse_objects**: https://flamegraph.com/share/08a70331-5f05-11ef-ab1b-b6898751f631
* **memory:alloc_space**: https://flamegraph.com/share/21f2b848-5f05-11ef-aba3-6a3d1814cbe4
* **memory:alloc_objects**: https://flamegraph.com/share/3eb0f66b-5f05-11ef-aba3-6a3d1814cbe4

This proof-of-concept demonstrate that each tenant cost ~6MB of ram and it is linear throughout all the proof-of-concept, I assume the samples stored in memory are neglectable.

For the usecase described at the beginning I would need `6MB * 400k * RF = 7,2TB` of memory only to create the tenants in the ingester. The replication factor, the shuffle sharding and the replica count could also impact the overhead. The worst case scenario is expected to be `6MB * tenants_count * ingesters_count`.

I've not benchmarked the compactor and the store-gateway but they might be impacted the overhead.

Similarly the number files created on disk and the objects in the bucket rapidly increase.

On top of the above resources, we should account for the regular capacity planning.

According to the[ capacity planning ](https://grafana.com/docs/mimir/latest/manage/run-production-environment/planning-capacity/#ingester)we should planned for 80M actives series * RF * 2.5GB / 300k active series = 2TB

My understanding is that Mimir creates a Prometheus' TSDB in memory for each tenant and store the sample accordingly.

One way to workaround this overhead is to store multiple tenant in a single TSDB (e.g: use a label to identify the owner of a given metrics).

However, this might not be as easy as it looks in particular for the rate-limiting and usage statistics, especially if this is done outside of Mimir.

I reckon it would be a good addition to Mimir to facilitate the multi-tenancy (not to be mistaken with actives series or ingestion rate) at such scale. Hence the attached proposal.

At OVHcloud, we are willing to pick up the work if the maintainers see the proposal worthy 🫡 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
