### PR TITLE
Fix typo in comment

### DIFF
--- a/pkg/streamingpromql/aggregations/aggregations_test.go
+++ b/pkg/streamingpromql/aggregations/aggregations_test.go
@@ -63,7 +63,7 @@ func TestAggregationGroupNativeHistogramSafety(t *testing.T) {
 				{T: 1, H: h5},  // h5 not retained (added to h2)
 				{T: 2, H: nil}, // h6 is retained for T=3
 				{T: 3, H: nil}, // h6 is retained for this point
-				{T: 4, H: nil}, // h6 is retained for T=4
+				{T: 4, H: nil}, // h6 is retained for T=3
 			}
 
 			require.Equal(t, expected, series.Histograms, "all histograms retained should be nil-ed out after accumulating series")


### PR DESCRIPTION
#### What this PR does

I noticed there was a typo in a comment added in https://github.com/grafana/mimir/pull/9260. This PR fixes the typo.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/9260

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
