### PR TITLE
Update to latest dskit commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20241004235212-a711ce30731c
+	github.com/grafana/dskit v0.0.0-20241007163720-de20fd2fe818
 	github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -1256,8 +1256,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20240926144415-27f4e81b4b6b h1:UO4mv94pG1kzKCgBKh20TXdACBCAK2vYjV3Q2MlcpEQ=
 github.com/grafana/alerting v0.0.0-20240926144415-27f4e81b4b6b/go.mod h1:GMLi6d09Xqo96fCVUjNk//rcjP5NKEdjOzfWIffD5r4=
-github.com/grafana/dskit v0.0.0-20241004235212-a711ce30731c h1:AMJ+saiPDxwi2sDj/tPP+RMH6xF63Lrib0l2aLJuuDI=
-github.com/grafana/dskit v0.0.0-20241004235212-a711ce30731c/go.mod h1:SPLNCARd4xdjCkue0O6hvuoveuS1dGJjDnfxYe405YQ=
+github.com/grafana/dskit v0.0.0-20241007163720-de20fd2fe818 h1:VPMurXtl+ONN13d9ge1TGTJDBsJNr9Vb1pNQHpQ/aro=
+github.com/grafana/dskit v0.0.0-20241007163720-de20fd2fe818/go.mod h1:SPLNCARd4xdjCkue0O6hvuoveuS1dGJjDnfxYe405YQ=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc h1:BW+LjKJDz0So5LI8UZfW5neWeKpSkWqhmGjQFzcFfLM=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/franz-go v0.0.0-20241003081803-835b5cb1ddcf h1:g6lIXOJlt9LMbx9fUJ+2RoO155txAtpPmM/8mdFq/B0=

--- a/pkg/storegateway/indexcache/remote_test.go
+++ b/pkg/storegateway/indexcache/remote_test.go
@@ -944,6 +944,20 @@ func (c *mockedRemoteCacheClient) SetMultiAsync(data map[string][]byte, _ time.D
 	}
 }
 
