### PR TITLE
Chore: Extract CustomTrackersConfig from the activeseries package

### DIFF
--- a/pkg/ingester/activeseries/active_labels_test.go
+++ b/pkg/ingester/activeseries/active_labels_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/require"
+
+	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 )
 
 type mockPostingsReader struct {
@@ -39,7 +41,7 @@ func TestIsLabelValueActive(t *testing.T) {
 		labels.FromStrings("a", "5"),
 	}
 	allStorageRefs := []storage.SeriesRef{1, 2, 3, 4, 5}
-	activeSeries := NewActiveSeries(&Matchers{}, time.Duration(ttl))
+	activeSeries := NewActiveSeries(&asmodel.Matchers{}, time.Duration(ttl))
 
 	memPostings := index.NewMemPostings()
 	for i, l := range series {

--- a/pkg/ingester/activeseries/active_native_histogram_postings_test.go
+++ b/pkg/ingester/activeseries/active_native_histogram_postings_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/require"
+
+	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 )
 
 func TestNativeHistogramPostings_Expand(t *testing.T) {
@@ -24,7 +26,7 @@ func TestNativeHistogramPostings_Expand(t *testing.T) {
 	}
 	allStorageRefs := []storage.SeriesRef{1, 2, 3, 4, 5}
 	storagePostings := index.NewListPostings(allStorageRefs)
-	activeSeries := NewActiveSeries(&Matchers{}, time.Duration(ttl))
+	activeSeries := NewActiveSeries(&asmodel.Matchers{}, time.Duration(ttl))
 
 	// Update each series at a different time according to its index.
 	for i := range allStorageRefs {
@@ -60,7 +62,7 @@ func TestNativeHistogramPostings_ExpandWithBucketCount(t *testing.T) {
 	}
 	allStorageRefs := []storage.SeriesRef{1, 2, 3, 4, 5}
 	storagePostings := index.NewListPostings(allStorageRefs)
-	activeSeries := NewActiveSeries(&Matchers{}, time.Duration(ttl))
+	activeSeries := NewActiveSeries(&asmodel.Matchers{}, time.Duration(ttl))
 
 	// Update each series at a different time according to its index.
 	for i := range allStorageRefs {
@@ -104,8 +106,7 @@ func TestNativeHistogramPostings_SeekSkipsNonNative(t *testing.T) {
 	}
 	allStorageRefs := []storage.SeriesRef{1, 2, 3, 4, 5}
 	storagePostings := index.NewListPostings(allStorageRefs)
-	activeSeries := NewActiveSeries(&Matchers{}, time.Duration(ttl))
-
+	activeSeries := NewActiveSeries(&asmodel.Matchers{}, time.Duration(ttl))
 	// Update each series at a different time according to its index.
 	for i := range allStorageRefs {
 		buckets := i * 10
@@ -144,8 +145,7 @@ func TestNativeHistogramPostings_Seek(t *testing.T) {
 	}
 	allStorageRefs := []storage.SeriesRef{1, 2, 3, 4, 5}
 	storagePostings := index.NewListPostings(allStorageRefs)
-	activeSeries := NewActiveSeries(&Matchers{}, time.Duration(ttl))
-
+	activeSeries := NewActiveSeries(&asmodel.Matchers{}, time.Duration(ttl))
 	// Update each series at a different time according to its index.
 	for i := range allStorageRefs {
 		buckets := i * 10
@@ -181,7 +181,7 @@ func TestNativeHistogramPostings_SeekToEnd(t *testing.T) {
 	}
 	allStorageRefs := []storage.SeriesRef{1, 2, 3, 4, 5}
 	storagePostings := index.NewListPostings(allStorageRefs)
-	activeSeries := NewActiveSeries(&Matchers{}, time.Duration(ttl))
+	activeSeries := NewActiveSeries(&asmodel.Matchers{}, time.Duration(ttl))
 
 	// Update each series at a different time according to its index.
 	for i := range allStorageRefs {

--- a/pkg/ingester/activeseries/active_postings_test.go
+++ b/pkg/ingester/activeseries/active_postings_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/require"
+
+	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 )
 
 func TestPostings_Expand(t *testing.T) {
@@ -24,8 +26,7 @@ func TestPostings_Expand(t *testing.T) {
 	}
 	allStorageRefs := []storage.SeriesRef{1, 2, 3, 4, 5}
 	storagePostings := index.NewListPostings(allStorageRefs)
-	activeSeries := NewActiveSeries(&Matchers{}, time.Duration(ttl))
-
+	activeSeries := NewActiveSeries(&asmodel.Matchers{}, time.Duration(ttl))
 	// Update each series at a different time according to its index.
 	for i := range allStorageRefs {
 		activeSeries.UpdateSeries(series[i], allStorageRefs[i], time.Unix(int64(i), 0), -1)
@@ -56,8 +57,7 @@ func TestPostings_Seek(t *testing.T) {
 	}
 	allStorageRefs := []storage.SeriesRef{1, 2, 3, 4, 5}
 	storagePostings := index.NewListPostings(allStorageRefs)
-	activeSeries := NewActiveSeries(&Matchers{}, time.Duration(ttl))
-
+	activeSeries := NewActiveSeries(&asmodel.Matchers{}, time.Duration(ttl))
 	// Update each series at a different time according to its index.
 	for i := range allStorageRefs {
 		activeSeries.UpdateSeries(series[i], allStorageRefs[i], time.Unix(int64(i), 0), -1)
@@ -88,8 +88,7 @@ func TestPostings_SeekToEnd(t *testing.T) {
 	}
 	allStorageRefs := []storage.SeriesRef{1, 2, 3, 4, 5}
 	storagePostings := index.NewListPostings(allStorageRefs)
-	activeSeries := NewActiveSeries(&Matchers{}, time.Duration(ttl))
-
+	activeSeries := NewActiveSeries(&asmodel.Matchers{}, time.Duration(ttl))
 	// Update each series at a different time according to its index.
 	for i := range allStorageRefs {
 		activeSeries.UpdateSeries(series[i], allStorageRefs[i], time.Unix(int64(i), 0), -1)

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -16,6 +16,8 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/util/zeropool"
 	"go.uber.org/atomic"
+
+	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 )
 
 const (
@@ -44,7 +46,7 @@ type ActiveSeries struct {
 
 	// matchersMutex protects matchers and lastMatchersUpdate.
 	matchersMutex      sync.RWMutex
-	matchers           *Matchers
+	matchers           *asmodel.Matchers
 	lastMatchersUpdate time.Time
 
 	// The duration after which series become inactive.
@@ -54,7 +56,7 @@ type ActiveSeries struct {
 
 // seriesStripe holds a subset of the series timestamps for a single tenant.
 type seriesStripe struct {
-	matchers *Matchers
+	matchers *asmodel.Matchers
 
 	deleted *deletedSeries
 
@@ -75,14 +77,14 @@ type seriesStripe struct {
 
 // seriesEntry holds a timestamp for single series.
 type seriesEntry struct {
-	nanos                     *atomic.Int64        // Unix timestamp in nanoseconds. Needs to be a pointer because we don't store pointers to entries in the stripe.
-	matches                   preAllocDynamicSlice //  Index of the matcher matching
-	numNativeHistogramBuckets int                  // Number of buckets in native histogram series, -1 if not a native histogram.
+	nanos                     *atomic.Int64                // Unix timestamp in nanoseconds. Needs to be a pointer because we don't store pointers to entries in the stripe.
+	matches                   asmodel.PreAllocDynamicSlice //  Index of the matcher matching
+	numNativeHistogramBuckets int                          // Number of buckets in native histogram series, -1 if not a native histogram.
 
 	deleted bool // This series was marked as deleted, so before purging we need to remove the refence to it from the deletedSeries.
 }
 
-func NewActiveSeries(asm *Matchers, timeout time.Duration) *ActiveSeries {
+func NewActiveSeries(asm *asmodel.Matchers, timeout time.Duration) *ActiveSeries {
 	c := &ActiveSeries{matchers: asm, timeout: timeout}
 
 	// Stripes are pre-allocated so that we only read on them and no lock is required.
@@ -99,7 +101,7 @@ func (c *ActiveSeries) CurrentMatcherNames() []string {
 	return c.matchers.MatcherNames()
 }
 
-func (c *ActiveSeries) ReloadMatchers(asm *Matchers, now time.Time) {
+func (c *ActiveSeries) ReloadMatchers(asm *asmodel.Matchers, now time.Time) {
 	c.matchersMutex.Lock()
 	defer c.matchersMutex.Unlock()
 
@@ -110,7 +112,7 @@ func (c *ActiveSeries) ReloadMatchers(asm *Matchers, now time.Time) {
 	c.lastMatchersUpdate = now
 }
 
-func (c *ActiveSeries) CurrentConfig() CustomTrackersConfig {
+func (c *ActiveSeries) CurrentConfig() asmodel.CustomTrackersConfig {
 	c.matchersMutex.RLock()
 	defer c.matchersMutex.RUnlock()
 	return c.matchers.Config()
@@ -335,21 +337,21 @@ func (s *seriesStripe) findAndUpdateOrCreateEntryForSeries(ref storage.SeriesRef
 	entry, ok := s.refs[ref]
 	if ok {
 		if entry.numNativeHistogramBuckets != numNativeHistogramBuckets {
-			matches := s.matchers.matches(series)
-			matchesLen := matches.len()
+			matches := s.matchers.Matches(series)
+			matchesLen := matches.Len()
 			if numNativeHistogramBuckets >= 0 && entry.numNativeHistogramBuckets >= 0 {
 				// change number of buckets but still a histogram
 				diff := numNativeHistogramBuckets - entry.numNativeHistogramBuckets
 				s.activeNativeHistogramBuckets = uint32(int(s.activeNativeHistogramBuckets) + diff)
 				for i := 0; i < matchesLen; i++ {
-					s.activeMatchingNativeHistogramBuckets[matches.get(i)] = uint32(int(s.activeMatchingNativeHistogramBuckets[matches.get(i)]) + diff)
+					s.activeMatchingNativeHistogramBuckets[matches.Get(i)] = uint32(int(s.activeMatchingNativeHistogramBuckets[matches.Get(i)]) + diff)
 				}
 			} else if numNativeHistogramBuckets >= 0 {
 				// change from float to histogram
 				s.activeNativeHistograms++
 				s.activeNativeHistogramBuckets += uint32(numNativeHistogramBuckets)
 				for i := 0; i < matchesLen; i++ {
-					match := matches.get(i)
+					match := matches.Get(i)
 					s.activeMatchingNativeHistograms[match]++
 					s.activeMatchingNativeHistogramBuckets[match] += uint32(numNativeHistogramBuckets)
 				}
@@ -358,7 +360,7 @@ func (s *seriesStripe) findAndUpdateOrCreateEntryForSeries(ref storage.SeriesRef
 				s.activeNativeHistograms--
 				s.activeNativeHistogramBuckets -= uint32(entry.numNativeHistogramBuckets)
 				for i := 0; i < matchesLen; i++ {
-					match := matches.get(i)
+					match := matches.Get(i)
 					s.activeMatchingNativeHistograms[match]--
 					s.activeMatchingNativeHistogramBuckets[match] -= uint32(entry.numNativeHistogramBuckets)
 				}
@@ -369,8 +371,8 @@ func (s *seriesStripe) findAndUpdateOrCreateEntryForSeries(ref storage.SeriesRef
 		return entry.nanos, false
 	}
 
-	matches := s.matchers.matches(series)
-	matchesLen := matches.len()
+	matches := s.matchers.Matches(series)
+	matchesLen := matches.Len()
 
 	s.active++
 	if numNativeHistogramBuckets >= 0 {
@@ -378,7 +380,7 @@ func (s *seriesStripe) findAndUpdateOrCreateEntryForSeries(ref storage.SeriesRef
 		s.activeNativeHistogramBuckets += uint32(numNativeHistogramBuckets)
 	}
 	for i := 0; i < matchesLen; i++ {
-		match := matches.get(i)
+		match := matches.Get(i)
 		s.activeMatching[match]++
 		if numNativeHistogramBuckets >= 0 {
 			s.activeMatchingNativeHistograms[match]++
@@ -413,7 +415,7 @@ func (s *seriesStripe) clear() {
 }
 
 // Reinitialize assigns new matchers and corresponding size activeMatching slices.
-func (s *seriesStripe) reinitialize(asm *Matchers, deleted *deletedSeries) {
+func (s *seriesStripe) reinitialize(asm *asmodel.Matchers, deleted *deletedSeries) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -462,9 +464,9 @@ func (s *seriesStripe) purge(keepUntil time.Time) {
 			s.activeNativeHistograms++
 			s.activeNativeHistogramBuckets += uint32(entry.numNativeHistogramBuckets)
 		}
-		ml := entry.matches.len()
+		ml := entry.matches.Len()
 		for i := 0; i < ml; i++ {
-			match := entry.matches.get(i)
+			match := entry.matches.Get(i)
 			s.activeMatching[match]++
 			if entry.numNativeHistogramBuckets >= 0 {
 				s.activeMatchingNativeHistograms[match]++
@@ -504,9 +506,9 @@ func (s *seriesStripe) remove(ref storage.SeriesRef) {
 		s.activeNativeHistograms--
 		s.activeNativeHistogramBuckets -= uint32(entry.numNativeHistogramBuckets)
 	}
-	ml := entry.matches.len()
+	ml := entry.matches.Len()
 	for i := 0; i < ml; i++ {
-		match := entry.matches.get(i)
+		match := entry.matches.Get(i)
 		s.activeMatching[match]--
 		if entry.numNativeHistogramBuckets >= 0 {
 			s.activeMatchingNativeHistograms[match]--

--- a/pkg/ingester/activeseries/model/custom_trackers_config.go
+++ b/pkg/ingester/activeseries/model/custom_trackers_config.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package activeseries
+package activeseriesmodel
 
 import (
 	"fmt"

--- a/pkg/ingester/activeseries/model/custom_trackers_config_test.go
+++ b/pkg/ingester/activeseries/model/custom_trackers_config_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package activeseries
+package activeseriesmodel
 
 import (
 	"bytes"

--- a/pkg/ingester/activeseries/model/matchers.go
+++ b/pkg/ingester/activeseries/model/matchers.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package activeseries
+package activeseriesmodel
 
 import (
 	"sort"
@@ -35,15 +35,15 @@ func (m *Matchers) Config() CustomTrackersConfig {
 	return m.cfg
 }
 
-// matches returns a PreAllocDynamicSlice containing only matcher indexes which are matching
-func (m *Matchers) matches(series labels.Labels) preAllocDynamicSlice {
+// Matches returns a PreAllocDynamicSlice containing only matcher indexes which are matching
+func (m *Matchers) Matches(series labels.Labels) PreAllocDynamicSlice {
 	if len(m.matchers) == 0 {
-		return preAllocDynamicSlice{}
+		return PreAllocDynamicSlice{}
 	}
-	var matches preAllocDynamicSlice
+	var matches PreAllocDynamicSlice
 	for i, sm := range m.matchers {
 		if sm.Matches(series) {
-			matches.append(i)
+			matches.Append(i)
 		}
 	}
 	return matches
@@ -83,17 +83,17 @@ func amlabelMatcherToProm(m *amlabels.Matcher) *labels.Matcher {
 
 const preAllocatedSize = 3
 
-// preAllocDynamicSlice is a slice-like uint16 data structure that allocates space for the first `preAllocatedSize` elements.
+// PreAllocDynamicSlice is a slice-like uint16 data structure that allocates space for the first `preAllocatedSize` elements.
 // When more than `preAllocatedSize` elements are appended, it allocates a slice that escapes to heap.
 // This trades in extra allocated space (2x more with `preAllocatedSize=3`) for zero-allocations in most of the cases,
 // relying on the assumption that most of the matchers will not match more than `preAllocatedSize` trackers.
-type preAllocDynamicSlice struct {
+type PreAllocDynamicSlice struct {
 	arr  [preAllocatedSize]uint16
 	arrl byte
 	rest []uint16
 }
 
-func (fs *preAllocDynamicSlice) append(val int) {
+func (fs *PreAllocDynamicSlice) Append(val int) {
 	if fs.arrl < preAllocatedSize {
 		fs.arr[fs.arrl] = uint16(val)
 		fs.arrl++
@@ -102,13 +102,13 @@ func (fs *preAllocDynamicSlice) append(val int) {
 	fs.rest = append(fs.rest, uint16(val))
 }
 
-func (fs *preAllocDynamicSlice) get(idx int) uint16 {
+func (fs *PreAllocDynamicSlice) Get(idx int) uint16 {
 	if idx < preAllocatedSize {
 		return fs.arr[idx]
 	}
 	return fs.rest[idx-preAllocatedSize]
 }
 
-func (fs *preAllocDynamicSlice) len() int {
+func (fs *PreAllocDynamicSlice) Len() int {
 	return int(fs.arrl) + len(fs.rest)
 }

--- a/pkg/ingester/activeseries/model/matchers_test.go
+++ b/pkg/ingester/activeseries/model/matchers_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package activeseries
+package activeseriesmodel
 
 import (
 	"fmt"
@@ -66,16 +66,16 @@ func TestMatcher_MatchesSeries(t *testing.T) {
 		},
 	} {
 		t.Run(tc.series.String(), func(t *testing.T) {
-			got := asm.matches(tc.series)
+			got := asm.Matches(tc.series)
 			assert.Equal(t, tc.expected, preAllocDynamicSliceToSlice(got))
 		})
 	}
 }
 
-func preAllocDynamicSliceToSlice(prealloc preAllocDynamicSlice) []int {
-	slice := make([]int, prealloc.len())
-	for i := 0; i < prealloc.len(); i++ {
-		slice[i] = int(prealloc.get(i))
+func preAllocDynamicSliceToSlice(prealloc PreAllocDynamicSlice) []int {
+	slice := make([]int, prealloc.Len())
+	for i := 0; i < prealloc.Len(); i++ {
+		slice[i] = int(prealloc.Get(i))
 	}
 	return slice
 }
@@ -128,8 +128,8 @@ func BenchmarkMatchesSeries(b *testing.B) {
 			series := makeLabels(bc.total, bc.matching)
 			b.Run(fmt.Sprintf("TrackerCount: %d, Labels: %d, Matching: %d", trackerCount, bc.total, bc.matching), func(b *testing.B) {
 				for x := 0; x < b.N; x++ {
-					got := asms[i].matches(series)
-					require.Equal(b, bc.matching, got.len())
+					got := asms[i].Matches(series)
+					require.Equal(b, bc.matching, got.Len())
 				}
 			})
 		}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -59,7 +59,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	"github.com/grafana/mimir/pkg/ingester/activeseries"
+	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/storage/chunk"
@@ -74,8 +74,8 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
-func mustNewActiveSeriesCustomTrackersConfigFromMap(t *testing.T, source map[string]string) activeseries.CustomTrackersConfig {
-	m, err := activeseries.NewCustomTrackersConfig(source)
+func mustNewActiveSeriesCustomTrackersConfigFromMap(t *testing.T, source map[string]string) asmodel.CustomTrackersConfig {
+	m, err := asmodel.NewCustomTrackersConfig(source)
 	require.NoError(t, err)
 	return m
 }
@@ -9297,7 +9297,7 @@ func TestIngesterActiveSeriesConfigChanges(t *testing.T) {
 		test               func(t *testing.T, ingester *Ingester, gatherer prometheus.Gatherer)
 		reqs               []*mimirpb.WriteRequest
 		expectedMetrics    string
-		activeSeriesConfig activeseries.CustomTrackersConfig
+		activeSeriesConfig asmodel.CustomTrackersConfig
 		tenantLimits       *TenantLimitsMock
 	}{
 		"override flag based config with runtime overwrite": {

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/grafana/dskit/flagext"
 
-	"github.com/grafana/mimir/pkg/ingester/activeseries"
+	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 	"github.com/grafana/mimir/pkg/util/configdoc"
 )
 
@@ -169,7 +169,7 @@ func parseStructure(structure interface{}, fields map[uintptr]reflect.StructFiel
 // then gets confused.
 var ignoredStructTypes = []reflect.Type{
 	reflect.TypeOf(flagext.Secret{}),
-	reflect.TypeOf(activeseries.CustomTrackersConfig{}),
+	reflect.TypeOf(asmodel.CustomTrackersConfig{}),
 }
 
 func ignoreStructType(fieldType reflect.Type) bool {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/time/rate"
 	"gopkg.in/yaml.v3"
 
-	"github.com/grafana/mimir/pkg/ingester/activeseries"
+	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/util"
@@ -135,7 +135,7 @@ type Limits struct {
 	// Native histograms
 	NativeHistogramsIngestionEnabled bool `yaml:"native_histograms_ingestion_enabled" json:"native_histograms_ingestion_enabled" category:"experimental"`
 	// Active series custom trackers
-	ActiveSeriesCustomTrackersConfig activeseries.CustomTrackersConfig `yaml:"active_series_custom_trackers" json:"active_series_custom_trackers" doc:"description=Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
+	ActiveSeriesCustomTrackersConfig asmodel.CustomTrackersConfig `yaml:"active_series_custom_trackers" json:"active_series_custom_trackers" doc:"description=Additional custom trackers for active metrics. If there are active series matching a provided matcher (map value), the count will be exposed in the custom trackers metric labeled using the tracker name (map key). Zero valued counts are not exposed (and removed when they go back to zero)." category:"advanced"`
 	// Max allowed time window for out-of-order samples.
 	OutOfOrderTimeWindow                 model.Duration `yaml:"out_of_order_time_window" json:"out_of_order_time_window" category:"experimental"`
 	OutOfOrderBlocksExternalLabelEnabled bool           `yaml:"out_of_order_blocks_external_label_enabled" json:"out_of_order_blocks_external_label_enabled" category:"experimental"`
@@ -748,7 +748,7 @@ func (o *Overrides) IgnoreOOOExemplars(userID string) bool {
 	return o.getOverridesForUser(userID).IgnoreOOOExemplars
 }
 
-func (o *Overrides) ActiveSeriesCustomTrackersConfig(userID string) activeseries.CustomTrackersConfig {
+func (o *Overrides) ActiveSeriesCustomTrackersConfig(userID string) asmodel.CustomTrackersConfig {
 	return o.getOverridesForUser(userID).ActiveSeriesCustomTrackersConfig
 }
 

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/time/rate"
 	"gopkg.in/yaml.v3"
 
-	"github.com/grafana/mimir/pkg/ingester/activeseries"
+	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 )
 
 func TestMain(m *testing.M) {
@@ -1025,7 +1025,7 @@ user1:
 }
 
 func TestCustomTrackerConfigDeserialize(t *testing.T) {
-	expectedConfig, err := activeseries.NewCustomTrackersConfig(map[string]string{"baz": `{foo="bar"}`})
+	expectedConfig, err := asmodel.NewCustomTrackersConfig(map[string]string{"baz": `{foo="bar"}`})
 	require.NoError(t, err, "creating expected config")
 	cfg := `
     user:

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -23,7 +23,7 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/thanos-io/objstore/providers/s3"
 
-	"github.com/grafana/mimir/pkg/ingester/activeseries"
+	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 	"github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/util/configdoc"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -365,7 +365,7 @@ func getFieldCustomType(t reflect.Type) (string, bool) {
 		return "relabel_config...", true
 	case reflect.TypeOf([]*validation.BlockedQuery{}).String():
 		return "blocked_queries_config...", true
-	case reflect.TypeOf(activeseries.CustomTrackersConfig{}).String():
+	case reflect.TypeOf(asmodel.CustomTrackersConfig{}).String():
 		return "map of tracker name (string) to matcher (string)", true
 	default:
 		return "", false
@@ -451,7 +451,7 @@ func getCustomFieldType(t reflect.Type) (string, bool) {
 		return "relabel_config...", true
 	case reflect.TypeOf([]*validation.BlockedQuery{}).String():
 		return "blocked_queries_config...", true
-	case reflect.TypeOf(activeseries.CustomTrackersConfig{}).String():
+	case reflect.TypeOf(asmodel.CustomTrackersConfig{}).String():
 		return "map of tracker name (string) to matcher (string)", true
 	default:
 		return "", false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This pull request seeks to extract the CustomTrackersConfig struct from the activeseries package. The reason for this is that pkg/util/validation depends on github.com/grafana/mimir/pkg/ingester/activeseries. If we introduce any services invoked by activeseries, they won't be able to depend on validation.Overrides, since it would result in a circular import problem.

In this PR, I've introduced activeseriesmodel, which will be utilized by both activeseries and validation. The entire PR should be Noop

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- na Tests updated.
- na Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- na [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
