### PR TITLE
Query Scheduler: Enable Querier-Worker Queue Priority Algorithm with prioritize-query-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 * [ENHANCEMENT] Add a new field, `encode_time_seconds` to query stats log messages, to record the amount of time it takes the query-frontend to encode a response. This does not include any serialization time for downstream components. #9062
 * [ENHANCEMENT] OTLP: If the flag `-distributor.otel-created-timestamp-zero-ingestion-enabled` is true, OTel start timestamps are converted to Prometheus zero samples to mark series start. #9131
 * [ENHANCEMENT] Querier: attach logs emitted during query consistency check to trace span for query. #9213
+* [ENHANCEMENT] Query-scheduler: experimental `-query-scheduler.prioritize-query-components` flag enables the querier-worker queue priority algorithm to take precedence over tenant rotation when dequeuing requests. #9220
 * [BUGFIX] Ruler: add support for draining any outstanding alert notifications before shutting down. This can be enabled with the `-ruler.drain-notification-queue-on-shutdown=true` CLI flag. #8346
 * [BUGFIX] Query-frontend: fix `-querier.max-query-lookback` enforcement when `-compactor.blocks-retention-period` is not set, and viceversa. #8388
 * [BUGFIX] Ingester: fix sporadic `not found` error causing an internal server error if label names are queried with matchers during head compaction. #8391

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@
 * [ENHANCEMENT] Add a new field, `encode_time_seconds` to query stats log messages, to record the amount of time it takes the query-frontend to encode a response. This does not include any serialization time for downstream components. #9062
 * [ENHANCEMENT] OTLP: If the flag `-distributor.otel-created-timestamp-zero-ingestion-enabled` is true, OTel start timestamps are converted to Prometheus zero samples to mark series start. #9131
 * [ENHANCEMENT] Querier: attach logs emitted during query consistency check to trace span for query. #9213
-* [ENHANCEMENT] Query-scheduler: experimental `-query-scheduler.prioritize-query-components` flag enables the querier-worker queue priority algorithm to take precedence over tenant rotation when dequeuing requests. #9220
+* [ENHANCEMENT] Query-scheduler: Experimental `-query-scheduler.prioritize-query-components` flag enables the querier-worker queue priority algorithm to take precedence over tenant rotation when dequeuing requests. #9220
 * [BUGFIX] Ruler: add support for draining any outstanding alert notifications before shutting down. This can be enabled with the `-ruler.drain-notification-queue-on-shutdown=true` CLI flag. #8346
 * [BUGFIX] Query-frontend: fix `-querier.max-query-lookback` enforcement when `-compactor.blocks-retention-period` is not set, and viceversa. #8388
 * [BUGFIX] Ingester: fix sporadic `not found` error causing an internal server error if label names are queried with matchers during head compaction. #8391

--- a/pkg/scheduler/queue/query_component_utilization.go
+++ b/pkg/scheduler/queue/query_component_utilization.go
@@ -15,12 +15,6 @@ const (
 	Ingester     QueryComponent = "ingester"
 )
 
