### PR TITLE
MQE: add support for `or`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   * `cortex_alertmanager_state_replication_failed_total`
   * `cortex_alertmanager_alerts`
   * `cortex_alertmanager_silences`
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] gRPC: Support S2 compression. #9322
   * `-alertmanager.alertmanager-client.grpc-compression=s2`

--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -170,9 +170,9 @@ func TestCases(metricSizes []int) []BenchCase {
 		{
 			Expr: "a_X and b_X{l=~'.*[0-4]$'}",
 		},
-		//{
-		//	Expr: "a_X or b_X{l=~'.*[0-4]$'}",
-		//},
+		{
+			Expr: "a_X or b_X{l=~'.*[0-4]$'}",
+		},
 		{
 			Expr: "a_X unless b_X{l=~'.*[0-4]$'}",
 		},

--- a/pkg/streamingpromql/engine_concurrency_test.go
+++ b/pkg/streamingpromql/engine_concurrency_test.go
@@ -157,6 +157,30 @@ func TestConcurrentQueries(t *testing.T) {
 			end:   startT.Add(10 * time.Minute),
 			step:  time.Minute,
 		},
+		{
+			expr:  `float{group="a"} or on (instance) float{group="b"}`,
+			start: startT,
+			end:   startT.Add(10 * time.Minute),
+			step:  time.Minute,
+		},
+		{
+			expr:  `native_histogram{group="a"} or on (instance) float{group="b"}`,
+			start: startT,
+			end:   startT.Add(10 * time.Minute),
+			step:  time.Minute,
+		},
+		{
+			expr:  `native_histogram{group="a"} or on (instance) native_histogram{group="b"}`,
+			start: startT,
+			end:   startT.Add(10 * time.Minute),
+			step:  time.Minute,
+		},
+		{
+			expr:  `{group="a"} or on (instance) float{group="b"}`,
+			start: startT,
+			end:   startT.Add(10 * time.Minute),
+			step:  time.Minute,
+		},
 	}
 
 	storage := promqltest.LoadedStorage(t, data)

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1923,7 +1923,7 @@ func TestCompareVariousMixedMetricsBinaryOperations(t *testing.T) {
 	expressions := []string{}
 
 	for _, labels := range labelCombinations {
-		for _, op := range []string{"+", "-", "*", "/", "and", "unless"} {
+		for _, op := range []string{"+", "-", "*", "/", "and", "unless", "or"} {
 			binaryExpr := fmt.Sprintf(`series{label="%s"}`, labels[0])
 			for _, label := range labels[1:] {
 				binaryExpr += fmt.Sprintf(` %s series{label="%s"}`, op, label)

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1913,10 +1913,8 @@ func runMixedMetricsTests(t *testing.T, expressions []string, pointsPerSeries in
 func TestCompareVariousMixedMetricsBinaryOperations(t *testing.T) {
 	labelsToUse, pointsPerSeries, seriesData := getMixedMetricsForTests()
 
-	// Test each label individually to catch edge cases in with single series
-	labelCombinations := testutils.Combinations(labelsToUse, 1)
 	// Generate combinations of 2 and 3 labels. (e.g., "a,b", "e,f", "c,d,e" etc)
-	labelCombinations = append(labelCombinations, testutils.Combinations(labelsToUse, 2)...)
+	labelCombinations := testutils.Combinations(labelsToUse, 2)
 	labelCombinations = append(labelCombinations, testutils.Combinations(labelsToUse, 3)...)
 
 	expressions := []string{}

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -42,7 +42,6 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 	// The goal of this is not to list every conceivable expression that is unsupported, but to cover all the
 	// different cases and make sure we produce a reasonable error message when these cases are encountered.
 	unsupportedExpressions := map[string]string{
-		"metric{} or other_metric{}":                   "binary expression with 'or'",
 		"metric{} + on() group_left() other_metric{}":  "binary expression with many-to-one matching",
 		"metric{} + on() group_right() other_metric{}": "binary expression with one-to-many matching",
 		"topk(5, metric{})":                            "'topk' aggregation with parameter",

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1926,6 +1926,13 @@ func TestCompareVariousMixedMetricsBinaryOperations(t *testing.T) {
 				binaryExpr += fmt.Sprintf(` %s series{label="%s"}`, op, label)
 			}
 			expressions = append(expressions, binaryExpr)
+
+			// Same thing again, this time with grouping.
+			binaryExpr = fmt.Sprintf(`series{label="%s"}`, labels[0])
+			for _, label := range labels[1:] {
+				binaryExpr += fmt.Sprintf(` %s on (group) series{label="%s"}`, op, label)
+			}
+			expressions = append(expressions, binaryExpr)
 		}
 	}
 

--- a/pkg/streamingpromql/operators/binary_operation.go
+++ b/pkg/streamingpromql/operators/binary_operation.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 // vectorMatchingGroupKeyFunc returns a function that computes the grouping key of the output group a series belongs to.
@@ -38,4 +41,59 @@ func vectorMatchingGroupKeyFunc(vectorMatching parser.VectorMatching) func(label
 	return func(l labels.Labels) []byte {
 		return l.BytesWithoutLabels(buf, lbls...)
 	}
+}
+
+// filterSeries returns data filtered based on the mask provided.
+//
+// mask is expected to contain one value for each time step in the query time range.
+// Samples in data where mask has value desiredMaskValue are returned.
+//
+// The return value reuses the slices from data, and returns any unused slices to the pool.
+func filterSeries(data types.InstantVectorSeriesData, mask []bool, desiredMaskValue bool, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, timeRange types.QueryTimeRange) (types.InstantVectorSeriesData, error) {
+	filteredData := types.InstantVectorSeriesData{}
+	nextOutputFloatIndex := 0
+
+	for _, p := range data.Floats {
+		if mask[timeRange.PointIndex(p.T)] != desiredMaskValue {
+			continue
+		}
+
+		data.Floats[nextOutputFloatIndex] = p
+		nextOutputFloatIndex++
+	}
+
+	if nextOutputFloatIndex > 0 {
+		// We have at least one output float point to return.
+		filteredData.Floats = data.Floats[:nextOutputFloatIndex]
+	} else {
+		// We don't have any float points to return, return the original slice to the pool.
+		types.FPointSlicePool.Put(data.Floats, memoryConsumptionTracker)
+	}
+
+	nextOutputHistogramIndex := 0
+
+	for idx, p := range data.Histograms {
+		if mask[timeRange.PointIndex(p.T)] != desiredMaskValue {
+			continue
+		}
+
+		data.Histograms[nextOutputHistogramIndex] = p
+
+		if idx > nextOutputHistogramIndex {
+			// Remove the histogram from the original point to ensure that it's not mutated unexpectedly when the HPoint slice is reused.
+			data.Histograms[idx].H = nil
+		}
+
+		nextOutputHistogramIndex++
+	}
+
+	if nextOutputHistogramIndex > 0 {
+		// We have at least one output histogram point to return.
+		filteredData.Histograms = data.Histograms[:nextOutputHistogramIndex]
+	} else {
+		// We don't have any histogram points to return, return the original slice to the pool.
+		types.HPointSlicePool.Put(data.Histograms, memoryConsumptionTracker)
+	}
+
+	return filteredData, nil
 }

--- a/pkg/streamingpromql/operators/or_binary_operation.go
+++ b/pkg/streamingpromql/operators/or_binary_operation.go
@@ -22,10 +22,12 @@ type OrBinaryOperation struct {
 	timeRange          types.QueryTimeRange
 	expressionPosition posrange.PositionRange
 
-	// If nextSeriesIsFromLeft is true, this operator will next return leftSeriesCount[0] series from the left side before switching to returning series from the right side, and vice versa.
+	// If nextSeriesIsFromLeft is true, this operator will next return leftSeriesCount[0] series from the left side before
+	// switching to returning series from the right side, and vice versa.
 	//
-	// For example, if nextSeriesIsFromLeft is true, and leftSeriesCount is [3, 5, 2], and rightSeriesCount is [1, 4], then this operator will first return three series from the left,
-	// then 1 from the right, then 5 from the left, then 4 from the right and finally 2 from the left.
+	// For example, if nextSeriesIsFromLeft is true, and leftSeriesCount is [3, 5, 2], and rightSeriesCount is [1, 4], then
+	// this operator will first return three series from the left, then 1 from the right, then 5 from the left, then 4 from
+	// the right and finally 2 from the left.
 	nextSeriesIsFromLeft bool
 	leftSeriesCount      []int
 	rightSeriesCount     []int

--- a/pkg/streamingpromql/operators/or_binary_operation.go
+++ b/pkg/streamingpromql/operators/or_binary_operation.go
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package operators
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+// OrBinaryOperation represents a logical 'or' between two vectors.
+type OrBinaryOperation struct {
+	Left                     types.InstantVectorOperator
+	Right                    types.InstantVectorOperator
+	VectorMatching           parser.VectorMatching
+	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
+
+	timeRange          types.QueryTimeRange
+	expressionPosition posrange.PositionRange
+
+	// If nextSeriesIsFromLeft is true, this operator will next return leftSeriesCount[0] series from the left side before switching to returning series from the right side, and vice versa.
+	//
+	// For example, if nextSeriesIsFromLeft is true, and leftSeriesCount is [3, 5, 2], and rightSeriesCount is [1, 4], then this operator will first return three series from the left,
+	// then 1 from the right, then 5 from the left, then 4 from the right and finally 2 from the left.
+	nextSeriesIsFromLeft bool
+	leftSeriesCount      []int
+	rightSeriesCount     []int
+
+	// These will both be nil if we only have series from one side (ie. there are series on the left but not the right, or vice versa).
+	leftSeriesGroups  []*orGroup
+	rightSeriesGroups []*orGroup
+}
+
+var _ types.InstantVectorOperator = &OrBinaryOperation{}
+
+func NewOrBinaryOperation(
+	left types.InstantVectorOperator,
+	right types.InstantVectorOperator,
+	vectorMatching parser.VectorMatching,
+	memoryConsumptionTracker *limiting.MemoryConsumptionTracker,
+	timeRange types.QueryTimeRange,
+	expressionPosition posrange.PositionRange,
+) *OrBinaryOperation {
+	return &OrBinaryOperation{
+		Left:                     left,
+		Right:                    right,
+		VectorMatching:           vectorMatching,
+		MemoryConsumptionTracker: memoryConsumptionTracker,
+		timeRange:                timeRange,
+		expressionPosition:       expressionPosition,
+	}
+}
+
+func (o *OrBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
+	leftMetadata, err := o.Left.SeriesMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	rightMetadata, err := o.Right.SeriesMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(leftMetadata) == 0 {
+		// We can just return everything from the right side.
+		o.nextSeriesIsFromLeft = false
+		o.rightSeriesCount = []int{len(rightMetadata)}
+		types.PutSeriesMetadataSlice(leftMetadata)
+
+		return rightMetadata, nil
+	}
+
+	if len(rightMetadata) == 0 {
+		// We can just return everything from the left side.
+		o.nextSeriesIsFromLeft = true
+		o.leftSeriesCount = []int{len(leftMetadata)}
+		types.PutSeriesMetadataSlice(rightMetadata)
+
+		return leftMetadata, nil
+	}
+
+	defer types.PutSeriesMetadataSlice(leftMetadata)
+	defer types.PutSeriesMetadataSlice(rightMetadata)
+
+	o.computeGroups(leftMetadata, rightMetadata)
+
+	return o.computeSeriesOutputOrder(leftMetadata, rightMetadata), nil
+}
+
+func (o *OrBinaryOperation) computeGroups(leftMetadata []types.SeriesMetadata, rightMetadata []types.SeriesMetadata) {
+	groupMap := map[string]*orGroup{}
+	groupKeyFunc := vectorMatchingGroupKeyFunc(o.VectorMatching)
+
+	// Iterate through the right-hand series, and create groups for each based on the matching labels.
+	o.rightSeriesGroups = make([]*orGroup, 0, len(rightMetadata))
+
+	for _, s := range rightMetadata {
+		groupKey := groupKeyFunc(s.Labels)
+		group, exists := groupMap[string(groupKey)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
+
+		if !exists {
+			group = &orGroup{lastLeftSeriesIndex: -1}
+			groupMap[string(groupKey)] = group
+		}
+
+		group.rightSeriesCount++
+		o.rightSeriesGroups = append(o.rightSeriesGroups, group)
+	}
+
+	// Iterate through the left-hand series, and find groups for each based on the matching labels.
+	o.leftSeriesGroups = make([]*orGroup, 0, len(leftMetadata))
+
+	for idx, s := range leftMetadata {
+		groupKey := groupKeyFunc(s.Labels)
+		group, exists := groupMap[string(groupKey)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
+
+		if exists {
+			group.lastLeftSeriesIndex = idx
+		}
+
+		// Even if there is no matching group, we want to store a nil value here so we know we don't need to store presence information later.
+		o.leftSeriesGroups = append(o.leftSeriesGroups, group)
+	}
+
+	// Iterate through the right-hand series again, and remove any groups that don't match any series from the left.
+	for idx, group := range o.rightSeriesGroups {
+		if group.lastLeftSeriesIndex == -1 {
+			o.rightSeriesGroups[idx] = nil
+		}
+	}
+}
+
+func (o *OrBinaryOperation) computeSeriesOutputOrder(leftMetadata []types.SeriesMetadata, rightMetadata []types.SeriesMetadata) []types.SeriesMetadata {
+	// The idea here is to determine the order we should return series in, returning series from the right side as soon as we've seen all
+	// the series from the left that we need.
+	//
+	// We can return left series as soon as they're read, given they are returned unmodified (we just need to store sample presence
+	// information so we can filter the corresponding right side series later on).
+	//
+	// A simpler version of this would be to just return all left side series first, then all right side series.
+	// However, if we do that, we will always need to hold presence bitmaps for every group in memory until we've read all left side series.
+	// By sorting the series so we return series from the right as soon as we've seen all of the corresponding series from the left, we
+	// minimise the number of presence bitmaps we need to hold in memory at once, at the cost of potentially holding some intermediate
+	// state on both sides.
+
+	nextLeftSeriesToRead := 0
+	lastSeriesFromLeft := false
+	series := types.GetSeriesMetadataSlice(len(leftMetadata) + len(rightMetadata))
+
+	for nextRightSeriesToRead, rightGroup := range o.rightSeriesGroups {
+		// Check if we need to advance through some left series first.
+		if rightGroup != nil && rightGroup.lastLeftSeriesIndex >= nextLeftSeriesToRead {
+			seriesCount := rightGroup.lastLeftSeriesIndex - nextLeftSeriesToRead + 1
+
+			o.leftSeriesCount = append(o.leftSeriesCount, seriesCount)
+			series = append(series, leftMetadata[nextLeftSeriesToRead:rightGroup.lastLeftSeriesIndex+1]...)
+			nextLeftSeriesToRead += seriesCount
+
+			if nextRightSeriesToRead == 0 {
+				// The first series this operator will return is from the left.
+				// Signal that to NextSeries.
+				o.nextSeriesIsFromLeft = true
+			}
+
+			lastSeriesFromLeft = true
+		}
+
+		// If the last series was from the left, or if this is the first series from the right, start a new run of right series.
+		if lastSeriesFromLeft || nextRightSeriesToRead == 0 {
+			o.rightSeriesCount = append(o.rightSeriesCount, 1)
+			lastSeriesFromLeft = false
+		} else {
+			o.rightSeriesCount[len(o.rightSeriesCount)-1]++
+		}
+
+		series = append(series, rightMetadata[nextRightSeriesToRead])
+	}
+
+	// Check if there are any remaining series on the left side.
+	if nextLeftSeriesToRead < len(leftMetadata) {
+		seriesCount := len(leftMetadata) - nextLeftSeriesToRead
+		series = append(series, leftMetadata[nextLeftSeriesToRead:]...)
+
+		if lastSeriesFromLeft {
+			o.leftSeriesCount[len(o.leftSeriesCount)-1] += seriesCount
+		} else {
+			o.leftSeriesCount = append(o.leftSeriesCount, seriesCount)
+		}
+	}
+
+	return series
+}
+
+func (o *OrBinaryOperation) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+	if o.nextSeriesIsFromLeft {
+		o.leftSeriesCount[0]--
+
+		if o.leftSeriesCount[0] == 0 {
+			o.nextSeriesIsFromLeft = false
+			o.leftSeriesCount = o.leftSeriesCount[1:]
+		}
+
+		return o.nextLeftSeries(ctx)
+	}
+
+	o.rightSeriesCount[0]--
+
+	if o.rightSeriesCount[0] == 0 {
+		o.nextSeriesIsFromLeft = true
+		o.rightSeriesCount = o.rightSeriesCount[1:]
+	}
+
+	return o.nextRightSeries(ctx)
+}
+
+func (o *OrBinaryOperation) nextLeftSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+	data, err := o.Left.NextSeries(ctx)
+	if err != nil {
+		return types.InstantVectorSeriesData{}, err
+	}
+
+	if o.leftSeriesGroups == nil {
+		// If we only have series from the left side, then leftSeriesGroups and rightSeriesGroups will be nil and we have no filtering to do.
+		return data, nil
+	}
+
+	group := o.leftSeriesGroups[0]
+	o.leftSeriesGroups = o.leftSeriesGroups[1:]
+
+	if group != nil {
+		if err := group.AccumulateLeftSeriesPresence(data, o.MemoryConsumptionTracker, o.timeRange); err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
+	}
+
+	return data, nil
+}
+
+func (o *OrBinaryOperation) nextRightSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+	data, err := o.Right.NextSeries(ctx) // We don't need to return this series to the pool: FilterRightSeries will handle that for us if needed.
+	if err != nil {
+		return types.InstantVectorSeriesData{}, err
+	}
+
+	if o.rightSeriesGroups == nil {
+		// If we only have series from the right side, then leftSeriesGroups and rightSeriesGroups will be nil and we have no filtering to do.
+		return data, nil
+	}
+
+	group := o.rightSeriesGroups[0]
+	o.rightSeriesGroups = o.rightSeriesGroups[1:]
+
+	if group == nil {
+		// This series matches nothing on the left side, we can return it as-is.
+		return data, nil
+	}
+
+	data, err = group.FilterRightSeries(data, o.MemoryConsumptionTracker, o.timeRange)
+	if err != nil {
+		return types.InstantVectorSeriesData{}, err
+	}
+
+	group.rightSeriesCount--
+	if group.rightSeriesCount == 0 {
+		// This is the last right series for the group, return it to the pool.
+		group.Close(o.MemoryConsumptionTracker)
+	}
+
+	return data, nil
+}
+
+func (o *OrBinaryOperation) ExpressionPosition() posrange.PositionRange {
+	return o.expressionPosition
+}
+
+func (o *OrBinaryOperation) Close() {
+	o.Left.Close()
+	o.Right.Close()
+}
+
+type orGroup struct {
+	lastLeftSeriesIndex int
+	rightSeriesCount    int
+	leftSamplePresence  []bool // FIXME: this would be a good candidate for a bitmap type
+}
+
+// AccumulateLeftSeriesPresence records the presence of samples on the left-hand side.
+func (g *orGroup) AccumulateLeftSeriesPresence(data types.InstantVectorSeriesData, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, timeRange types.QueryTimeRange) error {
+	if g.leftSamplePresence == nil {
+		var err error
+		g.leftSamplePresence, err = types.BoolSlicePool.Get(timeRange.StepCount, memoryConsumptionTracker)
+
+		if err != nil {
+			return err
+		}
+
+		g.leftSamplePresence = g.leftSamplePresence[:timeRange.StepCount]
+	}
+
+	for _, p := range data.Floats {
+		g.leftSamplePresence[timeRange.PointIndex(p.T)] = true
+	}
+
+	for _, p := range data.Histograms {
+		g.leftSamplePresence[timeRange.PointIndex(p.T)] = true
+	}
+
+	return nil
+}
+
+// FilterRightSeries returns rightData filtered based on samples seen for the left-hand side.
+// The return value reuses the slices from rightData, and returns any unused slices to the pool.
+func (g *orGroup) FilterRightSeries(rightData types.InstantVectorSeriesData, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, timeRange types.QueryTimeRange) (types.InstantVectorSeriesData, error) {
+	return filterSeries(rightData, g.leftSamplePresence, false, memoryConsumptionTracker, timeRange)
+}
+
+func (g *orGroup) Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) {
+	types.BoolSlicePool.Put(g.leftSamplePresence, memoryConsumptionTracker)
+}

--- a/pkg/streamingpromql/operators/or_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/or_binary_operation_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package operators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func TestOrBinaryOperationSorting(t *testing.T) {
+	// The majority of the functionality of OrBinaryOperation is exercised by the tests in the testdata directory.
+	// This test exists to exercise the output series sorting functionality, which is complex and may be incorrect
+	// but still result in correct query results (eg. if we read and return left side series earlier than strictly
+	// necessary).
+
+	testCases := map[string]struct {
+		leftSeries  []labels.Labels
+		rightSeries []labels.Labels
+
+		expectedOutputSeriesOrder []labels.Labels
+	}{
+		"no series from either side": {
+			leftSeries:  []labels.Labels{},
+			rightSeries: []labels.Labels{},
+
+			expectedOutputSeriesOrder: []labels.Labels{},
+		},
+		"only left series": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("series", "1"),
+				labels.FromStrings("series", "2"),
+			},
+			rightSeries: []labels.Labels{},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("series", "1"),
+				labels.FromStrings("series", "2"),
+			},
+		},
+		"only right series": {
+			leftSeries: []labels.Labels{},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("series", "1"),
+				labels.FromStrings("series", "2"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("series", "1"),
+				labels.FromStrings("series", "2"),
+			},
+		},
+		"no matching series on either side": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("right", "2", "group", "2"),
+				labels.FromStrings("right", "4", "group", "4"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("right", "2", "group", "2"),
+				labels.FromStrings("right", "4", "group", "4"),
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "3"),
+			},
+		},
+		"single left series returned first": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "1"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "1"),
+				labels.FromStrings("left", "3", "group", "2"),
+			},
+		},
+		"multiple left series returned first": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "1"),
+				labels.FromStrings("left", "5", "group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "1"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "1"),
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "1"),
+				labels.FromStrings("left", "5", "group", "2"),
+			},
+		},
+		"single right series returned first": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("left", "4", "group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("right", "1", "group", "1"),
+				labels.FromStrings("right", "2", "group", "2"),
+				labels.FromStrings("right", "3", "group", "2"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("right", "1", "group", "1"),
+				labels.FromStrings("left", "4", "group", "2"),
+				labels.FromStrings("right", "2", "group", "2"),
+				labels.FromStrings("right", "3", "group", "2"),
+			},
+		},
+		"multiple right series returned first": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("left", "4", "group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("right", "1", "group", "1"),
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "3", "group", "2"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("right", "1", "group", "1"),
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("left", "4", "group", "2"),
+				labels.FromStrings("right", "3", "group", "2"),
+			},
+		},
+		"single left series returned last": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "1"),
+				labels.FromStrings("left", "5", "group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "1"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "1"),
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "1"),
+				labels.FromStrings("left", "5", "group", "2"),
+			},
+		},
+		"multiple left series returned last": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "1"),
+				labels.FromStrings("left", "5", "group", "2"),
+				labels.FromStrings("left", "6", "group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "1"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "1"),
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "1"),
+				labels.FromStrings("left", "5", "group", "2"),
+				labels.FromStrings("left", "6", "group", "2"),
+			},
+		},
+		"single right series returned last": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "1"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("right", "2", "group", "1"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "1"),
+				labels.FromStrings("right", "2", "group", "1"),
+			},
+		},
+		"multiple right series returned last": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "1"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "1"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "1"),
+				labels.FromStrings("left", "3", "group", "1"),
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "1"),
+			},
+		},
+		"group order on left side different to right side": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "3"),
+				labels.FromStrings("left", "3", "group", "1"),
+				labels.FromStrings("left", "5", "group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("right", "4", "group", "2"),
+				labels.FromStrings("right", "6", "group", "3"),
+			},
+
+			expectedOutputSeriesOrder: []labels.Labels{
+				labels.FromStrings("left", "1", "group", "3"),
+				labels.FromStrings("left", "3", "group", "1"),
+				labels.FromStrings("right", "2", "group", "1"),
+				labels.FromStrings("left", "5", "group", "2"),
+				labels.FromStrings("right", "4", "group", "2"),
+				labels.FromStrings("right", "6", "group", "3"),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			left := &testOperator{series: testCase.leftSeries}
+			right := &testOperator{series: testCase.rightSeries}
+
+			op := NewOrBinaryOperation(
+				left,
+				right,
+				parser.VectorMatching{MatchingLabels: []string{"group"}, On: true},
+				limiting.NewMemoryConsumptionTracker(0, nil),
+				types.NewInstantQueryTimeRange(timestamp.Time(0)),
+				posrange.PositionRange{},
+			)
+
+			actualSeriesMetadata, err := op.SeriesMetadata(context.Background())
+			require.NoError(t, err)
+
+			expectedSeriesMetadata := labelsToSeriesMetadata(testCase.expectedOutputSeriesOrder)
+			require.Equal(t, expectedSeriesMetadata, actualSeriesMetadata)
+		})
+	}
+}

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -259,6 +259,8 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr) (types.InstantV
 		switch e.Op {
 		case parser.LAND, parser.LUNLESS:
 			return operators.NewAndUnlessBinaryOperation(lhs, rhs, *e.VectorMatching, q.memoryConsumptionTracker, e.Op == parser.LUNLESS, q.timeRange, e.PositionRange()), nil
+		case parser.LOR:
+			return operators.NewOrBinaryOperation(lhs, rhs, *e.VectorMatching, q.memoryConsumptionTracker, q.timeRange, e.PositionRange()), nil
 		default:
 			return operators.NewVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange())
 		}

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -765,14 +765,14 @@ clear
 # Logical operations: and, or and unless.
 # Single matching series on each side.
 load 6m
