### PR TITLE
Add support for sigv4 in metamonitoring

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -53,6 +53,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Alertmanager: Set -server.http-idle-timeout to avoid EOF errors in ruler. #8192
 * [BUGFIX] Helm: fix second relabeling in ServiceMonitor and PVC template in compactor to not show diff in ArgoCD. #9195
 * [BUGFIX] Helm: create query-scheduler `PodDisruptionBudget` only when the component is enabled. #9270
+* [ENHANCEMENT] Add support for sigv4 for metamonitoring. Allows you to connect metamonitoring to AMP #9279
 
 ## 5.4.1
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -53,7 +53,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Alertmanager: Set -server.http-idle-timeout to avoid EOF errors in ruler. #8192
 * [BUGFIX] Helm: fix second relabeling in ServiceMonitor and PVC template in compactor to not show diff in ArgoCD. #9195
 * [BUGFIX] Helm: create query-scheduler `PodDisruptionBudget` only when the component is enabled. #9270
-* [ENHANCEMENT] Add support for sigv4 for metamonitoring. Allows you to connect metamonitoring to AMP #9279
+* [ENHANCEMENT] Add support for sigv4 authentication for remote write in metamonitoring. #9279
 
 ## 5.4.1
 

--- a/operations/helm/charts/mimir-distributed/ci/offline/metamonitoring-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/metamonitoring-values.yaml
@@ -23,6 +23,13 @@ metaMonitoring:
             username: tenant-1
             passwordSecretName: my-secret
             passwordSecretKey: metrics
+        - url: https://amp.example.com/remote_write
+          sigv4:
+            accessKey: "abcd"
+            profile: "abcd"
+            region: "us-east-1"
+            roleARN: "arn:aws:iam::1234"
+            secretKey: "abcd"
 
     logs:
       remote:

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
@@ -27,6 +27,10 @@
   headers:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .sigv4 }}
+  sigv4:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}
 
 {{- define "mimir.metaMonitoring.logs.client" -}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -19,7 +19,7 @@ spec:
     {{- if or (.metrics).additionalRemoteWriteConfigs (.metrics).remote }}
     {{- range $i, $cfg := prepend ((.metrics).additionalRemoteWriteConfigs | default list) (.metrics).remote }}
     {{- with $cfg }}
-    {{- include "mimir.metaMonitoring.metrics.remoteWrite" (dict "ctx" $ "url" .url "auth" .auth "usernameKey" (printf "username-%d" $i) "headers" .headers ) | nindent 6 -}}
+    {{- include "mimir.metaMonitoring.metrics.remoteWrite" (dict "ctx" $ "url" .url "auth" .auth "usernameKey" (printf "username-%d" $i) "headers" .headers "sigv4" .sigv4 ) | nindent 6 -}}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3745,7 +3745,7 @@ metaMonitoring:
           # -- The value under this key in passwordSecretName will be used as the basic authentication password. Required only if passwordSecretName is set.
           passwordSecretKey: ""
 
-        # -- specifies configuration to perform SigV4 authentication.
+        # -- Configuration for SigV4 authentication.
         # sigv4:
         #   accessKey: abcd
         #   profile: default

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3745,6 +3745,15 @@ metaMonitoring:
           # -- The value under this key in passwordSecretName will be used as the basic authentication password. Required only if passwordSecretName is set.
           passwordSecretKey: ""
 
+        # -- specifies configuration to perform SigV4 authentication.
+        # sigv4:
+        #   accessKey: abcd
+        #   profile: default
+        #   region: us-east-1
+        #   roleARN: arn:aws:iam::1234:role/1234
+        #   secretKey: abcd
+        sigv4: {}
+
       # -- Additional remote-write for the MetricsInstance that will scrape Mimir pods. Follows the format of .remote.
       additionalRemoteWriteConfigs: []
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -26,6 +26,13 @@ spec:
             key: "metrics"
         headers:
           X-Scope-OrgID: tenant-1
+      - url: https://amp.example.com/remote_write
+        sigv4:
+          accessKey: abcd
+          profile: abcd
+          region: us-east-1
+          roleARN: arn:aws:iam::1234
+          secretKey: abcd
 
   # Supply an empty namespace selector to look in all namespaces. Remove
   # this to only look in the same namespace as the MetricsInstance CR


### PR DESCRIPTION
#### What this PR does
Add for sigv4 for mimir metamonitoring from https://github.com/grafana/helm-charts/blob/main/charts/agent-operator/crds/monitoring.grafana.com_metricsinstances.yaml#L275-L307

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
