### PR TITLE
Prevent renovate from upgrading grafana/franz-go

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -23,7 +23,8 @@
           "github.com/colega/go-yaml-yaml",
           "github.com/grafana/goautoneg",
           "github.com/grafana/opentracing-contrib-go-stdlib",
-          "github.com/charleskorn/go-grpc"
+          "github.com/charleskorn/go-grpc",
+          "github.com/grafana/franz-go", // pinned to 1.17.1 + grafana/franz-go#1, #3, and #4; We can remove this once 1.18.0 comes out, and we can use the master branch of our fork (or remove the fork entirely)
         ],
         "enabled": false
       },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

We're using a fork and using the latest release of upstream (1.17.1) with our three changes cherry-picked to it. Until there is 1.18.0 and we can use the master branch in our fork, renovate shouldn't upgrade the dependency.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
