### PR TITLE
query-tee: fix behaviour of `-proxy.compare-skip-recent-samples` for long-running queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,7 @@
 * [ENHANCEMENT] Optionally consider equivalent error messages the same when comparing responses. Enabled by default, disable with `-proxy.require-exact-error-match=true`. #9143 #9350 #9366
 * [BUGFIX] Ensure any errors encountered while forwarding a request to a backend (eg. DNS resolution failures) are logged. #8419
 * [BUGFIX] The comparison of the results should not fail when either side contains extra samples from within SkipRecentSamples duration. #8920
+* [BUGFIX] When `-proxy.compare-skip-recent-samples` is enabled, compare sample timestamps with the time the query requests were made, rather than the time at which the comparison is occurring. #9416
 
 ### Documentation
 

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -704,7 +704,7 @@ type mockComparator struct {
 	comparisonError  error
 }
 
-func (m *mockComparator) Compare(_, _ []byte) (ComparisonResult, error) {
+func (m *mockComparator) Compare(_, _ []byte, _ time.Time) (ComparisonResult, error) {
 	return m.comparisonResult, m.comparisonError
 }
 

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -47,7 +47,7 @@ var testRoutes = []Route{
 
 type testComparator struct{}
 
-func (testComparator) Compare(_, _ []byte) (ComparisonResult, error) {
+func (testComparator) Compare(_, _ []byte, _ time.Time) (ComparisonResult, error) {
 	return ComparisonSuccess, nil
 }
 

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -699,7 +699,7 @@ Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[1]`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := compareMatrix(tc.expected, tc.actual, SampleComparisonOptions{})
+			err := compareMatrix(tc.expected, tc.actual, time.Now(), SampleComparisonOptions{})
 			if tc.err == "" {
 				require.NoError(t, err)
 				return
@@ -1078,7 +1078,7 @@ func TestCompareVector(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := compareVector(tc.expected, tc.actual, SampleComparisonOptions{})
+			err := compareVector(tc.expected, tc.actual, time.Now(), SampleComparisonOptions{})
 			if tc.err == nil {
 				require.NoError(t, err)
 				return
@@ -1115,7 +1115,7 @@ func TestCompareScalar(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := compareScalar(tc.expected, tc.actual, SampleComparisonOptions{})
+			err := compareScalar(tc.expected, tc.actual, time.Now(), SampleComparisonOptions{})
 			if tc.err == nil {
 				require.NoError(t, err)
 				return
@@ -1127,8 +1127,9 @@ func TestCompareScalar(t *testing.T) {
 }
 
 func TestCompareSamplesResponse(t *testing.T) {
-	now := model.Now().String()
-	overAnHourAgo := model.Now().Add(-61 * time.Minute).String()
+	nowT := model.TimeFromUnixNano(time.Date(2099, 1, 2, 3, 4, 5, 6, time.UTC).UnixNano())
+	now := nowT.String()
+	overAnHourAgo := nowT.Add(-61 * time.Minute).String()
 
 	for _, tc := range []struct {
 		name              string
@@ -2172,7 +2173,7 @@ func TestCompareSamplesResponse(t *testing.T) {
 				UseRelativeError:  tc.useRelativeError,
 				SkipRecentSamples: tc.skipRecentSamples,
 			})
-			result, err := samplesComparator.Compare(tc.expected, tc.actual)
+			result, err := samplesComparator.Compare(tc.expected, tc.actual, nowT.Time())
 			if tc.err == nil {
 				require.NoError(t, err)
 				require.Equal(t, ComparisonSuccess, result)
@@ -2342,7 +2343,7 @@ func TestCompareSampleHistogramPair(t *testing.T) {
 					field.mutator(expected.Histogram, model.FloatString(testCase.expected))
 					field.mutator(actual.Histogram, model.FloatString(testCase.actual))
 
-					err := compareSampleHistogramPair(expected, actual, opts)
+					err := compareSampleHistogramPair(expected, actual, time.Now(), opts)
 
 					if testCase.shouldFail {
 						expectedError := field.expectedErrorMessageGenerator(&expected, &actual)


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue in the behaviour of the `-proxy.compare-skip-recent-samples` CLI flag in query-tee.

Previously, when deciding whether to skip a sample, sample timestamps were compared to the time at the time the comparison was occurring. However, for a slow query, this may be well after the query was evaluated, and so may mean that `-proxy.compare-skip-recent-samples` is ineffective.

This PR changes the behaviour of query-tee to compare sample timestamps to the time at which the query request was sent. This reduces the number of unwanted comparison failures for recent data.

For example, let's say query-tee receives a query at 12:00, the query takes 3 minutes to evaluate through both backends, and `-proxy.compare-skip-recent-samples` is set to 5 minutes. Let's assume everything else happens instantly, so result comparison happens at 12:03.

With the old behaviour, samples with timestamps after 11:58 will be considered too recent to compare and skipped.

With the new behaviour in this PR, samples with timestamps after 11:55 will be considered too recent to compare and skipped.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
