### PR TITLE
Remove use of leaf-node round-robin algorithm

### DIFF
--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
@@ -379,13 +379,13 @@ func TestMultiDimensionalQueueAlgorithmSlowConsumerEffects(t *testing.T) {
 		tqaFlipped := newTenantQuerierAssignments()
 		tqaQuerierWorkerPrioritization := newTenantQuerierAssignments()
 
-		nonFlippedRoundRobinTree, err := NewTree(tqaNonFlipped, &roundRobinState{}, &roundRobinState{})
+		nonFlippedRoundRobinTree, err := NewTree(tqaNonFlipped, &roundRobinState{})
 		require.NoError(t, err)
 
-		flippedRoundRobinTree, err := NewTree(&roundRobinState{}, tqaFlipped, &roundRobinState{})
+		flippedRoundRobinTree, err := NewTree(&roundRobinState{}, tqaFlipped)
 		require.NoError(t, err)
 
-		querierWorkerPrioritizationTree, err := NewTree(NewQuerierWorkerQueuePriorityAlgo(), tqaQuerierWorkerPrioritization, &roundRobinState{})
+		querierWorkerPrioritizationTree, err := NewTree(NewQuerierWorkerQueuePriorityAlgo(), tqaQuerierWorkerPrioritization)
 		require.NoError(t, err)
 
 		treeScenarios := []struct {

--- a/pkg/scheduler/queue/tenant_queues.go
+++ b/pkg/scheduler/queue/tenant_queues.go
@@ -55,14 +55,12 @@ func newQueueBroker(
 		algos = []QueuingAlgorithm{
 			NewQuerierWorkerQueuePriorityAlgo(), // root; algorithm selects query component based on worker ID
 			tqas,                                // query components; algorithm selects tenants
-			&roundRobinState{},                  // tenant queues; algorithm selects query from local queue
 
 		}
 	} else {
 		algos = []QueuingAlgorithm{
 			tqas,               // root; algorithm selects tenants
 			&roundRobinState{}, // tenant queues; algorithm selects query component
-			&roundRobinState{}, // query components; algorithm selects query from local queue
 		}
 	}
 	tree, err = NewTree(algos...)

--- a/pkg/scheduler/queue/tree_queue_algo_querier_worker_queue_priority_test.go
+++ b/pkg/scheduler/queue/tree_queue_algo_querier_worker_queue_priority_test.go
@@ -60,7 +60,7 @@ func TestQuerierWorkerQueuePriority_SingleWorkerBehavior(t *testing.T) {
 
 	querierWorkerPrioritizationQueueAlgo := NewQuerierWorkerQueuePriorityAlgo()
 
-	tree, err := NewTree(querierWorkerPrioritizationQueueAlgo, &roundRobinState{})
+	tree, err := NewTree(querierWorkerPrioritizationQueueAlgo)
 	require.NoError(t, err)
 
 	for _, operation := range operationOrder {
@@ -83,7 +83,7 @@ func TestQuerierWorkerQueuePriority_SingleWorkerBehavior(t *testing.T) {
 func TestQuerierWorkerQueuePriority_StartPositionByWorker(t *testing.T) {
 	querierWorkerPrioritizationQueueAlgo := NewQuerierWorkerQueuePriorityAlgo()
 
-	tree, err := NewTree(querierWorkerPrioritizationQueueAlgo, &roundRobinState{})
+	tree, err := NewTree(querierWorkerPrioritizationQueueAlgo)
 	require.NoError(t, err)
 
 	// enqueue 3 objects each to 3 different children;
@@ -165,7 +165,7 @@ func TestQuerierWorkerQueuePriority_StartPositionByWorker(t *testing.T) {
 func TestQuerierWorkerQueuePriority_StartPositionByWorker_MultipleNodeCountsInTree(t *testing.T) {
 	querierWorkerPrioritizationQueueAlgo := NewQuerierWorkerQueuePriorityAlgo()
 
-	tree, err := NewTree(&roundRobinState{}, querierWorkerPrioritizationQueueAlgo, &roundRobinState{})
+	tree, err := NewTree(&roundRobinState{}, querierWorkerPrioritizationQueueAlgo)
 	require.NoError(t, err)
 
 	// enqueue 2 objects each to 2 different children, each with 3 different grandchildren;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
At a leaf node, `QueuingAlgorithm` isn't used; we simply dequeue from the `Node`'s `localQueue`. To avoid confusion, we will use a `nil` `QueuingAlgorithm` in these cases, and append `nil` to the list of queuing algorithms at tree creation, so the leaf node behavior is always accounted for.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
