### PR TITLE
MQE: add support for `and`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * `cortex_alertmanager_alerts`
   * `cortex_alertmanager_silences`
 * [CHANGE] Cache: Deprecate experimental support for Redis as a cache backend. #9453
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] gRPC: Support S2 compression. #9322
   * `-alertmanager.alertmanager-client.grpc-compression=s2`

--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,8 @@ lint: ## Run lints to check for style issues.
 lint: check-makefiles
 	misspell -error $(DOC_SOURCES_PATH)
 
+	./tools/find-unpooled-slice-creation.sh
+
 	# Configured via .golangci.yml.
 	golangci-lint run
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2013,6 +2013,17 @@
             },
             {
               "kind": "field",
+              "name": "enable_binary_logical_operations",
+              "required": false,
+              "desc": "Enable support for binary logical operations in Mimir's query engine. Only applies if the Mimir query engine is in use.",
+              "fieldValue": null,
+              "fieldDefaultValue": true,
+              "fieldFlag": "querier.mimir-query-engine.enable-binary-logical-operations",
+              "fieldType": "boolean",
+              "fieldCategory": "experimental"
+            },
+            {
+              "kind": "field",
               "name": "enable_scalars",
               "required": false,
               "desc": "Enable support for scalars in Mimir's query engine. Only applies if the Mimir query engine is in use.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1939,6 +1939,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of samples a single query can load into memory. This config option should be set on query-frontend too when query sharding is enabled. (default 50000000)
   -querier.mimir-query-engine.enable-aggregation-operations
     	[experimental] Enable support for aggregation operations in Mimir's query engine. Only applies if the Mimir query engine is in use. (default true)
+  -querier.mimir-query-engine.enable-binary-logical-operations
+    	[experimental] Enable support for binary logical operations in Mimir's query engine. Only applies if the Mimir query engine is in use. (default true)
   -querier.mimir-query-engine.enable-scalar-scalar-binary-comparison-operations
     	[experimental] Enable support for binary comparison operations between two scalars in Mimir's query engine. Only applies if the Mimir query engine is in use. (default true)
   -querier.mimir-query-engine.enable-scalars

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1522,6 +1522,11 @@ mimir_query_engine:
   # CLI flag: -querier.mimir-query-engine.enable-scalar-scalar-binary-comparison-operations
   [enable_scalar_scalar_binary_comparison_operations: <boolean> | default = true]
 
+  # (experimental) Enable support for binary logical operations in Mimir's query
+  # engine. Only applies if the Mimir query engine is in use.
+  # CLI flag: -querier.mimir-query-engine.enable-binary-logical-operations
+  [enable_binary_logical_operations: <boolean> | default = true]
+
   # (experimental) Enable support for scalars in Mimir's query engine. Only
   # applies if the Mimir query engine is in use.
   # CLI flag: -querier.mimir-query-engine.enable-scalars

--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -167,18 +167,18 @@ func TestCases(metricSizes []int) []BenchCase {
 		{
 			Expr: `a_2000 - b_2000{l="1234"}`,
 		},
-		//{
-		//	Expr: "a_X and b_X{l=~'.*[0-4]$'}",
-		//},
+		{
+			Expr: "a_X and b_X{l=~'.*[0-4]$'}",
+		},
 		//{
 		//	Expr: "a_X or b_X{l=~'.*[0-4]$'}",
 		//},
 		//{
 		//	Expr: "a_X unless b_X{l=~'.*[0-4]$'}",
 		//},
-		//{
-		//	Expr: "a_X and b_X{l='notfound'}",
-		//},
+		{
+			Expr: "a_X and b_X{l='notfound'}",
+		},
 		//// Simple functions.
 		//{
 		//	Expr: "abs(a_X)",

--- a/pkg/streamingpromql/config.go
+++ b/pkg/streamingpromql/config.go
@@ -22,12 +22,14 @@ type FeatureToggles struct {
 	EnableVectorVectorBinaryComparisonOperations bool `yaml:"enable_vector_vector_binary_comparison_operations" category:"experimental"`
 	EnableVectorScalarBinaryComparisonOperations bool `yaml:"enable_vector_scalar_binary_comparison_operations" category:"experimental"`
 	EnableScalarScalarBinaryComparisonOperations bool `yaml:"enable_scalar_scalar_binary_comparison_operations" category:"experimental"`
+	EnableBinaryLogicalOperations                bool `yaml:"enable_binary_logical_operations" category:"experimental"`
 	EnableScalars                                bool `yaml:"enable_scalars" category:"experimental"`
 }
 
 // EnableAllFeatures enables all features supported by MQE, including experimental or incomplete features.
 var EnableAllFeatures = FeatureToggles{
 	// Note that we deliberately use a keyless literal here to force a compilation error if we don't keep this in sync with new fields added to FeatureToggles.
+	true,
 	true,
 	true,
 	true,
@@ -40,5 +42,6 @@ func (t *FeatureToggles) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&t.EnableVectorVectorBinaryComparisonOperations, "querier.mimir-query-engine.enable-vector-vector-binary-comparison-operations", true, "Enable support for binary comparison operations between two vectors in Mimir's query engine. Only applies if the Mimir query engine is in use.")
 	f.BoolVar(&t.EnableVectorScalarBinaryComparisonOperations, "querier.mimir-query-engine.enable-vector-scalar-binary-comparison-operations", true, "Enable support for binary comparison operations between a vector and a scalar in Mimir's query engine. Only applies if the Mimir query engine is in use.")
 	f.BoolVar(&t.EnableScalarScalarBinaryComparisonOperations, "querier.mimir-query-engine.enable-scalar-scalar-binary-comparison-operations", true, "Enable support for binary comparison operations between two scalars in Mimir's query engine. Only applies if the Mimir query engine is in use.")
+	f.BoolVar(&t.EnableBinaryLogicalOperations, "querier.mimir-query-engine.enable-binary-logical-operations", true, "Enable support for binary logical operations in Mimir's query engine. Only applies if the Mimir query engine is in use.")
 	f.BoolVar(&t.EnableScalars, "querier.mimir-query-engine.enable-scalars", true, "Enable support for scalars in Mimir's query engine. Only applies if the Mimir query engine is in use.")
 }

--- a/pkg/streamingpromql/engine_concurrency_test.go
+++ b/pkg/streamingpromql/engine_concurrency_test.go
@@ -133,6 +133,30 @@ func TestConcurrentQueries(t *testing.T) {
 			end:   startT.Add(10 * time.Minute),
 			step:  time.Minute,
 		},
+		{
+			expr:  `float{group="a"} and on (instance) float{group="b"}`,
+			start: startT,
+			end:   startT.Add(10 * time.Minute),
+			step:  time.Minute,
+		},
+		{
+			expr:  `native_histogram{group="a"} and on (instance) float{group="b"}`,
+			start: startT,
+			end:   startT.Add(10 * time.Minute),
+			step:  time.Minute,
+		},
+		{
+			expr:  `native_histogram{group="a"} and on (instance) native_histogram{group="b"}`,
+			start: startT,
+			end:   startT.Add(10 * time.Minute),
+			step:  time.Minute,
+		},
+		{
+			expr:  `{group="a"} and on (instance) float{group="b"}`,
+			start: startT,
+			end:   startT.Add(10 * time.Minute),
+			step:  time.Minute,
+		},
 	}
 
 	storage := promqltest.LoadedStorage(t, data)

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1909,7 +1909,7 @@ func TestCompareVariousMixedMetricsBinaryOperations(t *testing.T) {
 	expressions := []string{}
 
 	for _, labels := range labelCombinations {
-		for _, op := range []string{"+", "-", "*", "/"} {
+		for _, op := range []string{"+", "-", "*", "/", "and"} {
 			binaryExpr := fmt.Sprintf(`series{label="%s"}`, labels[0])
 			for _, label := range labels[1:] {
 				binaryExpr += fmt.Sprintf(` %s series{label="%s"}`, op, label)

--- a/pkg/streamingpromql/operators/and_binary_operation.go
+++ b/pkg/streamingpromql/operators/and_binary_operation.go
@@ -212,7 +212,7 @@ func (a *AndBinaryOperation) Close() {
 type andGroup struct {
 	leftSeriesCount      int
 	lastRightSeriesIndex int
-	rightSamplePresence  []bool // TODO: use a bitmap here
+	rightSamplePresence  []bool // FIXME: this would be a good candidate for a bitmap type
 }
 
 // AccumulateRightSeriesPresence records the presence of samples on the right-hand side.

--- a/pkg/streamingpromql/operators/and_binary_operation.go
+++ b/pkg/streamingpromql/operators/and_binary_operation.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package operators
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+// AndBinaryOperation represents a logical 'and' between two vectors.
+type AndBinaryOperation struct {
+	Left                     types.InstantVectorOperator
+	Right                    types.InstantVectorOperator
+	VectorMatching           parser.VectorMatching
+	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
+
+	expressionPosition posrange.PositionRange
+}
+
+var _ types.InstantVectorOperator = &AndBinaryOperation{}
+
+func NewAndBinaryOperation(
+	left types.InstantVectorOperator,
+	right types.InstantVectorOperator,
+	vectorMatching parser.VectorMatching,
+	memoryConsumptionTracker *limiting.MemoryConsumptionTracker,
+	expressionPosition posrange.PositionRange,
+) *AndBinaryOperation {
+	return &AndBinaryOperation{
+		Left:                     left,
+		Right:                    right,
+		VectorMatching:           vectorMatching,
+		MemoryConsumptionTracker: memoryConsumptionTracker,
+		expressionPosition:       expressionPosition,
+	}
+}
+
+func (a *AndBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
+	panic("implement me")
+}
+
+func (a *AndBinaryOperation) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+	panic("implement me")
+}
+
+func (a *AndBinaryOperation) ExpressionPosition() posrange.PositionRange {
+	return a.expressionPosition
+}
+
+func (a *AndBinaryOperation) Close() {
+	a.Left.Close()
+	a.Right.Close()
+}

--- a/pkg/streamingpromql/operators/and_binary_operation.go
+++ b/pkg/streamingpromql/operators/and_binary_operation.go
@@ -19,7 +19,11 @@ type AndBinaryOperation struct {
 	VectorMatching           parser.VectorMatching
 	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
 
-	expressionPosition posrange.PositionRange
+	timeRange            types.QueryTimeRange
+	expressionPosition   posrange.PositionRange
+	leftSeriesGroups     []*andGroup
+	rightSeriesGroups    []*andGroup
+	nextRightSeriesIndex int
 }
 
 var _ types.InstantVectorOperator = &AndBinaryOperation{}
@@ -29,6 +33,7 @@ func NewAndBinaryOperation(
 	right types.InstantVectorOperator,
 	vectorMatching parser.VectorMatching,
 	memoryConsumptionTracker *limiting.MemoryConsumptionTracker,
+	timeRange types.QueryTimeRange,
 	expressionPosition posrange.PositionRange,
 ) *AndBinaryOperation {
 	return &AndBinaryOperation{
@@ -36,16 +41,163 @@ func NewAndBinaryOperation(
 		Right:                    right,
 		VectorMatching:           vectorMatching,
 		MemoryConsumptionTracker: memoryConsumptionTracker,
+		timeRange:                timeRange,
 		expressionPosition:       expressionPosition,
 	}
 }
 
 func (a *AndBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
-	panic("implement me")
+	leftMetadata, err := a.Left.SeriesMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	defer types.PutSeriesMetadataSlice(leftMetadata)
+
+	if len(leftMetadata) == 0 {
+		// We can't produce any series, we are done.
+		return nil, nil
+	}
+
+	rightMetadata, err := a.Right.SeriesMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	defer types.PutSeriesMetadataSlice(rightMetadata)
+
+	if len(rightMetadata) == 0 {
+		// We can't produce any series, we are done.
+		return nil, nil
+	}
+
+	groupMap := map[string]*andGroup{}
+	groupKeyFunc := vectorMatchingGroupKeyFunc(a.VectorMatching)
+
+	// Iterate through the left-hand series, and create groups for each based on the matching labels.
+	a.leftSeriesGroups = make([]*andGroup, 0, len(leftMetadata))
+
+	for _, s := range leftMetadata {
+		groupKey := groupKeyFunc(s.Labels)
+		group, exists := groupMap[string(groupKey)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
+
+		if !exists {
+			group = &andGroup{lastRightSeriesIndex: -1}
+			groupMap[string(groupKey)] = group
+		}
+
+		group.leftSeriesCount++
+		a.leftSeriesGroups = append(a.leftSeriesGroups, group)
+	}
+
+	// Iterate through the right-hand series, and find groups for each based on the matching labels.
+	a.rightSeriesGroups = make([]*andGroup, 0, len(rightMetadata))
+	outputSeriesCount := 0
+
+	for idx, s := range rightMetadata {
+		groupKey := groupKeyFunc(s.Labels)
+		group, exists := groupMap[string(groupKey)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
+
+		if exists {
+			if group.lastRightSeriesIndex == -1 {
+				// First time a right-hand series has matched this group.
+				// We'll return all left-hand series matching this group, so add the count to the running total of output series.
+				outputSeriesCount += group.leftSeriesCount
+			}
+
+			group.lastRightSeriesIndex = idx
+		}
+
+		// Even if there is no matching group, we want to store a nil value here so we know to throw the series away when we read it later.
+		a.rightSeriesGroups = append(a.rightSeriesGroups, group)
+	}
+
+	// Iterate through the left-hand series again, and build the list of output series based on those that matched at least one series on the right.
+	outputSeries := make([]types.SeriesMetadata, 0, outputSeriesCount)
+
+	for seriesIdx, group := range a.leftSeriesGroups {
+		if group.lastRightSeriesIndex == -1 {
+			// This series doesn't match any series from the right side.
+			// Discard the group.
+			a.leftSeriesGroups[seriesIdx] = nil
+		} else {
+			outputSeries = append(outputSeries, leftMetadata[seriesIdx])
+		}
+	}
+
+	return outputSeries, nil
 }
 
 func (a *AndBinaryOperation) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
-	panic("implement me")
+	for {
+		if len(a.leftSeriesGroups) == 0 {
+			// No more series to return.
+			return types.InstantVectorSeriesData{}, types.EOS
+		}
+
+		thisSeriesGroup := a.leftSeriesGroups[0]
+		a.leftSeriesGroups = a.leftSeriesGroups[1:]
+
+		if thisSeriesGroup == nil {
+			// The next series from the left side has no matching series on the right side.
+			// Read it, discard it, and move on to the next series.
+			d, err := a.Left.NextSeries(ctx)
+			if err != nil {
+				return types.InstantVectorSeriesData{}, err
+			}
+
+			types.PutInstantVectorSeriesData(d, a.MemoryConsumptionTracker)
+			continue
+		}
+
+		if err := a.readRightSideUntilGroupComplete(ctx, thisSeriesGroup); err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
+
+		originalData, err := a.Left.NextSeries(ctx)
+		if err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
+
+		filteredData, err := thisSeriesGroup.FilterLeftSeries(originalData, a.MemoryConsumptionTracker, a.timeRange)
+		if err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
+
+		types.PutInstantVectorSeriesData(originalData, a.MemoryConsumptionTracker)
+		thisSeriesGroup.leftSeriesCount--
+
+		if thisSeriesGroup.leftSeriesCount == 0 {
+			// This is the last series for this group, return it to the pool.
+			thisSeriesGroup.Close(a.MemoryConsumptionTracker)
+		}
+
+		return filteredData, nil
+	}
+}
+
+// readRightSideUntilGroupComplete reads series from the right-hand side until all series for desiredGroup have been read.
+func (a *AndBinaryOperation) readRightSideUntilGroupComplete(ctx context.Context, desiredGroup *andGroup) error {
+	for a.nextRightSeriesIndex <= desiredGroup.lastRightSeriesIndex {
+		groupForRightSeries := a.rightSeriesGroups[0]
+		a.rightSeriesGroups = a.rightSeriesGroups[1:]
+
+		data, err := a.Right.NextSeries(ctx)
+		if err != nil {
+			return err
+		}
+
+		if groupForRightSeries != nil {
+			if err := groupForRightSeries.AccumulateRightSeriesPresence(data, a.MemoryConsumptionTracker, a.timeRange); err != nil {
+				return err
+			}
+		}
+
+		types.PutInstantVectorSeriesData(data, a.MemoryConsumptionTracker)
+		a.nextRightSeriesIndex++
+	}
+
+	return nil
 }
 
 func (a *AndBinaryOperation) ExpressionPosition() posrange.PositionRange {
@@ -55,4 +207,86 @@ func (a *AndBinaryOperation) ExpressionPosition() posrange.PositionRange {
 func (a *AndBinaryOperation) Close() {
 	a.Left.Close()
 	a.Right.Close()
+}
+
+type andGroup struct {
+	leftSeriesCount      int
+	lastRightSeriesIndex int
+	rightSamplePresence  []bool // TODO: use a bitmap here
+}
+
+// AccumulateRightSeriesPresence records the presence of samples on the right-hand side.
+func (g *andGroup) AccumulateRightSeriesPresence(data types.InstantVectorSeriesData, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, timeRange types.QueryTimeRange) error {
+	if g.rightSamplePresence == nil {
+		var err error
+		g.rightSamplePresence, err = types.BoolSlicePool.Get(timeRange.StepCount, memoryConsumptionTracker)
+
+		if err != nil {
+			return err
+		}
+
+		g.rightSamplePresence = g.rightSamplePresence[:timeRange.StepCount]
+	}
+
+	for _, p := range data.Floats {
+		g.rightSamplePresence[timeRange.PointIndex(p.T)] = true
+	}
+
+	for _, p := range data.Histograms {
+		g.rightSamplePresence[timeRange.PointIndex(p.T)] = true
+	}
+
+	return nil
+}
+
+// FilterLeftSeries returns leftData filtered based on samples seen for the right-hand side.
+func (g *andGroup) FilterLeftSeries(leftData types.InstantVectorSeriesData, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, timeRange types.QueryTimeRange) (types.InstantVectorSeriesData, error) {
+	filteredData := types.InstantVectorSeriesData{}
+
+	for idx, p := range leftData.Floats {
+		if !g.rightSamplePresence[timeRange.PointIndex(p.T)] {
+			continue
+		}
+
+		if filteredData.Floats == nil {
+			// First time we've seen a float sample that we should return, create a slice for the return values.
+			// We can reduce the length of the slice based on how many samples are left to check in the original series.
+
+			var err error
+			filteredData.Floats, err = types.FPointSlicePool.Get(len(leftData.Floats)-idx, memoryConsumptionTracker)
+			if err != nil {
+				return types.InstantVectorSeriesData{}, nil
+			}
+		}
+
+		filteredData.Floats = append(filteredData.Floats, p)
+	}
+
+	for idx, p := range leftData.Histograms {
+		if !g.rightSamplePresence[timeRange.PointIndex(p.T)] {
+			continue
+		}
+
+		if filteredData.Histograms == nil {
+			// First time we've seen a histogram sample that we should return, create a slice for the return values.
+			// We can reduce the length of the slice based on how many samples are left to check in the original series.
+
+			var err error
+			filteredData.Histograms, err = types.HPointSlicePool.Get(len(leftData.Histograms)-idx, memoryConsumptionTracker)
+			if err != nil {
+				return types.InstantVectorSeriesData{}, nil
+			}
+		}
+
+		filteredData.Histograms = append(filteredData.Histograms, p)
+
+		// Remove the original histogram from the original series to ensure that it's not mutated when the HPoint slice is reused.
+		leftData.Histograms[idx].H = nil
+	}
+
+	return filteredData, nil
+}
+
+func (g *andGroup) Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) {
+	types.BoolSlicePool.Put(g.rightSamplePresence, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/and_binary_operation.go
+++ b/pkg/streamingpromql/operators/and_binary_operation.go
@@ -139,7 +139,7 @@ func (a *AndBinaryOperation) NextSeries(ctx context.Context) (types.InstantVecto
 		a.leftSeriesGroups = a.leftSeriesGroups[1:]
 
 		if thisSeriesGroup == nil {
-			// The next series from the left side has no matching series on the right side.
+			// This series from the left side has no matching series on the right side.
 			// Read it, discard it, and move on to the next series.
 			d, err := a.Left.NextSeries(ctx)
 			if err != nil {
@@ -154,6 +154,8 @@ func (a *AndBinaryOperation) NextSeries(ctx context.Context) (types.InstantVecto
 			return types.InstantVectorSeriesData{}, err
 		}
 
+		// Only read the left series after we've finished reading right series, to minimise the number of series we're
+		// holding in memory at once.
 		originalData, err := a.Left.NextSeries(ctx)
 		if err != nil {
 			return types.InstantVectorSeriesData{}, err

--- a/pkg/streamingpromql/operators/and_binary_operation.go
+++ b/pkg/streamingpromql/operators/and_binary_operation.go
@@ -113,7 +113,7 @@ func (a *AndBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.Series
 	}
 
 	// Iterate through the left-hand series again, and build the list of output series based on those that matched at least one series on the right.
-	outputSeries := make([]types.SeriesMetadata, 0, outputSeriesCount)
+	outputSeries := types.GetSeriesMetadataSlice(outputSeriesCount)
 
 	for seriesIdx, group := range a.leftSeriesGroups {
 		if group.lastRightSeriesIndex == -1 {

--- a/pkg/streamingpromql/operators/binary_operation.go
+++ b/pkg/streamingpromql/operators/binary_operation.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package operators
+
+import (
+	"slices"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// vectorMatchingGroupKeyFunc returns a function that computes the grouping key of the output group a series belongs to.
+//
+// The return value from the function is valid until it is called again.
+func vectorMatchingGroupKeyFunc(vectorMatching parser.VectorMatching) func(labels.Labels) []byte {
+	buf := make([]byte, 0, 1024)
+
+	if vectorMatching.On {
+		slices.Sort(vectorMatching.MatchingLabels)
+
+		return func(l labels.Labels) []byte {
+			return l.BytesWithLabels(buf, vectorMatching.MatchingLabels...)
+		}
+	}
+
+	if len(vectorMatching.MatchingLabels) == 0 {
+		// Fast path for common case for expressions like "a + b" with no 'on' or 'without' labels.
+		return func(l labels.Labels) []byte {
+			return l.BytesWithoutLabels(buf, labels.MetricName)
+		}
+	}
+
+	lbls := make([]string, 0, len(vectorMatching.MatchingLabels)+1)
+	lbls = append(lbls, labels.MetricName)
+	lbls = append(lbls, vectorMatching.MatchingLabels...)
+	slices.Sort(lbls)
+
+	return func(l labels.Labels) []byte {
+		return l.BytesWithoutLabels(buf, lbls...)
+	}
+}

--- a/pkg/streamingpromql/operators/vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/vector_vector_binary_operation.go
@@ -255,7 +255,7 @@ func (b *VectorVectorBinaryOperation) computeOutputSeries() ([]types.SeriesMetad
 		}
 	}
 
-	allMetadata := make([]types.SeriesMetadata, 0, len(outputSeriesMap))
+	allMetadata := types.GetSeriesMetadataSlice(len(outputSeriesMap))
 	allSeries := make([]*binaryOperationOutputSeries, 0, len(outputSeriesMap))
 
 	leftSeriesUsed, err := types.BoolSlicePool.Get(len(b.leftMetadata), b.MemoryConsumptionTracker)

--- a/pkg/streamingpromql/operators/vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/vector_vector_binary_operation.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"slices"
 	"sort"
 	"time"
 
@@ -394,37 +393,6 @@ func (b *VectorVectorBinaryOperation) groupLabelsFunc() func(labels.Labels) labe
 		lb.Del(labels.MetricName)
 		lb.Del(b.VectorMatching.MatchingLabels...)
 		return lb.Labels()
-	}
-}
-
-// vectorMatchingGroupKeyFunc returns a function that computes the grouping key of the output group a series belongs to.
-//
-// The return value from the function is valid until it is called again.
-func vectorMatchingGroupKeyFunc(vectorMatching parser.VectorMatching) func(labels.Labels) []byte {
-	buf := make([]byte, 0, 1024)
-
-	if vectorMatching.On {
-		slices.Sort(vectorMatching.MatchingLabels)
-
-		return func(l labels.Labels) []byte {
-			return l.BytesWithLabels(buf, vectorMatching.MatchingLabels...)
-		}
-	}
-
-	if len(vectorMatching.MatchingLabels) == 0 {
-		// Fast path for common case for expressions like "a + b" with no 'on' or 'without' labels.
-		return func(l labels.Labels) []byte {
-			return l.BytesWithoutLabels(buf, labels.MetricName)
-		}
-	}
-
-	lbls := make([]string, 0, len(vectorMatching.MatchingLabels)+1)
-	lbls = append(lbls, labels.MetricName)
-	lbls = append(lbls, vectorMatching.MatchingLabels...)
-	slices.Sort(lbls)
-
-	return func(l labels.Labels) []byte {
-		return l.BytesWithoutLabels(buf, lbls...)
 	}
 }
 

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -238,7 +238,7 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr) (types.InstantV
 
 		switch e.Op {
 		case parser.LAND:
-			return operators.NewAndBinaryOperation(lhs, rhs, *e.VectorMatching, q.memoryConsumptionTracker, e.PositionRange()), nil
+			return operators.NewAndBinaryOperation(lhs, rhs, *e.VectorMatching, q.memoryConsumptionTracker, q.timeRange, e.PositionRange()), nil
 		default:
 			return operators.NewVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange())
 		}

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -218,7 +218,11 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr) (types.InstantV
 			return nil, compat.NewNotSupportedError(fmt.Sprintf("vector/vector binary expression with '%v'", e.Op))
 		}
 
-		if e.VectorMatching.Card != parser.CardOneToOne {
+		if e.Op.IsSetOperator() && !q.engine.featureToggles.EnableBinaryLogicalOperations {
+			return nil, compat.NewNotSupportedError(fmt.Sprintf("binary expression with '%v'", e.Op))
+		}
+
+		if !e.Op.IsSetOperator() && e.VectorMatching.Card != parser.CardOneToOne {
 			return nil, compat.NewNotSupportedError(fmt.Sprintf("binary expression with %v matching", e.VectorMatching.Card))
 		}
 
@@ -232,7 +236,13 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr) (types.InstantV
 			return nil, err
 		}
 
-		return operators.NewVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange())
+		switch e.Op {
+		case parser.LAND:
+			return operators.NewAndBinaryOperation(lhs, rhs, *e.VectorMatching, q.memoryConsumptionTracker, e.PositionRange()), nil
+		default:
+			return operators.NewVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange())
+		}
+
 	case *parser.UnaryExpr:
 		if e.Op != parser.SUB {
 			return nil, compat.NewNotSupportedError(fmt.Sprintf("unary expression with '%s'", e.Op))

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -808,7 +808,7 @@ eval range from 0 to 24m step 6m left_side and on(cluster, env) right_side
   left_side{env="test", cluster="food", pod="a"}  _  _  _  20
 
 # Same thing again, with labels in different order.
-eval range from 0 to 24m step 6m left_side and on(cluster, env) right_side
+eval range from 0 to 24m step 6m left_side and on(env, cluster) right_side
   left_side{env="test", cluster="blah", pod="a"}  1  2  3  _
   left_side{env="test", cluster="blah", pod="b"}  _  6  7  _
   left_side{env="prod", cluster="blah", pod="a"}  _  10 _  12

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -759,3 +759,73 @@ eval range from 0 to 24m step 6m left_side > bool on (env) right_side
 eval range from 0 to 24m step 6m left_side > bool ignoring (pod) right_side
   {env="test"} 0 0 0 1 1
   {env="prod"} 0 0 0 1 1
+
+clear
+
+# Logical operations: and, or and unless.
+# Single matching series on each side.
+load 6m
+  left_side{env="test", pod="a"}  1  2  3  4                 {{count:5 sum:5}}
+  left_side{env="test", pod="b"}  6  7  8  _                 10
+  left_side{env="prod", pod="a"}  11 12 13 14                15
+  left_side{env="prod", pod="b"}  16 17 18 _                 _
+  right_side{env="test", pod="a"} 0  0  0  {{count:0 sum:0}} {{count:0 sum:0}}
+  right_side{env="test", pod="b"} _  0  _  0                 _
+  right_side{env="prod", pod="b"} _  _  _  0                 0
+  right_side{env="foo", pod="a"}  0  0  0  0                 0
+
+# {env="test", pod="a"}: Matching series, all samples align
+# {env="test", pod="b"}: Matching series, only some samples align
+# {env="prod", pod="a"}: No matching series on RHS
+# {env="prod", pod="b"}: Matching series, but no samples align
+# {env="foo", pod="a"}:  No matching series on LHS
+eval range from 0 to 24m step 6m left_side and right_side
+  left_side{env="test", pod="a"} 1 2 3 4 {{count:5 sum:5}}
+  left_side{env="test", pod="b"} _ 7 _ _ _
+
+clear
+
+# Multiple matching series on each side.
+load 6m
+  left_side{env="test", cluster="blah", pod="a"}  1  2  3  4
+  left_side{env="test", cluster="blah", pod="b"}  _  6  7  8
+  left_side{env="prod", cluster="blah", pod="a"}  9  10 11 12
+  left_side{env="prod", cluster="blah", pod="b"}  13 14 15 16
+  left_side{env="test", cluster="food", pod="a"}  17 18 19 20
+  right_side{env="test", cluster="blah", idx="1"} 0  _  0  _
+  right_side{env="test", cluster="blah", idx="2"} 0  0  _  _
+  right_side{env="prod", cluster="blah", idx="3"} _  0  _  0
+  right_side{env="test", cluster="food", idx="4"}  _  _  _ 0
+
+eval range from 0 to 24m step 6m left_side and right_side
+  # Should return no results.
+
+eval range from 0 to 24m step 6m left_side and on(cluster, env) right_side
+  left_side{env="test", cluster="blah", pod="a"}  1  2  3  _
+  left_side{env="test", cluster="blah", pod="b"}  _  6  7  _
+  left_side{env="prod", cluster="blah", pod="a"}  _  10 _  12
+  left_side{env="prod", cluster="blah", pod="b"}  _  14 _  16
+  left_side{env="test", cluster="food", pod="a"}  _  _  _  20
+
+# Same thing again, with labels in different order.
+eval range from 0 to 24m step 6m left_side and on(cluster, env) right_side
+  left_side{env="test", cluster="blah", pod="a"}  1  2  3  _
+  left_side{env="test", cluster="blah", pod="b"}  _  6  7  _
+  left_side{env="prod", cluster="blah", pod="a"}  _  10 _  12
+  left_side{env="prod", cluster="blah", pod="b"}  _  14 _  16
+  left_side{env="test", cluster="food", pod="a"}  _  _  _  20
+
+eval range from 0 to 24m step 6m left_side and ignoring(idx, pod) right_side
+  left_side{env="test", cluster="blah", pod="a"}  1  2  3  _
+  left_side{env="test", cluster="blah", pod="b"}  _  6  7  _
+  left_side{env="prod", cluster="blah", pod="a"}  _  10 _  12
+  left_side{env="prod", cluster="blah", pod="b"}  _  14 _  16
+  left_side{env="test", cluster="food", pod="a"}  _  _  _  20
+
+# Same thing again, with labels in different order.
+eval range from 0 to 24m step 6m left_side and ignoring(pod, idx) right_side
+  left_side{env="test", cluster="blah", pod="a"}  1  2  3  _
+  left_side{env="test", cluster="blah", pod="b"}  _  6  7  _
+  left_side{env="prod", cluster="blah", pod="a"}  _  10 _  12
+  left_side{env="prod", cluster="blah", pod="b"}  _  14 _  16
+  left_side{env="test", cluster="food", pod="a"}  _  _  _  20

--- a/pkg/streamingpromql/testdata/upstream/operators.test
+++ b/pkg/streamingpromql/testdata/upstream/operators.test
@@ -144,35 +144,29 @@ eval instant at 50m (rate((http_requests[25m])) * 25) * 60
   {group="production", instance="1", job="app-server"} 300
 
 
-# Unsupported by streaming engine.
-# eval instant at 50m http_requests{group="canary"} and http_requests{instance="0"}
-#	http_requests{group="canary", instance="0", job="api-server"} 300
-#	http_requests{group="canary", instance="0", job="app-server"} 700
+eval instant at 50m http_requests{group="canary"} and http_requests{instance="0"}
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="0", job="app-server"} 700
 
-# Unsupported by streaming engine.
-# eval instant at 50m (http_requests{group="canary"} + 1) and http_requests{instance="0"}
-#	{group="canary", instance="0", job="api-server"} 301
-#	{group="canary", instance="0", job="app-server"} 701
+eval instant at 50m (http_requests{group="canary"} + 1) and http_requests{instance="0"}
+	{group="canary", instance="0", job="api-server"} 301
+	{group="canary", instance="0", job="app-server"} 701
 
-# Unsupported by streaming engine.
-# eval instant at 50m (http_requests{group="canary"} + 1) and on(instance, job) http_requests{instance="0", group="production"}
-#	{group="canary", instance="0", job="api-server"} 301
-#	{group="canary", instance="0", job="app-server"} 701
+eval instant at 50m (http_requests{group="canary"} + 1) and on(instance, job) http_requests{instance="0", group="production"}
+	{group="canary", instance="0", job="api-server"} 301
+	{group="canary", instance="0", job="app-server"} 701
 
-# Unsupported by streaming engine.
-# eval instant at 50m (http_requests{group="canary"} + 1) and on(instance) http_requests{instance="0", group="production"}
-#	{group="canary", instance="0", job="api-server"} 301
-#	{group="canary", instance="0", job="app-server"} 701
+eval instant at 50m (http_requests{group="canary"} + 1) and on(instance) http_requests{instance="0", group="production"}
+	{group="canary", instance="0", job="api-server"} 301
+	{group="canary", instance="0", job="app-server"} 701
 
-# Unsupported by streaming engine.
-# eval instant at 50m (http_requests{group="canary"} + 1) and ignoring(group) http_requests{instance="0", group="production"}
-#	{group="canary", instance="0", job="api-server"} 301
-#	{group="canary", instance="0", job="app-server"} 701
+eval instant at 50m (http_requests{group="canary"} + 1) and ignoring(group) http_requests{instance="0", group="production"}
+	{group="canary", instance="0", job="api-server"} 301
+	{group="canary", instance="0", job="app-server"} 701
 
-# Unsupported by streaming engine.
-# eval instant at 50m (http_requests{group="canary"} + 1) and ignoring(group, job) http_requests{instance="0", group="production"}
-#	{group="canary", instance="0", job="api-server"} 301
-#	{group="canary", instance="0", job="app-server"} 701
+eval instant at 50m (http_requests{group="canary"} + 1) and ignoring(group, job) http_requests{instance="0", group="production"}
+	{group="canary", instance="0", job="api-server"} 301
+	{group="canary", instance="0", job="app-server"} 701
 
 # Unsupported by streaming engine.
 # eval instant at 50m http_requests{group="canary"} or http_requests{group="production"}
@@ -250,27 +244,25 @@ eval instant at 50m http_requests{group="canary"} / ignoring(group) http_request
 	{instance="1", job="app-server"} 1.3333333333333333
 
 # https://github.com/prometheus/prometheus/issues/1489
-# Unsupported by streaming engine.
-# eval instant at 50m http_requests AND ON (dummy) vector(1)
-#	http_requests{group="canary", instance="0", job="api-server"} 300
-#	http_requests{group="canary", instance="0", job="app-server"} 700
-#	http_requests{group="canary", instance="1", job="api-server"} 400
-#	http_requests{group="canary", instance="1", job="app-server"} 800
-#	http_requests{group="production", instance="0", job="api-server"} 100
-#	http_requests{group="production", instance="0", job="app-server"} 500
-#	http_requests{group="production", instance="1", job="api-server"} 200
-#	http_requests{group="production", instance="1", job="app-server"} 600
+eval instant at 50m http_requests AND ON (dummy) vector(1)
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="production", instance="1", job="app-server"} 600
 
-# Unsupported by streaming engine.
-# eval instant at 50m http_requests AND IGNORING (group, instance, job) vector(1)
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="production", instance="1", job="app-server"} 600
+eval instant at 50m http_requests AND IGNORING (group, instance, job) vector(1)
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="production", instance="1", job="app-server"} 600
 
 
 # Comparisons.

--- a/tools/find-unpooled-slice-creation.sh
+++ b/tools/find-unpooled-slice-creation.sh
@@ -1,0 +1,29 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(realpath "$(dirname "${0}")")
+PROJECT_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+
+MATCHES=$(
+  cd "$PROJECT_DIR";
+  grep \
+    -R \
+    -n \
+    --exclude '*_test.go' \
+    --exclude '*pool.go' \
+    -e 'make(\[\]types\.SeriesMetadata,' \
+    -e 'make(\[\]promql\.FPoint,' \
+    -e 'make(\[\]promql\.HPoint,' \
+    -e 'make(\[\]float64,' \
+    -e 'make(\[\]bool,' \
+    -e 'make(\[\]\*histogram\.FloatHistogram,' \
+    -e 'make(promql\.Vector,' \
+    'pkg/streamingpromql' || true
+)
+
+if [ -n "$MATCHES" ]; then
+  echo "Found one or more instances of creating a slice directly that should be taken from a pool:"
+  echo "$MATCHES"
+  exit 1
+fi

--- a/tools/find-unpooled-slice-creation.sh
+++ b/tools/find-unpooled-slice-creation.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 
 set -euo pipefail
 


### PR DESCRIPTION
#### What this PR does

This PR adds support for the `and` binary operation.

Compared to Prometheus' engine, latency is up to 90% lower and peak memory consumption is up to 48% lower in our benchmarks:

```
                                                                       │  Prometheus   │                Mimir                │
                                                                       │    sec/op     │    sec/op     vs base               │
Query/a_1_and_b_1{l=~'.*[0-4]$'},_instant_query-10                        723.5µ ±  0%   717.8µ ±  1%        ~ (p=0.310 n=6)
Query/a_1_and_b_1{l=~'.*[0-4]$'},_range_query_with_100_steps-10           744.2µ ±  2%   734.0µ ±  4%        ~ (p=0.818 n=6)
Query/a_1_and_b_1{l=~'.*[0-4]$'},_range_query_with_1000_steps-10          1.269m ±  1%   1.130m ±  1%  -10.93% (p=0.002 n=6)
Query/a_100_and_b_100{l=~'.*[0-4]$'},_instant_query-10                    1.613m ± 11%   1.609m ±  2%        ~ (p=0.485 n=6)
Query/a_100_and_b_100{l=~'.*[0-4]$'},_range_query_with_100_steps-10       3.270m ±  2%   2.367m ± 10%  -27.62% (p=0.002 n=6)
Query/a_100_and_b_100{l=~'.*[0-4]$'},_range_query_with_1000_steps-10     17.321m ±  1%   8.414m ±  0%  -51.42% (p=0.002 n=6)
Query/a_2000_and_b_2000{l=~'.*[0-4]$'},_instant_query-10                  17.08m ±  1%   16.97m ±  2%        ~ (p=0.589 n=6)
Query/a_2000_and_b_2000{l=~'.*[0-4]$'},_range_query_with_100_steps-10     51.59m ±  4%   30.85m ±  1%  -40.20% (p=0.002 n=6)
Query/a_2000_and_b_2000{l=~'.*[0-4]$'},_range_query_with_1000_steps-10    392.2m ±  1%   146.9m ±  9%  -62.55% (p=0.002 n=6)
Query/a_1_and_b_1{l='notfound'},_instant_query-10                         232.3µ ±  2%   217.7µ ± 12%        ~ (p=0.065 n=6)
Query/a_1_and_b_1{l='notfound'},_range_query_with_100_steps-10            251.5µ ±  7%   218.5µ ±  6%  -13.12% (p=0.002 n=6)
Query/a_1_and_b_1{l='notfound'},_range_query_with_1000_steps-10           382.2µ ±  3%   235.5µ ±  1%  -38.38% (p=0.002 n=6)
Query/a_100_and_b_100{l='notfound'},_instant_query-10                     878.4µ ±  4%   524.2µ ±  5%  -40.32% (p=0.002 n=6)
Query/a_100_and_b_100{l='notfound'},_range_query_with_100_steps-10       1429.2µ ±  0%   570.8µ ±  1%  -60.06% (p=0.002 n=6)
Query/a_100_and_b_100{l='notfound'},_range_query_with_1000_steps-10       6.188m ±  3%   1.039m ±  2%  -83.22% (p=0.002 n=6)
Query/a_2000_and_b_2000{l='notfound'},_instant_query-10                  10.842m ±  1%   5.211m ±  1%  -51.93% (p=0.002 n=6)
Query/a_2000_and_b_2000{l='notfound'},_range_query_with_100_steps-10     21.741m ±  1%   5.582m ±  4%  -74.33% (p=0.002 n=6)
Query/a_2000_and_b_2000{l='notfound'},_range_query_with_1000_steps-10    144.98m ±  2%   12.39m ±  2%  -91.45% (p=0.002 n=6)
geomean                                                                   4.140m         2.229m        -46.17%

                                                                       │  Prometheus   │                Mimir                │
                                                                       │       B       │      B        vs base               │
Query/a_1_and_b_1{l=~'.*[0-4]$'},_instant_query-10                        70.23Mi ± 2%   69.00Mi ± 3%        ~ (p=0.143 n=6)
Query/a_1_and_b_1{l=~'.*[0-4]$'},_range_query_with_100_steps-10           69.90Mi ± 1%   70.33Mi ± 3%        ~ (p=0.589 n=6)
Query/a_1_and_b_1{l=~'.*[0-4]$'},_range_query_with_1000_steps-10          67.97Mi ± 1%   66.34Mi ± 4%        ~ (p=0.087 n=6)
Query/a_100_and_b_100{l=~'.*[0-4]$'},_instant_query-10                    66.05Mi ± 2%   66.66Mi ± 1%        ~ (p=0.420 n=6)
Query/a_100_and_b_100{l=~'.*[0-4]$'},_range_query_with_100_steps-10       66.83Mi ± 1%   66.73Mi ± 1%        ~ (p=0.394 n=6)
Query/a_100_and_b_100{l=~'.*[0-4]$'},_range_query_with_1000_steps-10      71.63Mi ± 1%   69.52Mi ± 2%   -2.96% (p=0.002 n=6)
Query/a_2000_and_b_2000{l=~'.*[0-4]$'},_instant_query-10                  68.12Mi ± 2%   69.08Mi ± 2%        ~ (p=0.310 n=6)
Query/a_2000_and_b_2000{l=~'.*[0-4]$'},_range_query_with_100_steps-10     83.23Mi ± 1%   72.56Mi ± 1%  -12.82% (p=0.002 n=6)
Query/a_2000_and_b_2000{l=~'.*[0-4]$'},_range_query_with_1000_steps-10    198.1Mi ± 1%   105.3Mi ± 4%  -46.83% (p=0.002 n=6)
Query/a_1_and_b_1{l='notfound'},_instant_query-10                         73.99Mi ± 2%   74.73Mi ± 1%        ~ (p=0.180 n=6)
Query/a_1_and_b_1{l='notfound'},_range_query_with_100_steps-10            73.16Mi ± 1%   74.46Mi ± 1%   +1.78% (p=0.004 n=6)
Query/a_1_and_b_1{l='notfound'},_range_query_with_1000_steps-10           70.31Mi ± 1%   73.52Mi ± 1%   +4.57% (p=0.002 n=6)
Query/a_100_and_b_100{l='notfound'},_instant_query-10                     67.06Mi ± 1%   67.49Mi ± 1%        ~ (p=0.093 n=6)
Query/a_100_and_b_100{l='notfound'},_range_query_with_100_steps-10        67.25Mi ± 3%   67.76Mi ± 1%        ~ (p=0.240 n=6)
Query/a_100_and_b_100{l='notfound'},_range_query_with_1000_steps-10       69.25Mi ± 1%   67.46Mi ± 1%   -2.58% (p=0.002 n=6)
Query/a_2000_and_b_2000{l='notfound'},_instant_query-10                   67.02Mi ± 2%   67.88Mi ± 2%        ~ (p=0.180 n=6)
Query/a_2000_and_b_2000{l='notfound'},_range_query_with_100_steps-10      75.27Mi ± 1%   68.97Mi ± 1%   -8.37% (p=0.002 n=6)
Query/a_2000_and_b_2000{l='notfound'},_range_query_with_1000_steps-10    129.24Mi ± 3%   67.18Mi ± 6%  -48.02% (p=0.002 n=6)
geomean                                                                   77.06Mi        70.97Mi        -7.90%
```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
