### PR TITLE
distributor: add logs to flaky TestDistributor_Push_ShouldSupportWriteBothToIngestersAndPartitions

### DIFF
--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -452,7 +453,15 @@ func TestDistributor_Push_ShouldSupportWriteBothToIngestersAndPartitions(t *test
 
 			// Ensure series has been correctly sharded to partitions.
 			actualSeriesByPartition := readAllMetricNamesByPartitionFromKafka(t, kafkaCluster.ListenAddrs(), testConfig.ingestStoragePartitions, time.Second)
-			assert.Equal(t, testData.expectedMetricsByPartition, actualSeriesByPartition)
+			if !assert.Equal(t, testData.expectedMetricsByPartition, actualSeriesByPartition, "please report this failure in https://github.com/grafana/mimir/issues/9299") {
+				// This test is sometimes flaky. Add a log line to help debug it.
+				// Inspect the offsets of partitions in Kafka. There may be records, but we couldn't fetch them in the 1s timeout above.
+				kafkaClient, err := kgo.NewClient(kgo.SeedBrokers(kafkaCluster.ListenAddrs()...))
+				assert.NoError(t, err)
+				offsets, err := kadm.NewClient(kafkaClient).ListEndOffsets(context.Background(), kafkaTopic)
+				assert.NoError(t, err)
+				t.Logf("Kafka topic %s end offsets: %v", kafkaTopic, offsets)
+			}
 
 			// Ensure series have been correctly sharded to ingesters.
 			for _, ingester := range ingesters {

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -460,7 +460,7 @@ func TestDistributor_Push_ShouldSupportWriteBothToIngestersAndPartitions(t *test
 				assert.NoError(t, err)
 				offsets, err := kadm.NewClient(kafkaClient).ListEndOffsets(context.Background(), kafkaTopic)
 				assert.NoError(t, err)
-				t.Logf("Kafka topic %s end offsets: %v", kafkaTopic, offsets)
+				t.Logf("Kafka topic %s end offsets: %#v", kafkaTopic, offsets)
 			}
 
 			// Ensure series have been correctly sharded to ingesters.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does


I suspect the 1s timeout can expire in CI. Let's inspect kafka in CI to check if that's the case or we have a bug.


#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/issues/9299

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
