### PR TITLE
jsonnet: set GOMAXPROCS on ingesters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@
 * [CHANGE] `$.replicaTemplate` function now takes replicas and labelSelector parameter. #9248
 * [CHANGE] Renamed `ingest_storage_ingester_autoscaling_replica_template_custom_resource_definition_enabled` to `replica_template_custom_resource_definition_enabled`. #9248
 * [FEATURE] Add support for automatically deleting compactor, store-gateway, ingester and read-write mode backend PVCs when the corresponding StatefulSet is scaled down. #8382 #8736
+* [FEATURE] Automatically set GOMAXPROCS on ingesters. #9273
 * [ENHANCEMENT] Added the following config options to set the number of partition ingester replicas when migrating to experimental ingest storage. #8517
   * `ingest_storage_migration_partition_ingester_zone_a_replicas`
   * `ingest_storage_migration_partition_ingester_zone_b_replicas`

--- a/operations/compare-helm-with-jsonnet/helm/06-pods/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/helm/06-pods/kustomization.yaml
@@ -83,3 +83,11 @@ patches:
     patch: |-
       - op: remove
         path: /spec/template/metadata/namespace
+
+  # TODO dimitarvdimitrov: GOMAXPROCS isn't present in Helm for now
+  - target:
+      name: mimir-ingester
+      kind: StatefulSet
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/env

--- a/operations/compare-helm-with-jsonnet/jsonnet/07-pods/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/jsonnet/07-pods/kustomization.yaml
@@ -13,6 +13,14 @@ patches:
       - op: remove
         path: /spec/template/spec/containers/0/env
 
+  # TODO dimitarvdimitrov: GOMAXPROCS isn't present in Helm for now
+  - target:
+      name: mimir-ingester
+      kind: StatefulSet
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/env
+
   # TODO(logiraptor): Jsonnet uses a deprecated PodDisruptionBudget api version
   - target:
       name: mimir-(ingester|store-gateway)

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -1161,6 +1161,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
@@ -1161,6 +1161,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
@@ -1170,6 +1170,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -1163,6 +1163,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -1162,6 +1162,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1403,6 +1403,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1529,6 +1531,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1655,6 +1659,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1515,6 +1515,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1515,6 +1515,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -1019,6 +1019,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -1019,6 +1019,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1534,6 +1534,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1760,6 +1760,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1878,6 +1880,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1996,6 +2000,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1402,6 +1402,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -959,6 +959,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -905,6 +905,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -1800,6 +1800,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1922,6 +1924,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2044,6 +2048,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1163,6 +1163,8 @@ spec:
         env:
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -905,6 +905,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1204,6 +1204,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1268,6 +1268,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -1783,6 +1783,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -1916,6 +1918,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2045,6 +2049,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -1857,6 +1857,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2001,6 +2003,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2135,6 +2139,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2273,6 +2279,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2403,6 +2411,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2541,6 +2551,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -1881,6 +1881,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2023,6 +2025,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -1885,6 +1885,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2027,6 +2029,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -1870,6 +1870,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2014,6 +2016,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2148,6 +2152,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2286,6 +2292,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2416,6 +2424,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2554,6 +2564,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -1892,6 +1892,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2036,6 +2038,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2170,6 +2174,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2308,6 +2314,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2438,6 +2446,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2576,6 +2586,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -1890,6 +1890,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2034,6 +2036,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2168,6 +2172,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2306,6 +2312,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2436,6 +2444,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2574,6 +2584,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -1890,6 +1890,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2034,6 +2036,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2168,6 +2172,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2306,6 +2312,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2436,6 +2444,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2574,6 +2584,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -1890,6 +1890,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2034,6 +2036,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2168,6 +2172,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2306,6 +2312,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2436,6 +2444,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2574,6 +2584,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -1829,6 +1829,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -1971,6 +1973,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2109,6 +2113,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -1845,6 +1845,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -1987,6 +1989,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2125,6 +2129,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -1845,6 +1845,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -1987,6 +1989,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2125,6 +2129,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -1822,6 +1822,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -1964,6 +1966,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -1908,6 +1908,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -2050,6 +2052,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -2188,6 +2192,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1161,6 +1161,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1167,6 +1167,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1173,6 +1173,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1167,6 +1167,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1534,6 +1534,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1617,6 +1617,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1617,6 +1617,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1617,6 +1617,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1617,6 +1617,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1164,6 +1164,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1161,6 +1161,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -1221,6 +1221,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1403,6 +1403,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -1531,6 +1533,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1655,6 +1659,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1454,6 +1454,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1576,6 +1578,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1698,6 +1702,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1820,6 +1826,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1481,6 +1481,8 @@ spec:
           value: ingester-a-only
         - name: GOGC
           value: "off"
