### PR TITLE
Add MimirGossipMembersEndpointsOutOfSync alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@
 * [ENHANCEMENT] Dashboards: add 'Read path' selector to 'Mimir / Queries' dashboard. #8878
 * [ENHANCEMENT] Dashboards: add annotation indicating active series are being reloaded to 'Mimir / Tenants' dashboard. #9257
 * [ENHANCEMENT] Dashboards: limit results on the 'Failed evaluations rate' panel of the 'Mimir / Tenants' dashboard to 50 to avoid crashing the page when there are many failing groups. #9262
+* [FEATURE] Alerts: add `MimirGossipMembersEndpointsOutOfSync` alert. #9347
 * [BUGFIX] Dashboards: fix "current replicas" in autoscaling panels when HPA is not active. #8566
 * [BUGFIX] Alerts: do not fire `MimirRingMembersMismatch` during the migration to experimental ingest storage. #8727
 * [BUGFIX] Dashboards: avoid over-counting of ingesters metrics when migrating to experimental ingest storage. #9170

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -963,12 +963,9 @@ How to **investigate**:
   2. Consider removing some deployments from `gossip-ring` selector label, to reduce the number of matching pods below 1000.
      This is a temporarily workaround, and you should revert it once you upgrade Kubernetes to a version with the bug fixed.
 
-     If you're using jsonnet, you can do:
+     An example of how you can do it with jsonnet:
 
      ```
-     # Repeat it for any deployment you want to remove from memberlist seed nodes,
-     # but make sure you keep a good number of Mimir pods with the label, so that
-     # there's no risk of having no running seed nodes when a Mimir pod starts.
      querier_deployment+:
        $.apps.v1.statefulSet.spec.template.metadata.withLabelsMixin({ [$._config.gossip_member_label]: 'false' }),
      ```

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -952,7 +952,6 @@ How to **investigate**:
      SERVICE="gossip-ring"
 
      # Re-apply the list of bad endpoints as is.
-     rm -f /tmp/service-endpoints.yaml
      kubectl --context "$CONTEXT" --namespace "$NAMESPACE" get endpoints "$SERVICE" -o yaml > /tmp/service-endpoints.yaml
      kubectl --context "$CONTEXT" --namespace "$NAMESPACE" apply -f /tmp/service-endpoints.yaml
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -956,13 +956,12 @@ How to **investigate**:
      kubectl --context "$CONTEXT" --namespace "$NAMESPACE" apply -f /tmp/service-endpoints.yaml
 
      # Delete a random querier pod to trigger K8S service endpoints reconciliation.
-    POD=$(kubectl --context "$CONTEXT" --namespace "$NAMESPACE" get pods -l name=querier --output="jsonpath={.items[0].metadata.name}")
-    kubectl --context "$CONTEXT" --namespace "$NAMESPACE" delete pod "$POD"
+     POD=$(kubectl --context "$CONTEXT" --namespace "$NAMESPACE" get pods -l name=querier --output="jsonpath={.items[0].metadata.name}")
+     kubectl --context "$CONTEXT" --namespace "$NAMESPACE" delete pod "$POD"
      ```
 
-  2. Consider changing the gossip-ring selector label from some deployments, up until the number of matching pods
-     goes below 1000. This should be a temporary workaround, and you should revert it once you upgrade Kubernetes to
-     a version with the bug fixed.
+  2. Consider removing some deployments from `gossip-ring` selector label, to reduce the number of matching pods below 1000.
+     This is a temporarily workaround, and you should revert it once you upgrade Kubernetes to a version with the bug fixed.
 
      If you're using jsonnet, you can do:
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -960,8 +960,8 @@ How to **investigate**:
      kubectl --context "$CONTEXT" --namespace "$NAMESPACE" get pods -l name=querier --no-headers | head -1 | awk '{print $1}' | xargs -I {} kubectl --context "$CONTEXT" --namespace "$NAMESPACE" delete pod {}
      ```
 
