### PR TITLE
Fix Alertmanager receiver firewal to detect 0.0.0.0 and IPv6 interface-local multicast address as local addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@
 * [BUGFIX] Alertmanager: Fix config validation gap around unreferenced templates. #9207
 * [BUGFIX] Alertmanager: Fix goroutine leak when stored config fails to apply and there is no existing tenant alertmanager #9211
 * [BUGFIX] Querier: fix issue where both recently compacted blocks and their source blocks can be skipped during querying if store-gateways are restarting. #9224
-* [BUGFIX] Alertmanager: fix receiver firewal to detect `0.0.0.0` and IPv6 interface-local multicast address as local addresses. #9308
+* [BUGFIX] Alertmanager: fix receiver firewall to detect `0.0.0.0` and IPv6 interface-local multicast address as local addresses. #9308
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 * [BUGFIX] Alertmanager: Fix config validation gap around unreferenced templates. #9207
 * [BUGFIX] Alertmanager: Fix goroutine leak when stored config fails to apply and there is no existing tenant alertmanager #9211
 * [BUGFIX] Querier: fix issue where both recently compacted blocks and their source blocks can be skipped during querying if store-gateways are restarting. #9224
+* [BUGFIX] Alertmanager: fix receiver firewal to detect `0.0.0.0` and IPv6 interface-local multicast address as local addresses. #9308
 
 ### Mixin
 

--- a/pkg/util/net/firewall_dialer.go
+++ b/pkg/util/net/firewall_dialer.go
@@ -72,5 +72,5 @@ func (d *FirewallDialer) control(_, address string, _ syscall.RawConn) error {
 }
 
 func isLocal(ip net.IP) bool {
-	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsInterfaceLocalMulticast() || ip.IsUnspecified()
 }

--- a/pkg/util/net/firewall_dialer_test.go
+++ b/pkg/util/net/firewall_dialer_test.go
@@ -35,6 +35,7 @@ func TestFirewallDialer(t *testing.T) {
 			cases: []testCase{
 				{"localhost", false},
 				{"127.0.0.1", false},
+				{"0.0.0.0", false},
 				{"google.com", false},
 				{"172.217.168.78", false},
 			},
@@ -46,15 +47,17 @@ func TestFirewallDialer(t *testing.T) {
 			cases: []testCase{
 				{"localhost", true},
 				{"127.0.0.1", true},
+				{"0.0.0.0", true},
 				{"192.168.0.1", true},
 				{"10.0.0.1", true},
 				{"google.com", false},
 				{"172.217.168.78", false},
-				{"fdf8:f53b:82e4::53", true},       // Local
-				{"fe80::200:5aee:feaa:20a2", true}, // Link-local
-				{"2001:4860:4860::8844", false},    // Google DNS
-				{"::ffff:172.217.168.78", false},   // IPv6 mapped v4 non-private
-				{"::ffff:192.168.0.1", true},       // IPv6 mapped v4 private
+				{"fdf8:f53b:82e4::53", true},        // Local
+				{"fe80::200:5aee:feaa:20a2", true},  // Link-local
+				{"ff01::2f3b:56a1:88e4:7c9d", true}, // Interface-local multicast address
+				{"2001:4860:4860::8844", false},     // Google DNS
+				{"::ffff:172.217.168.78", false},    // IPv6 mapped v4 non-private
+				{"::ffff:192.168.0.1", true},        // IPv6 mapped v4 private
 			},
 		},
 		"should support blocking custom CIDRs": {


### PR DESCRIPTION
#### What this PR does

In this PR I'm fixing the built-in Alertmanager receiver firewall detect `0.0.0.0` and IPv6 interface-local multicast address as local addresses, to be blocked if enabled via `-alertmanager.receivers-firewall-block-private-addresses`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
