### PR TITLE
Update embedded query in query sharding to include a separate map

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/embedded.go
+++ b/pkg/frontend/querymiddleware/astmapper/embedded.go
@@ -71,7 +71,7 @@ func (c jsonCodec) Decode(encoded string) (queries []EmbeddedQuery, err error) {
 	return embedded.Concat, nil
 }
 
-// VectorSquash reduces an AST into a single vector query which can be hijacked by a Queryable impl.
+// VectorSquash reduces multiple EmbeddedQueries into a single vector query which can be hijacked by a Queryable impl.
 // It always uses a VectorSelector as the substitution expr.
 // This is important because logical/set binops can only be applied against vectors and not matrices.
 func VectorSquasher(exprs ...EmbeddedQuery) (parser.Expr, error) {

--- a/pkg/frontend/querymiddleware/astmapper/embedded.go
+++ b/pkg/frontend/querymiddleware/astmapper/embedded.go
@@ -33,7 +33,19 @@ const (
 
 // EmbeddedQueries is a wrapper type for encoding queries
 type EmbeddedQueries struct {
-	Concat []string `json:"Concat"`
+	Concat []EmbeddedQuery `json:"Concat"`
+}
+
+type EmbeddedQuery struct {
+	Expr   string            `json:"Expr"`
+	Params map[string]string `json:"Params,omitempty"`
+}
+
+func NewEmbeddedQuery(expr string, params map[string]string) EmbeddedQuery {
+	return EmbeddedQuery{
+		Expr:   expr,
+		Params: params,
+	}
 }
 
 // JSONCodec is a Codec that uses JSON representations of EmbeddedQueries structs
@@ -41,7 +53,7 @@ var JSONCodec jsonCodec
 
 type jsonCodec struct{}
 
-func (c jsonCodec) Encode(queries []string) (string, error) {
+func (c jsonCodec) Encode(queries []EmbeddedQuery) (string, error) {
 	embedded := EmbeddedQueries{
 		Concat: queries,
 	}
@@ -49,7 +61,7 @@ func (c jsonCodec) Encode(queries []string) (string, error) {
 	return string(b), err
 }
 
-func (c jsonCodec) Decode(encoded string) (queries []string, err error) {
+func (c jsonCodec) Decode(encoded string) (queries []EmbeddedQuery, err error) {
 	var embedded EmbeddedQueries
 	err = json.Unmarshal([]byte(encoded), &embedded)
 	if err != nil {
@@ -62,14 +74,8 @@ func (c jsonCodec) Decode(encoded string) (queries []string, err error) {
 // VectorSquash reduces an AST into a single vector query which can be hijacked by a Queryable impl.
 // It always uses a VectorSelector as the substitution expr.
 // This is important because logical/set binops can only be applied against vectors and not matrices.
-func VectorSquasher(exprs ...parser.Expr) (parser.Expr, error) {
-	// concat OR legs
-	strs := make([]string, 0, len(exprs))
-	for _, expr := range exprs {
-		strs = append(strs, expr.String())
-	}
-
-	encoded, err := JSONCodec.Encode(strs)
+func VectorSquasher(exprs ...EmbeddedQuery) (parser.Expr, error) {
+	encoded, err := JSONCodec.Encode(exprs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting.go
@@ -358,7 +358,7 @@ func (i *instantSplitter) splitAndSquashCall(expr *parser.Call, rangeInterval ti
 	}
 
 	// Create a partial query for each split
-	embeddedQueries := make([]parser.Expr, 0, splitCount)
+	embeddedQueries := make([]EmbeddedQuery, 0, splitCount)
 	for split := 0; split < splitCount; split++ {
 		splitOffset := time.Duration(split) * i.interval
 		// The range interval of the last embedded query can be smaller than i.interval
@@ -377,7 +377,7 @@ func (i *instantSplitter) splitAndSquashCall(expr *parser.Call, rangeInterval ti
 		}
 
 		// Prepend to embedded queries
-		embeddedQueries = append([]parser.Expr{splitExpr}, embeddedQueries...)
+		embeddedQueries = append([]EmbeddedQuery{NewEmbeddedQuery(splitExpr.String(), nil)}, embeddedQueries...)
 	}
 
 	squashExpr, err := VectorSquasher(embeddedQueries...)

--- a/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/instant_splitting_test.go
@@ -281,59 +281,59 @@ func TestInstantSplitter(t *testing.T) {
 		// Offset operator
 		{
 			in:                   `rate({app="foo"}[3m] offset 3m)`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"increase({app=\\\"foo\\\"}[1m] offset 5m)\",\"increase({app=\\\"foo\\\"}[1m] offset 4m)\",\"increase({app=\\\"foo\\\"}[1m] offset 3m)\"]}"}) / 180`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"increase({app=\\\"foo\\\"}[1m] offset 5m)\"},{\"Expr\":\"increase({app=\\\"foo\\\"}[1m] offset 4m)\"},{\"Expr\":\"increase({app=\\\"foo\\\"}[1m] offset 3m)\"}]}"}) / 180`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `avg_over_time({app="foo"}[3m] offset 5m)`,
-			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] offset 7m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset 6m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset 5m)\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 7m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset 6m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset 5m)\"]}"}))`,
+			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[1m] offset 7m)\"},{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset 6m)\"},{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset 5m)\"}]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[1m] offset 7m)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset 6m)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset 5m)\"}]}"}))`,
 			expectedSplitQueries: 6,
 		},
 		{
 			in:                   `rate({app="foo"}[3m] offset 30s)`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"increase({app=\\\"foo\\\"}[1m] offset 2m30s)\",\"increase({app=\\\"foo\\\"}[1m] offset 1m30s)\",\"increase({app=\\\"foo\\\"}[1m] offset 30s)\"]}"}) / 180`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"increase({app=\\\"foo\\\"}[1m] offset 2m30s)\"},{\"Expr\":\"increase({app=\\\"foo\\\"}[1m] offset 1m30s)\"},{\"Expr\":\"increase({app=\\\"foo\\\"}[1m] offset 30s)\"}]}"}) / 180`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `count_over_time({app="foo"}[3m] offset -3m)`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset -1m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -2m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -3m)\"]}"})`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[1m] offset -1m)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -2m)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -3m)\"}]}"})`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `avg_over_time({app="foo"}[3m] offset -5m)`,
