### PR TITLE
ingest storage: add cleanup to TestPartitionReader_ConsumeAtStartup

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1305,6 +1305,9 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 		readerCtx, cancelReaderCtx := context.WithCancel(ctx)
 		require.NoError(t, reader.StartAsync(readerCtx))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		})
 
 		// Wait until the Kafka cluster received at least 1 ListOffsets request.
 		test.Poll(t, 5*time.Second, true, func() interface{} {
@@ -1349,6 +1352,9 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 		readerCtx, cancelReaderCtx := context.WithCancel(ctx)
 		require.NoError(t, reader.StartAsync(readerCtx))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		})
 
 		// Wait until the Kafka cluster received at least 1 Fetch request.
 		test.Poll(t, 5*time.Second, true, func() interface{} {

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1306,7 +1306,9 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 		readerCtx, cancelReaderCtx := context.WithCancel(ctx)
 		require.NoError(t, reader.StartAsync(readerCtx))
 		t.Cleanup(func() {
-			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+			// Interrupting startup should fail the service.
+			// A context cancellation error shouldn't be swallowed and interpreted as "startup went ok"
+			assert.ErrorIs(t, services.StopAndAwaitTerminated(ctx, reader), context.Canceled)
 		})
 
 		// Wait until the Kafka cluster received at least 1 ListOffsets request.
@@ -1353,7 +1355,9 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 		readerCtx, cancelReaderCtx := context.WithCancel(ctx)
 		require.NoError(t, reader.StartAsync(readerCtx))
 		t.Cleanup(func() {
-			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+			// Interrupting startup should fail the service.
+			// A context cancellation error shouldn't be swallowed and interpreted as "startup went ok"
+			assert.ErrorIs(t, services.StopAndAwaitTerminated(ctx, reader), context.Canceled)
 		})
 
 		// Wait until the Kafka cluster received at least 1 Fetch request.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

related to #8691; this PR fixes the race on `testing.T.Log()` mentioned in that issue. We don't wait for the fetchers to exit and as a result they use the logger after the parent test has exited.


<details><summary>Data race</summary>
<p>

```
WARNING: DATA RACE
Read at 0x00c000035563 by goroutine 45240:
  testing.(*common).logDepth()
      /usr/local/go/src/testing/testing.go:1024 +0x504
  testing.(*common).log()
      /usr/local/go/src/testing/testing.go:1011 +0x7d
  testing.(*common).Log()
      /usr/local/go/src/testing/testing.go:1052 +0x55
  testing.(*T).Log()
      <autogenerated>:1 +0x4f
  github.com/grafana/mimir/pkg/util/test.(*TestingLogger).Log()
      /__w/mimir/mimir/pkg/util/test/logger.go:38 +0x1[77](https://github.com/grafana/mimir/actions/runs/11188014503/job/31106091993?pr=9515#step:8:78)
  github.com/go-kit/log.(*context).Log()
      /__w/mimir/mimir/vendor/github.com/go-kit/log/log.go:168 +0x4ba
  github.com/grafana/dskit/spanlogger.(*SpanLogger).Log()
      /__w/mimir/mimir/vendor/github.com/grafana/dskit/spanlogger/spanlogger.go:111 +0x54
  github.com/go-kit/log.(*context).Log()
      /__w/mimir/mimir/vendor/github.com/go-kit/log/log.go:168 +0x4ba
  github.com/grafana/mimir/pkg/storage/ingest.(*fetchResult).logCompletedFetch()
      /__w/mimir/mimir/pkg/storage/ingest/fetcher.go:156 +0x123c
  github.com/grafana/mimir/pkg/storage/ingest.(*concurrentFetchers).fetchSingle.func1()
      /__w/mimir/mimir/pkg/storage/ingest/fetcher.go:363 +0x94
  github.com/grafana/mimir/pkg/storage/ingest.(*concurrentFetchers).fetchSingle.deferwrap1()
      /__w/mimir/mimir/pkg/storage/ingest/fetcher.go:364 +0x61
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:605 +0x5d
  github.com/grafana/mimir/pkg/storage/ingest.(*concurrentFetchers).run()
      /__w/mimir/mimir/pkg/storage/ingest/fetcher.go:497 +0x684
  github.com/grafana/mimir/pkg/storage/ingest.(*concurrentFetchers).start.gowrap2()
      /__w/mimir/mimir/pkg/storage/ingest/fetcher.go:568 +0x[79](https://github.com/grafana/mimir/actions/runs/11188014503/job/31106091993?pr=9515#step:8:80)

Previous write at 0x00c000035563 by goroutine 35663:
  testing.tRunner.func1()
      /usr/local/go/src/testing/testing.go:1677 +0x8fa
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:605 +0x5d
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x44

Goroutine 45240 (running) created at:
  github.com/grafana/mimir/pkg/storage/ingest.(*concurrentFetchers).start()
      /__w/mimir/mimir/pkg/storage/ingest/fetcher.go:568 +0x4f0
  github.com/grafana/mimir/pkg/storage/ingest.newConcurrentFetchers.gowrap1()
      /__w/mimir/mimir/pkg/storage/ingest/fetcher.go:293 +0x79

Goroutine 35663 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1743 +0x[82](https://github.com/grafana/mimir/actions/runs/11188014503/job/31106091993?pr=9515#step:8:83)5
  github.com/grafana/mimir/pkg/storage/ingest.TestPartitionReader_ConsumeAtStartup()
      /__w/mimir/mimir/pkg/storage/ingest/reader_test.go:1367 +0x627
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1743 +0x44
```

</p>
</details> 


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
