### PR TITLE
helm: Fix typo in 5.5.0 changelog

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,7 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-## 5.5.0-rc.0
+## 5.5.0
 
 * [ENHANCEMENT] Dashboards: allow switching between using classic or native histograms in dashboards.
   * Overview dashboard: status, read/write latency and queries/ingestion per sec panels, `cortex_request_duration_seconds` metric. #7674


### PR DESCRIPTION
#### What this PR does

This is a fixup to #9591 where I forgot to update the final version number in the Helm chart's changelog.

#### Which issue(s) this PR fixes or relates to

Relates to #https://github.com/grafana/mimir/issues/9382 