### PR TITLE
Mimir query engine: simplify benchmarking comparison script

### DIFF
--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -75,7 +75,7 @@ func BenchmarkQuery(b *testing.B) {
 			}
 
 			for name, engine := range engines {
-				b.Run(name, func(b *testing.B) {
+				b.Run("engine="+name, func(b *testing.B) {
 					for i := 0; i < b.N; i++ {
 						res, cleanup := c.Run(ctx, b, start, end, interval, engine, q)
 

--- a/tools/benchmark-query-engine/compare.sh
+++ b/tools/benchmark-query-engine/compare.sh
@@ -6,12 +6,4 @@ set -euo pipefail
 
 RESULTS_FILE="$1" # Should be the path to a file produced by a command like `go run . -count=6 | tee output.txt`
 
-PROMETHEUS_RESULTS_FILE=$(mktemp /tmp/prometheus.XXXX)
-MIMIR_RESULTS_FILE=$(mktemp /tmp/mimir.XXXX)
-
-grep --invert-match "Mimir-" "$RESULTS_FILE" | sed -E 's#/Prometheus-[0-9]+##g' > "$PROMETHEUS_RESULTS_FILE"
-grep --invert-match "Prometheus-" "$RESULTS_FILE" | sed -E 's#/Mimir-[0-9]+##g' > "$MIMIR_RESULTS_FILE"
-
-benchstat "$PROMETHEUS_RESULTS_FILE" "$MIMIR_RESULTS_FILE" | sed "s#$PROMETHEUS_RESULTS_FILE#     Prometheus     #g" | sed "s#$MIMIR_RESULTS_FILE#     Mimir     #g"
-
-rm "$PROMETHEUS_RESULTS_FILE" "$MIMIR_RESULTS_FILE"
+benchstat -col="/engine@(Prometheus Mimir)" "$RESULTS_FILE"

--- a/tools/benchmark-query-engine/main.go
+++ b/tools/benchmark-query-engine/main.go
@@ -271,8 +271,8 @@ func (a *app) allTestCaseNames() []string {
 	names := make([]string, 0, 2*len(cases))
 
 	for _, c := range cases {
-		names = append(names, benchmarkName+"/"+c.Name()+"/Mimir")
-		names = append(names, benchmarkName+"/"+c.Name()+"/Prometheus")
+		names = append(names, benchmarkName+"/"+c.Name()+"/engine=Mimir")
+		names = append(names, benchmarkName+"/"+c.Name()+"/engine=Prometheus")
 	}
 
 	return names


### PR DESCRIPTION
#### What this PR does

This PR makes use of `benchstat`'s `-col` flag to simplify the benchmark comparison script used for comparing MQE to Prometheus' engine.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
