### PR TITLE
Continuous-test: Move extra hash entropy to separate label.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,7 +182,7 @@
 * [ENHANCEMENT] Include human-friendly timestamps in diffs logged when a test fails. #8630
 * [ENHANCEMENT] Add histograms to measure latency of read and write requests. #8583
 * [ENHANCEMENT] Log successful test runs in addition to failed test runs. #8817
-* [ENHANCEMENT] Series emitted by continuous-test now distribute more uniformly across ingesters. #9218
+* [ENHANCEMENT] Series emitted by continuous-test now distribute more uniformly across ingesters. #9218 #9243
 * [BUGFIX] Initialize test result metrics to 0 at startup so that alerts can correctly identify the first failure after startup. #8630
 
 ### Query-tee

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -24,8 +24,8 @@ const (
 	floatMetricName = "mimir_continuous_test_sine_wave_v2"
 	floatTypeLabel  = "float"
 
-	// A prime factor to generate series IDs that hash more uniformly.
-	seriesFactor = 2689
+	// A prime factor to generate extra values to make continuous-test series hash more uniformly.
+	hashFactor = 2689
 )
 
 type generateHistogramFunc func(t time.Time) prompb.Histogram
@@ -237,7 +237,10 @@ func generateSineWaveSeries(name string, t time.Time, numSeries int) []prompb.Ti
 				Value: name,
 			}, {
 				Name:  "series_id",
-				Value: fmt.Sprintf("%x", i*seriesFactor),
+				Value: strconv.Itoa(i),
+			}, {
+				Name:  "hash_extra",
+				Value: strconv.Itoa(i * hashFactor),
 			}},
 			Samples: []prompb.Sample{{
 				Value:     value,
@@ -259,7 +262,10 @@ func generateHistogramSeriesInner(name string, t time.Time, numSeries int, histo
 				Value: name,
 			}, {
 				Name:  "series_id",
-				Value: fmt.Sprintf("%x", i*seriesFactor),
+				Value: strconv.Itoa(i),
+			}, {
+				Name:  "hash_extra",
+				Value: strconv.Itoa(i * hashFactor),
 			}},
 			Histograms: []prompb.Histogram{histogramGenerator(t)},
 		})


### PR DESCRIPTION
#### What this PR does

Address a comment on #9218 to make the extra entropy land in a new independent label, rather than stuffing it into `series_id`, as querying on `series_id` is useful when reverse-engineering continuous-test failures.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
