### PR TITLE
Fix a typo in the release-2.14 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.14.0-rc.0
+## 2.14.0-rc.0
 
 ### Grafana Mimir
 


### PR DESCRIPTION
#### What this PR does

This is a fixup for #9427

The release-notes preparation script currently fails with

```
Generating the draft release notes...
Unable to find the section title '## 2.14.0-rc.0' in the ./tools/release/../../CHANGELOG.md
```

This PR fixes the typo in the changelog.

#### Which issue(s) this PR fixes or relates to

Relates to #9382

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
