### PR TITLE
kafka replay speed: upstream partition_offset_reader.go

### DIFF
--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -4,6 +4,7 @@ package ingest
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -81,15 +82,19 @@ func TestPartitionOffsetReader_WaitNextFetchLastProducedOffset(t *testing.T) {
 			client               = createTestKafkaClient(t, kafkaCfg)
 			reader               = newPartitionOffsetReader(client, topicName, partitionID, pollInterval, nil, logger)
 
-			lastOffset           = atomic.NewInt64(1)
-			firstRequestReceived = make(chan struct{})
+			lastOffset            = atomic.NewInt64(1)
+			firstRequestReceived  = make(chan struct{})
+			secondRequestReceived = make(chan struct{})
 		)
 
 		cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 
-			if lastOffset.Load() == 1 {
+			switch lastOffset.Load() {
+			case 1:
 				close(firstRequestReceived)
+			case 2:
+				close(secondRequestReceived)
 			}
 
 			// Mock the response so that we can increase the offset each time.
@@ -109,20 +114,22 @@ func TestPartitionOffsetReader_WaitNextFetchLastProducedOffset(t *testing.T) {
 
 		wg := sync.WaitGroup{}
 
-		// The 1st WaitNextFetchLastProducedOffset() is called before the service starts, so it's expected
-		// to wait the result of the 1st request.
-		runAsync(&wg, func() {
-			actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, int64(1), actual)
-		})
-
-		// The 2nd WaitNextFetchLastProducedOffset() is called while the 1st request is running, so it's expected
+		// The 1st WaitNextFetchLastProducedOffset() is called before the service starts.
+		// The service fetches the offset once at startup, so it's expected that the first wait
 		// to wait the result of the 2nd request.
+		// If we don't do synchronisation, then it's also possible that we fit in the first request, but we synchronise to avoid flaky tests
 		runAsyncAfter(&wg, firstRequestReceived, func() {
 			actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, int64(2), actual)
+		})
+
+		// The 2nd WaitNextFetchLastProducedOffset() is called while the 1st is running, so it's expected
+		// to wait the result of the 3rd request.
+		runAsyncAfter(&wg, secondRequestReceived, func() {
+			actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, int64(3), actual)
 		})
 
 		// Now we can start the service.
@@ -215,15 +222,19 @@ func TestTopicOffsetsReader_WaitNextFetchLastProducedOffset(t *testing.T) {
 			client               = createTestKafkaClient(t, kafkaCfg)
 			reader               = NewTopicOffsetsReader(client, topicName, allPartitionIDs, pollInterval, nil, logger)
 
-			lastOffset           = atomic.NewInt64(1)
-			firstRequestReceived = make(chan struct{})
+			lastOffset            = atomic.NewInt64(1)
+			firstRequestReceived  = make(chan struct{})
+			secondRequestReceived = make(chan struct{})
 		)
 
 		cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 
-			if lastOffset.Load() == 1 {
+			switch lastOffset.Load() {
+			case 1:
 				close(firstRequestReceived)
+			case 3:
+				close(secondRequestReceived)
 			}
 
 			// Mock the response so that we can increase the offset each time.
@@ -247,20 +258,22 @@ func TestTopicOffsetsReader_WaitNextFetchLastProducedOffset(t *testing.T) {
 
 		wg := sync.WaitGroup{}
 
-		// The 1st WaitNextFetchLastProducedOffset() is called before the service starts, so it's expected
-		// to wait the result of the 1st request.
-		runAsync(&wg, func() {
-			actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, map[int32]int64{0: int64(1), 1: int64(2)}, actual)
-		})
-
-		// The 2nd WaitNextFetchLastProducedOffset() is called while the 1st request is running, so it's expected
+		// The 1st WaitNextFetchLastProducedOffset() is called before the service starts.
+		// The service fetches the offset once at startup, so it's expected that the first wait
 		// to wait the result of the 2nd request.
+		// If we don't do synchronisation, then it's also possible that we fit in the first request, but we synchronise to avoid flaky tests
 		runAsyncAfter(&wg, firstRequestReceived, func() {
 			actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, map[int32]int64{0: int64(3), 1: int64(4)}, actual)
+		})
+
+		// The 2nd WaitNextFetchLastProducedOffset() is called while the 1st is running, so it's expected
+		// to wait the result of the 3rd request.
+		runAsyncAfter(&wg, secondRequestReceived, func() {
+			actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, map[int32]int64{0: int64(5), 1: int64(6)}, actual)
 		})
 
 		// Now we can start the service.
@@ -287,5 +300,117 @@ func TestTopicOffsetsReader_WaitNextFetchLastProducedOffset(t *testing.T) {
 
 		_, err := reader.WaitNextFetchLastProducedOffset(canceledCtx)
 		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestGenericPartitionReader_Caching(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	t.Run("should initialize with fetched offset", func(t *testing.T) {
+		ctx := context.Background()
+		mockFetch := func(context.Context) (int64, error) {
+			return 42, nil
+		}
+
+		reader := newGenericOffsetReader[int64](mockFetch, time.Second, logger)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		})
+
+		offset, err := reader.CachedOffset()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(42), offset)
+	})
+
+	t.Run("should cache error from initial fetch", func(t *testing.T) {
+		ctx := context.Background()
+		expectedErr := fmt.Errorf("fetch error")
+		mockFetch := func(context.Context) (int64, error) {
+			return 0, expectedErr
+		}
+
+		reader := newGenericOffsetReader[int64](mockFetch, time.Second, logger)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		})
+
+		offset, err := reader.CachedOffset()
+		assert.ErrorIs(t, err, expectedErr)
+		assert.Equal(t, int64(0), offset)
+	})
+
+	t.Run("should update cache on poll interval", func(t *testing.T) {
+		ctx := context.Background()
+		fetchCount := 0
+		fetchChan := make(chan struct{}, 3) // Buffer size of 3 to allow multiple fetches
+		mockFetch := func(ctx context.Context) (int64, error) {
+			fetchCount++
+			select {
+			case <-ctx.Done():
+			case fetchChan <- struct{}{}:
+			}
+			return int64(fetchCount), nil
+		}
+
+		reader := newGenericOffsetReader[int64](mockFetch, 10*time.Millisecond, logger)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		})
+
+		// Wait for at least two fetches to complete and have their results cached.
+		<-fetchChan
+		<-fetchChan
+		<-fetchChan
+
+		offset, err := reader.CachedOffset()
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, offset, int64(2), "Offset should have been updated at least once")
+	})
+
+	t.Run("should handle context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		mockFetch := func(context.Context) (int64, error) {
+			return 42, nil
+		}
+
+		reader := newGenericOffsetReader[int64](mockFetch, time.Second, logger)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+		t.Cleanup(func() {
+			cancel()
+			require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+		})
+
+		// The cached offset should be available
+		offset, err := reader.CachedOffset()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(42), offset)
+	})
+
+	t.Run("should handle concurrent access", func(t *testing.T) {
+		ctx := context.Background()
+		mockFetch := func(context.Context) (int64, error) {
+			return 42, nil
+		}
+
+		reader := newGenericOffsetReader[int64](mockFetch, time.Second, logger)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		})
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				offset, err := reader.CachedOffset()
+				assert.NoError(t, err)
+				assert.Equal(t, int64(42), offset)
+			}()
+		}
+		wg.Wait()
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This is the first of series of PRs to upstream the code for improving Kafka replay speed in the ingester.

In this PR I'm upstreaming a tiny change related to partitionOffsetReader. We need caching in the reader so that we can check the start offset of the partition. We don't need that to be very exact because we use it to find out if we're trying to consume from before the start.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
