### PR TITLE
MQE: add support for `unless`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * `cortex_alertmanager_alerts`
   * `cortex_alertmanager_silences`
 * [CHANGE] Cache: Deprecate experimental support for Redis as a cache backend. #9453
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9533
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] gRPC: Support S2 compression. #9322
   * `-alertmanager.alertmanager-client.grpc-compression=s2`

--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -173,9 +173,9 @@ func TestCases(metricSizes []int) []BenchCase {
 		//{
 		//	Expr: "a_X or b_X{l=~'.*[0-4]$'}",
 		//},
-		//{
-		//	Expr: "a_X unless b_X{l=~'.*[0-4]$'}",
-		//},
+		{
+			Expr: "a_X unless b_X{l=~'.*[0-4]$'}",
+		},
 		{
 			Expr: "a_X and b_X{l='notfound'}",
 		},

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -43,7 +43,6 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 	// different cases and make sure we produce a reasonable error message when these cases are encountered.
 	unsupportedExpressions := map[string]string{
 		"metric{} or other_metric{}":                   "binary expression with 'or'",
-		"metric{} unless other_metric{}":               "binary expression with 'unless'",
 		"metric{} + on() group_left() other_metric{}":  "binary expression with many-to-one matching",
 		"metric{} + on() group_right() other_metric{}": "binary expression with one-to-many matching",
 		"topk(5, metric{})":                            "'topk' aggregation with parameter",
@@ -1903,7 +1902,7 @@ func TestCompareVariousMixedMetricsBinaryOperations(t *testing.T) {
 	expressions := []string{}
 
 	for _, labels := range labelCombinations {
-		for _, op := range []string{"+", "-", "*", "/", "and"} {
+		for _, op := range []string{"+", "-", "*", "/", "and", "unless"} {
 			binaryExpr := fmt.Sprintf(`series{label="%s"}`, labels[0])
 			for _, label := range labels[1:] {
 				binaryExpr += fmt.Sprintf(` %s series{label="%s"}`, op, label)

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -237,8 +237,8 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr) (types.InstantV
 		}
 
 		switch e.Op {
-		case parser.LAND:
-			return operators.NewAndBinaryOperation(lhs, rhs, *e.VectorMatching, q.memoryConsumptionTracker, q.timeRange, e.PositionRange()), nil
+		case parser.LAND, parser.LUNLESS:
+			return operators.NewAndUnlessBinaryOperation(lhs, rhs, *e.VectorMatching, q.memoryConsumptionTracker, e.Op == parser.LUNLESS, q.timeRange, e.PositionRange()), nil
 		default:
 			return operators.NewVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange())
 		}

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -766,13 +766,28 @@ clear
 # Single matching series on each side.
 load 6m
   left_side{env="test", pod="a"}  1  2  3  4                 {{count:5 sum:5}}
-  left_side{env="test", pod="b"}  6  7  8  _                 10
+  left_side{env="test", pod="b"}  6  7  8  _                 {{count:10 sum:10}}
   left_side{env="prod", pod="a"}  11 12 13 14                15
   left_side{env="prod", pod="b"}  16 17 18 _                 _
   right_side{env="test", pod="a"} 0  0  0  {{count:0 sum:0}} {{count:0 sum:0}}
   right_side{env="test", pod="b"} _  0  _  0                 _
   right_side{env="prod", pod="b"} _  _  _  0                 0
   right_side{env="foo", pod="a"}  0  0  0  0                 0
+
+eval range from 0 to 24m step 6m left_side and does_not_match
+  # Should return no results.
+
+eval range from 0 to 24m step 6m does_not_match and right_side
+  # Should return no results.
+
+eval range from 0 to 24m step 6m left_side unless does_not_match
+  left_side{env="test", pod="a"}  1  2  3  4  {{count:5 sum:5}}
+  left_side{env="test", pod="b"}  6  7  8  _  {{count:10 sum:10}}
+  left_side{env="prod", pod="a"}  11 12 13 14 15
+  left_side{env="prod", pod="b"}  16 17 18 _  _
+
+eval range from 0 to 24m step 6m does_not_match unless right_side
+  # Should return no results.
 
 # {env="test", pod="a"}: Matching series, all samples align
 # {env="test", pod="b"}: Matching series, only some samples align
@@ -782,6 +797,11 @@ load 6m
 eval range from 0 to 24m step 6m left_side and right_side
   left_side{env="test", pod="a"} 1 2 3 4 {{count:5 sum:5}}
   left_side{env="test", pod="b"} _ 7 _ _ _
+
+eval range from 0 to 24m step 6m left_side unless right_side
+  left_side{env="test", pod="b"} 6 _ 8 _ {{count:10 sum:10}}
+  left_side{env="prod", pod="a"} 11 12 13 14 15
+  left_side{env="prod", pod="b"} 16 17 18 _ _
 
 clear
 
@@ -800,32 +820,67 @@ load 6m
 eval range from 0 to 24m step 6m left_side and right_side
   # Should return no results.
 
+eval range from 0 to 24m step 6m left_side unless right_side
+  left_side{env="test", cluster="blah", pod="a"} 1  2  3  4
+  left_side{env="test", cluster="blah", pod="b"} _  6  7  8
+  left_side{env="prod", cluster="blah", pod="a"} 9  10 11 12
+  left_side{env="prod", cluster="blah", pod="b"} 13 14 15 16
+  left_side{env="test", cluster="food", pod="a"} 17 18 19 20
+
 eval range from 0 to 24m step 6m left_side and on(cluster, env) right_side
-  left_side{env="test", cluster="blah", pod="a"}  1  2  3  _
-  left_side{env="test", cluster="blah", pod="b"}  _  6  7  _
-  left_side{env="prod", cluster="blah", pod="a"}  _  10 _  12
-  left_side{env="prod", cluster="blah", pod="b"}  _  14 _  16
-  left_side{env="test", cluster="food", pod="a"}  _  _  _  20
+  left_side{env="test", cluster="blah", pod="a"} 1  2  3  _
+  left_side{env="test", cluster="blah", pod="b"} _  6  7  _
+  left_side{env="prod", cluster="blah", pod="a"} _  10 _  12
+  left_side{env="prod", cluster="blah", pod="b"} _  14 _  16
+  left_side{env="test", cluster="food", pod="a"} _  _  _  20
+
+eval range from 0 to 24m step 6m left_side unless on(cluster, env) right_side
+  left_side{env="test", cluster="blah", pod="a"} _  _  _  4
+  left_side{env="test", cluster="blah", pod="b"} _  _  _  8
+  left_side{env="prod", cluster="blah", pod="a"} 9  _  11 _
+  left_side{env="prod", cluster="blah", pod="b"} 13 _  15 _
+  left_side{env="test", cluster="food", pod="a"} 17 18 19 _
 
 # Same thing again, with labels in different order.
 eval range from 0 to 24m step 6m left_side and on(env, cluster) right_side
-  left_side{env="test", cluster="blah", pod="a"}  1  2  3  _
-  left_side{env="test", cluster="blah", pod="b"}  _  6  7  _
-  left_side{env="prod", cluster="blah", pod="a"}  _  10 _  12
-  left_side{env="prod", cluster="blah", pod="b"}  _  14 _  16
-  left_side{env="test", cluster="food", pod="a"}  _  _  _  20
+  left_side{env="test", cluster="blah", pod="a"} 1  2  3  _
+  left_side{env="test", cluster="blah", pod="b"} _  6  7  _
+  left_side{env="prod", cluster="blah", pod="a"} _  10 _  12
+  left_side{env="prod", cluster="blah", pod="b"} _  14 _  16
+  left_side{env="test", cluster="food", pod="a"} _  _  _  20
+
+eval range from 0 to 24m step 6m left_side unless on(env, cluster) right_side
+  left_side{env="test", cluster="blah", pod="a"} _  _  _  4
+  left_side{env="test", cluster="blah", pod="b"} _  _  _  8
+  left_side{env="prod", cluster="blah", pod="a"} 9  _  11 _
+  left_side{env="prod", cluster="blah", pod="b"} 13 _  15 _
+  left_side{env="test", cluster="food", pod="a"} 17 18 19 _
 
 eval range from 0 to 24m step 6m left_side and ignoring(idx, pod) right_side
-  left_side{env="test", cluster="blah", pod="a"}  1  2  3  _
-  left_side{env="test", cluster="blah", pod="b"}  _  6  7  _
-  left_side{env="prod", cluster="blah", pod="a"}  _  10 _  12
-  left_side{env="prod", cluster="blah", pod="b"}  _  14 _  16
-  left_side{env="test", cluster="food", pod="a"}  _  _  _  20
+  left_side{env="test", cluster="blah", pod="a"} 1  2  3  _
+  left_side{env="test", cluster="blah", pod="b"} _  6  7  _
+  left_side{env="prod", cluster="blah", pod="a"} _  10 _  12
+  left_side{env="prod", cluster="blah", pod="b"} _  14 _  16
+  left_side{env="test", cluster="food", pod="a"} _  _  _  20
+
+eval range from 0 to 24m step 6m left_side unless ignoring(idx, pod) right_side
+  left_side{env="test", cluster="blah", pod="a"} _  _  _  4
+  left_side{env="test", cluster="blah", pod="b"} _  _  _  8
+  left_side{env="prod", cluster="blah", pod="a"} 9  _  11 _
+  left_side{env="prod", cluster="blah", pod="b"} 13 _  15 _
+  left_side{env="test", cluster="food", pod="a"} 17 18 19 _
 
 # Same thing again, with labels in different order.
 eval range from 0 to 24m step 6m left_side and ignoring(pod, idx) right_side
-  left_side{env="test", cluster="blah", pod="a"}  1  2  3  _
-  left_side{env="test", cluster="blah", pod="b"}  _  6  7  _
-  left_side{env="prod", cluster="blah", pod="a"}  _  10 _  12
-  left_side{env="prod", cluster="blah", pod="b"}  _  14 _  16
-  left_side{env="test", cluster="food", pod="a"}  _  _  _  20
+  left_side{env="test", cluster="blah", pod="a"} 1  2  3  _
+  left_side{env="test", cluster="blah", pod="b"} _  6  7  _
+  left_side{env="prod", cluster="blah", pod="a"} _  10 _  12
+  left_side{env="prod", cluster="blah", pod="b"} _  14 _  16
+  left_side{env="test", cluster="food", pod="a"} _  _  _  20
+
+eval range from 0 to 24m step 6m left_side unless ignoring(pod, idx) right_side
+  left_side{env="test", cluster="blah", pod="a"} _  _  _  4
+  left_side{env="test", cluster="blah", pod="b"} _  _  _  8
+  left_side{env="prod", cluster="blah", pod="a"} 9  _  11 _
+  left_side{env="prod", cluster="blah", pod="b"} 13 _  15 _
+  left_side{env="test", cluster="food", pod="a"} 17 18 19 _

--- a/pkg/streamingpromql/testdata/upstream/operators.test
+++ b/pkg/streamingpromql/testdata/upstream/operators.test
@@ -210,18 +210,15 @@ eval instant at 50m (http_requests{group="canary"} + 1) and ignoring(group, job)
 #	vector_matching_a{l="x"} 10
 #	vector_matching_a{l="y"} 20
 
-# Unsupported by streaming engine.
-# eval instant at 50m http_requests{group="canary"} unless http_requests{instance="0"}
-#	http_requests{group="canary", instance="1", job="api-server"} 400
-#	http_requests{group="canary", instance="1", job="app-server"} 800
+eval instant at 50m http_requests{group="canary"} unless http_requests{instance="0"}
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
 
-# Unsupported by streaming engine.
-# eval instant at 50m http_requests{group="canary"} unless on(job) http_requests{instance="0"}
+eval instant at 50m http_requests{group="canary"} unless on(job) http_requests{instance="0"}
 
-# Unsupported by streaming engine.
-# eval instant at 50m http_requests{group="canary"} unless on(job, instance) http_requests{instance="0"}
-#	http_requests{group="canary", instance="1", job="api-server"} 400
-#	http_requests{group="canary", instance="1", job="app-server"} 800
+eval instant at 50m http_requests{group="canary"} unless on(job, instance) http_requests{instance="0"}
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
 
 eval instant at 50m http_requests{group="canary"} / on(instance,job) http_requests{group="production"}
 	{instance="0", job="api-server"} 3
@@ -229,13 +226,11 @@ eval instant at 50m http_requests{group="canary"} / on(instance,job) http_reques
 	{instance="1", job="api-server"} 2
 	{instance="1", job="app-server"} 1.3333333333333333
 
-# Unsupported by streaming engine.
-# eval instant at 50m http_requests{group="canary"} unless ignoring(group, instance) http_requests{instance="0"}
+eval instant at 50m http_requests{group="canary"} unless ignoring(group, instance) http_requests{instance="0"}
 
-# Unsupported by streaming engine.
-# eval instant at 50m http_requests{group="canary"} unless ignoring(group) http_requests{instance="0"}
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
+eval instant at 50m http_requests{group="canary"} unless ignoring(group) http_requests{instance="0"}
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
 
 eval instant at 50m http_requests{group="canary"} / ignoring(group) http_requests{group="production"}
 	{instance="0", job="api-server"} 3

--- a/pkg/streamingpromql/testutils/utils.go
+++ b/pkg/streamingpromql/testutils/utils.go
@@ -51,7 +51,7 @@ func RequireEqualResults(t testing.TB, expr string, expected, actual *promql.Res
 		actualMatrix, err := actual.Matrix()
 		require.NoError(t, err)
 
-		require.Len(t, actualMatrix, len(expectedMatrix))
+		require.Lenf(t, actualMatrix, len(expectedMatrix), "expected result %v", expectedMatrix)
 
 		for i, expectedSeries := range expectedMatrix {
 			actualSeries := actualMatrix[i]


### PR DESCRIPTION
#### What this PR does

This PR adds support for the `unless` binary operation, building on the support for `and` added in #9507.

Compared to Prometheus' engine, latency is up to 60% lower and peak memory consumption is up to 48% lower in our benchmarks:

```
                                                                          │  Prometheus   │               Mimir                │
                                                                          │    sec/op     │   sec/op     vs base               │
Query/a_1_unless_b_1{l=~'.*[0-4]$'},_instant_query-10                        721.4µ ± 12%   716.4µ ± 1%        ~ (p=0.093 n=6)
Query/a_1_unless_b_1{l=~'.*[0-4]$'},_range_query_with_100_steps-10           777.4µ ±  4%   745.8µ ± 6%        ~ (p=0.180 n=6)
Query/a_1_unless_b_1{l=~'.*[0-4]$'},_range_query_with_1000_steps-10          1.310m ±  3%   1.184m ± 3%   -9.67% (p=0.002 n=6)
Query/a_100_unless_b_100{l=~'.*[0-4]$'},_instant_query-10                    1.635m ±  2%   1.631m ± 2%        ~ (p=0.937 n=6)
Query/a_100_unless_b_100{l=~'.*[0-4]$'},_range_query_with_100_steps-10       3.266m ±  1%   2.343m ± 1%  -28.27% (p=0.002 n=6)
Query/a_100_unless_b_100{l=~'.*[0-4]$'},_range_query_with_1000_steps-10     17.681m ±  1%   8.731m ± 2%  -50.62% (p=0.002 n=6)
Query/a_2000_unless_b_2000{l=~'.*[0-4]$'},_instant_query-10                  17.30m ±  2%   17.06m ± 1%   -1.39% (p=0.041 n=6)
Query/a_2000_unless_b_2000{l=~'.*[0-4]$'},_range_query_with_100_steps-10     52.37m ±  1%   30.90m ± 1%  -41.01% (p=0.002 n=6)
Query/a_2000_unless_b_2000{l=~'.*[0-4]$'},_range_query_with_1000_steps-10    402.6m ±  5%   146.5m ± 1%  -63.61% (p=0.002 n=6)

                                                                          │  Prometheus   │                Mimir                │
                                                                          │       B       │      B        vs base               │
Query/a_1_unless_b_1{l=~'.*[0-4]$'},_instant_query-10                        70.76Mi ± 3%   68.78Mi ± 2%   -2.79% (p=0.041 n=6)
Query/a_1_unless_b_1{l=~'.*[0-4]$'},_range_query_with_100_steps-10           69.18Mi ± 2%   68.72Mi ± 3%        ~ (p=0.225 n=6)
Query/a_1_unless_b_1{l=~'.*[0-4]$'},_range_query_with_1000_steps-10          67.70Mi ± 3%   66.66Mi ± 2%        ~ (p=0.065 n=6)
Query/a_100_unless_b_100{l=~'.*[0-4]$'},_instant_query-10                    66.35Mi ± 1%   66.12Mi ± 2%        ~ (p=0.329 n=6)
Query/a_100_unless_b_100{l=~'.*[0-4]$'},_range_query_with_100_steps-10       66.99Mi ± 1%   66.29Mi ± 2%   -1.05% (p=0.026 n=6)
Query/a_100_unless_b_100{l=~'.*[0-4]$'},_range_query_with_1000_steps-10      72.31Mi ± 2%   67.63Mi ± 1%   -6.47% (p=0.002 n=6)
Query/a_2000_unless_b_2000{l=~'.*[0-4]$'},_instant_query-10                  68.11Mi ± 2%   69.30Mi ± 2%        ~ (p=0.065 n=6)
Query/a_2000_unless_b_2000{l=~'.*[0-4]$'},_range_query_with_100_steps-10     83.55Mi ± 2%   73.02Mi ± 2%  -12.61% (p=0.002 n=6)
Query/a_2000_unless_b_2000{l=~'.*[0-4]$'},_range_query_with_1000_steps-10    198.3Mi ± 1%   104.1Mi ± 3%  -47.50% (p=0.002 n=6)
```

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
