### PR TITLE
query-tee: fix error equivalence pattern for MQE binary operation conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,7 @@
 * [ENHANCEMENT] Don't consider responses to be different during response comparison if both backends' responses contain different series, but all samples are within the recent sample window. #8749 #8894
 * [ENHANCEMENT] When the expected and actual response for a matrix series is different, the full set of samples for that series from both backends will now be logged. #8947
 * [ENHANCEMENT] Wait up to `-server.graceful-shutdown-timeout` for inflight requests to finish when shutting down, rather than immediately terminating inflight requests on shutdown. #8985
-* [ENHANCEMENT] Optionally consider equivalent error messages the same when comparing responses. Enabled by default, disable with `-proxy.require-exact-error-match=true`. #9143
+* [ENHANCEMENT] Optionally consider equivalent error messages the same when comparing responses. Enabled by default, disable with `-proxy.require-exact-error-match=true`. #9143 #9350
 * [BUGFIX] Ensure any errors encountered while forwarding a request to a backend (eg. DNS resolution failures) are logged. #8419
 * [BUGFIX] The comparison of the results should not fail when either side contains extra samples from within SkipRecentSamples duration. #8920
 

--- a/tools/querytee/response_comparator.go
+++ b/tools/querytee/response_comparator.go
@@ -132,14 +132,14 @@ var errorEquivalenceClasses = [][]*regexp.Regexp{
 		// Prometheus' engine:
 		regexp.MustCompile(`found duplicate series for the match group \{.*\} on the (left|right) hand-side of the operation: \[.*\];many-to-many matching not allowed: matching labels must be unique on one side`),
 		// MQE:
-		regexp.MustCompile(`found duplicate series for the match group \{.*\} on the (left|right) side of the operation at timestamp \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z: \{.*\} and \{.*\}`),
+		regexp.MustCompile(`found duplicate series for the match group \{.*\} on the (left|right) side of the operation at timestamp \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z: \{.*\} and \{.*\}`),
 	},
 	{
 		// Same as above, but for left (one-to-one) / one (one-to-many/many-to-one) side.
 		// Prometheus' engine:
 		regexp.MustCompile(`multiple matches for labels: many-to-one matching must be explicit \(group_left/group_right\)`),
 		// MQE:
-		regexp.MustCompile(`found duplicate series for the match group \{.*\} on the (left|right) side of the operation at timestamp \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z: \{.*\} and \{.*\}`),
+		regexp.MustCompile(`found duplicate series for the match group \{.*\} on the (left|right) side of the operation at timestamp \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z: \{.*\} and \{.*\}`),
 	},
 }
 

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -1208,7 +1208,7 @@ func TestCompareSamplesResponse(t *testing.T) {
 						}`),
 			actual: json.RawMessage(`{
 							"status": "error",
-							"error": "found duplicate series for the match group {foo=\"bar\"} on the right side of the operation at timestamp 1970-01-01T00:00:00Z: {foo=\"bar\", env=\"test\"} and {foo=\"bar\", env=\"prod\"}"
+							"error": "found duplicate series for the match group {foo=\"bar\"} on the right side of the operation at timestamp 1970-01-01T00:00:00.123Z: {foo=\"bar\", env=\"test\"} and {foo=\"bar\", env=\"prod\"}"
 						}`),
 			err: nil,
 		},


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue in https://github.com/grafana/mimir/pull/9143, where the pattern for binary operation conflict errors returned by MQE did not consider timestamps with millisecond precision.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/9143

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