-// cannot import constants from frontend/v2 due to import cycle
-// these are attached to the request's AdditionalQueueDimensions by the frontend.
-const ingesterQueueDimension = "ingester"
-const storeGatewayQueueDimension = "store-gateway"
-const ingesterAndStoreGatewayQueueDimension = "ingester-and-store-gateway"
-
 // queryComponentFlags interprets annotations by the frontend for the expected query component,
 // and flags whether a query request is expected to be served by the ingesters, store-gateways, or both.
 func queryComponentFlags(queryComponentName string) (isIngester, isStoreGateway bool) {

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -240,7 +240,7 @@ type requestToEnqueue struct {
 func NewRequestQueue(
 	log log.Logger,
 	maxOutstandingPerTenant int,
-	_ bool, //prioritizeQueryComponents
+	prioritizeQueryComponents bool,
 	forgetDelay time.Duration,
 	queueLength *prometheus.GaugeVec,
 	discardedRequests *prometheus.CounterVec,
@@ -276,7 +276,7 @@ func NewRequestQueue(
 		waitingDequeueRequestsToDispatch: list.New(),
 
 		QueryComponentUtilization: queryComponentCapacity,
-		queueBroker:               newQueueBroker(maxOutstandingPerTenant, false, forgetDelay),
+		queueBroker:               newQueueBroker(maxOutstandingPerTenant, prioritizeQueryComponents, forgetDelay),
 	}
 
 	q.Service = services.NewBasicService(q.starting, q.running, q.stop).WithName("request queue")

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -13,7 +13,13 @@ import (
 type TenantID string
 
 const emptyTenantID = TenantID("")
-const unknownQueueDimension = "unknown"
+
+// cannot import constants from frontend/v2 due to import cycle
+// these are attached to the request's AdditionalQueueDimensions by the frontend.
+const ingesterQueueDimension = "ingester"
+const storeGatewayQueueDimension = "store-gateway"
+const ingesterAndStoreGatewayQueueDimension = "ingester-and-store-gateway"
+const unknownQueueDimension = "unknown" // utilized when AdditionalQueueDimensions is not assigned by the frontend
 
 type QuerierID string
 

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -50,16 +50,16 @@ func newQueueBroker(
 	var algos []QueuingAlgorithm
 	if prioritizeQueryComponents {
 		algos = []QueuingAlgorithm{
-			&roundRobinState{}, // root; QueuingAlgorithm selects query component
-			tqas,               // query components; QueuingAlgorithm selects tenants
-			&roundRobinState{}, // tenant queues; QueuingAlgorithm selects from local queue
+			NewQuerierWorkerQueuePriorityAlgo(), // root; algorithm selects query component based on worker ID
+			tqas,                                // query components; algorithm selects tenants
+			&roundRobinState{},                  // tenant queues; algorithm selects query from local queue
 
 		}
 	} else {
 		algos = []QueuingAlgorithm{
-			tqas,               // root; QueuingAlgorithm selects tenants
-			&roundRobinState{}, // tenant queues; QueuingAlgorithm selects query component
-			&roundRobinState{}, // query components; QueuingAlgorithm selects query from local queue
+			tqas,               // root; algorithm selects tenants
+			&roundRobinState{}, // tenant queues; algorithm selects query component
+			&roundRobinState{}, // query components; algorithm selects query from local queue
 		}
 	}
 	tree, err = NewTree(algos...)


### PR DESCRIPTION
### What this PR does

This PR allows the `-query-scheduler.prioritize-query-components` flag to utilize the querier-worker queue priority algorithm at the root of the scheduler's tree queue. It does not enable it by default as the flag remains default false.

This follows various benchmark and profiling tests to ensure that the algorithm solves the desired issue and that we have not introduced any performance issues.

### Benchmarks for Algorithm's Effectiveness
Our measure of success for this new queueing algorithm has been to keep moving queries to ingesters when the store-gateways experience a slowdown.
This has been simulated and compared between old and new queuing algorithms both in a Go benchmark unit test and in the docker-compose Mimir microservices mode dev environment.

#### Benchmark Unit Test: `TestMultiDimensionalQueueAlgorithmSlowConsumerEffects`
This was covered extensively in [PR 9013](https://github.com/grafana/mimir/pull/9013) and some benchmark results are included on the commit message for [46586430](https://github.com/grafana/mimir/commit/4658643059e2327cbc9381c25b001dce0da5f6a5).

We created an artificial slowdown for queries to store-gateways, and measure the ability to continue servicing ingester queries from the queue despite the backup in store-gateways. The benchmark scenarios use a range of single and multi-tenant scenarios with varying traffic profiles.
This was compared across 3 tree queue & algorithm configurations.
1. the original tree queue, whose hierarchy selected from a tenant round-robin, then a query component round robin
2. the new tree queue, which inverted the hierarchy to prioritize the query component round robin before tenant selection
3. the new tree queue with the inverted hierarchy, but with the querier-worker queue priority algorithm replacing the vanilla query component round robin as the first layer of queue selection.
    1. this is the configuration being enabled in this PR

The results showed the new algorithm (number 3)  massively outperforming the other two options, as measured by mean time in queue for ingester queries - a 30-50x improvement in most scenarios.

<details>

<summary>

**Results by Query Component**

</summary>

```
tree: tenant-querier -> query component round-robin tree, 1 tenant, 10pct slow queries: seconds in queue: [ingester: mean: 0.1050 stddev: 0.02 store-gateway: mean: 0.0148 stddev: 0.03]
tree: query component round-robin -> tenant-querier tree, 1 tenant, 10pct slow queries: seconds in queue: [ingester: mean: 0.1047 stddev: 0.02 store-gateway: mean: 0.0129 stddev: 0.03]
tree: worker-queue prioritization -> tenant-querier tree, 1 tenant, 10pct slow queries: seconds in queue: [ingester: mean: 0.0186 stddev: 0.01 store-gateway: mean: 0.0321 stddev: 0.04]
tree: tenant-querier -> query component round-robin tree, 1 tenant, 25pct slow queries: seconds in queue: [ingester: mean: 0.2734 stddev: 0.08 store-gateway: mean: 0.1101 stddev: 0.09]
tree: query component round-robin -> tenant-querier tree, 1 tenant, 25pct slow queries: seconds in queue: [ingester: mean: 0.2739 stddev: 0.08 store-gateway: mean: 0.1175 stddev: 0.09]
tree: worker-queue prioritization -> tenant-querier tree, 1 tenant, 25pct slow queries: seconds in queue: [ingester: mean: 0.0156 stddev: 0.01 store-gateway: mean: 0.1359 stddev: 0.10]
tree: tenant-querier -> query component round-robin tree, 1 tenant, 50pct slow queries: seconds in queue: [ingester: mean: 0.3900 stddev: 0.18 store-gateway: mean: 0.2478 stddev: 0.17]
tree: query component round-robin -> tenant-querier tree, 1 tenant, 50pct slow queries: seconds in queue: [ingester: mean: 0.3918 stddev: 0.18 store-gateway: mean: 0.2509 stddev: 0.17]
tree: worker-queue prioritization -> tenant-querier tree, 1 tenant, 50pct slow queries: seconds in queue: [ingester: mean: 0.0099 stddev: 0.00 store-gateway: mean: 0.2787 stddev: 0.18]
tree: tenant-querier -> query component round-robin tree, 1 tenant, 75pct slow queries: seconds in queue: [ingester: mean: 0.2567 stddev: 0.17 store-gateway: mean: 0.4013 stddev: 0.26]
tree: query component round-robin -> tenant-querier tree, 1 tenant, 75pct slow queries: seconds in queue: [ingester: mean: 0.2415 stddev: 0.17 store-gateway: mean: 0.4099 stddev: 0.26]
tree: worker-queue prioritization -> tenant-querier tree, 1 tenant, 75pct slow queries: seconds in queue: [ingester: mean: 0.0055 stddev: 0.00 store-gateway: mean: 0.4117 stddev: 0.26]
tree: tenant-querier -> query component round-robin tree, 1 tenant, 90pct slow queries: seconds in queue: [ingester: mean: 0.0899 stddev: 0.08 store-gateway: mean: 0.4847 stddev: 0.31]
tree: query component round-robin -> tenant-querier tree, 1 tenant, 90pct slow queries: seconds in queue: [ingester: mean: 0.0622 stddev: 0.06 store-gateway: mean: 0.4969 stddev: 0.31]
tree: worker-queue prioritization -> tenant-querier tree, 1 tenant, 90pct slow queries: seconds in queue: [ingester: mean: 0.0025 stddev: 0.00 store-gateway: mean: 0.4956 stddev: 0.31]
tree: tenant-querier -> query component round-robin tree, 2 tenants, first with 10pct slow queries, second with 90pct slow queries: seconds in queue: [ingester: mean: 0.0383 stddev: 0.03 store-gateway: mean: 0.2466 stddev: 0.17]
tree: query component round-robin -> tenant-querier tree, 2 tenants, first with 10pct slow queries, second with 90pct slow queries: seconds in queue: [ingester: mean: 0.1132 stddev: 0.04 store-gateway: mean: 0.2340 stddev: 0.17]
tree: worker-queue prioritization -> tenant-querier tree, 2 tenants, first with 10pct slow queries, second with 90pct slow queries: seconds in queue: [ingester: mean: 0.0103 stddev: 0.01 store-gateway: mean: 0.2426 stddev: 0.17]
tree: tenant-querier -> query component round-robin tree, 2 tenants, first with 25pct slow queries, second with 75pct slow queries: seconds in queue: [ingester: mean: 0.1922 stddev: 0.08 store-gateway: mean: 0.2323 stddev: 0.17]
tree: query component round-robin -> tenant-querier tree, 2 tenants, first with 25pct slow queries, second with 75pct slow queries: seconds in queue: [ingester: mean: 0.2283 stddev: 0.10 store-gateway: mean: 0.2214 stddev: 0.16]
tree: worker-queue prioritization -> tenant-querier tree, 2 tenants, first with 25pct slow queries, second with 75pct slow queries: seconds in queue: [ingester: mean: 0.0095 stddev: 0.00 store-gateway: mean: 0.2462 stddev: 0.17]
tree: tenant-querier -> query component round-robin tree, 2 tenants, first with 50pct slow queries, second with 50pct slow queries: seconds in queue: [ingester: mean: 0.3366 stddev: 0.17 store-gateway: mean: 0.2185 stddev: 0.15]
tree: query component round-robin -> tenant-querier tree, 2 tenants, first with 50pct slow queries, second with 50pct slow queries: seconds in queue: [ingester: mean: 0.3575 stddev: 0.18 store-gateway: mean: 0.2254 stddev: 0.16]
tree: worker-queue prioritization -> tenant-querier tree, 2 tenants, first with 50pct slow queries, second with 50pct slow queries: seconds in queue: [ingester: mean: 0.0096 stddev: 0.00 store-gateway: mean: 0.2211 stddev: 0.15]
```

</details>

<details>

<summary>

**Results for Ingester-Only Queries by Tenant ID**

</summary>

```
tree: tenant-querier -> query component round-robin tree, 1 tenant, 10pct slow queries: seconds in queue:[tenant-0: mean: 0.1050 stddev: 0.02]
tree: query component round-robin -> tenant-querier tree, 1 tenant, 10pct slow queries: seconds in queue:[tenant-0: mean: 0.1047 stddev: 0.02]
tree: worker-queue prioritization -> tenant-querier tree, 1 tenant, 10pct slow queries: seconds in queue:[tenant-0: mean: 0.0186 stddev: 0.01]
tree: tenant-querier -> query component round-robin tree, 1 tenant, 25pct slow queries: seconds in queue:[tenant-0: mean: 0.2734 stddev: 0.08]
tree: query component round-robin -> tenant-querier tree, 1 tenant, 25pct slow queries: seconds in queue:[tenant-0: mean: 0.2739 stddev: 0.08]
tree: worker-queue prioritization -> tenant-querier tree, 1 tenant, 25pct slow queries: seconds in queue:[tenant-0: mean: 0.0156 stddev: 0.01]
tree: tenant-querier -> query component round-robin tree, 1 tenant, 50pct slow queries: seconds in queue:[tenant-0: mean: 0.3900 stddev: 0.18]
tree: query component round-robin -> tenant-querier tree, 1 tenant, 50pct slow queries: seconds in queue:[tenant-0: mean: 0.3918 stddev: 0.18]
tree: worker-queue prioritization -> tenant-querier tree, 1 tenant, 50pct slow queries: seconds in queue:[tenant-0: mean: 0.0099 stddev: 0.00]
tree: tenant-querier -> query component round-robin tree, 1 tenant, 75pct slow queries: seconds in queue:[tenant-0: mean: 0.2567 stddev: 0.17]
tree: query component round-robin -> tenant-querier tree, 1 tenant, 75pct slow queries: seconds in queue:[tenant-0: mean: 0.2415 stddev: 0.17]
tree: worker-queue prioritization -> tenant-querier tree, 1 tenant, 75pct slow queries: seconds in queue:[tenant-0: mean: 0.0055 stddev: 0.00]
tree: tenant-querier -> query component round-robin tree, 1 tenant, 90pct slow queries: seconds in queue:[tenant-0: mean: 0.0899 stddev: 0.08]
tree: query component round-robin -> tenant-querier tree, 1 tenant, 90pct slow queries: seconds in queue:[tenant-0: mean: 0.0622 stddev: 0.06]
tree: worker-queue prioritization -> tenant-querier tree, 1 tenant, 90pct slow queries: seconds in queue:[tenant-0: mean: 0.0025 stddev: 0.00]
tree: tenant-querier -> query component round-robin tree, 2 tenants, first with 10pct slow queries, second with 90pct slow queries: seconds in queue:[tenant-0: mean: 0.0363 stddev: 0.02 tenant-1: mean: 0.0579 stddev: 0.05]
tree: query component round-robin -> tenant-querier tree, 2 tenants, first with 10pct slow queries, second with 90pct slow queries: seconds in queue:[tenant-0: mean: 0.1222 stddev: 0.02 tenant-1: mean: 0.0334 stddev: 0.05]
tree: worker-queue prioritization -> tenant-querier tree, 2 tenants, first with 10pct slow queries, second with 90pct slow queries: seconds in queue:[tenant-0: mean: 0.0114 stddev: 0.00 tenant-1: mean: 0.0023 stddev: 0.00]
tree: tenant-querier -> query component round-robin tree, 2 tenants, first with 25pct slow queries, second with 75pct slow queries: seconds in queue:[tenant-0: mean: 0.1930 stddev: 0.07 tenant-1: mean: 0.1895 stddev: 0.10]
tree: query component round-robin -> tenant-querier tree, 2 tenants, first with 25pct slow queries, second with 75pct slow queries: seconds in queue:[tenant-0: mean: 0.2391 stddev: 0.07 tenant-1: mean: 0.1945 stddev: 0.16]
tree: worker-queue prioritization -> tenant-querier tree, 2 tenants, first with 25pct slow queries, second with 75pct slow queries: seconds in queue:[tenant-0: mean: 0.0112 stddev: 0.00 tenant-1: mean: 0.0042 stddev: 0.00]
tree: tenant-querier -> query component round-robin tree, 2 tenants, first with 50pct slow queries, second with 50pct slow queries: seconds in queue:[tenant-0: mean: 0.3046 stddev: 0.15 tenant-1: mean: 0.3709 stddev: 0.17]
tree: query component round-robin -> tenant-querier tree, 2 tenants, first with 50pct slow queries, second with 50pct slow queries: seconds in queue:[tenant-0: mean: 0.3543 stddev: 0.19 tenant-1: mean: 0.3610 stddev: 0.18]
tree: worker-queue prioritization -> tenant-querier tree, 2 tenants, first with 50pct slow queries, second with 50pct slow queries: seconds in queue:[tenant-0: mean: 0.0096 stddev: 0.00 tenant-1: mean: 0.0095 stddev: 0.00]
```

</details>

#### Store-Gateway Slowdown Simulation in Mimir Microservices Mode Development Environment
To serve as a more live test, we also hacked up Mimir with a 5-second sleep in the store-gateway's `Series` method  and sent about 100 queries/second split between the ingesters and to the store-gateways. 
We utilized the Mimir dashboards to compare the `tenant round-robin -> query component round robin` configuration with the new `querier worker queue component priority -> tenant round-robin` version.

**Results for Old Tree Configuration & Algorithms**
As expected from the issues we have experienced, the store-gateway slowdown also backs up the ingester-only queries in the queue and results in all kinds of queries timing out in the queue.
![Screenshot from 2024-08-30 14-23-28](https://github.com/user-attachments/assets/ecbad627-4dce-4400-9e0e-d97de9c7d505)

**Results for New Tree Configuration & Querier-Worker Queue Priority Algorithm**
The new configuration resulted in the queue duration for ingester-only queries staying completely independent of the backed-up queue of store-gateway queries, and zero query timeouts for ingester-only queries.
![Screenshot from 2024-08-30 14-06-36](https://github.com/user-attachments/assets/26777288-0f64-47fd-a0c6-428c0dfd13d4)

### Profiling for CPU & Memory Usage
This was tested by scaling up ingesters & queriers in a dev environment so that they would not serve as a bottleneck, and sending ~12k requests/second of all low-to medium cardinality ingester queries.
We compared the `tenant round-robin -> query component round robin` configuration with the new `querier worker queue component priority -> tenant round-robin` version to ensure we did introduce any unexpected resource usage with the new algorithms and configuration.

**Results**
Profiling for high throughput shows absolutely no overall difference in CPU or memory usage when we turn on the querier-worker-priority queue algorithm. We actually got **~2% less CPU time in the `dispatcherLoop`** code which the part that has changed and what we care to measure.
Improvement in `dispatcherLoop` was offset by unrelated usage that came setting up gRPC connections and middleware during querier-scheduler connection churn from automated scaling during the comparison test phase.
![image](https://github.com/user-attachments/assets/478832d4-8717-44a9-ad35-fbc12863a491)

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
