### PR TITLE
grpcurl-query-ingesters: sort series and chunks and print full timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,8 @@
 * [ENHANCEMENT] `tsdb-print-chunk`: print counter reset information for native histograms. #8812
 * [ENHANCEMENT] `grpcurl-query-ingesters`: print counter reset information for native histograms. #8820
 * [ENHANCEMENT] `grpcurl-query-ingesters`: concurrently query ingesters. #9102
+* [ENHANCEMENT] `grpcurl-query-ingesters`: sort series and chunks in output. #9180
+* [ENHANCEMENT] `grpcurl-query-ingesters`: print full chunk timestamps, not just time component. #9180
 * [ENHANCEMENT] `tsdb-series`: Added `-json` option to generate JSON output for easier post-processing. #8844
 * [ENHANCEMENT] `tsdb-series`: Added `-min-time` and `-max-time` options to filter samples that are used for computing data-points per minute. #8844
 

--- a/tools/grpcurl-query-ingesters/main.go
+++ b/tools/grpcurl-query-ingesters/main.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
@@ -63,6 +65,10 @@ func parseFile(file string) ([]QueryStreamResponse, error) {
 }
 
 func dumpResponse(res QueryStreamResponse) {
+	slices.SortFunc(res.Chunkseries, func(a, b QueryStreamChunkseries) int {
+		return labels.Compare(a.LabelSet(), b.LabelSet())
+	})
+
 	for _, series := range res.Chunkseries {
 		fmt.Println(series.LabelSet().String())
 		var (
@@ -71,11 +77,15 @@ func dumpResponse(res QueryStreamResponse) {
 			ts int64
 		)
 
+		slices.SortFunc(series.Chunks, func(a, b Chunk) int {
+			return int(a.StartTimestamp() - b.StartTimestamp())
+		})
+
 		for _, chunk := range series.Chunks {
 			fmt.Printf(
 				"- Chunk: %s - %s\n",
-				chunk.StartTime().Format(time.TimeOnly),
-				chunk.EndTime().Format(time.TimeOnly))
+				chunk.StartTime().Format(time.RFC3339),
+				chunk.EndTime().Format(time.RFC3339))
 
 			chunkIterator := chunk.EncodedChunk().NewIterator(nil)
 			for {


### PR DESCRIPTION
#### What this PR does

This PR makes some changes to `tools/grpcurl-query-ingesters`:

* the output series will now be sorted by their labels
* the output chunks for each series will now be sorted by their timestamp
* chunk timestamps will now include the date, not just the time

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
