### PR TITLE
helm: create query-scheduler PDB only when enabled

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -51,6 +51,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Fix helm releases failing when `querier.kedaAutoscaling.predictiveScalingEnabled=true`. #8731
 * [BUGFIX] Alertmanager: Set -server.http-idle-timeout to avoid EOF errors in ruler. #8192
 * [BUGFIX] Helm: fix second relabeling in ServiceMonitor and PVC template in compactor to not show diff in ArgoCD. #9195
+* [BUGFIX] Helm: create query-scheduler `PodDisruptionBudget` only when the component is enabled. #9270
 
 ## 5.4.1
 

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
@@ -1,3 +1,3 @@
-{{- if .Values.query_scheduler.podDisruptionBudget -}}
+{{- if and .Values.query_scheduler.enabled .Values.query_scheduler.podDisruptionBudget -}}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "query-scheduler") }}
 {{- end -}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Added a check for `query_scheduler.enabled` to ensure the query-scheduler `PodDisruptionBudget` is only created when the component is enabled in the Helm chart configuration.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
