### PR TITLE
kafka replay speed: Handle offset out of range errors

### DIFF
--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -294,7 +294,7 @@ func TestCachingOffsetReader(t *testing.T) {
 
 	t.Run("should initialize with fetched offset", func(t *testing.T) {
 		ctx := context.Background()
-		mockFetch := func(ctx context.Context) (int64, error) {
+		mockFetch := func(context.Context) (int64, error) {
 			return 42, nil
 		}
 
@@ -312,7 +312,7 @@ func TestCachingOffsetReader(t *testing.T) {
 	t.Run("should cache error from initial fetch", func(t *testing.T) {
 		ctx := context.Background()
 		expectedErr := fmt.Errorf("fetch error")
-		mockFetch := func(ctx context.Context) (int64, error) {
+		mockFetch := func(context.Context) (int64, error) {
 			return 0, expectedErr
 		}
 
@@ -358,7 +358,7 @@ func TestCachingOffsetReader(t *testing.T) {
 
 	t.Run("should handle context cancellation", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		mockFetch := func(ctx context.Context) (int64, error) {
+		mockFetch := func(context.Context) (int64, error) {
 			return 42, nil
 		}
 
@@ -377,7 +377,7 @@ func TestCachingOffsetReader(t *testing.T) {
 
 	t.Run("should handle concurrent access", func(t *testing.T) {
 		ctx := context.Background()
-		mockFetch := func(ctx context.Context) (int64, error) {
+		mockFetch := func(context.Context) (int64, error) {
 			return 42, nil
 		}
 

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -191,8 +191,8 @@ func (r *PartitionReader) start(ctx context.Context) (returnErr error) {
 
 	// It's ok to have the start offset slightly outdated.
 	// We only need this offset accurate if we fall behind or if we start and the log gets truncated from beneath us.
-	// In both cases we should recover from a single updated value.
-	// This offset is more often used when we're fetching from after the end, there we don't need an accurate value.
+	// In both cases we should recover after receiving one updated value.
+	// In the more common case where this offset is used when we're fetching from after the end, there we don't need an accurate value.
 	const startOffsetReaderRefreshDuration = 10 * time.Second
 	getPartitionStart := func(ctx context.Context) (int64, error) {
 		return offsetsClient.FetchPartitionStartOffset(ctx, r.partitionID)

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2126,7 +2126,7 @@ func TestHandleKafkaFetchErr(t *testing.T) {
 			refreshed := false
 			refresher := refresherFunc(func() { refreshed = true })
 
-			offsetR := newCachingOffsetReader(func(ctx context.Context) (int64, error) {
+			offsetR := newCachingOffsetReader(func(_ context.Context) (int64, error) {
 				return testCase.lso, nil
 			}, time.Millisecond, logger)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), offsetR))

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2126,7 +2126,7 @@ func TestHandleKafkaFetchErr(t *testing.T) {
 			refreshed := false
 			refresher := refresherFunc(func() { refreshed = true })
 
-			offsetR := newCachingOffsetReader(func(_ context.Context) (int64, error) {
+			offsetR := newGenericOffsetReader(func(_ context.Context) (int64, error) {
 				return testCase.lso, nil
 			}, time.Millisecond, logger)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), offsetR))

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1973,7 +1973,6 @@ func TestHandleKafkaFetchErr(t *testing.T) {
 
 	tests := map[string]struct {
 		err error
-		hwm int64
 		lso int64
 		fw  fetchWant
 
@@ -1984,7 +1983,6 @@ func TestHandleKafkaFetchErr(t *testing.T) {
 	}{
 		"no error": {
 			err: nil,
-			hwm: 10,
 			lso: 1,
 			fw: fetchWant{
 				startOffset: 1,
@@ -1997,7 +1995,6 @@ func TestHandleKafkaFetchErr(t *testing.T) {
 		},
 		"offset out of range - fetching slightly before start": {
 			err: kerr.OffsetOutOfRange,
-			hwm: 10,
 			lso: 5,
 			fw: fetchWant{
 				startOffset: 4,
@@ -2010,7 +2007,6 @@ func TestHandleKafkaFetchErr(t *testing.T) {
 		},
 		"offset out of range - fetching completely outside of available offsets": {
 			err: kerr.OffsetOutOfRange,
-			hwm: 10,
 			lso: 5,
 			fw: fetchWant{
 				startOffset: 1,
@@ -2021,23 +2017,8 @@ func TestHandleKafkaFetchErr(t *testing.T) {
 				endOffset:   3,
 			},
 		},
-		"offset out of range - fetching after end": {
-			err: kerr.OffsetOutOfRange,
-			hwm: 10,
-			lso: 5,
-			fw: fetchWant{
-				startOffset: 11,
-				endOffset:   15,
-			},
-			expectedFw: fetchWant{
-				startOffset: 11,
-				endOffset:   15,
-			},
-			expectedShortBackoff: true,
-		},
 		"recoverable error": {
 			err: kerr.KafkaStorageError,
-			hwm: -1, // unknown
 			lso: -1, // unknown
 			fw: fetchWant{
 				startOffset: 11,
@@ -2144,14 +2125,16 @@ func TestHandleKafkaFetchErr(t *testing.T) {
 			longBackOff := waiterFunc(func() { waitedLong = true })
 			refreshed := false
 			refresher := refresherFunc(func() { refreshed = true })
-			result := fetchResult{
-				FetchPartition: kgo.FetchPartition{
-					Err:            testCase.err,
-					HighWatermark:  testCase.hwm,
-					LogStartOffset: testCase.lso,
-				},
-			}
-			actualFw := handleKafkaFetchErr(result, testCase.fw, shortBackOff, longBackOff, refresher, logger)
+
+			offsetR := newCachingOffsetReader(func(ctx context.Context) (int64, error) {
+				return testCase.lso, nil
+			}, time.Millisecond, logger)
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), offsetR))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), offsetR))
+			})
+
+			actualFw := handleKafkaFetchErr(testCase.err, testCase.fw, shortBackOff, longBackOff, offsetR, refresher, logger)
 			assert.Equal(t, testCase.expectedFw, actualFw)
 			assert.Equal(t, testCase.expectedShortBackoff, waitedShort)
 			assert.Equal(t, testCase.expectedLongBackoff, waitedLong)


### PR DESCRIPTION

#### Background


When we're fetching records after the end of a partition or before the start Kafka returns OffsetOutOfRange errors. In those cases we have to choose whether to 
1. abandon the request in case it covers already deleted offsets due to retention
2. wait it out incase we're fetching offsets which haven't been produced yet
3. adjust our request in case only some of the records have been deleted due to retention 


1\. and 2. can be decided only by suing the first available offset of a partition (`LogStartOffset`). If we get `OffsetOutOfRange` and  neither 1. nor 2. is correct, then 3. must be. Therefore, we only need `LogStartOffset`. 

#### Problem


Previously I thought that we can make a decision when we receive `OffsetOutOfRange` using the information from a `FetchPartition` response - `HighWatermark` and `LogStartOffset`. 

However, when running against a local kafka I noticed that it returns -1 for both of these fields when it returns `OffsetOutOfRange`. This means that it's up to us to figure out the start and end offsets and take one of the 3 decisions above.

#### What this PR does

Uses a new offset client which fetches the start of a partition. Based on that info we can chose between the 3 scenarios above.

We fetch the start of the partition periodically (@ 10s) and cache the results. I chose to trade a very accurate value for the start offset with a lower load on kafka. We only need this offset accurate if we fall behind or if we start and the log gets truncated from beneath us. In both cases we should recover after receiving one updated value. In the more common case where this offset is used when we're fetching from after the end, there we don't need an accurate value.

**One side effect of this change** is that now we'll be periodically fetching the start offset of a partition even if concurrency is 1 (i.e. disabled concurrent fetchers). I think it's acceptable because the load is 40x lower compared to the load from fetching the last produced offset every 250ms.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
