### PR TITLE
MQE: fix panic in `rate` or `increase` over native histograms with changing schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * `cortex_alertmanager_alerts`
   * `cortex_alertmanager_silences`
 * [CHANGE] Cache: Deprecate experimental support for Redis as a cache backend. #9453
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] gRPC: Support S2 compression. #9322
   * `-alertmanager.alertmanager-client.grpc-compression=s2`

--- a/pkg/streamingpromql/functions/rate_increase.go
+++ b/pkg/streamingpromql/functions/rate_increase.go
@@ -84,9 +84,9 @@ func histogramRate(isRate bool, step types.RangeVectorStepData, hHead []promql.H
 		emitAnnotation(annotations.NewNativeHistogramNotCounterWarning)
 	}
 
-	currentSchema := firstPoint.H.Schema
-	if lastPoint.H.Schema < currentSchema {
-		currentSchema = lastPoint.H.Schema
+	initialSchema := firstPoint.H.Schema
+	if lastPoint.H.Schema < initialSchema {
+		initialSchema = lastPoint.H.Schema
 	}
 
 	usingCustomBuckets := firstPoint.H.UsesCustomBuckets()
@@ -94,7 +94,7 @@ func histogramRate(isRate bool, step types.RangeVectorStepData, hHead []promql.H
 		return nil, histogram.ErrHistogramsIncompatibleSchema
 	}
 
-	delta := lastPoint.H.CopyToSchema(currentSchema)
+	delta := lastPoint.H.CopyToSchema(initialSchema)
 	_, err := delta.Sub(firstPoint.H)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func histogramRate(isRate bool, step types.RangeVectorStepData, hHead []promql.H
 				return histogram.ErrHistogramsIncompatibleSchema
 			}
 
-			if p.H.Schema < currentSchema {
+			if p.H.Schema < delta.Schema {
 				delta = delta.CopyToSchema(p.H.Schema)
 			}
 

--- a/pkg/streamingpromql/testdata/ours/native_histograms.test
+++ b/pkg/streamingpromql/testdata/ours/native_histograms.test
@@ -204,9 +204,12 @@ eval_warn range from 0 to 18m step 6m sum(metric)
 
 clear
 
-# Test rate() over native histograms with changing schemas.
+# Test rate() and increase() over native histograms with changing schemas.
 load 1m
   metric {{schema:4 sum:2 count:2 buckets:[2]}} {{schema:2 sum:6 count:12 buckets:[12]}} {{schema:3 sum:12 count:24 buckets:[24]}} {{schema:4 sum:164 count:326 buckets:[326]}}
 
 eval instant at 3m rate(metric[3m])
   {} {{schema:2 sum:1 count:2 buckets:[2] counter_reset_hint:gauge}}
+
+eval instant at 3m increase(metric[3m])
+  {} {{schema:2 sum:180 count:360 buckets:[360] counter_reset_hint:gauge}}

--- a/pkg/streamingpromql/testdata/ours/native_histograms.test
+++ b/pkg/streamingpromql/testdata/ours/native_histograms.test
@@ -201,3 +201,12 @@ load 6m
 # T=18: compatible
 eval_warn range from 0 to 18m step 6m sum(metric)
   {} _ {{schema:-53 sum:2 count:2 custom_values:[5 10] buckets:[2 4]}} _ {{schema:-53 sum:3.8 count:6 custom_values:[3] buckets:[6]}}
+
+clear
+
+# Test rate() over native histograms with changing schemas.
+load 1m
+  metric {{schema:4 sum:2 count:2 buckets:[2]}} {{schema:2 sum:6 count:12 buckets:[12]}} {{schema:3 sum:12 count:24 buckets:[24]}} {{schema:4 sum:164 count:326 buckets:[326]}}
+
+eval instant at 3m rate(metric[3m])
+  {} {{schema:2 sum:1 count:2 buckets:[2] counter_reset_hint:gauge}}


### PR DESCRIPTION
#### What this PR does

This PR fixes a panic in MQE when `rate` or `increase` is used over a range of native histograms that change schema multiple times.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
