### PR TITLE
Add `kafkatool dump`

### DIFF
--- a/tools/kafkatool/dump.go
+++ b/tools/kafkatool/dump.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.uber.org/atomic"
+)
+
+type DumpCommand struct {
+	topic             string
+	partition         int
+	skipFirst         int
+	mode              string
+	exportOffsetStart int64
+	exportMaxRecords  int
+	inOutFile         *os.File
+	getKafkaClient    func() *kgo.Client
+	printer           Printer
+}
+
+// Register is used to register the command to a parent command.
+func (c *DumpCommand) Register(app *kingpin.Application, getKafkaClient func() *kgo.Client, printer Printer) {
+	c.getKafkaClient = getKafkaClient
+	c.printer = printer
+
+	cmd := app.Command("dump", "Dump Kafka topic contents")
+	cmd.Flag("topic", "Kafka topic to dump").Required().StringVar(&c.topic)
+	cmd.Flag("partition", "Kafka partition to dump or import into").Required().IntVar(&c.partition)
+	cmd.Flag("skip-first", "Skip until input record with offset N").Default("0").IntVar(&c.skipFirst)
+	cmd.Flag("offset", "Offset to start exporting from").Default("0").Int64Var(&c.exportOffsetStart)
+	cmd.Flag("export-max-records", "Maximum number of records to export").Default("1000000").IntVar(&c.exportMaxRecords)
+	cmd.Flag("file", "File to read from or write to.").Required().OpenFileVar(&c.inOutFile, os.O_RDWR|os.O_CREATE, 0600)
+
+	cmd.Command("import", "Import records from a file into a Kafka topic").Action(c.doImport)
+	cmd.Command("export", "Export records from a Kafka topic into a file").Action(c.doExport)
+}
+
+type key int
+
+const (
+	originalOffsetKey key = iota
+)
+
+func (c *DumpCommand) doExport(*kingpin.ParseContext) error {
+	client := c.getKafkaClient()
+	client.AddConsumePartitions(map[string]map[int32]kgo.Offset{
+		c.topic: {int32(c.partition): kgo.NewOffset().At(c.exportOffsetStart)}},
+	)
+	go func() {
+		for {
+			time.Sleep(time.Second)
+			c.printer.PrintLine(fmt.Sprintf("produced records: %d, offset %d", recordCount.Load(), consumedOffset.Load()))
+		}
+	}()
+
+	encoder := json.NewEncoder(c.inOutFile)
+
+	lastAvailableOffset := int64(-1)
+	for recordCount.Load() < int64(c.exportMaxRecords) {
+		fetches := client.PollFetches(context.Background())
+		if err := fetches.Err(); err != nil {
+			return fmt.Errorf("failed to fetch records: %w", err)
+		}
+		fetches.EachPartition(func(partition kgo.FetchTopicPartition) {
+			lastAvailableOffset = max(lastAvailableOffset, partition.HighWatermark-1)
+		})
+		var err error
+		fetches.EachRecord(func(record *kgo.Record) {
+			if recordCount.Inc() > int64(c.exportMaxRecords) {
+				return
+			}
+			consumedOffset.Store(record.Offset)
+			encodeErr := encoder.Encode(record)
+			if encodeErr != nil {
+				err = fmt.Errorf("encoding offset %d: %v", record.Offset, encodeErr)
+			}
+		})
+		if err != nil {
+			return err
+		}
+		if lastAvailableOffset >= 0 && consumedOffset.Load() >= lastAvailableOffset {
+			c.printer.PrintLine("reached high watermark before max records")
+			break
+		}
+	}
+	return nil
+}
+
+var (
+	recordCount          = &atomic.Int64{}
+	consumedOffset       = &atomic.Int64{}
+	recordsTooLarge      = &atomic.Int64{}
+	corruptedJSONRecords = &atomic.Int64{}
+)
+
+func (c *DumpCommand) doImport(*kingpin.ParseContext) error {
+	client := c.getKafkaClient()
+
+	go func() {
+		for {
+			time.Sleep(time.Second)
+			c.printer.PrintLine(fmt.Sprintf(
+				"produced items: %d, of those skipped because too large: %d, buffered records: %d, buffered bytes: %d",
+				recordCount.Load(), recordsTooLarge.Load(), client.BufferedProduceRecords(), client.BufferedProduceBytes()),
+			)
+		}
+	}()
+
+	separator := bufio.NewScanner(c.inOutFile)
+	separator.Buffer(make([]byte, 10_000_000), 10_000_000) // 10MB buffer because we can have large records
+
+	produceErr := atomic.NewError(nil)
+	for recordsIdx := 0; separator.Scan(); recordsIdx++ {
+		item := separator.Bytes()
+		record := &kgo.Record{}
+		err := json.Unmarshal(item, record)
+		if err != nil {
+			corruptedJSONRecords.Inc()
+			c.printer.PrintLine(fmt.Sprintf("corrupted JSON record %d: %v", recordsIdx, err))
+			continue
+		}
+		if record.Offset < int64(c.skipFirst) {
+			continue
+		}
+		record.Topic = c.topic
+		record.Partition = int32(c.partition)
+		record.Context = context.WithValue(context.Background(), originalOffsetKey, record.Offset)
+
+		client.Produce(context.Background(), record, func(record *kgo.Record, err error) {
+			recordCount.Inc()
+			if errors.Is(err, kerr.MessageTooLarge) {
+				recordsTooLarge.Inc()
+				return
+			}
+			if err != nil {
+				produceErr.Store(fmt.Errorf("failed to produce record with offset %d: %v", record.Context.Value(originalOffsetKey), err))
+			}
+		})
+	}
+
+	c.printer.PrintLine("waiting for produce to finish")
+	err := client.Flush(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to flush records: %w", err)
+	}
+	if err = produceErr.Load(); err != nil {
+		return err
+	}
+	if separator.Err() != nil {
+		return fmt.Errorf("separator scan failed: %w", separator.Err())
+	}
+	return nil
+}

