### PR TITLE
Fix issue where both recently compacted blocks and their source blocks can be skipped during querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 * [BUGFIX] Querier: Support optional start and end times on `/prometheus/api/v1/labels`, `/prometheus/api/v1/label/<label>/values`, and `/prometheus/api/v1/series` when `max_query_into_future: 0`. #9129
 * [BUGFIX] Alertmanager: Fix config validation gap around unreferenced templates. #9207
 * [BUGFIX] Alertmanager: Fix goroutine leak when stored config fails to apply and there is no existing tenant alertmanager #9211
+* [BUGFIX] Querier: fix issue where both recently compacted blocks and their source blocks can be skipped during querying if store-gateways are restarting. #9224
 
 ### Mixin
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -9294,6 +9294,17 @@
               "fieldCategory": "advanced"
             },
             {
+              "kind": "field",
+              "name": "ignore_deletion_mark_while_querying_delay",
+              "required": false,
+              "desc": "Duration after which blocks marked for deletion will still be queried. This ensures queriers still query blocks that are meant to be deleted but do not have a replacement yet.",
+              "fieldValue": null,
+              "fieldDefaultValue": 3000000000000,
+              "fieldFlag": "blocks-storage.bucket-store.ignore-deletion-marks-while-querying-delay",
+              "fieldType": "duration",
+              "fieldCategory": "advanced"
+            },
+            {
               "kind": "block",
               "name": "bucket_index",
               "required": false,

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -9302,7 +9302,7 @@
               "fieldDefaultValue": 3000000000000,
               "fieldFlag": "blocks-storage.bucket-store.ignore-deletion-marks-while-querying-delay",
               "fieldType": "duration",
-              "fieldCategory": "advanced"
+              "fieldCategory": "experimental"
             },
             {
               "kind": "block",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -441,6 +441,8 @@ Usage of ./cmd/mimir/mimir:
     	Blocks with minimum time within this duration are ignored, and not loaded by store-gateway. Useful when used together with -querier.query-store-after to prevent loading young blocks, because there are usually many of them (depending on number of ingesters) and they are not yet compacted. Negative values or 0 disable the filter. (default 10h0m0s)
   -blocks-storage.bucket-store.ignore-deletion-marks-delay duration
     	Duration after which the blocks marked for deletion will be filtered out while fetching blocks. The idea of ignore-deletion-marks-delay is to ignore blocks that are marked for deletion with some delay. This ensures store can still serve blocks that are meant to be deleted but do not have a replacement yet. (default 1h0m0s)
+  -blocks-storage.bucket-store.ignore-deletion-marks-while-querying-delay duration
+    	Duration after which blocks marked for deletion will still be queried. This ensures queriers still query blocks that are meant to be deleted but do not have a replacement yet. (default 50m0s)
   -blocks-storage.bucket-store.index-cache.backend string
     	The index cache backend type. Supported values: inmemory, memcached, redis. (default "inmemory")
   -blocks-storage.bucket-store.index-cache.inmemory.max-size-bytes uint

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -442,7 +442,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.bucket-store.ignore-deletion-marks-delay duration
     	Duration after which the blocks marked for deletion will be filtered out while fetching blocks. The idea of ignore-deletion-marks-delay is to ignore blocks that are marked for deletion with some delay. This ensures store can still serve blocks that are meant to be deleted but do not have a replacement yet. (default 1h0m0s)
   -blocks-storage.bucket-store.ignore-deletion-marks-while-querying-delay duration
-    	Duration after which blocks marked for deletion will still be queried. This ensures queriers still query blocks that are meant to be deleted but do not have a replacement yet. (default 50m0s)
+    	[experimental] Duration after which blocks marked for deletion will still be queried. This ensures queriers still query blocks that are meant to be deleted but do not have a replacement yet. (default 50m0s)
   -blocks-storage.bucket-store.index-cache.backend string
     	The index cache backend type. Supported values: inmemory, memcached, redis. (default "inmemory")
   -blocks-storage.bucket-store.index-cache.inmemory.max-size-bytes uint

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -149,6 +149,7 @@ The following features are currently experimental:
   - Allow streaming of `/active_series` responses to the frontend (`-querier.response-streaming-enabled`)
   - Mimir query engine (`-querier.query-engine=mimir` and `-querier.enable-query-engine-fallback`, and all flags beginning with `-querier.mimir-query-engine`)
   - Maximum estimated memory consumption per query limit (`-querier.max-estimated-memory-consumption-per-query`)
+  - Ignore deletion marks while querying delay (`-blocks-storage.bucket-store.ignore-deletion-marks-while-querying-delay`)
 - Query-frontend
   - `-query-frontend.querier-forget-delay`
   - Instant query splitting (`-query-frontend.split-instant-queries-by-interval`)

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4071,7 +4071,7 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.ignore-deletion-marks-delay
   [ignore_deletion_mark_delay: <duration> | default = 1h]
 
-  # (advanced) Duration after which blocks marked for deletion will still be
+  # (experimental) Duration after which blocks marked for deletion will still be
   # queried. This ensures queriers still query blocks that are meant to be
   # deleted but do not have a replacement yet.
   # CLI flag: -blocks-storage.bucket-store.ignore-deletion-marks-while-querying-delay

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4071,6 +4071,12 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.ignore-deletion-marks-delay
   [ignore_deletion_mark_delay: <duration> | default = 1h]
 
+  # (advanced) Duration after which blocks marked for deletion will still be
+  # queried. This ensures queriers still query blocks that are meant to be
+  # deleted but do not have a replacement yet.
+  # CLI flag: -blocks-storage.bucket-store.ignore-deletion-marks-while-querying-delay
+  [ignore_deletion_mark_while_querying_delay: <duration> | default = 50m]
+
   bucket_index:
     # (advanced) How frequently a bucket index, which previously failed to load,
     # should be tried to load again. This option is used only by querier.

--- a/pkg/querier/blocks_consistency_checker.go
+++ b/pkg/querier/blocks_consistency_checker.go
@@ -18,17 +18,15 @@ import (
 )
 
 type BlocksConsistency struct {
-	uploadGracePeriod   time.Duration
-	deletionGracePeriod time.Duration
+	uploadGracePeriod time.Duration
 
 	checksTotal  prometheus.Counter
 	checksFailed prometheus.Counter
 }
 
-func NewBlocksConsistency(uploadGracePeriod, deletionGracePeriod time.Duration, reg prometheus.Registerer) *BlocksConsistency {
+func NewBlocksConsistency(uploadGracePeriod time.Duration, reg prometheus.Registerer) *BlocksConsistency {
 	return &BlocksConsistency{
-		uploadGracePeriod:   uploadGracePeriod,
-		deletionGracePeriod: deletionGracePeriod,
+		uploadGracePeriod: uploadGracePeriod,
 		checksTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_querier_blocks_consistency_checks_total",
 			Help: "Total number of queries that needed to run with consistency checks. A consistency check is required when querying blocks from store-gateways to make sure that all blocks are queried.",
@@ -42,7 +40,7 @@ func NewBlocksConsistency(uploadGracePeriod, deletionGracePeriod time.Duration, 
 
 // NewTracker creates a consistency tracker from the known blocks. It filters out any block uploaded within uploadGracePeriod
 // and with a deletion mark within deletionGracePeriod.
-func (c *BlocksConsistency) NewTracker(knownBlocks bucketindex.Blocks, knownDeletionMarks map[ulid.ULID]*bucketindex.BlockDeletionMark, logger log.Logger) BlocksConsistencyTracker {
+func (c *BlocksConsistency) NewTracker(knownBlocks bucketindex.Blocks, logger log.Logger) BlocksConsistencyTracker {
 	blocksToTrack := make(map[ulid.ULID]struct{}, len(knownBlocks))
 	for _, block := range knownBlocks {
 		// Some recently uploaded blocks, already discovered by the querier, may not have been discovered
@@ -53,22 +51,10 @@ func (c *BlocksConsistency) NewTracker(knownBlocks bucketindex.Blocks, knownDele
 		// - Blocks uploaded by compactor: the source blocks are marked for deletion but will continue to be
 		//   queried by queriers for a while (depends on the configured deletion marks delay).
 		if c.uploadGracePeriod > 0 && time.Since(block.GetUploadedAt()) < c.uploadGracePeriod {
-			level.Debug(logger).Log("msg", "block skipped from consistency check because it was uploaded recently", "block", block.ID.String(), "uploadedAt", block.GetUploadedAt().String())
+			level.Debug(logger).Log("msg", "block skipped from consistency check because it was uploaded recently; block will be queried at most once but not retried and failures will not cause the query to fail", "block", block.ID.String(), "uploadedAt", block.GetUploadedAt().String())
 			continue
 		}
 
-		// The store-gateway may offload blocks before the querier. If that happens, the querier will run a consistency check
-		// on blocks that can't be queried because they were offloaded. For this reason, we don't run the consistency check on any block
-		// which has been marked for deletion more then "grace period" time ago. Basically, the grace period is the time
-		// we still expect a block marked for deletion to be still queried.
-		if mark := knownDeletionMarks[block.ID]; mark != nil {
-			deletionTime := time.Unix(mark.DeletionTime, 0)
-
-			if c.deletionGracePeriod > 0 && time.Since(deletionTime) > c.deletionGracePeriod {
-				level.Debug(logger).Log("msg", "block skipped from consistency check because it is marked for deletion", "block", block.ID.String(), "deletionTime", deletionTime.String())
-				continue
-			}
-		}
 		blocksToTrack[block.ID] = struct{}{}
 	}
 

--- a/pkg/querier/blocks_consistency_checker_test.go
+++ b/pkg/querier/blocks_consistency_checker_test.go
@@ -22,7 +22,6 @@ import (
 func TestBlocksConsistencyTracker_Check(t *testing.T) {
 	now := time.Now()
 	uploadGracePeriod := 10 * time.Minute
-	deletionGracePeriod := 5 * time.Minute
 
 	block1 := ulid.MustNew(uint64(util.TimeToMillis(now.Add(-uploadGracePeriod*2))), nil)
 	block2 := ulid.MustNew(uint64(util.TimeToMillis(now.Add(-uploadGracePeriod*3))), nil)
@@ -30,38 +29,33 @@ func TestBlocksConsistencyTracker_Check(t *testing.T) {
 
 	tests := map[string]struct {
 		knownBlocks           bucketindex.Blocks
-		knownDeletionMarks    map[ulid.ULID]*bucketindex.BlockDeletionMark
 		queriedBlocks         [][]ulid.ULID
 		expectedMissingBlocks []ulid.ULID
 	}{
 		"no known blocks": {
-			knownBlocks:        bucketindex.Blocks{},
-			knownDeletionMarks: map[ulid.ULID]*bucketindex.BlockDeletionMark{},
-			queriedBlocks:      [][]ulid.ULID{{}},
+			knownBlocks:   bucketindex.Blocks{},
+			queriedBlocks: [][]ulid.ULID{{}},
 		},
 		"all known blocks have been queried from a single store-gateway": {
 			knownBlocks: bucketindex.Blocks{
 				{ID: block1, UploadedAt: now.Add(-time.Hour).Unix()},
 				{ID: block2, UploadedAt: now.Add(-time.Hour).Unix()},
 			},
-			knownDeletionMarks: map[ulid.ULID]*bucketindex.BlockDeletionMark{},
-			queriedBlocks:      [][]ulid.ULID{{block1, block2}},
+			queriedBlocks: [][]ulid.ULID{{block1, block2}},
 		},
 		"all known blocks have been queried from multiple store-gateway": {
 			knownBlocks: bucketindex.Blocks{
 				{ID: block1, UploadedAt: now.Add(-time.Hour).Unix()},
 				{ID: block2, UploadedAt: now.Add(-time.Hour).Unix()},
 			},
-			knownDeletionMarks: map[ulid.ULID]*bucketindex.BlockDeletionMark{},
-			queriedBlocks:      [][]ulid.ULID{{block1, block2}},
+			queriedBlocks: [][]ulid.ULID{{block1, block2}},
 		},
 		"store-gateway has queried more blocks than expected": {
 			knownBlocks: bucketindex.Blocks{
 				{ID: block1, UploadedAt: now.Add(-time.Hour).Unix()},
 				{ID: block2, UploadedAt: now.Add(-time.Hour).Unix()},
 			},
-			knownDeletionMarks: map[ulid.ULID]*bucketindex.BlockDeletionMark{},
-			queriedBlocks:      [][]ulid.ULID{{block1, block2, block3}},
+			queriedBlocks: [][]ulid.ULID{{block1, block2, block3}},
 		},
 		"store-gateway has queried less blocks than expected": {
 			knownBlocks: bucketindex.Blocks{
@@ -69,7 +63,6 @@ func TestBlocksConsistencyTracker_Check(t *testing.T) {
 				{ID: block2, UploadedAt: now.Add(-time.Hour).Unix()},
 				{ID: block3, UploadedAt: now.Add(-time.Hour).Unix()},
 			},
-			knownDeletionMarks:    map[ulid.ULID]*bucketindex.BlockDeletionMark{},
 			queriedBlocks:         [][]ulid.ULID{{block1, block3}},
 			expectedMissingBlocks: []ulid.ULID{block2},
 		},
@@ -79,30 +72,6 @@ func TestBlocksConsistencyTracker_Check(t *testing.T) {
 				{ID: block2, UploadedAt: now.Add(-time.Hour).Unix()},
 				{ID: block3, UploadedAt: now.Add(-uploadGracePeriod).Add(time.Minute).Unix()},
 			},
-			knownDeletionMarks: map[ulid.ULID]*bucketindex.BlockDeletionMark{},
-			queriedBlocks:      [][]ulid.ULID{{block1, block2}},
-		},
-		"store-gateway has queried less blocks than expected and the missing block has been recently marked for deletion": {
-			knownBlocks: bucketindex.Blocks{
-				{ID: block1, UploadedAt: now.Add(-time.Hour).Unix()},
-				{ID: block2, UploadedAt: now.Add(-time.Hour).Unix()},
-				{ID: block3, UploadedAt: now.Add(-time.Hour).Unix()},
-			},
-			knownDeletionMarks: map[ulid.ULID]*bucketindex.BlockDeletionMark{
-				block3: {DeletionTime: now.Add(-deletionGracePeriod / 2).Unix()},
-			},
-			queriedBlocks:         [][]ulid.ULID{{block1, block2}},
-			expectedMissingBlocks: []ulid.ULID{block3},
-		},
-		"store-gateway has queried less blocks than expected and the missing block has been marked for deletion long time ago": {
-			knownBlocks: bucketindex.Blocks{
-				{ID: block1, UploadedAt: now.Add(-time.Hour).Unix()},
-				{ID: block2, UploadedAt: now.Add(-time.Hour).Unix()},
-				{ID: block3, UploadedAt: now.Add(-time.Hour).Unix()},
-			},
-			knownDeletionMarks: map[ulid.ULID]*bucketindex.BlockDeletionMark{
-				block3: {DeletionTime: now.Add(-deletionGracePeriod * 2).Unix()},
-			},
 			queriedBlocks: [][]ulid.ULID{{block1, block2}},
 		},
 		"blocks are queried in multiple attempts": {
@@ -110,24 +79,22 @@ func TestBlocksConsistencyTracker_Check(t *testing.T) {
 				{ID: block1, UploadedAt: now.Add(-time.Hour).Unix()},
 				{ID: block2, UploadedAt: now.Add(-time.Hour).Unix()},
 			},
-			knownDeletionMarks: map[ulid.ULID]*bucketindex.BlockDeletionMark{},
-			queriedBlocks:      [][]ulid.ULID{{block1}, {block2}},
+			queriedBlocks: [][]ulid.ULID{{block1}, {block2}},
 		},
 		"querying the same block again doesn't fail the consistency check": {
 			knownBlocks: bucketindex.Blocks{
 				{ID: block1, UploadedAt: now.Add(-time.Hour).Unix()},
 				{ID: block2, UploadedAt: now.Add(-time.Hour).Unix()},
 			},
-			knownDeletionMarks: map[ulid.ULID]*bucketindex.BlockDeletionMark{},
-			queriedBlocks:      [][]ulid.ULID{{block1}, {block1, block2}},
+			queriedBlocks: [][]ulid.ULID{{block1}, {block1, block2}},
 		},
 	}
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
-			c := NewBlocksConsistency(uploadGracePeriod, deletionGracePeriod, reg)
-			tracker := c.NewTracker(testData.knownBlocks, testData.knownDeletionMarks, log.NewNopLogger())
+			c := NewBlocksConsistency(uploadGracePeriod, reg)
+			tracker := c.NewTracker(testData.knownBlocks, log.NewNopLogger())
 			var missingBlocks []ulid.ULID
 			for _, queriedBlocksAttempt := range testData.queriedBlocks {
 				missingBlocks = tracker.Check(queriedBlocksAttempt)

--- a/pkg/querier/blocks_finder_bucket_index.go
+++ b/pkg/querier/blocks_finder_bucket_index.go
@@ -53,12 +53,12 @@ func NewBucketIndexBlocksFinder(cfg BucketIndexBlocksFinderConfig, bkt objstore.
 }
 
 // GetBlocks implements BlocksFinder.
-func (f *BucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID string, minT, maxT int64) (bucketindex.Blocks, map[ulid.ULID]*bucketindex.BlockDeletionMark, error) {
+func (f *BucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID string, minT, maxT int64) (bucketindex.Blocks, error) {
 	if f.State() != services.Running {
-		return nil, nil, errBucketIndexBlocksFinderNotRunning
+		return nil, errBucketIndexBlocksFinderNotRunning
 	}
 	if maxT < minT {
-		return nil, nil, errInvalidBlocksRange
+		return nil, errInvalidBlocksRange
 	}
 
 	// Get the bucket index for this user.
@@ -66,21 +66,18 @@ func (f *BucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID string, 
 	if errors.Is(err, bucketindex.ErrIndexNotFound) {
 		// This is a legit edge case, happening when a new tenant has not shipped blocks to the storage yet
 		// so the bucket index hasn't been created yet.
-		return nil, nil, nil
+		return nil, nil
 	}
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Ensure the bucket index is not too old.
 	if time.Since(idx.GetUpdatedAt()) > f.cfg.MaxStalePeriod {
-		return nil, nil, newBucketIndexTooOldError(idx.GetUpdatedAt(), f.cfg.MaxStalePeriod)
+		return nil, newBucketIndexTooOldError(idx.GetUpdatedAt(), f.cfg.MaxStalePeriod)
 	}
 
-	var (
-		matchingBlocks        = map[ulid.ULID]*bucketindex.Block{}
-		matchingDeletionMarks = map[ulid.ULID]*bucketindex.BlockDeletionMark{}
-	)
+	matchingBlocks := map[ulid.ULID]*bucketindex.Block{}
 
 	// Filter blocks containing samples within the range.
 	for _, block := range idx.Blocks {
@@ -92,18 +89,11 @@ func (f *BucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID string, 
 	}
 
 	for _, mark := range idx.BlockDeletionMarks {
-		// Filter deletion marks by matching blocks only.
-		if _, ok := matchingBlocks[mark.ID]; !ok {
-			continue
-		}
-
 		// Exclude blocks marked for deletion. This is the same logic as Thanos IgnoreDeletionMarkFilter.
 		if time.Since(time.Unix(mark.DeletionTime, 0)).Seconds() > f.cfg.IgnoreDeletionMarksDelay.Seconds() {
 			delete(matchingBlocks, mark.ID)
 			continue
 		}
-
-		matchingDeletionMarks[mark.ID] = mark
 	}
 
 	// Convert matching blocks into a list.
@@ -112,7 +102,7 @@ func (f *BucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID string, 
 		blocks = append(blocks, b)
 	}
 
-	return blocks, matchingDeletionMarks, nil
+	return blocks, nil
 }
 
 func newBucketIndexTooOldError(updatedAt time.Time, maxStalePeriod time.Duration) error {

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -226,7 +226,7 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 			IdleTimeout:           storageCfg.BucketStore.BucketIndex.IdleTimeout,
 		},
 		MaxStalePeriod:           storageCfg.BucketStore.BucketIndex.MaxStalePeriod,
-		IgnoreDeletionMarksDelay: storageCfg.BucketStore.IgnoreDeletionMarksDelay,
+		IgnoreDeletionMarksDelay: storageCfg.BucketStore.IgnoreDeletionMarksInStoreGatewayDelay,
 	}, bucketClient, limits, logger, reg)
 
 	storesRingCfg := gatewayCfg.ShardingRing.ToRingConfig()
@@ -253,11 +253,11 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 	consistency := NewBlocksConsistency(
 		// Exclude blocks which have been recently uploaded, in order to give enough time to store-gateways
 		// to discover and load them (3 times the sync interval).
-		3*storageCfg.BucketStore.SyncInterval,
+		mimir_tsdb.NewBlockDiscoveryDelayMultiplier*storageCfg.BucketStore.SyncInterval,
 		// To avoid any false positive in the consistency check, we do exclude blocks which have been
 		// recently marked for deletion, until the "ignore delay / 2". This means the consistency checker
 		// exclude such blocks about 50% of the time before querier and store-gateway stops querying them.
-		storageCfg.BucketStore.IgnoreDeletionMarksDelay/2,
+		storageCfg.BucketStore.IgnoreDeletionMarksInStoreGatewayDelay/2,
 		reg,
 	)
 

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -1550,7 +1550,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 
 					stores := &blocksStoreSetMock{mockedResponses: storeSetResponses}
 					finder := &blocksFinderMock{}
-					finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(testData.finderResult, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), testData.finderErr)
+					finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(testData.finderResult, testData.finderErr)
 
 					ctx, cancel := context.WithCancel(context.Background())
 					t.Cleanup(cancel)
@@ -1563,7 +1563,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 						maxT:        maxT,
 						finder:      finder,
 						stores:      stores,
-						consistency: NewBlocksConsistency(0, 0, reg),
+						consistency: NewBlocksConsistency(0, reg),
 						logger:      log.NewNopLogger(),
 						metrics:     newBlocksStoreQueryableMetrics(reg),
 						limits:      testData.limits,
@@ -1677,7 +1677,7 @@ func TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhile
 
 		// Mock the blocks finder.
 		finder := &blocksFinderMock{}
-		finder.On("GetBlocks", mock.Anything, tenantID, minT, maxT).Return(bucketindex.Blocks{{ID: block1}}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
+		finder.On("GetBlocks", mock.Anything, tenantID, minT, maxT).Return(bucketindex.Blocks{{ID: block1}}, nil)
 
 		// Create a real gRPC client connecting to the gRPC server we control in this test.
 		clientCfg := grpcclient.Config{}
@@ -1704,7 +1704,7 @@ func TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhile
 			maxT:        maxT,
 			finder:      finder,
 			stores:      stores,
-			consistency: NewBlocksConsistency(0, 0, reg),
+			consistency: NewBlocksConsistency(0, reg),
 			logger:      logger,
 			metrics:     newBlocksStoreQueryableMetrics(reg),
 			limits:      &blocksStoreLimitsMock{},
@@ -1925,14 +1925,14 @@ func TestBlocksStoreQuerier_Select_cancelledContext(t *testing.T) {
 			finder := &blocksFinderMock{}
 			finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
 				{ID: block},
-			}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
+			}, nil)
 
 			q := &blocksStoreQuerier{
 				minT:        minT,
 				maxT:        maxT,
 				finder:      finder,
 				stores:      stores,
-				consistency: NewBlocksConsistency(0, 0, nil),
+				consistency: NewBlocksConsistency(0, nil),
 				logger:      log.NewNopLogger(),
 				metrics:     newBlocksStoreQueryableMetrics(reg),
 				limits:      &blocksStoreLimitsMock{},
@@ -2428,14 +2428,14 @@ func TestBlocksStoreQuerier_Labels(t *testing.T) {
 				reg := prometheus.NewPedanticRegistry()
 				stores := &blocksStoreSetMock{mockedResponses: testData.storeSetResponses}
 				finder := &blocksFinderMock{}
-				finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(testData.finderResult, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), testData.finderErr)
+				finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(testData.finderResult, testData.finderErr)
 
 				q := &blocksStoreQuerier{
 					minT:        minT,
 					maxT:        maxT,
 					finder:      finder,
 					stores:      stores,
-					consistency: NewBlocksConsistency(0, 0, nil),
+					consistency: NewBlocksConsistency(0, nil),
 					logger:      log.NewNopLogger(),
 					metrics:     newBlocksStoreQueryableMetrics(reg),
 					limits:      &blocksStoreLimitsMock{},
@@ -2499,14 +2499,14 @@ func TestBlocksStoreQuerier_Labels(t *testing.T) {
 				finder := &blocksFinderMock{}
 				finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
 					{ID: block1},
-				}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
+				}, nil)
 
 				q := &blocksStoreQuerier{
 					minT:        minT,
 					maxT:        maxT,
 					finder:      finder,
 					stores:      stores,
-					consistency: NewBlocksConsistency(0, 0, nil),
+					consistency: NewBlocksConsistency(0, nil),
 					logger:      log.NewNopLogger(),
 					metrics:     newBlocksStoreQueryableMetrics(reg),
 					limits:      &blocksStoreLimitsMock{},
@@ -2571,7 +2571,7 @@ func TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter(t *testing.T)
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			finder := &blocksFinderMock{}
-			finder.On("GetBlocks", mock.Anything, "user-1", mock.Anything, mock.Anything).Return(bucketindex.Blocks(nil), map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), error(nil))
+			finder.On("GetBlocks", mock.Anything, "user-1", mock.Anything, mock.Anything).Return(bucketindex.Blocks(nil), error(nil))
 
 			const tenantID = "user-1"
 			ctx = user.InjectOrgID(ctx, tenantID)
@@ -2580,7 +2580,7 @@ func TestBlocksStoreQuerier_SelectSortedShouldHonorQueryStoreAfter(t *testing.T)
 				maxT:            testData.queryMaxT,
 				finder:          finder,
 				stores:          &blocksStoreSetMock{},
-				consistency:     NewBlocksConsistency(0, 0, nil),
+				consistency:     NewBlocksConsistency(0, nil),
 				logger:          log.NewNopLogger(),
 				metrics:         newBlocksStoreQueryableMetrics(nil),
 				limits:          &blocksStoreLimitsMock{},
@@ -2675,7 +2675,7 @@ func TestBlocksStoreQuerier_MaxLabelsQueryRange(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			finder := &blocksFinderMock{}
-			finder.On("GetBlocks", mock.Anything, "user-1", mock.Anything, mock.Anything).Return(bucketindex.Blocks(nil), map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), error(nil))
+			finder.On("GetBlocks", mock.Anything, "user-1", mock.Anything, mock.Anything).Return(bucketindex.Blocks(nil), error(nil))
 
 			ctx := user.InjectOrgID(context.Background(), "user-1")
 			q := &blocksStoreQuerier{
@@ -2683,7 +2683,7 @@ func TestBlocksStoreQuerier_MaxLabelsQueryRange(t *testing.T) {
 				maxT:        testData.queryMaxT,
 				finder:      finder,
 				stores:      &blocksStoreSetMock{},
-				consistency: NewBlocksConsistency(0, 0, nil),
+				consistency: NewBlocksConsistency(0, nil),
 				logger:      log.NewNopLogger(),
 				metrics:     newBlocksStoreQueryableMetrics(nil),
 				limits: &blocksStoreLimitsMock{
@@ -2802,7 +2802,7 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 					finder.On("GetBlocks", mock.Anything, "user-1", mock.Anything, mock.Anything).Return(bucketindex.Blocks{
 						{ID: block1},
 						{ID: block2},
-					}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), error(nil))
+					}, error(nil))
 
 					// Mock the store-gateway response, to simulate the case each block is queried from a different gateway.
 					gateway1 := &storeGatewayClientMock{remoteAddr: "1.1.1.1", mockedSeriesResponses: append(testData.storeGateway1Responses, mockHintsResponse(block1))}
@@ -2824,7 +2824,7 @@ func TestBlocksStoreQuerier_PromQLExecution(t *testing.T) {
 
 					// Instantiate the querier that will be executed to run the query.
 					logger := log.NewNopLogger()
-					queryable, err := NewBlocksStoreQueryable(stores, finder, NewBlocksConsistency(0, 0, nil), &blocksStoreLimitsMock{}, 0, 0, logger, nil)
+					queryable, err := NewBlocksStoreQueryable(stores, finder, NewBlocksConsistency(0, nil), &blocksStoreLimitsMock{}, 0, 0, logger, nil)
 					require.NoError(t, err)
 					require.NoError(t, services.StartAndAwaitRunning(context.Background(), queryable))
 					defer services.StopAndAwaitTerminated(context.Background(), queryable) // nolint:errcheck
@@ -2982,9 +2982,9 @@ type blocksFinderMock struct {
 	mock.Mock
 }
 
-func (m *blocksFinderMock) GetBlocks(ctx context.Context, userID string, minT, maxT int64) (bucketindex.Blocks, map[ulid.ULID]*bucketindex.BlockDeletionMark, error) {
+func (m *blocksFinderMock) GetBlocks(ctx context.Context, userID string, minT, maxT int64) (bucketindex.Blocks, error) {
 	args := m.Called(ctx, userID, minT, maxT)
-	return args.Get(0).(bucketindex.Blocks), args.Get(1).(map[ulid.ULID]*bucketindex.BlockDeletionMark), args.Error(2)
+	return args.Get(0).(bucketindex.Blocks), args.Error(1)
 }
 
 type storeGatewayClientMock struct {

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -106,8 +106,7 @@ const (
 
 	DefaultMaxTSDBOpeningConcurrencyOnStartup = 10
 
-	seriesSelectionStrategyFlag = "blocks-storage.bucket-store.series-selection-strategy"
-	bucketIndexFlagPrefix       = "blocks-storage.bucket-store.bucket-index."
+	bucketIndexFlagPrefix = "blocks-storage.bucket-store.bucket-index."
 )
 
 // Validation errors

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -409,7 +409,7 @@ type BucketStoreConfig struct {
 	ChunksCache                            ChunksCacheConfig   `yaml:"chunks_cache"`
 	MetadataCache                          MetadataCacheConfig `yaml:"metadata_cache"`
 	IgnoreDeletionMarksInStoreGatewayDelay time.Duration       `yaml:"ignore_deletion_mark_delay" category:"advanced"`
-	IgnoreDeletionMarksWhileQueryingDelay  time.Duration       `yaml:"ignore_deletion_mark_while_querying_delay" category:"advanced"`
+	IgnoreDeletionMarksWhileQueryingDelay  time.Duration       `yaml:"ignore_deletion_mark_while_querying_delay" category:"experimental"`
 	BucketIndex                            BucketIndexConfig   `yaml:"bucket_index"`
 	IgnoreBlocksWithin                     time.Duration       `yaml:"ignore_blocks_within" category:"advanced"`
 

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -98,6 +98,14 @@ const (
 	// partitioner aggregates together two bucket GET object requests.
 	DefaultPartitionerMaxGapSize = uint64(512 * 1024)
 
+	// NewBlockDiscoveryDelayMultiplier is the factor used (multiplied with BucketStoreConfig.SyncInterval) to determine
+	// when querying a newly uploaded block is required.
+	// For example, if BucketStoreConfig.SyncInterval is 15 minutes, then a querier will require that it can query all
+	// blocks uploaded at least 45 minutes ago, and not fail queries when a store-gateway does not respond to queries for
+	// newer blocks (those uploaded in the last 45 minutes).
+	// This gives store-gateways time to discover and load newly created blocks.
+	NewBlockDiscoveryDelayMultiplier = 3
+
 	headChunksEndTimeVarianceHelp = "How much variance (as percentage between 0 and 1) should be applied to the chunk end time, to spread chunks writing across time. Doesn't apply to the last chunk of the chunk range. 0 means no variance."
 	headStripeSizeHelp            = "The number of shards of series to use in TSDB (must be a power of 2). Reducing this will decrease memory footprint, but can negatively impact performance."
 	headChunksWriteQueueSizeHelp  = "The size of the write queue used by the head chunks mapper. Lower values reduce memory utilisation at the cost of potentially higher ingest latency. Value of 0 switches chunks mapper to implementation without a queue."
@@ -107,6 +115,10 @@ const (
 	DefaultMaxTSDBOpeningConcurrencyOnStartup = 10
 
 	bucketIndexFlagPrefix = "blocks-storage.bucket-store.bucket-index."
+
+	syncIntervalFlag                           = "blocks-storage.bucket-store.sync-interval"
+	ignoreDeletionMarksInStoreGatewayDelayFlag = "blocks-storage.bucket-store.ignore-deletion-marks-delay"
+	ignoreDeletionMarksWhileQueryingDelayFlag  = "blocks-storage.bucket-store.ignore-deletion-marks-while-querying-delay"
 )
 
 // Validation errors
@@ -121,6 +133,8 @@ var (
 	errInvalidEarlyHeadCompactionMinSeriesReduction = errors.New("early compaction minimum series reduction percentage must be a value between 0 and 100 (included)")
 	errEarlyCompactionRequiresActiveSeries          = fmt.Errorf("early compaction requires -%s to be enabled", activeseries.EnabledFlag)
 	errEmptyBlockranges                             = errors.New("empty block ranges for TSDB")
+	errInvalidIgnoreDeletionMarksDelayConfig        = fmt.Errorf("value for -%s must be less than -%s", ignoreDeletionMarksWhileQueryingDelayFlag, ignoreDeletionMarksInStoreGatewayDelayFlag)
+	errIgnoreDeletionMarksDelayTooShort             = fmt.Errorf("value for -%s must be greater than %v× -%s to ensure that newly compacted blocks are queried before old blocks are ignored", ignoreDeletionMarksWhileQueryingDelayFlag, NewBlockDiscoveryDelayMultiplier, syncIntervalFlag)
 )
 
 // BlocksStorageConfig holds the config information for the blocks storage.
@@ -384,19 +398,20 @@ func (cfg *TSDBConfig) IsBlocksShippingEnabled() bool {
 
 // BucketStoreConfig holds the config information for Bucket Stores used by the querier and store-gateway.
 type BucketStoreConfig struct {
-	SyncDir                   string              `yaml:"sync_dir"`
-	SyncInterval              time.Duration       `yaml:"sync_interval" category:"advanced"`
-	MaxConcurrent             int                 `yaml:"max_concurrent" category:"advanced"`
-	MaxConcurrentQueueTimeout time.Duration       `yaml:"max_concurrent_queue_timeout" category:"advanced"`
-	TenantSyncConcurrency     int                 `yaml:"tenant_sync_concurrency" category:"advanced"`
-	BlockSyncConcurrency      int                 `yaml:"block_sync_concurrency" category:"advanced"`
-	MetaSyncConcurrency       int                 `yaml:"meta_sync_concurrency" category:"advanced"`
-	IndexCache                IndexCacheConfig    `yaml:"index_cache"`
-	ChunksCache               ChunksCacheConfig   `yaml:"chunks_cache"`
-	MetadataCache             MetadataCacheConfig `yaml:"metadata_cache"`
-	IgnoreDeletionMarksDelay  time.Duration       `yaml:"ignore_deletion_mark_delay" category:"advanced"`
-	BucketIndex               BucketIndexConfig   `yaml:"bucket_index"`
-	IgnoreBlocksWithin        time.Duration       `yaml:"ignore_blocks_within" category:"advanced"`
+	SyncDir                                string              `yaml:"sync_dir"`
+	SyncInterval                           time.Duration       `yaml:"sync_interval" category:"advanced"`
+	MaxConcurrent                          int                 `yaml:"max_concurrent" category:"advanced"`
+	MaxConcurrentQueueTimeout              time.Duration       `yaml:"max_concurrent_queue_timeout" category:"advanced"`
+	TenantSyncConcurrency                  int                 `yaml:"tenant_sync_concurrency" category:"advanced"`
+	BlockSyncConcurrency                   int                 `yaml:"block_sync_concurrency" category:"advanced"`
+	MetaSyncConcurrency                    int                 `yaml:"meta_sync_concurrency" category:"advanced"`
+	IndexCache                             IndexCacheConfig    `yaml:"index_cache"`
+	ChunksCache                            ChunksCacheConfig   `yaml:"chunks_cache"`
+	MetadataCache                          MetadataCacheConfig `yaml:"metadata_cache"`
+	IgnoreDeletionMarksInStoreGatewayDelay time.Duration       `yaml:"ignore_deletion_mark_delay" category:"advanced"`
+	IgnoreDeletionMarksWhileQueryingDelay  time.Duration       `yaml:"ignore_deletion_mark_while_querying_delay" category:"advanced"`
+	BucketIndex                            BucketIndexConfig   `yaml:"bucket_index"`
+	IgnoreBlocksWithin                     time.Duration       `yaml:"ignore_blocks_within" category:"advanced"`
 
 	// Series hash cache.
 	SeriesHashCacheMaxBytes uint64 `yaml:"series_hash_cache_max_size_bytes" category:"advanced"`
@@ -427,15 +442,17 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.IndexHeader.RegisterFlagsWithPrefix(f, "blocks-storage.bucket-store.index-header.")
 
 	f.StringVar(&cfg.SyncDir, "blocks-storage.bucket-store.sync-dir", "./tsdb-sync/", "Directory to store synchronized TSDB index headers. This directory is not required to be persisted between restarts, but it's highly recommended in order to improve the store-gateway startup time.")
-	f.DurationVar(&cfg.SyncInterval, "blocks-storage.bucket-store.sync-interval", 15*time.Minute, "How frequently to scan the bucket, or to refresh the bucket index (if enabled), in order to look for changes (new blocks shipped by ingesters and blocks deleted by retention or compaction).")
+	f.DurationVar(&cfg.SyncInterval, syncIntervalFlag, 15*time.Minute, "How frequently to scan the bucket, or to refresh the bucket index (if enabled), in order to look for changes (new blocks shipped by ingesters and blocks deleted by retention or compaction).")
 	f.Uint64Var(&cfg.SeriesHashCacheMaxBytes, "blocks-storage.bucket-store.series-hash-cache-max-size-bytes", uint64(1*units.Gibibyte), "Max size - in bytes - of the in-memory series hash cache. The cache is shared across all tenants and it's used only when query sharding is enabled.")
 	f.IntVar(&cfg.MaxConcurrent, "blocks-storage.bucket-store.max-concurrent", 200, "Max number of concurrent queries to execute against the long-term storage. The limit is shared across all tenants.")
 	f.DurationVar(&cfg.MaxConcurrentQueueTimeout, "blocks-storage.bucket-store.max-concurrent-queue-timeout", 5*time.Second, "Timeout for the queue of queries waiting for execution. If the queue is full and the timeout is reached, the query will be retried on another store-gateway. 0 means no timeout and all queries will wait indefinitely for their turn.")
 	f.IntVar(&cfg.TenantSyncConcurrency, "blocks-storage.bucket-store.tenant-sync-concurrency", 1, "Maximum number of concurrent tenants synching blocks.")
 	f.IntVar(&cfg.BlockSyncConcurrency, "blocks-storage.bucket-store.block-sync-concurrency", 4, "Maximum number of concurrent blocks synching per tenant.")
 	f.IntVar(&cfg.MetaSyncConcurrency, "blocks-storage.bucket-store.meta-sync-concurrency", 20, "Number of Go routines to use when syncing block meta files from object storage per tenant.")
-	f.DurationVar(&cfg.IgnoreDeletionMarksDelay, "blocks-storage.bucket-store.ignore-deletion-marks-delay", time.Hour*1, "Duration after which the blocks marked for deletion will be filtered out while fetching blocks. "+
+	f.DurationVar(&cfg.IgnoreDeletionMarksInStoreGatewayDelay, ignoreDeletionMarksInStoreGatewayDelayFlag, time.Hour*1, "Duration after which the blocks marked for deletion will be filtered out while fetching blocks. "+
 		"The idea of ignore-deletion-marks-delay is to ignore blocks that are marked for deletion with some delay. This ensures store can still serve blocks that are meant to be deleted but do not have a replacement yet.")
+	f.DurationVar(&cfg.IgnoreDeletionMarksWhileQueryingDelay, ignoreDeletionMarksWhileQueryingDelayFlag, 50*time.Minute, "Duration after which blocks marked for deletion will still be queried. "+
+		"This ensures queriers still query blocks that are meant to be deleted but do not have a replacement yet.")
 	f.DurationVar(&cfg.IgnoreBlocksWithin, "blocks-storage.bucket-store.ignore-blocks-within", 10*time.Hour, "Blocks with minimum time within this duration are ignored, and not loaded by store-gateway. Useful when used together with -querier.query-store-after to prevent loading young blocks, because there are usually many of them (depending on number of ingesters) and they are not yet compacted. Negative values or 0 disable the filter.")
 	f.IntVar(&cfg.PostingOffsetsInMemSampling, "blocks-storage.bucket-store.posting-offsets-in-mem-sampling", DefaultPostingOffsetInMemorySampling, "Controls what is the ratio of postings offsets that the store will hold in memory.")
 	f.Uint64Var(&cfg.PartitionerMaxGapBytes, "blocks-storage.bucket-store.partitioner-max-gap-bytes", DefaultPartitionerMaxGapSize, "Max size - in bytes - of a gap for which the partitioner aggregates together two bucket GET object requests.")
@@ -447,6 +464,16 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 func (cfg *BucketStoreConfig) Validate() error {
 	if cfg.StreamingBatchSize <= 0 {
 		return errInvalidStreamingBatchSize
+	}
+	if cfg.IgnoreDeletionMarksWhileQueryingDelay >= cfg.IgnoreDeletionMarksInStoreGatewayDelay {
+		// If we ignore deletion marks for longer while querying, we'll try to query blocks that store-gateways have
+		// already unloaded, which will cause consistency check failures.
+		return errInvalidIgnoreDeletionMarksDelayConfig
+	}
+	if cfg.IgnoreDeletionMarksWhileQueryingDelay <= NewBlockDiscoveryDelayMultiplier*cfg.SyncInterval {
+		// If we ignore deletion marks for less time while querying, we may skip querying both newly compacted blocks
+		// and their source blocks, and so missing querying some series.
+		return errIgnoreDeletionMarksDelayTooShort
 	}
 	if err := cfg.IndexCache.Validate(); err != nil {
 		return errors.Wrap(err, "index-cache configuration")

--- a/pkg/storage/tsdb/config_test.go
+++ b/pkg/storage/tsdb/config_test.go
@@ -134,6 +134,48 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			expectedErr: errInvalidEarlyHeadCompactionMinSeriesReduction,
 		},
+		"should not fail on 'ignore deletion marks while querying delay' less than 'ignore deletion marks in store-gateways delay'": {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
+				cfg.BucketStore.IgnoreDeletionMarksWhileQueryingDelay = 120 * time.Minute
+				cfg.BucketStore.IgnoreDeletionMarksInStoreGatewayDelay = 121 * time.Minute
+			},
+			expectedErr: nil,
+		},
+		"should fail on 'ignore deletion marks while querying delay' equal to 'ignore deletion marks in store-gateways delay'": {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
+				cfg.BucketStore.IgnoreDeletionMarksWhileQueryingDelay = 2 * time.Hour
+				cfg.BucketStore.IgnoreDeletionMarksInStoreGatewayDelay = 2 * time.Hour
+			},
+			expectedErr: errInvalidIgnoreDeletionMarksDelayConfig,
+		},
+		"should fail on 'ignore deletion marks while querying delay' greater than 'ignore deletion marks in store-gateways delay'": {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
+				cfg.BucketStore.IgnoreDeletionMarksWhileQueryingDelay = 121 * time.Minute
+				cfg.BucketStore.IgnoreDeletionMarksInStoreGatewayDelay = 120 * time.Minute
+			},
+			expectedErr: errInvalidIgnoreDeletionMarksDelayConfig,
+		},
+		"should not fail on 'ignore deletion marks while querying delay' greater than 3x sync interval": {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
+				cfg.BucketStore.SyncInterval = 10 * time.Minute
+				cfg.BucketStore.IgnoreDeletionMarksWhileQueryingDelay = 31 * time.Minute
+			},
+			expectedErr: nil,
+		},
+		"should fail on 'ignore deletion marks while query delay' equal to 3x sync interval": {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
+				cfg.BucketStore.SyncInterval = 10 * time.Minute
+				cfg.BucketStore.IgnoreDeletionMarksWhileQueryingDelay = 30 * time.Minute
+			},
+			expectedErr: errIgnoreDeletionMarksDelayTooShort,
+		},
+		"should fail on 'ignore deletion marks while query delay' less than 3x sync interval": {
+			setup: func(cfg *BlocksStorageConfig, _ *activeseries.Config) {
+				cfg.BucketStore.SyncInterval = 10 * time.Minute
+				cfg.BucketStore.IgnoreDeletionMarksWhileQueryingDelay = 29 * time.Minute
+			},
+			expectedErr: errIgnoreDeletionMarksDelayTooShort,
+		},
 	}
 
 	for testName, testData := range tests {

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -505,7 +505,7 @@ func (u *BucketStores) getOrCreateStore(ctx context.Context, userID string) (*Bu
 		NewShardingMetadataFilterAdapter(userID, u.shardingStrategy),
 		newMinTimeMetaFilter(u.cfg.BucketStore.IgnoreBlocksWithin),
 		// Use our own custom implementation.
-		NewIgnoreDeletionMarkFilter(userLogger, userBkt, u.cfg.BucketStore.IgnoreDeletionMarksDelay, u.cfg.BucketStore.MetaSyncConcurrency),
+		NewIgnoreDeletionMarkFilter(userLogger, userBkt, u.cfg.BucketStore.IgnoreDeletionMarksInStoreGatewayDelay, u.cfg.BucketStore.MetaSyncConcurrency),
 		// The duplicate filter has been intentionally omitted because it could cause troubles with
 		// the consistency check done on the querier. The duplicate filter removes redundant blocks
 		// but if the store-gateway removes redundant blocks before the querier discovers them, the


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where both recently compacted blocks and their source blocks can be skipped during querying if store-gateways are restarting around the time of the query.

Prior to this PR:

- The default value of `-blocks-storage.bucket-store.sync-interval` is 15 minutes. Any blocks that have been uploaded within `3× -blocks-storage.bucket-store.sync-interval` are queried with best effort (ie. no retries if the first store-gateway queried doesn't have the block). So any block uploaded within the last 45 minutes was only queried with best effort by default. ([source](https://github.com/grafana/mimir/blob/d16f21ce30356d53f6882e71cc05f043266ff01a/pkg/querier/blocks_store_queryable.go#L254-L256))
- The default value of `-blocks-storage.bucket-store.ignore-deletion-marks-delay` is 60 minutes. Any blocks that were marked as deleted more than `-blocks-storage.bucket-store.ignore-deletion-marks-delay / 2` ago are queried with best effort. So any block deleted 30 minutes ago or more was only queried with best effort by default. ([source](https://github.com/grafana/mimir/blob/d16f21ce30356d53f6882e71cc05f043266ff01a/pkg/querier/blocks_store_queryable.go#L257-L260))

This meant that if blocks A, B and C are compacted into block X, and block X is uploaded at 01:00 and blocks A, B and C are marked as deleted at 01:00, then there's a 15 minute window when all blocks containing the same data are queried with best effort only:

- Old blocks A, B and C must be queried until 01:30, then are best effort until 02:00, then not queried from 02:00
- New block X is queried with best effort until 01:45, then must be queried
- Between 01:30 and 01:45, all blocks are queried with best effort

This means that between 01:30 and 01:45, we may skip querying all blocks containing the data from A, B and C, which may lead to incorrect query results. This could happen if the first store-gateways selected to query for blocks A, B, C and X are restarting, for example, and other store-gateways in the same zone (which do not own those blocks) are selected instead.

This PR changes this behaviour to avoid this problem. 

Queriers will now always query blocks marked for deletion until `-blocks-storage.bucket-store.ignore-deletion-marks-while-querying-delay` has elapsed since the block has been marked for deletion, with no window where they are queried with best effort. This CLI flag defaults to 50 minutes: 
* this is more than `3× -blocks-storage.bucket-store.sync-interval`, so queriers will start querying newly compacted blocks before stopping querying the source blocks
* this is less than `-blocks-storage.bucket-store.ignore-deletion-marks-delay`, so queriers will stop querying deleted blocks before store-gateways stop serving them

This is guaranteed to be safe: compactors mark old blocks for deletion after they upload the new block, so with this change we are always guaranteed to either:

* query all the old blocks, and optionally the new block (01:00 to 01:45 in our example above)
* query all the old blocks and the new block (01:45 to 01:50)
* query only the new block (01:50 onwards)

Visually, the changes here look like this (using the same example from before): 

![PR-9224](https://github.com/user-attachments/assets/964f3067-8b1c-45f7-b0ce-cab2bc957b7c)

In addition to the changes above, I've also added some validation to the various CLI flags used here to ensure they are configured in a way that ensures queries will return correct results.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
