### PR TITLE
Fix flaky TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_...

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -229,6 +229,10 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 
 		writeClient := newKafkaProduceClient(t, clusterAddr)
 
+		t.Cleanup(func() {
+			assert.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+		})
+
 		return reader, writeClient, reg
 	}
 


### PR DESCRIPTION

This failed with the following data race on the testing logger


<details><summary>Details</summary>
<p>

```
==================
WARNING: DATA RACE
Read at 0x00c00056e863 by goroutine 5780:
  testing.(*common).logDepth()
      /usr/local/go/src/testing/testing.go:1024 +0x504
  testing.(*common).log()
      /usr/local/go/src/testing/testing.go:1011 +0x7d
  testing.(*common).Log()
      /usr/local/go/src/testing/testing.go:1052 +0x55
  github.com/prometheus/prometheus/util/testutil.logger.Log()
      /__w/mimir/mimir/vendor/github.com/prometheus/prometheus/util/testutil/logging.go:33 +0x46
  github.com/go-kit/log.(*context).Log()
      /__w/mimir/mimir/vendor/github.com/go-kit/log/log.go:168 +0x4ba
  github.com/grafana/mimir/pkg/storage/ingest.(*kafkaLogger).Log()
      /__w/mimir/mimir/pkg/storage/ingest/logger.go:34 +0x6a9
  github.com/twmb/franz-go/pkg/kgo.(*wrappedLogger).Log()
      /__w/mimir/mimir/vendor/github.com/twmb/franz-go/pkg/kgo/logger.go:123 +0xc6
  github.com/twmb/franz-go/pkg/kgo.(*consumer).assignPartitions()
      /__w/mimir/mimir/vendor/github.com/twmb/franz-go/pkg/kgo/consumer.go:976 +0x2ec
  github.com/twmb/franz-go/pkg/kgo.(*consumer).doOnMetadataUpdate.func1()
      /__w/mimir/mimir/vendor/github.com/twmb/franz-go/pkg/kgo/consumer.go:1208 +0x173
  github.com/twmb/franz-go/pkg/kgo.(*consumer).doOnMetadataUpdate.func2()
      /__w/mimir/mimir/vendor/github.com/twmb/franz-go/pkg/kgo/consumer.go:1220 +0x3a

Previous write at 0x00c00056e863 by goroutine 4270:
  testing.tRunner.func1()
      /usr/local/go/src/testing/testing.go:1677 +0x8fa
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:605 +0x5d
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x44

Goroutine 5780 (running) created at:
  github.com/twmb/franz-go/pkg/kgo.(*consumer).doOnMetadataUpdate()
      /__w/mimir/mimir/vendor/github.com/twmb/franz-go/pkg/kgo/consumer.go:1217 +0x187
  github.com/twmb/franz-go/pkg/kgo.(*Client).updateMetadataLoop()
      /__w/mimir/mimir/vendor/github.com/twmb/franz-go/pkg/kgo/metadata.go:269 +0x10b4
  github.com/twmb/franz-go/pkg/kgo.NewClient.gowrap1()
      /__w/mimir/mimir/vendor/github.com/twmb/franz-go/pkg/kgo/client.go:518 +0x33

Goroutine 4270 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1743 +0x825
  github.com/grafana/mimir/pkg/storage/ingest.TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitReadConsistencyUntilOffset()
      /__w/mimir/mimir/pkg/storage/ingest/reader_test.go:439 +0x3ea
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x44
==================
--- FAIL: TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitReadConsistencyUntilOffset (0.00s)
    logging.go:33: level info partition 0 component kafka_client msg assigning partitions why new assignments from direct consumer how assigning everything new, keeping current assignment input test[0{-2 e-1 ce0}]
    --- FAIL: TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitReadConsistencyUntilOffset/should_return_if_no_records_have_been_produced_yet (0.00s)
        --- FAIL: TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitReadConsistencyUntilOffset/should_return_if_no_records_have_been_produced_yet/with_offset_false (0.12s)
            logging.go:33: level info partition 0 msg starting consumption from partition start because no offset has been found start_offset -2 consumer_group test-group
            logging.go:33: level info partition 0 component kafka_client msg immediate metadata update triggered why querying metadata for consumer initialization
            logging.go:33: level info partition 0 component kafka_client msg assigning partitions why new assignments from direct consumer how assigning everything new, keeping current assignment input test[0{-2 e-1 ce0}]
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader is starting to consume partition until target and max consumer lag is honored
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader found no records to consume because partition is empty partition_start_offset 0 last_produced_offset -1
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader consumed partition and current lag is lower than configured target consumer lag last_consumed_offset -1 current_lag 0s
            logging.go:33: level debug partition 0 caller reader.go:622 msg waiting for read consistency
            logging.go:33: level debug partition 0 caller reader.go:643 msg catching up with offset offset -1
            logging.go:33: level info partition 0 msg stopping partition reader
            testing.go:1399: race detected during execution of test
    --- FAIL: TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitReadConsistencyUntilOffset/should_block_until_the_configured_wait_timeout_is_exceeded_if_produced_records_are_not_consumed (0.00s)
        --- FAIL: TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitReadConsistencyUntilOffset/should_block_until_the_configured_wait_timeout_is_exceeded_if_produced_records_are_not_consumed/with_offset_true (1.11s)
            logging.go:33: level info partition 0 msg starting consumption from partition start because no offset has been found start_offset -2 consumer_group test-group
            logging.go:33: level info partition 0 component kafka_client msg immediate metadata update triggered why querying metadata for consumer initialization
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader is starting to consume partition until target and max consumer lag is honored
            logging.go:33: level info partition 0 component kafka_client msg assigning partitions why new assignments from direct consumer how assigning everything new, keeping current assignment input test[0{-2 e-1 ce0}]
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader found no records to consume because partition is empty partition_start_offset 0 last_produced_offset -1
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader consumed partition and current lag is lower than configured target consumer lag last_consumed_offset -1 current_lag 0s
            reader_test.go:367: produced 1 record (last record offset: 0)
            logging.go:33: level debug partition 0 caller reader.go:622 msg waiting for read consistency
            logging.go:33: level debug partition 0 caller reader.go:643 msg catching up with offset offset 0
            logging.go:33: level debug partition 0 caller reader.go:622 msg waiting for read consistency
            logging.go:33: level debug partition 0 caller reader.go:643 msg catching up with offset offset 0
            logging.go:33: level info partition 0 msg stopping partition reader
            logging.go:33: level debug partition 0 msg last commit offset successfully committed to Kafka offset 0
            testing.go:1399: race detected during execution of test
        --- FAIL: TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitReadConsistencyUntilOffset/should_block_until_the_configured_wait_timeout_is_exceeded_if_produced_records_are_not_consumed/with_offset_false (1.13s)
            logging.go:33: level info partition 0 msg starting consumption from partition start because no offset has been found start_offset -2 consumer_group test-group
            logging.go:33: level info partition 0 component kafka_client msg immediate metadata update triggered why querying metadata for consumer initialization
            logging.go:33: level info partition 0 component kafka_client msg assigning partitions why new assignments from direct consumer how assigning everything new, keeping current assignment input test[0{-2 e-1 ce0}]
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader is starting to consume partition until target and max consumer lag is honored
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader found no records to consume because partition is empty partition_start_offset 0 last_produced_offset -1
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader consumed partition and current lag is lower than configured target consumer lag last_consumed_offset -1 current_lag 0s
            reader_test.go:367: produced 1 record (last record offset: 0)
            logging.go:33: level debug partition 0 caller reader.go:622 msg waiting for read consistency
            logging.go:33: level debug partition 0 caller reader.go:643 msg catching up with offset offset 0
            logging.go:33: level debug partition 0 caller reader.go:622 msg waiting for read consistency
            logging.go:33: level debug partition 0 caller reader.go:643 msg catching up with offset offset 0
            logging.go:33: level info partition 0 msg stopping partition reader
            logging.go:33: level debug partition 0 msg last commit offset successfully committed to Kafka offset 0
            testing.go:1399: race detected during execution of test
    --- FAIL: TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitReadConsistencyUntilOffset/should_return_after_all_produced_records_have_been_consumed (0.00s)
        --- FAIL: TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitReadConsistencyUntilOffset/should_return_after_all_produced_records_have_been_consumed/with_offset_false (1.05s)
            logging.go:33: level info partition 0 msg starting consumption from partition start because no offset has been found start_offset -2 consumer_group test-group
            logging.go:33: level info partition 0 component kafka_client msg immediate metadata update triggered why querying metadata for consumer initialization
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader is starting to consume partition until target and max consumer lag is honored
            logging.go:33: level info partition 0 component kafka_client msg assigning partitions why new assignments from direct consumer how assigning everything new, keeping current assignment input test[0{-2 e-1 ce0}]
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader found no records to consume because partition is empty partition_start_offset 0 last_produced_offset -1
            logging.go:33: level info partition 0 target_lag 2s max_lag 15s msg partition reader consumed partition and current lag is lower than configured target consumer lag last_consumed_offset -1 current_lag 0s
            reader_test.go:257: consumed record: record-1
            reader_test.go:268: produced 2 records (last record offset: 1)
            reader_test.go:2[72](https://github.com/grafana/mimir/actions/runs/10634893554/job/29483308789?pr=9129#step:8:73): started waiting for read consistency
            logging.go:33: level debug partition 0 caller reader.go:622 msg waiting for read consistency
            logging.go:33: level debug partition 0 caller reader.go:643 msg catching up with offset offset 1
            logging.go:33: level debug partition 0 msg last commit offset successfully committed to Kafka offset 0
            reader_test.go:257: consumed record: record-2
            reader_test.go:2[81](https://github.com/grafana/mimir/actions/runs/10634893554/job/29483308789?pr=9129#step:8:82): finished waiting for read consistency
            logging.go:33: level info partition 0 msg stopping partition reader
            logging.go:33: level debug partition 0 msg last commit offset successfully committed to Kafka offset 1
            testing.go:1399: race detected during execution of test
    --- FAIL: TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitReadConsistencyUntilOffset/should_block_until_the_request_context_deadline_is_exceeded_if_produced_records_are_not_consumed (0.00s)
        testing.go:1399: race detected during execution of test
```

</p>
</details> 

