### PR TITLE
Remove localQueueIndex from QueuingAlgorithms

### DIFF
--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue.go
@@ -157,7 +157,6 @@ func newNode(name string, height int, da QueuingAlgorithm) (*Node, error) {
 	n := &Node{
 		name:             name,
 		localQueue:       nil,
-		queuePosition:    localQueueIndex,
 		height:           height,
 		queuingAlgorithm: da,
 	}

--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue.go
@@ -10,8 +10,6 @@ import (
 type QueuePath []string //nolint:revive // disallows types beginning with package name
 type QueueIndex int     //nolint:revive // disallows types beginning with package name
 
-const localQueueIndex = -1
-
 type Tree interface {
 	EnqueueFrontByPath(QueuePath, any) error
 	EnqueueBackByPath(QueuePath, any) error

--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_test.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_test.go
@@ -750,7 +750,7 @@ func Test_EnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
 	item = makeItemForChildQueue(root, childPath, cache)
 	require.NoError(t, tree.EnqueueBackByPath(childPath, item))
 
-	require.Equal(t, []string{"0", "1", "2"}, root.queueOrder)
+	require.Equal(t, []string{"1", "2", "0"}, root.queueOrder)
 
 	// dequeue first item
 	dequeuedPath, _ := tree.Dequeue(nil)
@@ -760,7 +760,7 @@ func Test_EnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
 	dequeuedPath, _ = tree.Dequeue(nil)
 	require.Equal(t, QueuePath{"1"}, dequeuedPath)
 	require.Nil(t, root.getNode(QueuePath{"1"}))
-	require.Equal(t, []string{"0", "2"}, root.queueOrder)
+	require.Equal(t, []string{"2", "0"}, root.queueOrder)
 
 	// dequeue third item
 	dequeuedPath, _ = tree.Dequeue(nil)
@@ -772,7 +772,7 @@ func Test_EnqueueDuringDequeueRespectsRoundRobin(t *testing.T) {
 	item = makeItemForChildQueue(root, QueuePath{"1"}, cache)
 	require.NoError(t, tree.EnqueueBackByPath(QueuePath{"1"}, item))
 	require.NotNil(t, root.getNode(QueuePath{"1"}))
-	require.Equal(t, []string{"0", "2", "1"}, root.queueOrder)
+	require.Equal(t, []string{"2", "1", "0"}, root.queueOrder)
 
 	// dequeue fourth item; the newly-enqueued root:1 item
 	// has not jumped the line in front of root:0

--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_test.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_test.go
@@ -191,7 +191,7 @@ func Test_Dequeue_SingleAlgo(t *testing.T) {
 		{
 			name:        "dequeue from empty tenant-querier root node",
 			rootAlgo:    []QueuingAlgorithm{newTenantQuerierAssignments()},
-			dequeueArgs: &DequeueArgs{querierID: "placeholder", lastTenantIndex: localQueueIndex},
+			dequeueArgs: &DequeueArgs{querierID: "placeholder", lastTenantIndex: newQuerierTenantIndex},
 		},
 		{
 			name:        "dequeue from non-empty leaf node",
@@ -207,7 +207,7 @@ func Test_Dequeue_SingleAlgo(t *testing.T) {
 			name:        "dequeue from non-empty tenant-querier root node",
 			rootAlgo:    []QueuingAlgorithm{newTenantQuerierAssignments()},
 			enqueueObjs: []enqueueObj{{"tqa-child-object", QueuePath{"tqa-child"}}},
-			dequeueArgs: &DequeueArgs{querierID: "placeholder", lastTenantIndex: localQueueIndex},
+			dequeueArgs: &DequeueArgs{querierID: "placeholder", lastTenantIndex: newQuerierTenantIndex},
 		},
 		{
 			name:        "dequeue from non-empty tenant-querier root node with no current querier",

--- a/pkg/scheduler/queue/tenant_querier_assignment.go
+++ b/pkg/scheduler/queue/tenant_querier_assignment.go
@@ -254,13 +254,13 @@ func (tqa *tenantQuerierAssignments) dequeueSelectNode(node *Node) *Node {
 	if node.isLeaf() || len(node.queueMap) == 0 {
 		return node
 	}
-
 	// can't get a tenant if no querier set
 	if tqa.currentQuerier == "" {
 		return nil
 	}
 
-	// tenantOrderIndex is set to the _last_ tenant we dequeued from; advance queue position for dequeue
+	// Before this point, tenantOrderIndex represents the _last_ tenant we dequeued from;
+	// here, we advance queue position to point to the index we _will_ dequeue from
 	tqa.tenantOrderIndex++
 	if tqa.tenantOrderIndex >= len(tqa.tenantIDOrder) {
 		tqa.tenantOrderIndex = 0

--- a/pkg/scheduler/queue/tree_queueing_algorithms.go
+++ b/pkg/scheduler/queue/tree_queueing_algorithms.go
@@ -47,19 +47,18 @@ type roundRobinState struct {
 func (rrs *roundRobinState) setup(_ *DequeueArgs) {
 }
 
-// addChildNode adds a child Node to the "end" of the parent's queueOrder from the perspective
-// of the parent's queuePosition. Thus, If queuePosition is localQueueIndex, the new child is added to the end of
-// queueOrder. Otherwise, the new child is added at queuePosition - 1, and queuePosition is incremented to keep
-// it pointed to the same child.
+// addChildNode adds a child Node to the "end" of the parent's queueOrder from the perspective of the parent's
+// queuePosition. The new child is added at queuePosition - 1, and queuePosition is incremented to keep it pointed
+// to the same child.
 func (rrs *roundRobinState) addChildNode(parent, child *Node) {
 	// add childNode to n.queueMap
 	parent.queueMap[child.Name()] = child
 
-	// add childNode to n.queueOrder before the next-to-dequeue position, update n.queuePosition to current element
-	if parent.queuePosition <= localQueueIndex {
-		parent.queueOrder = append(parent.queueOrder, child.Name())
-	} else {
-		parent.queueOrder = append(parent.queueOrder[:parent.queuePosition], append([]string{child.Name()}, parent.queueOrder[parent.queuePosition:]...)...)
+	parent.queueOrder = append(parent.queueOrder[:parent.queuePosition], append([]string{child.Name()}, parent.queueOrder[parent.queuePosition:]...)...)
+
+	// if we added to a previously empty queueOrder, we want to keep the queuePosition at 0; otherwise, update
+	// n.queuePosition to point to the same element it was pointed at before.
+	if len(parent.queueOrder) > 1 {
 		parent.queuePosition++ // keep position pointed at same element
 	}
 }
@@ -67,13 +66,12 @@ func (rrs *roundRobinState) addChildNode(parent, child *Node) {
 // dequeueSelectNode returns the node at the node's queuePosition. queuePosition represents the position of
 // the next node to dequeue from, and is incremented in dequeueUpdateState.
 func (rrs *roundRobinState) dequeueSelectNode(node *Node) *Node {
-	if node.queuePosition == localQueueIndex {
+	if node.isLeaf() || len(node.queueOrder) == 0 {
 		return node
 	}
-
 	currentNodeName := node.queueOrder[node.queuePosition]
-	if node, ok := node.queueMap[currentNodeName]; ok {
-		return node
+	if child, ok := node.queueMap[currentNodeName]; ok {
+		return child
 	}
 	return nil
 }
@@ -81,9 +79,10 @@ func (rrs *roundRobinState) dequeueSelectNode(node *Node) *Node {
 // dequeueUpdateState does the following:
 //   - deletes the dequeued-from child node if it is empty after the dequeue operation
 //   - increments queuePosition if no child was deleted
-func (rrs *roundRobinState) dequeueUpdateState(node *Node, dequeuedFrom *Node) {
-	// if the child node is nil, we haven't done anything to the tree; return early
-	if dequeuedFrom == nil {
+func (rrs *roundRobinState) dequeueUpdateState(nodeToUpdate *Node, dequeuedFrom *Node) {
+	// if the child node is nil, we haven't done anything to the tree; if the nodeToUpdate is
+	// a leaf node, there's nothing to update; in both cases, return early
+	if dequeuedFrom == nil || nodeToUpdate.isLeaf() {
 		return
 	}
 
@@ -96,17 +95,18 @@ func (rrs *roundRobinState) dequeueUpdateState(node *Node, dequeuedFrom *Node) {
 	// from queueOrder sets our position to the next element already.
 	if childIsEmpty {
 		childName := dequeuedFrom.Name()
-		delete(node.queueMap, childName)
-		for idx, name := range node.queueOrder {
+		delete(nodeToUpdate.queueMap, childName)
+		for idx, name := range nodeToUpdate.queueOrder {
 			if name == childName {
-				node.queueOrder = append(node.queueOrder[:idx], node.queueOrder[idx+1:]...)
+				nodeToUpdate.queueOrder = append(nodeToUpdate.queueOrder[:idx], nodeToUpdate.queueOrder[idx+1:]...)
 			}
 		}
 
 	} else {
-		node.queuePosition++
+		nodeToUpdate.queuePosition++
 	}
-	if node.queuePosition >= len(node.queueOrder) {
-		node.queuePosition = localQueueIndex
+
+	if nodeToUpdate.queuePosition >= len(nodeToUpdate.queueOrder) {
+		nodeToUpdate.queuePosition = 0
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
With the introduction of leaf-node designations in #8871, we no longer need to maintain local queues on all nodes, and we can instead use `isLeaf()` to govern tree traversal decisions. 

Note that this introduces a subtle difference to the round-robin child queue ordering (`Node.queueOrder`) because all enqueued children will be enqueued "behind" the current `queueOrder[queuePosition]` node instead of maintaining a special case. This _does not_ change dequeue order, and is a no-op from the perspective of a caller to the tree.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
