### PR TITLE
blockbuilder: get rid of lag from section consumer loop

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/runutil"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
@@ -347,7 +348,7 @@ func (b *BlockBuilder) consumePartitionCycle(ctx context.Context, state *partiti
 	}(time.Now(), *state)
 
 	builder := NewTSDBBuilder(b.logger, b.cfg.DataDir, b.cfg.BlocksStorage, b.limits)
-	defer builder.Close()
+	defer runutil.CloseWithErrCapture(&retErr, builder, "closing tsdb builder")
 
 	level.Info(b.logger).Log("msg", "start consuming", "partition", state.Partition, "offset", state.Commit.At, "lag", state.Lag, "cycle_end", cycleEnd)
 

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -326,6 +326,8 @@ func (b *BlockBuilder) consumePartition(ctx context.Context, partition int32, st
 }
 
 func (b *BlockBuilder) consumePartitionSection(ctx context.Context, logger log.Logger, builder *TSDBBuilder, partition int32, state partitionState, sectionEnd time.Time) (_ partitionState, retErr error) {
+	// Oppose to the section's range (and cycle's range), that include the ConsumeIntervalBuffer, the block's range doesn't.
+	// Thus, truncate the timestamp with ConsumptionInterval here to round the block's range.
 	blockEnd := sectionEnd.Truncate(b.cfg.ConsumeInterval)
 
 	var numBlocks int

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -495,11 +495,12 @@ func (b *BlockBuilder) uploadBlocks(ctx context.Context, tenantID, dbDir string,
 		blockDir := path.Join(dbDir, bid)
 		meta, err := block.ReadMetaFromDir(blockDir)
 		if err != nil {
-			return err
+			return fmt.Errorf("read block meta for block %s (tenant %s): %w", bid, tenantID, err)
 		}
 
 		if meta.Stats.NumSamples == 0 {
 			// No need to upload empty block.
+			level.Info(b.logger).Log("skip uploading empty block", "tenant", tenantID, "block", bid)
 			return nil
 		}
 
@@ -513,7 +514,7 @@ func (b *BlockBuilder) uploadBlocks(ctx context.Context, tenantID, dbDir string,
 
 		// Upload block with custom metadata.
 		if err := block.Upload(ctx, b.logger, buc, blockDir, meta); err != nil {
-			return err
+			return fmt.Errorf("upload block %s (tenant %s): %w", bid, tenantID, err)
 		}
 	}
 	return nil

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -383,8 +383,7 @@ consumerLoop:
 		numRecs := fetches.NumRecords()
 		remaining -= int64(numRecs)
 
-		recIter := fetches.RecordIter()
-		for !recIter.Done() {
+		for recIter := fetches.RecordIter(); !recIter.Done(); {
 			rec := recIter.Next()
 
 			if firstRec == nil {
@@ -397,8 +396,8 @@ consumerLoop:
 				break consumerLoop
 			}
 
-			recProcessedBefore := rec.Offset <= state.LastSeenOffset
-			allSamplesProcessed, err := builder.Process(ctx, rec, state.LastBlockEnd.UnixMilli(), blockEnd.UnixMilli(), recProcessedBefore)
+			recordAlreadyProcessed := rec.Offset <= state.LastSeenOffset
+			allSamplesProcessed, err := builder.Process(ctx, rec, state.LastBlockEnd.UnixMilli(), blockEnd.UnixMilli(), recordAlreadyProcessed)
 			if err != nil {
 				// All "non-terminal" errors are handled by the TSDBBuilder.
 				return state, fmt.Errorf("process record in partition %d at offset %d: %w", rec.Partition, rec.Offset, err)

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -241,12 +241,18 @@ func (b *BlockBuilder) getLagForPartition(ctx context.Context, partition int32) 
 }
 
 type partitionState struct {
-	Partition          int32
-	Lag                int64
-	Commit             kadm.Offset
+	// Partition is the partition the state belongs to.
+	Partition int32
+	// Lag is the upperbound number of records the cycle will need to consume.
+	Lag int64
+	// Commit is the current offset commit for the partition.
+	Commit kadm.Offset
+	// CommitRecTimestamp is the timestamp of the record whose offset was committed (and not the time of commit).
 	CommitRecTimestamp time.Time
-	OldestSeenOffset   int64
-	LastBlockEnd       time.Time
+	// OldestSeenOffset is the offset of the last record consumed in the commiter-cycle. It can be greater than Commit.Offset if previous cycle overconumed.
+	OldestSeenOffset int64
+	// LastBlockEnd is the timestamp of the block end in the commiter-cycle.
+	LastBlockEnd time.Time
 }
 
 func partitionStateFromLag(logger log.Logger, lag kadm.GroupMemberLag, fallbackMillis int64) *partitionState {

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -465,7 +465,7 @@ consumerLoop:
 		LastSeenOffset:        lastSeenOffset,
 		LastBlockEnd:          lastBlockEnd,
 	}
-	if err := b.commitState(ctx, logger, b.cfg.Kafka.ConsumerGroup, newState); err != nil {
+	if err := b.commitState(ctx, logger, b.cfg.ConsumerGroup, newState); err != nil {
 		return state, err
 	}
 

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -509,7 +509,7 @@ func (b *BlockBuilder) uploadBlocks(ctx context.Context, tenantID, dbDir string,
 
 		if meta.Stats.NumSamples == 0 {
 			// No need to upload empty block.
-			level.Info(b.logger).Log("skip uploading empty block", "tenant", tenantID, "block", bid)
+			level.Info(b.logger).Log("msg", "skip uploading empty block", "tenant", tenantID, "block", bid)
 			return nil
 		}
 

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -421,15 +421,6 @@ consumerLoop:
 		}
 	}
 
-	compactStart := time.Now()
-	var err error
-	numBlocks, err = builder.CompactAndUpload(ctx, b.uploadBlocks)
-	if err != nil {
-		return err
-	}
-	compactionDur = time.Since(compactStart)
-	b.metrics.compactAndUploadDuration.WithLabelValues(fmt.Sprintf("%d", state.Partition)).Observe(compactionDur.Seconds())
-
 	// Nothing was consumed from Kafka at all.
 	if firstRec == nil {
 		level.Info(b.logger).Log("msg", "no records were consumed", "partition", state.Partition)
@@ -446,6 +437,15 @@ consumerLoop:
 	if commitRec == nil {
 		commitRec = lastRec
 	}
+
+	compactStart := time.Now()
+	var err error
+	numBlocks, err = builder.CompactAndUpload(ctx, b.uploadBlocks)
+	if err != nil {
+		return err
+	}
+	compactionDur = time.Since(compactStart)
+	b.metrics.compactAndUploadDuration.WithLabelValues(fmt.Sprintf("%d", state.Partition)).Observe(compactionDur.Seconds())
 
 	commitRecOffset := commitRec.Offset + 1 // offset+1 means everything up to (including) the offset was processed
 

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -98,11 +98,6 @@ func (b *BlockBuilder) starting(context.Context) (err error) {
 		return fmt.Errorf("creating kafka reader: %w", err)
 	}
 
-	// Immediately unassign (remove) all partitions from the client. We control the order and the pace of fetching within the cycles.
-	b.kafkaClient.RemoveConsumePartitions(map[string][]int32{
-		b.cfg.Kafka.Topic: b.assignedPartitionIDs,
-	})
-
 	return nil
 }
 

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -268,6 +268,8 @@ func partitionStateFromLag(logger log.Logger, lag kadm.GroupMemberLag, fallbackM
 		commitRecTs = fallbackMillis
 	}
 
+	level.Debug(logger).Log("msg", "creating partition state", "partition", lag.Partition, "lag", lag.Lag, "commit_rec_ts", commitRecTs, "last_seen_offset", lastSeenOffset, "last_block_end_ts", lastBlockEndTs)
+
 	return partitionState{
 		Lag:                lag.Lag,
 		Commit:             lag.Commit,
@@ -293,7 +295,7 @@ func (b *BlockBuilder) consumePartition(ctx context.Context, partition int32, st
 			b.cfg.ConsumeInterval,
 			b.cfg.ConsumeIntervalBuffer,
 		)
-		level.Info(b.logger).Log("msg", "partition is lagging behind the cycle", "partition", partition, "lag", state.Lag, "section_cycle_end", sectionCycleEnd, "cycle_end", cycleEnd)
+		level.Info(b.logger).Log("msg", "partition is lagging behind the cycle", "partition", partition, "lag", state.Lag, "section_cycle_end", sectionCycleEnd, "cycle_end", cycleEnd, "commit_rec_ts", state.CommitRecTimestamp)
 	}
 	for !sectionCycleEnd.After(cycleEnd) {
 		partitionLogger := log.With(b.logger, "partition", partition, "lag", state.Lag, "section_cycle_end", sectionCycleEnd)

--- a/pkg/blockbuilder/blockbuilder_metrics.go
+++ b/pkg/blockbuilder/blockbuilder_metrics.go
@@ -11,7 +11,6 @@ type blockBuilderMetrics struct {
 	consumeCycleDuration     prometheus.Histogram
 	processPartitionDuration *prometheus.HistogramVec
 	compactAndUploadDuration *prometheus.HistogramVec
-	fetchRecordsTotal        prometheus.Counter
 	fetchErrors              prometheus.Counter
 	consumerLagRecords       *prometheus.GaugeVec
 }
@@ -38,10 +37,6 @@ func newBlockBuilderMetrics(reg prometheus.Registerer) blockBuilderMetrics {
 		NativeHistogramBucketFactor: 1.1,
 	}, []string{"partition"})
 
-	m.fetchRecordsTotal = promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Name: "cortex_blockbuilder_fetch_records_total",
-		Help: "Total number of records received by the consumer.",
-	})
 	m.fetchErrors = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "cortex_blockbuilder_fetch_errors_total",
 		Help: "Total number of errors while fetching by the consumer.",

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -614,33 +614,14 @@ func TestPartitionStateFromLag(t *testing.T) {
 		wantState      partitionState
 	}{
 		{
-			name: "no commit, no lag",
+			name: "no commit",
 			lag: kadm.GroupMemberLag{
 				Topic:     testTopic,
 				Partition: 0,
 				Commit:    kadm.Offset{},
-				Lag:       0,
 			},
 			fallbackMillis: testTime.UnixMilli(),
 			wantState: partitionState{
-				Lag:                   0,
-				Commit:                kadm.Offset{},
-				CommitRecordTimestamp: testTime,
-				LastSeenOffset:        0,
-				LastBlockEnd:          time.UnixMilli(0),
-			},
-		},
-		{
-			name: "no commit, some lag",
-			lag: kadm.GroupMemberLag{
-				Topic:     testTopic,
-				Partition: 0,
-				Commit:    kadm.Offset{},
-				Lag:       10,
-			},
-			fallbackMillis: testTime.UnixMilli(),
-			wantState: partitionState{
-				Lag:                   10,
 				Commit:                kadm.Offset{},
 				CommitRecordTimestamp: testTime,
 				LastSeenOffset:        0,
@@ -653,11 +634,9 @@ func TestPartitionStateFromLag(t *testing.T) {
 				Topic:     testTopic,
 				Partition: 0,
 				Commit:    testKafkaOffset,
-				Lag:       10,
 			},
 			fallbackMillis: testTime.UnixMilli(),
 			wantState: partitionState{
-				Lag:                   10,
 				Commit:                testKafkaOffset,
 				CommitRecordTimestamp: commitRecTs,
 				LastSeenOffset:        lastRecOffset,

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -84,7 +84,7 @@ func TestBlockBuilder_consumerLagRecords(t *testing.T) {
 			cortex_blockbuilder_consumer_lag_records{partition="0",topic="test"} 1
 			cortex_blockbuilder_consumer_lag_records{partition="1",topic="test"} 0
 		`), "cortex_blockbuilder_consumer_lag_records"))
-	}, 3*time.Second, 100*time.Millisecond)
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 // Testing block builder starting up with an existing kafka commit.

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -210,14 +210,11 @@ func TestBlockBuilder_StartWithLookbackOnNoCommit(t *testing.T) {
 			# TYPE cortex_blockbuilder_consumer_lag_records gauge
 			cortex_blockbuilder_consumer_lag_records{partition="0",topic="test"} 0
 			cortex_blockbuilder_consumer_lag_records{partition="1",topic="test"} 0
-			# HELP cortex_blockbuilder_fetch_records_total Total number of records received by the consumer.
-			# TYPE cortex_blockbuilder_fetch_records_total counter
-			cortex_blockbuilder_fetch_records_total 0
-		`), "cortex_blockbuilder_consumer_lag_records", "cortex_blockbuilder_fetch_records_total"))
+		`), "cortex_blockbuilder_consumer_lag_records"))
 	}, 3*time.Second, 100*time.Millisecond, "expected skipping all records before lookback period")
 }
 
-func TestBlockBuilder_WithMultiplyTenants(t *testing.T) {
+func TestBlockBuilder_WithMultipleTenants(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancelCause(context.Background())

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -7,15 +7,23 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
 
+	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/testkafka"
 )
@@ -25,8 +33,6 @@ func TestBlockBuilder_WipeOutDataDirOnStart(t *testing.T) {
 
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
-
-	const numPartitions = 2
 
 	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
 	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
@@ -49,13 +55,11 @@ func TestBlockBuilder_WipeOutDataDirOnStart(t *testing.T) {
 	require.Empty(t, list, "expected data_dir to be empty")
 }
 
-func TestBlockBuilder_NextConsumeCycle(t *testing.T) {
+func TestBlockBuilder_consumerLagRecords(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
-
-	const numPartitions = 2
 
 	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
 	kafkaClient := mustKafkaClient(t, kafkaAddr)
@@ -63,9 +67,6 @@ func TestBlockBuilder_NextConsumeCycle(t *testing.T) {
 	produceRecords(ctx, t, kafkaClient, time.Now().Add(-time.Hour), "1", testTopic, 0, []byte(`test value`))
 
 	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
-	cfg.PartitionAssignment = map[string][]int32{
-		"block-builder-0": {0, 1}, // instance 0 -> partitions 0, 1
-	}
 
 	reg := prometheus.NewPedanticRegistry()
 	bb, err := New(cfg, test.NewTestingLogger(t), reg, overrides)
@@ -76,16 +77,302 @@ func TestBlockBuilder_NextConsumeCycle(t *testing.T) {
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
 	})
 
-	// Explicitly call nextConsumeCycle and verify that we observed the expected per-partition lag.
-	err = bb.nextConsumeCycle(ctx, time.Now())
+	require.Eventually(t, func() bool {
+		return assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+			# HELP cortex_blockbuilder_consumer_lag_records The per-topic-partition number of records, instance needs to work through each cycle.
+			# TYPE cortex_blockbuilder_consumer_lag_records gauge
+			cortex_blockbuilder_consumer_lag_records{partition="0",topic="test"} 1
+			cortex_blockbuilder_consumer_lag_records{partition="1",topic="test"} 0
+		`), "cortex_blockbuilder_consumer_lag_records"))
+	}, 3*time.Second, 100*time.Millisecond)
+}
+
+// Testing block builder starting up with an existing kafka commit.
+func TestBlockBuilder_StartWithExistingCommit(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
+
+	kafkaClient := mustKafkaClient(t, kafkaAddr)
+	kafkaClient.AddConsumeTopics(testTopic)
+
+	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
+
+	// Producing some records
+	cycleEndStartup := cycleEndAtStartup(time.Now, cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+
+	var producedSamples []mimirpb.Sample
+	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-7 * time.Hour).Add(29 * time.Minute)
+	for kafkaRecTime.Before(cycleEndStartup) {
+		samples := floatSample(kafkaRecTime.Add(-time.Minute).UnixMilli(), 0)
+		val := createWriteRequest(t, "", samples, nil)
+
+		produceRecords(ctx, t, kafkaClient, kafkaRecTime, "1", testTopic, 0, val)
+		producedSamples = append(producedSamples, samples...)
+
+		kafkaRecTime = kafkaRecTime.Add(cfg.ConsumeInterval / 2)
+	}
+	require.NotEmpty(t, producedSamples)
+
+	// Fetch all the records that were produced to choose one to commit.
+	var recs []*kgo.Record
+	for len(recs) < len(producedSamples) {
+		fetches := kafkaClient.PollFetches(ctx)
+		require.NoError(t, fetches.Err())
+		recs = append(recs, fetches.Records()...)
+	}
+	require.Len(t, recs, len(producedSamples))
+
+	// Choosing the midpoint record to commit and as the last seen record as well.
+	commitRec := recs[len(recs)/2]
+	require.NotNil(t, commitRec)
+
+	lastRec := commitRec
+	blockEnd := commitRec.Timestamp.Truncate(cfg.ConsumeInterval).Add(cfg.ConsumeInterval)
+	offset := kadm.Offset{
+		Topic:       commitRec.Topic,
+		Partition:   commitRec.Partition,
+		At:          commitRec.Offset + 1,
+		LeaderEpoch: -1, // not a group consumer
+		Metadata:    marshallCommitMeta(commitRec.Timestamp.UnixMilli(), lastRec.Timestamp.UnixMilli(), blockEnd.UnixMilli()),
+	}
+	commitOffset(ctx, t, kafkaClient, testGroup, offset)
+
+	bb, err := New(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), overrides)
 	require.NoError(t, err)
 
