### PR TITLE
Upgrade dskit and fix incorrect caller information on logs emitted with `SpanLogger`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20241011202249-8e7752e59bab
+	github.com/grafana/dskit v0.0.0-20241013223235-619c42124e93
 	github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -1256,8 +1256,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20240926144415-27f4e81b4b6b h1:UO4mv94pG1kzKCgBKh20TXdACBCAK2vYjV3Q2MlcpEQ=
 github.com/grafana/alerting v0.0.0-20240926144415-27f4e81b4b6b/go.mod h1:GMLi6d09Xqo96fCVUjNk//rcjP5NKEdjOzfWIffD5r4=
-github.com/grafana/dskit v0.0.0-20241011202249-8e7752e59bab h1:jrQwxBzwH5bjLUWXpaoTbq6BenhCCo2EjBLX10Hm0d4=
-github.com/grafana/dskit v0.0.0-20241011202249-8e7752e59bab/go.mod h1:SPLNCARd4xdjCkue0O6hvuoveuS1dGJjDnfxYe405YQ=
+github.com/grafana/dskit v0.0.0-20241013223235-619c42124e93 h1:MgJ51Z/pgKDx9t0UaenBXp4u2Q80yH/yLNvQ5Oe9OQQ=
+github.com/grafana/dskit v0.0.0-20241013223235-619c42124e93/go.mod h1:SPLNCARd4xdjCkue0O6hvuoveuS1dGJjDnfxYe405YQ=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc h1:BW+LjKJDz0So5LI8UZfW5neWeKpSkWqhmGjQFzcFfLM=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/franz-go v0.0.0-20241009101240-fa97d35e871f h1:nsrRsQHfpqs6dWxErIOS3gD6R20H/9XM0ItykNtBFW8=

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	dslog "github.com/grafana/dskit/log"
+	"github.com/grafana/dskit/spanlogger"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -39,11 +40,11 @@ func InitLogger(logFormat string, logLevel dslog.Level, buffered bool, rateLimit
 
 	if rateLimitedCfg.Enabled {
 		// use UTC timestamps and skip 6 stack frames if rate limited logger is needed.
-		logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.Caller(6))
+		logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", spanlogger.Caller(6))
 		logger = dslog.NewRateLimitedLogger(logger, rateLimitedCfg.LogsPerSecond, rateLimitedCfg.LogsBurstSize, rateLimitedCfg.Registry)
 	} else {
 		// use UTC timestamps and skip 5 stack frames if no rate limited logger is needed.
-		logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.Caller(5))
+		logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", spanlogger.Caller(5))
 	}
 	// Must put the level filter last for efficiency.
 	logger = newFilter(logger, logLevel)

--- a/vendor/github.com/grafana/dskit/concurrency/worker.go
+++ b/vendor/github.com/grafana/dskit/concurrency/worker.go
@@ -1,5 +1,9 @@
 package concurrency
 
+import (
+	"sync"
+)
+
 // NewReusableGoroutinesPool creates a new worker pool with the given size.
 // These workers will run the workloads passed through Go() calls.
 // If all workers are busy, Go() will spawn a new goroutine to run the workload.
@@ -18,12 +22,23 @@ func NewReusableGoroutinesPool(size int) *ReusableGoroutinesPool {
 }
 
 type ReusableGoroutinesPool struct {
-	jobs chan func()
+	jobsMu sync.RWMutex
+	closed bool
+	jobs   chan func()
 }
 
 // Go will run the given function in a worker of the pool.
 // If all workers are busy, Go() will spawn a new goroutine to run the workload.
 func (p *ReusableGoroutinesPool) Go(f func()) {
+	p.jobsMu.RLock()
+	defer p.jobsMu.RUnlock()
+
+	// If the pool is closed, run the function in a new goroutine.
+	if p.closed {
+		go f()
+		return
+	}
+
 	select {
 	case p.jobs <- f:
 	default:
@@ -32,7 +47,12 @@ func (p *ReusableGoroutinesPool) Go(f func()) {
 }
 
 // Close stops the workers of the pool.
-// No new Do() calls should be performed after calling Close().
+// No new Go() calls should be performed after calling Close().
 // Close does NOT wait for all jobs to finish, it is the caller's responsibility to ensure that in the provided workloads.
 // Close is intended to be used in tests to ensure that no goroutines are leaked.
-func (p *ReusableGoroutinesPool) Close() { close(p.jobs) }
+func (p *ReusableGoroutinesPool) Close() {
+	p.jobsMu.Lock()
+	defer p.jobsMu.Unlock()
+	p.closed = true
+	close(p.jobs)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -611,7 +611,7 @@ github.com/grafana/alerting/receivers/webex
 github.com/grafana/alerting/receivers/webhook
 github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
-# github.com/grafana/dskit v0.0.0-20241011202249-8e7752e59bab
+# github.com/grafana/dskit v0.0.0-20241013223235-619c42124e93
 ## explicit; go 1.21
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
#### What this PR does

This PR upgrades dskit to include the following changes:

* https://github.com/grafana/dskit/pull/607
* https://github.com/grafana/dskit/pull/604

This PR also modifies Mimir's logging configuration to make use of the new `SpanLogger`-aware `Caller` implementation added in https://github.com/grafana/dskit/pull/604. This fixes the issue where logs emitted with a `SpanLogger` have `caller=spanlogger.go:xxx` rather than the true caller.

I don't think these changes are worthy of a changelog entry given they are largely useful for engineers working on Mimir rather than operators or users of Mimir.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
