### PR TITLE
kafka replay speed: upstream local development environment

### DIFF
--- a/development/mimir-ingest-storage/config/datasource-mimir.yaml
+++ b/development/mimir-ingest-storage/config/datasource-mimir.yaml
@@ -1,11 +1,18 @@
 apiVersion: 1
 datasources:
-- name: Mimir
-  type: prometheus
-  access: proxy
-  uid: mimir
-  orgID: 1
-  url: http://nginx:8080/prometheus
-  isDefault: true
-  jsonData:
-    prometheusType: Mimir
+  - name: Mimir
+    type: prometheus
+    access: proxy
+    uid: mimir
+    orgID: 1
+    url: http://nginx:8080/prometheus
+    isDefault: true
+    jsonData:
+      prometheusType: Mimir
+      timeInterval: 5s
+  - name: Jaeger
+    type: jaeger
+    access: proxy
+    uid: jaeger
+    orgID: 1
+    url: http://jaeger:16686/

--- a/development/mimir-ingest-storage/config/grafana-agent.flow
+++ b/development/mimir-ingest-storage/config/grafana-agent.flow
@@ -36,13 +36,13 @@ prometheus.scrape "metrics_local_mimir_read_write_mode_mimir_write" {
                         container   = "mimir-write",
                         namespace   = "mimir-read-write-mode",
                 }],
-                                [{
-                                        __address__ = "mimir-write-zone-c-61:8080",
-                                        cluster     = "docker-compose",
-                                        container   = "mimir-write",
-                                        namespace   = "mimir-read-write-mode",
-                                        job         = "mimir-write-zone-c",
-                                }],
+                [{
+                        __address__ = "mimir-write-zone-c-61:8080",
+                        cluster     = "docker-compose",
+                        container   = "mimir-write",
+                        namespace   = "mimir-read-write-mode",
+                        job         = "mimir-write-zone-c",
+                }],
         )
         forward_to      = [prometheus.remote_write.metrics_local.receiver]
         job_name        = "mimir-read-write-mode/mimir-write"

--- a/development/mimir-ingest-storage/config/grafana-agent.flow
+++ b/development/mimir-ingest-storage/config/grafana-agent.flow
@@ -36,6 +36,13 @@ prometheus.scrape "metrics_local_mimir_read_write_mode_mimir_write" {
                         container   = "mimir-write",
                         namespace   = "mimir-read-write-mode",
                 }],
+                                [{
+                                        __address__ = "mimir-write-zone-c-61:8080",
+                                        cluster     = "docker-compose",
+                                        container   = "mimir-write",
+                                        namespace   = "mimir-read-write-mode",
+                                        job = "mimir-write-zone-c",
+                                }],
         )
         forward_to      = [prometheus.remote_write.metrics_local.receiver]
         job_name        = "mimir-read-write-mode/mimir-write"
