### PR TITLE
ingest storage: synchronize logger access between parallel tests

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1711,10 +1711,12 @@ func withLogger(logger log.Logger) func(cfg *readerTestCfg) {
 	}
 }
 
+var testingLogger = mimirtest.NewTestingLogger(nil)
+
 func defaultReaderTestConfig(t *testing.T, addr string, topicName string, partitionID int32, consumer recordConsumer) *readerTestCfg {
 	return &readerTestCfg{
 		registry:    prometheus.NewPedanticRegistry(),
-		logger:      mimirtest.NewTestingLogger(t),
+		logger:      testingLogger.WithT(t),
 		kafka:       createTestKafkaConfig(addr, topicName),
 		partitionID: partitionID,
 		consumer:    consumer,

--- a/pkg/util/test/logger.go
+++ b/pkg/util/test/logger.go
@@ -10,18 +10,27 @@ import (
 	"github.com/go-kit/log"
 )
 
-type testingLogger struct {
+type TestingLogger struct {
 	t   testing.TB
-	mtx sync.Mutex
+	mtx *sync.Mutex
 }
 
-func NewTestingLogger(t testing.TB) log.Logger {
-	return &testingLogger{
-		t: t,
+func NewTestingLogger(t testing.TB) *TestingLogger {
+	return &TestingLogger{
+		t:   t,
+		mtx: &sync.Mutex{},
 	}
 }
 
-func (l *testingLogger) Log(keyvals ...interface{}) error {
+// WithT returns a new logger that logs to t. Writes between the new logger and the original logger are synchronized.
+func (l *TestingLogger) WithT(t testing.TB) log.Logger {
+	return &TestingLogger{
+		t:   t,
+		mtx: l.mtx,
+	}
+}
+
+func (l *TestingLogger) Log(keyvals ...interface{}) error {
 	// Prepend log with timestamp.
 	keyvals = append([]interface{}{time.Now().String()}, keyvals...)
 


### PR DESCRIPTION

#### What this PR does

After https://github.com/grafana/mimir/pull/9326 we were using locks within a single test, but `Parallel()` tests were using difference instances of `testingLogger`, so there was no synchronization.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/9325

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