-			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] offset -3m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset -4m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset -5m)\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset -3m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -4m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -5m)\"]}"}))`,
+			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[1m] offset -3m)\"},{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset -4m)\"},{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[59s999ms] offset -5m)\"}]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[1m] offset -3m)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -4m)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -5m)\"}]}"}))`,
 			expectedSplitQueries: 6,
 		},
 		{
 			in:                   `count_over_time({app="foo"}[3m] offset -30s)`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 1m30s)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset 30s)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -30s)\"]}"})`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[1m] offset 1m30s)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset 30s)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[59s999ms] offset -30s)\"}]}"})`,
 			expectedSplitQueries: 3,
 		},
 		// @ modifier
 		{
 			in:                   `rate({app="foo"}[3m] @ start())`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"increase({app=\\\"foo\\\"}[1m] @ start() offset 2m)\",\"increase({app=\\\"foo\\\"}[1m] @ start() offset 1m)\",\"increase({app=\\\"foo\\\"}[1m] @ start())\"]}"}) / 180`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"increase({app=\\\"foo\\\"}[1m] @ start() offset 2m)\"},{\"Expr\":\"increase({app=\\\"foo\\\"}[1m] @ start() offset 1m)\"},{\"Expr\":\"increase({app=\\\"foo\\\"}[1m] @ start())\"}]}"}) / 180`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `sum(sum_over_time({app="foo"}[3m] @ end()))`,
