### PR TITLE
kafka replay speed: concurrency fetching improvements

### DIFF
--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -93,11 +93,12 @@ type KafkaConfig struct {
 	// Used when logging unsampled client errors. Set from ingester's ErrorSampleRate.
 	FallbackClientErrorSampleRate int64 `yaml:"-"`
 
-	FetchConcurrency                  int  `yaml:"fetch_concurrency"`
-	RecordsPerFetch                   int  `yaml:"records_per_fetch"`
-	UseCompressedBytesAsFetchMaxBytes bool `yaml:"use_compressed_bytes_as_fetch_max_bytes"`
-	IngestionConcurrency              int  `yaml:"ingestion_concurrency"`
-	IngestionConcurrencyBatchSize     int  `yaml:"ingestion_concurrency_batch_size"`
+	FetchConcurrency                  int           `yaml:"fetch_concurrency"`
+	FetchMinBytesMaxWait              time.Duration `yaml:"fetch_min_bytes_max_wait"`
+	RecordsPerFetch                   int           `yaml:"records_per_fetch"`
+	UseCompressedBytesAsFetchMaxBytes bool          `yaml:"use_compressed_bytes_as_fetch_max_bytes"`
+	IngestionConcurrency              int           `yaml:"ingestion_concurrency"`
+	IngestionConcurrencyBatchSize     int           `yaml:"ingestion_concurrency_batch_size"`
 }
 
 func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {
@@ -133,6 +134,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 
 	f.DurationVar(&cfg.WaitStrongReadConsistencyTimeout, prefix+".wait-strong-read-consistency-timeout", 20*time.Second, "The maximum allowed for a read requests processed by an ingester to wait until strong read consistency is enforced. 0 to disable the timeout.")
 	f.IntVar(&cfg.FetchConcurrency, prefix+".fetch-concurrency", 1, "The number of concurrent fetch requests that the ingester sends to Kafka when catching up during startup.")
+	f.DurationVar(&cfg.FetchMinBytesMaxWait, prefix+".fetch-min-bytes-max-wait", defaultMinBytesWaitTime, "The maximum time to wait for the minimum number of bytes to be fetched from Kafka before returning the fetched records. This is used to avoid waiting indefinitely for the minimum number of bytes to be fetched.")
 	f.IntVar(&cfg.RecordsPerFetch, prefix+".records-per-fetch", 128, "The number of records to fetch from Kafka in a single request.")
 	f.BoolVar(&cfg.UseCompressedBytesAsFetchMaxBytes, prefix+".use-compressed-bytes-as-fetch-max-bytes", true, "When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently.")
 	f.IntVar(&cfg.IngestionConcurrency, prefix+".ingestion-concurrency", 0, "The number of concurrent ingestion streams to the TSDB head. 0 to disable.")

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -93,12 +93,11 @@ type KafkaConfig struct {
 	// Used when logging unsampled client errors. Set from ingester's ErrorSampleRate.
 	FallbackClientErrorSampleRate int64 `yaml:"-"`
 
-	FetchConcurrency                  int           `yaml:"fetch_concurrency"`
-	FetchMinBytesMaxWait              time.Duration `yaml:"fetch_min_bytes_max_wait"`
-	RecordsPerFetch                   int           `yaml:"records_per_fetch"`
-	UseCompressedBytesAsFetchMaxBytes bool          `yaml:"use_compressed_bytes_as_fetch_max_bytes"`
-	IngestionConcurrency              int           `yaml:"ingestion_concurrency"`
-	IngestionConcurrencyBatchSize     int           `yaml:"ingestion_concurrency_batch_size"`
+	FetchConcurrency                  int  `yaml:"fetch_concurrency"`
+	RecordsPerFetch                   int  `yaml:"records_per_fetch"`
+	UseCompressedBytesAsFetchMaxBytes bool `yaml:"use_compressed_bytes_as_fetch_max_bytes"`
+	IngestionConcurrency              int  `yaml:"ingestion_concurrency"`
+	IngestionConcurrencyBatchSize     int  `yaml:"ingestion_concurrency_batch_size"`
 }
 
 func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {
@@ -134,7 +133,6 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 
 	f.DurationVar(&cfg.WaitStrongReadConsistencyTimeout, prefix+".wait-strong-read-consistency-timeout", 20*time.Second, "The maximum allowed for a read requests processed by an ingester to wait until strong read consistency is enforced. 0 to disable the timeout.")
 	f.IntVar(&cfg.FetchConcurrency, prefix+".fetch-concurrency", 1, "The number of concurrent fetch requests that the ingester sends to Kafka when catching up during startup.")
-	f.DurationVar(&cfg.FetchMinBytesMaxWait, prefix+".fetch-min-bytes-max-wait", defaultMinBytesWaitTime, "The maximum time to wait for the minimum number of bytes to be fetched from Kafka before returning the fetched records. This is used to avoid waiting indefinitely for the minimum number of bytes to be fetched.")
 	f.IntVar(&cfg.RecordsPerFetch, prefix+".records-per-fetch", 128, "The number of records to fetch from Kafka in a single request.")
 	f.BoolVar(&cfg.UseCompressedBytesAsFetchMaxBytes, prefix+".use-compressed-bytes-as-fetch-max-bytes", true, "When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently.")
 	f.IntVar(&cfg.IngestionConcurrency, prefix+".ingestion-concurrency", 0, "The number of concurrent ingestion streams to the TSDB head. 0 to disable.")

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -40,7 +40,7 @@ const (
 
 	// defaultMinBytesWaitTime is the time the Kafka broker can wait for MinBytes to be filled.
 	// This is usually used when there aren't enough records available to fulfil MinBytes, so the broker waits for more records to be produced.
-	defaultMinBytesWaitTime = 10 * time.Second
+	defaultMinBytesWaitTime = 3 * time.Second
 )
 
 var (

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -856,8 +856,8 @@ func (fr *fetchResult) finishWaitingForConsumption() {
 
 // Merge merges other with an older fetchResult. mergedWith keeps most of the fields of fr and assumes they are more up to date then other's.
 func (fr *fetchResult) Merge(older fetchResult) fetchResult {
-	if fr.ctx != nil {
-		level.Debug(spanlogger.FromContext(fr.ctx, log.NewNopLogger())).Log("msg", "merged fetch result with the next result")
+	if older.ctx != nil {
+		level.Debug(spanlogger.FromContext(older.ctx, log.NewNopLogger())).Log("msg", "merged fetch result with the next result")
 	}
 
 	// older.Records are older than fr.Records, so we append them first.

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -1144,7 +1144,7 @@ func (r *concurrentFetchers) runFetcher(ctx context.Context, fetchersWg *sync.Wa
 
 		var previousResult fetchResult
 		for attempt := 0; errBackoff.Ongoing() && w.endOffset > w.startOffset; attempt++ {
-			attemptSpan, ctx := spanlogger.NewWithLogger(ctx, wantSpan, "concurrentFetcher.fetch.attempt")
+			attemptSpan, ctx := spanlogger.NewWithLogger(ctx, logger, "concurrentFetcher.fetch.attempt")
 			attemptSpan.SetTag("attempt", attempt)
 
 			f := r.fetchSingle(ctx, w)

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -854,7 +854,7 @@ func (fr *fetchResult) finishWaitingForConsumption() {
 	fr.waitingToBePickedUpFromOrderedFetchesSpan.Finish()
 }
 
-// mergedWith merges other with an older fetchResult. mergedWith keeps most of the fields of fr and assumes they are more up to date then other's.
+// Merge merges other with an older fetchResult. mergedWith keeps most of the fields of fr and assumes they are more up to date then other's.
 func (fr *fetchResult) Merge(older fetchResult) fetchResult {
 	if fr.ctx != nil {
 		level.Debug(spanlogger.FromContext(fr.ctx, log.NewNopLogger())).Log("msg", "merged fetch result with the next result")

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,6 +27,8 @@ import (
 	"github.com/twmb/franz-go/plugin/kotel"
 	"github.com/twmb/franz-go/plugin/kprom"
 	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
 const (

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -1041,7 +1041,7 @@ func (r *concurrentFetchers) fetchSingle(ctx context.Context, fw fetchWant) (fr 
 
 func (r *concurrentFetchers) buildFetchRequest(fw fetchWant, leaderEpoch int32) kmsg.FetchRequest {
 	req := kmsg.NewFetchRequest()
-	req.MinBytes = 1
+	req.MinBytes = 1 // Warpstream ignores this field. This means that the WaitTime below is always waited and MaxBytes play a bigger role in how fast Ws responds.
 	req.Version = 13
 	req.MaxWaitMillis = int32(r.minBytesWaitTime / time.Millisecond)
 	req.MaxBytes = fw.MaxBytes()

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -40,7 +40,8 @@ const (
 
 	// defaultMinBytesWaitTime is the time the Kafka broker can wait for MinBytes to be filled.
 	// This is usually used when there aren't enough records available to fulfil MinBytes, so the broker waits for more records to be produced.
-	defaultMinBytesWaitTime = 3 * time.Second
+	// Warpstream clamps this between 5s and 30s.
+	defaultMinBytesWaitTime = 5 * time.Second
 )
 
 var (

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -968,8 +968,10 @@ func (r *concurrentFetchers) pollFetches(ctx context.Context) (kgo.Fetches, cont
 		firstUnreturnedRecordIdx := recordIndexAfterOffset(f.Records, r.lastReturnedRecord)
 		r.recordOrderedFetchTelemetry(f, firstUnreturnedRecordIdx, waitStartTime)
 
-		r.lastReturnedRecord = f.Records[len(f.Records)-1].Offset
 		f.Records = f.Records[firstUnreturnedRecordIdx:]
+		if len(f.Records) > 0 {
+			r.lastReturnedRecord = f.Records[len(f.Records)-1].Offset
+		}
 
 		return kgo.Fetches{{
 			Topics: []kgo.FetchTopic{
@@ -988,7 +990,7 @@ func recordIndexAfterOffset(records []*kgo.Record, offset int64) int {
 			return i
 		}
 	}
-	return len(records) - 1
+	return len(records)
 }
 
 func (r *concurrentFetchers) recordOrderedFetchTelemetry(f fetchResult, firstReturnedRecordIndex int, waitStartTime time.Time) {

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -119,7 +119,7 @@ func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, instanceID stri
 		consumerGroup:                         kafkaCfg.GetConsumerGroup(instanceID, partitionID),
 		metrics:                               newReaderMetrics(partitionID, reg),
 		consumedOffsetWatcher:                 newPartitionOffsetWatcher(),
-		concurrentFetchersMinBytesMaxWaitTime: kafkaCfg.FetchMinBytesMaxWait,
+		concurrentFetchersMinBytesMaxWaitTime: defaultMinBytesWaitTime,
 		logger:                                log.With(logger, "partition", partitionID),
 		reg:                                   reg,
 	}

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -857,7 +857,7 @@ func (fr *fetchResult) finishWaitingForConsumption() {
 // mergedWith merges fr with an older fetchResult. mergedWith keeps most of the fields of fr and assumes they are more up to date then other's.
 func (fr *fetchResult) mergedWith(other fetchResult) fetchResult {
 	other.logMerged()
-	fr.Records = append(fr.Records, other.Records...)
+	fr.Records = append(other.Records, fr.Records...)
 	// We ignore HighWatermark, LogStartOffset, LastStableOffset because this result should be more up to date.
 	fr.fetchedBytes += other.fetchedBytes
 	return *fr

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -1172,7 +1172,7 @@ func (r *concurrentFetchers) runFetcher(ctx context.Context, fetchersWg *sync.Wa
 			case <-ctx.Done():
 				attemptSpan.Finish()
 			default:
-				if w.endOffset >= w.startOffset {
+				if w.startOffset >= w.endOffset {
 					// we've fetched all we were asked for;
 					// the whole batch is ready, and we definitely have to wait to send on the channel now
 					f.startWaitingForConsumption()

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -819,6 +819,11 @@ func (fr *fetchResult) logCompletedFetch(fetchStartTime time.Time, w fetchWant) 
 	default:
 		logger = level.Error(logger)
 	}
+	firstTimestamp, lastTimestamp := "", ""
+	if gotRecords > 0 {
+		firstTimestamp = fr.Records[0].Timestamp.String()
+		lastTimestamp = fr.Records[gotRecords-1].Timestamp.String()
+	}
 	logger.Log(
 		"msg", msg,
 		"duration", time.Since(fetchStartTime),
@@ -830,6 +835,8 @@ func (fr *fetchResult) logCompletedFetch(fetchStartTime time.Time, w fetchWant) 
 		"asked_bytes", w.MaxBytes(),
 		"got_bytes", fr.fetchedBytes,
 		"diff_bytes", int(w.MaxBytes())-fr.fetchedBytes,
+		"first_timestamp", firstTimestamp,
+		"last_timestamp", lastTimestamp,
 		"hwm", fr.HighWatermark,
 		"lso", fr.LogStartOffset,
 		"err", fr.Err,

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -119,7 +119,7 @@ func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, instanceID stri
 		consumerGroup:                         kafkaCfg.GetConsumerGroup(instanceID, partitionID),
 		metrics:                               newReaderMetrics(partitionID, reg),
 		consumedOffsetWatcher:                 newPartitionOffsetWatcher(),
-		concurrentFetchersMinBytesMaxWaitTime: defaultMinBytesWaitTime,
+		concurrentFetchersMinBytesMaxWaitTime: kafkaCfg.FetchMinBytesMaxWait,
 		logger:                                log.With(logger, "partition", partitionID),
 		reg:                                   reg,
 	}

--- a/pkg/storage/ingest/reader_client.go
+++ b/pkg/storage/ingest/reader_client.go
@@ -3,8 +3,6 @@
 package ingest
 
 import (
-	"time"
-
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -20,7 +18,7 @@ func NewKafkaReaderClient(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Lo
 	opts = append(opts,
 		kgo.FetchMinBytes(1),
 		kgo.FetchMaxBytes(fetchMaxBytes), // these are unused by concurrent fetchers
-		kgo.FetchMaxWait(5*time.Second),
+		kgo.FetchMaxWait(defaultMinBytesWaitTime),
 		kgo.FetchMaxPartitionBytes(50_000_000), // these are unused by concurrent fetchers
 
 		// BrokerMaxReadBytes sets the maximum response size that can be read from

--- a/pkg/storage/ingest/reader_client.go
+++ b/pkg/storage/ingest/reader_client.go
@@ -18,7 +18,7 @@ func NewKafkaReaderClient(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Lo
 	opts = append(opts,
 		kgo.FetchMinBytes(1),
 		kgo.FetchMaxBytes(fetchMaxBytes), // these are unused by concurrent fetchers
-		kgo.FetchMaxWait(defaultMinBytesWaitTime),
+		kgo.FetchMaxWait(defaultMinBytesMaxWaitTime),
 		kgo.FetchMaxPartitionBytes(50_000_000), // these are unused by concurrent fetchers
 
 		// BrokerMaxReadBytes sets the maximum response size that can be read from

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2399,7 +2399,7 @@ func createConcurrentFetchers(t *testing.T, ctx context.Context, client *kgo.Cli
 		concurrency,
 		recordsPerFetch,
 		false,
-		time.Second, // same order of magnitude as the real one (defaultMinBytesWaitTime), but faster for tests
+		time.Second, // same order of magnitude as the real one (defaultMinBytesMaxWaitTime), but faster for tests
 		offsetReader,
 		startOffsetsReader,
 		&metrics,

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1852,7 +1852,7 @@ func createReader(t *testing.T, addr string, topicName string, partitionID int32
 	require.NoError(t, err)
 
 	// Reduce the time the fake kafka would wait for new records. Sometimes this blocks startup.
-	reader.concurrentFetchersMinBytesMaxWaitTime = time.Second
+	reader.concurrentFetchersMinBytesMaxWaitTime = 500 * time.Millisecond
 
 	return reader
 }

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2156,7 +2156,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(t, ctx, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
+		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
 
 		// This should not block forever now
 		fetches, fetchCtx := fetchers.pollFetches(ctx)
@@ -2177,7 +2177,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 		}
 
-		fetchers := createConcurrentFetchers(t, ctx, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
+		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
 
 		fetches, _ := fetchers.pollFetches(ctx)
 		assert.Equal(t, fetches.NumRecords(), 5)
@@ -2190,7 +2190,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(t, ctx, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
+		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
 
 		// Produce some records after starting the fetchers
 		for i := 0; i < 3; i++ {
@@ -2208,7 +2208,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(t, ctx, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
+		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
 
 		// Produce some records
 		for i := 0; i < 5; i++ {
@@ -2243,7 +2243,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(t, ctx, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
+		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
 
 		// Produce some records
 		for i := 0; i < 10; i++ {
@@ -2275,7 +2275,7 @@ func TestConcurrentFetchers(t *testing.T) {
 				_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 				client := newKafkaProduceClient(t, clusterAddr)
 
-				fetchers := createConcurrentFetchers(t, ctx, client, topicName, partitionID, 0, concurrency, 2)
+				fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 2)
 
 				// Produce some records
 				for i := 0; i < 20; i++ {
@@ -2309,7 +2309,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		lastOffset := produceRecord(ctx, t, client, topicName, partitionID, []byte("last-initial-record"))
 
 		// Start fetchers from the offset after the initial records
-		fetchers := createConcurrentFetchers(t, ctx, client, topicName, partitionID, lastOffset-1, concurrency, recordsPerFetch)
+		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, lastOffset-1, concurrency, recordsPerFetch)
 
 		// Produce some more records
 		for i := 0; i < 3; i++ {
@@ -2341,7 +2341,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(t, ctx, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
+		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
 
 		for round := 0; round < 3; round++ {
 			t.Log("starting round", round)
@@ -2372,7 +2372,7 @@ func TestConcurrentFetchers(t *testing.T) {
 
 }
 
-func createConcurrentFetchers(t *testing.T, ctx context.Context, client *kgo.Client, topic string, partition int32, startOffset int64, concurrency, recordsPerFetch int) *concurrentFetchers {
+func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Client, topic string, partition int32, startOffset int64, concurrency, recordsPerFetch int) *concurrentFetchers {
 	logger := log.NewNopLogger()
 	metrics := newReaderMetrics(partition, prometheus.NewRegistry())
 


### PR DESCRIPTION
#### What this PR does

* each concurrent fetcher no longer stops fetching when it's got 2 fetch results; it now continues fetching and combining the results (`fetchResult.Merge`)
* reduces MinBytesMaxWaitTime to 5s
* tracing improvements
* fixes a bug in tracking the last returned offset; this sometimes lead to returning the same record twice

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