-  left_side{env="test", pod="a"}  1  2  3  4                 {{count:5 sum:5}}
-  left_side{env="test", pod="b"}  6  7  8  _                 {{count:10 sum:10}}
-  left_side{env="prod", pod="a"}  11 12 13 14                15
-  left_side{env="prod", pod="b"}  16 17 18 _                 _
-  right_side{env="test", pod="a"} 0  0  0  {{count:0 sum:0}} {{count:0 sum:0}}
-  right_side{env="test", pod="b"} _  0  _  0                 _
-  right_side{env="prod", pod="b"} _  _  _  0                 0
-  right_side{env="foo", pod="a"}  0  0  0  0                 0
+  left_side{env="test", pod="a"}  1   2   3   4                   {{count:5 sum:5}}
+  left_side{env="test", pod="b"}  6   7   8   _                   {{count:10 sum:10}}
+  left_side{env="prod", pod="a"}  11  12  13  14                  15
+  left_side{env="prod", pod="b"}  16  17  18  _                   _
+  right_side{env="test", pod="a"} 10  20  30  {{count:40 sum:40}} {{count:50 sum:50}}
+  right_side{env="test", pod="b"} _   60  _   70                  _
+  right_side{env="prod", pod="b"} _   _   _   80                  90
+  right_side{env="foo", pod="a"}  100 110 120 130                 140
 
 eval range from 0 to 24m step 6m left_side and does_not_match
   # Should return no results.
