### PR TITLE
Log Ingester.LabelNames() matchers in traces

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1741,6 +1741,9 @@ func (i *Ingester) LabelNames(ctx context.Context, req *client.LabelNamesRequest
 	}
 	defer func() { finishReadRequest(err) }()
 
+	spanlog, ctx := spanlogger.NewWithLogger(ctx, i.logger, "Ingester.LabelNames")
+	defer spanlog.Finish()
+
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
@@ -1767,6 +1770,9 @@ func (i *Ingester) LabelNames(ctx context.Context, req *client.LabelNamesRequest
 		return nil, err
 	}
 	defer q.Close()
+
+	// Log the actual matchers passed down to TSDB. This can be useful for troubleshooting purposes.
+	spanlog.DebugLog("num_matchers", len(matchers), "matchers", util.LabelMatchersToString(matchers))
 
 	hints := &storage.LabelHints{}
 	names, _, err := q.LabelNames(ctx, hints, matchers...)


### PR DESCRIPTION
#### What this PR does

I'm troubleshooting some label names API requests and I don't understand if, for some reason, the `Ingester.LabelNames()` gets any matcher or not. In this PR I'm proposing to add a span log.

Example with no matchers:

![Screenshot 2024-10-07 at 16 29 28](https://github.com/user-attachments/assets/1fa1e955-7a4a-4003-90bd-03ed0534b71f)

Example with matchers:

![Screenshot 2024-10-07 at 16 36 28](https://github.com/user-attachments/assets/788d0b70-bbf0-437f-9eed-04c83fb616ed)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
