### PR TITLE
Alertmanager: Add grafana config size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3284,7 +3284,7 @@ _Changes since `grafana/cortex-jsonnet` `1.9.0`._
    }
    ```
 * [FEATURE] Added multi-zone ingesters and store-gateways support. #1352 #1552
-* [FEATURE] The following alertmanager limit was added: #TODO
+* [FEATURE] The following alertmanager limit was added: #9402
   * User grafana config size (`-alertmanager.max-config-size-bytes`)
 * [ENHANCEMENT] Add overrides config to compactor. This allows setting retention configs per user. [#386](https://github.com/grafana/cortex-jsonnet/pull/386)
 * [ENHANCEMENT] Added 256MB memory ballast to querier. [#369](https://github.com/grafana/cortex-jsonnet/pull/369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3284,6 +3284,8 @@ _Changes since `grafana/cortex-jsonnet` `1.9.0`._
    }
    ```
 * [FEATURE] Added multi-zone ingesters and store-gateways support. #1352 #1552
+* [FEATURE] The following alertmanager limit was added: #TODO
+  * User grafana config size (`-alertmanager.max-config-size-bytes`)
 * [ENHANCEMENT] Add overrides config to compactor. This allows setting retention configs per user. [#386](https://github.com/grafana/cortex-jsonnet/pull/386)
 * [ENHANCEMENT] Added 256MB memory ballast to querier. [#369](https://github.com/grafana/cortex-jsonnet/pull/369)
 * [ENHANCEMENT] Update `etcd-operator` to latest version (see https://github.com/grafana/jsonnet-libs/pull/480). [#263](https://github.com/grafana/cortex-jsonnet/pull/263)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,18 @@
 * [FEATURE] Query frontend: added new query pruning middleware to enable pruning dead code (eg. expressions that cannot produce any results) and simplifying expressions (eg. expressions that can be evaluated immediately) in queries. #9086
 * [FEATURE] Ruler: added experimental configuration, `-ruler.rule-evaluation-write-enabled`, to disable writing the result of rule evaluation to ingesters. This feature can be used for testing purposes. #9060
 * [FEATURE] Ingester: added experimental configuration `ingester.ignore-ooo-exemplars`. When set to `true` out of order exemplars are no longer reported to the remote write client. #9151
+* [FEATURE] gRPC: Support S2 compression. #9322
+  * `-alertmanager.alertmanager-client.grpc-compression=s2`
+  * `-ingester.client.grpc-compression=s2`
+  * `-querier.frontend-client.grpc-compression=s2`
+  * `-querier.scheduler-client.grpc-compression=s2`
+  * `-query-frontend.grpc-client-config.grpc-compression=s2`
+  * `-query-scheduler.grpc-client-config.grpc-compression=s2`
+  * `-ruler.client.grpc-compression=s2`
+  * `-ruler.query-frontend.grpc-client-config.grpc-compression=s2`
+* [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
+* [FEATURE] The following alertmanager limit was added: #9402
+  * User grafana config size (`-alertmanager.max-config-size-bytes`)
 * [ENHANCEMENT] Compactor: Add `cortex_compactor_compaction_job_duration_seconds` and `cortex_compactor_compaction_job_blocks` histogram metrics to track duration of individual compaction jobs and number of blocks per job. #8371
 * [ENHANCEMENT] Rules: Added per namespace max rules per rule group limit. The maximum number of rules per rule groups for all namespaces continues to be configured by `-ruler.max-rules-per-rule-group`, but now, this can be superseded by the new `-ruler.max-rules-per-rule-group-by-namespace` option on a per namespace basis. This new limit can be overridden using the overrides mechanism to be applied per-tenant. #8378
 * [ENHANCEMENT] Rules: Added per namespace max rule groups per tenant limit. The maximum number of rule groups per rule tenant for all namespaces continues to be configured by `-ruler.max-rule-groups-per-tenant`, but now, this can be superseded by the new `-ruler.max-rule-groups-per-tenant-by-namespace` option on a per namespace basis. This new limit can be overridden using the overrides mechanism to be applied per-tenant. #8425
@@ -3284,8 +3296,6 @@ _Changes since `grafana/cortex-jsonnet` `1.9.0`._
    }
    ```
 * [FEATURE] Added multi-zone ingesters and store-gateways support. #1352 #1552
-* [FEATURE] The following alertmanager limit was added: #9402
-  * User grafana config size (`-alertmanager.max-config-size-bytes`)
 * [ENHANCEMENT] Add overrides config to compactor. This allows setting retention configs per user. [#386](https://github.com/grafana/cortex-jsonnet/pull/386)
 * [ENHANCEMENT] Added 256MB memory ballast to querier. [#369](https://github.com/grafana/cortex-jsonnet/pull/369)
 * [ENHANCEMENT] Update `etcd-operator` to latest version (see https://github.com/grafana/jsonnet-libs/pull/480). [#263](https://github.com/grafana/cortex-jsonnet/pull/263)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   * `-query-scheduler.grpc-client-config.grpc-compression=s2`
   * `-ruler.client.grpc-compression=s2`
   * `-ruler.query-frontend.grpc-client-config.grpc-compression=s2`
+* [FEATURE] The following alertmanager limit was added: #9402
+  * User grafana config size (`-alertmanager.max-config-size-bytes`)
 * [ENHANCEMENT] Ruler: Support `exclude_alerts` parameter in `<prometheus-http-prefix>/api/v1/rules` endpoint. #9300
 * [ENHANCEMENT] Distributor: add a metric to track tenants who are sending newlines in their label values called `cortex_distributor_label_values_with_newlines_total`. #9400
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,7 @@
   * `-query-scheduler.grpc-client-config.grpc-compression=s2`
   * `-ruler.client.grpc-compression=s2`
   * `-ruler.query-frontend.grpc-client-config.grpc-compression=s2`
-* [FEATURE] The following alertmanager limit was added: #9402
-  * User grafana config size (`-alertmanager.max-config-size-bytes`)
+* [FEATURE] Alertmanager: limit added for maximum size of the Grafana configuration (`-alertmanager.max-config-size-bytes`). #9402
 * [ENHANCEMENT] Ruler: Support `exclude_alerts` parameter in `<prometheus-http-prefix>/api/v1/rules` endpoint. #9300
 * [ENHANCEMENT] Distributor: add a metric to track tenants who are sending newlines in their label values called `cortex_distributor_label_values_with_newlines_total`. #9400
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,18 +98,6 @@
 * [FEATURE] Query frontend: added new query pruning middleware to enable pruning dead code (eg. expressions that cannot produce any results) and simplifying expressions (eg. expressions that can be evaluated immediately) in queries. #9086
 * [FEATURE] Ruler: added experimental configuration, `-ruler.rule-evaluation-write-enabled`, to disable writing the result of rule evaluation to ingesters. This feature can be used for testing purposes. #9060
 * [FEATURE] Ingester: added experimental configuration `ingester.ignore-ooo-exemplars`. When set to `true` out of order exemplars are no longer reported to the remote write client. #9151
-* [FEATURE] gRPC: Support S2 compression. #9322
-  * `-alertmanager.alertmanager-client.grpc-compression=s2`
-  * `-ingester.client.grpc-compression=s2`
-  * `-querier.frontend-client.grpc-compression=s2`
-  * `-querier.scheduler-client.grpc-compression=s2`
-  * `-query-frontend.grpc-client-config.grpc-compression=s2`
-  * `-query-scheduler.grpc-client-config.grpc-compression=s2`
-  * `-ruler.client.grpc-compression=s2`
-  * `-ruler.query-frontend.grpc-client-config.grpc-compression=s2`
-* [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
-* [FEATURE] The following alertmanager limit was added: #9402
-  * User grafana config size (`-alertmanager.max-config-size-bytes`)
 * [ENHANCEMENT] Compactor: Add `cortex_compactor_compaction_job_duration_seconds` and `cortex_compactor_compaction_job_blocks` histogram metrics to track duration of individual compaction jobs and number of blocks per job. #8371
 * [ENHANCEMENT] Rules: Added per namespace max rules per rule group limit. The maximum number of rules per rule groups for all namespaces continues to be configured by `-ruler.max-rules-per-rule-group`, but now, this can be superseded by the new `-ruler.max-rules-per-rule-group-by-namespace` option on a per namespace basis. This new limit can be overridden using the overrides mechanism to be applied per-tenant. #8378
 * [ENHANCEMENT] Rules: Added per namespace max rule groups per tenant limit. The maximum number of rule groups per rule tenant for all namespaces continues to be configured by `-ruler.max-rule-groups-per-tenant`, but now, this can be superseded by the new `-ruler.max-rule-groups-per-tenant-by-namespace` option on a per namespace basis. This new limit can be overridden using the overrides mechanism to be applied per-tenant. #8425

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4577,6 +4577,16 @@
         },
         {
           "kind": "field",
+          "name": "alertmanager_max_grafana_config_size_bytes",
+          "required": false,
+          "desc": "Maximum size of the grafana configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "alertmanager.max-grafana-config-size-bytes",
+          "fieldType": "int"
+        },
+        {
+          "kind": "field",
           "name": "alertmanager_max_config_size_bytes",
           "required": false,
           "desc": "Maximum size of configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4579,7 +4579,7 @@
           "kind": "field",
           "name": "alertmanager_max_grafana_config_size_bytes",
           "required": false,
-          "desc": "Maximum size of the grafana configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.",
+          "desc": "Maximum size of the Grafana configuration file for Alertmanager that a tenant can upload via the Alertmanager API. 0 = no limit.",
           "fieldValue": null,
           "fieldDefaultValue": 0,
           "fieldFlag": "alertmanager.max-grafana-config-size-bytes",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -203,6 +203,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum size of configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.
   -alertmanager.max-dispatcher-aggregation-groups int
     	Maximum number of aggregation groups in Alertmanager's dispatcher that a tenant can have. Each active aggregation group uses single goroutine. When the limit is reached, dispatcher will not dispatch alerts that belong to additional aggregation groups, but existing groups will keep working properly. 0 = no limit.
+  -alertmanager.max-grafana-config-size-bytes int
+    	Maximum size of the grafana configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.
   -alertmanager.max-recv-msg-size int
     	Maximum size (bytes) of an accepted HTTP request body. (default 104857600)
   -alertmanager.max-silence-size-bytes int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -204,7 +204,7 @@ Usage of ./cmd/mimir/mimir:
   -alertmanager.max-dispatcher-aggregation-groups int
     	Maximum number of aggregation groups in Alertmanager's dispatcher that a tenant can have. Each active aggregation group uses single goroutine. When the limit is reached, dispatcher will not dispatch alerts that belong to additional aggregation groups, but existing groups will keep working properly. 0 = no limit.
   -alertmanager.max-grafana-config-size-bytes int
-    	Maximum size of the grafana configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.
+    	Maximum size of the Grafana configuration file for Alertmanager that a tenant can upload via the Alertmanager API. 0 = no limit.
   -alertmanager.max-recv-msg-size int
     	Maximum size (bytes) of an accepted HTTP request body. (default 104857600)
   -alertmanager.max-silence-size-bytes int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -89,6 +89,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum size of configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.
   -alertmanager.max-dispatcher-aggregation-groups int
     	Maximum number of aggregation groups in Alertmanager's dispatcher that a tenant can have. Each active aggregation group uses single goroutine. When the limit is reached, dispatcher will not dispatch alerts that belong to additional aggregation groups, but existing groups will keep working properly. 0 = no limit.
+  -alertmanager.max-grafana-config-size-bytes int
+    	Maximum size of the grafana configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.
   -alertmanager.max-silence-size-bytes int
     	Maximum silence size in bytes. 0 = no limit.
   -alertmanager.max-silences-count int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -90,7 +90,7 @@ Usage of ./cmd/mimir/mimir:
   -alertmanager.max-dispatcher-aggregation-groups int
     	Maximum number of aggregation groups in Alertmanager's dispatcher that a tenant can have. Each active aggregation group uses single goroutine. When the limit is reached, dispatcher will not dispatch alerts that belong to additional aggregation groups, but existing groups will keep working properly. 0 = no limit.
   -alertmanager.max-grafana-config-size-bytes int
-    	Maximum size of the grafana configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.
+    	Maximum size of the Grafana configuration file for Alertmanager that a tenant can upload via the Alertmanager API. 0 = no limit.
   -alertmanager.max-silence-size-bytes int
     	Maximum silence size in bytes. 0 = no limit.
   -alertmanager.max-silences-count int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3644,6 +3644,11 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -alertmanager.notification-rate-limit-per-integration
 [alertmanager_notification_rate_limit_per_integration: <map of string to float64> | default = {}]
 
+# Maximum size of the Grafana configuration file for Alertmanager that tenant can upload via
+# Alertmanager API. 0 = no limit.
+# CLI flag: -alertmanager.max-grafana-config-size-bytes
+[alertmanager_max_grafana_config_size_bytes: <int> | default = 0]
+
 # Maximum size of configuration file for Alertmanager that tenant can upload via
 # Alertmanager API. 0 = no limit.
 # CLI flag: -alertmanager.max-config-size-bytes

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3644,8 +3644,8 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -alertmanager.notification-rate-limit-per-integration
 [alertmanager_notification_rate_limit_per_integration: <map of string to float64> | default = {}]
 
-# Maximum size of the Grafana configuration file for Alertmanager that tenant can upload via
-# Alertmanager API. 0 = no limit.
+# Maximum size of the grafana configuration file for Alertmanager that tenant
+# can upload via Alertmanager API. 0 = no limit.
 # CLI flag: -alertmanager.max-grafana-config-size-bytes
 [alertmanager_max_grafana_config_size_bytes: <int> | default = 0]
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3644,8 +3644,8 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -alertmanager.notification-rate-limit-per-integration
 [alertmanager_notification_rate_limit_per_integration: <map of string to float64> | default = {}]
 
-# Maximum size of the grafana configuration file for Alertmanager that tenant
-# can upload via Alertmanager API. 0 = no limit.
+# Maximum size of the Grafana configuration file for Alertmanager that a tenant
+# can upload via the Alertmanager API. 0 = no limit.
 # CLI flag: -alertmanager.max-grafana-config-size-bytes
 [alertmanager_max_grafana_config_size_bytes: <int> | default = 0]
 

--- a/pkg/alertmanager/api_grafana.go
+++ b/pkg/alertmanager/api_grafana.go
@@ -309,8 +309,25 @@ func (am *MultitenantAlertmanager) SetUserGrafanaConfig(w http.ResponseWriter, r
 		return
 	}
 
-	payload, err := io.ReadAll(r.Body)
+	var input io.Reader
+	maxConfigSize := am.limits.AlertmanagerMaxGrafanaConfigSize(userID)
+	if maxConfigSize > 0 {
+		input = http.MaxBytesReader(w, r.Body, int64(maxConfigSize))
+	} else {
+		input = r.Body
+	}
+
+	payload, err := io.ReadAll(input)
 	if err != nil {
+		maxBytesErr := &http.MaxBytesError{}
+		if errors.As(err, &maxBytesErr) {
+			msg := fmt.Sprintf(errConfigurationTooBig, maxConfigSize)
+			level.Warn(logger).Log("msg", msg)
+			w.WriteHeader(http.StatusBadRequest)
+			util.WriteJSONResponse(w, errorResult{Status: statusError, Error: msg})
+			return
+		}
+
 		level.Error(logger).Log("msg", errReadingGrafanaConfig, "err", err.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		util.WriteJSONResponse(w, errorResult{Status: statusError, Error: fmt.Sprintf("%s: %s", errReadingGrafanaConfig, err.Error())})

--- a/pkg/alertmanager/api_grafana.go
+++ b/pkg/alertmanager/api_grafana.go
@@ -319,8 +319,7 @@ func (am *MultitenantAlertmanager) SetUserGrafanaConfig(w http.ResponseWriter, r
 
 	payload, err := io.ReadAll(input)
 	if err != nil {
-		maxBytesErr := &http.MaxBytesError{}
-		if errors.As(err, &maxBytesErr) {
+		if maxBytesErr := (&http.MaxBytesError{}); errors.As(err, &maxBytesErr) {
 			msg := fmt.Sprintf(errConfigurationTooBig, maxConfigSize)
 			level.Warn(logger).Log("msg", msg)
 			w.WriteHeader(http.StatusBadRequest)

--- a/pkg/alertmanager/api_grafana_test.go
+++ b/pkg/alertmanager/api_grafana_test.go
@@ -322,6 +322,32 @@ func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 			expStatusCode: http.StatusUnauthorized,
 		},
 		{
+			name: "config size > max size",
+			body: fmt.Sprintf(`
+			{
+				"configuration": %s,
+				"configuration_hash": "ChEKBW5mbG9nEghzb21lZGF0YQ==",
+				"created": 12312414343,
+				"default": false,
+				"promoted": true,
+				"external_url": "http://test.grafana.com",
+				"static_headers": {
+					"Header-1": "Value-1",
+					"Header-2": "Value-2"
+				}
+			}
+			`, testGrafanaConfig),
+			orgID:         "test_user",
+			maxConfigSize: 10,
+			expStatusCode: http.StatusBadRequest,
+			expResponseBody: `
+			{
+			"error": "Alertmanager configuration is too big, limit: 10 bytes",
+				"status": "error"
+			}
+			`,
+		},
+		{
 			name: "invalid config",
 			body: `
 			{

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -234,6 +234,9 @@ type Limits interface {
 	// when limit == rate.Inf.
 	NotificationBurstSize(tenant string, integration string) int
 
+	// AlertmanagerMaxGrafanaConfigSize returns max size of the grafana configuration file that user is allowed to upload. If 0, there is no limit.
+	AlertmanagerMaxGrafanaConfigSize(tenant string) int
+
 	// AlertmanagerMaxConfigSize returns max size of configuration file that user is allowed to upload. If 0, there is no limit.
 	AlertmanagerMaxConfigSize(tenant string) int
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -3293,6 +3293,7 @@ type mockAlertManagerLimits struct {
 	emailNotificationRateLimit     rate.Limit
 	emailNotificationBurst         int
 	maxConfigSize                  int
+	maxGrafanaConfigSize           int
 	maxSilencesCount               int
 	maxSilenceSizeBytes            int
 	maxTemplatesCount              int
@@ -3304,6 +3305,10 @@ type mockAlertManagerLimits struct {
 
 func (m *mockAlertManagerLimits) AlertmanagerMaxConfigSize(string) int {
 	return m.maxConfigSize
+}
+
+func (m *mockAlertManagerLimits) AlertmanagerMaxGrafanaConfigSize(string) int {
+	return m.maxGrafanaConfigSize
 }
 
 func (m *mockAlertManagerLimits) AlertmanagerMaxSilencesCount(string) int { return m.maxSilencesCount }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -369,7 +369,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 		l.NotificationRateLimitPerIntegration = NotificationRateLimitMap()
 	}
 	f.Var(&l.NotificationRateLimitPerIntegration, "alertmanager.notification-rate-limit-per-integration", "Per-integration notification rate limits. Value is a map, where each key is integration name and value is a rate-limit (float). On command line, this map is given in JSON format. Rate limit has the same meaning as -alertmanager.notification-rate-limit, but only applies for specific integration. Allowed integration names: "+strings.Join(allowedIntegrationNames, ", ")+".")
-	f.IntVar(&l.AlertmanagerMaxGrafanaConfigSizeBytes, "alertmanager.max-grafana-config-size-bytes", 0, "Maximum size of the grafana configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.")
+	f.IntVar(&l.AlertmanagerMaxGrafanaConfigSizeBytes, "alertmanager.max-grafana-config-size-bytes", 0, "Maximum size of the Grafana configuration file for Alertmanager that a tenant can upload via the Alertmanager API. 0 = no limit.")
 	f.IntVar(&l.AlertmanagerMaxConfigSizeBytes, "alertmanager.max-config-size-bytes", 0, "Maximum size of configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.")
 	f.IntVar(&l.AlertmanagerMaxSilencesCount, "alertmanager.max-silences-count", 0, "Maximum number of silences, including expired silences, that a tenant can have at once. 0 = no limit.")
 	f.IntVar(&l.AlertmanagerMaxSilenceSizeBytes, "alertmanager.max-silence-size-bytes", 0, "Maximum silence size in bytes. 0 = no limit.")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -220,6 +220,7 @@ type Limits struct {
 	NotificationRateLimit               float64            `yaml:"alertmanager_notification_rate_limit" json:"alertmanager_notification_rate_limit"`
 	NotificationRateLimitPerIntegration LimitsMap[float64] `yaml:"alertmanager_notification_rate_limit_per_integration" json:"alertmanager_notification_rate_limit_per_integration"`
 
+	AlertmanagerMaxGrafanaConfigSizeBytes      int `yaml:"alertmanager_max_grafana_config_size_bytes" json:"alertmanager_max_grafana_config_size_bytes"`
 	AlertmanagerMaxConfigSizeBytes             int `yaml:"alertmanager_max_config_size_bytes" json:"alertmanager_max_config_size_bytes"`
 	AlertmanagerMaxSilencesCount               int `yaml:"alertmanager_max_silences_count" json:"alertmanager_max_silences_count"`
 	AlertmanagerMaxSilenceSizeBytes            int `yaml:"alertmanager_max_silence_size_bytes" json:"alertmanager_max_silence_size_bytes"`
@@ -368,6 +369,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 		l.NotificationRateLimitPerIntegration = NotificationRateLimitMap()
 	}
 	f.Var(&l.NotificationRateLimitPerIntegration, "alertmanager.notification-rate-limit-per-integration", "Per-integration notification rate limits. Value is a map, where each key is integration name and value is a rate-limit (float). On command line, this map is given in JSON format. Rate limit has the same meaning as -alertmanager.notification-rate-limit, but only applies for specific integration. Allowed integration names: "+strings.Join(allowedIntegrationNames, ", ")+".")
+	f.IntVar(&l.AlertmanagerMaxGrafanaConfigSizeBytes, "alertmanager.max-grafana-config-size-bytes", 0, "Maximum size of the grafana configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.")
 	f.IntVar(&l.AlertmanagerMaxConfigSizeBytes, "alertmanager.max-config-size-bytes", 0, "Maximum size of configuration file for Alertmanager that tenant can upload via Alertmanager API. 0 = no limit.")
 	f.IntVar(&l.AlertmanagerMaxSilencesCount, "alertmanager.max-silences-count", 0, "Maximum number of silences, including expired silences, that a tenant can have at once. 0 = no limit.")
 	f.IntVar(&l.AlertmanagerMaxSilenceSizeBytes, "alertmanager.max-silence-size-bytes", 0, "Maximum silence size in bytes. 0 = no limit.")
@@ -1001,6 +1003,10 @@ func (o *Overrides) NotificationBurstSize(user string, integration string) int {
 	}
 
 	return int(l)
+}
+
+func (o *Overrides) AlertmanagerMaxGrafanaConfigSize(userID string) int {
+	return o.getOverridesForUser(userID).AlertmanagerMaxGrafanaConfigSizeBytes
 }
 
 func (o *Overrides) AlertmanagerMaxConfigSize(userID string) int {


### PR DESCRIPTION
Remote AM already has limits in place for it's own configuration. However, when using grafana compat mode, it doesn't have any. This aims to add a new config limit for grafana configuration.

<img width="476" alt="Screenshot 2024-09-25 at 12 21 06" src="https://github.com/user-attachments/assets/023c319c-57ab-4ad5-a292-57467afa8b9a">
