### PR TITLE
ingest storage: don't return an error when records are successfully ingested

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -503,7 +503,8 @@ func (r *PartitionReader) consumeFetches(ctx context.Context, fetches kgo.Fetche
 		err := consumer.Consume(consumeCtx, records)
 		if err == nil {
 			level.Debug(logger).Log("msg", "closing consumer after successful consumption")
-			break
+			// The context might have been cancelled in the meantime, so we return here instead of breaking the loop and returning the context error
+			return nil
 		}
 		level.Error(logger).Log(
 			"msg", "encountered error while ingesting data from Kafka; should retry",


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This fixes a flaky `TestPartitionReader_Commit` because we'd shut down the reader right after receiving the records. That would return an error as if ingesting caused an error. The bug was introduced in #9454 where we did the opposite change. The opposite change isn't functionally necessary.

#### Which issue(s) this PR fixes or relates to

Related to #8697 


#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
