### PR TITLE
query-tee: Add an option to skip samples for comparison before a given timestamp

### DIFF
--- a/cmd/query-tee/main.go
+++ b/cmd/query-tee/main.go
@@ -106,6 +106,7 @@ func mimirReadRoutes(cfg Config) []querytee.Route {
 		Tolerance:              cfg.ProxyConfig.ValueComparisonTolerance,
 		UseRelativeError:       cfg.ProxyConfig.UseRelativeError,
 		SkipRecentSamples:      cfg.ProxyConfig.SkipRecentSamples,
+		SkipSamplesBefore:      cfg.ProxyConfig.SkipSamplesBefore * 1000,
 		RequireExactErrorMatch: cfg.ProxyConfig.RequireExactErrorMatch,
 	})
 

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -39,6 +39,7 @@ type ProxyConfig struct {
 	UseRelativeError                    bool
 	PassThroughNonRegisteredRoutes      bool
 	SkipRecentSamples                   time.Duration
+	SkipSamplesBefore                   int64
 	RequireExactErrorMatch              bool
 	BackendSkipTLSVerify                bool
 	AddMissingTimeParamToInstantQueries bool
@@ -65,6 +66,7 @@ func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&cfg.ValueComparisonTolerance, "proxy.value-comparison-tolerance", 0.000001, "The tolerance to apply when comparing floating point values in the responses. 0 to disable tolerance and require exact match (not recommended).")
 	f.BoolVar(&cfg.UseRelativeError, "proxy.compare-use-relative-error", false, "Use relative error tolerance when comparing floating point values.")
 	f.DurationVar(&cfg.SkipRecentSamples, "proxy.compare-skip-recent-samples", 2*time.Minute, "The window from now to skip comparing samples. 0 to disable.")
