### PR TITLE
development: enable metric suffixes by default on OTLP by default

### DIFF
--- a/development/mimir-monolithic-mode/config/mimir.yaml
+++ b/development/mimir-monolithic-mode/config/mimir.yaml
@@ -74,6 +74,7 @@ ruler_storage:
 limits:
   native_histograms_ingestion_enabled: true
   max_global_exemplars_per_user: 100000
+  otel_metric_suffixes_enabled: true
 
 runtime_config:
   file: ./config/runtime.yaml


### PR DESCRIPTION
I was confused why the docker compose profiles yielded different metrics:
```
 ./compose-up.sh --profile otel-collector-otlp-push
```
 had no unit suffix like milliseconds.

But
```
./compose-up.sh --profile otel-collector-remote-write
```
did. It was because we don't add the suffixes by default.
