### PR TITLE
Skip image checks to match other repositories that use the asset server for images

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Run doc-validator tool (mimir)
         run: >
           doc-validator
-          '--skip-checks=^canonical-does-not-match-pretty-URL$'
+          '--skip-checks=^canonical-does-not-match-pretty-URL|image.+$'
           docs/sources/mimir
           /docs/mimir/latest
           | reviewdog


### PR DESCRIPTION
#### What this PR does

Stop erroring when images are not included in page bundles. The image rules are documented in https://grafana.com/docs/writers-toolkit/review/doc-validator/errata/#image-does-not-exist. They insist that all images are stored in the repository in a page bundle and are only referenced by the containing page.

Assets should instead be stored in https://grafana.com/docs/writers-toolkit/write/image-guidelines/#where-to-store-media-assets to avoid bloating this repository and the website repository with binary files.

@tacole02 We'll probably want to migrate images as they are updated unless you want to do them all together?

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