@@ -789,6 +789,18 @@ eval range from 0 to 24m step 6m left_side unless does_not_match
 eval range from 0 to 24m step 6m does_not_match unless right_side
   # Should return no results.
 
+eval range from 0 to 24m step 6m left_side or does_not_match
+  left_side{env="test", pod="a"} 1  2  3  4  {{count:5 sum:5}}
+  left_side{env="test", pod="b"} 6  7  8  _  {{count:10 sum:10}}
+  left_side{env="prod", pod="a"} 11 12 13 14 15
+  left_side{env="prod", pod="b"} 16 17 18 _  _
+
+eval range from 0 to 24m step 6m does_not_match or right_side
+  right_side{env="test", pod="a"} 10  20  30  {{count:40 sum:40}} {{count:50 sum:50}}
+  right_side{env="test", pod="b"} _   60  _   70                  _
+  right_side{env="prod", pod="b"} _   _   _   80                  90
+  right_side{env="foo", pod="a"}  100 110 120 130                 140
+
 # {env="test", pod="a"}: Matching series, all samples align
 # {env="test", pod="b"}: Matching series, only some samples align
 # {env="prod", pod="a"}: No matching series on RHS
@@ -803,6 +815,24 @@ eval range from 0 to 24m step 6m left_side unless right_side
   left_side{env="prod", pod="a"} 11 12 13 14 15
   left_side{env="prod", pod="b"} 16 17 18 _ _
 
