### PR TITLE
Register block-builder target in mimir

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -198,12 +198,12 @@ func (b *BlockBuilder) nextConsumeCycle(ctx context.Context, cycleEnd time.Time)
 		b.blockBuilderMetrics.consumerLagRecords.WithLabelValues(fmt.Sprintf("%d", lag.Partition)).Set(float64(lag.Lag))
 
 		if lag.Lag <= 0 {
-			level.Info(b.logger).Log("msg", "nothing to consume in partition", "partition", partition, "offset", lag.Commit.At, "end_offset", lag.End.Offset, "lag", lag.Lag)
+			level.Info(b.logger).Log("msg", "nothing to consume in partition", "partition", partition, "commit_offset", lag.Commit.At, "start_offset", lag.Start.Offset, "end_offset", lag.End.Offset, "lag", lag.Lag)
 			continue
 		}
 
 		state := partitionStateFromLag(b.logger, lag, b.fallbackOffsetMillis)
-		if err := b.consumePartition(ctx, partition, state, cycleEnd); err != nil {
+		if err := b.consumePartition(ctx, partition, state, cycleEnd, lag.End.Offset); err != nil {
 			level.Error(b.logger).Log("msg", "failed to consume partition", "err", err, "partition", partition)
 		}
 	}
@@ -239,8 +239,6 @@ func (b *BlockBuilder) getLagForPartition(ctx context.Context, partition int32) 
 }
 
 type partitionState struct {
-	// Lag is the upperbound number of records the cycle will need to consume.
-	Lag int64
 	// Commit is the offset of the next record we'll start consuming.
 	Commit kadm.Offset
 	// CommitRecordTimestamp is the timestamp of the record whose offset was committed (and not the time of commit).
@@ -256,7 +254,7 @@ func partitionStateFromLag(logger log.Logger, lag kadm.GroupMemberLag, fallbackM
 	if err != nil {
 		// If there is an error in unmarshalling the metadata, treat it as if
 		// we have no commit. There is no reason to stop the cycle for this.
-		level.Error(logger).Log("msg", "error unmarshalling commit metadata", "err", err, "partition", lag.Partition, "offset", lag.Commit.At, "metadata", lag.Commit.Metadata)
+		level.Error(logger).Log("msg", "error unmarshalling commit metadata", "err", err, "partition", lag.Partition, "commit_offset", lag.Commit.At, "metadata", lag.Commit.Metadata)
 	}
 
 	if commitRecTs == 0 {
@@ -264,22 +262,23 @@ func partitionStateFromLag(logger log.Logger, lag kadm.GroupMemberLag, fallbackM
 		// records because it is non-trivial to peek at the first record in a partition to determine
 		// the range of replay required. Without knowing the range, we might end up trying to consume
 		// a lot of records in a single partition consumption call and end up in an OOM loop.
-		level.Info(logger).Log("msg", "no commit record timestamp in commit metadata; needs to fall back", "partition", lag.Partition, "offset", lag.Commit.At, "metadata", lag.Commit.Metadata, "fallback_millis", fallbackMillis)
+		level.Info(logger).Log("msg", "no commit record timestamp in commit metadata; needs to fall back", "partition", lag.Partition, "commit_offset", lag.Commit.At, "metadata", lag.Commit.Metadata, "fallback_millis", fallbackMillis)
 		commitRecTs = fallbackMillis
 	}
 
-	level.Debug(logger).Log(
+	level.Info(logger).Log(
 		"msg", "creating partition state",
 		"partition", lag.Partition,
+		"start_offset", lag.Start.Offset,
+		"end_offset", lag.End.Offset,
 		"lag", lag.Lag,
 		"commit_rec_ts", commitRecTs,
-		"commit_rec_offset", lag.Commit.At,
+		"commit_offset", lag.Commit.At,
 		"last_seen_offset", lastSeenOffset,
 		"last_block_end_ts", lastBlockEndTs,
 	)
 
 	return partitionState{
-		Lag:                   lag.Lag,
 		Commit:                lag.Commit,
 		CommitRecordTimestamp: time.UnixMilli(commitRecTs),
 		LastSeenOffset:        lastSeenOffset,
@@ -289,7 +288,7 @@ func partitionStateFromLag(logger log.Logger, lag kadm.GroupMemberLag, fallbackM
 
 // consumePartition consumes records from the given partition until the cycleEnd timestamp.
 // If the partition is lagging behind, it takes care of consuming it in sections.
-func (b *BlockBuilder) consumePartition(ctx context.Context, partition int32, state partitionState, cycleEnd time.Time) (err error) {
+func (b *BlockBuilder) consumePartition(ctx context.Context, partition int32, state partitionState, cycleEnd time.Time, cycleEndOffset int64) (err error) {
 	builder := NewTSDBBuilder(b.logger, b.cfg.DataDir, b.cfg.BlocksStorage, b.limits, b.tsdbBuilderMetrics)
 	defer runutil.CloseWithErrCapture(&err, builder, "closing tsdb builder")
 
@@ -306,11 +305,11 @@ func (b *BlockBuilder) consumePartition(ctx context.Context, partition int32, st
 			b.cfg.ConsumeInterval,
 			b.cfg.ConsumeIntervalBuffer,
 		)
-		level.Info(b.logger).Log("msg", "partition is lagging behind the cycle", "partition", partition, "lag", state.Lag, "section_end", sectionEnd, "cycle_end", cycleEnd, "commit_rec_ts", state.CommitRecordTimestamp)
+		level.Info(b.logger).Log("msg", "partition is lagging behind the cycle", "partition", partition, "section_end", sectionEnd, "cycle_end", cycleEnd, "cycle_end_offset", cycleEndOffset, "commit_rec_ts", state.CommitRecordTimestamp)
 	}
 	for !sectionEnd.After(cycleEnd) {
-		partitionLogger := log.With(b.logger, "partition", partition, "lag", state.Lag, "section_end", sectionEnd)
-		state, err = b.consumePartitionSection(ctx, partitionLogger, builder, partition, state, sectionEnd)
+		logger := log.With(b.logger, "partition", partition, "section_end", sectionEnd, "cycle_end_offset", cycleEndOffset)
+		state, err = b.consumePartitionSection(ctx, logger, builder, partition, state, sectionEnd, cycleEndOffset)
 		if err != nil {
 			return fmt.Errorf("consume partition %d: %w", partition, err)
 		}
@@ -320,7 +319,15 @@ func (b *BlockBuilder) consumePartition(ctx context.Context, partition int32, st
 	return nil
 }
 
-func (b *BlockBuilder) consumePartitionSection(ctx context.Context, logger log.Logger, builder *TSDBBuilder, partition int32, state partitionState, sectionEnd time.Time) (retState partitionState, retErr error) {
+func (b *BlockBuilder) consumePartitionSection(
+	ctx context.Context,
+	logger log.Logger,
+	builder *TSDBBuilder,
+	partition int32,
+	state partitionState,
+	sectionEnd time.Time,
+	cycleEndOffset int64,
+) (retState partitionState, retErr error) {
 	// Oppose to the section's range (and cycle's range), that include the ConsumeIntervalBuffer, the block's range doesn't.
 	// Thus, truncate the timestamp with ConsumptionInterval here to round the block's range.
 	blockEnd := sectionEnd.Truncate(b.cfg.ConsumeInterval)
@@ -335,14 +342,14 @@ func (b *BlockBuilder) consumePartitionSection(ctx context.Context, logger log.L
 		dur := time.Since(t)
 
 		if retErr != nil {
-			level.Error(logger).Log("msg", "partition consumption failed", "err", retErr, "duration", dur, "curr_lag", retState.Lag)
+			level.Error(logger).Log("msg", "partition consumption failed", "err", retErr, "duration", dur)
 			return
 		}
 
 		b.blockBuilderMetrics.processPartitionDuration.WithLabelValues(fmt.Sprintf("%d", partition)).Observe(dur.Seconds())
-		level.Info(logger).Log("msg", "done consuming", "duration", dur, "curr_lag", retState.Lag,
+		level.Info(logger).Log("msg", "done consuming", "duration", dur,
 			"last_block_end", startState.LastBlockEnd, "curr_block_end", blockEnd,
-			"last_seen_offset", startState.LastSeenOffset, "curr_seen_offset", retState.LastSeenOffset,
+			"last_seen_offset", startState.LastSeenOffset, "curr_seen_offset", retState.LastSeenOffset, "cycle_end_offset", cycleEndOffset,
 			"num_blocks", numBlocks)
 	}(time.Now(), state)
 
@@ -357,7 +364,7 @@ func (b *BlockBuilder) consumePartitionSection(ctx context.Context, logger log.L
 	})
 	defer b.kafkaClient.RemoveConsumePartitions(map[string][]int32{b.cfg.Kafka.Topic: {partition}})
 
-	level.Info(logger).Log("msg", "start consuming", "offset", state.Commit.At)
+	level.Info(logger).Log("msg", "start consuming", "offset", state.Commit.At, "cycle_end_offset", cycleEndOffset)
 
 	var (
 		firstRec  *kgo.Record
@@ -366,7 +373,7 @@ func (b *BlockBuilder) consumePartitionSection(ctx context.Context, logger log.L
 	)
 
 consumerLoop:
-	for remaining := state.Lag; remaining > 0; {
+	for recOffset := int64(-1); recOffset < cycleEndOffset-1; {
 		if err := context.Cause(ctx); err != nil {
 			return partitionState{}, err
 		}
@@ -383,16 +390,9 @@ consumerLoop:
 			}
 		})
 
-		// If the partition had gaps in its offsets there is a potential edge-case here.
-		// In theory, the initial remaining value (i.e. the lag) can over-count how many records are available in partition
-		// to consume. Theoretically, if this is an inactive partition that doesn't receive new records, in the case of the gaps,
-		// the consumerLoop loop can end up into an infinite loop.
-		// TODO(v): Instead of counting the number of remaining records, we may rework it to use the partition end's offset
-		// from the time of lag calculation as the guard for the loop.
-		remaining -= int64(fetches.NumRecords())
-
 		for recIter := fetches.RecordIter(); !recIter.Done(); {
 			rec := recIter.Next()
+			recOffset = rec.Offset
 
 			if firstRec == nil {
 				firstRec = rec
@@ -472,7 +472,6 @@ consumerLoop:
 		Metadata:    marshallCommitMeta(commitRec.Timestamp.UnixMilli(), lastSeenOffset, lastBlockEnd.UnixMilli()),
 	}
 	newState := partitionState{
-		Lag:                   state.Lag - (commit.At - firstRec.Offset), // the new lag is the distance between fully processed offsets
 		Commit:                commit,
 		CommitRecordTimestamp: commitRec.Timestamp,
 		LastSeenOffset:        lastSeenOffset,

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -614,33 +614,14 @@ func TestPartitionStateFromLag(t *testing.T) {
 		wantState      partitionState
 	}{
 		{
-			name: "no commit, no lag",
+			name: "no commit",
 			lag: kadm.GroupMemberLag{
 				Topic:     testTopic,
 				Partition: 0,
 				Commit:    kadm.Offset{},
-				Lag:       0,
 			},
 			fallbackMillis: testTime.UnixMilli(),
 			wantState: partitionState{
-				Lag:                   0,
-				Commit:                kadm.Offset{},
-				CommitRecordTimestamp: testTime,
-				LastSeenOffset:        0,
-				LastBlockEnd:          time.UnixMilli(0),
-			},
-		},
-		{
-			name: "no commit, some lag",
-			lag: kadm.GroupMemberLag{
-				Topic:     testTopic,
-				Partition: 0,
-				Commit:    kadm.Offset{},
-				Lag:       10,
-			},
-			fallbackMillis: testTime.UnixMilli(),
-			wantState: partitionState{
-				Lag:                   10,
 				Commit:                kadm.Offset{},
 				CommitRecordTimestamp: testTime,
 				LastSeenOffset:        0,
@@ -653,11 +634,9 @@ func TestPartitionStateFromLag(t *testing.T) {
 				Topic:     testTopic,
 				Partition: 0,
 				Commit:    testKafkaOffset,
-				Lag:       10,
 			},
 			fallbackMillis: testTime.UnixMilli(),
 			wantState: partitionState{
-				Lag:                   10,
 				Commit:                testKafkaOffset,
 				CommitRecordTimestamp: commitRecTs,
 				LastSeenOffset:        lastRecOffset,

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -48,6 +48,7 @@ import (
 	alertbucketclient "github.com/grafana/mimir/pkg/alertmanager/alertstore/bucketclient"
 	alertstorelocal "github.com/grafana/mimir/pkg/alertmanager/alertstore/local"
 	"github.com/grafana/mimir/pkg/api"
+	"github.com/grafana/mimir/pkg/blockbuilder"
 	"github.com/grafana/mimir/pkg/compactor"
 	"github.com/grafana/mimir/pkg/continuoustest"
 	"github.com/grafana/mimir/pkg/distributor"
@@ -123,6 +124,7 @@ type Config struct {
 	Worker           querier_worker.Config           `yaml:"frontend_worker"`
 	Frontend         frontend.CombinedFrontendConfig `yaml:"frontend"`
 	IngestStorage    ingest.Config                   `yaml:"ingest_storage"`
+	BlockBuilder     blockbuilder.Config             `yaml:"block_builder" doc:"hidden"`
 	BlocksStorage    tsdb.BlocksStorageConfig        `yaml:"blocks_storage"`
 	Compactor        compactor.Config                `yaml:"compactor"`
 	StoreGateway     storegateway.Config             `yaml:"store_gateway"`
@@ -181,6 +183,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.Worker.RegisterFlags(f)
 	c.Frontend.RegisterFlags(f, logger)
 	c.IngestStorage.RegisterFlags(f)
+	c.BlockBuilder.RegisterFlags(f, logger)
 	c.BlocksStorage.RegisterFlags(f)
 	c.Compactor.RegisterFlags(f, logger)
 	c.StoreGateway.RegisterFlags(f, logger)
@@ -730,6 +733,7 @@ type Mimir struct {
 	ActivityTracker                 *activitytracker.ActivityTracker
 	Vault                           *vault.Vault
 	UsageStatsReporter              *usagestats.Reporter
+	BlockBuilder                    *blockbuilder.BlockBuilder
 	ContinuousTestManager           *continuoustest.Manager
 	BuildInfoHandler                http.Handler
 }

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -39,6 +39,7 @@ import (
 	"github.com/grafana/mimir/pkg/alertmanager/alertstore"
 	"github.com/grafana/mimir/pkg/alertmanager/alertstore/bucketclient"
 	"github.com/grafana/mimir/pkg/api"
+	"github.com/grafana/mimir/pkg/blockbuilder"
 	"github.com/grafana/mimir/pkg/compactor"
 	"github.com/grafana/mimir/pkg/continuoustest"
 	"github.com/grafana/mimir/pkg/distributor"
@@ -100,6 +101,7 @@ const (
 	Vault                           string = "vault"
 	TenantFederation                string = "tenant-federation"
 	UsageStats                      string = "usage-stats"
+	BlockBuilder                    string = "block-builder"
 	ContinuousTest                  string = "continuous-test"
 	All                             string = "all"
 
@@ -1083,6 +1085,16 @@ func (t *Mimir) initUsageStats() (services.Service, error) {
 	return t.UsageStatsReporter, nil
 }
 
+func (t *Mimir) initBlockBuilder() (_ services.Service, err error) {
+	t.Cfg.BlockBuilder.Kafka = t.Cfg.IngestStorage.KafkaConfig
+	t.Cfg.BlockBuilder.BlocksStorage = t.Cfg.BlocksStorage
+	t.BlockBuilder, err = blockbuilder.New(t.Cfg.BlockBuilder, util_log.Logger, t.Registerer, t.Overrides)
+	if err != nil {
+		return nil, errors.Wrap(err, "block-builder init")
+	}
+	return t.BlockBuilder, nil
+}
+
 func (t *Mimir) initContinuousTest() (services.Service, error) {
 	client, err := continuoustest.NewClient(t.Cfg.ContinuousTest.Client, util_log.Logger)
 	if err != nil {
@@ -1133,6 +1145,7 @@ func (t *Mimir) setupModuleManager() error {
 	mm.RegisterModule(QueryScheduler, t.initQueryScheduler)
 	mm.RegisterModule(TenantFederation, t.initTenantFederation, modules.UserInvisibleModule)
 	mm.RegisterModule(UsageStats, t.initUsageStats, modules.UserInvisibleModule)
+	mm.RegisterModule(BlockBuilder, t.initBlockBuilder)
 	mm.RegisterModule(ContinuousTest, t.initContinuousTest)
 	mm.RegisterModule(Vault, t.initVault, modules.UserInvisibleModule)
 	mm.RegisterModule(Write, nil)
@@ -1168,6 +1181,7 @@ func (t *Mimir) setupModuleManager() error {
 		Compactor:                       {API, MemberlistKV, Overrides, Vault},
 		StoreGateway:                    {API, Overrides, MemberlistKV, Vault},
 		TenantFederation:                {Queryable},
+		BlockBuilder:                    {API, Overrides},
 		ContinuousTest:                  {API},
 		Write:                           {Distributor, Ingester},
 		Read:                            {QueryFrontend, Querier},


### PR DESCRIPTION
#### What this PR does

~~_This one seats atop https://github.com/grafana/mimir/pull/9199 for now_~~

This is part of https://github.com/grafana/mimir/pull/8635; refer to it for more details.

Here we register the `block-builder` target in mimir. The block-builder is still in an earlier experiment, thus don't expose any documentation or changelog for now.

Also, the PR addresses the discussion we had with @dimitarvdimitrov in https://github.com/grafana/mimir/pull/9199#discussion_r1773600398 about a potential edge-case for a partition that has offset gaps. Here we refactor the internals of the consumer loop replacing the use of remaining lag with the reference to the partition end, at the time of the cycle.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
