### PR TITLE
bugfix: Stop the current fetcher before replacing it

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -259,6 +259,9 @@ func (r *PartitionReader) switchToOngoingFetcher(ctx context.Context) {
 	}
 
 	if r.kafkaCfg.StartupFetchConcurrency > 0 && r.kafkaCfg.OngoingFetchConcurrency == 0 {
+		// Stop the current fetcher before replacing it.
+		r.fetcher.Stop()
+
 		if r.fetcher == r {
 			// This method has been called before, no need to switch the fetcher.
 			return


### PR DESCRIPTION
#### What this PR does

Otherwise, this causes a memory leak as we leave lingering around the resources we used to catch up as quickly as possible as the ingester was starting.

![image](https://github.com/user-attachments/assets/053b50f5-9f50-4c1f-9c5d-bb496d49f92f)

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
