### PR TITLE
Add locking around test logger to avoid data race

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/atomic"
 
+	mimirtest "github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/testkafka"
 )
 
@@ -1713,7 +1714,7 @@ func withLogger(logger log.Logger) func(cfg *readerTestCfg) {
 func defaultReaderTestConfig(t *testing.T, addr string, topicName string, partitionID int32, consumer recordConsumer) *readerTestCfg {
 	return &readerTestCfg{
 		registry:    prometheus.NewPedanticRegistry(),
-		logger:      testutil.NewLogger(t),
+		logger:      mimirtest.NewTestingLogger(t),
 		kafka:       createTestKafkaConfig(addr, topicName),
 		partitionID: partitionID,
 		consumer:    consumer,

--- a/pkg/util/test/logger.go
+++ b/pkg/util/test/logger.go
@@ -3,6 +3,7 @@
 package test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -10,7 +11,8 @@ import (
 )
 
 type testingLogger struct {
-	t testing.TB
+	t   testing.TB
+	mtx sync.Mutex
 }
 
 func NewTestingLogger(t testing.TB) log.Logger {
@@ -22,6 +24,10 @@ func NewTestingLogger(t testing.TB) log.Logger {
 func (l *testingLogger) Log(keyvals ...interface{}) error {
 	// Prepend log with timestamp.
 	keyvals = append([]interface{}{time.Now().String()}, keyvals...)
+
+	l.mtx.Lock()
 	l.t.Log(keyvals...)
+	l.mtx.Unlock()
+
 	return nil
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes or relates to

Fixes #9325

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