+eval range from 0 to 24m step 6m left_side or right_side
+  left_side{env="test", pod="a"}  1   2   3   4   {{count:5 sum:5}}
+  left_side{env="test", pod="b"}  6   7   8   _   {{count:10 sum:10}}
+  left_side{env="prod", pod="a"}  11  12  13  14  15
+  left_side{env="prod", pod="b"}  16  17  18  _   _
+  right_side{env="test", pod="b"} _   _   _   70  _
+  right_side{env="prod", pod="b"} _   _   _   80  90
+  right_side{env="foo", pod="a"}  100 110 120 130 140
+
+eval range from 0 to 24m step 6m right_side or left_side
+  right_side{env="test", pod="a"} 10  20  30  {{count:40 sum:40}} {{count:50 sum:50}}
+  right_side{env="test", pod="b"} _   60  _   70                  _
+  right_side{env="prod", pod="b"} _   _   _   80                  90
+  right_side{env="foo", pod="a"}  100 110 120 130                 140
+  left_side{env="test", pod="b"}  6   _   8   _                   {{count:10 sum:10}}
+  left_side{env="prod", pod="a"}  11  12  13  14                  15
+  left_side{env="prod", pod="b"}  16  17  18  _                   _
+
 clear
 
 # Multiple matching series on each side.
