### PR TITLE
Don't return incorrect position information from annotations generated by sharded query legs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508
+* [BUGFIX] Fix issue where sharded queries could return annotations with incorrect or confusing position information. #9536
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -202,9 +202,11 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Metr
 	warn, info := res.Warnings.AsStrings("", 0, 0)
 
 	// Add any annotations returned by the sharded queries, and remove any duplicates.
+	// We remove any position information for the same reason as above: the position information
+	// relates to the rewritten expression sent to queriers, not the original expression provided by the user.
 	accumulatedWarnings, accumulatedInfos := annotationAccumulator.getAll()
-	warn = append(warn, accumulatedWarnings...)
-	info = append(info, accumulatedInfos...)
+	warn = append(warn, removeAllAnnotationPositionInformation(accumulatedWarnings)...)
+	info = append(info, removeAllAnnotationPositionInformation(accumulatedInfos)...)
 	warn = removeDuplicates(warn)
 	info = removeDuplicates(info)
 

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -516,8 +516,9 @@ func TestInstantQuerySplittingCorrectness(t *testing.T) {
 							reg := prometheus.NewPedanticRegistry()
 							engine := newEngine()
 							downstream := &downstreamHandler{
-								engine:    engine,
-								queryable: queryable,
+								engine:                                  engine,
+								queryable:                               queryable,
+								includePositionInformationInAnnotations: true,
 							}
 
 							// Run the query with the normal engine
@@ -530,6 +531,12 @@ func TestInstantQuerySplittingCorrectness(t *testing.T) {
 							// Ensure the query produces some results.
 							require.NotEmpty(t, expectedPrometheusRes.Data.Result)
 							requireValidSamples(t, expectedPrometheusRes.Data.Result)
+
+							if testData.expectedSplitQueries > 0 {
+								// Remove position information from annotations, to mirror what we expect from the split queries below.
+								removeAllAnnotationPositionInformation(expectedPrometheusRes.Infos)
+								removeAllAnnotationPositionInformation(expectedPrometheusRes.Warnings)
+							}
 
 							splittingware := newSplitInstantQueryByIntervalMiddleware(mockLimits{splitInstantQueriesInterval: 1 * time.Minute}, log.NewNopLogger(), engine, reg)
 


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where annotations could be returned to a user with incorrect position information if the query is sharded and the sharded legs generate annotations.

For example, running the query `avg(rate(up[1m]))` can produce two annotations:

- `PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "up" (1:10)`
- `PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "up" (1:12)`

...but `up` appears at position 10 on line 1, so the second annotation at position 12 is misleading or confusing. It comes about because `avg(...)` is rewritten as `sum(...) / count(...)` for sharding and the second annotation is generated by queriers for the sharded `count(rate(up[1m]))` legs.

Another example: running the query `ceil(sum(rate(up[1m])))` returns `PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "up" (1:10)` (because `sum(rate(up[1m]))` is what is run in queriers), but `up` appears at position 15.

We already remove position information for annotations generated by the parent query (ie. the one run in query-frontends to combine the results of the sharded legs), so this PR does the same for annotations from sharded legs.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/pull/9138

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
