### PR TITLE
Skip stale postings in `/active_series`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508
 * [BUGFIX] Fix issue where sharded queries could return annotations with incorrect or confusing position information. #9536
 * [BUGFIX] Fix issue where downstream consumers may not generate correct cache keys for experimental error caching. #9644
+* [BUGFIX] Fix issue where active series requests error when encountering a stale posting. #9580
 
 ### Mixin
 

--- a/pkg/ingester/active_series.go
+++ b/pkg/ingester/active_series.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
@@ -77,6 +78,10 @@ func (i *Ingester) ActiveSeries(request *client.ActiveSeriesRequest, stream clie
 		seriesRef, count := postings.AtBucketCount()
 		err = idx.Series(seriesRef, &buf, nil)
 		if err != nil {
+			// Postings may be stale. Skip if no underlying series exists.
+			if errors.Is(err, storage.ErrNotFound) {
+				continue
+			}
 			return fmt.Errorf("error getting series: %w", err)
 		}
 		m := &mimirpb.Metric{Labels: mimirpb.FromLabelsToLabelAdapters(buf.Labels())}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When iterating over postings to build the response for `/active_series`, it's not guaranteed that all series references will still be valid at iteration time. We should not error when hitting a stale reference but just build a response that does not include the series referenced by the stale posting.

Thanks to @bboreham for pointing this out.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
