### PR TITLE
docs: deprecate redis-based caching

### DIFF
--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -144,7 +144,6 @@ The following features are currently experimental:
     - `-ingester.read-circuit-breaker.initial-delay`
     - `-ingester.read-circuit-breaker.request-timeout`
 - Querier
-  - Use of Redis cache backend (`-blocks-storage.bucket-store.metadata-cache.backend=redis`)
   - Limiting queries based on the estimated number of chunks that will be used (`-querier.max-estimated-fetched-chunks-per-query-multiplier`)
   - Max concurrency for tenant federated queries (`-tenant-federation.max-concurrent`)
   - Maximum response size for active series queries (`-querier.active-series-results-max-size-bytes`)
@@ -157,7 +156,6 @@ The following features are currently experimental:
   - `-query-frontend.querier-forget-delay`
   - Instant query splitting (`-query-frontend.split-instant-queries-by-interval`)
   - Lower TTL for cache entries overlapping the out-of-order samples ingestion window (re-using `-ingester.out-of-order-window` from ingesters)
-  - Use of Redis cache backend (`-query-frontend.results-cache.backend=redis`)
   - Query blocking on a per-tenant basis (configured with the limit `blocked_queries`)
   - Sharding of active series queries (`-query-frontend.shard-active-series-queries`)
   - Server-side write timeout for responses to active series requests (`-query-frontend.active-series-write-timeout`)
@@ -165,7 +163,6 @@ The following features are currently experimental:
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
 - Store-gateway
-  - Use of Redis cache backend (`-blocks-storage.bucket-store.chunks-cache.backend=redis`, `-blocks-storage.bucket-store.index-cache.backend=redis`, `-blocks-storage.bucket-store.metadata-cache.backend=redis`)
   - Eagerly loading some blocks on startup even when lazy loading is enabled `-blocks-storage.bucket-store.index-header.eager-loading-startup-enabled`
 - Read-write deployment mode
 - API endpoints:
@@ -212,3 +209,4 @@ The following features or configuration parameters are currently deprecated and 
 
 - Rule group configuration file
   - `evaluation_delay` field: use `query_offset` instead
+- Support for Redis-based caching

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4826,11 +4826,6 @@ The `memcached` block configures the Memcached-based caching backend. The suppor
 
 ### redis
 
-{{< admonition type="caution" >}}
-Starting with Mimir 2.14, Redis-based caching is deprecated.
-It will be removed in a future release.
-{{< /admonition >}}
-
 The `redis` block configures the Redis-based caching backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
 
 - `blocks-storage.bucket-store.chunks-cache`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4825,10 +4825,6 @@ The `memcached` block configures the Memcached-based caching backend. The suppor
 ```
 
 ### redis
-{{< admonition type="caution" >}}
-Starting with Mimir 2.14, Redis-based caching is deprecated.
-It will be removed in a future release.
-{{< /admonition >}}
 
 The `redis` block configures the Redis-based caching backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4826,6 +4826,11 @@ The `memcached` block configures the Memcached-based caching backend. The suppor
 
 ### redis
 
+{{< admonition type="caution" >}}
+Starting with Mimir 2.14, Redis-based caching is deprecated.
+It will be removed in a future release.
+{{< /admonition >}}
+
 The `redis` block configures the Redis-based caching backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
 
 - `blocks-storage.bucket-store.chunks-cache`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4826,8 +4826,6 @@ The `memcached` block configures the Memcached-based caching backend. The suppor
 
 ### redis
 
-Test
-
 The `redis` block configures the Redis-based caching backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
 
 - `blocks-storage.bucket-store.chunks-cache`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4826,10 +4826,8 @@ The `memcached` block configures the Memcached-based caching backend. The suppor
 
 ### redis
 
-{{< admonition type="caution" >}}
-Starting with Mimir 2.14, Redis-based caching is deprecated.
+**Note:** Starting with Mimir 2.14, Redis-based caching is deprecated.
 It will be removed in a future release.
-{{< /admonition >}}
 
 The `redis` block configures the Redis-based caching backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4826,8 +4826,7 @@ The `memcached` block configures the Memcached-based caching backend. The suppor
 
 ### redis
 
-**Note:** Starting with Mimir 2.14, Redis-based caching is deprecated.
-It will be removed in a future release.
+Test
 
 The `redis` block configures the Redis-based caching backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4825,7 +4825,6 @@ The `memcached` block configures the Memcached-based caching backend. The suppor
 ```
 
 ### redis
-
 {{< admonition type="caution" >}}
 Starting with Mimir 2.14, Redis-based caching is deprecated.
 It will be removed in a future release.


### PR DESCRIPTION
#### What this PR does
This PR marks the experimental support for Redis-based caching as deprecated.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/2414

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [X] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
