### PR TITLE
Add active series reloading annotation to Tenants dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
 * [ENHANCEMENT] Dashboards: add "Out-of-order samples appended" panel to "Mimir / Tenants" dashboard. #8939
 * [ENHANCEMENT] Alerts: `RequestErrors` and `RulerRemoteEvaluationFailing` have been enriched with a native histogram version. #9004
 * [ENHANCEMENT] Dashboards: add 'Read path' selector to 'Mimir / Queries' dashboard. #8878
+* [ENHANCEMENT] Dashboards: add annotation indicating active series are being reloaded to 'Mimir / Tenants' dashboard. #9257
 * [BUGFIX] Dashboards: fix "current replicas" in autoscaling panels when HPA is not active. #8566
 * [BUGFIX] Alerts: do not fire `MimirRingMembersMismatch` during the migration to experimental ingest storage. #8727
 * [BUGFIX] Dashboards: avoid over-counting of ingesters metrics when migrating to experimental ingest storage. #9170

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -32602,7 +32602,25 @@ data:
              }
           ],
           "annotations": {
-             "list": [ ]
+             "list": [
+                {
+                   "datasource": "$datasource",
+                   "enable": true,
+                   "expr": "sum by (user) (cortex_ingester_active_series_loading{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}) > 0",
+                   "filter": {
+                      "exclude": false,
+                      "ids": [
+                         2,
+                         7,
+                         8
+                      ]
+                   },
+                   "hide": true,
+                   "iconColor": "yellow",
+                   "name": "Active Series Reload",
+                   "titleFormat": "Active series reloading for user {{user}}"
+                }
+             ]
           },
           "editable": true,
           "gnetId": null,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -8,7 +8,25 @@
          }
       ],
       "annotations": {
-         "list": [ ]
+         "list": [
+            {
+               "datasource": "$datasource",
+               "enable": true,
+               "expr": "sum by (user) (cortex_ingester_active_series_loading{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}) > 0",
+               "filter": {
+                  "exclude": false,
+                  "ids": [
+                     2,
+                     7,
+                     8
+                  ]
+               },
+               "hide": true,
+               "iconColor": "yellow",
+               "name": "Active Series Reload",
+               "titleFormat": "Active series reloading for user {{user}}"
+            }
+         ]
       },
       "editable": true,
       "gnetId": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -8,7 +8,25 @@
          }
       ],
       "annotations": {
-         "list": [ ]
+         "list": [
+            {
+               "datasource": "$datasource",
+               "enable": true,
+               "expr": "sum by (user) (cortex_ingester_active_series_loading{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}) > 0",
+               "filter": {
+                  "exclude": false,
+                  "ids": [
+                     2,
+                     7,
+                     8
+                  ]
+               },
+               "hide": true,
+               "iconColor": "yellow",
+               "name": "Active Series Reload",
+               "titleFormat": "Active series reloading for user {{user}}"
+            }
+         ]
       },
       "editable": true,
       "gnetId": null,

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -17,6 +17,10 @@ local filename = 'mimir-tenants.json';
     $.overrideProperty('custom.lineStyle', { fill: 'dash' }),
   ]),
 
+  // These are the IDs of the 'All series', 'Native histogram series', and 'Total number of buckets used by native histogram series' panels
+  // Not ideal, since these will change if the dashboard is rearranged
+  local reload_annotation_panel_ids = [2, 7, 8],
+
   [filename]:
     assert std.md5(filename) == '35fa247ce651ba189debf33d7ae41611' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Tenants') + { uid: std.md5(filename) })
@@ -823,5 +827,23 @@ local filename = 'mimir-tenants.json';
           |||
         )
       ),
-    ),
+    ) + {
+      annotations+: {
+        list+: [
+          {
+            name: 'Active Series Reload',
+            datasource: '$datasource',
+            expr: 'sum by (user) (cortex_ingester_active_series_loading{cluster=~"$cluster", job=~"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))", user="$user"}) > 0',
+            titleFormat: 'Active series reloading for user {{user}}',
+            enable: true,
+            hide: true,
+            iconColor: 'yellow',
+            filter: {
+              exclude: false,
+              ids: reload_annotation_panel_ids,
+            },
+          },
+        ],
+      },
+    },
 }

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -833,7 +833,7 @@ local filename = 'mimir-tenants.json';
           {
             name: 'Active Series Reload',
             datasource: '$datasource',
-            expr: 'sum by (user) (cortex_ingester_active_series_loading{cluster=~"$cluster", job=~"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))", user="$user"}) > 0',
+            expr: 'sum by (user) (cortex_ingester_active_series_loading{%s, user="$user"}) > 0' % [$.jobMatcher($._config.job_names.ingester)],
             titleFormat: 'Active series reloading for user {{user}}',
             enable: true,
             hide: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When active series are purged the counts are inaccurate until the idle timeout elapses. During this time, we stop exporting the active series counts, which can be jarring to encounter on the Tenants dashboard if you don't have the context for what is happening.

This PR adds an annotation to three panels on the Tenants dashboard that indicates when active series for the tenant are being reloaded, as indicated by the `cortex_ingester_active_series_loading` metric.

The panel IDs are currently hard-coded, which means it will break if we change the order in the dashboard 😢 but I couldn't think of a way to be more clever here, without rewriting a chunk of the jsonnet dashboard scaffolding.

![SCR-20240910-ktia](https://github.com/user-attachments/assets/9063127a-9449-47f4-8739-4e1204551a47)

#### Which issue(s) this PR fixes or relates to

Fixes n/a

#### Checklist
- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