-			out:                  `sum(sum(__embedded_queries__{__queries__="{\"Concat\":[\"sum(sum_over_time({app=\\\"foo\\\"}[1m] @ end() offset 2m))\",\"sum(sum_over_time({app=\\\"foo\\\"}[59s999ms] @ end() offset 1m))\",\"sum(sum_over_time({app=\\\"foo\\\"}[59s999ms] @ end()))\"]}"}))`,
+			out:                  `sum(sum(__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"sum(sum_over_time({app=\\\"foo\\\"}[1m] @ end() offset 2m))\"},{\"Expr\":\"sum(sum_over_time({app=\\\"foo\\\"}[59s999ms] @ end() offset 1m))\"},{\"Expr\":\"sum(sum_over_time({app=\\\"foo\\\"}[59s999ms] @ end()))\"}]}"}))`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `avg(avg_over_time({app="foo"}[3m] @ 1609746000))`,
-			out:                  `avg((sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000 offset 1m)\",\"sum_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000)\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000 offset 1m)\",\"count_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000)\"]}"})))`,
+			out:                  `avg((sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\"},{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000 offset 1m)\"},{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000)\"}]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000 offset 1m)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[59s999ms] @ 1609746000.000)\"}]}"})))`,
 			expectedSplitQueries: 6,
 		},
 		// Should support both offset and @ operators
 		{
 			in:                   `max_over_time({app="foo"}[3m] @ 1609746000 offset 1m)`,
-			out:                  `max without() (__embedded_queries__{__queries__="{\"Concat\":[\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 3m)\",\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\",\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 1m)\"]}"})`,
+			out:                  `max without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 3m)\"},{\"Expr\":\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\"},{\"Expr\":\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 1m)\"}]}"})`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `max_over_time({app="foo"}[3m] offset 1m @ 1609746000)`,
-			out:                  `max without() (__embedded_queries__{__queries__="{\"Concat\":[\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 3m)\",\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\",\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 1m)\"]}"})`,
+			out:                  `max without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 3m)\"},{\"Expr\":\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 2m)\"},{\"Expr\":\"max_over_time({app=\\\"foo\\\"}[1m] @ 1609746000.000 offset 1m)\"}]}"})`,
 			expectedSplitQueries: 3,
 		},
 		// Should split deeper in the tree if an inner expression is splittable
