### PR TITLE
objtools: fix 5GiB+ server-side copies on S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,7 @@
 * [ENHANCEMENT] `tsdb-series`: Added `-min-time` and `-max-time` options to filter samples that are used for computing data-points per minute. #8844
 * [ENHANCEMENT] `mimir-rules-action`: Added new input to support matching target namespaces by regex. #9244
 * [ENHANCEMENT] `mimir-rules-action`: Added new inputs to support ignoring namespaces and ignoring namespaces by regex. #9258 #9324
+* [BUGFIX] `copyblocks`, `undelete-blocks`, `copyprefix`: use a multipart upload to server-side copy objects greater than 5GiB in size on S3. #9357
 
 ## 2.13.0
 


### PR DESCRIPTION
This is a rebased, fixed, and tested version of https://github.com/grafana/mimir/pull/8427. I'm opening a new PR since I let that one rot while it was waiting to be tested (sorry!).

#### What this PR does

The primary motivation of this change is allowing `undelete-blocks` to recover very large blocks in S3 where an `index` object may exceed 5GiB.

A server-side copy on S3 with minio's `CopyObject` fails if the object is greater than 5GiB in size. When testing the previous PR I found a bug that was fixable by supplying `MatchRange: true` in the `srcOptions` for `ComposeObject`. Upon further inspection I realized the byte ranges don't need to be created at all because `ComposeObject` already handles it.

I commented that I don't think this approach works cross-region. The minio code tries to double check the source object size rather than allowing it to be supplied, but it unfortunately uses the destination client while doing so. Our test buckets don't work in that particular scenario anyway for other reasons so I was unable to directly verify this.

Manually tested using `copyprefix` to copy a 6GiB object from one prefix to another. It fails before this change and succeeds with it. A sha256 of the content of the copied object matched the source.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/2163

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