@@ -812,10 +842,10 @@ load 6m
   left_side{env="prod", cluster="blah", pod="a"}  9  10 11 12
   left_side{env="prod", cluster="blah", pod="b"}  13 14 15 16
   left_side{env="test", cluster="food", pod="a"}  17 18 19 20
-  right_side{env="test", cluster="blah", idx="1"} 0  _  0  _
-  right_side{env="test", cluster="blah", idx="2"} 0  0  _  _
-  right_side{env="prod", cluster="blah", idx="3"} _  0  _  0
-  right_side{env="test", cluster="food", idx="4"}  _  _  _ 0
+  right_side{env="test", cluster="blah", idx="1"} -1 _  -2 _
+  right_side{env="test", cluster="blah", idx="2"} -3 -4 _  _
+  right_side{env="prod", cluster="blah", idx="3"} _  -5 _  -6
+  right_side{env="test", cluster="food", idx="4"} _  _  _ -7
 
 eval range from 0 to 24m step 6m left_side and right_side
   # Should return no results.
@@ -826,6 +856,17 @@ eval range from 0 to 24m step 6m left_side unless right_side
   left_side{env="prod", cluster="blah", pod="a"} 9  10 11 12
   left_side{env="prod", cluster="blah", pod="b"} 13 14 15 16
   left_side{env="test", cluster="food", pod="a"} 17 18 19 20
