### PR TITLE
Allow matchers for label names endpoint in e2emimir client

### DIFF
--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -413,11 +413,11 @@ func (c *Client) LabelValues(label string, start, end time.Time, matches []strin
 }
 
 // LabelNames gets label names
-func (c *Client) LabelNames(start, end time.Time) ([]string, error) {
+func (c *Client) LabelNames(start, end time.Time, matches []string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
-	result, _, err := c.querierClient.LabelNames(ctx, nil, start, end)
+	result, _, err := c.querierClient.LabelNames(ctx, matches, start, end)
 	return result, err
 }
 

--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -97,7 +97,7 @@ func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService, s
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(v1.MinTime, v1.MaxTime)
+	labelNames, err := c.LabelNames(v1.MinTime, v1.MaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -101,7 +101,7 @@ func testOTLPIngestion(t *testing.T, enableSuffixes bool) {
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := c.LabelNames(v1.MinTime, v1.MaxTime)
+	labelNames, err := c.LabelNames(v1.MinTime, v1.MaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -760,7 +760,7 @@ func testMetadataQueriesWithBlocksStorage(
 				require.Equal(t, exp, labelsRes, lvt)
 			}
 
-			labelNames, err := c.LabelNames(tc.from, tc.to)
+			labelNames, err := c.LabelNames(tc.from, tc.to, nil)
 			require.NoError(t, err)
 			require.Equal(t, tc.labelNames, labelNames)
 		})

--- a/integration/read_write_mode_test.go
+++ b/integration/read_write_mode_test.go
@@ -59,7 +59,7 @@ func runQueryingIngester(t *testing.T, client *e2emimir.Client, seriesName strin
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := client.LabelNames(v1.MinTime, v1.MaxTime)
+	labelNames, err := client.LabelNames(v1.MinTime, v1.MaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 }
@@ -112,7 +112,7 @@ func runQueryingStoreGateway(t *testing.T, client *e2emimir.Client, cluster read
 	require.NoError(t, err)
 	require.Equal(t, model.LabelValues{"bar"}, labelValues)
 
-	labelNames, err := client.LabelNames(v1.MinTime, v1.MaxTime)
+	labelNames, err := client.LabelNames(v1.MinTime, v1.MaxTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 }


### PR DESCRIPTION
#### What this PR does

Allow matchers for label names endpoint in e2emimir client

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Minor non-user-facing change.