### PR TITLE
development: Fix exposing otel collector OTLP endpoints

### DIFF
--- a/development/mimir-monolithic-mode/config/otel-collector-otlp-push-config.yaml
+++ b/development/mimir-monolithic-mode/config/otel-collector-otlp-push-config.yaml
@@ -4,7 +4,9 @@ receivers:
   otlp: # Allow sending data via OTLP protocol
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
   # Data sources: metrics
   prometheus: # Scrape self

--- a/development/mimir-monolithic-mode/config/otel-collector-remote-write-config.yaml
+++ b/development/mimir-monolithic-mode/config/otel-collector-remote-write-config.yaml
@@ -4,7 +4,9 @@ receivers:
   otlp: # Allow sending data via OTLP protocol
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
   # Data sources: metrics
   prometheus: # Scrape self


### PR DESCRIPTION
To allow connecting to the collector from outside docker network.

Not sure when this was changed, but latest docs include this: https://opentelemetry.io/docs/collector/configuration/#basics

Discover while testing https://github.com/grafana/mimir/pull/9172

