### PR TITLE
kafka replay speed: ingestion metrics

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1021,7 +1021,6 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
-github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
 github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-jose/go-jose/v4 v4.0.1 h1:QVEPDE3OluqXBQZDcnNvQrInro2h0e4eqNbnZSWqS6U=

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -274,10 +274,10 @@ local filename = 'mimir-writes.json';
         ) +
         $.queryPanel(
           [
-            'histogram_avg(sum(rate(cortex_ingest_storage_reader_processing_time_seconds{%s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-            'histogram_quantile(0.99, sum(rate(cortex_ingest_storage_reader_processing_time_seconds{%s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-            'histogram_quantile(0.999, sum(rate(cortex_ingest_storage_reader_processing_time_seconds{%s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
-            'histogram_quantile(1.0, sum(rate(cortex_ingest_storage_reader_processing_time_seconds{%s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+            'histogram_avg(sum(rate(cortex_ingest_storage_reader_records_processing_time_seconds{%s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+            'histogram_quantile(0.99, sum(rate(cortex_ingest_storage_reader_records_processing_time_seconds{%s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+            'histogram_quantile(0.999, sum(rate(cortex_ingest_storage_reader_records_processing_time_seconds{%s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+            'histogram_quantile(1.0, sum(rate(cortex_ingest_storage_reader_records_processing_time_seconds{%s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
           ],
           [
             'avg',

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -15,8 +15,6 @@ import (
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/user"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -51,93 +49,6 @@ type pusherConsumer struct {
 	kafkaConfig KafkaConfig
 
 	pusher Pusher
-}
-
-type pusherConsumerMetrics struct {
-	processingTimeSeconds prometheus.Observer
-	clientErrRequests     prometheus.Counter
-	serverErrRequests     prometheus.Counter
-	totalRequests         prometheus.Counter
-
-	storagePusherMetrics *storagePusherMetrics
-}
-
-// newPusherConsumerMetrics creates a new pusherConsumerMetrics instance.
-func newPusherConsumerMetrics(reg prometheus.Registerer) *pusherConsumerMetrics {
-	errRequestsCounter := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-		Name: "cortex_ingest_storage_reader_records_failed_total",
-		Help: "Number of records (write requests) which caused errors while processing. Client errors are errors such as tenant limits and samples out of bounds. Server errors indicate internal recoverable errors.",
-	}, []string{"cause"})
-
-	return &pusherConsumerMetrics{
-		storagePusherMetrics: newStoragePusherMetrics(reg),
-		processingTimeSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:                            "cortex_ingest_storage_reader_records_processing_time_seconds",
-			Help:                            "Time taken to process a batch of fetched records. Fetched records are effectively a set of WriteRequests read from Kafka.",
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: 1 * time.Hour,
-			Buckets:                         prometheus.DefBuckets,
-		}),
-
-		clientErrRequests: errRequestsCounter.WithLabelValues("client"),
-		serverErrRequests: errRequestsCounter.WithLabelValues("server"),
-		totalRequests: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_ingest_storage_reader_records_total",
-			Help: "Number of attempted records (write requests).",
-		}),
-	}
-}
-
-// batchingQueueMetrics holds the metrics for the batchingQueue.
-type batchingQueueMetrics struct {
-	flushTotal       prometheus.Counter
-	flushErrorsTotal prometheus.Counter
-}
-
-// newBatchingQueueMetrics creates a new batchingQueueMetrics instance.
-func newBatchingQueueMetrics(reg prometheus.Registerer) *batchingQueueMetrics {
-	return &batchingQueueMetrics{
-		flushTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_ingest_storage_reader_batching_queue_flush_total",
-			Help: "Number of times a batch of samples is flushed to the storage.",
-		}),
-		flushErrorsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_ingest_storage_reader_batching_queue_flush_errors_total",
-			Help: "Number of errors encountered while flushing a batch of samples to the storage.",
-		}),
-	}
-}
-
-// storagePusherMetrics holds the metrics for both the sequentialStoragePusher and the parallelStoragePusher.
-type storagePusherMetrics struct {
-	// batchAge is not really important unless we're pushing many things at once, so it's only used as part of parallelStoragePusher.
-	batchAge             prometheus.Histogram
-	processingTime       *prometheus.HistogramVec
-	timeSeriesPerFlush   prometheus.Histogram
-	batchingQueueMetrics *batchingQueueMetrics
-}
-
-// newStoragePusherMetrics creates a new storagePusherMetrics instance.
-func newStoragePusherMetrics(reg prometheus.Registerer) *storagePusherMetrics {
-	return &storagePusherMetrics{
-		batchingQueueMetrics: newBatchingQueueMetrics(reg),
-		batchAge: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:                        "cortex_ingest_storage_reader_pusher_batch_age_seconds",
-			Help:                        "Age of the batch of samples that are being ingested by an ingestion shard. This is the time since adding the first sample to the batch. Higher values indicates that the batching queue is not processing fast enough or that the batches are not filling up fast enough.",
-			NativeHistogramBucketFactor: 1.1,
-		}),
-		processingTime: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:                        "cortex_ingest_storage_reader_pusher_processing_time_seconds",
-			Help:                        "Time to ingest a batch of samples for timeseries or metadata by an ingestion shard. The 'batch_contents' label indicates the contents of the batch.",
-			NativeHistogramBucketFactor: 1.1,
-		}, []string{"content"}),
-		timeSeriesPerFlush: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:                        "cortex_ingest_storage_reader_pusher_timeseries_per_flush",
-			Help:                        "Number of time series pushed in each batch to an ingestion shard. A lower number than -ingest-storage.kafka.ingestion-concurrency-batch-size indicates that shards are not filling up and may not be parallelizing ingestion as efficiently.",
-			NativeHistogramBucketFactor: 1.1,
-		}),
-	}
 }
 
 // newPusherConsumer creates a new pusherConsumer instance.

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -86,12 +86,12 @@ func newPusherConsumerMetrics(reg prometheus.Registerer) *pusherConsumerMetrics 
 			Buckets:                         prometheus.DefBuckets,
 		}),
 		ingestionShardBatchAge: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:                        "cortex_ingest_storage_reader_ingestion_shard_batch_age_seconds",
