### PR TITLE
Upgrade Delve

### DIFF
--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_IMAGE # Use ./compose-up.sh to build this image.
 FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.22.0
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.23.0
 
 FROM alpine:3.20.3
 


### PR DESCRIPTION
#### What this PR does

This PR upgrades Delve to a version compatible with Go 1.23.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
