### PR TITLE
chore: Run shellcheck on Github action script and cleanup warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ all: $(UPTODATE_FILES)
 test: protos
 test-with-race: protos
 mod-check: protos
-lint: lint-packaging-scripts protos
+lint: lint-gh-action lint-packaging-scripts protos
 mimir-build-image/$(UPTODATE): mimir-build-image/*
 
 # All the boiler plate for building golang follows:
@@ -300,7 +300,7 @@ GOVOLUMES=	-v mimir-go-cache:/go/cache \
 # Mount local ssh credentials to be able to clone private repos when doing `mod-check`
 SSHVOLUME=  -v ~/.ssh/:/root/.ssh:$(CONTAINER_MOUNT_OPTIONS)
 
-exes $(EXES) $(EXES_RACE) protos $(PROTO_GOS) lint lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests print-go-version: fetch-build-image
+exes $(EXES) $(EXES_RACE) protos $(PROTO_GOS) lint lint-gh-action lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests print-go-version: fetch-build-image
 	@echo ">>>> Entering build container: $@"
 	$(SUDO) time docker run --rm $(TTY) -i $(SSHVOLUME) $(GOVOLUMES) $(BUILD_IMAGE) GOOS=$(GOOS) GOARCH=$(GOARCH) BINARY_SUFFIX=$(BINARY_SUFFIX) $@;
 
@@ -331,6 +331,9 @@ else
 endif
 
 lint-packaging-scripts: packaging/nfpm/mimir/postinstall.sh packaging/nfpm/mimir/preremove.sh
+	shellcheck $?
+
+lint-gh-action: operations/mimir-rules-action/entrypoint.sh
 	shellcheck $?
 
 lint: ## Run lints to check for style issues.

--- a/operations/mimir-rules-action/entrypoint.sh
+++ b/operations/mimir-rules-action/entrypoint.sh
@@ -78,10 +78,11 @@ case "${ACTION}" in
 esac
 
 SINGLE_LINE_OUTPUT=$(echo "${OUTPUT}" | awk 'BEGIN { RS="%0A" } { gsub(/%/, "%25"); gsub(/\r/, "%0D"); gsub(/\n/, "%0A") } { print }')
-echo "detailed=${SINGLE_LINE_OUTPUT}" >> $GITHUB_OUTPUT
+echo "detailed=${SINGLE_LINE_OUTPUT}" >> "${GITHUB_OUTPUT}"
 SUMMARY=$(echo "${OUTPUT}" | grep Summary)
-echo 'summary<<ENDOFSUMMARY' >> $GITHUB_OUTPUT
-echo "${SUMMARY}" >> $GITHUB_OUTPUT
-echo 'ENDOFSUMMARY' >> $GITHUB_OUTPUT
+# shellcheck disable=SC2129
+echo 'summary<<ENDOFSUMMARY' >> "${GITHUB_OUTPUT}"
+echo "${SUMMARY}" >> "${GITHUB_OUTPUT}"
+echo 'ENDOFSUMMARY' >> "${GITHUB_OUTPUT}"
 
 exit $STATUS


### PR DESCRIPTION
#### What this PR does

Run `shellcheck` on the mimirtool Github action script and fix existing warnings.

#### Which issue(s) this PR fixes or relates to

Related https://github.com/grafana/mimir/pull/9251

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
