### PR TITLE
Alertmanager: Fix goroutine leak when stored config fails to apply and there is no existing tenant alertmanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 * [BUGFIX] Query-frontend: return annotations generated during evaluation of sharded queries. #9138
 * [BUGFIX] Querier: Support optional start and end times on `/prometheus/api/v1/labels`, `/prometheus/api/v1/label/<label>/values`, and `/prometheus/api/v1/series` when `max_query_into_future: 0`. #9129
 * [BUGFIX] Alertmanager: Fix config validation gap around unreferenced templates. #9207
+* [BUGFIX] Alertmanager: Fix goroutine leak when stored config fails to apply and there is no existing tenant alertmanager #9211
 
 ### Mixin
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -925,6 +925,7 @@ func (am *MultitenantAlertmanager) newAlertmanager(userID string, amConfig *defi
 	}
 
 	if err := newAM.ApplyConfig(amConfig, templates, rawCfg, tmplExternalURL, staticHeaders); err != nil {
+		newAM.Stop()
 		return nil, fmt.Errorf("unable to apply initial config for user %v: %v", userID, err)
 	}
 

--- a/pkg/util/test/leak.go
+++ b/pkg/util/test/leak.go
@@ -8,15 +8,15 @@ import (
 	"go.uber.org/goleak"
 )
 
-func VerifyNoLeak(t testing.TB) {
+func VerifyNoLeak(t testing.TB, extraOpts ...goleak.Option) {
 	// Run it as a cleanup function so that "last added, first called" ordering execution is guaranteed.
 	t.Cleanup(func() {
-		goleak.VerifyNone(t, goLeakOptions()...)
+		goleak.VerifyNone(t, append(goLeakOptions(), extraOpts...)...)
 	})
 }
 
-func VerifyNoLeakTestMain(m *testing.M) {
-	goleak.VerifyTestMain(m, goLeakOptions()...)
+func VerifyNoLeakTestMain(m *testing.M, extraOpts ...goleak.Option) {
+	goleak.VerifyTestMain(m, append(goLeakOptions(), extraOpts...)...)
 }
 
 func goLeakOptions() []goleak.Option {


### PR DESCRIPTION
#### What this PR does

When a tenant has bad config in the store and no prior running alertmanager, we start a new one and try to apply the bad config to it. When the apply fails, we forget to shut down the alertmanager we just started.

This means we leak an alertmanager every time we sync that user's config.

There is a check for config correctness earlier on when syncing configs, but it is only a partial check - for example, it does not check templates - so it is easily bypassed (nor should we trust it). This PR fixes the leak directly.

#### Which issue(s) this PR fixes or relates to

Contrib https://github.com/grafana/mimir/issues/73

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
