### PR TITLE
kafka replay speed: compressed/uncompressed bytes for MaxBytes in fetch requests

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -6632,6 +6632,16 @@
               "fieldDefaultValue": 128,
               "fieldFlag": "ingest-storage.kafka.records-per-fetch",
               "fieldType": "int"
+            },
+            {
+              "kind": "field",
+              "name": "use_compressed_bytes_as_fetch_max_bytes",
+              "required": false,
+              "desc": "When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently.",
+              "fieldValue": null,
+              "fieldDefaultValue": true,
+              "fieldFlag": "ingest-storage.kafka.use-compressed-bytes-as-fetch-max-bytes",
+              "fieldType": "boolean"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1355,6 +1355,8 @@ Usage of ./cmd/mimir/mimir:
     	The best-effort maximum lag a consumer tries to achieve at startup. Set both -ingest-storage.kafka.target-consumer-lag-at-startup and -ingest-storage.kafka.max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup. (default 2s)
   -ingest-storage.kafka.topic string
     	The Kafka topic name.
+  -ingest-storage.kafka.use-compressed-bytes-as-fetch-max-bytes
+    	When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently. (default true)
   -ingest-storage.kafka.wait-strong-read-consistency-timeout duration
     	The maximum allowed for a read requests processed by an ingester to wait until strong read consistency is enforced. 0 to disable the timeout. (default 20s)
   -ingest-storage.kafka.write-clients int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -431,6 +431,8 @@ Usage of ./cmd/mimir/mimir:
     	The best-effort maximum lag a consumer tries to achieve at startup. Set both -ingest-storage.kafka.target-consumer-lag-at-startup and -ingest-storage.kafka.max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup. (default 2s)
   -ingest-storage.kafka.topic string
     	The Kafka topic name.
+  -ingest-storage.kafka.use-compressed-bytes-as-fetch-max-bytes
+    	When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently. (default true)
   -ingest-storage.kafka.wait-strong-read-consistency-timeout duration
     	The maximum allowed for a read requests processed by an ingester to wait until strong read consistency is enforced. 0 to disable the timeout. (default 20s)
   -ingest-storage.kafka.write-clients int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3835,6 +3835,13 @@ kafka:
   # CLI flag: -ingest-storage.kafka.records-per-fetch
   [records_per_fetch: <int> | default = 128]
 
+  # When enabled, the fetch request MaxBytes field is computed using the
+  # compressed size of previous records. When disabled, MaxBytes is computed
+  # using uncompressed bytes. Different Kafka implementations interpret MaxBytes
+  # differently.
+  # CLI flag: -ingest-storage.kafka.use-compressed-bytes-as-fetch-max-bytes
+  [use_compressed_bytes_as_fetch_max_bytes: <boolean> | default = true]
+
 migration:
   # When both this option and ingest storage are enabled, distributors write to
   # both Kafka and ingesters. A write request is considered successful only when

--- a/docs/sources/mimir/configure/configure-kafka-backend.md
+++ b/docs/sources/mimir/configure/configure-kafka-backend.md
@@ -1,0 +1,35 @@
+---
+aliases:
+  - ../operators-guide/configure/configure-kafka-backend/
+description: Learn how to configure Grafana Mimir to use Kafka for ingest storage.
+menuTitle: Kafka
+title: Configure Grafana Mimir kafka backend
+weight: 66
+---
+
+# Configure the Grafana Mimir Kafka backend
+
+Grafana Mimir supports using Kafka for the first layer of ingestion. This is an experimental feature released in Mimir 2.14.
+This page is incomplete. It will be updated as the ingest storage feature matures and moves out of the experimental phase.
+
+## Different Kafka backend implementations
+
+Some Kafka-compatible implementations have different behavior for the Kafka API.
+To set up Mimir to work with different Kafka backends, you need to configure some parameters.
+Here are the Kafka flavors and additional configurations needed to set them up in Mimir.
+
+### Apache Kafka
+
+Use the default options with Apache Kafka. No additional configuration is needed.
+
+### Confluent Kafka
+
+Use the default options with Confluent Kafka. No additional configuration is needed.
+
+### Warpstream
+
+Configure the following CLI flags or their YAML equivalent.
+
+```
+-ingest-storage.kafka.use-compressed-bytes-as-fetch-max-bytes=false
+```

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -91,11 +91,12 @@ type KafkaConfig struct {
 	WaitStrongReadConsistencyTimeout time.Duration `yaml:"wait_strong_read_consistency_timeout"`
 
 	// Used when logging unsampled client errors. Set from ingester's ErrorSampleRate.
-	FallbackClientErrorSampleRate int64 `yaml:"-"`
-	ReplayConcurrency             int   `yaml:"replay_concurrency"`
-	ReplayShards                  int   `yaml:"replay_shards"`
-	BatchSize                     int   `yaml:"batch_size"`
-	RecordsPerFetch               int   `yaml:"records_per_fetch"`
+	FallbackClientErrorSampleRate     int64 `yaml:"-"`
+	ReplayConcurrency                 int   `yaml:"replay_concurrency"`
+	ReplayShards                      int   `yaml:"replay_shards"`
+	BatchSize                         int   `yaml:"batch_size"`
+	RecordsPerFetch                   int   `yaml:"records_per_fetch"`
+	UseCompressedBytesAsFetchMaxBytes bool  `yaml:"use_compressed_bytes_as_fetch_max_bytes"`
 }
 
 func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {
@@ -134,6 +135,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.IntVar(&cfg.ReplayShards, prefix+".replay-shards", 0, "The number of concurrent appends to the TSDB head. 0 to disable.")
 	f.IntVar(&cfg.BatchSize, prefix+".batch-size", 128, "The number of timeseries to batch together before ingesting into TSDB.")
 	f.IntVar(&cfg.RecordsPerFetch, prefix+".records-per-fetch", 128, "The number of records to fetch from Kafka in a single request.")
+	f.BoolVar(&cfg.UseCompressedBytesAsFetchMaxBytes, prefix+".use-compressed-bytes-as-fetch-max-bytes", true, "When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently.")
 }
 
 func (cfg *KafkaConfig) Validate() error {


### PR DESCRIPTION
Normally all kafka flavours support the same API, except when they don't. Warpstream treats the `MaxBytes` field of a Fetch request as a limit on the uncompressed bytes of all the records. Apache Kafka treats it as a limit on the compressed bytes.

This difference in behaviour is quite significant and leads to very suboptimal performance when using the wrong interpretation.

This PR adds a config flag to be able to choose between the Kafka flavours. Open to feedback on what to call the flag and what to call the options.


#### Note to reviewers
 
This PR is based on #9203, but will also conflict with #9153 when merged. The conflicts should be tiny, so I think this is ready for a review. I'll rebase when the two PRs above are merged.


#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