@@ -401,23 +401,23 @@ func TestInstantSplitterUnevenRangeInterval(t *testing.T) {
 	}{
 		{
 			in:                   `rate({app="foo"}[5m])`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"increase({app=\\\"foo\\\"}[1m] offset 4m)\",\"increase({app=\\\"foo\\\"}[2m] offset 2m)\",\"increase({app=\\\"foo\\\"}[2m])\"]}"}) / 300`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"increase({app=\\\"foo\\\"}[1m] offset 4m)\"},{\"Expr\":\"increase({app=\\\"foo\\\"}[2m] offset 2m)\"},{\"Expr\":\"increase({app=\\\"foo\\\"}[2m])\"}]}"}) / 300`,
 			expectedSplitQueries: 3,
 		},
 		{
 			in:                   `avg_over_time({app="foo"}[3m])`,
-			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[1m] offset 2m)\",\"sum_over_time({app=\\\"foo\\\"}[1m59s999ms])\"]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 2m)\",\"count_over_time({app=\\\"foo\\\"}[1m59s999ms])\"]}"}))`,
+			out:                  `(sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[1m] offset 2m)\"},{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[1m59s999ms])\"}]}"})) / (sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[1m] offset 2m)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[1m59s999ms])\"}]}"}))`,
 			expectedSplitQueries: 4,
 		},
 		// Should support expressions with offset operator
 		{
 			in:                   `sum_over_time({app="foo"}[4m] offset 1m)`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"sum_over_time({app=\\\"foo\\\"}[2m] offset 3m)\",\"sum_over_time({app=\\\"foo\\\"}[1m59s999ms] offset 1m)\"]}"})`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[2m] offset 3m)\"},{\"Expr\":\"sum_over_time({app=\\\"foo\\\"}[1m59s999ms] offset 1m)\"}]}"})`,
 			expectedSplitQueries: 2,
 		},
 		{
 			in:                   `count_over_time({app="foo"}[3m] offset 1m)`,
-			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[\"count_over_time({app=\\\"foo\\\"}[1m] offset 3m)\",\"count_over_time({app=\\\"foo\\\"}[1m59s999ms] offset 1m)\"]}"})`,
+			out:                  `sum without() (__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[1m] offset 3m)\"},{\"Expr\":\"count_over_time({app=\\\"foo\\\"}[1m59s999ms] offset 1m)\"}]}"})`,
 			expectedSplitQueries: 2,
 		},
 	} {

--- a/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
+++ b/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
@@ -39,7 +39,7 @@ func (f *subtreeFolder) MapExpr(expr parser.Expr) (mapped parser.Expr, finished 
 
 	// Change the expr if it contains vector selectors, as only those need to be embedded.
 	if hasVectorSelector {
-		expr, err := VectorSquasher(expr)
+		expr, err := VectorSquasher(NewEmbeddedQuery(expr.String(), nil))
 		return expr, true, err
 	}
 	return expr, false, nil

--- a/pkg/frontend/querymiddleware/astmapper/subtree_folder_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/subtree_folder_test.go
@@ -78,18 +78,17 @@ func TestSubtreeFolder(t *testing.T) {
 	}{
 		"embed an entire histogram": {
 			input:    "histogram_quantile(0.5, rate(alertmanager_http_request_duration_seconds_bucket[1m]))",
-			expected: `__embedded_queries__{__queries__="{\"Concat\":[\"histogram_quantile(0.5, rate(alertmanager_http_request_duration_seconds_bucket[1m]))\"]}"}`,
+			expected: `__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"histogram_quantile(0.5, rate(alertmanager_http_request_duration_seconds_bucket[1m]))\"}]}"}`,
 		},
 		"embed a binary expression across two functions": {
 			input:    `rate(http_requests_total{cluster="eu-west2"}[5m]) or rate(http_requests_total{cluster="us-central1"}[5m])`,
-			expected: `__embedded_queries__{__queries__="{\"Concat\":[\"rate(http_requests_total{cluster=\\\"eu-west2\\\"}[5m]) or rate(http_requests_total{cluster=\\\"us-central1\\\"}[5m])\"]}"}`,
+			expected: `__embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"rate(http_requests_total{cluster=\\\"eu-west2\\\"}[5m]) or rate(http_requests_total{cluster=\\\"us-central1\\\"}[5m])\"}]}"}`,
 		},
 		"embed one out of two legs of the query (right leg has already been embedded)": {
 			input: `sum(histogram_quantile(0.5, rate(selector[1m]))) +
 				sum without(__query_shard__) (__embedded_queries__{__queries__="tstquery"})`,
 			expected: `
-			  __embedded_queries__{__queries__="{\"Concat\":[\"sum(histogram_quantile(0.5, rate(selector[1m])))\"]}"} +
-			  sum without(__query_shard__) (__embedded_queries__{__queries__="tstquery"})`,
+			  __embedded_queries__{__queries__="{\"Concat\":[{\"Expr\":\"sum(histogram_quantile(0.5, rate(selector[1m])))\"}]}"} + sum without (__query_shard__) (__embedded_queries__{__queries__="tstquery"})`,
 		},
 		"should not embed scalars": {
 			input:    `histogram_quantile(0.5, __embedded_queries__{__queries__="tstquery"})`,

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -601,7 +601,7 @@ type PrometheusLabelNamesQueryRequest struct {
 	Path  string
 	Start int64
 	End   int64
-	// labelMatcherSets is a repeated field here in order to enable the representation
+	// LabelMatcherSets is a repeated field here in order to enable the representation
 	// of labels queries which have not yet been split; the prometheus querier code
 	// will eventually split requests like `?match[]=up&match[]=process_start_time_seconds{job="prometheus"}`
 	// into separate queries, one for each matcher set
@@ -642,7 +642,7 @@ type PrometheusLabelValuesQueryRequest struct {
 	LabelName string
 	Start     int64
 	End       int64
-	// labelMatcherSets is a repeated field here in order to enable the representation
+	// LabelMatcherSets is a repeated field here in order to enable the representation
 	// of labels queries which have not yet been split; the prometheus querier code
 	// will eventually split requests like `?match[]=up&match[]=process_start_time_seconds{job="prometheus"}`
 	// into separate queries, one for each matcher set
@@ -683,7 +683,7 @@ type PrometheusSeriesQueryRequest struct {
 	Path  string
 	Start int64
 	End   int64
-	// labelMatcherSets is a repeated field here in order to enable the representation
+	// LabelMatcherSets is a repeated field here in order to enable the representation
 	// of labels queries which have not yet been split; the prometheus querier code
 	// will eventually split requests like `?match[]=up&match[]=process_start_time_seconds{job="prometheus"}`
 	// into separate queries, one for each matcher set

--- a/pkg/frontend/querymiddleware/sharded_queryable_test.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable_test.go
@@ -65,7 +65,7 @@ func TestShardedQuerier_Select(t *testing.T) {
 					},
 				)
 
-				encoded, err := astmapper.JSONCodec.Encode([]string{`http_requests_total{cluster="prod"}`})
+				encoded, err := astmapper.JSONCodec.Encode([]astmapper.EmbeddedQuery{astmapper.NewEmbeddedQuery(`http_requests_total{cluster="prod"}`, nil)})
 				require.Nil(t, err)
 				set := q.Select(
 					ctx,
@@ -86,7 +86,7 @@ func TestShardedQuerier_Select(t *testing.T) {
 				nil,
 			)),
 			fn: func(t *testing.T, q *shardedQuerier) {
-				encoded, err := astmapper.JSONCodec.Encode([]string{`http_requests_total{cluster="prod"}`})
+				encoded, err := astmapper.JSONCodec.Encode([]astmapper.EmbeddedQuery{astmapper.NewEmbeddedQuery(`http_requests_total{cluster="prod"}`, nil)})
 				require.Nil(t, err)
 				set := q.Select(
 					ctx,
@@ -143,7 +143,7 @@ func TestShardedQuerier_Select(t *testing.T) {
 				nil,
 			)),
 			fn: func(t *testing.T, q *shardedQuerier) {
-				encoded, err := astmapper.JSONCodec.Encode([]string{`http_requests_total{cluster="prod"}`})
+				encoded, err := astmapper.JSONCodec.Encode([]astmapper.EmbeddedQuery{astmapper.NewEmbeddedQuery(`http_requests_total{cluster="prod"}`, nil)})
 				require.Nil(t, err)
 				set := q.Select(
 					ctx,
@@ -204,10 +204,15 @@ func TestShardedQuerier_Select(t *testing.T) {
 }
 
 func TestShardedQuerier_Select_ShouldConcurrentlyRunEmbeddedQueries(t *testing.T) {
-	embeddedQueries := []string{
+	embeddedQueriesRaw := []string{
 		`sum(rate(metric{__query_shard__="0_of_3"}[1m]))`,
 		`sum(rate(metric{__query_shard__="1_of_3"}[1m]))`,
 		`sum(rate(metric{__query_shard__="2_of_3"}[1m]))`,
+	}
+
+	embeddedQueries := make([]astmapper.EmbeddedQuery, len(embeddedQueriesRaw))
+	for i, query := range embeddedQueriesRaw {
+		embeddedQueries[i] = astmapper.NewEmbeddedQuery(query, nil)
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
#### What this PR does

Adds a separate map to embedded query struct in query sharding so that other kinds of sharding can use extra info without needing to extract it through regular expressions which are less reliable.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Not a user-facing change.