-  2. Consider to change the gossip-ring selector label from some deployments, up until the number of matching pods
-     goes below 1000. This should be a temporarily workaround, and you should revert it once you upgrade Kubernetes to
+  2. Consider changing the gossip-ring selector label from some deployments, up until the number of matching pods
+     goes below 1000. This should be a temporary workaround, and you should revert it once you upgrade Kubernetes to
      a version with the bug fixed.
 
      If you're using jsonnet, you can do:

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -946,7 +946,7 @@ How to **investigate**:
 
   1. Stop the bleed re-creating the service endpoints list
 
-     ```
+     ```sh
      CONTEXT="TODO"
      NAMESPACE="TODO"
      SERVICE="gossip-ring"
@@ -956,7 +956,8 @@ How to **investigate**:
      kubectl --context "$CONTEXT" --namespace "$NAMESPACE" apply -f /tmp/service-endpoints.yaml
 
      # Delete a random querier pod to trigger K8S service endpoints reconciliation.
-     kubectl --context "$CONTEXT" --namespace "$NAMESPACE" get pods -l name=querier --no-headers | head -1 | awk '{print $1}' | xargs -I {} kubectl --context "$CONTEXT" --namespace "$NAMESPACE" delete pod {}
+    POD=$(kubectl --context "$CONTEXT" --namespace "$NAMESPACE" get pods -l name=querier --output="jsonpath={.items[0].metadata.name}")
+    kubectl --context "$CONTEXT" --namespace "$NAMESPACE" delete pod "$POD"
      ```
 
   2. Consider changing the gossip-ring selector label from some deployments, up until the number of matching pods

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -920,6 +920,60 @@ How to **investigate**:
     - These errors (and others) can be found by searching for messages prefixed with `TCPTransport:`.
 - Logs coming directly from memberlist are also logged by Mimir; they may indicate where to investigate further. These can be identified as such due to being tagged with `caller=memberlist_logger.go:<line>`.
 
+### MimirGossipMembersEndpointsOutOfSync
+
+This alert fires when the list of endpoints returned by the `gossip-ring` service is out-of-sync.
+
+How it **works**:
+
+- The Kubernetes service `gossip-ring` is used by Mimir to find memberlist seed nodes to join at startup. The service
+  DNS returns all Mimir pods by default, which means any Mimir pod can be used as a seed node (this is the safest option).
+- Due to Kubernetes bugs (for example, [this one](https://github.com/kubernetes/kubernetes/issues/127370)) the pod IPs
+  returned by the service DNS address may go out-of-sync, up to a point where none of the returned IPs belongs to any
+  live pod. If that happens, then new Mimir pods can't join memberlist at startup.
+
+How to **investigate**:
+
+- Check the number of endpoints matching the `gossip-ring` service:
+  ```
+  kubectl --namespace <namespace> get endpoints gossip-ring
+  ```
+- If the number of endpoints is 1000 then it means you reached the Kubernetes limit, the endpoints get truncated and
+  you could be hit by [this bug](https://github.com/kubernetes/kubernetes/issues/127370). Having more than 1000 pods
+  matched by the `gossip-ring` service and then getting endpoints truncated to 1000 is not an issue per-se, but it's
+  an issue if you're running a version of Kubernetes affected by the mentioned bug.
+- If you've been affected by the Kubernetes bug:
+
+  1. Stop the bleed re-creating the service endpoints list
+
+     ```
+     CONTEXT="TODO"
+     NAMESPACE="TODO"
+     SERVICE="gossip-ring"
+
+     # Re-apply the list of bad endpoints as is.
+     rm -f /tmp/service-endpoints.yaml
+     kubectl --context "$CONTEXT" --namespace "$NAMESPACE" get endpoints "$SERVICE" -o yaml > /tmp/service-endpoints.yaml
+     kubectl --context "$CONTEXT" --namespace "$NAMESPACE" apply -f /tmp/service-endpoints.yaml
+
+     # Delete a random querier pod to trigger K8S service endpoints reconciliation.
+     kubectl --context "$CONTEXT" --namespace "$NAMESPACE" get pods -l name=querier --no-headers | head -1 | awk '{print $1}' | xargs -I {} kubectl --context "$CONTEXT" --namespace "$NAMESPACE" delete pod {}
+     ```
+
+  2. Consider to change the gossip-ring selector label from some deployments, up until the number of matching pods
+     goes below 1000. This should be a temporarily workaround, and you should revert it once you upgrade Kubernetes to
+     a version with the bug fixed.
+
+     If you're using jsonnet, you can do:
+
+     ```
+     # Repeat it for any deployment you want to remove from memberlist seed nodes,
+     # but make sure you keep a good number of Mimir pods with the label, so that
+     # there's no risk of having no running seed nodes when a Mimir pod starts.
+     querier_deployment+:
+       $.apps.v1.statefulSet.spec.template.metadata.withLabelsMixin({ [$._config.gossip_member_label]: 'false' }),
+     ```
+
 ### EtcdAllocatingTooMuchMemory
 
 This can be triggered if there are too many HA dedupe keys in etcd. We saw this when one of our clusters hit 20K tenants that were using HA dedupe config. Raise the etcd limits via:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -558,12 +558,12 @@ spec:
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
             expr: |
               (
-                sum by(cluster, namespace) (
+                count by(cluster, namespace) (
                   kube_endpoint_address{endpoint="gossip-ring"}
                   unless on (cluster, namespace, ip)
                   label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
                 /
-                sum by(cluster, namespace) (
+                count by(cluster, namespace) (
                   kube_endpoint_address{endpoint="gossip-ring"}
                 )
                 * 100 > 10
@@ -580,12 +580,12 @@ spec:
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
             expr: |
               (
-                sum by(cluster, namespace) (
+                count by(cluster, namespace) (
                   kube_endpoint_address{endpoint="gossip-ring"}
                   unless on (cluster, namespace, ip)
                   label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
                 /
-                sum by(cluster, namespace) (
+                count by(cluster, namespace) (
                   kube_endpoint_address{endpoint="gossip-ring"}
                 )
                 * 100 > 50

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -560,7 +560,7 @@ spec:
               (
                 sum by(cluster, namespace) (
                   kube_endpoint_address{endpoint="gossip-ring"}
-                  unless on (ip)
+                  unless on (cluster, namespace, ip)
                   label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
                 /
                 sum by(cluster, namespace) (
@@ -582,7 +582,7 @@ spec:
               (
                 sum by(cluster, namespace) (
                   kube_endpoint_address{endpoint="gossip-ring"}
-                  unless on (ip)
+                  unless on (cluster, namespace, ip)
                   label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
                 /
                 sum by(cluster, namespace) (

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -552,6 +552,50 @@ spec:
             for: 20m
             labels:
               severity: warning
+          - alert: MimirGossipMembersEndpointsOutOfSync
+            annotations:
+              message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+            expr: |
+              (
+                sum by(cluster, namespace) (
+                  kube_endpoint_address{endpoint="gossip-ring"}
+                  unless on (ip)
+                  label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
+                /
+                sum by(cluster, namespace) (
+                  kube_endpoint_address{endpoint="gossip-ring"}
+                )
+                * 100 > 10
+              )
+  
+              # Filter by Mimir only.
+              and (count by(cluster, namespace) (cortex_build_info) > 0)
+            for: 15m
+            labels:
+              severity: warning
+          - alert: MimirGossipMembersEndpointsOutOfSync
+            annotations:
+              message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+            expr: |
+              (
+                sum by(cluster, namespace) (
+                  kube_endpoint_address{endpoint="gossip-ring"}
+                  unless on (ip)
+                  label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
+                /
+                sum by(cluster, namespace) (
+                  kube_endpoint_address{endpoint="gossip-ring"}
+                )
+                * 100 > 50
+              )
+  
+              # Filter by Mimir only.
+              and (count by(cluster, namespace) (cortex_build_info) > 0)
+            for: 5m
+            labels:
+              severity: critical
       - name: etcd_alerts
         rules:
           - alert: EtcdAllocatingTooMuchMemory

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -530,6 +530,50 @@ groups:
           for: 20m
           labels:
             severity: warning
+        - alert: MimirGossipMembersEndpointsOutOfSync
+          annotations:
+            message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+          expr: |
+            (
+              sum by(cluster, namespace) (
+                kube_endpoint_address{endpoint="gossip-ring"}
+                unless on (ip)
+                label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
+              /
+              sum by(cluster, namespace) (
+                kube_endpoint_address{endpoint="gossip-ring"}
+              )
+              * 100 > 10
+            )
+
+            # Filter by Mimir only.
+            and (count by(cluster, namespace) (cortex_build_info) > 0)
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MimirGossipMembersEndpointsOutOfSync
+          annotations:
+            message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+          expr: |
+            (
+              sum by(cluster, namespace) (
+                kube_endpoint_address{endpoint="gossip-ring"}
+                unless on (ip)
+                label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
+              /
+              sum by(cluster, namespace) (
+                kube_endpoint_address{endpoint="gossip-ring"}
+              )
+              * 100 > 50
+            )
+
+            # Filter by Mimir only.
+            and (count by(cluster, namespace) (cortex_build_info) > 0)
+          for: 5m
+          labels:
+            severity: critical
     - name: etcd_alerts
       rules:
         - alert: EtcdAllocatingTooMuchMemory

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -536,12 +536,12 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
           expr: |
             (
-              sum by(cluster, namespace) (
+              count by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
                 unless on (cluster, namespace, ip)
                 label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
               /
-              sum by(cluster, namespace) (
+              count by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
               )
               * 100 > 10
@@ -558,12 +558,12 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
           expr: |
             (
-              sum by(cluster, namespace) (
+              count by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
                 unless on (cluster, namespace, ip)
                 label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
               /
-              sum by(cluster, namespace) (
+              count by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
               )
               * 100 > 50

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -538,7 +538,7 @@ groups:
             (
               sum by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
-                unless on (ip)
+                unless on (cluster, namespace, ip)
                 label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
               /
               sum by(cluster, namespace) (
@@ -560,7 +560,7 @@ groups:
             (
               sum by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
-                unless on (ip)
+                unless on (cluster, namespace, ip)
                 label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
               /
               sum by(cluster, namespace) (

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -546,12 +546,12 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
           expr: |
             (
-              sum by(cluster, namespace) (
+              count by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
                 unless on (cluster, namespace, ip)
                 label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
               /
-              sum by(cluster, namespace) (
+              count by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
               )
               * 100 > 10
@@ -568,12 +568,12 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
           expr: |
             (
-              sum by(cluster, namespace) (
+              count by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
                 unless on (cluster, namespace, ip)
                 label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
               /
-              sum by(cluster, namespace) (
+              count by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
               )
               * 100 > 50

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -540,6 +540,50 @@ groups:
           for: 20m
           labels:
             severity: warning
+        - alert: MimirGossipMembersEndpointsOutOfSync
+          annotations:
+            message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+          expr: |
+            (
+              sum by(cluster, namespace) (
+                kube_endpoint_address{endpoint="gossip-ring"}
+                unless on (ip)
+                label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
+              /
+              sum by(cluster, namespace) (
+                kube_endpoint_address{endpoint="gossip-ring"}
+              )
+              * 100 > 10
+            )
+
+            # Filter by Mimir only.
+            and (count by(cluster, namespace) (cortex_build_info) > 0)
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MimirGossipMembersEndpointsOutOfSync
+          annotations:
+            message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+          expr: |
+            (
+              sum by(cluster, namespace) (
+                kube_endpoint_address{endpoint="gossip-ring"}
+                unless on (ip)
+                label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
+              /
+              sum by(cluster, namespace) (
+                kube_endpoint_address{endpoint="gossip-ring"}
+              )
+              * 100 > 50
+            )
+
+            # Filter by Mimir only.
+            and (count by(cluster, namespace) (cortex_build_info) > 0)
+          for: 5m
+          labels:
+            severity: critical
     - name: etcd_alerts
       rules:
         - alert: EtcdAllocatingTooMuchMemory

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -548,7 +548,7 @@ groups:
             (
               sum by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
-                unless on (ip)
+                unless on (cluster, namespace, ip)
                 label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
               /
               sum by(cluster, namespace) (
@@ -570,7 +570,7 @@ groups:
             (
               sum by(cluster, namespace) (
                 kube_endpoint_address{endpoint="gossip-ring"}
-                unless on (ip)
+                unless on (cluster, namespace, ip)
                 label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
               /
               sum by(cluster, namespace) (

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -806,6 +806,64 @@ local utils = import 'mixin-utils/utils.libsonnet';
             message: 'One or more %(product)s instances in %(alert_aggregation_variables)s consistently sees a lower than expected number of gossip members.' % $._config,
           },
         },
+        {
+          // Alert if the list of endpoints returned by the gossip-ring service (used as memberlist seed nodes)
+          // is out-of-sync. This is a warning alert with 10% out-of-sync threshold.
+          alert: $.alertName('GossipMembersEndpointsOutOfSync'),
+          expr:
+            |||
+              (
+                sum by(%(alert_aggregation_labels)s) (
+                  kube_endpoint_address{endpoint="gossip-ring"}
+                  unless on (ip)
+                  label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
+                /
+                sum by(%(alert_aggregation_labels)s) (
+                  kube_endpoint_address{endpoint="gossip-ring"}
+                )
+                * 100 > 10
+              )
+
+              # Filter by Mimir only.
+              and (count by(%(alert_aggregation_labels)s) (cortex_build_info) > 0)
+            ||| % $._config,
+          'for': '15m',
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s gossip-ring service endpoints list in %(alert_aggregation_variables)s is out of sync.' % $._config,
+          },
+        },
+        {
+          // Alert if the list of endpoints returned by the gossip-ring service (used as memberlist seed nodes)
+          // is out-of-sync. This is a critical alert with 50% out-of-sync threshold.
+          alert: $.alertName('GossipMembersEndpointsOutOfSync'),
+          expr:
+            |||
+              (
+                sum by(%(alert_aggregation_labels)s) (
+                  kube_endpoint_address{endpoint="gossip-ring"}
+                  unless on (ip)
+                  label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
+                /
+                sum by(%(alert_aggregation_labels)s) (
+                  kube_endpoint_address{endpoint="gossip-ring"}
+                )
+                * 100 > 50
+              )
+
+              # Filter by Mimir only.
+              and (count by(%(alert_aggregation_labels)s) (cortex_build_info) > 0)
+            ||| % $._config,
+          'for': '5m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: '%(product)s gossip-ring service endpoints list in %(alert_aggregation_variables)s is out of sync.' % $._config,
+          },
+        },
       ],
     },
     {

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -813,12 +813,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr:
             |||
               (
-                sum by(%(alert_aggregation_labels)s) (
+                count by(%(alert_aggregation_labels)s) (
                   kube_endpoint_address{endpoint="gossip-ring"}
                   unless on (%(alert_aggregation_labels)s, ip)
                   label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
                 /
-                sum by(%(alert_aggregation_labels)s) (
+                count by(%(alert_aggregation_labels)s) (
                   kube_endpoint_address{endpoint="gossip-ring"}
                 )
                 * 100 > 10
@@ -842,12 +842,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr:
             |||
               (
-                sum by(%(alert_aggregation_labels)s) (
+                count by(%(alert_aggregation_labels)s) (
                   kube_endpoint_address{endpoint="gossip-ring"}
                   unless on (%(alert_aggregation_labels)s, ip)
                   label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
                 /
-                sum by(%(alert_aggregation_labels)s) (
+                count by(%(alert_aggregation_labels)s) (
                   kube_endpoint_address{endpoint="gossip-ring"}
                 )
                 * 100 > 50

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -815,7 +815,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               (
                 sum by(%(alert_aggregation_labels)s) (
                   kube_endpoint_address{endpoint="gossip-ring"}
-                  unless on (ip)
+                  unless on (%(alert_aggregation_labels)s, ip)
                   label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
                 /
                 sum by(%(alert_aggregation_labels)s) (
@@ -844,7 +844,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               (
                 sum by(%(alert_aggregation_labels)s) (
                   kube_endpoint_address{endpoint="gossip-ring"}
-                  unless on (ip)
+                  unless on (%(alert_aggregation_labels)s, ip)
                   label_replace(kube_pod_info, "ip", "$1", "pod_ip", "(.*)"))
                 /
                 sum by(%(alert_aggregation_labels)s) (


### PR DESCRIPTION
#### What this PR does

Yesterday we found out a Kubernetes bug https://github.com/kubernetes/kubernetes/issues/127370 causing K8S service endpoints not getting updated when pods are stopped/started if there are more than 1K pods matching the service. This is badly affecting `gossip-ring` service, which includes all Mimir components.

In this PR I'm adding an alert + runbook specific to `gossip-ring` service.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
