### PR TITLE
Alertmanager: Fix custom Grafana templates not defined

### DIFF
--- a/pkg/alertmanager/alertmanager_template.go
+++ b/pkg/alertmanager/alertmanager_template.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	tmpltext "text/template"
 
-	alertingTemplates "github.com/grafana/alerting/templates"
 	"github.com/prometheus/alertmanager/asset"
 	"github.com/prometheus/alertmanager/template"
 )
@@ -96,7 +95,7 @@ func WithCustomFunctions(userID string) template.Option {
 
 // loadTemplates produces a template.Template from several in-memory template files.
 // It is adapted from FromGlobs in prometheus/alertmanager: https://github.com/prometheus/alertmanager/blob/9de8ef36755298a68b6ab20244d4369d38bdea99/template/template.go#L67-L95
-func loadTemplates(tmpls []alertingTemplates.TemplateDefinition, options ...template.Option) (*template.Template, error) {
+func loadTemplates(tmpls []string, options ...template.Option) (*template.Template, error) {
 	t, err := template.New(options...)
 	if err != nil {
 		return nil, err
@@ -119,7 +118,7 @@ func loadTemplates(tmpls []alertingTemplates.TemplateDefinition, options ...temp
 	}
 
 	for _, tp := range tmpls {
-		if err := t.Parse(strings.NewReader(tp.Template)); err != nil {
+		if err := t.Parse(strings.NewReader(tp)); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/alertmanager/alertmanager_template.go
+++ b/pkg/alertmanager/alertmanager_template.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	tmplhtml "html/template"
-	"io"
 	"net/url"
 	"path"
+	"strings"
 	tmpltext "text/template"
 
+	alertingTemplates "github.com/grafana/alerting/templates"
 	"github.com/prometheus/alertmanager/asset"
 	"github.com/prometheus/alertmanager/template"
 )
@@ -95,7 +96,7 @@ func WithCustomFunctions(userID string) template.Option {
 
 // loadTemplates produces a template.Template from several in-memory template files.
 // It is adapted from FromGlobs in prometheus/alertmanager: https://github.com/prometheus/alertmanager/blob/9de8ef36755298a68b6ab20244d4369d38bdea99/template/template.go#L67-L95
-func loadTemplates(tmpls []io.Reader, options ...template.Option) (*template.Template, error) {
+func loadTemplates(tmpls []alertingTemplates.TemplateDefinition, options ...template.Option) (*template.Template, error) {
 	t, err := template.New(options...)
 	if err != nil {
 		return nil, err
@@ -118,7 +119,7 @@ func loadTemplates(tmpls []io.Reader, options ...template.Option) (*template.Tem
 	}
 
 	for _, tp := range tmpls {
-		if err := t.Parse(tp); err != nil {
+		if err := t.Parse(strings.NewReader(tp.Template)); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/alertmanager/alertmanager_template_test.go
+++ b/pkg/alertmanager/alertmanager_template_test.go
@@ -4,11 +4,10 @@ package alertmanager
 
 import (
 	"fmt"
-	"io"
 	"net/url"
-	"strings"
 	"testing"
 
+	alertingTemplates "github.com/grafana/alerting/templates"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
@@ -140,9 +139,11 @@ func Test_loadTemplates(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			readers := make([]io.Reader, 0, len(c.loaded))
+			readers := make([]alertingTemplates.TemplateDefinition, 0, len(c.loaded))
 			for _, tmpl := range c.loaded {
-				readers = append(readers, strings.NewReader(tmpl))
+				readers = append(readers, alertingTemplates.TemplateDefinition{
+					Template: tmpl,
+				})
 			}
 			tmpl, err := loadTemplates(readers, WithCustomFunctions("test"))
 			assert.NoError(t, err)

--- a/pkg/alertmanager/alertmanager_template_test.go
+++ b/pkg/alertmanager/alertmanager_template_test.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"testing"
 
-	alertingTemplates "github.com/grafana/alerting/templates"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
@@ -139,13 +138,7 @@ func Test_loadTemplates(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			readers := make([]alertingTemplates.TemplateDefinition, 0, len(c.loaded))
-			for _, tmpl := range c.loaded {
-				readers = append(readers, alertingTemplates.TemplateDefinition{
-					Template: tmpl,
-				})
-			}
-			tmpl, err := loadTemplates(readers, WithCustomFunctions("test"))
+			tmpl, err := loadTemplates(c.loaded, WithCustomFunctions("test"))
 			assert.NoError(t, err)
 
 			call := fmt.Sprintf(`{{ template "%s" . }}`, c.invoke)

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -644,8 +644,8 @@ func TestGrafanaAlertmanagerTemplates(t *testing.T) {
 	var got struct {
 		Message string `json:"message"`
 	}
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewDecoder(r.Body).Decode(&got)
+	s := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
 		defer func() {
 			require.NoError(t, r.Body.Close())
 		}()


### PR DESCRIPTION
As we're using `[]io.Reader` for templates, we can read them only once. This is a problem because we use different structs to execute templates for Mimir and Grafana integrations, and both need the same templates. When we create the Grafana template struct, the templates have already been read, resulting in "template not defined" errors when trying to send notifications with custom templates.

Since we stopped reading templates from disk, there's no advantage in using an `io.Reader` besides using the interface  
`github.com/prometheus/alertmanager/template` expects in `template.Parse()`.

This PR replaces `[]io.Reader` for templates in favor of `[]TemplateDefinition`, converting them into an `io.Reader` when calling `template.Parse()`.

Fixes https://github.com/grafana/alerting-squad/issues/929