### PR TITLE
Alertmanager: Fix config validation gap around unreferenced templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 * [BUGFIX] Querier: Fix invalid query results when multiple chunks are being merged. #8992
 * [BUGFIX] Query-frontend: return annotations generated during evaluation of sharded queries. #9138
 * [BUGFIX] Querier: Support optional start and end times on `/prometheus/api/v1/labels`, `/prometheus/api/v1/label/<label>/values`, and `/prometheus/api/v1/series` when `max_query_into_future: 0`. #9129
+* [BUGFIX] Alertmanager: Fix config validation gap around unreferenced templates. #9207
 
 ### Mixin
 

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"reflect"
 
 	"github.com/go-kit/log"
@@ -246,6 +245,7 @@ func validateUserConfig(logger log.Logger, cfg alertspb.AlertConfigDesc, limits 
 	}
 	defer os.RemoveAll(userTempDir)
 
+	templateFiles := make([]string, 0, len(cfg.Templates))
 	for _, tmpl := range cfg.Templates {
 		templateFilepath, err := safeTemplateFilepath(userTempDir, tmpl.Filename)
 		if err != nil {
@@ -257,11 +257,8 @@ func validateUserConfig(logger log.Logger, cfg alertspb.AlertConfigDesc, limits 
 			level.Error(logger).Log("msg", "unable to store template file", "err", err, "user", cfg.User)
 			return fmt.Errorf("unable to store template file '%s'", tmpl.Filename)
 		}
-	}
 
-	templateFiles := make([]string, len(amCfg.Templates))
-	for i, t := range amCfg.Templates {
-		templateFiles[i] = filepath.Join(userTempDir, t)
+		templateFiles = append(templateFiles, templateFilepath)
 	}
 
 	_, err = template.FromGlobs(templateFiles, WithCustomFunctions(user))

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -750,6 +750,23 @@ template_files:
 			err: fmt.Errorf(`error validating Alertmanager config: template: test.tmpl:1: function "invalid" not defined`),
 		},
 		{
+			name: "should return error if template is wrong even when not referenced by config",
+			cfg: `
+alertmanager_config: |
+  route:
+    receiver: 'default-receiver'
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    group_by: [cluster, alertname]
+  receivers:
+    - name: default-receiver
+template_files:
+  "test.tmpl": "{{ invalid Go template }}"
+`,
+			err: fmt.Errorf(`error validating Alertmanager config: template: test.tmpl:1: function "invalid" not defined`),
+		},
+		{
 			name: "config too big",
 			cfg: `
 alertmanager_config: |


### PR DESCRIPTION
#### What this PR does

Alertmanager config validation also checks for template correctness. In the API, only templates that are directly referenced under `alertmanager_config` are checked - unreferenced template content is not validated.

Upstream alertmanager does validate all template content, regardless of references: https://github.com/prometheus/alertmanager/blob/a6df704408ba303c5d1d4e8e751da227e0ab08bf/cmd/alertmanager/main.go#L418-L421

Mimir does the same when bootstrapping alertmanager - all template files are loaded (and eventually parsed) without checking references:
https://github.com/grafana/mimir/blob/f52911d917c8c52e0da6a59348a64dd7f7622072/pkg/alertmanager/api.go#L149

This PR solves this validation gap in Mimir's API - users can create bad templates by simply not referencing them, resulting in their tenant Alertmanagers continually failing to apply config.

Arguably the inverse approach could also solve this (changing Mimir to not load templates that aren't referenced) but I felt the current approach is more closely aligned with how upstream behaves.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