--- a/tools/kafkatool/dump.go
+++ b/tools/kafkatool/dump.go
@@ -59,7 +59,7 @@ func (c *DumpCommand) doExport(*kingpin.ParseContext) error {
 	go func() {
 		for {
 			time.Sleep(time.Second)
-			c.printer.PrintLine(fmt.Sprintf("produced records: %d, offset %d", recordCount.Load(), consumedOffset.Load()))
+			c.printer.PrintLine(fmt.Sprintf("consumed records: %d, offset %d", recordCount.Load(), consumedOffset.Load()))
 		}
 	}()
 

--- a/tools/kafkatool/dump.go
+++ b/tools/kafkatool/dump.go
@@ -21,7 +21,6 @@ type DumpCommand struct {
 	topic             string
 	partition         int
 	skipFirst         int
-	mode              string
 	exportOffsetStart int64
 	exportMaxRecords  int
 	inOutFile         *os.File

--- a/tools/kafkatool/dump_test.go
+++ b/tools/kafkatool/dump_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/mimir/pkg/util/testkafka"
+)
+
+func TestDumpCommand_ExportImport(t *testing.T) {
+	const (
+		partitionID = 1
+		sourceTopic = "source-topic"
+		destTopic   = "dest-topic"
+		numRecords  = 100
+	)
+
+	// Create a Kafka cluster
+	kafkaCluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, sourceTopic)
+	defer kafkaCluster.Close()
+
+	// Create a Kafka client
+	clientProvider, err := createKafkaClientProvider(t, clusterAddr, "")
+	require.NoError(t, err)
+	client := clientProvider()
+
+	// Generate records and push them to the source topic
+	generatedRecords := generateAndPushRecords(t, client, sourceTopic, partitionID, numRecords)
+
+	// Create temporary files for export and import
+	exportFile, err := os.CreateTemp(t.TempDir(), "export_test")
+	require.NoError(t, err)
+	defer exportFile.Close()
+
+	// Create the DumpCommand
+	app := kingpin.New("test", "Test application")
+	cmd := &DumpCommand{}
+	printer := &BufferedPrinter{}
+	t.Cleanup(func() {
+		t.Log(strings.Join(printer.Lines, "\n"))
+	})
+	cmd.Register(app, clientProvider, printer)
+
+	// Create the destination topic
+	_, err = kadm.NewClient(clientProvider()).CreateTopic(context.Background(), partitionID+1, 1, nil, destTopic)
+	require.NoError(t, err)
+
+	// Export from the source topic
+	_, err = app.Parse([]string{
+		"dump", "export",
+		"--topic", sourceTopic,
+		"--partition", fmt.Sprintf("%d", partitionID),
+		"--file", exportFile.Name(),
+	})
+	require.NoError(t, err)
+
+	// Import into the destination topic
+	_, err = app.Parse([]string{
+		"dump", "import",
+		"--topic", destTopic,
+		"--partition", fmt.Sprintf("%d", partitionID),
+		"--file", exportFile.Name(),
+	})
+	require.NoError(t, err)
+
+	// Read from Kafka from the destination topic
+	importedRecords := consumeRecordsFromKafka(t, client, destTopic, numRecords)
+
+	// Assert that the records are the same ones that were generated in step 1
+	assert.Equal(t, len(generatedRecords), len(importedRecords), "Number of imported records should match generated records")
+	for i, genRecord := range generatedRecords {
+		importedRecord := importedRecords[i]
+		assert.Equal(t, genRecord.Value, importedRecord.Value, "Record values should match")
+		assert.Equal(t, genRecord.Key, importedRecord.Key, "Record keys should match")
+		// Note: We don't compare offsets as they might be different in the new topic
+	}
+}
+
+func generateAndPushRecords(t *testing.T, client *kgo.Client, topic string, partition int32, numRecords int) []*kgo.Record {
+	var generatedRecords []*kgo.Record
+	for i := 0; i < numRecords; i++ {
+		record := &kgo.Record{
+			Topic:     topic,
+			Partition: partition,
+			Key:       []byte(fmt.Sprintf("key-%d", i)),
+			Value:     []byte(fmt.Sprintf("test-value-%d", i)),
+		}
+		err := client.ProduceSync(context.Background(), record).FirstErr()
+		require.NoError(t, err)
+		generatedRecords = append(generatedRecords, record)
+	}
+	return generatedRecords
+}
+
+func consumeRecordsFromKafka(t *testing.T, client *kgo.Client, topic string, numRecords int) []*kgo.Record {
+	var records []*kgo.Record
+	client.AddConsumeTopics(topic)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for len(records) < numRecords {
+		fetches := client.PollFetches(ctx)
+		require.NoError(t, fetches.Err())
+		fetches.EachRecord(func(record *kgo.Record) {
+			records = append(records, record)
+		})
+	}
+
+	return records
+}

