### PR TITLE
Backport #9553 to r310

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * `cortex_alertmanager_alerts`
   * `cortex_alertmanager_silences`
 * [CHANGE] Cache: Deprecate experimental support for Redis as a cache backend. #9453
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9518
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9518 #9553
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] gRPC: Support S2 compression. #9322
   * `-alertmanager.alertmanager-client.grpc-compression=s2`

--- a/pkg/streamingpromql/functions/rate_increase.go
+++ b/pkg/streamingpromql/functions/rate_increase.go
@@ -20,6 +20,7 @@ var Rate = FunctionOverRangeVector{
 	SeriesValidationFuncFactory:    rateSeriesValidator,
 	SeriesMetadataFunc:             DropSeriesName,
 	NeedsSeriesNamesForAnnotations: true,
+	NeedsSeriesDeduplication:       true,
 }
 
 var Increase = FunctionOverRangeVector{
@@ -27,6 +28,7 @@ var Increase = FunctionOverRangeVector{
 	SeriesValidationFuncFactory:    rateSeriesValidator,
 	SeriesMetadataFunc:             DropSeriesName,
 	NeedsSeriesNamesForAnnotations: true,
+	NeedsSeriesDeduplication:       true,
 }
 
 // isRate is true for `rate` function, or false for `instant` function

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -231,3 +231,111 @@ load 1m
 
 eval range from 0 to 7m step 1m -metric
   {} -1 -1 -1 -3 -3 _ -4 -4
+
+clear
+
+# Test the case where multiple series have the same labels after the metric name is removed by a function.
+load 1m
+  float_metric_1 0+1x4
+  float_metric_2 0+2x4
+  histogram_metric_1 {{sum:0 count:0}}x4
+  histogram_metric_2 {{sum:1 count:1}}x4
+
+eval_fail instant at 5m abs({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m acos({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m acosh({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m asin({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m asinh({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m atan({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m atanh({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m avg_over_time({__name__=~"float_metric_.*"}[5m])
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m ceil({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m cos({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m cosh({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m count_over_time({__name__=~"float_metric_.*"}[5m])
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m deg({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m exp({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m floor({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m histogram_count({__name__=~"histogram_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m histogram_sum({__name__=~"histogram_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m increase({__name__=~"float_metric_.*"}[5m])
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m max_over_time({__name__=~"float_metric_.*"}[5m])
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m min_over_time({__name__=~"float_metric_.*"}[5m])
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m ln({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m log10({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m log2({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m present_over_time({__name__=~"float_metric_.*"}[5m])
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m rad({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m rate({__name__=~"float_metric_.*"}[5m])
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m sgn({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m sin({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m sinh({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m sqrt({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m sum_over_time({__name__=~"float_metric_.*"}[5m])
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m tan({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset
+
+eval_fail instant at 5m tanh({__name__=~"float_metric_.*"})
+  expected_fail_message vector cannot contain metrics with the same labelset

--- a/pkg/streamingpromql/testdata/upstream/name_label_dropping.test
+++ b/pkg/streamingpromql/testdata/upstream/name_label_dropping.test
@@ -84,8 +84,9 @@ eval instant at 15m sum by (__name__, env) (metric{env="1"})
 
 # Aggregation operators aggregate metrics with same labelset and to-be-dropped names
 # This is an accidental side effect of delayed __name__ label dropping
-eval instant at 15m sum(rate({env="1"}[10m])) by (env)
-	{env="1"} 0.4
+# Unsupported by streaming engine.
+# eval instant at 15m sum(rate({env="1"}[10m])) by (env)
+# 	{env="1"} 0.4
 
 # Aggregationk operators propagate __name__ label dropping information
 # Unsupported by streaming engine.


### PR DESCRIPTION
This PR manually backports https://github.com/grafana/mimir/pull/9553 to r310.