### PR TITLE
kafka replay speed: address post-merge feedback from 9152

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -30,11 +30,6 @@ import (
 	"github.com/grafana/mimir/pkg/util/testkafka"
 )
 
-func init() {
-	// Reduce the time the fake kafka would wait for new records. Sometimes this blocks startup.
-	defaultMinBytesWaitTime = time.Second
-}
-
 func TestKafkaStartOffset(t *testing.T) {
 	t.Run("should match Kafka client start offset", func(t *testing.T) {
 		expected := kgo.NewOffset().AtStart().EpochOffset().Offset
@@ -1852,6 +1847,9 @@ func createReader(t *testing.T, addr string, topicName string, partitionID int32
 
 	reader, err := newPartitionReader(cfg.kafka, cfg.partitionID, "test-group", cfg.consumer, cfg.logger, cfg.registry)
 	require.NoError(t, err)
+
+	// Reduce the time the fake kafka would wait for new records. Sometimes this blocks startup.
+	reader.concurrentFetchersMinBytesMaxWaitTime = time.Second
 
 	return reader
 }


### PR DESCRIPTION
The suggestion in the PR was to make `concurrentFetchersMinBytesMaxWaitTime` a field on `concurrentFetchers`. But those are created and started by the `PartitionReader` in its `starting` function [here](https://github.com/grafana/mimir/blob/b5050f31e51b8b2224ae10983f5221c9368897e8/pkg/storage/ingest/reader.go#L196). So the tests don't have control over them.

This is another approach where we have the field on `PartitionReader` and pass it to the constructor of `concurrentFetchers`.