-	require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_blockbuilder_consumer_lag_records The per-topic-partition number of records, instance needs to work through each cycle.
-		# TYPE cortex_blockbuilder_consumer_lag_records gauge
-		cortex_blockbuilder_consumer_lag_records{partition="0",topic="test"} 1
-		cortex_blockbuilder_consumer_lag_records{partition="1",topic="test"} 0
-	`), "cortex_blockbuilder_consumer_lag_records"))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
+	})
+
+	// Wait for all cycles.
+	time.Sleep(time.Second * 3)
+
+	// Because there is a commit, on startup, block-builder must consume samples only after the commit.
+	expSamples := producedSamples[1+(len(producedSamples)/2):]
+
+	bucketDir := path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, "1")
+	db, err := tsdb.Open(bucketDir, log.NewNopLogger(), nil, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	compareQuery(t,
+		db,
+		expSamples,
+		nil,
+		labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
+	)
+}
+
+// When there is no commit on startup, and the first cycleEnd is at T, and all the samples are from before T-lookback, then
+// the first consumption cycle skips all the records.
+func TestBlockBuilder_StartWithLookbackOnNoCommit(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
+
+	kafkaClient := mustKafkaClient(t, kafkaAddr)
+
+	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
+	cfg.LookbackOnNoCommit = 3 * time.Hour
+
+	// Producing some records, all before LookbackOnNoCommit
+	kafkaRecTime := time.Now().Truncate(cfg.ConsumeInterval).Add(-7 * time.Hour).Add(29 * time.Minute)
+	for range 3 {
+		kafkaRecTime = kafkaRecTime.Add(cfg.ConsumeInterval / 2)
+		samples := floatSample(kafkaRecTime.Add(-time.Minute).UnixMilli(), 0)
+		val := createWriteRequest(t, "", samples, nil)
+		produceRecords(ctx, t, kafkaClient, kafkaRecTime, "1", testTopic, 0, val)
+	}
+
+	reg := prometheus.NewPedanticRegistry()
+
+	bb, err := New(cfg, test.NewTestingLogger(t), reg, overrides)
+	require.NoError(t, err)
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
+	})
+
+	time.Sleep(time.Second * 3)
+
+	// Nothing is consumed due to zero lag.
+	require.Eventually(t, func() bool {
+		return assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+			# HELP cortex_blockbuilder_consumer_lag_records The per-topic-partition number of records, instance needs to work through each cycle.
+			# TYPE cortex_blockbuilder_consumer_lag_records gauge
+			cortex_blockbuilder_consumer_lag_records{partition="0",topic="test"} 0
+			cortex_blockbuilder_consumer_lag_records{partition="1",topic="test"} 0
+			# HELP cortex_blockbuilder_fetch_records_total Total number of records received by the consumer.
+			# TYPE cortex_blockbuilder_fetch_records_total counter
+			cortex_blockbuilder_fetch_records_total 0
+		`), "cortex_blockbuilder_consumer_lag_records", "cortex_blockbuilder_fetch_records_total"))
+	}, 3*time.Second, 100*time.Millisecond, "expected skipping all records before lookback period")
+}
+
+func TestBlockBuilder_WithMultiplyTenants(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
+
+	kafkaClient := mustKafkaClient(t, kafkaAddr)
+	kafkaClient.AddConsumeTopics(testTopic)
+
+	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
+
+	cycleEndStartup := cycleEndAtStartup(time.Now, cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-cfg.ConsumeInterval)
+
+	producedSamples := map[string][]mimirpb.Sample{}
+	tenants := []string{"1", "2", "3"}
+
+	// Producing some records for multiple tenants
+	for range 10 {
+		samples := floatSample(kafkaRecTime.UnixMilli(), 0)
+		for _, tenant := range tenants {
+			val := createWriteRequest(t, tenant, samples, nil)
+			produceRecords(ctx, t, kafkaClient, kafkaRecTime, tenant, testTopic, 0, val)
+			producedSamples[tenant] = append(producedSamples[tenant], samples...)
+		}
+
+		kafkaRecTime = kafkaRecTime.Add(15 * time.Second)
+	}
+
+	bb, err := New(cfg, log.NewNopLogger(), prometheus.NewPedanticRegistry(), overrides)
+	require.NoError(t, err)
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
+	})
+
+	// Wait for all compacts.
+	time.Sleep(time.Second * 3)
+
+	for _, tenant := range tenants {
+		bucketDir := path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, tenant)
+		db, err := tsdb.Open(bucketDir, log.NewNopLogger(), nil, nil, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+		compareQuery(t,
+			db,
+			producedSamples[tenant],
+			nil,
+			labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
+		)
+	}
+}
+
+func TestBlockBuilder_WithNonMonotonicRecordTimestamps(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
+
+	kafkaClient := mustKafkaClient(t, kafkaAddr)
+
+	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
+
+	cycleEndStartup := cycleEndAtStartup(time.Now, cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+
+	const tenantID = "1"
+	var expSamplesPhase1, expSamplesPhase2 []mimirpb.Sample
+
+	produceSamples := func(kafkaTime time.Time, sampleTs ...time.Time) {
+		samples := floatSample(sampleTs[0].UnixMilli(), 1)
+		for _, ts := range sampleTs[1:] {
+			samples = append(samples, floatSample(ts.UnixMilli(), 1)...)
+		}
+		val := createWriteRequest(t, tenantID, samples, nil)
+		produceRecords(ctx, t, kafkaClient, kafkaTime, tenantID, testTopic, 0, val)
+	}
+
+	{
+		// Simple first record with all samples in the block.
+		kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-2 * cfg.ConsumeIntervalBuffer)
+		produceSamples(kafkaRecTime, kafkaRecTime)
+		expSamplesPhase1 = append(expSamplesPhase1, floatSample(kafkaRecTime.UnixMilli(), 1)...)
+	}
+
+	var lastSeenRecTime time.Time
+	{
+		// Record in the buffer zone with a sample in the block and a sample outside the block.
+		// This is the last record in this cycle. So this will be the "last seen" record for the next cycle.
+		kafkaTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(cfg.ConsumeIntervalBuffer / 2)
+		inBlockTs := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-cfg.ConsumeIntervalBuffer)
+		lastSeenRecTime = kafkaTime
+		produceSamples(kafkaTime, inBlockTs, kafkaTime)
+		expSamplesPhase1 = append(expSamplesPhase1, floatSample(inBlockTs.UnixMilli(), 1)...)
+		expSamplesPhase2 = append(expSamplesPhase2, floatSample(kafkaTime.UnixMilli(), 1)...)
+	}
+
+	{
+		// Record outside this cycle but with sample valid for this block.
+		// This sample will be consumed in the next cycle because of the record timestamp.
+		// The block builder will treat this as the stopping point for the cycle since the record
+		// timestamp is outside the cycle.
+		kafkaTime := cycleEndStartup.Add(cfg.ConsumeInterval - time.Minute)
+		inBlockTs := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-cfg.ConsumeIntervalBuffer + time.Minute)
+		produceSamples(kafkaTime, inBlockTs)
+		expSamplesPhase2 = append(expSamplesPhase2, floatSample(inBlockTs.UnixMilli(), 1)...)
+	}
+
+	{
+		// Record inside this cycle with sample in this block, but it is not consumed in this cycle
+		// because block builder stops at the previous record.
+		// This sample will be consumed in the next cycle.
+		// To test correct working of non-monotonic timestamps, we should have this record's timestamp to be
+		// before the last seen timestamp of the cycle.
+		// If we were working with record timestamp, this sample will go missing. If we use offset of record
+		// instead, then this sample will not go missing.
+		kafkaTime := lastSeenRecTime.Add(-2 * time.Minute)
+		inBlockTs := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-cfg.ConsumeIntervalBuffer + 2*time.Minute)
+		produceSamples(kafkaTime, inBlockTs)
+		expSamplesPhase2 = append(expSamplesPhase2, floatSample(inBlockTs.UnixMilli(), 1)...)
+	}
+
+	bb, err := New(cfg, log.NewNopLogger(), prometheus.NewPedanticRegistry(), overrides)
+	require.NoError(t, err)
+
+	// We don't want to run the service here. Instead, the test cases below trigger and assert the consumption cycles explicitly.
+	require.NoError(t, bb.starting(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, bb.stopping(nil))
+	})
+
+	runTest := func(name string, end time.Time, expSamples []mimirpb.Sample) {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, bb.nextConsumeCycle(ctx, end))
+
+			bucketDir := path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, tenantID)
+			db, err := tsdb.Open(bucketDir, log.NewNopLogger(), nil, nil, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+			compareQuery(t,
+				db,
+				expSamples,
+				nil,
+				labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
+			)
+		})
+	}
+
+	runTest("phase 1", cycleEndStartup, expSamplesPhase1)
+	runTest("phase 2", cycleEndStartup.Add(cfg.ConsumeInterval), append(expSamplesPhase1, expSamplesPhase2...))
 }
 
 func TestCycleEndAtStartup(t *testing.T) {

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -86,7 +86,7 @@ func TestBlockBuilder_consumerLagRecords(t *testing.T) {
 		return assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_blockbuilder_consumer_lag_records The per-topic-partition number of records, instance needs to work through each cycle.
 			# TYPE cortex_blockbuilder_consumer_lag_records gauge
-			cortex_blockbuilder_consumer_lag_records{partition="0",topic="test"} 1
+			cortex_blockbuilder_consumer_lag_records{partition="0"} 1
 		`), "cortex_blockbuilder_consumer_lag_records"))
 	}, 5*time.Second, 100*time.Millisecond)
 }
@@ -220,8 +220,8 @@ func TestBlockBuilder_StartWithLookbackOnNoCommit(t *testing.T) {
 	require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_blockbuilder_consumer_lag_records The per-topic-partition number of records, instance needs to work through each cycle.
 		# TYPE cortex_blockbuilder_consumer_lag_records gauge
-		cortex_blockbuilder_consumer_lag_records{partition="0",topic="test"} 0
-		cortex_blockbuilder_consumer_lag_records{partition="1",topic="test"} 0
+		cortex_blockbuilder_consumer_lag_records{partition="0"} 0
+		cortex_blockbuilder_consumer_lag_records{partition="1"} 0
 	`), "cortex_blockbuilder_consumer_lag_records"))
 }
 

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -102,7 +102,7 @@ func TestBlockBuilder_StartWithExistingCommit(t *testing.T) {
 	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
 
 	// Producing some records
-	cycleEndStartup := cycleEndAtStartup(time.Now, cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 
 	var producedSamples []mimirpb.Sample
 	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-7 * time.Hour).Add(29 * time.Minute)
@@ -230,7 +230,7 @@ func TestBlockBuilder_WithMultiplyTenants(t *testing.T) {
 
 	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
 
-	cycleEndStartup := cycleEndAtStartup(time.Now, cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-cfg.ConsumeInterval)
 
 	producedSamples := map[string][]mimirpb.Sample{}
@@ -286,7 +286,7 @@ func TestBlockBuilder_WithNonMonotonicRecordTimestamps(t *testing.T) {
 
 	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
 
-	cycleEndStartup := cycleEndAtStartup(time.Now, cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 
 	const tenantID = "1"
 	var expSamplesPhase1, expSamplesPhase2 []mimirpb.Sample
@@ -431,10 +431,8 @@ func TestCycleEndAtStartup(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("now=%s/%s+%s", tc.nowTimeStr, tc.interval, tc.buffer), func(t *testing.T) {
-			nowFunc := func() time.Time {
-				return mustTimeParse(t, time.TimeOnly, tc.nowTimeStr)
-			}
-			cycleEnd := cycleEndAtStartup(nowFunc, tc.interval, tc.buffer)
+			now := mustTimeParse(t, time.TimeOnly, tc.nowTimeStr)
+			cycleEnd := cycleEndAtStartup(now, tc.interval, tc.buffer)
 			tc.testFunc(t, cycleEnd)
 		})
 	}
@@ -501,10 +499,8 @@ func TestNextCycleEnd(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("now=%s/%s+%s", tc.nowTimeStr, tc.interval, tc.buffer), func(t *testing.T) {
-			nowFunc := func() time.Time {
-				return mustTimeParse(t, time.TimeOnly, tc.nowTimeStr)
-			}
-			cycleEnd, wait := nextCycleEnd(nowFunc, tc.interval, tc.buffer)
+			now := mustTimeParse(t, time.TimeOnly, tc.nowTimeStr)
+			cycleEnd, wait := nextCycleEnd(now, tc.interval, tc.buffer)
 			tc.testFunc(t, cycleEnd, wait)
 		})
 	}

--- a/pkg/blockbuilder/config.go
+++ b/pkg/blockbuilder/config.go
@@ -41,7 +41,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&cfg.InstanceID, "block-builder.instance-id", hostname, "Instance id.")
 	f.Var(newPartitionAssignmentVar(&cfg.PartitionAssignment), "block-builder.partition-assignment", "Static partition assignment. Format is a JSON encoded map[instance-id][]partitions).")
 	f.StringVar(&cfg.DataDir, "block-builder.data-dir", "./data-block-builder/", "Directory to temporarily store blocks during building. This directory is wiped out between the restarts.")
-	f.StringVar(&cfg.ConsumerGroup, "block-builder.kafka.consumer-group", "block-builder", "The Kafka consumer group used to keep track of the consumed offsets for assigned partitions.")
+	f.StringVar(&cfg.ConsumerGroup, "block-builder.consumer-group", "block-builder", "The Kafka consumer group used to keep track of the consumed offsets for assigned partitions.")
 	f.DurationVar(&cfg.ConsumeInterval, "block-builder.consume-interval", time.Hour, "Interval between consumption cycles.")
 	f.DurationVar(&cfg.ConsumeIntervalBuffer, "block-builder.consume-interval-buffer", 15*time.Minute, "Extra buffer between subsequent consumption cycles. To avoid small blocks the block-builder consumes until the last hour boundary of the consumption interval, plus the buffer.")
 	f.DurationVar(&cfg.LookbackOnNoCommit, "block-builder.lookback-on-no-commit", 12*time.Hour, "How much of the historical records to look back when there is no kafka commit for a partition.")

--- a/pkg/blockbuilder/config_test.go
+++ b/pkg/blockbuilder/config_test.go
@@ -85,7 +85,7 @@ func blockBuilderConfig(t *testing.T, addr string) (Config, *validation.Override
 
 	cfg.InstanceID = "block-builder-0"
 	cfg.PartitionAssignment = map[string][]int32{
-		"block-builder-0": {0, 1}, // instance 0 -> partition 0
+		"block-builder-0": {0, 1}, // instance 0 -> partitions 0 and 1
 	}
 	cfg.ConsumerGroup = testGroup
 	cfg.DataDir = t.TempDir()

--- a/pkg/blockbuilder/config_test.go
+++ b/pkg/blockbuilder/config_test.go
@@ -75,6 +75,8 @@ func TestConfig_Validate(t *testing.T) {
 const (
 	testTopic = "test"
 	testGroup = "testgroup"
+
+	numPartitions = 2
 )
 
 func blockBuilderConfig(t *testing.T, addr string) (Config, *validation.Overrides) {
@@ -83,7 +85,7 @@ func blockBuilderConfig(t *testing.T, addr string) (Config, *validation.Override
 
 	cfg.InstanceID = "block-builder-0"
 	cfg.PartitionAssignment = map[string][]int32{
-		"block-builder-0": {0}, // instance 0 -> partition 0
+		"block-builder-0": {0, 1}, // instance 0 -> partition 0
 	}
 	cfg.ConsumerGroup = testGroup
 	cfg.DataDir = t.TempDir()

--- a/pkg/blockbuilder/kafkautil.go
+++ b/pkg/blockbuilder/kafkautil.go
@@ -83,15 +83,15 @@ const (
 
 // commitRecTs: timestamp of the record which was committed (and not the commit time).
 // lastRecOffset: offset of the last record processed (which will be >= commit record offset).
-// blockEnd: timestamp of the block end in this cycle.
-func marshallCommitMeta(commitRecTs, lastRecOffset, blockEnd int64) string {
-	return fmt.Sprintf("%d,%d,%d,%d", kafkaCommitMetaV1, commitRecTs, lastRecOffset, blockEnd)
+// blockEndTs: timestamp of the block end in this cycle.
+func marshallCommitMeta(commitRecTs, lastRecOffset, blockEndTs int64) string {
+	return fmt.Sprintf("%d,%d,%d,%d", kafkaCommitMetaV1, commitRecTs, lastRecOffset, blockEndTs)
 }
 
 // commitRecTs: timestamp of the record which was committed (and not the commit time).
 // lastRecOffset: offset of the last record processed (which will be >= commit record offset).
-// blockEnd: timestamp of the block end in this cycle.
-func unmarshallCommitMeta(s string) (commitRecTs, lastRecOffset, blockEnd int64, err error) {
+// blockEndTs: timestamp of the block end in this cycle.
+func unmarshallCommitMeta(s string) (commitRecTs, lastRecOffset, blockEndTs int64, err error) {
 	if s == "" {
 		return
 	}
@@ -107,6 +107,6 @@ func unmarshallCommitMeta(s string) (commitRecTs, lastRecOffset, blockEnd int64,
 	if version != kafkaCommitMetaV1 {
 		return 0, 0, 0, fmt.Errorf("unsupported commit meta version %d", version)
 	}
-	_, err = fmt.Sscanf(metaStr, "%d,%d,%d", &commitRecTs, &lastRecOffset, &blockEnd)
+	_, err = fmt.Sscanf(metaStr, "%d,%d,%d", &commitRecTs, &lastRecOffset, &blockEndTs)
 	return
 }

--- a/pkg/blockbuilder/kafkautil.go
+++ b/pkg/blockbuilder/kafkautil.go
@@ -101,12 +101,15 @@ func unmarshallCommitMeta(s string) (commitRecTs, lastRecOffset, blockEndTs int6
 	)
 	_, err = fmt.Sscanf(s, "%d,%s", &version, &metaStr)
 	if err != nil {
-		return
+		return 0, 0, 0, fmt.Errorf("invalid commit metadata format: parse meta version: %w", err)
 	}
 
 	if version != kafkaCommitMetaV1 {
 		return 0, 0, 0, fmt.Errorf("unsupported commit meta version %d", version)
 	}
 	_, err = fmt.Sscanf(metaStr, "%d,%d,%d", &commitRecTs, &lastRecOffset, &blockEndTs)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid commit metadata format: %w", err)
+	}
 	return
 }

--- a/pkg/blockbuilder/metrics.go
+++ b/pkg/blockbuilder/metrics.go
@@ -10,7 +10,7 @@ import (
 type blockBuilderMetrics struct {
 	consumeCycleDuration     prometheus.Histogram
 	processPartitionDuration *prometheus.HistogramVec
-	fetchErrors              prometheus.Counter
+	fetchErrors              *prometheus.CounterVec
 	consumerLagRecords       *prometheus.GaugeVec
 }
 
@@ -30,15 +30,15 @@ func newBlockBuilderMetrics(reg prometheus.Registerer) blockBuilderMetrics {
 		NativeHistogramBucketFactor: 1.1,
 	}, []string{"partition"})
 
-	m.fetchErrors = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+	m.fetchErrors = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_blockbuilder_fetch_errors_total",
 		Help: "Total number of errors while fetching by the consumer.",
-	})
+	}, []string{"partition"})
 
 	m.consumerLagRecords = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 		Name: "cortex_blockbuilder_consumer_lag_records",
 		Help: "The per-topic-partition number of records, instance needs to work through each cycle.",
-	}, []string{"topic", "partition"})
+	}, []string{"partition"})
 
 	return m
 }