@@ -97,7 +104,7 @@ prometheus.scrape "metrics_local_mimir_read_write_mode_mimir_backend" {
 prometheus.remote_write "metrics_local" {
         endpoint {
                 name                   = "local"
-                url                    = "http://mimir-write-zone-a-1:8080/api/v1/push"
+                url                    = "http://mimir-write-zone-a-2:8080/api/v1/push"
                 send_native_histograms = true
 
                 queue_config { }

--- a/development/mimir-ingest-storage/config/grafana-agent.flow
+++ b/development/mimir-ingest-storage/config/grafana-agent.flow
@@ -41,7 +41,7 @@ prometheus.scrape "metrics_local_mimir_read_write_mode_mimir_write" {
                                         cluster     = "docker-compose",
                                         container   = "mimir-write",
                                         namespace   = "mimir-read-write-mode",
-                                        job = "mimir-write-zone-c",
+                                        job         = "mimir-write-zone-c",
                                 }],
         )
         forward_to      = [prometheus.remote_write.metrics_local.receiver]

--- a/development/mimir-ingest-storage/config/mimir.yaml
+++ b/development/mimir-ingest-storage/config/mimir.yaml
@@ -12,15 +12,19 @@ common:
 ingest_storage:
   enabled:       true
   kafka:
-    address: kafka:9092
+    address: kafka_1:9092
     topic:   mimir-ingest
     last_produced_offset_poll_interval: 500ms
+    startup_fetch_concurrency: 15
+    startup_records_per_fetch: 2400
+    ongoing_fetch_concurrency: 2
+    ongoing_records_per_fetch: 30
 
 ingester:
   track_ingester_owned_series: true
 
   partition_ring:
-    min_partition_owners_count:       2
+    min_partition_owners_count:       1
     min_partition_owners_duration:    10s
     delete_inactive_partition_after:  1m
 
@@ -99,3 +103,6 @@ limits:
 
 runtime_config:
   file: ./config/runtime.yaml
+
+server:
+  log_level: debug

--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -9,7 +9,10 @@ std.manifestYamlDoc({
     self.grafana +
     self.grafana_agent +
     self.memcached +
-    self.kafka +
+    self.kafka_1 +
+    self.kafka_2 +
+    self.kafka_3 +
+    self.jaeger +
     {},
 
   write:: {
@@ -35,28 +38,25 @@ std.manifestYamlDoc({
       extraArguments: ['-ingester.ring.instance-availability-zone=zone-a'],
       extraVolumes: ['.data-mimir-write-zone-a-3:/data:delegated'],
     }),
-
-    // Zone-b.
-    'mimir-write-zone-b-1': mimirService({
-      name: 'mimir-write-zone-b-1',
-      target: 'write',
-      publishedHttpPort: 8011,
-      extraArguments: ['-ingester.ring.instance-availability-zone=zone-b'],
-      extraVolumes: ['.data-mimir-write-zone-b-1:/data:delegated'],
-    }),
-    'mimir-write-zone-b-2': mimirService({
-      name: 'mimir-write-zone-b-2',
-      target: 'write',
-      publishedHttpPort: 8012,
-      extraArguments: ['-ingester.ring.instance-availability-zone=zone-b'],
-      extraVolumes: ['.data-mimir-write-zone-b-2:/data:delegated'],
-    }),
-    'mimir-write-zone-b-3': mimirService({
-      name: 'mimir-write-zone-b-3',
-      target: 'write',
-      publishedHttpPort: 8013,
-      extraArguments: ['-ingester.ring.instance-availability-zone=zone-b'],
-      extraVolumes: ['.data-mimir-write-zone-b-3:/data:delegated'],
+    'mimir-write-zone-c-61': mimirService({
+      name: 'mimir-write-zone-c-61',
+      target: 'ingester',
+      publishedHttpPort: 8064,
+      extraArguments: [
+        '-ingester.ring.instance-availability-zone=zone-c',
+        '-ingester.ring.instance-id=ingester-zone-c-61',
+        '-ingester.partition-ring.prefix=exclusive-prefix',
+        '-ingester.ring.prefix=exclusive-prefix',
+        '-ingest-storage.kafka.consume-from-position-at-startup=end',
+        '-ingest-storage.kafka.consume-from-timestamp-at-startup=0',
+        '-ingest-storage.kafka.ingestion-concurrency=2',
+        '-ingest-storage.kafka.ingestion-concurrency-batch-size=150',
+        '-ingest-storage.kafka.startup-fetch-concurrency=15',
+        '-ingest-storage.kafka.startup-records-per-fetch=2400',
+        '-ingest-storage.kafka.ongoing-fetch-concurrency=2',
+        '-ingest-storage.kafka.ongoing-records-per-fetch=30',
+      ],
+      extraVolumes: ['.data-mimir-write-zone-c-61:/data:delegated'],
     }),
   },
 
@@ -116,30 +116,76 @@ std.manifestYamlDoc({
     },
   },
 
-  kafka:: {
-    kafka: {
-      image: 'confluentinc/cp-kafka:latest',
-      environment: [
-        'CLUSTER_ID=zH1GDqcNTzGMDCXm5VZQdg',  // Cluster ID is required in KRaft mode; the value is random UUID.
-        'KAFKA_BROKER_ID=1',
-        'KAFKA_NUM_PARTITIONS=100',  // Default number of partitions for auto-created topics.
-        'KAFKA_PROCESS_ROLES=broker,controller',
-        'KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_HOST://:29092',
-        'KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092',
-        'KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT',
-        'KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT',
-        'KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER',
-        'KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093',
-        'KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1',
-        'KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=10000',
+  local commonKafkaEnvVars = [
+    'CLUSTER_ID=zH1GDqcNTzGMDCXm5VZQdg',  // Cluster ID is required in KRaft mode; the value is random UUID.
+    'KAFKA_NUM_PARTITIONS=100',  // Default number of partitions for auto-created topics.
+    'KAFKA_PROCESS_ROLES=broker,controller',
+    'KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT',
+    'KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT',
+    'KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER',
+    'KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka_1:9093,2@kafka_2:9093,3@kafka_3:9093',
+    'KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=2',
+    'KAFKA_DEFAULT_REPLICATION_FACTOR=2',
+    'KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=10000',
 
-        // Decomment the following config to keep a short retention of records in Kafka.
-        // This is useful to test the behaviour when Kafka records are deleted.
-        // 'KAFKA_LOG_RETENTION_MINUTES=1',
-        // 'KAFKA_LOG_SEGMENT_BYTES=1000000',
+    // Decomment the following config to keep a short retention of records in Kafka.
+    // This is useful to test the behaviour when Kafka records are deleted.
+    // 'KAFKA_LOG_RETENTION_MINUTES=1',
+    // 'KAFKA_LOG_SEGMENT_BYTES=1000000',
+  ],
+
+  kafka_1:: {
+    kafka_1: {
+      image: 'confluentinc/cp-kafka:latest',
+      environment: commonKafkaEnvVars + [
+        'KAFKA_BROKER_ID=1',
+        'KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_HOST://:29092',
+        'KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka_1:9092,PLAINTEXT_HOST://localhost:29092',
       ],
       ports: [
         '29092:29092',
+      ],
+      healthcheck: {
+        test: 'nc -z localhost 9092 || exit -1',
+        start_period: '1s',
+        interval: '1s',
+        timeout: '1s',
+        retries: '30',
+      },
+    },
+  },
+
+
+  kafka_2:: {
+    kafka_2: {
+      image: 'confluentinc/cp-kafka:latest',
+      environment: commonKafkaEnvVars + [
+        'KAFKA_BROKER_ID=2',
+        'KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_HOST://:29093',
+        'KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka_2:9092,PLAINTEXT_HOST://localhost:29093',
+      ],
+      ports: [
+        '29093:29093',
+      ],
+      healthcheck: {
+        test: 'nc -z localhost 9092 || exit -1',
+        start_period: '1s',
+        interval: '1s',
+        timeout: '1s',
+        retries: '30',
+      },
+    },
+  },
+  kafka_3:: {
+    kafka_3: {
+      image: 'confluentinc/cp-kafka:latest',
+      environment: commonKafkaEnvVars + [
+        'KAFKA_BROKER_ID=3',
+        'KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_HOST://:29094',
+        'KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka_3:9092,PLAINTEXT_HOST://localhost:29094',
+      ],
+      ports: [
+        '29094:29094',
       ],
       healthcheck: {
         test: 'nc -z localhost 9092 || exit -1',
@@ -187,6 +233,22 @@ std.manifestYamlDoc({
     },
   },
 
+  jaeger:: {
+    jaeger: {
+      image: 'jaegertracing/all-in-one',
+      ports: ['16686:16686', '14268'],
+    },
+  },
+
+  local jaegerEnv(appName) = {
+    JAEGER_AGENT_HOST: 'jaeger',
+    JAEGER_AGENT_PORT: 6831,
+    JAEGER_SAMPLER_TYPE: 'const',
+    JAEGER_SAMPLER_PARAM: 1,
+    JAEGER_TAGS: 'app=%s' % appName,
+    JAEGER_REPORTER_MAX_QUEUE_SIZE: 1000,
+  },
+
   // This function builds docker-compose declaration for Mimir service.
   local mimirService(serviceOptions) = {
     local defaultOptions = {
@@ -196,10 +258,13 @@ std.manifestYamlDoc({
       publishedHttpPort: error 'missing publishedHttpPort',
       dependsOn: {
         minio: { condition: 'service_started' },
-        kafka: { condition: 'service_healthy' },
+        kafka_1: { condition: 'service_healthy' },
+        kafka_2: { condition: 'service_healthy' },
       },
-      env: {},
+      env: jaegerEnv(self.target),
       extraArguments: [],
+      debug: false,
+      debugPort: self.publishedHttpPort + 3000,
       extraVolumes: [],
       memberlistBindPort: self.publishedHttpPort + 2000,
     },
@@ -212,11 +277,15 @@ std.manifestYamlDoc({
     },
     image: 'mimir',
     command: [
-      './mimir',
-      '-config.file=./config/mimir.yaml' % options,
-      '-target=%(target)s' % options,
-      '-activity-tracker.filepath=/activity/%(name)s' % options,
-    ] + options.extraArguments,
+      'sh',
+      '-c',
+      std.join(' ', [
+        (if options.debug then 'exec ./dlv exec ./mimir --listen=:%(debugPort)d --headless=true --api-version=2 --accept-multiclient --continue -- ' % options else 'exec ./mimir'),
+        '-config.file=./config/mimir.yaml' % options,
+        '-target=%(target)s' % options,
+        '-activity-tracker.filepath=/activity/%(name)s' % options,
+      ] + options.extraArguments),
+    ],
     environment: [
       '%s=%s' % [key, options.env[key]]
       for key in std.objectFields(options.env)
@@ -224,7 +293,7 @@ std.manifestYamlDoc({
     ],
     hostname: options.name,
     // Only publish HTTP port, but not gRPC one.
-    ports: ['%d:8080' % options.publishedHttpPort],
+    ports: ['%d:8080' % options.publishedHttpPort, '%(debugPort)d:%(debugPort)d' % options],
     depends_on: options.dependsOn,
     volumes: ['./config:/mimir/config', './activity:/activity'] + options.extraVolumes,
   },

--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -38,6 +38,11 @@ std.manifestYamlDoc({
       extraArguments: ['-ingester.ring.instance-availability-zone=zone-a'],
       extraVolumes: ['.data-mimir-write-zone-a-3:/data:delegated'],
     }),
+    // mimir-write-zone-c-61 is an instance that's not connected to the rest of the cluster.
+    // The idea is that it can be used to test replay speed on a kafka partition without affecting the
+    // availability of the rest of the cluster (for example by using `kafkatool dump`).
+    // The rest of the cluster can be used to monitor c-61 and ingest metrics as usual.
+    // c-61 deployed in its own hash ring. For complete disambiguation, it's deployed in a separate zone and has a separate instance ID.
     'mimir-write-zone-c-61': mimirService({
       name: 'mimir-write-zone-c-61',
       target: 'ingester',

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -23,20 +23,26 @@
       - "9091:9091"
     "volumes":
       - "./config:/etc/agent-config"
-  "kafka":
+  "jaeger":
+    "image": "jaegertracing/all-in-one"
+    "ports":
+      - "16686:16686"
+      - "14268"
+  "kafka_1":
     "environment":
       - "CLUSTER_ID=zH1GDqcNTzGMDCXm5VZQdg"
-      - "KAFKA_BROKER_ID=1"
       - "KAFKA_NUM_PARTITIONS=100"
       - "KAFKA_PROCESS_ROLES=broker,controller"
-      - "KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_HOST://:29092"
-      - "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092"
       - "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
       - "KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
       - "KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER"
-      - "KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093"
-      - "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1"
+      - "KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka_1:9093,2@kafka_2:9093,3@kafka_3:9093"
+      - "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=2"
+      - "KAFKA_DEFAULT_REPLICATION_FACTOR=2"
       - "KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=10000"
+      - "KAFKA_BROKER_ID=1"
+      - "KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_HOST://:29092"
+      - "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka_1:9092,PLAINTEXT_HOST://localhost:29092"
     "healthcheck":
       "interval": "1s"
       "retries": "30"
@@ -46,6 +52,54 @@
     "image": "confluentinc/cp-kafka:latest"
     "ports":
       - "29092:29092"
+  "kafka_2":
+    "environment":
+      - "CLUSTER_ID=zH1GDqcNTzGMDCXm5VZQdg"
+      - "KAFKA_NUM_PARTITIONS=100"
+      - "KAFKA_PROCESS_ROLES=broker,controller"
+      - "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
+      - "KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      - "KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka_1:9093,2@kafka_2:9093,3@kafka_3:9093"
+      - "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=2"
+      - "KAFKA_DEFAULT_REPLICATION_FACTOR=2"
+      - "KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=10000"
+      - "KAFKA_BROKER_ID=2"
+      - "KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_HOST://:29093"
+      - "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka_2:9092,PLAINTEXT_HOST://localhost:29093"
+    "healthcheck":
+      "interval": "1s"
+      "retries": "30"
+      "start_period": "1s"
+      "test": "nc -z localhost 9092 || exit -1"
+      "timeout": "1s"
+    "image": "confluentinc/cp-kafka:latest"
+    "ports":
+      - "29093:29093"
+  "kafka_3":
+    "environment":
+      - "CLUSTER_ID=zH1GDqcNTzGMDCXm5VZQdg"
+      - "KAFKA_NUM_PARTITIONS=100"
+      - "KAFKA_PROCESS_ROLES=broker,controller"
+      - "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
+      - "KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      - "KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka_1:9093,2@kafka_2:9093,3@kafka_3:9093"
+      - "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=2"
+      - "KAFKA_DEFAULT_REPLICATION_FACTOR=2"
+      - "KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=10000"
+      - "KAFKA_BROKER_ID=3"
+      - "KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_HOST://:29094"
+      - "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka_3:9092,PLAINTEXT_HOST://localhost:29094"
+    "healthcheck":
+      "interval": "1s"
+      "retries": "30"
+      "start_period": "1s"
+      "test": "nc -z localhost 9092 || exit -1"
+      "timeout": "1s"
+    "image": "confluentinc/cp-kafka:latest"
+    "ports":
+      - "29094:29094"
   "memcached":
     "image": "memcached:1.6.19-alpine"
   "mimir-backend-1":
@@ -53,20 +107,28 @@
       "context": "."
       "dockerfile": "dev.dockerfile"
     "command":
-      - "./mimir"
-      - "-config.file=./config/mimir.yaml"
-      - "-target=backend"
-      - "-activity-tracker.filepath=/activity/mimir-backend-1"
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=backend -activity-tracker.filepath=/activity/mimir-backend-1"
     "depends_on":
-      "kafka":
+      "kafka_1":
+        "condition": "service_healthy"
+      "kafka_2":
         "condition": "service_healthy"
       "minio":
         "condition": "service_started"
-    "environment": []
+    "environment":
+      - "JAEGER_AGENT_HOST=jaeger"
+      - "JAEGER_AGENT_PORT=6831"
+      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
+      - "JAEGER_SAMPLER_PARAM=1"
+      - "JAEGER_SAMPLER_TYPE=const"
+      - "JAEGER_TAGS=app=backend"
     "hostname": "mimir-backend-1"
     "image": "mimir"
     "ports":
       - "8006:8080"
+      - "11006:11006"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -75,20 +137,28 @@
       "context": "."
       "dockerfile": "dev.dockerfile"
     "command":
-      - "./mimir"
-      - "-config.file=./config/mimir.yaml"
-      - "-target=backend"
-      - "-activity-tracker.filepath=/activity/mimir-backend-2"
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=backend -activity-tracker.filepath=/activity/mimir-backend-2"
     "depends_on":
-      "kafka":
+      "kafka_1":
+        "condition": "service_healthy"
+      "kafka_2":
         "condition": "service_healthy"
       "minio":
         "condition": "service_started"
-    "environment": []
+    "environment":
+      - "JAEGER_AGENT_HOST=jaeger"
+      - "JAEGER_AGENT_PORT=6831"
+      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
+      - "JAEGER_SAMPLER_PARAM=1"
+      - "JAEGER_SAMPLER_TYPE=const"
+      - "JAEGER_TAGS=app=backend"
     "hostname": "mimir-backend-2"
     "image": "mimir"
     "ports":
       - "8007:8080"
+      - "11007:11007"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -97,20 +167,28 @@
       "context": "."
       "dockerfile": "dev.dockerfile"
     "command":
-      - "./mimir"
-      - "-config.file=./config/mimir.yaml"
-      - "-target=read"
-      - "-activity-tracker.filepath=/activity/mimir-read-1"
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=read -activity-tracker.filepath=/activity/mimir-read-1"
     "depends_on":
-      "kafka":
+      "kafka_1":
+        "condition": "service_healthy"
+      "kafka_2":
         "condition": "service_healthy"
       "minio":
         "condition": "service_started"
-    "environment": []
+    "environment":
+      - "JAEGER_AGENT_HOST=jaeger"
+      - "JAEGER_AGENT_PORT=6831"
+      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
+      - "JAEGER_SAMPLER_PARAM=1"
+      - "JAEGER_SAMPLER_TYPE=const"
+      - "JAEGER_TAGS=app=read"
     "hostname": "mimir-read-1"
     "image": "mimir"
     "ports":
       - "8004:8080"
+      - "11004:11004"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -119,20 +197,28 @@
       "context": "."
       "dockerfile": "dev.dockerfile"
     "command":
-      - "./mimir"
-      - "-config.file=./config/mimir.yaml"
-      - "-target=read"
-      - "-activity-tracker.filepath=/activity/mimir-read-2"
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=read -activity-tracker.filepath=/activity/mimir-read-2"
     "depends_on":
-      "kafka":
+      "kafka_1":
+        "condition": "service_healthy"
+      "kafka_2":
         "condition": "service_healthy"
       "minio":
         "condition": "service_started"
-    "environment": []
+    "environment":
+      - "JAEGER_AGENT_HOST=jaeger"
+      - "JAEGER_AGENT_PORT=6831"
+      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
+      - "JAEGER_SAMPLER_PARAM=1"
+      - "JAEGER_SAMPLER_TYPE=const"
+      - "JAEGER_TAGS=app=read"
     "hostname": "mimir-read-2"
     "image": "mimir"
     "ports":
       - "8005:8080"
+      - "11005:11005"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -141,21 +227,28 @@
       "context": "."
       "dockerfile": "dev.dockerfile"
     "command":
-      - "./mimir"
-      - "-config.file=./config/mimir.yaml"
-      - "-target=write"
-      - "-activity-tracker.filepath=/activity/mimir-write-zone-a-1"
-      - "-ingester.ring.instance-availability-zone=zone-a"
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=write -activity-tracker.filepath=/activity/mimir-write-zone-a-1 -ingester.ring.instance-availability-zone=zone-a"
     "depends_on":
-      "kafka":
+      "kafka_1":
+        "condition": "service_healthy"
+      "kafka_2":
         "condition": "service_healthy"
       "minio":
         "condition": "service_started"
-    "environment": []
+    "environment":
+      - "JAEGER_AGENT_HOST=jaeger"
+      - "JAEGER_AGENT_PORT=6831"
+      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
+      - "JAEGER_SAMPLER_PARAM=1"
+      - "JAEGER_SAMPLER_TYPE=const"
+      - "JAEGER_TAGS=app=write"
     "hostname": "mimir-write-zone-a-1"
     "image": "mimir"
     "ports":
       - "8001:8080"
+      - "11001:11001"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -165,21 +258,28 @@
       "context": "."
       "dockerfile": "dev.dockerfile"
     "command":
-      - "./mimir"
-      - "-config.file=./config/mimir.yaml"
-      - "-target=write"
-      - "-activity-tracker.filepath=/activity/mimir-write-zone-a-2"
-      - "-ingester.ring.instance-availability-zone=zone-a"
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=write -activity-tracker.filepath=/activity/mimir-write-zone-a-2 -ingester.ring.instance-availability-zone=zone-a"
     "depends_on":
-      "kafka":
+      "kafka_1":
+        "condition": "service_healthy"
+      "kafka_2":
         "condition": "service_healthy"
       "minio":
         "condition": "service_started"
-    "environment": []
+    "environment":
+      - "JAEGER_AGENT_HOST=jaeger"
+      - "JAEGER_AGENT_PORT=6831"
+      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
+      - "JAEGER_SAMPLER_PARAM=1"
+      - "JAEGER_SAMPLER_TYPE=const"
+      - "JAEGER_TAGS=app=write"
     "hostname": "mimir-write-zone-a-2"
     "image": "mimir"
     "ports":
       - "8002:8080"
+      - "11002:11002"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -189,97 +289,63 @@
       "context": "."
       "dockerfile": "dev.dockerfile"
     "command":
-      - "./mimir"
-      - "-config.file=./config/mimir.yaml"
-      - "-target=write"
-      - "-activity-tracker.filepath=/activity/mimir-write-zone-a-3"
-      - "-ingester.ring.instance-availability-zone=zone-a"
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=write -activity-tracker.filepath=/activity/mimir-write-zone-a-3 -ingester.ring.instance-availability-zone=zone-a"
     "depends_on":
-      "kafka":
+      "kafka_1":
+        "condition": "service_healthy"
+      "kafka_2":
         "condition": "service_healthy"
       "minio":
         "condition": "service_started"
-    "environment": []
+    "environment":
+      - "JAEGER_AGENT_HOST=jaeger"
+      - "JAEGER_AGENT_PORT=6831"
+      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
+      - "JAEGER_SAMPLER_PARAM=1"
+      - "JAEGER_SAMPLER_TYPE=const"
+      - "JAEGER_TAGS=app=write"
     "hostname": "mimir-write-zone-a-3"
     "image": "mimir"
     "ports":
       - "8003:8080"
+      - "11003:11003"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
       - ".data-mimir-write-zone-a-3:/data:delegated"
-  "mimir-write-zone-b-1":
+  "mimir-write-zone-c-61":
     "build":
       "context": "."
       "dockerfile": "dev.dockerfile"
     "command":
-      - "./mimir"
-      - "-config.file=./config/mimir.yaml"
-      - "-target=write"
-      - "-activity-tracker.filepath=/activity/mimir-write-zone-b-1"
-      - "-ingester.ring.instance-availability-zone=zone-b"
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/mimir-write-zone-c-61 -ingester.ring.instance-availability-zone=zone-c -ingester.ring.instance-id=ingester-zone-c-61 -ingester.partition-ring.prefix=exclusive-prefix -ingester.ring.prefix=exclusive-prefix -ingest-storage.kafka.consume-from-position-at-startup=end -ingest-storage.kafka.consume-from-timestamp-at-startup=0 -ingest-storage.kafka.ingestion-concurrency=2 -ingest-storage.kafka.ingestion-concurrency-batch-size=150 -ingest-storage.kafka.startup-fetch-concurrency=15 -ingest-storage.kafka.startup-records-per-fetch=2400 -ingest-storage.kafka.ongoing-fetch-concurrency=2 -ingest-storage.kafka.ongoing-records-per-fetch=30"
     "depends_on":
-      "kafka":
+      "kafka_1":
+        "condition": "service_healthy"
+      "kafka_2":
         "condition": "service_healthy"
       "minio":
         "condition": "service_started"
-    "environment": []
-    "hostname": "mimir-write-zone-b-1"
+    "environment":
+      - "JAEGER_AGENT_HOST=jaeger"
+      - "JAEGER_AGENT_PORT=6831"
+      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
+      - "JAEGER_SAMPLER_PARAM=1"
+      - "JAEGER_SAMPLER_TYPE=const"
+      - "JAEGER_TAGS=app=ingester"
+    "hostname": "mimir-write-zone-c-61"
     "image": "mimir"
     "ports":
-      - "8011:8080"
+      - "8064:8080"
+      - "11064:11064"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
-      - ".data-mimir-write-zone-b-1:/data:delegated"
-  "mimir-write-zone-b-2":
-    "build":
-      "context": "."
-      "dockerfile": "dev.dockerfile"
-    "command":
-      - "./mimir"
-      - "-config.file=./config/mimir.yaml"
-      - "-target=write"
-      - "-activity-tracker.filepath=/activity/mimir-write-zone-b-2"
-      - "-ingester.ring.instance-availability-zone=zone-b"
-    "depends_on":
-      "kafka":
-        "condition": "service_healthy"
-      "minio":
-        "condition": "service_started"
-    "environment": []
-    "hostname": "mimir-write-zone-b-2"
-    "image": "mimir"
-    "ports":
-      - "8012:8080"
-    "volumes":
-      - "./config:/mimir/config"
-      - "./activity:/activity"
-      - ".data-mimir-write-zone-b-2:/data:delegated"
-  "mimir-write-zone-b-3":
-    "build":
-      "context": "."
-      "dockerfile": "dev.dockerfile"
-    "command":
-      - "./mimir"
-      - "-config.file=./config/mimir.yaml"
-      - "-target=write"
-      - "-activity-tracker.filepath=/activity/mimir-write-zone-b-3"
-      - "-ingester.ring.instance-availability-zone=zone-b"
-    "depends_on":
-      "kafka":
-        "condition": "service_healthy"
-      "minio":
-        "condition": "service_started"
-    "environment": []
-    "hostname": "mimir-write-zone-b-3"
-    "image": "mimir"
-    "ports":
-      - "8013:8080"
-    "volumes":
-      - "./config:/mimir/config"
-      - "./activity:/activity"
-      - ".data-mimir-write-zone-b-3:/data:delegated"
+      - ".data-mimir-write-zone-c-61:/data:delegated"
   "minio":
     "command":
       - "server"


### PR DESCRIPTION

#### What this PR does

This is the fourth of series of PRs to upstream the code for improving Kafka replay speed in the ingester.

This PR makes several changes to development/mimir-ingest-storage

* deploys a jaeger instance to collect traces
* deploys ingester-zone-c-61. This ingester is totally separate from the other two zones. The idea is to be able to feed its partition with old data and test replay speed. That ingester doesn't ingest metrics from the cluster itself, so being down doesn't affect the cluster's query availability
* deploys 3 kafkas with RF=2 so that we can bring down brokers and test how our code reacts to leader reelections
* optinally enabled dlv debugging for the Mimir images
* configures ingesters to use concurrent fetching


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
