### PR TITLE
Fix doc about max number of failing zone

### DIFF
--- a/docs/sources/mimir/configure/configure-zone-aware-replication.md
+++ b/docs/sources/mimir/configure/configure-zone-aware-replication.md
@@ -71,7 +71,7 @@ With a replication factor of 3, which is the default, deploy the Grafana Mimir c
 Deploying Grafana Mimir clusters to more zones than the configured replication factor does not have a negative impact.
 Deploying Grafana Mimir clusters to fewer zones than the configured replication factor can cause writes to the replica to be missed, or can cause writes to fail completely.
 
-Mimir deployment should have at least `floor(replication factor / 2) + 1` healthy mimir zone to operate.
+A Grafana Mimir deployment should have at least `floor(replication factor / 2) + 1` healthy zones to operate.
 
 ## Unbalanced zones
 


### PR DESCRIPTION
The doc related to maximum number of failing zone to operate is wrong. 

You say that the system can tolerate failures as long as the number of failing zones is `fewer than floor(replication_factor / 2)`. For example:

`Replication Factor = 3 => floor(3 / 2) = 1 > max-num-of-failing-zone => max-num-of-failing-zone = 0`
 
However, we know that Mimir can tolerate 1 zone loss when RF=3.

I updated the doc to give number of healthy zone instead of number of maximum failing zone to operate.
