### PR TITLE
Move rollout-operator's role access to ReplicaTemplate to rollout-operator.libsonnet

### DIFF
--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -178,22 +178,6 @@
       $.ingester_primary_zone_replica_template
     ),
 
-  //
-  // Grant extra privileges to rollout-operator.
-  //
-
-  local role = $.rbac.v1.role,
-  local policyRule = $.rbac.v1.policyRule,
-  rollout_operator_role: overrideSuperIfExists(
-    'rollout_operator_role',
-    if !$._config.ingest_storage_ingester_autoscaling_enabled then {} else
-      role.withRulesMixin([
-        policyRule.withApiGroups($.replica_template.spec.group) +
-        policyRule.withResources(['%s/scale' % $.replica_template.spec.names.plural, '%s/status' % $.replica_template.spec.names.plural]) +
-        policyRule.withVerbs(['get', 'patch']),
-      ])
-  ),
-
   // Utility used to override a field only if exists in super.
   local overrideSuperIfExists(name, override) = if !( name in super) || super[name] == null || super[name] == {} then null else
     super[name] + override,

--- a/operations/mimir/rollout-operator.libsonnet
+++ b/operations/mimir/rollout-operator.libsonnet
@@ -29,6 +29,8 @@
 
     // Ignore these labels used for controlling webhook behavior when creating services.
     service_ignored_labels+:: ['grafana.com/no-downscale', 'grafana.com/prepare-downscale'],
+
+    rollout_operator_replica_template_access_enabled: $._config.ingest_storage_ingester_autoscaling_enabled,
   },
 
   local rollout_operator_enabled =
@@ -80,17 +82,25 @@
   rollout_operator_role: if !rollout_operator_enabled then null else
     role.new('rollout-operator-role') +
     role.mixin.metadata.withNamespace($._config.namespace) +
-    role.withRulesMixin([
-      policyRule.withApiGroups('') +
-      policyRule.withResources(['pods']) +
-      policyRule.withVerbs(['list', 'get', 'watch', 'delete']),
-      policyRule.withApiGroups('apps') +
-      policyRule.withResources(['statefulsets']) +
-      policyRule.withVerbs(['list', 'get', 'watch', 'patch']),
-      policyRule.withApiGroups('apps') +
-      policyRule.withResources(['statefulsets/status']) +
-      policyRule.withVerbs(['update']),
-    ]),
+    role.withRulesMixin(
+      [
+        policyRule.withApiGroups('') +
+        policyRule.withResources(['pods']) +
+        policyRule.withVerbs(['list', 'get', 'watch', 'delete']),
+        policyRule.withApiGroups('apps') +
+        policyRule.withResources(['statefulsets']) +
+        policyRule.withVerbs(['list', 'get', 'watch', 'patch']),
+        policyRule.withApiGroups('apps') +
+        policyRule.withResources(['statefulsets/status']) +
+        policyRule.withVerbs(['update']),
+      ] + (
+        if $._config.rollout_operator_replica_template_access_enabled then [
+          policyRule.withApiGroups($.replica_template.spec.group) +
+          policyRule.withResources(['%s/scale' % $.replica_template.spec.names.plural, '%s/status' % $.replica_template.spec.names.plural]) +
+          policyRule.withVerbs(['get', 'patch']),
+        ] else []
+      )
+    ),
 
   rollout_operator_rolebinding: if !rollout_operator_enabled then null else
     roleBinding.new('rollout-operator-rolebinding') +


### PR DESCRIPTION
#### What this PR does

Rollout-operator's access to ReplicaTemplate is now configured via `$._config.rollout_operator_replica_template_access_enabled` and moved to `rollout-operator.libsonnet`. This allows for easier reuse.

#### Checklist

- [na] Tests updated.
- [na] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