+        - name: GOMAXPROCS
+          value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
@@ -1609,6 +1611,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1733,6 +1737,8 @@ spec:
         env:
         - name: A
           value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -905,6 +905,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
+++ b/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
@@ -997,6 +997,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -1145,6 +1145,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1269,6 +1271,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0
@@ -1393,6 +1397,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1544,6 +1544,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1580,6 +1580,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1192,6 +1192,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1180,6 +1180,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1166,6 +1166,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1522,6 +1522,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1520,6 +1520,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1170,6 +1170,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
@@ -1174,6 +1174,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1171,6 +1171,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1171,6 +1171,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1161,6 +1161,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-redis-generated.yaml
@@ -1030,6 +1030,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1166,6 +1166,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -808,6 +808,8 @@ spec:
         - -target=ingester
         - -usage-stats.installation-mode=jsonnet
         env:
+        - name: GOMAXPROCS
+          value: "9"
         - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
           value: "1000"
         image: grafana/mimir:2.13.0

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -56,6 +56,20 @@
 
   ingester_env_map:: {
     JAEGER_REPORTER_MAX_QUEUE_SIZE: '1000',
+
+    local requests = $.util.parseCPU($.ingester_container.resources.requests.cpu),
+    local requestsWithHeadroom = std.ceil(
+      // double the requests, but with headroom of at least 3 and at most 6 CPU
+      // too little headroom can lead to throttling
+      // too much headroom can lead to setting the limit above the available CPU cores
+      requests + std.max(3, std.min(6, requests)),
+    ) + 1,
+    // If the ingester read path is limited,
+    // we don't want to set GOMAXPROCS to something higher than that because then the read path limit will never be hit.
+    local limitBasedGOMAXPROCS = std.parseInt($.ingester_args['ingester.read-path-cpu-utilization-limit']) + 1,
+    local GOMAXPROCS = if 'ingester.read-path-cpu-utilization-limit' in $.ingester_args then limitBasedGOMAXPROCS else requestsWithHeadroom,
+
+    GOMAXPROCS: std.toString(GOMAXPROCS),
   },
 
   ingester_node_affinity_matchers:: [],

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -61,7 +61,8 @@
     local requestsWithHeadroom = std.ceil(
       // double the requests, but with headroom of at least 3 and at most 6 CPU
       // too little headroom can lead to throttling
-      // too much headroom can lead to setting the limit above the available CPU cores
+      // too much headroom can lead to inefficeint scheduling of goroutines
+      // (e.g. when NumCPU is 128, but the ingester only needs 5 cores).
       requests + std.max(3, std.min(6, requests)),
     ) + 1,
     // If the ingester read path is limited,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does


We've been experimenting with GOMAXPROCS on ingesters at GL for the past few months. The test included all production cells and was comparing ingester-zone-a and zone-b (with GOMAXPROCS) to zone-c (without GOMAXPROCS)

 This is the summary of results:
 > * Push & Query outlier pods are significantly lower with GOMAXPROCS. This makes the cell more resilient to bad nodes and to inefficient NUMA node assignment; this was the goal of the experiment
 > * QueryStream performance under sudden load is worse
 > * CPU usage is generally slightly lower. Reduced available cores via GOMAXPROCS explains this
 > * heap might appear slightly increased. However, reduced CPU time (due to fewer cores, see point above) for garbage collection can explain why peak heap can be left to rise before GC kicks in. This is generally safe and should not lead to OOMs for example
 >
 > To me GOMAXPROCS is a tradeoff between lower stable-state resource usage and resilience to outlier infrastructure **and** being able to handle sudden usage peaks without increasing latency. With the help of query-scheduler scheduling improvements (prioritizing queries that wouldn't touch slowed-down components) and autoscaling (more frequent ingester vertical autoscaling, querier autoscaling) I think we can accept the increased QueryStream latency.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
