### PR TITLE
Upgrade github.com/gogo/protobuf/protoc-gen-gogoslick to v1.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr10708-6841577474
+LATEST_BUILD_IMAGE_TAG ?= pr9545-de5fc9e58f
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -49,7 +49,7 @@ RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers
 RUN GO111MODULE=on \
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 && \
-	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 && \
+	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.2 && \
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
 	go install github.com/fatih/faillint@v1.12.0 && \
 	go install github.com/campoy/embedmd@v1.0.0 && \

--- a/pkg/alertmanager/alertmanagerpb/alertmanager.pb.go
+++ b/pkg/alertmanager/alertmanagerpb/alertmanager.pb.go
@@ -824,10 +824,7 @@ func (m *UpdateStateResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthAlertmanager
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthAlertmanager
 			}
 			if (iNdEx + skippy) > l {
@@ -877,10 +874,7 @@ func (m *ReadStateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthAlertmanager
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthAlertmanager
 			}
 			if (iNdEx + skippy) > l {
@@ -1017,10 +1011,7 @@ func (m *ReadStateResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthAlertmanager
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthAlertmanager
 			}
 			if (iNdEx + skippy) > l {
@@ -1038,6 +1029,7 @@ func (m *ReadStateResponse) Unmarshal(dAtA []byte) error {
 func skipAlertmanager(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1069,10 +1061,8 @@ func skipAlertmanager(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1093,55 +1083,30 @@ func skipAlertmanager(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthAlertmanager
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthAlertmanager
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowAlertmanager
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipAlertmanager(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthAlertmanager
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupAlertmanager
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthAlertmanager
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthAlertmanager = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowAlertmanager   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthAlertmanager        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowAlertmanager          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupAlertmanager = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/alertmanager/alertspb/alerts.pb.go
+++ b/pkg/alertmanager/alertspb/alerts.pb.go
@@ -997,10 +997,7 @@ func (m *AlertConfigDesc) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthAlerts
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthAlerts
 			}
 			if (iNdEx + skippy) > l {
@@ -1114,10 +1111,7 @@ func (m *TemplateDesc) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthAlerts
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthAlerts
 			}
 			if (iNdEx + skippy) > l {
@@ -1203,10 +1197,7 @@ func (m *FullStateDesc) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthAlerts
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthAlerts
 			}
 			if (iNdEx + skippy) > l {
@@ -1553,7 +1544,7 @@ func (m *GrafanaAlertConfigDesc) Unmarshal(dAtA []byte) error {
 					if err != nil {
 						return err
 					}
-					if skippy < 0 {
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
 						return ErrInvalidLengthAlerts
 					}
 					if (iNdEx + skippy) > postIndex {
@@ -1570,10 +1561,7 @@ func (m *GrafanaAlertConfigDesc) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthAlerts
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthAlerts
 			}
 			if (iNdEx + skippy) > l {
@@ -1591,6 +1579,7 @@ func (m *GrafanaAlertConfigDesc) Unmarshal(dAtA []byte) error {
 func skipAlerts(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1622,10 +1611,8 @@ func skipAlerts(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1646,55 +1633,30 @@ func skipAlerts(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthAlerts
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthAlerts
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowAlerts
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipAlerts(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthAlerts
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupAlerts
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthAlerts
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthAlerts = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowAlerts   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthAlerts        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowAlerts          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupAlerts = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/blockbuilder/schedulerpb/scheduler.pb.go
+++ b/pkg/blockbuilder/schedulerpb/scheduler.pb.go
@@ -1398,10 +1398,7 @@ func (m *JobKey) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -1677,10 +1674,7 @@ func (m *JobSpec) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -1762,10 +1756,7 @@ func (m *AssignJobRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -1887,10 +1878,7 @@ func (m *AssignJobResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -2064,10 +2052,7 @@ func (m *UpdateJobRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -2117,10 +2102,7 @@ func (m *UpdateJobResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -2138,6 +2120,7 @@ func (m *UpdateJobResponse) Unmarshal(dAtA []byte) error {
 func skipScheduler(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -2169,10 +2152,8 @@ func skipScheduler(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -2193,55 +2174,30 @@ func skipScheduler(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthScheduler
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthScheduler
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowScheduler
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipScheduler(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthScheduler
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupScheduler
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthScheduler
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthScheduler = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowScheduler   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthScheduler        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowScheduler          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupScheduler = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/distributor/ha_tracker.pb.go
+++ b/pkg/distributor/ha_tracker.pb.go
@@ -449,10 +449,7 @@ func (m *ReplicaDesc) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthHaTracker
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthHaTracker
 			}
 			if (iNdEx + skippy) > l {
@@ -470,6 +467,7 @@ func (m *ReplicaDesc) Unmarshal(dAtA []byte) error {
 func skipHaTracker(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -501,10 +499,8 @@ func skipHaTracker(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -525,55 +521,30 @@ func skipHaTracker(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthHaTracker
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthHaTracker
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowHaTracker
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipHaTracker(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthHaTracker
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupHaTracker
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthHaTracker
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthHaTracker = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowHaTracker   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthHaTracker        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowHaTracker          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupHaTracker = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/frontend/querymiddleware/model.pb.go
+++ b/pkg/frontend/querymiddleware/model.pb.go
@@ -1224,9 +1224,9 @@ func (this *PrometheusData) GoString() string {
 	s = append(s, "&querymiddleware.PrometheusData{")
 	s = append(s, "ResultType: "+fmt.Sprintf("%#v", this.ResultType)+",\n")
 	if this.Result != nil {
-		vs := make([]*SampleStream, len(this.Result))
+		vs := make([]SampleStream, len(this.Result))
 		for i := range vs {
-			vs[i] = &this.Result[i]
+			vs[i] = this.Result[i]
 		}
 		s = append(s, "Result: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -1241,16 +1241,16 @@ func (this *SampleStream) GoString() string {
 	s = append(s, "&querymiddleware.SampleStream{")
 	s = append(s, "Labels: "+fmt.Sprintf("%#v", this.Labels)+",\n")
 	if this.Samples != nil {
-		vs := make([]*mimirpb.Sample, len(this.Samples))
+		vs := make([]mimirpb.Sample, len(this.Samples))
 		for i := range vs {
-			vs[i] = &this.Samples[i]
+			vs[i] = this.Samples[i]
 		}
 		s = append(s, "Samples: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
 	if this.Histograms != nil {
-		vs := make([]*mimirpb.FloatHistogramPair, len(this.Histograms))
+		vs := make([]mimirpb.FloatHistogramPair, len(this.Histograms))
 		for i := range vs {
-			vs[i] = &this.Histograms[i]
+			vs[i] = this.Histograms[i]
 		}
 		s = append(s, "Histograms: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -1277,9 +1277,9 @@ func (this *CachedResponse) GoString() string {
 	s = append(s, "&querymiddleware.CachedResponse{")
 	s = append(s, "Key: "+fmt.Sprintf("%#v", this.Key)+",\n")
 	if this.Extents != nil {
-		vs := make([]*Extent, len(this.Extents))
+		vs := make([]Extent, len(this.Extents))
 		for i := range vs {
-			vs[i] = &this.Extents[i]
+			vs[i] = this.Extents[i]
 		}
 		s = append(s, "Extents: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -2467,10 +2467,7 @@ func (m *PrometheusHeader) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -2750,10 +2747,7 @@ func (m *PrometheusResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -2869,10 +2863,7 @@ func (m *PrometheusData) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -3024,10 +3015,7 @@ func (m *SampleStream) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -3173,10 +3161,7 @@ func (m *CachedError) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -3292,10 +3277,7 @@ func (m *CachedResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -3470,10 +3452,7 @@ func (m *Extent) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -3621,10 +3600,7 @@ func (m *Options) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -3693,10 +3669,7 @@ func (m *QueryStatistics) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -3865,10 +3838,7 @@ func (m *CachedHTTPResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -3982,10 +3952,7 @@ func (m *CachedHTTPHeader) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthModel
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthModel
 			}
 			if (iNdEx + skippy) > l {
@@ -4003,6 +3970,7 @@ func (m *CachedHTTPHeader) Unmarshal(dAtA []byte) error {
 func skipModel(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -4034,10 +4002,8 @@ func skipModel(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -4058,55 +4024,30 @@ func skipModel(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthModel
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthModel
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowModel
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipModel(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthModel
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupModel
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthModel
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthModel = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowModel   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthModel        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowModel          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupModel = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/frontend/v1/frontendv1pb/frontend.pb.go
+++ b/pkg/frontend/v1/frontendv1pb/frontend.pb.go
@@ -1063,10 +1063,7 @@ func (m *FrontendToClient) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthFrontend
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthFrontend
 			}
 			if (iNdEx + skippy) > l {
@@ -1220,10 +1217,7 @@ func (m *ClientToFrontend) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthFrontend
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthFrontend
 			}
 			if (iNdEx + skippy) > l {
@@ -1305,10 +1299,7 @@ func (m *NotifyClientShutdownRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthFrontend
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthFrontend
 			}
 			if (iNdEx + skippy) > l {
@@ -1358,10 +1349,7 @@ func (m *NotifyClientShutdownResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthFrontend
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthFrontend
 			}
 			if (iNdEx + skippy) > l {
@@ -1379,6 +1367,7 @@ func (m *NotifyClientShutdownResponse) Unmarshal(dAtA []byte) error {
 func skipFrontend(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1410,10 +1399,8 @@ func skipFrontend(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1434,55 +1421,30 @@ func skipFrontend(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthFrontend
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthFrontend
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowFrontend
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipFrontend(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthFrontend
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupFrontend
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthFrontend
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthFrontend = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowFrontend   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthFrontend        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowFrontend          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupFrontend = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/frontend/v2/frontendv2pb/frontend.pb.go
+++ b/pkg/frontend/v2/frontendv2pb/frontend.pb.go
@@ -139,10 +139,10 @@ type isQueryResultStreamRequest_Data interface {
 }
 
 type QueryResultStreamRequest_Metadata struct {
-	Metadata *QueryResultMetadata `protobuf:"bytes,2,opt,name=metadata,proto3,oneof"`
+	Metadata *QueryResultMetadata `protobuf:"bytes,2,opt,name=metadata,proto3,oneof" json:"metadata,omitempty"`
 }
 type QueryResultStreamRequest_Body struct {
-	Body *QueryResultBody `protobuf:"bytes,3,opt,name=body,proto3,oneof"`
+	Body *QueryResultBody `protobuf:"bytes,3,opt,name=body,proto3,oneof" json:"body,omitempty"`
 }
 
 func (*QueryResultStreamRequest_Metadata) isQueryResultStreamRequest_Data() {}
@@ -886,7 +886,8 @@ func (m *QueryResultStreamRequest) MarshalToSizedBuffer(dAtA []byte) (int, error
 }
 
 func (m *QueryResultStreamRequest_Metadata) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *QueryResultStreamRequest_Metadata) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -906,7 +907,8 @@ func (m *QueryResultStreamRequest_Metadata) MarshalToSizedBuffer(dAtA []byte) (i
 	return len(dAtA) - i, nil
 }
 func (m *QueryResultStreamRequest_Body) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *QueryResultStreamRequest_Body) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1365,10 +1367,7 @@ func (m *QueryResultRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthFrontend
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthFrontend
 			}
 			if (iNdEx + skippy) > l {
@@ -1507,10 +1506,7 @@ func (m *QueryResultStreamRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthFrontend
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthFrontend
 			}
 			if (iNdEx + skippy) > l {
@@ -1649,10 +1645,7 @@ func (m *QueryResultMetadata) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthFrontend
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthFrontend
 			}
 			if (iNdEx + skippy) > l {
@@ -1736,10 +1729,7 @@ func (m *QueryResultBody) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthFrontend
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthFrontend
 			}
 			if (iNdEx + skippy) > l {
@@ -1789,10 +1779,7 @@ func (m *QueryResultResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthFrontend
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthFrontend
 			}
 			if (iNdEx + skippy) > l {
@@ -1810,6 +1797,7 @@ func (m *QueryResultResponse) Unmarshal(dAtA []byte) error {
 func skipFrontend(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1841,10 +1829,8 @@ func skipFrontend(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1865,55 +1851,30 @@ func skipFrontend(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthFrontend
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthFrontend
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowFrontend
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipFrontend(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthFrontend
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupFrontend
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthFrontend
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthFrontend = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowFrontend   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthFrontend        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowFrontend          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupFrontend = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ingester/client/ingester.pb.go
+++ b/pkg/ingester/client/ingester.pb.go
@@ -3089,9 +3089,9 @@ func (this *QueryResponse) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&client.QueryResponse{")
 	if this.Timeseries != nil {
-		vs := make([]*mimirpb.TimeSeries, len(this.Timeseries))
+		vs := make([]mimirpb.TimeSeries, len(this.Timeseries))
 		for i := range vs {
-			vs[i] = &this.Timeseries[i]
+			vs[i] = this.Timeseries[i]
 		}
 		s = append(s, "Timeseries: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -3105,31 +3105,31 @@ func (this *QueryStreamResponse) GoString() string {
 	s := make([]string, 0, 9)
 	s = append(s, "&client.QueryStreamResponse{")
 	if this.Chunkseries != nil {
-		vs := make([]*TimeSeriesChunk, len(this.Chunkseries))
+		vs := make([]TimeSeriesChunk, len(this.Chunkseries))
 		for i := range vs {
-			vs[i] = &this.Chunkseries[i]
+			vs[i] = this.Chunkseries[i]
 		}
 		s = append(s, "Chunkseries: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
 	if this.Timeseries != nil {
-		vs := make([]*mimirpb.TimeSeries, len(this.Timeseries))
+		vs := make([]mimirpb.TimeSeries, len(this.Timeseries))
 		for i := range vs {
-			vs[i] = &this.Timeseries[i]
+			vs[i] = this.Timeseries[i]
 		}
 		s = append(s, "Timeseries: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
 	if this.StreamingSeries != nil {
-		vs := make([]*QueryStreamSeries, len(this.StreamingSeries))
+		vs := make([]QueryStreamSeries, len(this.StreamingSeries))
 		for i := range vs {
-			vs[i] = &this.StreamingSeries[i]
+			vs[i] = this.StreamingSeries[i]
 		}
 		s = append(s, "StreamingSeries: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
 	s = append(s, "IsEndOfSeriesStream: "+fmt.Sprintf("%#v", this.IsEndOfSeriesStream)+",\n")
 	if this.StreamingSeriesChunks != nil {
-		vs := make([]*QueryStreamSeriesChunks, len(this.StreamingSeriesChunks))
+		vs := make([]QueryStreamSeriesChunks, len(this.StreamingSeriesChunks))
 		for i := range vs {
-			vs[i] = &this.StreamingSeriesChunks[i]
+			vs[i] = this.StreamingSeriesChunks[i]
 		}
 		s = append(s, "StreamingSeriesChunks: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -3155,9 +3155,9 @@ func (this *QueryStreamSeriesChunks) GoString() string {
 	s = append(s, "&client.QueryStreamSeriesChunks{")
 	s = append(s, "SeriesIndex: "+fmt.Sprintf("%#v", this.SeriesIndex)+",\n")
 	if this.Chunks != nil {
-		vs := make([]*Chunk, len(this.Chunks))
+		vs := make([]Chunk, len(this.Chunks))
 		for i := range vs {
-			vs[i] = &this.Chunks[i]
+			vs[i] = this.Chunks[i]
 		}
 		s = append(s, "Chunks: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -3171,9 +3171,9 @@ func (this *ExemplarQueryResponse) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&client.ExemplarQueryResponse{")
 	if this.Timeseries != nil {
-		vs := make([]*mimirpb.TimeSeries, len(this.Timeseries))
+		vs := make([]mimirpb.TimeSeries, len(this.Timeseries))
 		for i := range vs {
-			vs[i] = &this.Timeseries[i]
+			vs[i] = this.Timeseries[i]
 		}
 		s = append(s, "Timeseries: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -3353,9 +3353,9 @@ func (this *TimeSeriesChunk) GoString() string {
 	s = append(s, "UserId: "+fmt.Sprintf("%#v", this.UserId)+",\n")
 	s = append(s, "Labels: "+fmt.Sprintf("%#v", this.Labels)+",\n")
 	if this.Chunks != nil {
-		vs := make([]*Chunk, len(this.Chunks))
+		vs := make([]Chunk, len(this.Chunks))
 		for i := range vs {
-			vs[i] = &this.Chunks[i]
+			vs[i] = this.Chunks[i]
 		}
 		s = append(s, "Chunks: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -6562,10 +6562,7 @@ func (m *LabelNamesAndValuesRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -6649,10 +6646,7 @@ func (m *LabelNamesAndValuesResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -6766,10 +6760,7 @@ func (m *LabelValues) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -6904,10 +6895,7 @@ func (m *LabelValuesCardinalityRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -6991,10 +6979,7 @@ func (m *LabelValuesCardinalityResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -7172,7 +7157,7 @@ func (m *LabelValueSeriesCount) Unmarshal(dAtA []byte) error {
 					if err != nil {
 						return err
 					}
-					if skippy < 0 {
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
 						return ErrInvalidLengthIngester
 					}
 					if (iNdEx + skippy) > postIndex {
@@ -7189,10 +7174,7 @@ func (m *LabelValueSeriesCount) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -7333,10 +7315,7 @@ func (m *QueryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -7458,10 +7437,7 @@ func (m *ExemplarQueryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -7564,10 +7540,7 @@ func (m *ActiveSeriesRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -7651,10 +7624,7 @@ func (m *QueryResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -7860,10 +7830,7 @@ func (m *QueryStreamResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -7966,10 +7933,7 @@ func (m *QueryStreamSeries) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -8072,10 +8036,7 @@ func (m *QueryStreamSeriesChunks) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -8159,10 +8120,7 @@ func (m *ExemplarQueryResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -8337,10 +8295,7 @@ func (m *LabelValuesRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -8422,10 +8377,7 @@ func (m *LabelValuesResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -8568,10 +8520,7 @@ func (m *LabelNamesRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -8653,10 +8602,7 @@ func (m *LabelNamesResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -8725,10 +8671,7 @@ func (m *UserStatsRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -8830,10 +8773,7 @@ func (m *UserStatsResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -8951,10 +8891,7 @@ func (m *UserIDStatsResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -9038,10 +8975,7 @@ func (m *UsersStatsResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -9182,10 +9116,7 @@ func (m *MetricsForLabelMatchersRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -9269,10 +9200,7 @@ func (m *MetricsForLabelMatchersResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -9396,10 +9324,7 @@ func (m *MetricsMetadataRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -9483,10 +9408,7 @@ func (m *MetricsMetadataResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -9646,10 +9568,7 @@ func (m *ActiveSeriesResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -9831,10 +9750,7 @@ func (m *TimeSeriesChunk) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -9974,10 +9890,7 @@ func (m *Chunk) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -10061,10 +9974,7 @@ func (m *LabelMatchers) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -10197,10 +10107,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthIngester
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthIngester
 			}
 			if (iNdEx + skippy) > l {
@@ -10218,6 +10125,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 func skipIngester(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -10249,10 +10157,8 @@ func skipIngester(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -10273,55 +10179,30 @@ func skipIngester(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthIngester
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthIngester
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowIngester
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipIngester(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthIngester
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupIngester
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthIngester
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthIngester = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowIngester   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthIngester        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowIngester          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupIngester = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -796,16 +796,16 @@ type isHistogram_ZeroCount interface {
 }
 
 type Histogram_CountInt struct {
-	CountInt uint64 `protobuf:"varint,1,opt,name=count_int,json=countInt,proto3,oneof"`
+	CountInt uint64 `protobuf:"varint,1,opt,name=count_int,json=countInt,proto3,oneof" json:"count_int,omitempty"`
 }
 type Histogram_CountFloat struct {
-	CountFloat float64 `protobuf:"fixed64,2,opt,name=count_float,json=countFloat,proto3,oneof"`
+	CountFloat float64 `protobuf:"fixed64,2,opt,name=count_float,json=countFloat,proto3,oneof" json:"count_float,omitempty"`
 }
 type Histogram_ZeroCountInt struct {
-	ZeroCountInt uint64 `protobuf:"varint,6,opt,name=zero_count_int,json=zeroCountInt,proto3,oneof"`
+	ZeroCountInt uint64 `protobuf:"varint,6,opt,name=zero_count_int,json=zeroCountInt,proto3,oneof" json:"zero_count_int,omitempty"`
 }
 type Histogram_ZeroCountFloat struct {
-	ZeroCountFloat float64 `protobuf:"fixed64,7,opt,name=zero_count_float,json=zeroCountFloat,proto3,oneof"`
+	ZeroCountFloat float64 `protobuf:"fixed64,7,opt,name=zero_count_float,json=zeroCountFloat,proto3,oneof" json:"zero_count_float,omitempty"`
 }
 
 func (*Histogram_CountInt) isHistogram_Count()           {}
@@ -1416,16 +1416,16 @@ type isQueryResponse_Data interface {
 }
 
 type QueryResponse_String_ struct {
-	String_ *StringData `protobuf:"bytes,4,opt,name=string,proto3,oneof"`
+	String_ *StringData `protobuf:"bytes,4,opt,name=string,proto3,oneof" json:"string,omitempty"`
 }
 type QueryResponse_Vector struct {
-	Vector *VectorData `protobuf:"bytes,5,opt,name=vector,proto3,oneof"`
+	Vector *VectorData `protobuf:"bytes,5,opt,name=vector,proto3,oneof" json:"vector,omitempty"`
 }
 type QueryResponse_Scalar struct {
-	Scalar *ScalarData `protobuf:"bytes,6,opt,name=scalar,proto3,oneof"`
+	Scalar *ScalarData `protobuf:"bytes,6,opt,name=scalar,proto3,oneof" json:"scalar,omitempty"`
 }
 type QueryResponse_Matrix struct {
-	Matrix *MatrixData `protobuf:"bytes,7,opt,name=matrix,proto3,oneof"`
+	Matrix *MatrixData `protobuf:"bytes,7,opt,name=matrix,proto3,oneof" json:"matrix,omitempty"`
 }
 
 func (*QueryResponse_String_) isQueryResponse_Data() {}
@@ -3247,23 +3247,23 @@ func (this *TimeSeries) GoString() string {
 	s = append(s, "&mimirpb.TimeSeries{")
 	s = append(s, "Labels: "+fmt.Sprintf("%#v", this.Labels)+",\n")
 	if this.Samples != nil {
-		vs := make([]*Sample, len(this.Samples))
+		vs := make([]Sample, len(this.Samples))
 		for i := range vs {
-			vs[i] = &this.Samples[i]
+			vs[i] = this.Samples[i]
 		}
 		s = append(s, "Samples: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
 	if this.Exemplars != nil {
-		vs := make([]*Exemplar, len(this.Exemplars))
+		vs := make([]Exemplar, len(this.Exemplars))
 		for i := range vs {
-			vs[i] = &this.Exemplars[i]
+			vs[i] = this.Exemplars[i]
 		}
 		s = append(s, "Exemplars: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
 	if this.Histograms != nil {
-		vs := make([]*Histogram, len(this.Histograms))
+		vs := make([]Histogram, len(this.Histograms))
 		for i := range vs {
-			vs[i] = &this.Histograms[i]
+			vs[i] = this.Histograms[i]
 		}
 		s = append(s, "Histograms: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -3343,18 +3343,18 @@ func (this *Histogram) GoString() string {
 		s = append(s, "ZeroCount: "+fmt.Sprintf("%#v", this.ZeroCount)+",\n")
 	}
 	if this.NegativeSpans != nil {
-		vs := make([]*BucketSpan, len(this.NegativeSpans))
+		vs := make([]BucketSpan, len(this.NegativeSpans))
 		for i := range vs {
-			vs[i] = &this.NegativeSpans[i]
+			vs[i] = this.NegativeSpans[i]
 		}
 		s = append(s, "NegativeSpans: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
 	s = append(s, "NegativeDeltas: "+fmt.Sprintf("%#v", this.NegativeDeltas)+",\n")
 	s = append(s, "NegativeCounts: "+fmt.Sprintf("%#v", this.NegativeCounts)+",\n")
 	if this.PositiveSpans != nil {
-		vs := make([]*BucketSpan, len(this.PositiveSpans))
+		vs := make([]BucketSpan, len(this.PositiveSpans))
 		for i := range vs {
-			vs[i] = &this.PositiveSpans[i]
+			vs[i] = this.PositiveSpans[i]
 		}
 		s = append(s, "PositiveSpans: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -3410,16 +3410,16 @@ func (this *FloatHistogram) GoString() string {
 	s = append(s, "Count: "+fmt.Sprintf("%#v", this.Count)+",\n")
 	s = append(s, "Sum: "+fmt.Sprintf("%#v", this.Sum)+",\n")
 	if this.PositiveSpans != nil {
-		vs := make([]*BucketSpan, len(this.PositiveSpans))
+		vs := make([]BucketSpan, len(this.PositiveSpans))
 		for i := range vs {
-			vs[i] = &this.PositiveSpans[i]
+			vs[i] = this.PositiveSpans[i]
 		}
 		s = append(s, "PositiveSpans: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
 	if this.NegativeSpans != nil {
-		vs := make([]*BucketSpan, len(this.NegativeSpans))
+		vs := make([]BucketSpan, len(this.NegativeSpans))
 		for i := range vs {
-			vs[i] = &this.NegativeSpans[i]
+			vs[i] = this.NegativeSpans[i]
 		}
 		s = append(s, "NegativeSpans: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -3560,16 +3560,16 @@ func (this *VectorData) GoString() string {
 	s := make([]string, 0, 6)
 	s = append(s, "&mimirpb.VectorData{")
 	if this.Samples != nil {
-		vs := make([]*VectorSample, len(this.Samples))
+		vs := make([]VectorSample, len(this.Samples))
 		for i := range vs {
-			vs[i] = &this.Samples[i]
+			vs[i] = this.Samples[i]
 		}
 		s = append(s, "Samples: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
 	if this.Histograms != nil {
-		vs := make([]*VectorHistogram, len(this.Histograms))
+		vs := make([]VectorHistogram, len(this.Histograms))
 		for i := range vs {
-			vs[i] = &this.Histograms[i]
+			vs[i] = this.Histograms[i]
 		}
 		s = append(s, "Histograms: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -3618,9 +3618,9 @@ func (this *MatrixData) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&mimirpb.MatrixData{")
 	if this.Series != nil {
-		vs := make([]*MatrixSeries, len(this.Series))
+		vs := make([]MatrixSeries, len(this.Series))
 		for i := range vs {
-			vs[i] = &this.Series[i]
+			vs[i] = this.Series[i]
 		}
 		s = append(s, "Series: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -3635,16 +3635,16 @@ func (this *MatrixSeries) GoString() string {
 	s = append(s, "&mimirpb.MatrixSeries{")
 	s = append(s, "Metric: "+fmt.Sprintf("%#v", this.Metric)+",\n")
 	if this.Samples != nil {
-		vs := make([]*Sample, len(this.Samples))
+		vs := make([]Sample, len(this.Samples))
 		for i := range vs {
-			vs[i] = &this.Samples[i]
+			vs[i] = this.Samples[i]
 		}
 		s = append(s, "Samples: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
 	if this.Histograms != nil {
-		vs := make([]*FloatHistogramPair, len(this.Histograms))
+		vs := make([]FloatHistogramPair, len(this.Histograms))
 		for i := range vs {
-			vs[i] = &this.Histograms[i]
+			vs[i] = this.Histograms[i]
 		}
 		s = append(s, "Histograms: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -4229,7 +4229,8 @@ func (m *Histogram) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Histogram_CountInt) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Histogram_CountInt) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -4240,7 +4241,8 @@ func (m *Histogram_CountInt) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *Histogram_CountFloat) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Histogram_CountFloat) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -4252,7 +4254,8 @@ func (m *Histogram_CountFloat) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *Histogram_ZeroCountInt) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Histogram_ZeroCountInt) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -4263,7 +4266,8 @@ func (m *Histogram_ZeroCountInt) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 func (m *Histogram_ZeroCountFloat) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Histogram_ZeroCountFloat) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -4667,7 +4671,8 @@ func (m *QueryResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *QueryResponse_String_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *QueryResponse_String_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -4687,7 +4692,8 @@ func (m *QueryResponse_String_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *QueryResponse_Vector) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *QueryResponse_Vector) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -4707,7 +4713,8 @@ func (m *QueryResponse_Vector) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *QueryResponse_Scalar) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *QueryResponse_Scalar) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -4727,7 +4734,8 @@ func (m *QueryResponse_Scalar) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *QueryResponse_Matrix) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *QueryResponse_Matrix) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -6316,10 +6324,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -6369,10 +6374,7 @@ func (m *WriteResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -6441,10 +6443,7 @@ func (m *ErrorDetails) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -6632,10 +6631,7 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -6753,10 +6749,7 @@ func (m *LabelPair) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -6836,10 +6829,7 @@ func (m *Sample) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -7004,10 +6994,7 @@ func (m *MetricMetadata) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -7091,10 +7078,7 @@ func (m *Metric) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -7208,10 +7192,7 @@ func (m *Exemplar) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -7736,10 +7717,7 @@ func (m *Histogram) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -8103,10 +8081,7 @@ func (m *FloatHistogram) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -8196,10 +8171,7 @@ func (m *BucketSpan) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -8304,10 +8276,7 @@ func (m *FloatHistogramPair) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -8413,10 +8382,7 @@ func (m *SampleHistogram) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -8518,10 +8484,7 @@ func (m *HistogramBucket) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -8626,10 +8589,7 @@ func (m *SampleHistogramPair) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -8953,10 +8913,7 @@ func (m *QueryResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -9057,10 +9014,7 @@ func (m *StringData) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -9178,10 +9132,7 @@ func (m *VectorData) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -9293,10 +9244,7 @@ func (m *VectorSample) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -9430,10 +9378,7 @@ func (m *VectorHistogram) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -9513,10 +9458,7 @@ func (m *ScalarData) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -9600,10 +9542,7 @@ func (m *MatrixData) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -9753,10 +9692,7 @@ func (m *MatrixSeries) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMimir
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMimir
 			}
 			if (iNdEx + skippy) > l {
@@ -9774,6 +9710,7 @@ func (m *MatrixSeries) Unmarshal(dAtA []byte) error {
 func skipMimir(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -9805,10 +9742,8 @@ func skipMimir(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -9829,55 +9764,30 @@ func skipMimir(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthMimir
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthMimir
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowMimir
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipMimir(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthMimir
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupMimir
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthMimir
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthMimir = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowMimir   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthMimir        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowMimir          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupMimir = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/querier/stats/stats.pb.go
+++ b/pkg/querier/stats/stats.pb.go
@@ -781,10 +781,7 @@ func (m *Stats) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthStats
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthStats
 			}
 			if (iNdEx + skippy) > l {
@@ -802,6 +799,7 @@ func (m *Stats) Unmarshal(dAtA []byte) error {
 func skipStats(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -833,10 +831,8 @@ func skipStats(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -857,55 +853,30 @@ func skipStats(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthStats
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthStats
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowStats
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipStats(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthStats
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupStats
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthStats
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthStats = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowStats   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthStats        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowStats          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupStats = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ruler/ruler.pb.go
+++ b/pkg/ruler/ruler.pb.go
@@ -2098,10 +2098,7 @@ func (m *RulesRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRuler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRuler
 			}
 			if (iNdEx + skippy) > l {
@@ -2185,10 +2182,7 @@ func (m *RulesResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRuler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRuler
 			}
 			if (iNdEx + skippy) > l {
@@ -2270,10 +2264,7 @@ func (m *SyncRulesRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRuler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRuler
 			}
 			if (iNdEx + skippy) > l {
@@ -2323,10 +2314,7 @@ func (m *SyncRulesResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRuler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRuler
 			}
 			if (iNdEx + skippy) > l {
@@ -2512,10 +2500,7 @@ func (m *GroupStateDesc) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRuler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRuler
 			}
 			if (iNdEx + skippy) > l {
@@ -2797,10 +2782,7 @@ func (m *RuleStateDesc) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRuler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRuler
 			}
 			if (iNdEx + skippy) > l {
@@ -3159,10 +3141,7 @@ func (m *AlertStateDesc) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRuler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRuler
 			}
 			if (iNdEx + skippy) > l {
@@ -3180,6 +3159,7 @@ func (m *AlertStateDesc) Unmarshal(dAtA []byte) error {
 func skipRuler(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -3211,10 +3191,8 @@ func skipRuler(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -3235,55 +3213,30 @@ func skipRuler(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthRuler
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthRuler
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowRuler
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipRuler(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthRuler
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupRuler
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthRuler
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthRuler = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowRuler   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthRuler        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowRuler          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupRuler = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ruler/rulespb/rules.pb.go
+++ b/pkg/ruler/rulespb/rules.pb.go
@@ -1153,10 +1153,7 @@ func (m *RuleGroupDesc) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRules
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRules
 			}
 			if (iNdEx + skippy) > l {
@@ -1436,10 +1433,7 @@ func (m *RuleDesc) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRules
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRules
 			}
 			if (iNdEx + skippy) > l {
@@ -1457,6 +1451,7 @@ func (m *RuleDesc) Unmarshal(dAtA []byte) error {
 func skipRules(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1488,10 +1483,8 @@ func skipRules(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1512,55 +1505,30 @@ func skipRules(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthRules
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthRules
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowRules
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipRules(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthRules
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupRules
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthRules
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthRules = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowRules   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthRules        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowRules          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupRules = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/scheduler/schedulerpb/scheduler.pb.go
+++ b/pkg/scheduler/schedulerpb/scheduler.pb.go
@@ -1606,10 +1606,7 @@ func (m *QuerierToScheduler) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -1817,10 +1814,7 @@ func (m *SchedulerToQuerier) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -2060,10 +2054,7 @@ func (m *FrontendToScheduler) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -2164,10 +2155,7 @@ func (m *SchedulerToFrontend) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -2249,10 +2237,7 @@ func (m *NotifyQuerierShutdownRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -2302,10 +2287,7 @@ func (m *NotifyQuerierShutdownResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthScheduler
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthScheduler
 			}
 			if (iNdEx + skippy) > l {
@@ -2323,6 +2305,7 @@ func (m *NotifyQuerierShutdownResponse) Unmarshal(dAtA []byte) error {
 func skipScheduler(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -2354,10 +2337,8 @@ func skipScheduler(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -2378,55 +2359,30 @@ func skipScheduler(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthScheduler
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthScheduler
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowScheduler
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipScheduler(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthScheduler
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupScheduler
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthScheduler
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthScheduler = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowScheduler   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthScheduler        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowScheduler          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupScheduler = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/storage/indexheader/indexheaderpb/sparse.pb.go
+++ b/pkg/storage/indexheader/indexheaderpb/sparse.pb.go
@@ -1080,10 +1080,7 @@ func (m *Sparse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthSparse
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthSparse
 			}
 			if (iNdEx + skippy) > l {
@@ -1228,10 +1225,7 @@ func (m *Symbols) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthSparse
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthSparse
 			}
 			if (iNdEx + skippy) > l {
@@ -1393,7 +1387,7 @@ func (m *PostingOffsetTable) Unmarshal(dAtA []byte) error {
 					if err != nil {
 						return err
 					}
-					if skippy < 0 {
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
 						return ErrInvalidLengthSparse
 					}
 					if (iNdEx + skippy) > postIndex {
@@ -1429,10 +1423,7 @@ func (m *PostingOffsetTable) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthSparse
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthSparse
 			}
 			if (iNdEx + skippy) > l {
@@ -1535,10 +1526,7 @@ func (m *PostingValueOffsets) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthSparse
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthSparse
 			}
 			if (iNdEx + skippy) > l {
@@ -1639,10 +1627,7 @@ func (m *PostingOffset) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthSparse
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthSparse
 			}
 			if (iNdEx + skippy) > l {
@@ -1660,6 +1645,7 @@ func (m *PostingOffset) Unmarshal(dAtA []byte) error {
 func skipSparse(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1691,10 +1677,8 @@ func skipSparse(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1715,55 +1699,30 @@ func skipSparse(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthSparse
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthSparse
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowSparse
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipSparse(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthSparse
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupSparse
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthSparse
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthSparse = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowSparse   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthSparse        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowSparse          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupSparse = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/storegateway/hintspb/hints.pb.go
+++ b/pkg/storegateway/hintspb/hints.pb.go
@@ -534,9 +534,9 @@ func (this *SeriesRequestHints) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&hintspb.SeriesRequestHints{")
 	if this.BlockMatchers != nil {
-		vs := make([]*storepb.LabelMatcher, len(this.BlockMatchers))
+		vs := make([]storepb.LabelMatcher, len(this.BlockMatchers))
 		for i := range vs {
-			vs[i] = &this.BlockMatchers[i]
+			vs[i] = this.BlockMatchers[i]
 		}
 		s = append(s, "BlockMatchers: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -550,9 +550,9 @@ func (this *SeriesResponseHints) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&hintspb.SeriesResponseHints{")
 	if this.QueriedBlocks != nil {
-		vs := make([]*Block, len(this.QueriedBlocks))
+		vs := make([]Block, len(this.QueriedBlocks))
 		for i := range vs {
-			vs[i] = &this.QueriedBlocks[i]
+			vs[i] = this.QueriedBlocks[i]
 		}
 		s = append(s, "QueriedBlocks: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -576,9 +576,9 @@ func (this *LabelNamesRequestHints) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&hintspb.LabelNamesRequestHints{")
 	if this.BlockMatchers != nil {
-		vs := make([]*storepb.LabelMatcher, len(this.BlockMatchers))
+		vs := make([]storepb.LabelMatcher, len(this.BlockMatchers))
 		for i := range vs {
-			vs[i] = &this.BlockMatchers[i]
+			vs[i] = this.BlockMatchers[i]
 		}
 		s = append(s, "BlockMatchers: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -592,9 +592,9 @@ func (this *LabelNamesResponseHints) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&hintspb.LabelNamesResponseHints{")
 	if this.QueriedBlocks != nil {
-		vs := make([]*Block, len(this.QueriedBlocks))
+		vs := make([]Block, len(this.QueriedBlocks))
 		for i := range vs {
-			vs[i] = &this.QueriedBlocks[i]
+			vs[i] = this.QueriedBlocks[i]
 		}
 		s = append(s, "QueriedBlocks: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -608,9 +608,9 @@ func (this *LabelValuesRequestHints) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&hintspb.LabelValuesRequestHints{")
 	if this.BlockMatchers != nil {
-		vs := make([]*storepb.LabelMatcher, len(this.BlockMatchers))
+		vs := make([]storepb.LabelMatcher, len(this.BlockMatchers))
 		for i := range vs {
-			vs[i] = &this.BlockMatchers[i]
+			vs[i] = this.BlockMatchers[i]
 		}
 		s = append(s, "BlockMatchers: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -624,9 +624,9 @@ func (this *LabelValuesResponseHints) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&hintspb.LabelValuesResponseHints{")
 	if this.QueriedBlocks != nil {
-		vs := make([]*Block, len(this.QueriedBlocks))
+		vs := make([]Block, len(this.QueriedBlocks))
 		for i := range vs {
-			vs[i] = &this.QueriedBlocks[i]
+			vs[i] = this.QueriedBlocks[i]
 		}
 		s = append(s, "QueriedBlocks: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -1190,10 +1190,7 @@ func (m *SeriesRequestHints) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthHints
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthHints
 			}
 			if (iNdEx + skippy) > l {
@@ -1277,10 +1274,7 @@ func (m *SeriesResponseHints) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthHints
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthHints
 			}
 			if (iNdEx + skippy) > l {
@@ -1362,10 +1356,7 @@ func (m *Block) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthHints
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthHints
 			}
 			if (iNdEx + skippy) > l {
@@ -1449,10 +1440,7 @@ func (m *LabelNamesRequestHints) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthHints
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthHints
 			}
 			if (iNdEx + skippy) > l {
@@ -1536,10 +1524,7 @@ func (m *LabelNamesResponseHints) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthHints
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthHints
 			}
 			if (iNdEx + skippy) > l {
@@ -1623,10 +1608,7 @@ func (m *LabelValuesRequestHints) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthHints
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthHints
 			}
 			if (iNdEx + skippy) > l {
@@ -1710,10 +1692,7 @@ func (m *LabelValuesResponseHints) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthHints
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthHints
 			}
 			if (iNdEx + skippy) > l {
@@ -1731,6 +1710,7 @@ func (m *LabelValuesResponseHints) Unmarshal(dAtA []byte) error {
 func skipHints(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1762,10 +1742,8 @@ func skipHints(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1786,55 +1764,30 @@ func skipHints(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthHints
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthHints
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowHints
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipHints(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthHints
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupHints
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthHints
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthHints = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowHints   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthHints        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowHints          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupHints = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/storegateway/storepb/cache.pb.go
+++ b/pkg/storegateway/storepb/cache.pb.go
@@ -347,10 +347,7 @@ func (m *CachedSeries) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCache
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCache
 			}
 			if (iNdEx + skippy) > l {
@@ -368,6 +365,7 @@ func (m *CachedSeries) Unmarshal(dAtA []byte) error {
 func skipCache(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -399,10 +397,8 @@ func skipCache(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -423,55 +419,30 @@ func skipCache(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthCache
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthCache
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowCache
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipCache(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthCache
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupCache
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthCache
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthCache = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowCache   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthCache        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowCache          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupCache = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/storegateway/storepb/rpc.pb.go
+++ b/pkg/storegateway/storepb/rpc.pb.go
@@ -171,25 +171,25 @@ type isSeriesResponse_Result interface {
 }
 
 type SeriesResponse_Series struct {
-	Series *Series `protobuf:"bytes,1,opt,name=series,proto3,oneof"`
+	Series *Series `protobuf:"bytes,1,opt,name=series,proto3,oneof" json:"series,omitempty"`
 }
 type SeriesResponse_Warning struct {
-	Warning string `protobuf:"bytes,2,opt,name=warning,proto3,oneof"`
+	Warning string `protobuf:"bytes,2,opt,name=warning,proto3,oneof" json:"warning,omitempty"`
 }
 type SeriesResponse_Hints struct {
-	Hints *types.Any `protobuf:"bytes,3,opt,name=hints,proto3,oneof"`
+	Hints *types.Any `protobuf:"bytes,3,opt,name=hints,proto3,oneof" json:"hints,omitempty"`
 }
 type SeriesResponse_Stats struct {
-	Stats *Stats `protobuf:"bytes,4,opt,name=stats,proto3,oneof"`
+	Stats *Stats `protobuf:"bytes,4,opt,name=stats,proto3,oneof" json:"stats,omitempty"`
 }
 type SeriesResponse_StreamingSeries struct {
-	StreamingSeries *StreamingSeriesBatch `protobuf:"bytes,5,opt,name=streaming_series,json=streamingSeries,proto3,oneof"`
+	StreamingSeries *StreamingSeriesBatch `protobuf:"bytes,5,opt,name=streaming_series,json=streamingSeries,proto3,oneof" json:"streaming_series,omitempty"`
 }
 type SeriesResponse_StreamingChunks struct {
-	StreamingChunks *StreamingChunksBatch `protobuf:"bytes,6,opt,name=streaming_chunks,json=streamingChunks,proto3,oneof"`
+	StreamingChunks *StreamingChunksBatch `protobuf:"bytes,6,opt,name=streaming_chunks,json=streamingChunks,proto3,oneof" json:"streaming_chunks,omitempty"`
 }
 type SeriesResponse_StreamingChunksEstimate struct {
-	StreamingChunksEstimate *StreamingChunksEstimate `protobuf:"bytes,7,opt,name=streaming_chunks_estimate,json=streamingChunksEstimate,proto3,oneof"`
+	StreamingChunksEstimate *StreamingChunksEstimate `protobuf:"bytes,7,opt,name=streaming_chunks_estimate,json=streamingChunksEstimate,proto3,oneof" json:"streaming_chunks_estimate,omitempty"`
 }
 
 func (*SeriesResponse_Series) isSeriesResponse_Result()                  {}
@@ -941,9 +941,9 @@ func (this *SeriesRequest) GoString() string {
 	s = append(s, "MinTime: "+fmt.Sprintf("%#v", this.MinTime)+",\n")
 	s = append(s, "MaxTime: "+fmt.Sprintf("%#v", this.MaxTime)+",\n")
 	if this.Matchers != nil {
-		vs := make([]*LabelMatcher, len(this.Matchers))
+		vs := make([]LabelMatcher, len(this.Matchers))
 		for i := range vs {
-			vs[i] = &this.Matchers[i]
+			vs[i] = this.Matchers[i]
 		}
 		s = append(s, "Matchers: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -1045,9 +1045,9 @@ func (this *LabelNamesRequest) GoString() string {
 		s = append(s, "Hints: "+fmt.Sprintf("%#v", this.Hints)+",\n")
 	}
 	if this.Matchers != nil {
-		vs := make([]*LabelMatcher, len(this.Matchers))
+		vs := make([]LabelMatcher, len(this.Matchers))
 		for i := range vs {
-			vs[i] = &this.Matchers[i]
+			vs[i] = this.Matchers[i]
 		}
 		s = append(s, "Matchers: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -1082,9 +1082,9 @@ func (this *LabelValuesRequest) GoString() string {
 		s = append(s, "Hints: "+fmt.Sprintf("%#v", this.Hints)+",\n")
 	}
 	if this.Matchers != nil {
-		vs := make([]*LabelMatcher, len(this.Matchers))
+		vs := make([]LabelMatcher, len(this.Matchers))
 		for i := range vs {
-			vs[i] = &this.Matchers[i]
+			vs[i] = this.Matchers[i]
 		}
 		s = append(s, "Matchers: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -1251,7 +1251,8 @@ func (m *SeriesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *SeriesResponse_Series) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *SeriesResponse_Series) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1271,7 +1272,8 @@ func (m *SeriesResponse_Series) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *SeriesResponse_Warning) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *SeriesResponse_Warning) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1284,7 +1286,8 @@ func (m *SeriesResponse_Warning) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 func (m *SeriesResponse_Hints) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *SeriesResponse_Hints) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1304,7 +1307,8 @@ func (m *SeriesResponse_Hints) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *SeriesResponse_Stats) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *SeriesResponse_Stats) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1324,7 +1328,8 @@ func (m *SeriesResponse_Stats) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *SeriesResponse_StreamingSeries) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *SeriesResponse_StreamingSeries) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1344,7 +1349,8 @@ func (m *SeriesResponse_StreamingSeries) MarshalToSizedBuffer(dAtA []byte) (int,
 	return len(dAtA) - i, nil
 }
 func (m *SeriesResponse_StreamingChunks) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *SeriesResponse_StreamingChunks) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1364,7 +1370,8 @@ func (m *SeriesResponse_StreamingChunks) MarshalToSizedBuffer(dAtA []byte) (int,
 	return len(dAtA) - i, nil
 }
 func (m *SeriesResponse_StreamingChunksEstimate) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *SeriesResponse_StreamingChunksEstimate) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -2251,10 +2258,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -2323,10 +2327,7 @@ func (m *Stats) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -2618,10 +2619,7 @@ func (m *SeriesResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -2798,10 +2796,7 @@ func (m *LabelNamesRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -2951,10 +2946,7 @@ func (m *LabelNamesResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -3163,10 +3155,7 @@ func (m *LabelValuesRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -3316,10 +3305,7 @@ func (m *LabelValuesResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthRpc
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -3337,6 +3323,7 @@ func (m *LabelValuesResponse) Unmarshal(dAtA []byte) error {
 func skipRpc(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -3368,10 +3355,8 @@ func skipRpc(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -3392,55 +3377,30 @@ func skipRpc(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthRpc
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthRpc
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowRpc
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipRpc(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthRpc
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupRpc
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthRpc
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthRpc = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowRpc   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthRpc        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowRpc          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupRpc = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/storegateway/storepb/types.pb.go
+++ b/pkg/storegateway/storepb/types.pb.go
@@ -780,9 +780,9 @@ func (this *Series) GoString() string {
 	s = append(s, "&storepb.Series{")
 	s = append(s, "Labels: "+fmt.Sprintf("%#v", this.Labels)+",\n")
 	if this.Chunks != nil {
-		vs := make([]*AggrChunk, len(this.Chunks))
+		vs := make([]AggrChunk, len(this.Chunks))
 		for i := range vs {
-			vs[i] = &this.Chunks[i]
+			vs[i] = this.Chunks[i]
 		}
 		s = append(s, "Chunks: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -820,9 +820,9 @@ func (this *StreamingChunks) GoString() string {
 	s = append(s, "&storepb.StreamingChunks{")
 	s = append(s, "SeriesIndex: "+fmt.Sprintf("%#v", this.SeriesIndex)+",\n")
 	if this.Chunks != nil {
-		vs := make([]*AggrChunk, len(this.Chunks))
+		vs := make([]AggrChunk, len(this.Chunks))
 		for i := range vs {
-			vs[i] = &this.Chunks[i]
+			vs[i] = this.Chunks[i]
 		}
 		s = append(s, "Chunks: "+fmt.Sprintf("%#v", vs)+",\n")
 	}
@@ -1628,10 +1628,7 @@ func (m *Chunk) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -1749,10 +1746,7 @@ func (m *Series) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -1836,10 +1830,7 @@ func (m *StreamingSeries) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -1943,10 +1934,7 @@ func (m *StreamingSeriesBatch) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -2049,10 +2037,7 @@ func (m *StreamingChunks) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -2136,10 +2121,7 @@ func (m *StreamingChunksBatch) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -2208,10 +2190,7 @@ func (m *StreamingChunksEstimate) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -2332,10 +2311,7 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -2468,10 +2444,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthTypes
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -2489,6 +2462,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -2520,10 +2494,8 @@ func skipTypes(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -2544,55 +2516,30 @@ func skipTypes(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthTypes
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthTypes
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowTypes
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipTypes(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthTypes
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupTypes
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthTypes
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthTypes = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowTypes   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthTypes        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowTypes          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupTypes = fmt.Errorf("proto: unexpected end of group")
 )


### PR DESCRIPTION
#### What this PR does

Upgrade [github.com/gogo/protobuf/protoc-gen-gogoslick](https://github.com/gogo/protobuf/tree/master/protoc-gen-gogoslick) to its latest version, i.e. v1.3.2.

It has the following bug fixes:

* skippy peanut butter
* proto/buffer: fix proto.Buffer marshaling.
* plugin/gostring: generate values instead of pointers when a field is repeated and non-nullable.
* protoc-gen-gogo/generator: Generate json and custom tags for oneof
* plugin/marshalto: Use ProtoSize() in MarshalTo when enabled for oneof fields.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
