### PR TITLE
Generalise some of Mimir's query sharding code to be more reusable

### DIFF
--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -218,7 +218,7 @@ func testFrontend(t *testing.T, config CombinedFrontendConfig, handler http.Hand
 	if l != nil {
 		logger = l
 	}
-	codec := querymiddleware.NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, "json")
+	codec := querymiddleware.NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, "json", nil)
 
 	var workerConfig querier_worker.Config
 	flagext.DefaultValues(&workerConfig)

--- a/pkg/frontend/querymiddleware/codec_json.go
+++ b/pkg/frontend/querymiddleware/codec_json.go
@@ -13,11 +13,11 @@ const jsonMimeType = "application/json"
 
 type jsonFormatter struct{}
 
-func (j jsonFormatter) EncodeResponse(resp *PrometheusResponse) ([]byte, error) {
+func (j jsonFormatter) EncodeQueryResponse(resp *PrometheusResponse) ([]byte, error) {
 	return json.Marshal(resp)
 }
 
-func (j jsonFormatter) DecodeResponse(buf []byte) (*PrometheusResponse, error) {
+func (j jsonFormatter) DecodeQueryResponse(buf []byte) (*PrometheusResponse, error) {
 	var resp PrometheusResponse
 
 	if err := json.Unmarshal(buf, &resp); err != nil {

--- a/pkg/frontend/querymiddleware/codec_json.go
+++ b/pkg/frontend/querymiddleware/codec_json.go
@@ -5,7 +5,9 @@
 
 package querymiddleware
 
-import v1 "github.com/prometheus/prometheus/web/api/v1"
+import (
+	v1 "github.com/prometheus/prometheus/web/api/v1"
+)
 
 const jsonMimeType = "application/json"
 
@@ -17,6 +19,34 @@ func (j jsonFormatter) EncodeResponse(resp *PrometheusResponse) ([]byte, error) 
 
 func (j jsonFormatter) DecodeResponse(buf []byte) (*PrometheusResponse, error) {
 	var resp PrometheusResponse
+
+	if err := json.Unmarshal(buf, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (j jsonFormatter) EncodeLabelsResponse(resp *PrometheusLabelsResponse) ([]byte, error) {
+	return json.Marshal(resp)
+}
+
+func (j jsonFormatter) DecodeLabelsResponse(buf []byte) (*PrometheusLabelsResponse, error) {
+	var resp PrometheusLabelsResponse
+
+	if err := json.Unmarshal(buf, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (j jsonFormatter) EncodeSeriesResponse(resp *PrometheusSeriesResponse) ([]byte, error) {
+	return json.Marshal(resp)
+}
+
+func (j jsonFormatter) DecodeSeriesResponse(buf []byte) (*PrometheusSeriesResponse, error) {
+	var resp PrometheusSeriesResponse
 
 	if err := json.Unmarshal(buf, &resp); err != nil {
 		return nil, err

--- a/pkg/frontend/querymiddleware/codec_protobuf.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf.go
@@ -326,6 +326,22 @@ func (f protobufFormatter) decodeMatrixData(data *mimirpb.MatrixData) (*Promethe
 	}, nil
 }
 
+func (f protobufFormatter) EncodeLabelsResponse(*PrometheusLabelsResponse) ([]byte, error) {
+	return nil, errors.New("protobuf labels encoding is not supported")
+}
+
+func (f protobufFormatter) DecodeLabelsResponse([]byte) (*PrometheusLabelsResponse, error) {
+	return nil, errors.New("protobuf labels decoding is not supported")
+}
+
+func (f protobufFormatter) EncodeSeriesResponse(*PrometheusSeriesResponse) ([]byte, error) {
+	return nil, errors.New("protobuf series encoding is not supported")
+}
+
+func (f protobufFormatter) DecodeSeriesResponse([]byte) (*PrometheusSeriesResponse, error) {
+	return nil, errors.New("protobuf series decoding is not supported")
+}
+
 func labelsFromStringArray(s []string) ([]mimirpb.LabelAdapter, error) {
 	if len(s)%2 != 0 {
 		return nil, fmt.Errorf("metric is malformed: expected even number of symbols, but got %v", len(s))

--- a/pkg/frontend/querymiddleware/codec_protobuf.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf.go
@@ -22,7 +22,7 @@ func (f protobufFormatter) ContentType() v1.MIMEType {
 	return v1.MIMEType{Type: mimirpb.QueryResponseMimeTypeType, SubType: mimirpb.QueryResponseMimeTypeSubType}
 }
 
-func (f protobufFormatter) EncodeResponse(resp *PrometheusResponse) ([]byte, error) {
+func (f protobufFormatter) EncodeQueryResponse(resp *PrometheusResponse) ([]byte, error) {
 	status, err := mimirpb.StatusFromPrometheusString(resp.Status)
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func (protobufFormatter) encodeMatrixData(data []SampleStream) mimirpb.MatrixDat
 	return mimirpb.MatrixData{Series: series}
 }
 
-func (f protobufFormatter) DecodeResponse(buf []byte) (*PrometheusResponse, error) {
+func (f protobufFormatter) DecodeQueryResponse(buf []byte) (*PrometheusResponse, error) {
 	var resp mimirpb.QueryResponse
 
 	if err := resp.Unmarshal(buf); err != nil {

--- a/pkg/frontend/querymiddleware/codec_protobuf_test.go
+++ b/pkg/frontend/querymiddleware/codec_protobuf_test.go
@@ -633,7 +633,7 @@ func TestProtobufFormat_DecodeResponse(t *testing.T) {
 	for _, tc := range protobufCodecScenarios {
 		t.Run(tc.name, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
-			codec := NewPrometheusCodec(reg, 0*time.Minute, formatProtobuf)
+			codec := NewPrometheusCodec(reg, 0*time.Minute, formatProtobuf, nil)
 
 			body, err := tc.payload.Marshal()
 			require.NoError(t, err)
@@ -643,7 +643,7 @@ func TestProtobufFormat_DecodeResponse(t *testing.T) {
 				Body:          io.NopCloser(bytes.NewBuffer(body)),
 				ContentLength: int64(len(body)),
 			}
-			decoded, err := codec.DecodeResponse(context.Background(), httpResponse, nil, log.NewNopLogger())
+			decoded, err := codec.DecodeMetricsQueryResponse(context.Background(), httpResponse, nil, log.NewNopLogger())
 			if err != nil || tc.expectedDecodingError != nil {
 				require.Equal(t, tc.expectedDecodingError, err)
 				return
@@ -674,7 +674,7 @@ func TestProtobufFormat_EncodeResponse(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
-			codec := NewPrometheusCodec(reg, 0*time.Minute, formatProtobuf)
+			codec := NewPrometheusCodec(reg, 0*time.Minute, formatProtobuf, nil)
 
 			expectedBodyBytes, err := tc.payload.Marshal()
 			require.NoError(t, err)
@@ -683,7 +683,7 @@ func TestProtobufFormat_EncodeResponse(t *testing.T) {
 				Header: http.Header{"Accept": []string{mimirpb.QueryResponseMimeType}},
 			}
 
-			httpResponse, err := codec.EncodeResponse(context.Background(), httpRequest, tc.response)
+			httpResponse, err := codec.EncodeMetricsQueryResponse(context.Background(), httpRequest, tc.response)
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, httpResponse.StatusCode)
 			require.Equal(t, mimirpb.QueryResponseMimeType, httpResponse.Header.Get("Content-Type"))
@@ -714,7 +714,7 @@ func TestProtobufFormat_EncodeResponse(t *testing.T) {
 func BenchmarkProtobufFormat_DecodeResponse(b *testing.B) {
 	headers := http.Header{"Content-Type": []string{mimirpb.QueryResponseMimeType}}
 	reg := prometheus.NewPedanticRegistry()
-	codec := NewPrometheusCodec(reg, 0*time.Minute, formatProtobuf)
+	codec := NewPrometheusCodec(reg, 0*time.Minute, formatProtobuf, nil)
 
 	for _, tc := range protobufCodecScenarios {
 		body, err := tc.payload.Marshal()
@@ -728,7 +728,7 @@ func BenchmarkProtobufFormat_DecodeResponse(b *testing.B) {
 					ContentLength: int64(len(body)),
 				}
 
-				_, err = codec.DecodeResponse(context.Background(), httpResponse, nil, log.NewNopLogger())
+				_, err = codec.DecodeMetricsQueryResponse(context.Background(), httpResponse, nil, log.NewNopLogger())
 				if err != nil || tc.expectedDecodingError != nil {
 					require.Equal(b, tc.expectedDecodingError, err)
 				}
@@ -739,7 +739,7 @@ func BenchmarkProtobufFormat_DecodeResponse(b *testing.B) {
 
 func BenchmarkProtobufFormat_EncodeResponse(b *testing.B) {
 	reg := prometheus.NewPedanticRegistry()
-	codec := NewPrometheusCodec(reg, 0*time.Minute, formatProtobuf)
+	codec := NewPrometheusCodec(reg, 0*time.Minute, formatProtobuf, nil)
 
 	req := &http.Request{
 		Header: http.Header{"Accept": []string{mimirpb.QueryResponseMimeType}},
@@ -752,7 +752,7 @@ func BenchmarkProtobufFormat_EncodeResponse(b *testing.B) {
 
 		b.Run(tc.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := codec.EncodeResponse(context.Background(), req, tc.response)
+				_, err := codec.EncodeMetricsQueryResponse(context.Background(), req, tc.response)
 
 				if err != nil {
 					require.NoError(b, err)

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -692,7 +692,7 @@ func TestPrometheusCodec_EncodeLabelsQueryRequest(t *testing.T) {
 func TestPrometheusCodec_EncodeMetricsQueryRequest_AcceptHeader(t *testing.T) {
 	for _, queryResultPayloadFormat := range allFormats {
 		t.Run(queryResultPayloadFormat, func(t *testing.T) {
-			codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, queryResultPayloadFormat)
+			codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, queryResultPayloadFormat, nil)
 			req := PrometheusInstantQueryRequest{}
 			encodedRequest, err := codec.EncodeMetricsQueryRequest(context.Background(), &req)
 			require.NoError(t, err)
@@ -712,7 +712,7 @@ func TestPrometheusCodec_EncodeMetricsQueryRequest_AcceptHeader(t *testing.T) {
 func TestPrometheusCodec_EncodeMetricsQueryRequest_ReadConsistency(t *testing.T) {
 	for _, consistencyLevel := range api.ReadConsistencies {
 		t.Run(consistencyLevel, func(t *testing.T) {
-			codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, formatProtobuf)
+			codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, formatProtobuf, nil)
 			ctx := api.ContextWithReadConsistencyLevel(context.Background(), consistencyLevel)
 			encodedRequest, err := codec.EncodeMetricsQueryRequest(ctx, &PrometheusInstantQueryRequest{})
 			require.NoError(t, err)
@@ -724,7 +724,7 @@ func TestPrometheusCodec_EncodeMetricsQueryRequest_ReadConsistency(t *testing.T)
 func TestPrometheusCodec_EncodeMetricsQueryRequest_ShouldPropagateHeadersInAllowList(t *testing.T) {
 	const notAllowedHeader = "X-Some-Name"
 
-	codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, formatProtobuf)
+	codec := NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, formatProtobuf, nil)
 	expectedOffsets := map[int32]int64{0: 1, 1: 2}
 
 	req, err := codec.EncodeMetricsQueryRequest(context.Background(), &PrometheusInstantQueryRequest{
@@ -761,10 +761,10 @@ func TestPrometheusCodec_EncodeResponse_ContentNegotiation(t *testing.T) {
 		Error:     "something went wrong",
 	}
 
-	jsonBody, err := jsonFormatter{}.EncodeResponse(testResponse)
+	jsonBody, err := jsonFormatter{}.EncodeQueryResponse(testResponse)
 	require.NoError(t, err)
 
-	protobufBody, err := protobufFormatter{}.EncodeResponse(testResponse)
+	protobufBody, err := protobufFormatter{}.EncodeQueryResponse(testResponse)
 	require.NoError(t, err)
 
 	scenarios := map[string]struct {
@@ -816,7 +816,7 @@ func TestPrometheusCodec_EncodeResponse_ContentNegotiation(t *testing.T) {
 			require.NoError(t, err)
 			req.Header.Set("Accept", scenario.acceptHeader)
 
-			encodedResponse, err := codec.EncodeResponse(context.Background(), req, testResponse)
+			encodedResponse, err := codec.EncodeMetricsQueryResponse(context.Background(), req, testResponse)
 			require.Equal(t, scenario.expectedError, err)
 
 			if scenario.expectedError == nil {
@@ -919,7 +919,7 @@ func TestPrometheusCodec_DecodeResponse_Errors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			codec := newTestPrometheusCodec()
 
-			_, err := codec.DecodeResponse(context.Background(), testCase.response, nil, testutil.NewTestingLogger(t))
+			_, err := codec.DecodeMetricsQueryResponse(context.Background(), testCase.response, nil, testutil.NewTestingLogger(t))
 			require.Error(t, err)
 			require.True(t, apierror.IsAPIError(err))
 			resp, ok := apierror.HTTPResponseFromError(err)
@@ -948,7 +948,7 @@ func TestPrometheusCodec_DecodeResponse_ContentTypeHandling(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			reg := prometheus.NewPedanticRegistry()
-			codec := NewPrometheusCodec(reg, 0*time.Minute, formatJSON)
+			codec := NewPrometheusCodec(reg, 0*time.Minute, formatJSON, nil)
 
 			resp := prometheusAPIResponse{}
 			body, err := json.Marshal(resp)
@@ -960,7 +960,7 @@ func TestPrometheusCodec_DecodeResponse_ContentTypeHandling(t *testing.T) {
 				ContentLength: int64(len(body)),
 			}
 
-			_, err = codec.DecodeResponse(context.Background(), httpResponse, nil, log.NewNopLogger())
+			_, err = codec.DecodeMetricsQueryResponse(context.Background(), httpResponse, nil, log.NewNopLogger())
 			require.Equal(t, tc.expectedErr, err)
 		})
 	}
@@ -1441,7 +1441,7 @@ func BenchmarkPrometheusCodec_DecodeResponse(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		_, err := codec.DecodeResponse(context.Background(), &http.Response{
+		_, err := codec.DecodeMetricsQueryResponse(context.Background(), &http.Response{
 			StatusCode:    200,
 			Body:          io.NopCloser(bytes.NewReader(encodedRes)),
 			ContentLength: int64(len(encodedRes)),
@@ -1470,7 +1470,7 @@ func BenchmarkPrometheusCodec_EncodeResponse(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		_, err := codec.EncodeResponse(context.Background(), req, res)
+		_, err := codec.EncodeMetricsQueryResponse(context.Background(), req, res)
 		require.NoError(b, err)
 	}
 }
@@ -1618,9 +1618,9 @@ func Test_DecodeOptions(t *testing.T) {
 	}
 }
 
-// TestPrometheusCodec_DecodeEncode tests that decoding and re-encoding a
-// request does not lose relevant information about the original request.
-func TestPrometheusCodec_DecodeEncode(t *testing.T) {
+// TestPrometheusCodec_DecodeEncode_Metrics tests that decoding and re-encoding a
+// metrics query request does not lose relevant information about the original request.
+func TestPrometheusCodec_DecodeEncode_Metrics(t *testing.T) {
 	codec := newTestPrometheusCodec().(prometheusCodec)
 	for _, tt := range []struct {
 		name    string
@@ -1670,6 +1670,63 @@ func TestPrometheusCodec_DecodeEncode(t *testing.T) {
 			decoded, err := codec.DecodeMetricsQueryRequest(ctx, expected)
 			require.NoError(t, err)
 			encoded, err := codec.EncodeMetricsQueryRequest(ctx, decoded)
+			require.NoError(t, err)
+
+			assert.Equal(t, expected.URL, encoded.URL)
+			assert.Equal(t, expected.Header, encoded.Header)
+		})
+	}
+}
+
+// TestPrometheusCodec_DecodeEncode_Labels tests that decoding and re-encoding a
+// labels query request does not lose relevant information about the original request.
+func TestPrometheusCodec_DecodeEncode_Labels(t *testing.T) {
+	codec := newTestPrometheusCodec().(prometheusCodec)
+	for _, tc := range []struct {
+		name     string
+		queryURL string
+	}{
+		{
+			name:     "label names - minimal",
+			queryURL: "/api/v1/labels?end=1708588800&start=1708502400",
+		},
+		{
+			name:     "label names - all",
+			queryURL: "/api/v1/labels?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+		},
+		{
+			name:     "label values - minimal",
+			queryURL: "/api/v1/label/job/values?end=1708588800&start=1708502400",
+		},
+		{
+			name:     "label values - all",
+			queryURL: "/api/v1/label/job/values?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+		},
+		{
+			name:     "series - minimal",
+			queryURL: "/api/v1/series?end=1708588800&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+		},
+		{
+			name:     "series - all",
+			queryURL: "/api/v1/series?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expected, err := http.NewRequest("GET", tc.queryURL, nil)
+			require.NoError(t, err)
+			expected.Body = http.NoBody
+			expected.Header = make(http.Header)
+
+			// This header is set by EncodeLabelsQueryRequest according to the codec's config, so we
+			// should always expect it to be present on the re-encoded request.
+			expected.Header.Set("Accept", "application/json")
+
+			ctx := context.Background()
+			decoded, err := codec.DecodeLabelsQueryRequest(ctx, expected)
+			require.NoError(t, err)
+			encoded, err := codec.EncodeLabelsQueryRequest(ctx, decoded)
 			require.NoError(t, err)
 
 			assert.Equal(t, expected.URL, encoded.URL)
@@ -1731,7 +1788,7 @@ func TestPrometheusCodec_DecodeMultipleTimes(t *testing.T) {
 }
 
 func newTestPrometheusCodec() Codec {
-	return NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, formatJSON)
+	return NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, formatJSON, nil)
 }
 
 func mustSucceed[T any](value T, err error) T {

--- a/pkg/frontend/querymiddleware/generic_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache_test.go
@@ -226,7 +226,7 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
 						initialStoreCallsCount := cacheBackend.CountStoreCalls()
 
 						reg := prometheus.NewPedanticRegistry()
-						rt := newRoundTripper(cacheBackend, DefaultCacheKeyGenerator{codec: NewPrometheusCodec(reg, 0*time.Minute, formatJSON)}, limits, downstream, testutil.NewLogger(t), reg)
+						rt := newRoundTripper(cacheBackend, DefaultCacheKeyGenerator{codec: NewPrometheusCodec(reg, 0*time.Minute, formatJSON, nil)}, limits, downstream, testutil.NewLogger(t), reg)
 						res, err := rt.RoundTrip(req)
 						require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -142,7 +142,7 @@ func TestDefaultCacheKeyGenerator_LabelValuesCacheKey(t *testing.T) {
 	}
 
 	reg := prometheus.NewPedanticRegistry()
-	codec := NewPrometheusCodec(reg, 0*time.Minute, formatJSON)
+	codec := NewPrometheusCodec(reg, 0*time.Minute, formatJSON, nil)
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -248,7 +248,7 @@ func (rt limitedParallelismRoundTripper) RoundTrip(r *http.Request) (*http.Respo
 		return nil, err
 	}
 
-	return rt.codec.EncodeResponse(ctx, r, response)
+	return rt.codec.EncodeMetricsQueryResponse(ctx, r, response)
 }
 
 // roundTripperHandler is an adapter that implements the MetricsQueryHandler interface using a http.RoundTripper to perform
@@ -276,7 +276,7 @@ func (rth roundTripperHandler) Do(ctx context.Context, r MetricsQueryRequest) (R
 	}
 	defer func() { _ = response.Body.Close() }()
 
-	return rth.codec.DecodeResponse(ctx, response, r, rth.logger)
+	return rth.codec.DecodeMetricsQueryResponse(ctx, response, r, rth.logger)
 }
 
 // smallestPositiveNonZeroDuration returns the smallest positive and non-zero value

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -198,8 +198,8 @@ type limitedParallelismRoundTripper struct {
 	middleware MetricsQueryMiddleware
 }
 
-// newLimitedParallelismRoundTripper creates a new roundtripper that enforces MaxQueryParallelism to the `next` roundtripper across `middlewares`.
-func newLimitedParallelismRoundTripper(next http.RoundTripper, codec Codec, limits Limits, middlewares ...MetricsQueryMiddleware) http.RoundTripper {
+// NewLimitedParallelismRoundTripper creates a new roundtripper that enforces MaxQueryParallelism to the `next` roundtripper across `middlewares`.
+func NewLimitedParallelismRoundTripper(next http.RoundTripper, codec Codec, limits Limits, middlewares ...MetricsQueryMiddleware) http.RoundTripper {
 	return limitedParallelismRoundTripper{
 		downstream: roundTripperHandler{
 			next:  next,

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -762,7 +762,7 @@ func TestLimitedRoundTripper_MaxQueryParallelism(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	_, err = newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
+	_, err = NewLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
 		MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				var wg sync.WaitGroup
@@ -806,7 +806,7 @@ func TestLimitedRoundTripper_MaxQueryParallelismLateScheduling(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	_, err = newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
+	_, err = NewLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
 		MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				// fire up work and we don't wait.
@@ -847,7 +847,7 @@ func TestLimitedRoundTripper_OriginalRequestContextCancellation(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	_, err = newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
+	_, err = NewLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
 		MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				var wg sync.WaitGroup
@@ -906,7 +906,7 @@ func BenchmarkLimitedParallelismRoundTripper(b *testing.B) {
 
 	for _, concurrentRequestCount := range []int{1, 10, 100} {
 		for _, subRequestCount := range []int{1, 2, 5, 10, 20, 50, 100} {
-			tripper := newLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxParallelism},
+			tripper := NewLimitedParallelismRoundTripper(downstream, codec, mockLimits{maxQueryParallelism: maxParallelism},
 				MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 					return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 						wg := sync.WaitGroup{}

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -511,7 +511,7 @@ func (r *PrometheusSeriesQueryRequest) GetHeaders() []*PrometheusHeader {
 
 // WithLabelName clones the current `PrometheusLabelNamesQueryRequest` with a new label name param.
 func (r *PrometheusLabelNamesQueryRequest) WithLabelName(string) (LabelsQueryRequest, error) {
-	return nil, fmt.Errorf("not implemented")
+	panic("PrometheusLabelNamesQueryRequest.WithLabelName is not implemented")
 }
 
 // WithLabelName clones the current `PrometheusLabelValuesQueryRequest` with a new label name param.
@@ -524,7 +524,7 @@ func (r *PrometheusLabelValuesQueryRequest) WithLabelName(name string) (LabelsQu
 
 // WithLabelName clones the current `PrometheusSeriesQueryRequest` with a new label name param.
 func (r *PrometheusSeriesQueryRequest) WithLabelName(string) (LabelsQueryRequest, error) {
-	return nil, fmt.Errorf("not implemented")
+	panic("PrometheusSeriesQueryRequest.WithLabelName is not implemented")
 }
 
 // WithLabelMatcherSets clones the current `PrometheusLabelNamesQueryRequest` with new label matcher sets.

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -451,6 +451,10 @@ func (r *PrometheusLabelNamesQueryRequest) GetLabelName() string {
 	return ""
 }
 
+func (r *PrometheusSeriesQueryRequest) GetLabelName() string {
+	return ""
+}
+
 func (r *PrometheusLabelNamesQueryRequest) GetStartOrDefault() int64 {
 	if r.GetStart() == 0 {
 		return v1.MinTime.UnixMilli()
@@ -479,6 +483,95 @@ func (r *PrometheusLabelValuesQueryRequest) GetEndOrDefault() int64 {
 	return r.GetEnd()
 }
 
+func (r *PrometheusSeriesQueryRequest) GetStartOrDefault() int64 {
+	if r.GetStart() == 0 {
+		return v1.MinTime.UnixMilli()
+	}
+	return r.GetStart()
+}
+
+func (r *PrometheusSeriesQueryRequest) GetEndOrDefault() int64 {
+	if r.GetEnd() == 0 {
+		return v1.MaxTime.UnixMilli()
+	}
+	return r.GetEnd()
+}
+
+func (r *PrometheusLabelNamesQueryRequest) GetHeaders() []*PrometheusHeader {
+	return r.Headers
+}
+
+func (r *PrometheusLabelValuesQueryRequest) GetHeaders() []*PrometheusHeader {
+	return r.Headers
+}
+
+func (r *PrometheusSeriesQueryRequest) GetHeaders() []*PrometheusHeader {
+	return r.Headers
+}
+
+// WithLabelName clones the current `PrometheusLabelNamesQueryRequest` with a new label name param.
+func (r *PrometheusLabelNamesQueryRequest) WithLabelName(string) (LabelsQueryRequest, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// WithLabelName clones the current `PrometheusLabelValuesQueryRequest` with a new label name param.
+func (r *PrometheusLabelValuesQueryRequest) WithLabelName(name string) (LabelsQueryRequest, error) {
+	newRequest := *r
+	newRequest.Path = labelValuesPathSuffix.ReplaceAllString(r.Path, `/api/v1/label/`+name+`/values`)
+	newRequest.LabelName = name
+	return &newRequest, nil
+}
+
+// WithLabelName clones the current `PrometheusSeriesQueryRequest` with a new label name param.
+func (r *PrometheusSeriesQueryRequest) WithLabelName(string) (LabelsQueryRequest, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// WithLabelMatcherSets clones the current `PrometheusLabelNamesQueryRequest` with new label matcher sets.
+func (r *PrometheusLabelNamesQueryRequest) WithLabelMatcherSets(labelMatcherSets []string) (LabelsQueryRequest, error) {
+	newRequest := *r
+	newRequest.LabelMatcherSets = make([]string, len(labelMatcherSets))
+	copy(newRequest.LabelMatcherSets, labelMatcherSets)
+	return &newRequest, nil
+}
+
+// WithLabelMatcherSets clones the current `PrometheusLabelValuesQueryRequest` with new label matcher sets.
+func (r *PrometheusLabelValuesQueryRequest) WithLabelMatcherSets(labelMatcherSets []string) (LabelsQueryRequest, error) {
+	newRequest := *r
+	newRequest.LabelMatcherSets = make([]string, len(labelMatcherSets))
+	copy(newRequest.LabelMatcherSets, labelMatcherSets)
+	return &newRequest, nil
+}
+
+// WithLabelMatcherSets clones the current `PrometheusSeriesQueryRequest` with new label matcher sets.
+func (r *PrometheusSeriesQueryRequest) WithLabelMatcherSets(labelMatcherSets []string) (LabelsQueryRequest, error) {
+	newRequest := *r
+	newRequest.LabelMatcherSets = make([]string, len(labelMatcherSets))
+	copy(newRequest.LabelMatcherSets, labelMatcherSets)
+	return &newRequest, nil
+}
+
+// WithHeaders clones the current `PrometheusLabelNamesQueryRequest` with new headers.
+func (r *PrometheusLabelNamesQueryRequest) WithHeaders(headers []*PrometheusHeader) (LabelsQueryRequest, error) {
+	newRequest := *r
+	newRequest.Headers = cloneHeaders(headers)
+	return &newRequest, nil
+}
+
+// WithHeaders clones the current `PrometheusLabelValuesQueryRequest` with new headers.
+func (r *PrometheusLabelValuesQueryRequest) WithHeaders(headers []*PrometheusHeader) (LabelsQueryRequest, error) {
+	newRequest := *r
+	newRequest.Headers = cloneHeaders(headers)
+	return &newRequest, nil
+}
+
+// WithHeaders clones the current `PrometheusSeriesQueryRequest` with new headers.
+func (r *PrometheusSeriesQueryRequest) WithHeaders(headers []*PrometheusHeader) (LabelsQueryRequest, error) {
+	newRequest := *r
+	newRequest.Headers = cloneHeaders(headers)
+	return &newRequest, nil
+}
+
 // AddSpanTags writes query information about the current `PrometheusLabelNamesQueryRequest`
 // to a span's tag ("attributes" in OpenTelemetry parlance).
 func (r *PrometheusLabelNamesQueryRequest) AddSpanTags(sp opentracing.Span) {
@@ -496,6 +589,14 @@ func (r *PrometheusLabelValuesQueryRequest) AddSpanTags(sp opentracing.Span) {
 	sp.SetTag("end", timestamp.Time(r.GetEnd()).String())
 }
 
+// AddSpanTags writes query information about the current `PrometheusSeriesQueryRequest`
+// to a span's tag ("attributes" in OpenTelemetry parlance).
+func (r *PrometheusSeriesQueryRequest) AddSpanTags(sp opentracing.Span) {
+	sp.SetTag("matchers", fmt.Sprintf("%v", r.GetLabelMatcherSets()))
+	sp.SetTag("start", timestamp.Time(r.GetStart()).String())
+	sp.SetTag("end", timestamp.Time(r.GetEnd()).String())
+}
+
 type PrometheusLabelNamesQueryRequest struct {
 	Path  string
 	Start int64
@@ -508,7 +609,8 @@ type PrometheusLabelNamesQueryRequest struct {
 	// ID of the request used to correlate downstream requests and responses.
 	ID int64
 	// Limit the number of label names returned. A value of 0 means no limit
-	Limit uint64
+	Limit   uint64
+	Headers []*PrometheusHeader
 }
 
 func (r *PrometheusLabelNamesQueryRequest) GetPath() string {
@@ -548,7 +650,8 @@ type PrometheusLabelValuesQueryRequest struct {
 	// ID of the request used to correlate downstream requests and responses.
 	ID int64
 	// Limit the number of label values returned. A value of 0 means no limit.
-	Limit uint64
+	Limit   uint64
+	Headers []*PrometheusHeader
 }
 
 func (r *PrometheusLabelValuesQueryRequest) GetLabelName() string {
@@ -575,6 +678,88 @@ func (r *PrometheusLabelValuesQueryRequest) GetID() int64 {
 func (r *PrometheusLabelValuesQueryRequest) GetLimit() uint64 {
 	return r.Limit
 }
+
+type PrometheusSeriesQueryRequest struct {
+	Path  string
+	Start int64
+	End   int64
+	// labelMatcherSets is a repeated field here in order to enable the representation
+	// of labels queries which have not yet been split; the prometheus querier code
+	// will eventually split requests like `?match[]=up&match[]=process_start_time_seconds{job="prometheus"}`
+	// into separate queries, one for each matcher set
+	LabelMatcherSets []string
+	// ID of the request used to correlate downstream requests and responses.
+	ID int64
+	// Limit the number of label names returned. A value of 0 means no limit
+	Limit   uint64
+	Headers []*PrometheusHeader
+}
+
+func (r *PrometheusSeriesQueryRequest) GetPath() string {
+	return r.Path
+}
+
+func (r *PrometheusSeriesQueryRequest) GetStart() int64 {
+	return r.Start
+}
+
+func (r *PrometheusSeriesQueryRequest) GetEnd() int64 {
+	return r.End
+}
+
+func (r *PrometheusSeriesQueryRequest) GetLabelMatcherSets() []string {
+	return r.LabelMatcherSets
+}
+
+func (r *PrometheusSeriesQueryRequest) GetID() int64 {
+	return r.ID
+}
+
+func (r *PrometheusSeriesQueryRequest) GetLimit() uint64 {
+	return r.Limit
+}
+
+type PrometheusLabelsResponse struct {
+	Status    string              `json:"status"`
+	Data      []string            `json:"data"`
+	ErrorType string              `json:"errorType,omitempty"`
+	Error     string              `json:"error,omitempty"`
+	Headers   []*PrometheusHeader `json:"-"`
+}
+
+func (m *PrometheusLabelsResponse) GetHeaders() []*PrometheusHeader {
+	if m != nil {
+		return m.Headers
+	}
+	return nil
+}
+
+func (m *PrometheusLabelsResponse) Reset()         { *m = PrometheusLabelsResponse{} }
+func (*PrometheusLabelsResponse) ProtoMessage()    {}
+func (m *PrometheusLabelsResponse) String() string { return fmt.Sprintf("%+v", *m) }
+
+type SeriesData map[string]string
+
+func (d *SeriesData) String() string { return fmt.Sprintf("%+v", *d) }
+
+type PrometheusSeriesResponse struct {
+	Status    string              `json:"status"`
+	Data      []SeriesData        `json:"data"`
+	ErrorType string              `json:"errorType,omitempty"`
+	Error     string              `json:"error,omitempty"`
+	Headers   []*PrometheusHeader `json:"-"`
+}
+
+func (m *PrometheusSeriesResponse) GetHeaders() []*PrometheusHeader {
+	if m != nil {
+		return m.Headers
+	}
+	return nil
+}
+
+func (m *PrometheusSeriesResponse) Reset()         { *m = PrometheusSeriesResponse{} }
+func (*PrometheusSeriesResponse) ProtoMessage()    {}
+func (m *PrometheusSeriesResponse) String() string { return fmt.Sprintf("%+v", *m) }
 
 func (d *PrometheusData) UnmarshalJSON(b []byte) error {
 	v := struct {

--- a/pkg/frontend/querymiddleware/model_extra_test.go
+++ b/pkg/frontend/querymiddleware/model_extra_test.go
@@ -118,7 +118,7 @@ func TestMetricQueryRequestCloneHeaders(t *testing.T) {
 			httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			httpReq.Header.Set("X-Test-Header", "test-value")
 
-			c := NewPrometheusCodec(prometheus.NewPedanticRegistry(), time.Minute*5, "json")
+			c := NewPrometheusCodec(prometheus.NewPedanticRegistry(), time.Minute*5, "json", nil)
 			originalReq, err := c.DecodeMetricsQueryRequest(context.Background(), httpReq)
 			require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/prune.go
+++ b/pkg/frontend/querymiddleware/prune.go
@@ -59,7 +59,7 @@ func (p *pruneMiddleware) pruneQuery(ctx context.Context, query string) (string,
 	// Parse the query.
 	expr, err := parser.ParseExpr(query)
 	if err != nil {
-		return "", false, apierror.New(apierror.TypeBadData, decorateWithParamName(err, "query").Error())
+		return "", false, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}
 	origQueryString := expr.String()
 

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -75,9 +75,9 @@ func approximatelyEqualsSamples(t *testing.T, a, b *PrometheusResponse) {
 	require.Equal(t, statusSuccess, a.Status)
 	require.Equal(t, statusSuccess, b.Status)
 
-	as, err := responseToSamples(a)
+	as, err := ResponseToSamples(a)
 	require.Nil(t, err)
-	bs, err := responseToSamples(b)
+	bs, err := ResponseToSamples(b)
 	require.Nil(t, err)
 
 	require.Equalf(t, len(as), len(bs), "expected same number of series: one contains %v, other %v", sampleStreamsStrings(as), sampleStreamsStrings(bs))
@@ -923,7 +923,7 @@ func TestQueryshardingDeterminism(t *testing.T) {
 
 		shardedPrometheusRes := shardedRes.(*PrometheusResponse)
 
-		sampleStreams, err := responseToSamples(shardedPrometheusRes)
+		sampleStreams, err := ResponseToSamples(shardedPrometheusRes)
 		require.NoError(t, err)
 
 		require.Lenf(t, sampleStreams, 1, "There should be 1 samples stream (query %d)", i)

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -37,7 +37,7 @@ type remoteReadRoundTripper struct {
 	middleware MetricsQueryMiddleware
 }
 
-func newRemoteReadRoundTripper(next http.RoundTripper, middlewares ...MetricsQueryMiddleware) http.RoundTripper {
+func NewRemoteReadRoundTripper(next http.RoundTripper, middlewares ...MetricsQueryMiddleware) http.RoundTripper {
 	return &remoteReadRoundTripper{
 		next:       next,
 		middleware: MergeMetricsQueryMiddlewares(middlewares...),

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -135,7 +135,7 @@ func TestRemoteReadRoundTripperCallsDownstreamOnAll(t *testing.T) {
 				actualMiddleWareCalls++
 				return tc.handler
 			})
-			rr := newRemoteReadRoundTripper(roundTripper, middleware)
+			rr := NewRemoteReadRoundTripper(roundTripper, middleware)
 			_, err := rr.RoundTrip(makeTestHTTPRequestFromRemoteRead(makeTestRemoteReadRequest()))
 			if tc.expectError != "" {
 				require.Error(t, err)
@@ -195,7 +195,7 @@ func TestRemoteReadRoundTripper_ShouldAllowMiddlewaresToManipulateRequest(t *tes
 		},
 	}
 
-	rr := newRemoteReadRoundTripper(downstream, middleware)
+	rr := NewRemoteReadRoundTripper(downstream, middleware)
 	_, err := rr.RoundTrip(makeTestHTTPRequestFromRemoteRead(origRemoteReadReq))
 	require.NoError(t, err)
 	require.NotNil(t, downstreamReq)
@@ -255,7 +255,7 @@ func TestRemoteReadRoundTripper_ShouldAllowMiddlewaresToReturnEmptyResponse(t *t
 		},
 	}
 
-	rr := newRemoteReadRoundTripper(downstream, middleware)
+	rr := NewRemoteReadRoundTripper(downstream, middleware)
 	origRemoteReadReq := makeTestRemoteReadRequest()
 
 	_, err := rr.RoundTrip(makeTestHTTPRequestFromRemoteRead(origRemoteReadReq))

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -566,7 +566,7 @@ func TestPartitionCacheExtents(t *testing.T) {
 func TestDefaultSplitter_QueryRequest(t *testing.T) {
 	t.Parallel()
 	reg := prometheus.NewPedanticRegistry()
-	codec := NewPrometheusCodec(reg, 0*time.Minute, formatJSON)
+	codec := NewPrometheusCodec(reg, 0*time.Minute, formatJSON, nil)
 
 	ctx := context.Background()
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -38,6 +38,7 @@ const (
 	cardinalityActiveNativeHistogramMetricsPathSuffix = "/api/v1/cardinality/active_native_histogram_metrics"
 	labelNamesPathSuffix                              = "/api/v1/labels"
 	remoteReadPathSuffix                              = "/api/v1/read"
+	seriesPathSuffix                                  = "/api/v1/series"
 
 	queryTypeInstant                      = "query"
 	queryTypeRange                        = "query_range"
@@ -134,6 +135,19 @@ func (q HandlerFunc) Do(ctx context.Context, req MetricsQueryRequest) (Response,
 // MetricsQueryHandler is like http.Handle, but specifically for Prometheus query and query_range calls.
 type MetricsQueryHandler interface {
 	Do(context.Context, MetricsQueryRequest) (Response, error)
+}
+
+// LabelsHandlerFunc is like http.HandlerFunc, but for LabelsQueryHandler.
+type LabelsHandlerFunc func(context.Context, LabelsQueryRequest) (Response, error)
+
+// Do implements LabelsQueryHandler.
+func (q LabelsHandlerFunc) Do(ctx context.Context, req LabelsQueryRequest) (Response, error) {
+	return q(ctx, req)
+}
+
+// LabelsQueryHandler is like http.Handle, but specifically for Prometheus label names and values calls.
+type LabelsQueryHandler interface {
+	Do(context.Context, LabelsQueryRequest) (Response, error)
 }
 
 // MetricsQueryMiddlewareFunc is like http.HandlerFunc, but for MetricsQueryMiddleware.
@@ -245,14 +259,14 @@ func newQueryTripperware(
 		// It means that the first roundtrippers defined in this function will be the last to be
 		// executed.
 
-		queryrange := newLimitedParallelismRoundTripper(next, codec, limits, queryRangeMiddleware...)
-		instant := newLimitedParallelismRoundTripper(next, codec, limits, queryInstantMiddleware...)
-		remoteRead := newRemoteReadRoundTripper(next, remoteReadMiddleware...)
+		queryrange := NewLimitedParallelismRoundTripper(next, codec, limits, queryRangeMiddleware...)
+		instant := NewLimitedParallelismRoundTripper(next, codec, limits, queryInstantMiddleware...)
+		remoteRead := NewRemoteReadRoundTripper(next, remoteReadMiddleware...)
 
 		// Wrap next for cardinality, labels queries and all other queries.
 		// That attempts to parse "start" and "end" from the HTTP request and set them in the request's QueryDetails.
 		// range and instant queries have more accurate logic for query details.
-		next = newQueryDetailsStartEndRoundTripper(next)
+		next = NewQueryDetailsStartEndRoundTripper(next)
 		cardinality := next
 		activeSeries := next
 		activeNativeHistogramMetrics := next
@@ -442,8 +456,8 @@ func newQueryMiddlewares(
 	return
 }
 
-// newQueryDetailsStartEndRoundTripper parses "start" and "end" parameters from the query and sets same fields in the QueryDetails in the context.
-func newQueryDetailsStartEndRoundTripper(next http.RoundTripper) http.RoundTripper {
+// NewQueryDetailsStartEndRoundTripper parses "start" and "end" parameters from the query and sets same fields in the QueryDetails in the context.
+func NewQueryDetailsStartEndRoundTripper(next http.RoundTripper) http.RoundTripper {
 	return RoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		params, _ := util.ParseRequestFormWithoutConsumingBody(req)
 		if details := QueryDetailsFromContext(req.Context()); details != nil {
@@ -531,6 +545,10 @@ func IsLabelValuesQuery(path string) bool {
 
 func IsLabelsQuery(path string) bool {
 	return IsLabelNamesQuery(path) || IsLabelValuesQuery(path)
+}
+
+func IsSeriesQuery(path string) bool {
+	return strings.HasSuffix(path, seriesPathSuffix)
 }
 
 func IsActiveSeriesQuery(path string) bool {

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -132,7 +132,7 @@ func (q HandlerFunc) Do(ctx context.Context, req MetricsQueryRequest) (Response,
 	return q(ctx, req)
 }
 
-// MetricsQueryHandler is like http.Handle, but specifically for Prometheus query and query_range calls.
+// MetricsQueryHandler is like http.Handler, but specifically for Prometheus query and query_range calls.
 type MetricsQueryHandler interface {
 	Do(context.Context, MetricsQueryRequest) (Response, error)
 }
@@ -145,7 +145,7 @@ func (q LabelsHandlerFunc) Do(ctx context.Context, req LabelsQueryRequest) (Resp
 	return q(ctx, req)
 }
 
-// LabelsQueryHandler is like http.Handle, but specifically for Prometheus label names and values calls.
+// LabelsQueryHandler is like http.Handler, but specifically for Prometheus label names and values calls.
 type LabelsQueryHandler interface {
 	Do(context.Context, LabelsQueryRequest) (Response, error)
 }

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -154,7 +154,7 @@ func TestTripperware_InstantQuery(t *testing.T) {
 			return nil, err
 		}
 
-		return codec.EncodeResponse(r.Context(), r, &PrometheusResponse{
+		return codec.EncodeMetricsQueryResponse(r.Context(), r, &PrometheusResponse{
 			Status: "success",
 			Data: &PrometheusData{
 				ResultType: "vector",
@@ -899,7 +899,7 @@ func TestTripperware_ShouldSupportReadConsistencyOffsetsInjection(t *testing.T) 
 		}),
 		log.NewNopLogger(),
 		mockLimits{},
-		NewPrometheusCodec(nil, 0, formatJSON),
+		NewPrometheusCodec(nil, 0, formatJSON, nil),
 		nil,
 		promql.EngineOpts{
 			Logger:     log.NewNopLogger(),

--- a/pkg/frontend/querymiddleware/sharded_queryable.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable.go
@@ -37,7 +37,7 @@ type HandleEmbeddedQueryFunc func(ctx context.Context, queryString string, query
 // shardedQueryable is an implementor of the Queryable interface.
 type shardedQueryable struct {
 	req                   MetricsQueryRequest
-	annotationAccumulator *annotationAccumulator
+	annotationAccumulator *AnnotationAccumulator
 	handler               MetricsQueryHandler
 	responseHeaders       *responseHeadersTracker
 	handleEmbeddedQuery   HandleEmbeddedQueryFunc
@@ -46,7 +46,7 @@ type shardedQueryable struct {
 // NewShardedQueryable makes a new shardedQueryable. We expect a new queryable is created for each
 // query, otherwise the response headers tracker doesn't work as expected, because it merges the
 // headers for all queries run through the queryable and never reset them.
-func NewShardedQueryable(req MetricsQueryRequest, annotationAccumulator *annotationAccumulator, next MetricsQueryHandler, handleEmbeddedQuery HandleEmbeddedQueryFunc) *shardedQueryable { //nolint:revive
+func NewShardedQueryable(req MetricsQueryRequest, annotationAccumulator *AnnotationAccumulator, next MetricsQueryHandler, handleEmbeddedQuery HandleEmbeddedQueryFunc) *shardedQueryable { //nolint:revive
 	if handleEmbeddedQuery == nil {
 		handleEmbeddedQuery = defaultHandleEmbeddedQueryFunc
 	}
@@ -75,7 +75,7 @@ func (q *shardedQueryable) getResponseHeaders() []*PrometheusHeader {
 // through the downstream handler.
 type shardedQuerier struct {
 	req                   MetricsQueryRequest
-	annotationAccumulator *annotationAccumulator
+	annotationAccumulator *AnnotationAccumulator
 	handler               MetricsQueryHandler
 
 	// Keep track of response headers received when running embedded queries.

--- a/pkg/frontend/querymiddleware/sharded_queryable_test.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable_test.go
@@ -257,7 +257,7 @@ func TestShardedQuerier_Select_ShouldConcurrentlyRunEmbeddedQueries(t *testing.T
 }
 
 func TestShardedQueryable_GetResponseHeaders(t *testing.T) {
-	queryable := newShardedQueryable(&PrometheusRangeQueryRequest{}, nil, nil)
+	queryable := NewShardedQueryable(&PrometheusRangeQueryRequest{}, nil, nil, nil)
 	assert.Empty(t, queryable.getResponseHeaders())
 
 	// Merge some response headers from the 1st querier.
@@ -288,7 +288,7 @@ func TestShardedQueryable_GetResponseHeaders(t *testing.T) {
 }
 
 func mkShardedQuerier(handler MetricsQueryHandler) *shardedQuerier {
-	return &shardedQuerier{req: &PrometheusRangeQueryRequest{}, handler: handler, responseHeaders: newResponseHeadersTracker()}
+	return &shardedQuerier{req: &PrometheusRangeQueryRequest{}, handler: handler, responseHeaders: newResponseHeadersTracker(), handleEmbeddedQuery: defaultHandleEmbeddedQueryFunc()}
 }
 
 func TestNewSeriesSetFromEmbeddedQueriesResults(t *testing.T) {
@@ -418,7 +418,7 @@ func TestResponseToSamples(t *testing.T) {
 		},
 	}
 
-	streams, err := responseToSamples(input)
+	streams, err := ResponseToSamples(input)
 	require.NoError(t, err)
 	assertEqualSampleStream(t, input.Data.Result, streams)
 }

--- a/pkg/frontend/querymiddleware/sharded_queryable_test.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable_test.go
@@ -288,7 +288,7 @@ func TestShardedQueryable_GetResponseHeaders(t *testing.T) {
 }
 
 func mkShardedQuerier(handler MetricsQueryHandler) *shardedQuerier {
-	return &shardedQuerier{req: &PrometheusRangeQueryRequest{}, handler: handler, responseHeaders: newResponseHeadersTracker(), handleEmbeddedQuery: defaultHandleEmbeddedQueryFunc()}
+	return &shardedQuerier{req: &PrometheusRangeQueryRequest{}, handler: handler, responseHeaders: newResponseHeadersTracker(), handleEmbeddedQuery: defaultHandleEmbeddedQueryFunc}
 }
 
 func TestNewSeriesSetFromEmbeddedQueriesResults(t *testing.T) {

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -678,7 +678,7 @@ func splitQueryByInterval(req MetricsQueryRequest, interval time.Duration) ([]Me
 func evaluateAtModifierFunction(query string, start, end int64) (string, error) {
 	expr, err := parser.ParseExpr(query)
 	if err != nil {
-		return "", apierror.New(apierror.TypeBadData, decorateWithParamName(err, "query").Error())
+		return "", apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}
 	parser.Inspect(expr, func(n parser.Node, _ []parser.Node) error {
 		switch exprAt := n.(type) {

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -1699,7 +1699,7 @@ func (q roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	return q.codec.EncodeResponse(r.Context(), r, response)
+	return q.codec.EncodeMetricsQueryResponse(r.Context(), r, response)
 }
 
 const seconds = 1e3 // 1e3 milliseconds per second.

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -130,7 +130,7 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Metr
 	if err != nil {
 		level.Warn(spanLog).Log("msg", "failed to parse query", "err", err)
 		s.metrics.splittingSkipped.WithLabelValues(skippedReasonParsingFailed).Inc()
-		return nil, apierror.New(apierror.TypeBadData, decorateWithParamName(err, "query").Error())
+		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}
 
 	instantSplitQuery, err := mapper.Map(expr)
@@ -180,8 +180,8 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Metr
 		return nil, err
 	}
 
-	annotationAccumulator := newAnnotationAccumulator()
-	shardedQueryable := newShardedQueryable(req, annotationAccumulator, s.next)
+	annotationAccumulator := NewAnnotationAccumulator()
+	shardedQueryable := NewShardedQueryable(req, annotationAccumulator, s.next, nil)
 
 	qry, err := newQuery(ctx, req, s.engine, lazyquery.NewLazyQueryable(shardedQueryable))
 	if err != nil {

--- a/pkg/frontend/v2/frontend_scheduler_adapter_test.go
+++ b/pkg/frontend/v2/frontend_scheduler_adapter_test.go
@@ -63,7 +63,7 @@ func TestExtractAdditionalQueueDimensions(t *testing.T) {
 	adapter := &frontendToSchedulerAdapter{
 		cfg:    Config{QueryStoreAfter: 12 * time.Hour},
 		limits: limits{queryIngestersWithin: 13 * time.Hour},
-		codec:  querymiddleware.NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, "json"),
+		codec:  querymiddleware.NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, "json", nil),
 	}
 
 	now := time.Now()
@@ -196,7 +196,7 @@ func TestQueryDecoding(t *testing.T) {
 	adapter := &frontendToSchedulerAdapter{
 		cfg:    Config{QueryStoreAfter: 12 * time.Hour},
 		limits: limits{queryIngestersWithin: 13 * time.Hour},
-		codec:  querymiddleware.NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, "json"),
+		codec:  querymiddleware.NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, "json", nil),
 	}
 
 	now := time.Now()

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -76,7 +76,7 @@ func setupFrontendWithConcurrencyAndServerOptions(t *testing.T, reg prometheus.R
 	cfg.Port = grpcPort
 
 	logger := log.NewLogfmtLogger(os.Stdout)
-	codec := querymiddleware.NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, "json")
+	codec := querymiddleware.NewPrometheusCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, "json", nil)
 
 	f, err := NewFrontend(cfg, limits{}, logger, reg, codec)
 	require.NoError(t, err)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -696,7 +696,7 @@ func (t *Mimir) initFlusher() (serv services.Service, err error) {
 // initQueryFrontendCodec initializes query frontend codec.
 // NOTE: Grafana Enterprise Metrics depends on this.
 func (t *Mimir) initQueryFrontendCodec() (services.Service, error) {
-	t.QueryFrontendCodec = querymiddleware.NewPrometheusCodec(t.Registerer, t.Cfg.Frontend.FrontendV2.LookBackDelta, t.Cfg.Frontend.QueryMiddleware.QueryResultResponseFormat)
+	t.QueryFrontendCodec = querymiddleware.NewPrometheusCodec(t.Registerer, t.Cfg.Frontend.FrontendV2.LookBackDelta, t.Cfg.Frontend.QueryMiddleware.QueryResultResponseFormat, nil)
 	return nil, nil
 }
 

--- a/pkg/querier/tenantfederation/merge_exemplar_queryable.go
+++ b/pkg/querier/tenantfederation/merge_exemplar_queryable.go
@@ -225,7 +225,7 @@ func filterTenantsAndRewriteMatchers(idLabelName string, ids []string, allMatche
 	// In order to support that, we start with a set of 0 tenant IDs and add any tenant IDs that remain
 	// after filtering (based on the inner slice of matchers), for each outer slice.
 	for i, matchers := range allMatchers {
-		filteredIDs, unrelatedMatchers := filterValuesByMatchers(idLabelName, ids, matchers...)
+		filteredIDs, unrelatedMatchers := FilterValuesByMatchers(idLabelName, ids, matchers...)
 		for k := range filteredIDs {
 			outIDs[k] = struct{}{}
 		}

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -198,7 +198,7 @@ func (m *mergeQuerier) LabelValues(ctx context.Context, name string, hints *stor
 	spanlog, ctx := spanlogger.NewWithLogger(ctx, m.logger, "mergeQuerier.LabelValues")
 	defer spanlog.Finish()
 
-	matchedIDs, filteredMatchers := filterValuesByMatchers(m.idLabelName, ids, matchers...)
+	matchedIDs, filteredMatchers := FilterValuesByMatchers(m.idLabelName, ids, matchers...)
 
 	if name == m.idLabelName {
 		labelValues := make([]string, 0, len(matchedIDs))
@@ -237,7 +237,7 @@ func (m *mergeQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints
 	spanlog, ctx := spanlogger.NewWithLogger(ctx, m.logger, "mergeQuerier.LabelNames")
 	defer spanlog.Finish()
 
-	matchedIDs, filteredMatchers := filterValuesByMatchers(m.idLabelName, ids, matchers...)
+	matchedIDs, filteredMatchers := FilterValuesByMatchers(m.idLabelName, ids, matchers...)
 
 	labelNames, warnings, err := m.mergeDistinctStringSliceWithTenants(ctx, matchedIDs, func(ctx context.Context, id string) ([]string, annotations.Annotations, error) {
 		return m.upstream.LabelNames(ctx, id, hints, filteredMatchers...)
@@ -349,7 +349,7 @@ func (m *mergeQuerier) Select(ctx context.Context, sortSeries bool, hints *stora
 	spanlog, ctx := spanlogger.NewWithLogger(ctx, m.logger, "mergeQuerier.Select")
 	defer spanlog.Finish()
 
-	matchedIDs, filteredMatchers := filterValuesByMatchers(m.idLabelName, ids, matchers...)
+	matchedIDs, filteredMatchers := FilterValuesByMatchers(m.idLabelName, ids, matchers...)
 
 	jobs := make([]string, 0, len(matchedIDs))
 	seriesSets := make([]storage.SeriesSet, len(matchedIDs))

--- a/pkg/querier/tenantfederation/tenant_federation.go
+++ b/pkg/querier/tenantfederation/tenant_federation.go
@@ -31,7 +31,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxTenants, "tenant-federation.max-tenants", defaultMaxTenants, "The max number of tenant IDs that may be supplied for a federated query if enabled. 0 to disable the limit.")
 }
 
-// filterValuesByMatchers applies matchers to inputed `idLabelName` and
+// FilterValuesByMatchers applies matchers to inputed `idLabelName` and
 // `ids`. A set of matched IDs is returned and also all label matchers not
 // targeting the `idLabelName` label.
 //
@@ -40,7 +40,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // to as part of Select in the mergeQueryable, to ensure only relevant queries
 // are considered and the forwarded matchers do not contain matchers on the
 // `idLabelName`.
-func filterValuesByMatchers(idLabelName string, ids []string, matchers ...*labels.Matcher) (matchedIDs map[string]struct{}, unrelatedMatchers []*labels.Matcher) {
+func FilterValuesByMatchers(idLabelName string, ids []string, matchers ...*labels.Matcher) (matchedIDs map[string]struct{}, unrelatedMatchers []*labels.Matcher) {
 	// this contains the matchers which are not related to idLabelName
 	unrelatedMatchers = make([]*labels.Matcher, 0, len(matchers))
 


### PR DESCRIPTION
#### What this PR does

Generalise some of Mimir's query sharding code to be more reusable for other kinds of sharded queries.

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/grafana/mimir/pull/8755

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

No docs as these are minor, non-user-facing changes.