### PR TITLE
Use node fields instead of custom queuing algorithm to count children checked

### DIFF
--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
@@ -347,8 +347,6 @@ func TestMultiDimensionalQueueAlgorithmSlowConsumerEffects(t *testing.T) {
 		},
 	}
 
-	maxQueriersPerTenant := 0 // disable shuffle sharding
-
 	// Increase totalRequests to tighten up variations when running locally, but do not commit higher values;
 	// the later test cases with a higher percentage of slow queries will take a long time to run.
 	totalRequests := 1000
@@ -364,6 +362,12 @@ func TestMultiDimensionalQueueAlgorithmSlowConsumerEffects(t *testing.T) {
 	// slow request approximately 100x longer than the fast request seems fair;
 	// an ingester can respond in 0.3 seconds while a slow store-gateway query can take 30 seconds
 	slowConsumerLatency := 100 * time.Millisecond
+
+	// enable shuffle sharding; we cannot be too restrictive with only two tenants,
+	// or some consumers will not get sharded to any of the two tenants.
+	// enabling shuffle sharding ensures we will hit cases where a querier-worker
+	// does not find any tenant leaf nodes it can work on under its prioritized query component node
+	maxQueriersPerTenant := numConsumers - 1
 
 	var testCaseNames []string
 	testCaseReports := map[string]*testScenarioQueueDurationReport{}

--- a/pkg/scheduler/queue/tenant_querier_assignment.go
+++ b/pkg/scheduler/queue/tenant_querier_assignment.go
@@ -451,7 +451,7 @@ func (tqa *tenantQuerierAssignments) dequeueSelectNode(node *Node) (*Node, bool)
 		return nil, true
 	}
 
-	checkedAllNodes := node.childrenChecked == len(node.queueMap) // must check local queue as well
+	checkedAllNodes := node.childrenChecked == len(node.queueMap)
 
 	// advance queue position for dequeue
 	tqa.tenantOrderIndex++
@@ -483,8 +483,6 @@ func (tqa *tenantQuerierAssignments) dequeueSelectNode(node *Node) (*Node, bool)
 			checkIndex++
 			continue
 		}
-
-		checkedAllNodes = node.childrenChecked == len(node.queueMap)
 
 		// if the tenant-querier set is nil, any querier can serve this tenant
 		if tqa.tenantQuerierIDs[tenantID] == nil {

--- a/pkg/scheduler/queue/tenant_querier_assignment.go
+++ b/pkg/scheduler/queue/tenant_querier_assignment.go
@@ -451,7 +451,7 @@ func (tqa *tenantQuerierAssignments) dequeueSelectNode(node *Node) (*Node, bool)
 		return nil, true
 	}
 
-	checkedAllNodes := node.childrenChecked == len(node.queueMap)+1 // must check local queue as well
+	checkedAllNodes := node.childrenChecked == len(node.queueMap) // must check local queue as well
 
 	// advance queue position for dequeue
 	tqa.tenantOrderIndex++
@@ -484,7 +484,7 @@ func (tqa *tenantQuerierAssignments) dequeueSelectNode(node *Node) (*Node, bool)
 			continue
 		}
 
-		checkedAllNodes = node.childrenChecked == len(node.queueMap)+1
+		checkedAllNodes = node.childrenChecked == len(node.queueMap)
 
 		// if the tenant-querier set is nil, any querier can serve this tenant
 		if tqa.tenantQuerierIDs[tenantID] == nil {

--- a/pkg/scheduler/queue/tree_queue_algo_querier_worker_queue_priority.go
+++ b/pkg/scheduler/queue/tree_queue_algo_querier_worker_queue_priority.go
@@ -59,7 +59,6 @@ type QuerierWorkerQueuePriorityAlgo struct {
 	currentNodeOrderIndex int
 	nodeOrder             []string
 	nodeCounts            map[string]int
-	nodesChecked          int
 }
 
 func NewQuerierWorkerQueuePriorityAlgo() *QuerierWorkerQueuePriorityAlgo {
@@ -87,8 +86,8 @@ func (qa *QuerierWorkerQueuePriorityAlgo) wrapCurrentNodeOrderIndex(increment bo
 	}
 }
 
-func (qa *QuerierWorkerQueuePriorityAlgo) checkedAllNodes() bool {
-	return qa.nodesChecked == len(qa.nodeOrder)
+func (qa *QuerierWorkerQueuePriorityAlgo) checkedAllNodes(n *Node) bool {
+	return n.childrenChecked == len(n.queueMap)
 }
 
 func (qa *QuerierWorkerQueuePriorityAlgo) addChildNode(parent, child *Node) {
@@ -118,11 +117,11 @@ func (qa *QuerierWorkerQueuePriorityAlgo) addChildNode(parent, child *Node) {
 
 func (qa *QuerierWorkerQueuePriorityAlgo) dequeueSelectNode(node *Node) (*Node, bool) {
 	currentNodeName := qa.nodeOrder[qa.currentNodeOrderIndex]
-	if node, ok := node.queueMap[currentNodeName]; ok {
-		qa.nodesChecked++
-		return node, qa.checkedAllNodes()
+	checkedAllNodes := qa.checkedAllNodes(node)
+	if childNode, ok := node.queueMap[currentNodeName]; ok {
+		return childNode, checkedAllNodes
 	}
-	return nil, qa.checkedAllNodes()
+	return nil, checkedAllNodes
 }
 
 func (qa *QuerierWorkerQueuePriorityAlgo) dequeueUpdateState(node *Node, dequeuedFrom *Node) {
@@ -155,7 +154,4 @@ func (qa *QuerierWorkerQueuePriorityAlgo) dequeueUpdateState(node *Node, dequeue
 		// delete child node from its parent's queueMap
 		delete(node.queueMap, childName)
 	}
-
-	// reset state after successful dequeue
-	qa.nodesChecked = 0
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Updates `QuerierWorkerQueuePriorityAlgo` to use the `Node`'s `childrenChecked` field instead of keeping its own count of nodes checked; this lets the tree reset the count after the dequeue operation is completed. This also includes a small bugfix introduced to `tenantQuerierAssignments` by defining leaf nodes.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