--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -66,8 +66,8 @@ func NewTSDBBuilder(logger log.Logger, dataDir string, blocksStorageCfg mimir_ts
 // where the sample was not put in the TSDB because it was discarded or was already processed before.
 // lastBlockMax: max time of the block in the previous block building cycle.
 // blockMax: max time of the block in the current block building cycle. This blockMax is exclusive of the last sample by design in TSDB.
-// recordProcessedBefore: true if the record was processed in the previous cycle. (It gets processed again if some samples did not fit in the previous cycle.)
-func (b *TSDBBuilder) Process(ctx context.Context, rec *kgo.Record, lastBlockMax, blockMax int64, recordProcessedBefore bool) (_ bool, err error) {
+// recordAlreadyProcessed: true if the record was processed in the previous cycle. (It gets processed again if some samples did not fit in the previous cycle.)
+func (b *TSDBBuilder) Process(ctx context.Context, rec *kgo.Record, lastBlockMax, blockMax int64, recordAlreadyProcessed bool) (_ bool, err error) {
 	userID := string(rec.Key)
 
 	req := mimirpb.PreallocWriteRequest{
@@ -123,7 +123,7 @@ func (b *TSDBBuilder) Process(ctx context.Context, rec *kgo.Record, lastBlockMax
 				allSamplesProcessed = false
 				continue
 			}
-			if recordProcessedBefore && s.TimestampMs < lastBlockMax {
+			if recordAlreadyProcessed && s.TimestampMs < lastBlockMax {
 				// This sample was already processed in the previous cycle.
 				continue
 			}
@@ -154,7 +154,7 @@ func (b *TSDBBuilder) Process(ctx context.Context, rec *kgo.Record, lastBlockMax
 				allSamplesProcessed = false
 				continue
 			}
-			if recordProcessedBefore && h.Timestamp < lastBlockMax {
+			if recordAlreadyProcessed && h.Timestamp < lastBlockMax {
 				// This sample was already processed in the previous cycle.
 				continue
 			}

--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
@@ -157,7 +158,8 @@ func TestTSDBBuilder(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			expSamples = expSamples[:0]
 			expHistograms = expHistograms[:0]
-			builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides)
+			metrics := newTSDBBBuilderMetrics(prometheus.NewPedanticRegistry())
+			builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides, metrics)
 
 			currEnd, lastEnd := tc.currEnd, tc.lastEnd
 			{ // Add float samples.
@@ -346,7 +348,8 @@ func TestProcessingEmptyRequest(t *testing.T) {
 
 	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(t, err)
-	builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides)
+	metrics := newTSDBBBuilderMetrics(prometheus.NewPedanticRegistry())
+	builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides, metrics)
 
 	// Has a timeseries with no samples.
 	var rec kgo.Record

--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -157,11 +157,7 @@ func TestTSDBBuilder(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			expSamples = expSamples[:0]
 			expHistograms = expHistograms[:0]
-			builder := NewTSDBBuilder(log.NewNopLogger(), overrides, mimir_tsdb.BlocksStorageConfig{
-				TSDB: mimir_tsdb.TSDBConfig{
-					Dir: t.TempDir(),
-				},
-			})
+			builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides)
 
 			currEnd, lastEnd := tc.currEnd, tc.lastEnd
 			{ // Add float samples.
@@ -350,11 +346,7 @@ func TestProcessingEmptyRequest(t *testing.T) {
 
 	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	require.NoError(t, err)
-	builder := NewTSDBBuilder(log.NewNopLogger(), overrides, mimir_tsdb.BlocksStorageConfig{
-		TSDB: mimir_tsdb.TSDBConfig{
-			Dir: t.TempDir(),
-		},
-	})
+	builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides)
 
 	// Has a timeseries with no samples.
 	var rec kgo.Record

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -48,6 +48,7 @@ import (
 	alertbucketclient "github.com/grafana/mimir/pkg/alertmanager/alertstore/bucketclient"
 	alertstorelocal "github.com/grafana/mimir/pkg/alertmanager/alertstore/local"
 	"github.com/grafana/mimir/pkg/api"
+	"github.com/grafana/mimir/pkg/blockbuilder"
 	"github.com/grafana/mimir/pkg/compactor"
 	"github.com/grafana/mimir/pkg/continuoustest"
 	"github.com/grafana/mimir/pkg/distributor"
@@ -123,6 +124,7 @@ type Config struct {
 	Worker           querier_worker.Config           `yaml:"frontend_worker"`
 	Frontend         frontend.CombinedFrontendConfig `yaml:"frontend"`
 	IngestStorage    ingest.Config                   `yaml:"ingest_storage"`
+	BlockBuilder     blockbuilder.Config             `yaml:"block_builder" doc:"hidden"`
 	BlocksStorage    tsdb.BlocksStorageConfig        `yaml:"blocks_storage"`
 	Compactor        compactor.Config                `yaml:"compactor"`
 	StoreGateway     storegateway.Config             `yaml:"store_gateway"`
@@ -181,6 +183,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.Worker.RegisterFlags(f)
 	c.Frontend.RegisterFlags(f, logger)
 	c.IngestStorage.RegisterFlags(f)
+	c.BlockBuilder.RegisterFlags(f, logger)
 	c.BlocksStorage.RegisterFlags(f)
 	c.Compactor.RegisterFlags(f, logger)
 	c.StoreGateway.RegisterFlags(f, logger)
@@ -730,6 +733,7 @@ type Mimir struct {
 	ActivityTracker                 *activitytracker.ActivityTracker
 	Vault                           *vault.Vault
 	UsageStatsReporter              *usagestats.Reporter
+	BlockBuilder                    *blockbuilder.BlockBuilder
 	ContinuousTestManager           *continuoustest.Manager
 	BuildInfoHandler                http.Handler
 }

--- a/pkg/storage/tsdb/block/meta.go
+++ b/pkg/storage/tsdb/block/meta.go
@@ -29,6 +29,7 @@ const (
 	CompactorSource       SourceType = "compactor"
 	CompactorRepairSource SourceType = "compactor.repair"
 	BucketRepairSource    SourceType = "bucket.repair"
+	BlockBuilderSource    SourceType = "block-builder"
 	TestSource            SourceType = "test"
 )
 


### PR DESCRIPTION
#### What this PR does

_This one seats atop https://github.com/grafana/mimir/pull/9199 for now_

This is part of https://github.com/grafana/mimir/pull/8635; refer to it for more details.

This PR addresses the discussion we had with @dimitarvdimitrov in https://github.com/grafana/mimir/pull/9199#discussion_r1773600398 about a potential edge-case for a partition that has offset gaps. Here we refactor the internals of the consumer loop replacing the use of `remaining` lag with the reference to the partition end, at the time of the cycle.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
