### PR TITLE
Jsonnet: add config option for querier-only CLI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [ENHANCEMENT] Add `ingest_storage_ingester_autoscaling_triggers` option to specify multiple triggers in ScaledObject created for ingest-store ingester autoscaling. #9422
 * [ENHANCEMENT] Add `ingest_storage_ingester_autoscaling_scale_up_stabilization_window_seconds` and `ingest_storage_ingester_autoscaling_scale_down_stabilization_window_seconds` config options to make stabilization window for ingester autoscaling when using ingest-storage configurable. #9445
 * [ENHANCEMENT] Make label-selector in ReplicaTemplate/ingester-zone-a object configurable when using ingest-storage. #9480
+* [ENHANCEMENT] Add `querier_only_args` option to specify CLI flags that apply only to queriers but not ruler-queriers. #9503
 
 ### Mimirtool
 

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -1,6 +1,7 @@
 {
   local container = $.core.v1.container,
 
+  // CLI flags for queriers. Also applied to ruler-queriers.
   querier_args::
     $._config.commonConfig +
     $._config.usageStatsConfig +
@@ -28,6 +29,10 @@
       // the GC to trigger continuously. Setting a ballast of 256MB reduces GC.
       'mem-ballast-size-bytes': 1 << 28,  // 256M
     },
+
+  // CLI flags that are applied only to queriers, and not ruler-queriers.
+  // Values take precedence over querier_args.
+  querier_only_args:: {},
 
   querier_ports:: $.util.defaultPorts,
 
@@ -58,7 +63,7 @@
   querier_node_affinity_matchers:: [],
 
   querier_container::
-    self.newQuerierContainer('querier', $.querier_args, $.querier_env_map),
+    self.newQuerierContainer('querier', $.querier_args + $.querier_only_args, $.querier_env_map),
 
   newQuerierDeployment(name, container, nodeAffinityMatchers=[])::
     local deployment = $.apps.v1.deployment;


### PR DESCRIPTION
#### What this PR does

This PR introduces `querier_only_args` to the Jsonnet library.

These CLI flags are applied only to queriers, not ruler-queriers, unlike `querier_args` which are applied to both queriers and ruler-queriers.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
