### PR TITLE
Fix TestSchedulerProcessor_processQueriesOnSingleStream flakyness

### DIFF
--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/gogo/status"
+	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/httpgrpc"

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -529,7 +529,7 @@ func TestDefaultManagerFactory_CorrectQueryableUsed(t *testing.T) {
 
 			// Ensure the result has been written.
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				pusher.AssertCalled(&collectWithLogf{collect}, "Push", mock.Anything, mock.Anything)
+				pusher.AssertCalled(test.NewCollectWithLogf(collect), "Push", mock.Anything, mock.Anything)
 			}, 5*time.Second, 100*time.Millisecond)
 
 			manager.Stop()
@@ -593,7 +593,7 @@ func TestDefaultManagerFactory_ShouldNotWriteRecordingRuleResultsWhenDisabled(t 
 			if writeEnabled {
 				// Ensure the result has been written.
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					pusher.AssertCalled(&collectWithLogf{collect}, "Push", mock.Anything, mock.Anything)
+					pusher.AssertCalled(test.NewCollectWithLogf(collect), "Push", mock.Anything, mock.Anything)
 				}, 5*time.Second, 100*time.Millisecond)
 			} else {
 				// Ensure no write occurred within a reasonable amount of time.
@@ -846,9 +846,3 @@ func mustStatusWithDetails(code codes.Code, cause mimirpb.ErrorCause) *status.St
 	}
 	return s
 }
-
-type collectWithLogf struct {
-	*assert.CollectT
-}
-
-func (c *collectWithLogf) Logf(_ string, _ ...interface{}) {}

--- a/pkg/util/test/collect.go
+++ b/pkg/util/test/collect.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package test
+
+import "github.com/stretchr/testify/assert"
+
+type CollectWithLogf struct {
+	*assert.CollectT
+}
+
+func NewCollectWithLogf(collectT *assert.CollectT) *CollectWithLogf {
+	return &CollectWithLogf{
+		CollectT: collectT,
+	}
+}
+
+func (c *CollectWithLogf) Logf(_ string, _ ...interface{}) {}


### PR DESCRIPTION
#### What this PR does

This PR fixes `TestSchedulerProcessor_processQueriesOnSingleStream` flakyness reported in https://github.com/grafana/mimir/issues/7888. The explanation is in the code comment.

#### Which issue(s) this PR fixes or relates to

Fixes #7888

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
