### PR TITLE
kafka replay speed: move error handling closer to actual ingestion

### DIFF
--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -157,7 +157,6 @@ func (c pusherConsumer) pushToStorage(ctx context.Context, tenantID string, req 
 	ctx = user.InjectOrgID(ctx, tenantID)
 	err := writer.PushToStorage(ctx, req)
 
-	c.metrics.totalRequests.Inc()
 	return err
 }
 
@@ -181,6 +180,7 @@ func newClientErrorFilteringPusher(upstream Pusher, metrics *pusherConsumerMetri
 
 func (p *clientErrorFilteringPusher) PushToStorage(ctx context.Context, request *mimirpb.WriteRequest) error {
 	err := p.upstream.PushToStorage(ctx, request)
+	p.metrics.totalRequests.Inc()
 	if p.handlePushErr(ctx, err, spanlogger.FromContext(ctx, p.fallbackLogger)) {
 		return err
 	}

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -239,7 +239,7 @@ func removeUnimportantLogFields(lines []string) []string {
 	return lines
 }
 
-func TestClientErrorFilteringPusher_PushToStorage(t *testing.T) {
+func TestPushErrorHandler_IsServerError(t *testing.T) {
 	type testCase struct {
 		sampler         *util_log.Sampler
 		err             error

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -279,7 +279,7 @@ func TestClientErrorFilteringPusher_PushToStorage(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			c := newClientErrorFilteringPusher(nil, newPusherConsumerMetrics(prometheus.NewPedanticRegistry()), tc.sampler, log.NewNopLogger())
+			c := newPushErrorHandler(nil, newPusherConsumerMetrics(prometheus.NewPedanticRegistry()), tc.sampler, log.NewNopLogger())
 
 			sampled, reason := c.shouldLogClientError(context.Background(), tc.err)
 			assert.Equal(t, tc.expectedSampled, sampled)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Previously, we'd let error bubble-up and only take decisions on whether to abort the request or not at the very top (`pusherConsumer`). This meant that we'd potentially buffer more requests before we detect an error.

This change extracts error handling logic into a `Pusher` implementation: `clientErrorFilteringPusher`. This implementation logs client errors and then swallows them. We inject that implementation in front of the ingester. This means that the parallel storage implementation can abort ASAP instead of collecting and bubbling up the errors.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
