### PR TITLE
Move the e2e histograms code to somewhere where it can be exported

### DIFF
--- a/integration/e2ehistograms/e2ehistograms.go
+++ b/integration/e2ehistograms/e2ehistograms.go
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-//go:build requires_docker
 
 package e2ehistograms
 

--- a/integration/e2ehistograms/e2ehistograms.go
+++ b/integration/e2ehistograms/e2ehistograms.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//go:build requires_docker
+
+package e2ehistograms
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/grafana/e2e"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+
+	"github.com/grafana/mimir/pkg/util/test"
+)
+
+var (
+	generateTestHistogram           = test.GenerateTestHistogram
+	generateTestFloatHistogram      = test.GenerateTestFloatHistogram
+	generateTestGaugeHistogram      = test.GenerateTestGaugeHistogram
+	generateTestGaugeFloatHistogram = test.GenerateTestGaugeFloatHistogram
+	generateTestSampleHistogram     = test.GenerateTestSampleHistogram
+)
+
+// generateHistogramFunc defines what kind of native histograms to generate: float/integer, counter/gauge
+type generateHistogramFunc func(tsMillis int64, value int) prompb.Histogram
+
+func GenerateHistogramSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
+	return generateHistogramSeriesWrapper(func(tsMillis int64, value int) prompb.Histogram {
+		return prompb.FromIntHistogram(tsMillis, generateTestHistogram(value))
+	}, name, ts, additionalLabels...)
+}
+
+func GenerateFloatHistogramSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
+	return generateHistogramSeriesWrapper(func(tsMillis int64, value int) prompb.Histogram {
+		return prompb.FromFloatHistogram(tsMillis, generateTestFloatHistogram(value))
+	}, name, ts, additionalLabels...)
+}
+
+func GenerateGaugeHistogramSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
+	return generateHistogramSeriesWrapper(func(tsMillis int64, value int) prompb.Histogram {
+		return prompb.FromIntHistogram(tsMillis, generateTestGaugeHistogram(value))
+	}, name, ts, additionalLabels...)
+}
+
+func GenerateGaugeFloatHistogramSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
+	return generateHistogramSeriesWrapper(func(tsMillis int64, value int) prompb.Histogram {
+		return prompb.FromFloatHistogram(tsMillis, generateTestGaugeFloatHistogram(value))
+	}, name, ts, additionalLabels...)
+}
+
+func generateHistogramSeriesWrapper(generateHistogram generateHistogramFunc, name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
+	tsMillis := e2e.TimeToMilliseconds(ts)
+
+	value := rand.Intn(1000)
+
+	lbls := append(
+		[]prompb.Label{
+			{Name: labels.MetricName, Value: name},
+		},
+		additionalLabels...,
+	)
+
+	// Generate the series
+	series = append(series, prompb.TimeSeries{
+		Labels: lbls,
+		Exemplars: []prompb.Exemplar{
+			{Value: float64(value), Timestamp: tsMillis, Labels: []prompb.Label{
+				{Name: "trace_id", Value: "1234"},
+			}},
+		},
+		Histograms: []prompb.Histogram{generateHistogram(tsMillis, value)},
+	})
+
+	// Generate the expected vector and matrix when querying it
+	metric := model.Metric{}
+	metric[labels.MetricName] = model.LabelValue(name)
+	for _, lbl := range additionalLabels {
+		metric[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+	}
+
+	vector = append(vector, &model.Sample{
+		Metric:    metric,
+		Timestamp: model.Time(tsMillis),
+		Histogram: generateTestSampleHistogram(value),
+	})
+
+	matrix = append(matrix, &model.SampleStream{
+		Metric: metric,
+		Histograms: []model.SampleHistogramPair{
+			{
+				Timestamp: model.Time(tsMillis),
+				Histogram: generateTestSampleHistogram(value),
+			},
+		},
+	})
+
+	return
+}
+
+func GenerateNHistogramSeries(nSeries, nExemplars int, name func() string, ts time.Time, additionalLabels func() []prompb.Label) (series []prompb.TimeSeries, vector model.Vector) {
+	tsMillis := e2e.TimeToMilliseconds(ts)
+
+	// Generate the series
+	for i := 0; i < nSeries; i++ {
+		lbls := []prompb.Label{
+			{Name: labels.MetricName, Value: name()},
+		}
+		if additionalLabels != nil {
+			lbls = append(lbls, additionalLabels()...)
+		}
+
+		exemplars := []prompb.Exemplar{}
+		if i < nExemplars {
+			exemplars = []prompb.Exemplar{
+				{Value: float64(i), Timestamp: tsMillis, Labels: []prompb.Label{{Name: "trace_id", Value: "1234"}}},
+			}
+		}
+
+		series = append(series, prompb.TimeSeries{
+			Labels:     lbls,
+			Histograms: []prompb.Histogram{prompb.FromIntHistogram(tsMillis, generateTestHistogram(i))},
+			Exemplars:  exemplars,
+		})
+	}
+
+	// Generate the expected vector when querying it
+	for i := 0; i < nSeries; i++ {
+		metric := model.Metric{}
+		for _, lbl := range series[i].Labels {
+			metric[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+		}
+
+		vector = append(vector, &model.Sample{
+			Metric:    metric,
+			Timestamp: model.Time(tsMillis),
+			Histogram: generateTestSampleHistogram(i),
+		})
+	}
+	return
+}

--- a/integration/util.go
+++ b/integration/util.go
@@ -8,7 +8,6 @@ package integration
 
 import (
 	"bytes"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,7 +21,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 
-	"github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/integration/e2ehistograms"
 )
 
 var (
@@ -34,13 +33,8 @@ var (
 	generateNFloatSeries = e2e.GenerateNSeries
 
 	// These are local, because e2e is used by non metric products that do not have native histograms
-	generateHistogramSeries         = GenerateHistogramSeries
-	generateNHistogramSeries        = GenerateNHistogramSeries
-	generateTestHistogram           = test.GenerateTestHistogram
-	generateTestFloatHistogram      = test.GenerateTestFloatHistogram
-	generateTestGaugeHistogram      = test.GenerateTestGaugeHistogram
-	generateTestGaugeFloatHistogram = test.GenerateTestGaugeFloatHistogram
-	generateTestSampleHistogram     = test.GenerateTestSampleHistogram
+	generateHistogramSeries  = e2ehistograms.GenerateHistogramSeries
+	generateNHistogramSeries = e2ehistograms.GenerateNHistogramSeries
 )
 
 // generateSeriesFunc defines what kind of series (and expected vectors/matrices) to generate - float samples or native histograms
@@ -55,11 +49,11 @@ func generateAlternatingSeries(i int) generateSeriesFunc {
 	case 1:
 		return generateHistogramSeries
 	case 2:
-		return GenerateFloatHistogramSeries
+		return e2ehistograms.GenerateFloatHistogramSeries
 	case 3:
-		return GenerateGaugeHistogramSeries
+		return e2ehistograms.GenerateGaugeHistogramSeries
 	case 4:
-		return GenerateGaugeFloatHistogramSeries
+		return e2ehistograms.GenerateGaugeFloatHistogramSeries
 	default:
 		return nil
 	}
@@ -140,124 +134,6 @@ func getTLSFlagsWithPrefix(prefix string, servername string, http bool) map[stri
 	}
 
 	return flags
-}
-
-// generateHistogramFunc defines what kind of native histograms to generate: float/integer, counter/gauge
-type generateHistogramFunc func(tsMillis int64, value int) prompb.Histogram
-
-func GenerateHistogramSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
-	return generateHistogramSeriesWrapper(func(tsMillis int64, value int) prompb.Histogram {
-		return prompb.FromIntHistogram(tsMillis, generateTestHistogram(value))
-	}, name, ts, additionalLabels...)
-}
-
-func GenerateFloatHistogramSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
-	return generateHistogramSeriesWrapper(func(tsMillis int64, value int) prompb.Histogram {
-		return prompb.FromFloatHistogram(tsMillis, generateTestFloatHistogram(value))
-	}, name, ts, additionalLabels...)
-}
-
-func GenerateGaugeHistogramSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
-	return generateHistogramSeriesWrapper(func(tsMillis int64, value int) prompb.Histogram {
-		return prompb.FromIntHistogram(tsMillis, generateTestGaugeHistogram(value))
-	}, name, ts, additionalLabels...)
-}
-
-func GenerateGaugeFloatHistogramSeries(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
-	return generateHistogramSeriesWrapper(func(tsMillis int64, value int) prompb.Histogram {
-		return prompb.FromFloatHistogram(tsMillis, generateTestGaugeFloatHistogram(value))
-	}, name, ts, additionalLabels...)
-}
-
-func generateHistogramSeriesWrapper(generateHistogram generateHistogramFunc, name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix) {
-	tsMillis := e2e.TimeToMilliseconds(ts)
-
-	value := rand.Intn(1000)
-
-	lbls := append(
-		[]prompb.Label{
-			{Name: labels.MetricName, Value: name},
-		},
-		additionalLabels...,
-	)
-
-	// Generate the series
-	series = append(series, prompb.TimeSeries{
-		Labels: lbls,
-		Exemplars: []prompb.Exemplar{
-			{Value: float64(value), Timestamp: tsMillis, Labels: []prompb.Label{
-				{Name: "trace_id", Value: "1234"},
-			}},
-		},
-		Histograms: []prompb.Histogram{generateHistogram(tsMillis, value)},
-	})
-
-	// Generate the expected vector and matrix when querying it
-	metric := model.Metric{}
-	metric[labels.MetricName] = model.LabelValue(name)
-	for _, lbl := range additionalLabels {
-		metric[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-	}
-
-	vector = append(vector, &model.Sample{
-		Metric:    metric,
-		Timestamp: model.Time(tsMillis),
-		Histogram: generateTestSampleHistogram(value),
-	})
-
-	matrix = append(matrix, &model.SampleStream{
-		Metric: metric,
-		Histograms: []model.SampleHistogramPair{
-			{
-				Timestamp: model.Time(tsMillis),
-				Histogram: generateTestSampleHistogram(value),
-			},
-		},
-	})
-
-	return
-}
-
-func GenerateNHistogramSeries(nSeries, nExemplars int, name func() string, ts time.Time, additionalLabels func() []prompb.Label) (series []prompb.TimeSeries, vector model.Vector) {
-	tsMillis := e2e.TimeToMilliseconds(ts)
-
-	// Generate the series
-	for i := 0; i < nSeries; i++ {
-		lbls := []prompb.Label{
-			{Name: labels.MetricName, Value: name()},
-		}
-		if additionalLabels != nil {
-			lbls = append(lbls, additionalLabels()...)
-		}
-
-		exemplars := []prompb.Exemplar{}
-		if i < nExemplars {
-			exemplars = []prompb.Exemplar{
-				{Value: float64(i), Timestamp: tsMillis, Labels: []prompb.Label{{Name: "trace_id", Value: "1234"}}},
-			}
-		}
-
-		series = append(series, prompb.TimeSeries{
-			Labels:     lbls,
-			Histograms: []prompb.Histogram{prompb.FromIntHistogram(tsMillis, generateTestHistogram(i))},
-			Exemplars:  exemplars,
-		})
-	}
-
-	// Generate the expected vector when querying it
-	for i := 0; i < nSeries; i++ {
-		metric := model.Metric{}
-		for _, lbl := range series[i].Labels {
-			metric[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
-		}
-
-		vector = append(vector, &model.Sample{
-			Metric:    metric,
-			Timestamp: model.Time(tsMillis),
-			Histogram: generateTestSampleHistogram(i),
-		})
-	}
-	return
 }
 
 func filterSamplesByTimestamp(input []prompb.Sample, startMs, endMs int64) []prompb.Sample {


### PR DESCRIPTION
#### What this PR does

Minor refactor of integration/util.go to separate concerns more cleanly, moving the e2e histograms code to its own package, which will allow us to export it without exporting a lot of other unnecessary code.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

None as these are minor, non-user-facing changes.