+
+eval range from 0 to 24m step 6m left_side or right_side
+  left_side{env="test", cluster="blah", pod="a"}  1  2  3  4
+  left_side{env="test", cluster="blah", pod="b"}  _  6  7  8
+  left_side{env="prod", cluster="blah", pod="a"}  9  10 11 12
+  left_side{env="prod", cluster="blah", pod="b"}  13 14 15 16
+  left_side{env="test", cluster="food", pod="a"}  17 18 19 20
+  right_side{env="test", cluster="blah", idx="1"} -1 _  -2 _
+  right_side{env="test", cluster="blah", idx="2"} -3 -4 _  _
+  right_side{env="prod", cluster="blah", idx="3"} _  -5 _  -6
+  right_side{env="test", cluster="food", idx="4"}  _  _  _ -7
 
 eval range from 0 to 24m step 6m left_side and on(cluster, env) right_side
   left_side{env="test", cluster="blah", pod="a"} 1  2  3  _
@@ -840,6 +881,24 @@ eval range from 0 to 24m step 6m left_side unless on(cluster, env) right_side
   left_side{env="prod", cluster="blah", pod="a"} 9  _  11 _
   left_side{env="prod", cluster="blah", pod="b"} 13 _  15 _
   left_side{env="test", cluster="food", pod="a"} 17 18 19 _
+
+eval range from 0 to 24m step 6m left_side or on(cluster, env) right_side
+  left_side{env="test", cluster="blah", pod="a"}  1  2  3  4
+  left_side{env="test", cluster="blah", pod="b"}  _  6  7  8
+  left_side{env="prod", cluster="blah", pod="a"}  9  10 11 12
+  left_side{env="prod", cluster="blah", pod="b"}  13 14 15 16
+  left_side{env="test", cluster="food", pod="a"}  17 18 19 20
+
+eval range from 0 to 24m step 6m right_side or on(cluster, env) left_side
+  right_side{env="test", cluster="blah", idx="1"} -1 _  -2 _
+  right_side{env="test", cluster="blah", idx="2"} -3 -4 _  _
+  right_side{env="prod", cluster="blah", idx="3"} _  -5 _  -6
+  right_side{env="test", cluster="food", idx="4"} _  _  _ -7
+  left_side{env="test", cluster="blah", pod="a"}  _  _  _  4
+  left_side{env="test", cluster="blah", pod="b"}  _  _  _  8
+  left_side{env="prod", cluster="blah", pod="a"}  9  _  11 _
+  left_side{env="prod", cluster="blah", pod="b"}  13 _  15 _
+  left_side{env="test", cluster="food", pod="a"}  17 18 19 _
 
 # Same thing again, with labels in different order.
 eval range from 0 to 24m step 6m left_side and on(env, cluster) right_side
@@ -856,6 +915,25 @@ eval range from 0 to 24m step 6m left_side unless on(env, cluster) right_side
   left_side{env="prod", cluster="blah", pod="b"} 13 _  15 _
   left_side{env="test", cluster="food", pod="a"} 17 18 19 _
 
+eval range from 0 to 24m step 6m left_side or on(env, cluster) right_side
+  left_side{env="test", cluster="blah", pod="a"}  1  2  3  4
+  left_side{env="test", cluster="blah", pod="b"}  _  6  7  8
+  left_side{env="prod", cluster="blah", pod="a"}  9  10 11 12
+  left_side{env="prod", cluster="blah", pod="b"}  13 14 15 16
+  left_side{env="test", cluster="food", pod="a"}  17 18 19 20
+
+eval range from 0 to 24m step 6m right_side or on(env, cluster) left_side
+  right_side{env="test", cluster="blah", idx="1"} -1 _  -2 _
+  right_side{env="test", cluster="blah", idx="2"} -3 -4 _  _
+  right_side{env="prod", cluster="blah", idx="3"} _  -5 _  -6
+  right_side{env="test", cluster="food", idx="4"} _  _  _ -7
+  left_side{env="test", cluster="blah", pod="a"}  _  _  _  4
+  left_side{env="test", cluster="blah", pod="b"}  _  _  _  8
+  left_side{env="prod", cluster="blah", pod="a"}  9  _  11 _
+  left_side{env="prod", cluster="blah", pod="b"}  13 _  15 _
+  left_side{env="test", cluster="food", pod="a"}  17 18 19 _
+
+# Same thing again, with 'ignoring'.
 eval range from 0 to 24m step 6m left_side and ignoring(idx, pod) right_side
   left_side{env="test", cluster="blah", pod="a"} 1  2  3  _
   left_side{env="test", cluster="blah", pod="b"} _  6  7  _
@@ -869,6 +947,24 @@ eval range from 0 to 24m step 6m left_side unless ignoring(idx, pod) right_side
   left_side{env="prod", cluster="blah", pod="a"} 9  _  11 _
   left_side{env="prod", cluster="blah", pod="b"} 13 _  15 _
   left_side{env="test", cluster="food", pod="a"} 17 18 19 _
+
+eval range from 0 to 24m step 6m left_side or ignoring(idx, pod) right_side
+  left_side{env="test", cluster="blah", pod="a"}  1  2  3  4
+  left_side{env="test", cluster="blah", pod="b"}  _  6  7  8
+  left_side{env="prod", cluster="blah", pod="a"}  9  10 11 12
+  left_side{env="prod", cluster="blah", pod="b"}  13 14 15 16
+  left_side{env="test", cluster="food", pod="a"}  17 18 19 20
+
+eval range from 0 to 24m step 6m right_side or ignoring(idx, pod) left_side
+  right_side{env="test", cluster="blah", idx="1"} -1 _  -2 _
+  right_side{env="test", cluster="blah", idx="2"} -3 -4 _  _
+  right_side{env="prod", cluster="blah", idx="3"} _  -5 _  -6
+  right_side{env="test", cluster="food", idx="4"} _  _  _ -7
+  left_side{env="test", cluster="blah", pod="a"}  _  _  _  4
+  left_side{env="test", cluster="blah", pod="b"}  _  _  _  8
+  left_side{env="prod", cluster="blah", pod="a"}  9  _  11 _
+  left_side{env="prod", cluster="blah", pod="b"}  13 _  15 _
+  left_side{env="test", cluster="food", pod="a"}  17 18 19 _
 
 # Same thing again, with labels in different order.
 eval range from 0 to 24m step 6m left_side and ignoring(pod, idx) right_side
@@ -884,3 +980,21 @@ eval range from 0 to 24m step 6m left_side unless ignoring(pod, idx) right_side
   left_side{env="prod", cluster="blah", pod="a"} 9  _  11 _
   left_side{env="prod", cluster="blah", pod="b"} 13 _  15 _
   left_side{env="test", cluster="food", pod="a"} 17 18 19 _
