### PR TITLE
Add MimirKubernetesServiceEndpointsApproachingLimit and MimirKubernetesServiceEndpointsOverLimit alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@
 ### Mixin
 
 * [CHANGE] Dashboards: set default auto-refresh rate to 5m. #8758
+* [FEATURE] Alerts: add `MimirGossipMembersEndpointsOutOfSync` alert. #9347
+* [FEATURE] Alerts: add `MimirKubernetesServiceEndpointsApproachingLimit` and `MimirKubernetesServiceEndpointsOverLimit` alerts. Please configure `_config.kubernetes_endpoints_limit` in the mixin to the actual endpoints limit configured in your Kubernetes cluster. The mixin default is 1000, which is the upperbound configurabled in Kubernetes. #9381
 * [ENHANCEMENT] Dashboards: allow switching between using classic or native histograms in dashboards.
   * Overview dashboard: status, read/write latency and queries/ingestion per sec panels, `cortex_request_duration_seconds` metric. #7674 #8502 #8791
   * Writes dashboard: `cortex_request_duration_seconds` metric. #8757 #8791
@@ -146,7 +148,6 @@
 * [ENHANCEMENT] Dashboards: add 'Read path' selector to 'Mimir / Queries' dashboard. #8878
 * [ENHANCEMENT] Dashboards: add annotation indicating active series are being reloaded to 'Mimir / Tenants' dashboard. #9257
 * [ENHANCEMENT] Dashboards: limit results on the 'Failed evaluations rate' panel of the 'Mimir / Tenants' dashboard to 50 to avoid crashing the page when there are many failing groups. #9262
-* [FEATURE] Alerts: add `MimirGossipMembersEndpointsOutOfSync` alert. #9347
 * [BUGFIX] Dashboards: fix "current replicas" in autoscaling panels when HPA is not active. #8566
 * [BUGFIX] Alerts: do not fire `MimirRingMembersMismatch` during the migration to experimental ingest storage. #8727
 * [BUGFIX] Dashboards: avoid over-counting of ingesters metrics when migrating to experimental ingest storage. #9170

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -970,6 +970,30 @@ How to **investigate**:
        $.apps.v1.statefulSet.spec.template.metadata.withLabelsMixin({ [$._config.gossip_member_label]: 'false' }),
      ```
 
+
+### MimirKubernetesServiceEndpointsApproachingLimit
+
+This alert fires if a Kubernetes service used by Mimir for service discovery is approaching the endpoints limit.
+
+See [MimirKubernetesServiceEndpointsOverLimit](#MimirKubernetesServiceEndpointsOverLimit).
+
+
+### MimirKubernetesServiceEndpointsOverLimit
+
+This alert fires if a Kubernetes service used by Mimir for service discovery has reached the endpoints limit.
+
+How it **works**:
+
+- By default, the Kubernetes control plane creates and manages service endpoints to have no more than 100 endpoints each ([doc](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/)). You can configure this limit with the `--max-endpoints-per-slice kube-controller-manager` flag, up to a maximum of 1000.
+- Once a Kubernetes service endpoints list reached the limit, the endpoints are truncated to the limit.
+- Mimir uses some Kubernetes services for DNS-based service discovery. If the endpoints of one of such services is getting truncated, Mimir is unable to discover all pods.
+
+How to **fix** it:
+
+- Increase Kubernetes `--max-endpoints-per-slice kube-controller-manager` to 1000, if it's currently running with a lower value. Configure the limit in the alert to reflect the new setting.
+- Reduce the number of replicas of the affected service and vertically scale it up.
+
+
 ### EtcdAllocatingTooMuchMemory
 
 This can be triggered if there are too many HA dedupe keys in etcd. We saw this when one of our clusters hit 20K tenants that were using HA dedupe config. Raise the etcd limits via:

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -970,13 +970,11 @@ How to **investigate**:
        $.apps.v1.statefulSet.spec.template.metadata.withLabelsMixin({ [$._config.gossip_member_label]: 'false' }),
      ```
 
