### PR TITLE
Tenant Dashboard: Use natural sort for "user" variable

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -35250,7 +35250,7 @@ data:
                    "query": "label_values(cortex_ingester_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\"}, user)",
                    "refresh": 1,
                    "regex": "",
-                   "sort": 1,
+                   "sort": 7,
                    "tagValuesQuery": "",
                    "tags": [ ],
                    "tagsQuery": "",

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -2656,7 +2656,7 @@
                "query": "label_values(cortex_ingester_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\"}, user)",
                "refresh": 1,
                "regex": "",
-               "sort": 1,
+               "sort": 7,
                "tagValuesQuery": "",
                "tags": [ ],
                "tagsQuery": "",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -2656,7 +2656,7 @@
                "query": "label_values(cortex_ingester_active_series{cluster=~\"$cluster\", namespace=~\"$namespace\"}, user)",
                "refresh": 1,
                "regex": "",
-               "sort": 1,
+               "sort": 7,
                "tagValuesQuery": "",
                "tags": [ ],
                "tagsQuery": "",

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -25,6 +25,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   ]),
 
   local sortAscending = 1,
+  local sortNaturalAscending = 7,
 
   _config:: error 'must provide _config',
 
@@ -124,7 +125,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                .addTemplate('namespace', $._config.dashboard_variables.namespace_query, '%s' % $._config.per_namespace_label, sort=sortAscending),
 
       addActiveUserSelectorTemplates()::
-        self.addTemplate('user', 'cortex_ingester_active_series{%s=~"$cluster", %s=~"$namespace"}' % [$._config.per_cluster_label, $._config.per_namespace_label], 'user', sort=sortAscending),
+        self.addTemplate('user', 'cortex_ingester_active_series{%s=~"$cluster", %s=~"$namespace"}' % [$._config.per_cluster_label, $._config.per_namespace_label], 'user', sort=sortNaturalAscending),
 
       addCustomTemplate(label, name, options, defaultIndex=0):: self {
         // Escape the comma because it's used a separator in the options list.


### PR DESCRIPTION
#### What this PR does

So instead of getting `11000, 100000, 9000, struser`, we'll get `9000, 11000, 100000, struser`

#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