+
+eval range from 0 to 24m step 6m left_side or ignoring(pod, idx) right_side
+  left_side{env="test", cluster="blah", pod="a"}  1  2  3  4
+  left_side{env="test", cluster="blah", pod="b"}  _  6  7  8
+  left_side{env="prod", cluster="blah", pod="a"}  9  10 11 12
+  left_side{env="prod", cluster="blah", pod="b"}  13 14 15 16
+  left_side{env="test", cluster="food", pod="a"}  17 18 19 20
+
+eval range from 0 to 24m step 6m right_side or ignoring(pod, idx) left_side
+  right_side{env="test", cluster="blah", idx="1"} -1 _  -2 _
+  right_side{env="test", cluster="blah", idx="2"} -3 -4 _  _
+  right_side{env="prod", cluster="blah", idx="3"} _  -5 _  -6
+  right_side{env="test", cluster="food", idx="4"} _  _  _ -7
+  left_side{env="test", cluster="blah", pod="a"}  _  _  _  4
+  left_side{env="test", cluster="blah", pod="b"}  _  _  _  8
+  left_side{env="prod", cluster="blah", pod="a"}  9  _  11 _
+  left_side{env="prod", cluster="blah", pod="b"}  13 _  15 _
+  left_side{env="test", cluster="food", pod="a"}  17 18 19 _

--- a/pkg/streamingpromql/testdata/upstream/aggregators.test
+++ b/pkg/streamingpromql/testdata/upstream/aggregators.test
@@ -60,12 +60,11 @@ eval instant at 50m sum without () (http_requests{job="api-server",group="produc
   {group="production",job="api-server",instance="1"} 200
 
 # Without with mismatched and missing labels. Do not do this.
-# Unsupported by streaming engine.
-# eval instant at 50m sum without (instance) (http_requests{job="api-server"} or foo)
-#   {group="canary",job="api-server"} 700
-#   {group="production",job="api-server"} 300
-#   {region="europe",job="api-server"} 900
-#   {job="api-server"} 1000
+eval instant at 50m sum without (instance) (http_requests{job="api-server"} or foo)
+  {group="canary",job="api-server"} 700
+  {group="production",job="api-server"} 300
+  {region="europe",job="api-server"} 900
+  {job="api-server"} 1000
 
 # Lower-cased aggregation operators should work too.
 eval instant at 50m sum(http_requests) by (job) + min(http_requests) by (job) + max(http_requests) by (job) + avg(http_requests) by (job)

--- a/pkg/streamingpromql/testdata/upstream/operators.test
+++ b/pkg/streamingpromql/testdata/upstream/operators.test
@@ -168,47 +168,43 @@ eval instant at 50m (http_requests{group="canary"} + 1) and ignoring(group, job)
 	{group="canary", instance="0", job="api-server"} 301
 	{group="canary", instance="0", job="app-server"} 701
 
-# Unsupported by streaming engine.
-# eval instant at 50m http_requests{group="canary"} or http_requests{group="production"}
-#	http_requests{group="canary", instance="0", job="api-server"} 300
-#	http_requests{group="canary", instance="0", job="app-server"} 700
-#	http_requests{group="canary", instance="1", job="api-server"} 400
-#	http_requests{group="canary", instance="1", job="app-server"} 800
-#	http_requests{group="production", instance="0", job="api-server"} 100
-#	http_requests{group="production", instance="0", job="app-server"} 500
-#	http_requests{group="production", instance="1", job="api-server"} 200
-#	http_requests{group="production", instance="1", job="app-server"} 600
+eval instant at 50m http_requests{group="canary"} or http_requests{group="production"}
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="production", instance="1", job="app-server"} 600
 
 # On overlap the rhs samples must be dropped.
-# Unsupported by streaming engine.
-# eval instant at 50m (http_requests{group="canary"} + 1) or http_requests{instance="1"}
-#	{group="canary", instance="0", job="api-server"} 301
-#	{group="canary", instance="0", job="app-server"} 701
-#	{group="canary", instance="1", job="api-server"} 401
-#	{group="canary", instance="1", job="app-server"} 801
-#	http_requests{group="production", instance="1", job="api-server"} 200
-#	http_requests{group="production", instance="1", job="app-server"} 600
+eval instant at 50m (http_requests{group="canary"} + 1) or http_requests{instance="1"}
+	{group="canary", instance="0", job="api-server"} 301
+	{group="canary", instance="0", job="app-server"} 701
+	{group="canary", instance="1", job="api-server"} 401
+	{group="canary", instance="1", job="app-server"} 801
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="production", instance="1", job="app-server"} 600
 
 
 # Matching only on instance excludes everything that has instance=0/1 but includes
 # entries without the instance label.
-# Unsupported by streaming engine.
-# eval instant at 50m (http_requests{group="canary"} + 1) or on(instance) (http_requests or cpu_count or vector_matching_a)
-#	{group="canary", instance="0", job="api-server"} 301
-#	{group="canary", instance="0", job="app-server"} 701
-#	{group="canary", instance="1", job="api-server"} 401
-#	{group="canary", instance="1", job="app-server"} 801
-#	vector_matching_a{l="x"} 10
-#	vector_matching_a{l="y"} 20
+eval instant at 50m (http_requests{group="canary"} + 1) or on(instance) (http_requests or cpu_count or vector_matching_a)
+	{group="canary", instance="0", job="api-server"} 301
+	{group="canary", instance="0", job="app-server"} 701
+	{group="canary", instance="1", job="api-server"} 401
+	{group="canary", instance="1", job="app-server"} 801
+	vector_matching_a{l="x"} 10
+	vector_matching_a{l="y"} 20
 
-# Unsupported by streaming engine.
-# eval instant at 50m (http_requests{group="canary"} + 1) or ignoring(l, group, job) (http_requests or cpu_count or vector_matching_a)
-#	{group="canary", instance="0", job="api-server"} 301
-#	{group="canary", instance="0", job="app-server"} 701
-#	{group="canary", instance="1", job="api-server"} 401
-#	{group="canary", instance="1", job="app-server"} 801
-#	vector_matching_a{l="x"} 10
-#	vector_matching_a{l="y"} 20
+eval instant at 50m (http_requests{group="canary"} + 1) or ignoring(l, group, job) (http_requests or cpu_count or vector_matching_a)
+	{group="canary", instance="0", job="api-server"} 301
+	{group="canary", instance="0", job="app-server"} 701
+	{group="canary", instance="1", job="api-server"} 401
+	{group="canary", instance="1", job="app-server"} 801
+	vector_matching_a{l="x"} 10
+	vector_matching_a{l="y"} 20
 
 eval instant at 50m http_requests{group="canary"} unless http_requests{instance="0"}
 	http_requests{group="canary", instance="1", job="api-server"} 400

