### PR TITLE
Unify direct and caching `RuleStore`s in ruler

### DIFF
--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -294,7 +294,7 @@ std.manifestYamlDoc({
 
   memcached:: {
     memcached: {
-      image: 'memcached:1.6.19-alpine',
+      image: 'memcached:1.6.28-alpine',
       ports: [
         '11211:11211',
       ],
@@ -303,7 +303,7 @@ std.manifestYamlDoc({
 
   memcached_exporter:: {
     'memcached-exporter': {
-      image: 'prom/memcached-exporter:v0.6.0',
+      image: 'prom/memcached-exporter:v0.14.4',
       command: ['--memcached.address=memcached:11211', '--web.listen-address=0.0.0.0:9150'],
     },
   },

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -275,14 +275,14 @@
     "ports":
       - "9900:9900"
   "memcached":
-    "image": "memcached:1.6.19-alpine"
+    "image": "memcached:1.6.28-alpine"
     "ports":
       - "11211:11211"
   "memcached-exporter":
     "command":
       - "--memcached.address=memcached:11211"
       - "--web.listen-address=0.0.0.0:9150"
-    "image": "prom/memcached-exporter:v0.6.0"
+    "image": "prom/memcached-exporter:v0.14.4"
   "minio":
     "command":
       - "server"

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -723,8 +723,7 @@ type Mimir struct {
 	QueryFrontendTopicOffsetsReader *ingest.TopicOffsetsReader
 	QueryFrontendCodec              querymiddleware.Codec
 	Ruler                           *ruler.Ruler
-	RulerDirectStorage              rulestore.RuleStore
-	RulerCachedStorage              rulestore.RuleStore
+	RulerStorage                    rulestore.RuleStore
 	Alertmanager                    *alertmanager.MultitenantAlertmanager
 	Compactor                       *compactor.MultitenantCompactor
 	StoreGateway                    *storegateway.StoreGateway

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -830,13 +830,12 @@ func (t *Mimir) initRulerStorage() (serv services.Service, err error) {
 	// we do accept stale data for about a polling interval (2 intervals in the worst
 	// case scenario due to the jitter applied).
 	cacheTTL := t.Cfg.Ruler.PollInterval
-
-	t.RulerDirectStorage, t.RulerCachedStorage, err = ruler.NewRuleStore(context.Background(), t.Cfg.RulerStorage, t.Overrides, rules.FileLoader{}, cacheTTL, util_log.Logger, t.Registerer)
+	t.RulerStorage, err = ruler.NewRuleStore(context.Background(), t.Cfg.RulerStorage, t.Overrides, rules.FileLoader{}, cacheTTL, util_log.Logger, t.Registerer)
 	return
 }
 
 func (t *Mimir) initRuler() (serv services.Service, err error) {
-	if t.RulerDirectStorage == nil {
+	if t.RulerStorage == nil {
 		level.Info(util_log.Logger).Log("msg", "The ruler storage has not been configured. Not starting the ruler.")
 		return nil, nil
 	}
@@ -939,8 +938,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 		manager,
 		t.Registerer,
 		util_log.Logger,
-		t.RulerDirectStorage,
-		t.RulerCachedStorage,
+		t.RulerStorage,
 		t.Overrides,
 	)
 	if err != nil {
@@ -951,7 +949,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 	t.API.RegisterRuler(t.Ruler)
 
 	// Expose HTTP configuration and prometheus-compatible Ruler APIs
-	t.API.RegisterRulerAPI(ruler.NewAPI(t.Ruler, t.RulerDirectStorage, util_log.Logger), t.Cfg.Ruler.EnableAPI, t.BuildInfoHandler)
+	t.API.RegisterRulerAPI(ruler.NewAPI(t.Ruler, t.RulerStorage, util_log.Logger), t.Cfg.Ruler.EnableAPI, t.BuildInfoHandler)
 
 	return t.Ruler, nil
 }

--- a/pkg/mimir/modules_test.go
+++ b/pkg/mimir/modules_test.go
@@ -159,11 +159,9 @@ func TestMimir_InitRulerStorage(t *testing.T) {
 			require.NoError(t, err)
 
 			if testData.expectedInit {
-				assert.NotNil(t, mimir.RulerDirectStorage)
-				assert.NotNil(t, mimir.RulerCachedStorage)
+				assert.NotNil(t, mimir.RulerStorage)
 			} else {
-				assert.Nil(t, mimir.RulerDirectStorage)
-				assert.Nil(t, mimir.RulerCachedStorage)
+				assert.Nil(t, mimir.RulerStorage)
 			}
 		})
 	}

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -54,12 +54,12 @@ import (
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/bucket/filesystem"
 	"github.com/grafana/mimir/pkg/util"
-	util_test "github.com/grafana/mimir/pkg/util/test"
+	utiltest "github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 func TestMain(m *testing.M) {
-	util_test.VerifyNoLeakTestMain(m)
+	utiltest.VerifyNoLeakTestMain(m)
 }
 
 func defaultRulerConfig(t testing.TB) Config {
@@ -210,7 +210,7 @@ func prepareRuler(t *testing.T, cfg Config, storage rulestore.RuleStore, opts ..
 	options := applyPrepareOptions(t, cfg.Ring.Common.InstanceID, opts...)
 	manager := prepareRulerManager(t, cfg, opts...)
 
-	ruler, err := newRuler(cfg, manager, options.registerer, options.logger, storage, storage, options.limits, newMockClientsPool(cfg, options.logger, options.registerer, options.rulerAddrMap))
+	ruler, err := newRuler(cfg, manager, options.registerer, options.logger, storage, options.limits, newMockClientsPool(cfg, options.logger, options.registerer, options.rulerAddrMap))
 	require.NoError(t, err)
 
 	if options.rulerAddrAutoMap {
@@ -1571,7 +1571,7 @@ func verifyExpectedDeletedRuleGroupsForUser(t *testing.T, r *Ruler, userID strin
 	ctx := context.Background()
 
 	t.Run("ListRuleGroupsForUserAndNamespace()", func(t *testing.T) {
-		list, err := r.directStore.ListRuleGroupsForUserAndNamespace(ctx, userID, "")
+		list, err := r.store.ListRuleGroupsForUserAndNamespace(ctx, userID, "")
 		require.NoError(t, err)
 
 		if expectedDeleted {

--- a/pkg/ruler/rulestore/bucketclient/bucket_client_test.go
+++ b/pkg/ruler/rulestore/bucketclient/bucket_client_test.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/cache"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/stretchr/testify/assert"
@@ -24,6 +26,7 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/ruler/rulespb"
 	"github.com/grafana/mimir/pkg/ruler/rulestore"
+	"github.com/grafana/mimir/pkg/storage/tsdb/bucketcache"
 )
 
 type testGroup struct {
@@ -442,4 +445,154 @@ func (mb mockBucket) Iter(_ context.Context, _ string, f func(string) error, _ .
 		}
 	}
 	return nil
+}
+
+func TestCachingAndInvalidation(t *testing.T) {
+	fixtureGroups := []testGroup{
+		{user: "user1", namespace: "hello", ruleGroup: rulefmt.RuleGroup{Name: "first testGroup"}},
+		{user: "user1", namespace: "hello", ruleGroup: rulefmt.RuleGroup{Name: "second testGroup"}},
+		{user: "user1", namespace: "world", ruleGroup: rulefmt.RuleGroup{Name: "another namespace testGroup"}},
+		{user: "user2", namespace: "+-!@#$%. ", ruleGroup: rulefmt.RuleGroup{Name: "different user"}},
+	}
+
+	setup := func(t *testing.T) (*cache.InstrumentedMockCache, *BucketRuleStore) {
+		iterCodec := &bucketcache.JSONIterCodec{}
+		baseClient := objstore.NewInMemBucket()
+		mockCache := cache.NewInstrumentedMockCache()
+
+		cacheCfg := bucketcache.NewCachingBucketConfig()
+		cacheCfg.CacheIter("rule-iter", mockCache, matchAll, time.Minute, iterCodec)
+		cacheCfg.CacheGet("rule-groups", mockCache, matchAll, 1024^2, time.Minute, time.Minute, time.Minute, true)
+		cacheClient, err := bucketcache.NewCachingBucket("rule-store", baseClient, cacheCfg, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+		require.NoError(t, err)
+
+		ruleStore := NewBucketRuleStore(cacheClient, nil, log.NewNopLogger())
+
+		for _, g := range fixtureGroups {
+			desc := rulespb.ToProto(g.user, g.namespace, g.ruleGroup)
+			require.NoError(t, ruleStore.SetRuleGroup(context.Background(), g.user, g.namespace, desc))
+		}
+
+		return mockCache, ruleStore
+	}
+
+	t.Run("list users with cache", func(t *testing.T) {
+		mockCache, ruleStore := setup(t)
+		users, err := ruleStore.ListAllUsers(context.Background())
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"user1", "user2"}, users)
+
+		require.Equal(t, 1, mockCache.CountStoreCalls())
+		require.Equal(t, 1, mockCache.CountFetchCalls())
+	})
+
+	t.Run("list users no cache", func(t *testing.T) {
+		mockCache, rs := setup(t)
+		users, err := rs.ListAllUsers(context.Background(), rulestore.WithCacheDisabled())
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"user1", "user2"}, users)
+
+		require.Equal(t, 1, mockCache.CountStoreCalls())
+		require.Equal(t, 0, mockCache.CountFetchCalls())
+	})
+
+	t.Run("list rule groups with cache", func(t *testing.T) {
+		mockCache, ruleStore := setup(t)
+		groups, err := ruleStore.ListRuleGroupsForUserAndNamespace(context.Background(), "user1", "")
+
+		require.NoError(t, err)
+		require.Equal(t, rulespb.RuleGroupList{
+			{
+				Name:      "first testGroup",
+				User:      "user1",
+				Namespace: "hello",
+			},
+			{
+				Name:      "second testGroup",
+				User:      "user1",
+				Namespace: "hello",
+			},
+			{
+				Name:      "another namespace testGroup",
+				User:      "user1",
+				Namespace: "world",
+			},
+		}, groups)
+
+		require.Equal(t, 1, mockCache.CountStoreCalls())
+		require.Equal(t, 1, mockCache.CountFetchCalls())
+	})
+
+	t.Run("list rule groups no cache", func(t *testing.T) {
+		mockCache, ruleStore := setup(t)
+		groups, err := ruleStore.ListRuleGroupsForUserAndNamespace(context.Background(), "user1", "", rulestore.WithCacheDisabled())
+
+		require.NoError(t, err)
+		require.Equal(t, rulespb.RuleGroupList{
+			{
+				Name:      "first testGroup",
+				User:      "user1",
+				Namespace: "hello",
+			},
+			{
+				Name:      "second testGroup",
+				User:      "user1",
+				Namespace: "hello",
+			},
+			{
+				Name:      "another namespace testGroup",
+				User:      "user1",
+				Namespace: "world",
+			},
+		}, groups)
+
+		require.Equal(t, 1, mockCache.CountStoreCalls())
+		require.Equal(t, 0, mockCache.CountFetchCalls())
+	})
+
+	t.Run("get rule group from cache", func(t *testing.T) {
+		mockCache, ruleStore := setup(t)
+		group, err := ruleStore.GetRuleGroup(context.Background(), "user1", "world", "another namespace testGroup")
+
+		require.NoError(t, err)
+		require.NotNil(t, group)
+
+		require.Equal(t, 2, mockCache.CountStoreCalls())
+		require.Equal(t, 1, mockCache.CountFetchCalls())
+	})
+
+	t.Run("get rule groups after invalidation", func(t *testing.T) {
+		mockCache, ruleStore := setup(t)
+		group, err := ruleStore.GetRuleGroup(context.Background(), "user1", "world", "another namespace testGroup")
+
+		require.NoError(t, err)
+		require.NotNil(t, group)
+		require.Zero(t, group.QueryOffset)
+
+		require.Equal(t, 2, mockCache.CountStoreCalls())
+		require.Equal(t, 1, mockCache.CountFetchCalls())
+
+		origDeletes := mockCache.CountDeleteCalls()
+		group.QueryOffset = 42 * time.Second
+		require.NoError(t, ruleStore.SetRuleGroup(context.Background(), group.User, group.Namespace, group))
+
+		require.Equal(t, 2, mockCache.CountStoreCalls())
+		require.Equal(t, 1, mockCache.CountFetchCalls())
+		require.Equal(t, 2, mockCache.CountDeleteCalls()-origDeletes)
+
+		modifiedGroup, err := ruleStore.GetRuleGroup(context.Background(), "user1", "world", "another namespace testGroup")
+		require.NoError(t, err)
+		require.NotNil(t, modifiedGroup)
+		require.Equal(t, 42*time.Second, modifiedGroup.QueryOffset)
+
+		require.Equal(t, 4, mockCache.CountStoreCalls())
+		require.Equal(t, 2, mockCache.CountFetchCalls())
+		require.Equal(t, 2, mockCache.CountDeleteCalls()-origDeletes)
+	})
+}
+
+func matchAll(string) bool {
+	return true
 }

--- a/pkg/ruler/rulestore/local/local.go
+++ b/pkg/ruler/rulestore/local/local.go
@@ -37,7 +37,7 @@ func NewLocalRulesClient(cfg rulestore.LocalStoreConfig, loader promRules.GroupL
 	}, nil
 }
 
-func (l *Client) ListAllUsers(_ context.Context) ([]string, error) {
+func (l *Client) ListAllUsers(_ context.Context, _ ...rulestore.Option) ([]string, error) {
 	root := l.cfg.Directory
 	infos, err := os.ReadDir(root)
 	if err != nil {
@@ -69,7 +69,7 @@ func (l *Client) ListAllUsers(_ context.Context) ([]string, error) {
 }
 
 // ListRuleGroupsForUserAndNamespace implements rules.RuleStore. This method also loads the rules.
-func (l *Client) ListRuleGroupsForUserAndNamespace(ctx context.Context, userID string, namespace string) (rulespb.RuleGroupList, error) {
+func (l *Client) ListRuleGroupsForUserAndNamespace(ctx context.Context, userID string, namespace string, _ ...rulestore.Option) (rulespb.RuleGroupList, error) {
 	if namespace == "" {
 		return l.loadAllRulesGroupsForUser(ctx, userID)
 	}

--- a/pkg/ruler/store_mock_test.go
+++ b/pkg/ruler/store_mock_test.go
@@ -10,10 +10,19 @@ import (
 	"encoding/base64"
 	"fmt"
 	"sync"
+	"testing"
 	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/cache"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/mimir/pkg/ruler/rulespb"
 	"github.com/grafana/mimir/pkg/ruler/rulestore"
+	"github.com/grafana/mimir/pkg/ruler/rulestore/bucketclient"
+	"github.com/grafana/mimir/pkg/storage/tsdb/bucketcache"
 )
 
 var (
@@ -41,6 +50,19 @@ var (
 	}
 )
 
+func newInMemoryRuleStore(t *testing.T) (*cache.InstrumentedMockCache, *bucketclient.BucketRuleStore) {
+	bkt := objstore.NewInMemBucket()
+	mockCache := cache.NewInstrumentedMockCache()
+	cfg := bucketcache.NewCachingBucketConfig()
+	cfg.CacheIter("iter", mockCache, isNotTenantsDir, time.Minute, &bucketcache.JSONIterCodec{})
+	cfg.CacheGet("rules", mockCache, isRuleGroup, 1024^2, time.Minute, time.Minute, time.Minute, true)
+
+	cachingBkt, err := bucketcache.NewCachingBucket("rules", bkt, cfg, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+	require.NoError(t, err)
+
+	return mockCache, bucketclient.NewBucketRuleStore(cachingBkt, nil, log.NewNopLogger())
+}
+
 type mockRuleStore struct {
 	rules        map[string]rulespb.RuleGroupList
 	missingRules rulespb.RuleGroupList
@@ -61,7 +83,7 @@ func (m *mockRuleStore) setMissingRuleGroups(missing rulespb.RuleGroupList) {
 	m.mtx.Unlock()
 }
 
-func (m *mockRuleStore) ListAllUsers(_ context.Context) ([]string, error) {
+func (m *mockRuleStore) ListAllUsers(_ context.Context, _ ...rulestore.Option) ([]string, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -72,7 +94,7 @@ func (m *mockRuleStore) ListAllUsers(_ context.Context) ([]string, error) {
 	return result, nil
 }
 
-func (m *mockRuleStore) ListRuleGroupsForUserAndNamespace(_ context.Context, userID, namespace string) (rulespb.RuleGroupList, error) {
+func (m *mockRuleStore) ListRuleGroupsForUserAndNamespace(_ context.Context, userID, namespace string, _ ...rulestore.Option) (rulespb.RuleGroupList, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 


### PR DESCRIPTION
#### What this PR does

Instead of using two different `RuleStore` implementations within the Ruler, use a single caching implementation and selectively disable caching when required.

This change removes the "direct" `RuleStore` implementation from the Ruler's gRPC and HTTP API layers. Instead, the caching implementation is used for all calls. In cases where caching returning stale results would not be acceptable, the caching is disabled _just_ for that call.

This allows rule group contents to be safety cached with the understanding that it is safe to cache them because they will correctly invalidated when deleted or modified.

#### Which issue(s) this PR fixes or relates to

Part of #9386

#### Notes to reviewers

I had a bit of trouble getting my head around this change. I've found the following to be a good way of thinking about it:

* We allow `Bucket.Iter()` calls to be cached already but use a non-caching bucket in some places where that's not acceptable.
* This change removes the non-caching bucket and selectively disables caching where stale `Bucket.Iter()` results are not acceptable. The point of using a single bucket is to allow caches to be invalidated on mutations (uploads, deletes).
* This allows us to add caching to rule group contents in the future but does not configure caching for them yet.
* When we add caching to rule group contents, it will be unconditional because cached rule group contents can be easily invalidated when the rule group is deleted or modified. Invalidating `Bucket.Iter()` calls is not so easy which is why this change adds the ability to disable caching of them.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
