### PR TITLE
kafka replay speed: adjust batchingQueueCapacity

### DIFF
--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -469,7 +469,7 @@ type batchingQueue struct {
 func newBatchingQueue(capacity int, batchSize int) *batchingQueue {
 	return &batchingQueue{
 		ch:           make(chan flushableWriteRequest, capacity),
-		errCh:        make(chan error, capacity),
+		errCh:        make(chan error, capacity+1),
 		done:         make(chan struct{}),
 		currentBatch: flushableWriteRequest{WriteRequest: &mimirpb.WriteRequest{Timeseries: mimirpb.PreallocTimeseriesSliceFromPool()}},
 		batchSize:    batchSize,

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -31,7 +31,8 @@ import (
 // If we're still flushing batch `N`, batch `N+1` is enqueued for flushing, and we've just finished batching batch `N+2`,
 // then we're going too fast - in the time to flush `N` we've created `N+2` and `N+1`.
 // A buffer of 1 doesn't let us go too far ahead with batching, but still doesn't require synchronisation between batching and flushing.
-const batchingQueueCapacity = 1
+// If there's high variability in the time to flush or in the time to batch, then this buffer might need to be increased.
+const batchingQueueCapacity = 5
 
 type Pusher interface {
 	PushToStorage(context.Context, *mimirpb.WriteRequest) error

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -25,12 +25,9 @@ import (
 )
 
 // batchingQueueCapacity controls how many batches can be enqueued for flushing.
-// We want to batch and flush in parallel. There's no point in batching faster than we can flush.
-// A buffer of 1 would allow to balance the time for batching and flushing 50/50.
+// We don't want to push any batches in parallel and instead want to prepare the next one while the current one finishes, hence the buffer of 1.
 // For example, if we flush 1 batch/sec, then batching 2 batches/sec doesn't make us faster.
-// If we're still flushing batch `N`, batch `N+1` is enqueued for flushing, and we've just finished batching batch `N+2`,
-// then we're going too fast - in the time to flush `N` we've created `N+2` and `N+1`.
-// A buffer of 1 doesn't let us go too far ahead with batching, but still doesn't require synchronisation between batching and flushing.
+// This is our initial assumption, and there's potential in testing with higher numbers if there's a high variability in flush times - assuming we can preserve the order of the batches. For now, we'll stick to 1.
 // If there's high variability in the time to flush or in the time to batch, then this buffer might need to be increased.
 const batchingQueueCapacity = 5
 

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -27,7 +27,7 @@ import (
 // batchingQueueCapacity controls how many batches can be enqueued for flushing.
 // We don't want to push any batches in parallel and instead want to prepare the next one while the current one finishes, hence the buffer of 1.
 // For example, if we flush 1 batch/sec, then batching 2 batches/sec doesn't make us faster.
-// This is our initial assumption, and there's potential in testing with higher numbers if there's a high variability in flush times - assuming we can preserve the order of the batches. For now, we'll stick to 1.
+// This is our initial assumption, and there's potential in testing with higher numbers if there's a high variability in flush times - assuming we can preserve the order of the batches. For now, we'll stick to 5.
 // If there's high variability in the time to flush or in the time to batch, then this buffer might need to be increased.
 const batchingQueueCapacity = 5
 

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -469,7 +469,7 @@ type batchingQueue struct {
 func newBatchingQueue(capacity int, batchSize int) *batchingQueue {
 	return &batchingQueue{
 		ch:           make(chan flushableWriteRequest, capacity),
-		errCh:        make(chan error, capacity+1),
+		errCh:        make(chan error, capacity+1), // We check errs before pushing to the channel, so we need to have a buffer of at least capacity+1 so that the consumer can push all of its errors and not rely on the producer to unblock it.
 		done:         make(chan struct{}),
 		currentBatch: flushableWriteRequest{WriteRequest: &mimirpb.WriteRequest{Timeseries: mimirpb.PreallocTimeseriesSliceFromPool()}},
 		batchSize:    batchSize,

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -673,6 +673,7 @@ func TestBatchingQueue_NoDeadlock(t *testing.T) {
 
 	// Ensure the queue is empty and no deadlock occurred
 	require.Len(t, queue.ch, 0)
+	require.Len(t, queue.errCh, 0)
 	require.Len(t, queue.currentBatch.Timeseries, 0)
 }
 

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -638,6 +638,7 @@ func TestParallelStorageShards_ShardWriteRequest(t *testing.T) {
 		})
 	}
 }
+
 func TestBatchingQueue_NoDeadlock(t *testing.T) {
 	capacity := 2
 	batchSize := 3


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

I made 2000 up when we were flushing individual series to the channel. Then 2000 might have made sense, but when flushing whole WriteRequests a capacity of 1 should be sufficient.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
