### PR TITLE
[jsonnet] Allow multi_zone_ingester_replicas = 0 for downscaling v2

### DIFF
--- a/operations/mimir/ingester-automated-downscale-v2.libsonnet
+++ b/operations/mimir/ingester-automated-downscale-v2.libsonnet
@@ -34,7 +34,6 @@
 
   // Validate the configuration.
   assert !$._config.ingester_automated_downscale_v2_enabled || $._config.multi_zone_ingester_enabled : 'ingester downscaling requires multi_zone_ingester_enabled in namespace %s' % $._config.namespace,
-  assert !$._config.ingester_automated_downscale_v2_enabled || $._config.multi_zone_ingester_replicas > 0 : 'ingester downscaling requires multi_zone_ingester_replicas > 0 in namespace %s' % $._config.namespace,
   assert !$._config.ingester_automated_downscale_v2_enabled || !$._config.ingester_automated_downscale_enabled : 'ingester_automated_downscale_enabled_v2 and ingester_automated_downscale_enabled are mutually exclusive in namespace %s' % $._config.namespace,
 
   // Utility used to override a field only if exists in super.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

It's valid to downscale ingesters to 0 replicas, so don't require the value to be > 0 for ingester downscaling v2. The check for `multi_zone_ingester_enabled` should be sufficient.

#### Which issue(s) this PR fixes or relates to

Fixes #N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
