### PR TITLE
Block upload: Verify block ranges of uploaded blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [ENHANCEMENT] Ruler: Support `exclude_alerts` parameter in `<prometheus-http-prefix>/api/v1/rules` endpoint. #9300
 * [ENHANCEMENT] Distributor: add a metric to track tenants who are sending newlines in their label values called `cortex_distributor_label_values_with_newlines_total`. #9400
 * [ENHANCEMENT] Ingester: improve performance of reading the WAL. #9508
+* [ENHANCEMENT] Compactor: uploaded blocks cannot be bigger than max configured compactor time range, and cannot cross the boundary for given time range.
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508

--- a/pkg/compactor/block_upload_test.go
+++ b/pkg/compactor/block_upload_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -62,13 +63,13 @@ func TestMultitenantCompactor_StartBlockUpload(t *testing.T) {
 	const tenantID = "test"
 	const blockID = "01G3FZ0JWJYJC0ZM6Y9778P6KD"
 	bULID := ulid.MustParse(blockID)
-	now := time.Now().UnixMilli()
+	now := time.Now()
 	validMeta := block.Meta{
 		BlockMeta: tsdb.BlockMeta{
 			ULID:    bULID,
 			Version: block.TSDBVersion1,
-			MinTime: now - 1000,
-			MaxTime: now,
+			MinTime: now.UnixMilli() - 1000,
+			MaxTime: now.UnixMilli(),
 		},
 		Thanos: block.ThanosMeta{
 			Labels: map[string]string{
@@ -89,6 +90,21 @@ func TestMultitenantCompactor_StartBlockUpload(t *testing.T) {
 			},
 		},
 	}
+
+	// Block between 00:00 ... 01:00 the next day (25 hours)
+	blockWithLargeDuration := validMeta
+	blockWithLargeDuration.MinTime = now.Add(-25 * time.Hour).Truncate(24 * time.Hour).UnixMilli()
+	blockWithLargeDuration.MaxTime = timestamp.Time(blockWithLargeDuration.MinTime).Add(25 * time.Hour).UnixMilli()
+
+	// Block between 12:00 and 12:00 the next day (24 hours)
+	blockCrossingDayBoundary := validMeta
+	blockCrossingDayBoundary.MinTime = now.Add(-48 * time.Hour).Truncate(24 * time.Hour).Add(12 * time.Hour).UnixMilli()
+	blockCrossingDayBoundary.MaxTime = timestamp.Time(blockCrossingDayBoundary.MinTime).Add(24 * time.Hour).UnixMilli()
+
+	// Block between 00:00 and 24:00 the next day (24 hours)
+	blockAtTheBoundary := validMeta
+	blockAtTheBoundary.MinTime = now.Truncate(24 * time.Hour).UnixMilli()
+	blockAtTheBoundary.MaxTime = timestamp.Time(blockAtTheBoundary.MinTime).Add(24 * time.Hour).UnixMilli()
 
 	metaPath := path.Join(tenantID, blockID, block.MetaFilename)
 	uploadingMetaPath := path.Join(tenantID, blockID, fmt.Sprintf("uploading-%s", block.MetaFilename))
@@ -457,6 +473,22 @@ func TestMultitenantCompactor_StartBlockUpload(t *testing.T) {
 			expBadRequest:           fmt.Sprintf(maxBlockUploadSizeBytesFormat, 1),
 		},
 		{
+			name:                   "block with too big time range",
+			tenantID:               tenantID,
+			blockID:                blockID,
+			setUpBucketMock:        setUpPartialBlock,
+			meta:                   &blockWithLargeDuration,
+			expUnprocessableEntity: "block duration (1d1h) is larger than max configured compactor time range (1d)",
+		},
+		{
+			name:                   "block crossing the day boundary",
+			tenantID:               tenantID,
+			blockID:                blockID,
+			setUpBucketMock:        setUpPartialBlock,
+			meta:                   &blockCrossingDayBoundary,
+			expUnprocessableEntity: "block time range crosses boundary of configured compactor time range (1d)",
+		},
+		{
 			name:            "valid request",
 			tenantID:        tenantID,
 			blockID:         blockID,
@@ -477,8 +509,8 @@ func TestMultitenantCompactor_StartBlockUpload(t *testing.T) {
 				BlockMeta: tsdb.BlockMeta{
 					ULID:    bULID,
 					Version: block.TSDBVersion1,
-					MinTime: now - 1000,
-					MaxTime: now,
+					MinTime: now.UnixMilli() - 1000,
+					MaxTime: now.UnixMilli(),
 				},
 				Thanos: block.ThanosMeta{
 					Labels: map[string]string{
@@ -512,8 +544,8 @@ func TestMultitenantCompactor_StartBlockUpload(t *testing.T) {
 				BlockMeta: tsdb.BlockMeta{
 					ULID:    bULID,
 					Version: block.TSDBVersion1,
-					MinTime: now - 1000,
-					MaxTime: now,
+					MinTime: now.UnixMilli() - 1000,
+					MaxTime: now.UnixMilli(),
 				},
 				Thanos: block.ThanosMeta{
 					Files: []block.File{
@@ -544,8 +576,8 @@ func TestMultitenantCompactor_StartBlockUpload(t *testing.T) {
 				BlockMeta: tsdb.BlockMeta{
 					ULID:    ulid.MustParse("11A2FZ0JWJYJC0ZM6Y9778P6KD"),
 					Version: block.TSDBVersion1,
-					MinTime: now - 1000,
-					MaxTime: now,
+					MinTime: now.UnixMilli() - 1000,
+					MaxTime: now.UnixMilli(),
 				},
 				Thanos: block.ThanosMeta{
 					Files: []block.File{
@@ -583,6 +615,9 @@ func TestMultitenantCompactor_StartBlockUpload(t *testing.T) {
 				logger:       log.NewNopLogger(),
 				bucketClient: &bkt,
 				cfgProvider:  cfgProvider,
+				compactorCfg: Config{
+					BlockRanges: mimir_tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour},
+				},
 			}
 			var rdr io.Reader
 			if tc.body != "" {
@@ -730,6 +765,9 @@ func TestMultitenantCompactor_StartBlockUpload(t *testing.T) {
 				logger:       log.NewNopLogger(),
 				bucketClient: bkt,
 				cfgProvider:  cfgProvider,
+				compactorCfg: Config{
+					BlockRanges: mimir_tsdb.DurationList{2 * time.Hour, 12 * time.Hour, 24 * time.Hour},
+				},
 			}
 			r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/upload/block/%s/start", blockID), bytes.NewReader(metaJSON))
 			r = r.WithContext(user.InjectOrgID(r.Context(), tenantID))


### PR DESCRIPTION
#### What this PR does

Verify that backfilled blocks do not cover too big time range or cross the boundary of the max time range used by compactor.

Larger blocks can be split using tool from https://github.com/grafana/mimir/pull/9517.

#### Checklist

- [x] Tests updated.
- [na] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [na] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
