### PR TITLE
2.14 Update minimum supported versions

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -7,13 +7,13 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
-	"grafana/mimir:2.11.0": e2emimir.ChainFlagMappers(
-		removePartitionRingFlags,
-	),
 	"grafana/mimir:2.12.0": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 	),
 	"grafana/mimir:2.13.0": e2emimir.ChainFlagMappers(
+		removePartitionRingFlags,
+	),
+	"grafana/mimir:2.14.0": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 	),
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,7 @@
     "extends": [
       "config:base"
     ],
-    "baseBranches": ["main", "release-2.14", "release-2.13", "release-2.12"],
+    "baseBranches": ["main", "release-2.14", "release-2.13"],
     "postUpdateOptions": [
       "gomodTidy",
       "gomodUpdateImportPaths"
@@ -11,7 +11,7 @@
     "schedule": ["before 9am on Monday"],
     "packageRules": [
       {
-        "matchBaseBranches": ["release-2.14", "release-2.13", "release-2.12"],
+        "matchBaseBranches": ["release-2.14", "release-2.13"],
         "packagePatterns": ["*"],
         "enabled": false
       },


### PR DESCRIPTION
#### What this PR does

Following the [2.14.0 release](https://github.com/grafana/mimir/releases/tag/mimir-2.14.0), here we update the minimum supported set of versions.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/issues/9382