### PR TITLE
copyblocks: add option to bypass duration check for no-compact blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
 
 ### Tools
 
+* [ENHANCEMENT] `copyblocks`: Added `--any-no-compact-block-duration`, which defaults to `false`, to simplify targeting blocks that are not awaiting compaction. #9439
+
 ## v2.14.0-rc.0
 
 ### Grafana Mimir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 
 ### Tools
 
-* [ENHANCEMENT] `copyblocks`: Added `--any-no-compact-block-duration`, which defaults to `false`, to simplify targeting blocks that are not awaiting compaction. #9439
+* [ENHANCEMENT] `copyblocks`: Added `--skip-no-compact-block-duration-check`, which defaults to `false`, to simplify targeting blocks that are not awaiting compaction. #9439
 
 ## v2.14.0-rc.0
 

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -11,7 +11,7 @@ The currently supported services are Amazon Simple Storage Service (S3 and S3-co
 - Prevents copying blocks multiple times to the same destination bucket by uploading block marker files to the source bucket
 - Runs continuously with periodic checks when supplied a time duration with `--copy-period`, otherwise runs one check then exits
 - Include or exclude users from having blocks copied (`--enabled-users` and `--disabled-users`)
-- Configurable minimum block duration (`--min-block-duration`) to avoid copying blocks that will be compacted
+- Configurable minimum block duration (`--min-block-duration`) and (`--any-no-compact-block-duration`) to target blocks that are not awaiting compaction
 - Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range
 - Log what would be copied without actually copying anything with `--dry-run`
 

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -11,7 +11,7 @@ The currently supported services are Amazon Simple Storage Service (S3 and S3-co
 - Prevents copying blocks multiple times to the same destination bucket by uploading block marker files to the source bucket
 - Runs continuously with periodic checks when supplied a time duration with `--copy-period`, otherwise runs one check then exits
 - Include or exclude users from having blocks copied (`--enabled-users` and `--disabled-users`)
-- Configurable minimum block duration (`--min-block-duration`) and (`--any-no-compact-block-duration`) to target blocks that are not awaiting compaction
+- Configurable minimum block duration (`--min-block-duration`) and (`--skip-no-compact-block-duration-check`) to target blocks that are not awaiting compaction
 - Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range
 - Log what would be copied without actually copying anything with `--dry-run`
 

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -35,18 +35,18 @@ import (
 )
 
 type config struct {
-	copyConfig                objtools.CopyBucketConfig
-	minBlockDuration          time.Duration
-	minTime                   flagext.Time
-	maxTime                   flagext.Time
-	tenantConcurrency         int
-	blockConcurrency          int
-	copyPeriod                time.Duration
-	enabledUsers              flagext.StringSliceCSV
-	disabledUsers             flagext.StringSliceCSV
-	dryRun                    bool
-	anyNoCompactBlockDuration bool
-	httpListen                string
+	copyConfig                      objtools.CopyBucketConfig
+	minBlockDuration                time.Duration
+	minTime                         flagext.Time
+	maxTime                         flagext.Time
+	tenantConcurrency               int
+	blockConcurrency                int
+	copyPeriod                      time.Duration
+	enabledUsers                    flagext.StringSliceCSV
+	disabledUsers                   flagext.StringSliceCSV
+	dryRun                          bool
+	skipNoCompactBlockDurationCheck bool
+	httpListen                      string
 }
 
 func (c *config) registerFlags(f *flag.FlagSet) {
@@ -60,7 +60,7 @@ func (c *config) registerFlags(f *flag.FlagSet) {
 	f.Var(&c.enabledUsers, "enabled-users", "If not empty, only blocks for these users are copied.")
 	f.Var(&c.disabledUsers, "disabled-users", "If not empty, blocks for these users are not copied.")
 	f.BoolVar(&c.dryRun, "dry-run", false, "Don't perform any copy; only log what would happen.")
-	f.BoolVar(&c.anyNoCompactBlockDuration, "any-no-compact-block-duration", false, "If set, blocks marked as no-compact are not checked against min-block-duration")
+	f.BoolVar(&c.skipNoCompactBlockDurationCheck, "skip-no-compact-block-duration-check", false, "If set, blocks marked as no-compact are not checked against min-block-duration")
 	f.StringVar(&c.httpListen, "http-listen-address", ":8080", "HTTP listen address.")
 }
 
@@ -271,7 +271,7 @@ func copyBlocks(ctx context.Context, cfg config, logger log.Logger, m *metrics) 
 				return nil
 			}
 
-			skipDurationCheck := cfg.anyNoCompactBlockDuration && markers[blockID].noCompact
+			skipDurationCheck := cfg.skipNoCompactBlockDurationCheck && markers[blockID].noCompact
 			if !skipDurationCheck && cfg.minBlockDuration > 0 {
 				blockDuration := time.Millisecond * time.Duration(blockMeta.MaxTime-blockMeta.MinTime)
 				if blockDuration < cfg.minBlockDuration {


### PR DESCRIPTION
#### What this PR does

Adds a flag to bypass the block duration check in `copyblocks` for blocks marked as no-compact.

It's a common pattern to use `min-block-duration` with the intent of targeting blocks that are fully compacted. This can miss blocks that are marked as `no-compact` that have a shorter duration. This flag makes it easier to not miss those blocks.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
