### PR TITLE
Adds bearer token support for mimirtool's analyze ruler/prometheus co…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [ENHANCEMENT] Adds bearer token support for mimirtool's analyze ruler/prometheus commands.
 * [CHANGE] Alertmanager: the following metrics are not exported for a given `user` when the metric value is zero: #9359
   * `cortex_alertmanager_alerts_received_total`
   * `cortex_alertmanager_alerts_invalid_total`

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -729,12 +729,13 @@ mimirtool analyze ruler --address=<url> --id=<tenant_id>
 
 ##### Configuration
 
-| Environment variable | Flag        | Description                                                                                     |
-| -------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
-| `MIMIR_ADDRESS`      | `--address` | Sets the address of the Prometheus instance.                                                    |
-| `MIMIR_TENANT_ID`    | `--id`      | Sets the basic auth username. If you're using Grafana Cloud, this variable is your instance ID. |
-| `MIMIR_API_KEY`      | `--key`     | Sets the basic auth password. If you're using Grafana Cloud, this variable is your API key.     |
-| -                    | `--output`  | Sets the output file path, which by default is `metrics-in-ruler.json`.                         |
+| Environment variable | Flag            | Description                                                                                         |
+| -------------------- | --------------- | --------------------------------------------------------------------------------------------------- |
+| `MIMIR_ADDRESS`      | `--address`     | Sets the address of the Prometheus instance.                                                        |
+| `MIMIR_TENANT_ID`    | `--id`          | Sets the basic auth username. If you're using Grafana Cloud, this variable is your instance ID.     |
+| `MIMIR_API_KEY`      | `--key`         | Sets the basic auth password. If you're using Grafana Cloud, this variable is your API key.         |
+| `MIMIR_AUTH_TOKEN`   | `--auth-token`  | Sets bearer or JWT token that is required for Mimir clusters authenticating by bearer or JWT token. |
+| -                    | `--output`      | Sets the output file path, which by default is `metrics-in-ruler.json`.                             |
 
 ##### Example output file
 
@@ -814,6 +815,7 @@ mimirtool analyze prometheus --address=<url> --id=<tenant_id>
 | `MIMIR_ADDRESS`      | `--address`                | Sets the address of the Prometheus instance.                                                                             |
 | `MIMIR_TENANT_ID`    | `--id`                     | Sets the basic auth username. If you're using Grafana Cloud this variable is your instance ID, also set as tenant ID.    |
 | `MIMIR_API_KEY`      | `--key`                    | Sets the basic auth password. If you're using Grafana Cloud, this variable is your API key.                              |
+| `MIMIR_AUTH_TOKEN`   | `--auth-token`             | Sets bearer or JWT token that is required for Mimir clusters authenticating by bearer or JWT token.                      |
 | -                    | `--grafana-metrics-file`   | `mimirtool analyze grafana` or `mimirtool analyze dashboard` output file, which by default is `metrics-in-grafana.json`. |
 | -                    | `--ruler-metrics-file`     | `mimirtool analyze ruler` or `mimirtool analyze rule-file` output file, which by default is `metrics-in-ruler.json`.     |
 | -                    | `--output`                 | Sets the output file path, which by default is `prometheus-metrics.json`.                                                |

--- a/pkg/mimirtool/commands/analyse.go
+++ b/pkg/mimirtool/commands/analyse.go
@@ -26,6 +26,10 @@ func (cmd *AnalyzeCommand) Register(app *kingpin.Application, envVars EnvVarName
 	prometheusAnalyzeCmd.Flag("prometheus-http-prefix", "HTTP URL path under which the Prometheus api will be served.").
 		Default("").
 		StringVar(&paCmd.prometheusHTTPPrefix)
+	prometheusAnalyzeCmd.Flag("auth-token", "Authentication token bearer authentication; alternatively, set "+envVars.AuthToken+".").
+		Default("").
+		Envar(envVars.AuthToken).
+		StringVar(&paCmd.authToken)
 	prometheusAnalyzeCmd.Flag("id", "Basic auth username to use when contacting Prometheus or Grafana Mimir, also set as tenant ID; alternatively, set "+envVars.TenantID+".").
 		Envar(envVars.TenantID).
 		Default("").
@@ -88,6 +92,10 @@ func (cmd *AnalyzeCommand) Register(app *kingpin.Application, envVars EnvVarName
 	rulerAnalyzeCmd.Flag("output", "The path for the output file").
 		Default("metrics-in-ruler.json").
 		StringVar(&raCmd.outputFile)
+	rulerAnalyzeCmd.Flag("auth-token", "Authentication token bearer authentication; alternatively, set "+envVars.AuthToken+".").
+		Default("").
+		Envar(envVars.AuthToken).
+		StringVar(&raCmd.ClientConfig.AuthToken)
 
 	daCmd := &DashboardAnalyzeCommand{}
 	dashboardAnalyzeCmd := analyzeCmd.Command("dashboard", "Analyze and output the metrics used in Grafana dashboard files").Action(daCmd.run)

--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -35,6 +35,7 @@ type PrometheusAnalyzeCommand struct {
 	prometheusHTTPPrefix string
 	username             string
 	password             string
+	authToken            string
 	readTimeout          time.Duration
 
 	grafanaMetricsFile string
@@ -89,7 +90,9 @@ func (cmd *PrometheusAnalyzeCommand) parseUsedMetrics() (model.LabelValues, erro
 func (cmd *PrometheusAnalyzeCommand) newAPI() (v1.API, error) {
 	rt := api.DefaultRoundTripper
 	rt = config.NewUserAgentRoundTripper(client.UserAgent(), rt)
-	if cmd.username != "" {
+	if cmd.authToken != "" {
+		rt = config.NewAuthorizationCredentialsRoundTripper("Bearer", config.NewInlineSecret(cmd.authToken), rt)
+	} else if cmd.username != "" {
 		rt = &setTenantIDTransport{
 			RoundTripper: rt,
 			tenantID:     cmd.username,


### PR DESCRIPTION
…mmands

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
mimirtool has support for authenticating using `--auth-token` (since https://github.com/grafana/mimir/pull/2146)  to supply a bearer token for the `rules` command, but the `analyze ruler` and `analyze prometheus` commands do not currently support using a bearer token. This PR adds support for that.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
