### PR TITLE
Validate only a single tenant ID passed to ruler API

### DIFF
--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -1614,7 +1614,7 @@ func TestAlertStateDescToPrometheusAlert(t *testing.T) {
 	})
 }
 
-func TestAPIRoutesCorrectlyHandleInvalidOrgID(t *testing.T) {
+func TestAPIRoutesCorrectlyHandleInvalidTenantID(t *testing.T) {
 	tcs := []struct {
 		route  string
 		method string
@@ -1630,8 +1630,8 @@ func TestAPIRoutesCorrectlyHandleInvalidOrgID(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		for _, tenantID := range []string{"", "user1|user2"} {
-			t.Run(fmt.Sprintf("method=%s, route=%s, userID=%s", tc.method, tc.route, tenantID), func(t *testing.T) {
+		for _, tenantID := range []string{"", "team1|team2"} {
+			t.Run(fmt.Sprintf("method=%s, route=%s, tenantID=%s", tc.method, tc.route, tenantID), func(t *testing.T) {
 				cfg := defaultRulerConfig(t)
 				cfg.TenantFederation.Enabled = true
 

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -1630,32 +1630,33 @@ func TestAPIRoutesCorrectlyHandleInvalidOrgID(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		const invalidOrgID = ""
+		for _, tenantID := range []string{"", "user1|user2"} {
+			t.Run(fmt.Sprintf("method=%s, route=%s, userID=%s", tc.method, tc.route, tenantID), func(t *testing.T) {
+				cfg := defaultRulerConfig(t)
+				cfg.TenantFederation.Enabled = true
 
-		cfg := defaultRulerConfig(t)
-		cfg.TenantFederation.Enabled = true
+				r := prepareRuler(t, cfg, newMockRuleStore(map[string]rulespb.RuleGroupList{}), withStart())
+				a := NewAPI(r, r.store, log.NewNopLogger())
 
-		r := prepareRuler(t, cfg, newMockRuleStore(map[string]rulespb.RuleGroupList{}), withStart())
+				router := mux.NewRouter()
+				router.Path("/api/v1/rules").Methods(http.MethodGet).HandlerFunc(a.PrometheusRules)
+				router.Path("/api/v1/alerts").Methods(http.MethodGet).HandlerFunc(a.PrometheusAlerts)
+				router.Path("/config/v1/rules").Methods(http.MethodGet).HandlerFunc(a.ListRules)
+				router.Path("/config/v1/rules/{namespace}").Methods(http.MethodGet).HandlerFunc(a.ListRules)
+				router.Path("/config/v1/rules/{namespace}/{groupName}").Methods(http.MethodGet).HandlerFunc(a.GetRuleGroup)
+				router.Path("/config/v1/rules/{namespace}").Methods(http.MethodPost).HandlerFunc(a.CreateRuleGroup)
+				router.Path("/config/v1/rules/{namespace}/{groupName}").Methods(http.MethodDelete).HandlerFunc(a.DeleteRuleGroup)
+				router.Path("/config/v1/rules/{namespace}").Methods(http.MethodDelete).HandlerFunc(a.DeleteNamespace)
 
-		a := NewAPI(r, r.store, log.NewNopLogger())
+				req := requestFor(t, tc.method, "https://localhost:8080"+tc.route, nil, tenantID)
 
-		router := mux.NewRouter()
-		router.Path("/api/v1/rules").Methods(http.MethodGet).HandlerFunc(a.PrometheusRules)
-		router.Path("/api/v1/alerts").Methods(http.MethodGet).HandlerFunc(a.PrometheusAlerts)
-		router.Path("/config/v1/rules").Methods(http.MethodGet).HandlerFunc(a.ListRules)
-		router.Path("/config/v1/rules/{namespace}").Methods(http.MethodGet).HandlerFunc(a.ListRules)
-		router.Path("/config/v1/rules/{namespace}/{groupName}").Methods(http.MethodGet).HandlerFunc(a.GetRuleGroup)
-		router.Path("/config/v1/rules/{namespace}").Methods(http.MethodPost).HandlerFunc(a.CreateRuleGroup)
-		router.Path("/config/v1/rules/{namespace}/{groupName}").Methods(http.MethodDelete).HandlerFunc(a.DeleteRuleGroup)
-		router.Path("/config/v1/rules/{namespace}").Methods(http.MethodDelete).HandlerFunc(a.DeleteNamespace)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
 
-		req := requestFor(t, tc.method, "https://localhost:8080"+tc.route, nil, invalidOrgID)
-
-		w := httptest.NewRecorder()
-		router.ServeHTTP(w, req)
-
-		resp := w.Result()
-		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+				resp := w.Result()
+				require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
#### What this PR does

This change extends an existing test to validate the ruler API endpoints only accept a single tenant ID, not multiple tenant IDs joined via `|` pipes.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