+	f.Int64Var(&cfg.SkipSamplesBefore, "proxy.compare-skip-samples-before", 0, "Skip the samples before the given unix timestamp in seconds for comparison.")
 	f.BoolVar(&cfg.RequireExactErrorMatch, "proxy.compare-exact-error-matching", false, "If true, errors will be considered the same only if they are exactly the same. If false, errors will be considered the same if they are considered equivalent.")
 	f.BoolVar(&cfg.PassThroughNonRegisteredRoutes, "proxy.passthrough-non-registered-routes", false, "Passthrough requests for non-registered routes to preferred backend.")
 	f.BoolVar(&cfg.AddMissingTimeParamToInstantQueries, "proxy.add-missing-time-parameter-to-instant-queries", true, "Add a 'time' parameter to proxied instant query requests if they do not have one.")

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -1139,6 +1139,7 @@ func TestCompareSamplesResponse(t *testing.T) {
 		err               error
 		useRelativeError  bool
 		skipRecentSamples time.Duration
+		skipSamplesBefore int64 // In unix milliseconds
 	}{
 		{
 			name: "difference in response status",
@@ -2166,12 +2167,259 @@ func TestCompareSamplesResponse(t *testing.T) {
 						}`),
 			err: errors.New(`expected info annotations ["\"info\" #1"] but got ["\"info\" #2"]`),
 		},
+		{
+			name: "should not fail when we skip samples from the beginning of a matrix for expected and actual - float",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[90,"9"], [100,"10"]]}, {"metric":{"foo":"bar2"},"values":[[100,"10"]]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[100,"10"]]}, {"metric":{"foo":"bar2"},"values":[[80,"9"], [100,"10"]]}]}
+						}`),
+			skipSamplesBefore: 95 * 1000,
+		},
+		{
+			name: "should not fail when we skip all samples starting from the beginning - float",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[90,"9"], [100,"10"]]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[100,"10"]]}]}
+						}`),
+			skipSamplesBefore: 105 * 1000,
+		},
+		{
+			name: "should fail when we skip partial samples in the beginning but compare some other - float",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[90,"9"], [97,"7"], [100,"10"]]}, {"metric":{"foo":"bar2"},"values":[[100,"10"]]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[100,"10"]]}, {"metric":{"foo":"bar2"},"values":[[90,"10"], [100,"10"]]}]}
+						}`),
+			skipSamplesBefore: 95 * 1000,
+			// 9 @[90] is not compared. foo=bar2 does not fail.
+			err: errors.New(`float sample pair does not match for metric {foo="bar"}: expected timestamp 97 but got 100
+Expected result for series:
+{foo="bar"} =>
+7 @[97]
+10 @[100]
+
+Actual result for series:
+{foo="bar"} =>
+10 @[100]`),
+		},
+		{
+			name: "should not fail when we skip samples from the beginning of a matrix for expected and actual - histogram",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[
+								{"metric":{"foo":"bar"},"histograms":[[90,{"count": "2","sum": "4","buckets": [[1,"0","2","2"]]}], [100,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]]},
+								{"metric":{"foo":"bar2"},"histograms":[[100,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[
+								{"metric":{"foo":"bar"},"histograms":[[100,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]]}, 
+								{"metric":{"foo":"bar2"},"histograms":[[80,{"count": "2","sum": "4","buckets": [[1,"0","2","2"]]}], [100,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]]}]}
+						}`),
+			skipSamplesBefore: 95 * 1000,
+		},
+		{
+			name: "should not fail when we skip all samples starting from the beginning - histogram",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"histograms":[[90,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}], [100,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"histograms":[[100,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]]}]}
+						}`),
+			skipSamplesBefore: 105 * 1000,
+		},
+		{
+			name: "should fail when we skip partial samples in the beginning but compare some other - histogram",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[
+								{"metric":{"foo":"bar"},"histograms":[[90,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}], [97,{"count": "2","sum": "33","buckets": [[1,"0","2","2"]]}], [100,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]]},
+								{"metric":{"foo":"bar2"},"histograms":[[100,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[
+								{"metric":{"foo":"bar"},"histograms":[[100,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]]},
+								{"metric":{"foo":"bar2"},"histograms":[[90,{"count": "2","sum": "44","buckets": [[1,"0","2","2"]]}], [100,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]]}]}
+						}`),
+			skipSamplesBefore: 95 * 1000,
+			// @[90] is not compared. foo=bar2 does not fail.
+			err: errors.New(`histogram sample pair does not match for metric {foo="bar"}: expected timestamp 97 but got 100
+Expected result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 33.000000, Buckets: [[0,2):2] @[97]
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[100]
+
+Actual result for series:
+{foo="bar"} =>
+Count: 2.000000, Sum: 3.000000, Buckets: [[0,2):2] @[100]`),
+		},
+		{
+			name: "should not fail when skipped samples properly for vectors",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[90,"1"]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[95,"1"]}]}
+						}`),
+			skipSamplesBefore: 100 * 1000,
+		},
+		{
+			name: "should not fail when skipped samples properly for vectors - histogram",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"histogram":[90,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"histogram":[95,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]}]}
+						}`),
+			skipSamplesBefore: 100 * 1000,
+		},
+		{
+			name: "should fail when skipped samples only for expected vector",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[90,"1"]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[105,"1"]}]}
+						}`),
+			skipSamplesBefore: 100 * 1000,
+			err:               errors.New(`expected 0 metrics but got 1`),
+		},
+		{
+			name: "should fail when skipped samples only for actual vector",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[105,"1"]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[95,"1"]}]}
+						}`),
+			skipSamplesBefore: 100 * 1000,
+			err:               errors.New(`expected 1 metrics but got 0`),
+		},
+		{
+			name: "should skip properly when there are multiple series in a vector",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[90,"1"]}, {"metric":{"foo":"bar2"},"value":[105,"1"]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[95,"1"]}, {"metric":{"foo":"bar2"},"value":[105,"1"]}]}
+						}`),
+			skipSamplesBefore: 100 * 1000,
+		},
+		{
+			name: "should skip properly when there are multiple series in a vector - histogram",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[
+								{"metric":{"foo":"bar"},"histogram":[90,{"count":"2","sum":"333","buckets":[[1,"0","2","2"]]}]}, 
+								{"metric":{"foo":"bar2"},"histogram":[105,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[
+								{"metric":{"foo":"bar"},"histogram":[95,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]}, 
+								{"metric":{"foo":"bar2"},"histogram":[105,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]}]}
+						}`),
+			skipSamplesBefore: 100 * 1000,
+		},
+		{
+			name: "different series skipped in expected and actual, causing an error",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[105,"1"]}, {"metric":{"foo":"bar2"},"value":[90,"1"]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[{"metric":{"foo":"bar"},"value":[95,"1"]}, {"metric":{"foo":"bar2"},"value":[105,"1"]}]}
+						}`),
+			skipSamplesBefore: 100 * 1000,
+			err:               errors.New(`expected metric {foo="bar"} missing from actual response`),
+		},
+		{
+			name: "different series skipped in expected and actual, causing an error - histogram",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[
+								{"metric":{"foo":"bar"},"histogram":[105,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]}, 
+								{"metric":{"foo":"bar2"},"histogram":[90,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"vector","result":[
+								{"metric":{"foo":"bar"},"histogram":[95,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]}, 
+								{"metric":{"foo":"bar2"},"histogram":[105,{"count":"2","sum":"3","buckets":[[1,"0","2","2"]]}]}]}
+						}`),
+			skipSamplesBefore: 100 * 1000,
+			err:               errors.New(`expected metric {foo="bar"} missing from actual response`),
+		},
+		{
+			name: "expected is skippable but not the actual, causing an error",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"scalar","result":[90,"1"]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"scalar","result":[100,"1"]}
+						}`),
+			skipSamplesBefore: 95 * 1000,
+			err:               errors.New(`expected timestamp 90 but got 100`),
+		},
+		{
+			name: "actual is skippable but not the expected, causing an error",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"scalar","result":[100,"1"]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"scalar","result":[90,"1"]}
+						}`),
+			skipSamplesBefore: 95 * 1000,
+			err:               errors.New(`expected timestamp 100 but got 90`),
+		},
+		{
+			name: "both expected and actual are skippable",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"scalar","result":[95,"1"]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"scalar","result":[90,"1"]}
+						}`),
+			skipSamplesBefore: 100 * 1000,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			samplesComparator := NewSamplesComparator(SampleComparisonOptions{
 				Tolerance:         tc.tolerance,
 				UseRelativeError:  tc.useRelativeError,
 				SkipRecentSamples: tc.skipRecentSamples,
+				SkipSamplesBefore: tc.skipSamplesBefore,
 			})
 			result, err := samplesComparator.Compare(tc.expected, tc.actual, nowT.Time())
 			if tc.err == nil {


### PR DESCRIPTION
#### What this PR does

Similar to how we have `-proxy.compare-skip-recent-samples`, this PR adds `-proxy.compare-skip-samples-before` to skip samples for comparison that are before the given unix timestamp. It is useful for block builders where you don't want to compare beyond a certain point.

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