+			Name:                        "cortex_ingest_storage_reader_batching_queue_age_seconds",
 			Help:                        "Age of the batch when it is being ingested by an ingestion shard. This is the time since adding the first sample to the batch. A high value indicated that the batching queue is not processing fast enough or that the batches are not filling up fast enough.",
 			NativeHistogramBucketFactor: 1.1,
 		}, []string{"user"}),
 		batchProcessingTimeSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:                        "cortex_ingest_storage_reader_ingestion_shard_batch_processing_time_seconds",
+			Name:                        "cortex_ingest_storage_reader_batching_queue_processing_time_seconds",
 			Help:                        "Time to process a batch of samples in an ingestion shard.",
 			NativeHistogramBucketFactor: 1.1,
 		}, []string{"batch_contents", "user"}),

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -541,6 +541,9 @@ func (q *batchingQueue) AddToBatch(ctx context.Context, source mimirpb.WriteRequ
 
 // AddMetadataToBatch adds metadata to the current batch.
 func (q *batchingQueue) AddMetadataToBatch(ctx context.Context, source mimirpb.WriteRequest_SourceEnum, metadata *mimirpb.MetricMetadata) error {
+	if q.currentBatch.startedAt.IsZero() {
+		q.currentBatch.startedAt = time.Now()
+	}
 	q.currentBatch.Metadata = append(q.currentBatch.Metadata, metadata)
 	q.currentBatch.Context = ctx
 	q.currentBatch.Source = source

--- a/pkg/storage/ingest/pusher_metrics.go
+++ b/pkg/storage/ingest/pusher_metrics.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingest
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// pusherConsumerMetrics holds the metrics for the pusherConsumer.
+type pusherConsumerMetrics struct {
+	processingTimeSeconds prometheus.Observer
+	clientErrRequests     prometheus.Counter
+	serverErrRequests     prometheus.Counter
+	totalRequests         prometheus.Counter
+
+	storagePusherMetrics *storagePusherMetrics
+}
+
+// newPusherConsumerMetrics creates a new pusherConsumerMetrics instance.
+func newPusherConsumerMetrics(reg prometheus.Registerer) *pusherConsumerMetrics {
+	errRequestsCounter := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_ingest_storage_reader_records_failed_total",
+		Help: "Number of records (write requests) which caused errors while processing. Client errors are errors such as tenant limits and samples out of bounds. Server errors indicate internal recoverable errors.",
+	}, []string{"cause"})
+
+	return &pusherConsumerMetrics{
+		storagePusherMetrics: newStoragePusherMetrics(reg),
+		processingTimeSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:                            "cortex_ingest_storage_reader_records_processing_time_seconds",
+			Help:                            "Time taken to process a batch of fetched records. Fetched records are effectively a set of WriteRequests read from Kafka.",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+			Buckets:                         prometheus.DefBuckets,
+		}),
+
+		clientErrRequests: errRequestsCounter.WithLabelValues("client"),
+		serverErrRequests: errRequestsCounter.WithLabelValues("server"),
+		totalRequests: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingest_storage_reader_records_total",
+			Help: "Number of attempted records (write requests).",
+		}),
+	}
+}
+
+// storagePusherMetrics holds the metrics for both the sequentialStoragePusher and the parallelStoragePusher.
+type storagePusherMetrics struct {
+	// batchAge is not really important unless we're pushing many things at once, so it's only used as part of parallelStoragePusher.
+	batchAge             prometheus.Histogram
+	processingTime       *prometheus.HistogramVec
+	timeSeriesPerFlush   prometheus.Histogram
+	batchingQueueMetrics *batchingQueueMetrics
+}
+
+// newStoragePusherMetrics creates a new storagePusherMetrics instance.
+func newStoragePusherMetrics(reg prometheus.Registerer) *storagePusherMetrics {
+	return &storagePusherMetrics{
+		batchingQueueMetrics: newBatchingQueueMetrics(reg),
+		batchAge: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:                        "cortex_ingest_storage_reader_pusher_batch_age_seconds",
+			Help:                        "Age of the batch of samples that are being ingested by an ingestion shard. This is the time since adding the first sample to the batch. Higher values indicates that the batching queue is not processing fast enough or that the batches are not filling up fast enough.",
+			NativeHistogramBucketFactor: 1.1,
+		}),
+		processingTime: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                        "cortex_ingest_storage_reader_pusher_processing_time_seconds",
+			Help:                        "Time to ingest a batch of samples for timeseries or metadata by an ingestion shard. The 'batch_contents' label indicates the contents of the batch.",
+			NativeHistogramBucketFactor: 1.1,
+		}, []string{"content"}),
+		timeSeriesPerFlush: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:                        "cortex_ingest_storage_reader_pusher_timeseries_per_flush",
+			Help:                        "Number of time series pushed in each batch to an ingestion shard. A lower number than -ingest-storage.kafka.ingestion-concurrency-batch-size indicates that shards are not filling up and may not be parallelizing ingestion as efficiently.",
+			NativeHistogramBucketFactor: 1.1,
+		}),
+	}
+}
+
+// batchingQueueMetrics holds the metrics for the batchingQueue.
+type batchingQueueMetrics struct {
+	flushTotal       prometheus.Counter
+	flushErrorsTotal prometheus.Counter
+}
+
+// newBatchingQueueMetrics creates a new batchingQueueMetrics instance.
+func newBatchingQueueMetrics(reg prometheus.Registerer) *batchingQueueMetrics {
+	return &batchingQueueMetrics{
+		flushTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingest_storage_reader_batching_queue_flush_total",
+			Help: "Number of times a batch of samples is flushed to the storage.",
+		}),
+		flushErrorsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_ingest_storage_reader_batching_queue_flush_errors_total",
+			Help: "Number of errors encountered while flushing a batch of samples to the storage.",
+		}),
+	}
+}


### PR DESCRIPTION

#### What this PR does


* `cortex_ingest_storage_reader_processing_time_seconds` now records the time to process the whole batch of requests; this is useful in measuring the effectiveness of fetching from kafka vs ingesting
* `cortex_ingester_pusher_ingestion_shard_batch_age_seconds` to keep an eye on the performance of the queue
* `cortex_ingest_storage_reader_ingestion_shard_batch_processing_time_seconds` to know when popping form the queue slows down


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
