### PR TITLE
ingest storage: proper shutdown of partitionCommitter

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -131,7 +131,9 @@ func (r *PartitionReader) start(ctx context.Context) (returnErr error) {
 	if err != nil {
 		return errors.Wrap(err, "creating service manager")
 	}
-	err = services.StartManagerAndAwaitHealthy(ctx, r.dependencies)
+	// Use context.Background() because we want to stop all dependencies when the PartitionReader stops
+	// instead of stopping them when ctx is cancelled and while the PartitionReader is still running.
+	err = services.StartManagerAndAwaitHealthy(context.Background(), r.dependencies)
 	if err != nil {
 		return errors.Wrap(err, "starting service manager")
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This `partitionCommitter` would be shut down via the services manager as soon as the service context is cancelled. This means that they shut down in parallel with the `PartitionReader`. The race comes when the `partitionCommitter` has already shut down while the `PartitionReader` is still processing some records. Then when the `PartitionReader` tries to `enqueueCommit`, that sets the atomic, but does not send this to Kafka.

As a result we may not always persist the latest commit to Kafka on shutdown.


#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/8697

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