-
 ### MimirKubernetesServiceEndpointsApproachingLimit
 
 This alert fires if a Kubernetes service used by Mimir for service discovery is approaching the endpoints limit.
 
 See [MimirKubernetesServiceEndpointsOverLimit](#MimirKubernetesServiceEndpointsOverLimit).
-
 
 ### MimirKubernetesServiceEndpointsOverLimit
 
@@ -992,7 +990,6 @@ How to **fix** it:
 
 - Increase Kubernetes `--max-endpoints-per-slice kube-controller-manager` to 1000, if it's currently running with a lower value. Configure the limit in the alert to reflect the new setting.
 - Reduce the number of replicas of the affected service and vertically scale it up.
-
 
 ### EtcdAllocatingTooMuchMemory
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -626,6 +626,40 @@ spec:
             for: 15m
             labels:
               severity: critical
+      - name: kubernetes_alerts
+        rules:
+          - alert: MimirKubernetesServiceEndpointsApproachingLimit
+            annotations:
+              message: |
+                  Kubernetes service {{ $labels.endpoint }} in {{ $labels.cluster }}/{{ $labels.namespace }} is approaching the maximum number of endpoints (limit set to 1000).
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkubernetesserviceendpointsapproachinglimit
+            expr: |
+              (
+                count by(cluster, namespace, endpoint) (kube_endpoint_address{endpoint=~"memcached|memcached-frontend|memcached-index-queries|memcached-metadata|redis|redis-frontend|redis-index-queries|redis-metadata|query-scheduler|ruler-query-scheduler|query-scheduler-discovery|query-frontend-discovery|ruler-query-frontend"})
+                > 900
+              )
+  
+              # Filter by Mimir only.
+              and on (cluster, namespace) (count by(cluster, namespace) (cortex_build_info) > 0)
+            for: 15m
+            labels:
+              severity: warning
+          - alert: MimirKubernetesServiceEndpointsOverLimit
+            annotations:
+              message: |
+                  Kubernetes service {{ $labels.endpoint }} in {{ $labels.cluster }}/{{ $labels.namespace }} reached the maximum number of endpoints (limit set to 1000).
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkubernetesserviceendpointsoverlimit
+            expr: |
+              (
+                count by(cluster, namespace, endpoint) (kube_endpoint_address{endpoint=~"memcached|memcached-frontend|memcached-index-queries|memcached-metadata|redis|redis-frontend|redis-index-queries|redis-metadata|query-scheduler|ruler-query-scheduler|query-scheduler-discovery|query-frontend-discovery|ruler-query-frontend"})
+                >= 1000
+              )
+  
+              # Filter by Mimir only.
+              and on (cluster, namespace) (count by(cluster, namespace) (cortex_build_info) > 0)
+            for: 15m
+            labels:
+              severity: critical
       - name: alertmanager_alerts
         rules:
           - alert: MimirAlertmanagerSyncConfigsFailing

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -604,6 +604,40 @@ groups:
           for: 15m
           labels:
             severity: critical
+    - name: kubernetes_alerts
+      rules:
+        - alert: MimirKubernetesServiceEndpointsApproachingLimit
+          annotations:
+            message: |
+                Kubernetes service {{ $labels.endpoint }} in {{ $labels.cluster }}/{{ $labels.namespace }} is approaching the maximum number of endpoints (limit set to 1000).
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkubernetesserviceendpointsapproachinglimit
+          expr: |
+            (
+              count by(cluster, namespace, endpoint) (kube_endpoint_address{endpoint=~"memcached|memcached-frontend|memcached-index-queries|memcached-metadata|redis|redis-frontend|redis-index-queries|redis-metadata|query-scheduler|ruler-query-scheduler|query-scheduler-discovery|query-frontend-discovery|ruler-query-frontend"})
+              > 900
+            )
+
+            # Filter by Mimir only.
+            and on (cluster, namespace) (count by(cluster, namespace) (cortex_build_info) > 0)
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MimirKubernetesServiceEndpointsOverLimit
+          annotations:
+            message: |
+                Kubernetes service {{ $labels.endpoint }} in {{ $labels.cluster }}/{{ $labels.namespace }} reached the maximum number of endpoints (limit set to 1000).
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkubernetesserviceendpointsoverlimit
+          expr: |
+            (
+              count by(cluster, namespace, endpoint) (kube_endpoint_address{endpoint=~"memcached|memcached-frontend|memcached-index-queries|memcached-metadata|redis|redis-frontend|redis-index-queries|redis-metadata|query-scheduler|ruler-query-scheduler|query-scheduler-discovery|query-frontend-discovery|ruler-query-frontend"})
+              >= 1000
+            )
+
+            # Filter by Mimir only.
+            and on (cluster, namespace) (count by(cluster, namespace) (cortex_build_info) > 0)
+          for: 15m
+          labels:
+            severity: critical
     - name: alertmanager_alerts
       rules:
         - alert: MimirAlertmanagerSyncConfigsFailing

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -614,6 +614,40 @@ groups:
           for: 15m
           labels:
             severity: critical
+    - name: kubernetes_alerts
+      rules:
+        - alert: MimirKubernetesServiceEndpointsApproachingLimit
+          annotations:
+            message: |
+                Kubernetes service {{ $labels.endpoint }} in {{ $labels.cluster }}/{{ $labels.namespace }} is approaching the maximum number of endpoints (limit set to 1000).
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkubernetesserviceendpointsapproachinglimit
+          expr: |
+            (
+              count by(cluster, namespace, endpoint) (kube_endpoint_address{endpoint=~"memcached|memcached-frontend|memcached-index-queries|memcached-metadata|redis|redis-frontend|redis-index-queries|redis-metadata|query-scheduler|ruler-query-scheduler|query-scheduler-discovery|query-frontend-discovery|ruler-query-frontend"})
+              > 900
+            )
+
+            # Filter by Mimir only.
+            and on (cluster, namespace) (count by(cluster, namespace) (cortex_build_info) > 0)
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MimirKubernetesServiceEndpointsOverLimit
+          annotations:
+            message: |
+                Kubernetes service {{ $labels.endpoint }} in {{ $labels.cluster }}/{{ $labels.namespace }} reached the maximum number of endpoints (limit set to 1000).
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkubernetesserviceendpointsoverlimit
+          expr: |
+            (
+              count by(cluster, namespace, endpoint) (kube_endpoint_address{endpoint=~"memcached|memcached-frontend|memcached-index-queries|memcached-metadata|redis|redis-frontend|redis-index-queries|redis-metadata|query-scheduler|ruler-query-scheduler|query-scheduler-discovery|query-frontend-discovery|ruler-query-frontend"})
+              >= 1000
+            )
+
+            # Filter by Mimir only.
+            and on (cluster, namespace) (count by(cluster, namespace) (cortex_build_info) > 0)
+          for: 15m
+          labels:
+            severity: critical
     - name: alertmanager_alerts
       rules:
         - alert: MimirAlertmanagerSyncConfigsFailing

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -704,5 +704,8 @@
 
     // Show panels that use queries for "ingest storage" ingestion (distributor -> Kafka, Kafka -> ingesters)
     show_ingest_storage_panels: false,
+
+    // The configured Kubernetes endpoints limit.
+    kubernetes_endpoints_limit: 1000,
   },
 }


### PR DESCRIPTION
#### What this PR does

Last week I learned that K8S service endpoints is limited. Kubernetes default is 100, but can be increased up to 1000. This is an issue for K8S services used by Mimir for service discovery. In this PR I propose to add a couple of alerts firing when is approaching, or has reached, such limit. The alert checks only services used by Mimir for service discovery, given for others it's not expected to be a real issue.

There's no Prometheus metric exposing the limit, so I added a mixin config option for that. The mixin default is 1000,  Kubernetes default is 100 and Kubernetes max is 1000. Why did I pick 1000 as mixin default? To try to avoid having such limit firing for people running Mimir at large scale as soon as they updated the alerts (assuming the already raised the Kubernetes limit to the max). I'm open to feedback tho.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
