### PR TITLE
Invalidate bucket caches on object modification or deletion

### DIFF
--- a/pkg/storage/tsdb/bucketcache/caching_bucket.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket.go
@@ -159,14 +159,16 @@ func NewCachingBucket(bucketID string, bucketClient objstore.Bucket, cfg *Cachin
 	return cb, nil
 }
 
+// invalidate invalidates content, attributes, and existence caches for the given
+// object. Note that this is best-effort and errors invalidating the cache are ignored.
 func (cb *CachingBucket) invalidate(ctx context.Context, name string) {
 	_, cfg := cb.cfg.findGetConfig(name)
-	if cfg != nil {
+	if cfg != nil && cfg.invalidateOnMutation {
 		contentKey := cachingKeyContent(cb.bucketID, name)
 		attrsKey := cachingKeyAttributes(cb.bucketID, name)
 		existsKey := cachingKeyExists(cb.bucketID, name)
 
-		// Cache might be down or key might not exist. Ignore errors since invalidation is best-effort.
+		// Cache might be down or key might not exist.
 		_ = cfg.cache.Delete(ctx, contentKey)
 		_ = cfg.cache.Delete(ctx, attrsKey)
 		_ = cfg.cache.Delete(ctx, existsKey)

--- a/pkg/storage/tsdb/bucketcache/caching_bucket_config.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket_config.go
@@ -78,7 +78,8 @@ type getRangeConfig struct {
 
 type attributesConfig struct {
 	operationConfig
-	ttl time.Duration
+	ttl                  time.Duration
+	invalidateOnMutation bool
 }
 
 func newOperationConfig(cache cache.Cache, matcher func(string) bool) operationConfig {
@@ -146,10 +147,11 @@ func (cfg *CachingBucketConfig) CacheGetRange(configName string, cache cache.Cac
 }
 
 // CacheAttributes configures caching of "Attributes" operation for matching files.
-func (cfg *CachingBucketConfig) CacheAttributes(configName string, cache cache.Cache, matcher func(name string) bool, ttl time.Duration) {
+func (cfg *CachingBucketConfig) CacheAttributes(configName string, cache cache.Cache, matcher func(name string) bool, ttl time.Duration, invalidateOnMutation bool) {
 	cfg.attributes[configName] = &attributesConfig{
-		operationConfig: newOperationConfig(cache, matcher),
-		ttl:             ttl,
+		operationConfig:      newOperationConfig(cache, matcher),
+		ttl:                  ttl,
+		invalidateOnMutation: invalidateOnMutation,
 	}
 }
 

--- a/pkg/storage/tsdb/bucketcache/caching_bucket_config.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket_config.go
@@ -60,8 +60,9 @@ type existsConfig struct {
 
 type getConfig struct {
 	existsConfig
-	contentTTL       time.Duration
-	maxCacheableSize int
+	contentTTL           time.Duration
+	maxCacheableSize     int
+	invalidateOnMutation bool
 }
 
 type getRangeConfig struct {
@@ -104,15 +105,16 @@ func (cfg *CachingBucketConfig) CacheIter(configName string, cache cache.Cache, 
 }
 
 // CacheGet configures caching of "Get" operation for matching files. Content of the object is cached, as well as whether object exists or not.
-func (cfg *CachingBucketConfig) CacheGet(configName string, cache cache.Cache, matcher func(string) bool, maxCacheableSize int, contentTTL, existsTTL, doesntExistTTL time.Duration) {
+func (cfg *CachingBucketConfig) CacheGet(configName string, cache cache.Cache, matcher func(string) bool, maxCacheableSize int, contentTTL, existsTTL, doesntExistTTL time.Duration, invalidateOnMutation bool) {
 	cfg.get[configName] = &getConfig{
 		existsConfig: existsConfig{
 			operationConfig: newOperationConfig(cache, matcher),
 			existsTTL:       existsTTL,
 			doesntExistTTL:  doesntExistTTL,
 		},
-		contentTTL:       contentTTL,
-		maxCacheableSize: maxCacheableSize,
+		contentTTL:           contentTTL,
+		maxCacheableSize:     maxCacheableSize,
+		invalidateOnMutation: invalidateOnMutation,
 	}
 }
 

--- a/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
@@ -770,7 +770,7 @@ func TestAttributes(t *testing.T) {
 
 	cfg := NewCachingBucketConfig()
 	const cfgName = "test"
-	cfg.CacheAttributes(cfgName, cache, matchAll, time.Minute)
+	cfg.CacheAttributes(cfgName, cache, matchAll, time.Minute, false)
 
 	cb, err := NewCachingBucket("test", inmem, cfg, nil, nil)
 	assert.NoError(t, err)
@@ -920,7 +920,7 @@ func TestMutationInvalidatesCache(t *testing.T) {
 	cfg := NewCachingBucketConfig()
 	cfg.CacheGet(cfgName, c, matchAll, 1024, time.Minute, time.Minute, time.Minute, true)
 	cfg.CacheExists(cfgName, c, matchAll, time.Minute, time.Minute)
-	cfg.CacheAttributes(cfgName, c, matchAll, time.Minute)
+	cfg.CacheAttributes(cfgName, c, matchAll, time.Minute, true)
 
 	cb, err := NewCachingBucket("test", inmem, cfg, nil, nil)
 	require.NoError(t, err)

--- a/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
@@ -604,7 +604,7 @@ func TestGet(t *testing.T) {
 
 	cfg := NewCachingBucketConfig()
 	const cfgName = "metafile"
-	cfg.CacheGet(cfgName, cache, matchAll, 1024, 10*time.Minute, 10*time.Minute, 2*time.Minute)
+	cfg.CacheGet(cfgName, cache, matchAll, 1024, 10*time.Minute, 10*time.Minute, 2*time.Minute, false)
 	cfg.CacheExists(cfgName, cache, matchAll, 10*time.Minute, 2*time.Minute)
 
 	cb, err := NewCachingBucket("test", inmem, cfg, nil, nil)
@@ -682,7 +682,7 @@ func TestGetTooBigObject(t *testing.T) {
 	const filename = "/object-1"
 	const cfgName = "metafile"
 	// Only allow 5 bytes to be cached.
-	cfg.CacheGet(cfgName, cache, matchAll, 5, 10*time.Minute, 10*time.Minute, 2*time.Minute)
+	cfg.CacheGet(cfgName, cache, matchAll, 5, 10*time.Minute, 10*time.Minute, 2*time.Minute, false)
 	cfg.CacheExists(cfgName, cache, matchAll, 10*time.Minute, 2*time.Minute)
 
 	cb, err := NewCachingBucket("test", inmem, cfg, nil, nil)
@@ -706,7 +706,7 @@ func TestGetPartialRead(t *testing.T) {
 	cfg := NewCachingBucketConfig()
 	const filename = "/object-1"
 	const cfgName = "metafile"
-	cfg.CacheGet(cfgName, cache, matchAll, 1024, 10*time.Minute, 10*time.Minute, 2*time.Minute)
+	cfg.CacheGet(cfgName, cache, matchAll, 1024, 10*time.Minute, 10*time.Minute, 2*time.Minute, false)
 	cfg.CacheExists(cfgName, cache, matchAll, 10*time.Minute, 2*time.Minute)
 
 	cb, err := NewCachingBucket("test", inmem, cfg, nil, nil)
@@ -918,7 +918,7 @@ func TestMutationInvalidatesCache(t *testing.T) {
 
 	const cfgName = "test"
 	cfg := NewCachingBucketConfig()
-	cfg.CacheGet(cfgName, c, matchAll, 1024^2, time.Minute, time.Minute, time.Minute)
+	cfg.CacheGet(cfgName, c, matchAll, 1024, time.Minute, time.Minute, time.Minute, true)
 	cfg.CacheExists(cfgName, c, matchAll, time.Minute, time.Minute)
 	cfg.CacheAttributes(cfgName, c, matchAll, time.Minute)
 

--- a/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
@@ -909,6 +909,55 @@ func TestCachingKey_ShouldKeepAllocationsToMinimum(t *testing.T) {
 	}
 }
 
+func TestMutationInvalidatesCache(t *testing.T) {
+	inmem := objstore.NewInMemBucket()
+
+	// We reuse cache between tests (!)
+	c := cache.NewMockCache()
+	ctx := context.Background()
+
+	const cfgName = "test"
+	cfg := NewCachingBucketConfig()
+	cfg.CacheGet(cfgName, c, matchAll, 1024^2, time.Minute, time.Minute, time.Minute)
+	cfg.CacheExists(cfgName, c, matchAll, time.Minute, time.Minute)
+	cfg.CacheAttributes(cfgName, c, matchAll, time.Minute)
+
+	cb, err := NewCachingBucket("test", inmem, cfg, nil, nil)
+	require.NoError(t, err)
+
+	t.Run("invalidated on upload", func(t *testing.T) {
+		c.Flush()
+
+		// Initial upload bypassing the CachingBucket but read the object back to ensure it is in cache.
+		require.NoError(t, inmem.Upload(ctx, "/object-1", strings.NewReader("test content 1")))
+		verifyGet(ctx, t, cb, "/object-1", []byte("test content 1"), true, false, cfgName)
+		verifyExists(ctx, t, cb, "/object-1", true, true, true, cfgName)
+		verifyObjectAttrs(ctx, t, cb, "/object-1", 14, true, false, cfgName)
+
+		// Do an upload via the CachingBucket and ensure the first read after does not come from cache.
+		require.NoError(t, cb.Upload(ctx, "/object-1", strings.NewReader("test content 12")))
+		verifyGet(ctx, t, cb, "/object-1", []byte("test content 12"), true, false, cfgName)
+		verifyExists(ctx, t, cb, "/object-1", true, true, true, cfgName)
+		verifyObjectAttrs(ctx, t, cb, "/object-1", 15, true, false, cfgName)
+	})
+
+	t.Run("invalidated on delete", func(t *testing.T) {
+		c.Flush()
+
+		// Initial upload bypassing the CachingBucket but read the object back to ensure it is in cache.
+		require.NoError(t, inmem.Upload(ctx, "/object-1", strings.NewReader("test content 1")))
+		verifyGet(ctx, t, cb, "/object-1", []byte("test content 1"), true, false, cfgName)
+		verifyExists(ctx, t, cb, "/object-1", true, true, true, cfgName)
+		verifyObjectAttrs(ctx, t, cb, "/object-1", 14, true, false, cfgName)
+
+		// Delete via the CachingBucket and ensure the first read after does not come from cache but non-existence is cached.
+		require.NoError(t, cb.Delete(ctx, "/object-1"))
+		verifyGet(ctx, t, cb, "/object-1", nil, true, false, cfgName)
+		verifyExists(ctx, t, cb, "/object-1", false, true, true, cfgName)
+		verifyObjectAttrs(ctx, t, cb, "/object-1", -1, true, false, cfgName)
+	})
+}
+
 func BenchmarkCachingKey(b *testing.B) {
 	tests := map[string]struct {
 		run func(bucketID string)

--- a/pkg/storage/tsdb/caching_config.go
+++ b/pkg/storage/tsdb/caching_config.go
@@ -108,8 +108,8 @@ func CreateCachingBucket(chunksCache cache.Cache, chunksConfig ChunksCacheConfig
 
 		cfg.CacheExists("metafile", metadataCache, isMetaFile, metadataConfig.MetafileExistsTTL, metadataConfig.MetafileDoesntExistTTL)
 		cfg.CacheGet("metafile", metadataCache, isMetaFile, metadataConfig.MetafileMaxSize, metadataConfig.MetafileContentTTL, metadataConfig.MetafileExistsTTL, metadataConfig.MetafileDoesntExistTTL, false)
-		cfg.CacheAttributes("metafile", metadataCache, isMetaFile, metadataConfig.MetafileAttributesTTL)
-		cfg.CacheAttributes("block-index", metadataCache, isBlockIndexFile, metadataConfig.BlockIndexAttributesTTL)
+		cfg.CacheAttributes("metafile", metadataCache, isMetaFile, metadataConfig.MetafileAttributesTTL, false)
+		cfg.CacheAttributes("block-index", metadataCache, isBlockIndexFile, metadataConfig.BlockIndexAttributesTTL, false)
 		cfg.CacheGet("bucket-index", metadataCache, isBucketIndexFile, metadataConfig.BucketIndexMaxSize, metadataConfig.BucketIndexContentTTL /* do not cache exist / not exist: */, 0, 0, false)
 
 		codec := bucketcache.SnappyIterCodec{IterCodec: bucketcache.JSONIterCodec{}}

--- a/pkg/storage/tsdb/caching_config.go
+++ b/pkg/storage/tsdb/caching_config.go
@@ -107,10 +107,10 @@ func CreateCachingBucket(chunksCache cache.Cache, chunksConfig ChunksCacheConfig
 		metadataCache = cache.NewSpanlessTracingCache(metadataCache, logger, tenant.NewMultiResolver())
 
 		cfg.CacheExists("metafile", metadataCache, isMetaFile, metadataConfig.MetafileExistsTTL, metadataConfig.MetafileDoesntExistTTL)
-		cfg.CacheGet("metafile", metadataCache, isMetaFile, metadataConfig.MetafileMaxSize, metadataConfig.MetafileContentTTL, metadataConfig.MetafileExistsTTL, metadataConfig.MetafileDoesntExistTTL)
+		cfg.CacheGet("metafile", metadataCache, isMetaFile, metadataConfig.MetafileMaxSize, metadataConfig.MetafileContentTTL, metadataConfig.MetafileExistsTTL, metadataConfig.MetafileDoesntExistTTL, false)
 		cfg.CacheAttributes("metafile", metadataCache, isMetaFile, metadataConfig.MetafileAttributesTTL)
 		cfg.CacheAttributes("block-index", metadataCache, isBlockIndexFile, metadataConfig.BlockIndexAttributesTTL)
-		cfg.CacheGet("bucket-index", metadataCache, isBucketIndexFile, metadataConfig.BucketIndexMaxSize, metadataConfig.BucketIndexContentTTL /* do not cache exist / not exist: */, 0, 0)
+		cfg.CacheGet("bucket-index", metadataCache, isBucketIndexFile, metadataConfig.BucketIndexMaxSize, metadataConfig.BucketIndexContentTTL /* do not cache exist / not exist: */, 0, 0, false)
 
 		codec := bucketcache.SnappyIterCodec{IterCodec: bucketcache.JSONIterCodec{}}
 		cfg.CacheIter("tenants-iter", metadataCache, isTenantsDir, metadataConfig.TenantsListTTL, codec)


### PR DESCRIPTION
#### What this PR does

Invalidate content, existence, and attributes cached for a particular object when the object is modified or deleted.

#### Which issue(s) this PR fixes or relates to

Part of #9386

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