--- a/tools/kafkatool/dump_test.go
+++ b/tools/kafkatool/dump_test.go
@@ -49,7 +49,7 @@ func TestDumpCommand_ExportImport(t *testing.T) {
 	cmd := &DumpCommand{}
 	printer := &BufferedPrinter{}
 	t.Cleanup(func() {
-		t.Log(strings.Join(printer.Lines, "\n"))
+		t.Log(strings.Join(printer.GetLines(), "\n"))
 	})
 	cmd.Register(app, clientProvider, printer)
 

--- a/tools/kafkatool/main.go
+++ b/tools/kafkatool/main.go
@@ -50,5 +50,8 @@ func main() {
 	clusterMetadataCommand := &BrokersCommand{}
 	clusterMetadataCommand.Register(app, getKafkaClient, printer)
 
+	dumpCommand := &DumpCommand{}
+	dumpCommand.Register(app, getKafkaClient, printer)
+
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }

--- a/tools/kafkatool/util.go
+++ b/tools/kafkatool/util.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/twmb/franz-go/pkg/kgo"
 )
@@ -31,13 +32,19 @@ func (StdoutPrinter) PrintLine(line string) {
 }
 
 type BufferedPrinter struct {
+	mtx   sync.Mutex
 	Lines []string
 }
 
 func (p *BufferedPrinter) Reset() {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
 	p.Lines = nil
 }
 
 func (p *BufferedPrinter) PrintLine(line string) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
 	p.Lines = append(p.Lines, line)
 }

--- a/tools/kafkatool/util.go
+++ b/tools/kafkatool/util.go
@@ -36,6 +36,12 @@ type BufferedPrinter struct {
 	Lines []string
 }
 
+func (p *BufferedPrinter) GetLines() []string {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	return p.Lines
+}
+
 func (p *BufferedPrinter) Reset() {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()

--- a/tools/kafkatool/util.go
+++ b/tools/kafkatool/util.go
@@ -9,7 +9,15 @@ import (
 )
 
 func CreateKafkaClient(kafkaAddress, kafkaClientID string) (*kgo.Client, error) {
-	return kgo.NewClient(kgo.SeedBrokers(kafkaAddress), kgo.ClientID(kafkaClientID))
+	return kgo.NewClient(
+		kgo.SeedBrokers(kafkaAddress),
+		kgo.ClientID(kafkaClientID),
+		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+		kgo.DisableIdempotentWrite(),
+		kgo.AllowAutoTopicCreation(),
+		kgo.BrokerMaxWriteBytes(268_435_456),
+		kgo.MaxBufferedBytes(268_435_456),
+	)
 }
 
 type Printer interface {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

As part of the replay speed work I created a tool to import and export data from Kafka.

This PR adds two commands

* `kafkatool dump import`: this dumps some records from a kafka partition to a file
* `kafkatool dump export`: this takes the same file format from `import` and imports them into another kafka partition


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
