### PR TITLE
Make continuous-test writes hash more uniformly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@
 * [ENHANCEMENT] Include human-friendly timestamps in diffs logged when a test fails. #8630
 * [ENHANCEMENT] Add histograms to measure latency of read and write requests. #8583
 * [ENHANCEMENT] Log successful test runs in addition to failed test runs. #8817
+* [ENHANCEMENT] Series emitted by continuous-test now distribute more uniformly across ingesters. #9218
 * [BUGFIX] Initialize test result metrics to 0 at startup so that alerts can correctly identify the first failure after startup. #8630
 
 ### Query-tee

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -23,6 +23,9 @@ const (
 
 	floatMetricName = "mimir_continuous_test_sine_wave_v2"
 	floatTypeLabel  = "float"
+
+	// A prime factor to generate series IDs that hash more uniformly.
+	seriesFactor = 2689
 )
 
 type generateHistogramFunc func(t time.Time) prompb.Histogram
@@ -234,7 +237,7 @@ func generateSineWaveSeries(name string, t time.Time, numSeries int) []prompb.Ti
 				Value: name,
 			}, {
 				Name:  "series_id",
-				Value: strconv.Itoa(i),
+				Value: fmt.Sprintf("%x", i*seriesFactor),
 			}},
 			Samples: []prompb.Sample{{
 				Value:     value,
@@ -256,7 +259,7 @@ func generateHistogramSeriesInner(name string, t time.Time, numSeries int, histo
 				Value: name,
 			}, {
 				Name:  "series_id",
-				Value: strconv.Itoa(i),
+				Value: fmt.Sprintf("%x", i*seriesFactor),
 			}},
 			Histograms: []prompb.Histogram{histogramGenerator(t)},
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This adds more fluctuation to the byte contents of the the labels emitted by continuous-test, because if the only difference in the labels is a monotonically increasing integer, the resulting tokens are poorly distributed.

Histogram of 10K hashes before:
<img width="798" alt="image" src="https://github.com/user-attachments/assets/c341c7c1-f233-4ec0-9280-7a082355fcd0">

and after:
<img width="797" alt="image" src="https://github.com/user-attachments/assets/8410c706-b5cd-4055-bb03-21d82f1470af">


#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