--- a/pkg/streamingpromql/testdata/upstream/range_queries.test
+++ b/pkg/streamingpromql/testdata/upstream/range_queries.test
@@ -62,10 +62,9 @@ load 30s
   foo{job="1"} 1+1x4
   bar{job="2"} 1+1x4
 
-# Unsupported by streaming engine.
-# eval range from 0 to 2m step 1m foo > 2 or bar
-#   foo{job="1"} _ 3 5
-#   bar{job="2"} 1 3 5
+eval range from 0 to 2m step 1m foo > 2 or bar
+  foo{job="1"} _ 3 5
+  bar{job="2"} 1 3 5
 
 clear
 

--- a/pkg/streamingpromql/testdata/upstream/selectors.test
+++ b/pkg/streamingpromql/testdata/upstream/selectors.test
@@ -119,10 +119,9 @@ load 1m
     metric1{a="a"} 0+1x100
     metric2{b="b"} 0+1x50
 
-# Unsupported by streaming engine.
-# eval instant at 90m metric1 offset 15m or metric2 offset 45m
-#     metric1{a="a"} 75
-#     metric2{b="b"} 45
+eval instant at 90m metric1 offset 15m or metric2 offset 45m
+    metric1{a="a"} 75
+    metric2{b="b"} 45
 
 clear
 

--- a/pkg/streamingpromql/testutils/utils.go
+++ b/pkg/streamingpromql/testutils/utils.go
@@ -112,7 +112,11 @@ func requireInEpsilonIfNotZero(t testing.TB, expected, actual float64, msgAndArg
 func requireFloatBucketsMatch(t testing.TB, b1, b2 []float64) {
 	require.Equal(t, len(b1), len(b2), "bucket lengths match")
 	for i, b := range b1 {
-		require.InEpsilon(t, b, b2[i], 1e-10, "bucket values match")
+		if b == 0 {
+			require.Equal(t, b, b2[i], "bucket values match")
+		} else {
+			require.InEpsilon(t, b, b2[i], 1e-10, "bucket values match")
+		}
 	}
 }
 


### PR DESCRIPTION
#### What this PR does

This PR adds support for the `or` binary operation to MQE.

In comparison to Prometheus' engine, MQE runs up to 70% faster and with up to 40% lower peak memory utilisation in our benchmarks: 

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/streamingpromql/benchmarks
cpu: Apple M1 Pro
                                                                      │  Prometheus  │               Mimir                │
                                                                      │    sec/op    │   sec/op     vs base               │
Query/a_1_or_b_1{l=~'.*[0-4]$'},_instant_query-10                        724.9µ ± 1%   728.9µ ± 2%        ~ (p=0.937 n=6)
Query/a_1_or_b_1{l=~'.*[0-4]$'},_range_query_with_100_steps-10           750.8µ ± 1%   727.2µ ± 1%   -3.15% (p=0.002 n=6)
Query/a_1_or_b_1{l=~'.*[0-4]$'},_range_query_with_1000_steps-10          1.328m ± 3%   1.188m ± 1%  -10.54% (p=0.002 n=6)
Query/a_100_or_b_100{l=~'.*[0-4]$'},_instant_query-10                    1.633m ± 1%   1.622m ± 2%        ~ (p=0.093 n=6)
Query/a_100_or_b_100{l=~'.*[0-4]$'},_range_query_with_100_steps-10       3.600m ± 1%   2.334m ± 1%  -35.16% (p=0.002 n=6)
Query/a_100_or_b_100{l=~'.*[0-4]$'},_range_query_with_1000_steps-10     20.976m ± 1%   8.572m ± 0%  -59.13% (p=0.002 n=6)
Query/a_2000_or_b_2000{l=~'.*[0-4]$'},_instant_query-10                  17.38m ± 1%   17.01m ± 7%        ~ (p=0.065 n=6)
Query/a_2000_or_b_2000{l=~'.*[0-4]$'},_range_query_with_100_steps-10     61.91m ± 2%   30.69m ± 2%  -50.43% (p=0.002 n=6)
Query/a_2000_or_b_2000{l=~'.*[0-4]$'},_range_query_with_1000_steps-10    487.5m ± 1%   145.3m ± 1%  -70.19% (p=0.002 n=6)
geomean                                                                  7.116m        4.874m       -31.51%

                                                                      │  Prometheus  │                Mimir                │
                                                                      │      B       │      B        vs base               │
Query/a_1_or_b_1{l=~'.*[0-4]$'},_instant_query-10                       69.93Mi ± 1%   69.32Mi ± 3%        ~ (p=0.394 n=6)
Query/a_1_or_b_1{l=~'.*[0-4]$'},_range_query_with_100_steps-10          69.87Mi ± 0%   69.73Mi ± 1%        ~ (p=0.240 n=6)
Query/a_1_or_b_1{l=~'.*[0-4]$'},_range_query_with_1000_steps-10         67.76Mi ± 2%   68.26Mi ± 3%        ~ (p=0.818 n=6)
Query/a_100_or_b_100{l=~'.*[0-4]$'},_instant_query-10                   65.95Mi ± 1%   66.36Mi ± 1%        ~ (p=0.132 n=6)
Query/a_100_or_b_100{l=~'.*[0-4]$'},_range_query_with_100_steps-10      67.23Mi ± 0%   66.59Mi ± 1%   -0.95% (p=0.009 n=6)
Query/a_100_or_b_100{l=~'.*[0-4]$'},_range_query_with_1000_steps-10     73.69Mi ± 1%   69.51Mi ± 1%   -5.67% (p=0.002 n=6)
Query/a_2000_or_b_2000{l=~'.*[0-4]$'},_instant_query-10                 68.48Mi ± 1%   69.93Mi ± 1%   +2.12% (p=0.009 n=6)
Query/a_2000_or_b_2000{l=~'.*[0-4]$'},_range_query_with_100_steps-10    87.44Mi ± 1%   78.52Mi ± 1%  -10.19% (p=0.002 n=6)
Query/a_2000_or_b_2000{l=~'.*[0-4]$'},_range_query_with_1000_steps-10   227.8Mi ± 4%   134.0Mi ± 3%  -41.16% (p=0.002 n=6)
geomean                                                                 80.85Mi        74.94Mi        -7.30%
```

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
