### PR TITLE
MQE: add docs about native histogram memory pooling and safety

### DIFF
--- a/pkg/streamingpromql/README.md
+++ b/pkg/streamingpromql/README.md
@@ -119,4 +119,4 @@ If this is not done, query results may become corrupted due to multiple queries 
 This can also manifest as panics while interacting with `FloatHistogram`s.
 
 The same problem does not apply to `*histogram.FloatHistogram` slices returned by `types.HistogramSlicePool`. Slices from this pool are used only by
-parts of MQE that do not benefit from reusing `FloatHistogram` instances, and so `types.HistogramSlicePool` clears all slices returned.
+parts of MQE that do not benefit from reusing `FloatHistogram` instances, and so `types.HistogramSlicePool` clears all slices returned for you.

--- a/pkg/streamingpromql/README.md
+++ b/pkg/streamingpromql/README.md
@@ -112,7 +112,10 @@ reuse `FloatHistogram` instances already present in the `HPoint` slice that back
 a new `FloatHistogram` instance.
 
 The implication of this is that anywhere that returns a `promql.HPoint` slice `s` to `types.HPointSlicePool` must remove references in
-`s` to any `FloatHistogram`s retained after `s` is returned. The simplest way to do this is to set the `H` field on `promql.HPoint` to `nil`.
+`s` to any `FloatHistogram`s retained after `s` is returned. For example, binary operations that act as a filter retain the
+`FloatHistogram`s that satisfy the filter in a new, smaller slice, and return the original unfiltered slice `s` to the pool.
+
+The simplest way to do this is to set the `H` field on `promql.HPoint` to `nil`.
 If all points in `s` are being retained, then calling `clear(s)` is also sufficient.
 
 If this is not done, query results may become corrupted due to multiple queries simultaneously modifying the same `FloatHistogram` instance.


### PR DESCRIPTION
#### What this PR does

This PR expands the readme for `pkg/streamingpromql` to explain how `histogram.FloatHistogram` instances are reused and what should be done to ensure this happens correctly and safely.

I've also taken this opportunity to update references to "the streaming PromQL engine" to "MQE" in the readme.

I have not added a changelog entry given this is not a user-facing change.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [x] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
