### PR TITLE
Run `skopeo` via docker in integration test jobs (#8355)

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -346,7 +346,9 @@ jobs:
         run: |
           export IMAGE_TAG=$(make image-tag)
           # skopeo will by default load system-specific version of the image (linux/amd64).
-          skopeo copy oci-archive:/tmp/images/mimirtool.oci "docker-daemon:grafana/mimirtool:$IMAGE_TAG"
+          # note that this doesn't use skopeo version from our build-image, because we don't use build-image when running integration tests.
+          # that's why we use docker run to run latest version.
+          docker run -v /tmp/images:/tmp/images -v /var/run/docker.sock:/var/run/docker.sock quay.io/skopeo/stable:v1.15.1 copy oci-archive:/tmp/images/mimirtool.oci "docker-daemon:grafana/mimirtool:$IMAGE_TAG"
       - name: Download Archive with Docker Images
         uses: actions/download-artifact@v4
         with:
@@ -419,7 +421,9 @@ jobs:
         run: |
           export IMAGE_TAG=$(make image-tag)
           # skopeo will by default load system-specific version of the image (linux/amd64).
-          skopeo copy oci-archive:/tmp/images/mimirtool.oci "docker-daemon:grafana/mimirtool:$IMAGE_TAG"
+          # note that this doesn't use skopeo version from our build-image, because we don't use build-image when running integration tests.
+          # that's why we use docker run to run latest version.
+          docker run -v /tmp/images:/tmp/images -v /var/run/docker.sock:/var/run/docker.sock quay.io/skopeo/stable:v1.15.1 copy oci-archive:/tmp/images/mimirtool.oci "docker-daemon:grafana/mimirtool:$IMAGE_TAG"
       - name: Download Archive with Docker Images
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
* run skopeo via docker in integration tests.

Signed-off-by: Peter Štibraný <pstibrany@gmail.com>

* Use fixed version.

Signed-off-by: Peter Štibraný <pstibrany@gmail.com>

* Add /tmp volume and path to docker.sock.

Signed-off-by: Peter Štibraný <pstibrany@gmail.com>

* Only map /tmp/images.

Signed-off-by: Peter Štibraný <pstibrany@gmail.com>

---------

Signed-off-by: Peter Štibraný <pstibrany@gmail.com>
(cherry picked from commit 24ae27e41b91f2091f2f6c11744d407ad80ab663)

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