+func (c *mockedRemoteCacheClient) Set(_ context.Context, key string, value []byte, _ time.Duration) error {
+	c.cache[key] = value
+	return nil
+}
+
+func (c *mockedRemoteCacheClient) Add(_ context.Context, key string, value []byte, _ time.Duration) error {
+	if _, ok := c.cache[key]; ok {
+		return cache.ErrNotStored
+	}
+
+	c.cache[key] = value
+	return nil
+}
+
 func (c *mockedRemoteCacheClient) Delete(_ context.Context, key string) error {
 	delete(c.cache, key)
 

--- a/vendor/github.com/grafana/dskit/cache/cache.go
+++ b/vendor/github.com/grafana/dskit/cache/cache.go
@@ -13,6 +13,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var (
+	ErrNotStored  = errors.New("item not stored")
+	ErrInvalidTTL = errors.New("invalid TTL")
+)
+
 // Cache is a high level interface to interact with a cache.
 type Cache interface {
 	// GetMulti fetches multiple keys at once from a cache. In case of error,
@@ -27,6 +32,14 @@ type Cache interface {
 	// SetMultiAsync enqueues operations to store a keys and values into a cache. In case
 	// any underlying async operations fail, the errors will be tracked/logged.
 	SetMultiAsync(data map[string][]byte, ttl time.Duration)
+
+	// Set stores a key and value into a cache.
+	Set(ctx context.Context, key string, value []byte, ttl time.Duration) error
+
+	// Add stores a key and value into a cache only if it does not already exist. If the
+	// item was not stored because an entry already exists in the cache, ErrNotStored will
+	// be returned.
+	Add(ctx context.Context, key string, value []byte, ttl time.Duration) error
 
 	// Delete deletes a key from a cache. This is a synchronous operation. If an asynchronous
 	// set operation for key is still pending to be processed, it will wait for it to complete

--- a/vendor/github.com/grafana/dskit/cache/compression.go
+++ b/vendor/github.com/grafana/dskit/cache/compression.go
@@ -85,6 +85,14 @@ func (s *SnappyCache) SetMultiAsync(data map[string][]byte, ttl time.Duration) {
 	s.next.SetMultiAsync(encoded, ttl)
 }
 
+func (s *SnappyCache) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return s.next.Set(ctx, key, snappy.Encode(nil, value), ttl)
+}
+
+func (s *SnappyCache) Add(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return s.next.Add(ctx, key, snappy.Encode(nil, value), ttl)
+}
+
 // GetMulti implements Cache.
 func (s *SnappyCache) GetMulti(ctx context.Context, keys []string, opts ...Option) map[string][]byte {
 	found := s.next.GetMulti(ctx, keys, opts...)

--- a/vendor/github.com/grafana/dskit/cache/memcached_client.go
+++ b/vendor/github.com/grafana/dskit/cache/memcached_client.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	dnsProviderUpdateInterval = 30 * time.Second
+	maxTTL                    = 30 * 24 * time.Hour
 )
 
 var (
@@ -43,6 +44,7 @@ var (
 type memcachedClientBackend interface {
 	GetMulti(keys []string, opts ...memcache.Option) (map[string]*memcache.Item, error)
 	Set(item *memcache.Item) error
+	Add(item *memcache.Item) error
 	Delete(key string) error
 	Decrement(key string, delta uint64) (uint64, error)
 	Increment(key string, delta uint64) (uint64, error)
@@ -322,14 +324,47 @@ func (c *MemcachedClient) SetAsync(key string, value []byte, ttl time.Duration) 
 	c.setAsync(key, value, ttl, c.setSingleItem)
 }
 
+func (c *MemcachedClient) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.storeOperation(ctx, key, value, ttl, opSet, func(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return c.setSingleItem(key, value, ttl)
+		}
+	})
+}
+
+func (c *MemcachedClient) Add(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.storeOperation(ctx, key, value, ttl, opAdd, func(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			ttlSeconds, ok := toSeconds(ttl)
+			if !ok {
+				return fmt.Errorf("%w: for set operation on %s %s", ErrInvalidTTL, key, ttl)
+			}
+
+			err := c.client.Add(&memcache.Item{
+				Key:        key,
+				Value:      value,
+				Expiration: ttlSeconds,
+			})
+
+			if errors.Is(err, memcache.ErrNotStored) {
+				return fmt.Errorf("%w: for add operation on %s", ErrNotStored, key)
+			}
+
+			return err
+		}
+	})
+}
+
 func (c *MemcachedClient) setSingleItem(key string, value []byte, ttl time.Duration) error {
-	ttlSeconds := int32(ttl.Seconds())
-	// If a TTL of exactly 0 is passed, we honor it and pass it to Memcached which will
-	// interpret it as an infinite TTL. However, if we get a non-zero TTL that is truncated
-	// to 0 seconds, we discard the update since the caller didn't intend to set an infinite
-	// TTL.
-	if ttl != 0 && ttlSeconds <= 0 {
-		return nil
+	ttlSeconds, ok := toSeconds(ttl)
+	if !ok {
+		return fmt.Errorf("%w: for set operation on %s %s", ErrInvalidTTL, key, ttl)
 	}
 
 	return c.client.Set(&memcache.Item{
@@ -337,6 +372,24 @@ func (c *MemcachedClient) setSingleItem(key string, value []byte, ttl time.Durat
 		Value:      value,
 		Expiration: ttlSeconds,
 	})
+}
+
+// toSeconds converts a time.Duration to seconds as an int32 and returns a boolean
+// indicating if the value is valid to be used as a TTL. Durations might not be valid
+// to be used for a TTL if they are non-zero but less than a second long (Memcached
+// uses seconds for TTL units but "0" to mean infinite TTL) or if they are longer than
+// 30 days (Memcached treats TTLs more than 30 days as UNIX timestamps).
+func toSeconds(d time.Duration) (int32, bool) {
+	if d > maxTTL {
+		return 0, false
+	}
+
+	secs := int32(d.Seconds())
+	if d != 0 && secs <= 0 {
+		return 0, false
+	}
+
+	return secs, true
 }
 
 func toMemcacheOptions(opts ...Option) []memcache.Option {

--- a/vendor/github.com/grafana/dskit/cache/redis_client.go
+++ b/vendor/github.com/grafana/dskit/cache/redis_client.go
@@ -226,7 +226,7 @@ func NewRedisClient(logger log.Logger, name string, config RedisClientConfig, re
 	return c, nil
 }
 
-// SetMultiAsync implements RemoteCacheClient.
+// SetMultiAsync implements Cache.
 func (c *RedisClient) SetMultiAsync(data map[string][]byte, ttl time.Duration) {
 	c.setMultiAsync(data, ttl, func(key string, value []byte, ttl time.Duration) error {
 		_, err := c.client.Set(context.Background(), key, value, ttl).Result()
@@ -234,7 +234,7 @@ func (c *RedisClient) SetMultiAsync(data map[string][]byte, ttl time.Duration) {
 	})
 }
 
-// SetAsync implements RemoteCacheClient.
+// SetAsync implements Cache.
 func (c *RedisClient) SetAsync(key string, value []byte, ttl time.Duration) {
 	c.setAsync(key, value, ttl, func(key string, buf []byte, ttl time.Duration) error {
 		_, err := c.client.Set(context.Background(), key, buf, ttl).Result()
@@ -242,7 +242,30 @@ func (c *RedisClient) SetAsync(key string, value []byte, ttl time.Duration) {
 	})
 }
 
-// GetMulti implements RemoteCacheClient.
+// Set implements Cache.
+func (c *RedisClient) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.storeOperation(ctx, key, value, ttl, opSet, func(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+		_, err := c.client.Set(ctx, key, value, ttl).Result()
+		return err
+	})
+}
+
+// Add implements Cache.
+func (c *RedisClient) Add(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.storeOperation(ctx, key, value, ttl, opAdd, func(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+		stored, err := c.client.SetNX(ctx, key, value, ttl).Result()
+		if err != nil {
+			return err
+		}
+		if !stored {
+			return fmt.Errorf("%w: for Set NX operation on %s", ErrNotStored, key)
+		}
+
+		return nil
+	})
+}
+
+// GetMulti implements Cache.
 func (c *RedisClient) GetMulti(ctx context.Context, keys []string, _ ...Option) map[string][]byte {
 	if len(keys) == 0 {
 		return nil

--- a/vendor/github.com/grafana/dskit/cache/tracing.go
+++ b/vendor/github.com/grafana/dskit/cache/tracing.go
@@ -31,6 +31,14 @@ func (t *SpanlessTracingCache) SetMultiAsync(data map[string][]byte, ttl time.Du
 	t.next.SetMultiAsync(data, ttl)
 }
 
+func (t *SpanlessTracingCache) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return t.next.Set(ctx, key, value, ttl)
+}
+
+func (t *SpanlessTracingCache) Add(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return t.next.Add(ctx, key, value, ttl)
+}
+
 func (t *SpanlessTracingCache) GetMulti(ctx context.Context, keys []string, opts ...Option) (result map[string][]byte) {
 	var (
 		bytes  int

--- a/vendor/github.com/grafana/dskit/cache/versioned.go
+++ b/vendor/github.com/grafana/dskit/cache/versioned.go
@@ -36,6 +36,14 @@ func (c *Versioned) SetMultiAsync(data map[string][]byte, ttl time.Duration) {
 	c.cache.SetMultiAsync(versioned, ttl)
 }
 
+func (c *Versioned) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.cache.Set(ctx, c.addVersion(key), value, ttl)
+}
+
+func (c *Versioned) Add(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	return c.cache.Add(ctx, c.addVersion(key), value, ttl)
+}
+
 func (c *Versioned) GetMulti(ctx context.Context, keys []string, opts ...Option) map[string][]byte {
 	versionedKeys := make([]string, len(keys))
 	for i, k := range keys {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -611,7 +611,7 @@ github.com/grafana/alerting/receivers/webex
 github.com/grafana/alerting/receivers/webhook
 github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
-# github.com/grafana/dskit v0.0.0-20241004235212-a711ce30731c
+# github.com/grafana/dskit v0.0.0-20241007163720-de20fd2fe818
 ## explicit; go 1.21
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
#### What this PR does

Specifically, this pulls in https://github.com/grafana/dskit/pull/591 which adds new `.Set()` and `.Add()` methods to cache interfaces and clients.

#### Which issue(s) this PR fixes or relates to

Related https://github.com/grafana/mimir/issues/9386

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
