### PR TITLE
add new NAMESPACES_REGEX input to mimir-rules-action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,7 @@
 * [ENHANCEMENT] `grpcurl-query-ingesters`: print full chunk timestamps, not just time component. #9180
 * [ENHANCEMENT] `tsdb-series`: Added `-json` option to generate JSON output for easier post-processing. #8844
 * [ENHANCEMENT] `tsdb-series`: Added `-min-time` and `-max-time` options to filter samples that are used for computing data-points per minute. #8844
+* [ENHANCEMENT] `mimir-rules-action`: Added new input to support matching target namespaces by regex.
 
 ## 2.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,7 +227,7 @@
 * [ENHANCEMENT] `grpcurl-query-ingesters`: print full chunk timestamps, not just time component. #9180
 * [ENHANCEMENT] `tsdb-series`: Added `-json` option to generate JSON output for easier post-processing. #8844
 * [ENHANCEMENT] `tsdb-series`: Added `-min-time` and `-max-time` options to filter samples that are used for computing data-points per minute. #8844
-* [ENHANCEMENT] `mimir-rules-action`: Added new input to support matching target namespaces by regex.
+* [ENHANCEMENT] `mimir-rules-action`: Added new input to support matching target namespaces by regex. #9244
 
 ## 2.13.0
 

--- a/operations/mimir-rules-action/README.md
+++ b/operations/mimir-rules-action/README.md
@@ -18,6 +18,7 @@ This action is configured using environment variables defined in the workflow. T
 | `LABEL`                      | Label to include as part of the aggregations. This option is supported only by the `prepare` action.                                                                                                                                                                                               | `false`  | N/A     |
 | `LABEL_EXCLUDED_RULE_GROUPS` | Comma separated list of rule group names to exclude when including the configured label to aggregations. This option is supported only by the `prepare` action.                                                                                                                                    | `false`  | N/A     |
 | `NAMESPACES`                 | Comma-separated list of namespaces to use                                                                                                                                                                                                                                                          | `false`  | N/A     |
+| `NAMESPACES_REGEX`           | Regex matching namespaces to check during a sync or diff.                                                                                                                                                                                                                                          | `false`  | N/A     |
 
 ## Authentication
 

--- a/operations/mimir-rules-action/entrypoint.sh
+++ b/operations/mimir-rules-action/entrypoint.sh
@@ -39,15 +39,20 @@ if [ -z "${ACTION}" ]; then
   exit 1
 fi
 
+if [ -n "${NAMESPACES}" && -n "${NAMESPACES_REGEX}" ]; then
+  err "NAMESPACES and NAMESPACES_REGEX cannot both be set."
+  exit 1
+fi
+
 case "${ACTION}" in
   "$SYNC_CMD")
     verifyTenantAndAddress
-    OUTPUT=$(/bin/mimirtool rules sync --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} "$@")
+    OUTPUT=$(/bin/mimirtool rules sync --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} ${NAMESPACES_REGEX:+ --namespaces-regex=${NAMESPACES_REGEX}} "$@")
     STATUS=$?
     ;;
   "$DIFF_CMD")
     verifyTenantAndAddress
-    OUTPUT=$(/bin/mimirtool rules diff --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} --disable-color "$@")
+    OUTPUT=$(/bin/mimirtool rules diff --rule-dirs="${RULES_DIR}" ${NAMESPACES:+ --namespaces=${NAMESPACES}} ${NAMESPACES_REGEX:+ --namespaces-regex=${NAMESPACES_REGEX}} --disable-color "$@")
     STATUS=$?
     ;;
   "$LINT_CMD")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds a new input (`NAMESPACES_REGEX`) to `mimir-rules-action`. This input is applicable for `diff` and `sync` actions, and corresponds to the mimirtool [`--namespaces-regex` parameter for diff and sync](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/#diff).

Also adds a check to verify that at most only one of the `NAMESPACES` or `NAMESPACES_REGEX` inputs is set, as mimirtool docs specify that "only one of the namespace selection flags can be specified."

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
