### PR TITLE
Increase block-ranges-period for OOO native histogram integration test

### DIFF
--- a/integration/ooo_ingestion_test.go
+++ b/integration/ooo_ingestion_test.go
@@ -166,8 +166,9 @@ func TestOOOHistogramIngestionDisabled(t *testing.T) {
 		BlocksStorageFlags(),
 		BlocksStorageS3Flags(),
 		map[string]string{
-			"-ingester.out-of-order-time-window":            "10m",
-			"-ingester.native-histograms-ingestion-enabled": "true",
+			"-ingester.out-of-order-time-window":                "10m",
+			"-ingester.native-histograms-ingestion-enabled":     "true",
+			"-ingester.ooo-native-histograms-ingestion-enabled": "false",
 			// Default block-ranges-period for integration tests is 1m
 			// When OOO NH is disabled, all NH samples must be greater than or equal to minValidTime, otherwise an out
 			// of bounds error is returned. minValidTime which max sample time - (block-ranges-period[0]/2). Increase

--- a/integration/ooo_ingestion_test.go
+++ b/integration/ooo_ingestion_test.go
@@ -168,6 +168,12 @@ func TestOOOHistogramIngestionDisabled(t *testing.T) {
 		map[string]string{
 			"-ingester.out-of-order-time-window":            "10m",
 			"-ingester.native-histograms-ingestion-enabled": "true",
+			// Default block-ranges-period for integration tests is 1m
+			// When OOO NH is disabled, all NH samples must be greater than or equal to minValidTime, otherwise an out
+			// of bounds error is returned. minValidTime which max sample time - (block-ranges-period[0]/2). Increase
+			// tsdb.block-ranges-period to 2h so when we ingest 1m OOO data, the out of bounds check passes and we hit
+			// the specific OOO NH disabled error instead.
+			"-blocks-storage.tsdb.block-ranges-period": "2h",
 		},
 	)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This is a follow up to https://github.com/grafana/mimir/pull/9567 - that PR spotted an issue where the OOO native histograms disabled error was not being mapped to a client error.

Prior to that PR, we already had an integration test that checked that trying to ingest OOO NH samples when the OOO NH flag was disabled returned a 400 and that test actually passed. The reason why it passed was that another 400 error being returned (out of bounds) - this is as `-blocks-storage.tsdb.block-ranges-period`, which is used to determine if a sample is out of bounds, is set to a very low value in tests. I've increased this value the out of bounds check passes and the OOO NH disabled error is hit instead.

Note that the test expectations haven't changed - we check OOO NH samples error with a 400, but the underlying error is now the OOO NH disabled error (I checked by running the test and looking at logs). The current integration test Mimir client doesn't return the response body so we can only access the status code. The bugfix PR (https://github.com/grafana/mimir/pull/9567) has a unit test that checks the specific error is returned. It's still useful to modify `-blocks-storage.tsdb.block-ranges-period` just in case in the future we accidentally start mapping the OOO NH error incorrectly again.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
