### PR TITLE
fix configure-hash-rings.md there is a switch of value for cluster-label-verification-disabled

### DIFF
--- a/docs/sources/mimir/configure/configure-hash-rings.md
+++ b/docs/sources/mimir/configure/configure-hash-rings.md
@@ -108,7 +108,7 @@ Any traffic that does not match that prefix is discarded, to ensure that only th
    This label must be the same on all instances that are part of the same cluster.
    For example, if you run a Grafana Mimir cluster in a dedicated namespace, then set the cluster label to the name of the namespace.
 4. **Wait** until the configuration change has been rolled out to all Grafana Mimir instances.
-5. Enable cluster label verification on all clusters instances by removing the configuration option `-memberlist.cluster-label-verification-disabled=true`.
+5. Enable cluster label verification on all clusters instances by removing the configuration option `-memberlist.cluster-label-verification-disabled=false`.
 6. **Wait** until the configuration change has been rolled out to all Grafana Mimir instances.
 
 ### Fine tuning memberlist changes propagation latency


### PR DESCRIPTION
> 5. Enable cluster label verification on all clusters instances by removing the configuration option `-memberlist.cluster-label-verification-disabled=true`.

Need to be false if we want to enable cluster-label-verification : 

> 5. Enable cluster label verification on all clusters instances by removing the configuration option `-memberlist.cluster-label-verification-disabled=false`.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
