### PR TITLE
[dashboards] Unify ingester autoscaling panels on writes dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 
 ### Mixin
 
+* [ENHANCEMENT] Unify ingester autoscaling panels on 'Mimir / Writes' dashboard to work for both ingest-storage and non-ingest-storage autoscaling. #9617
 * [BUGFIX] Dashboards: Fix autoscaling metrics joins when series churn. #9412 #9450 #9432
 * [BUGFIX] Alerts: Fix autoscaling metrics joins in `MimirAutoscalerNotActive` when series churn. #9412
 

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -653,6 +653,7 @@
       ingester: {
         enabled: false,
         hpa_name: $._config.autoscaling_hpa_prefix + 'ingester-zone-a',
+        replica_template_name: 'ingester-zone-a',
       },
       compactor: {
         enabled: false,

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -617,7 +617,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ),
 
   // The provided componentName should be the name of a component among the ones defined in $._config.autoscaling.
-  autoScalingActualReplicas(componentName)::
+  autoScalingActualReplicas(componentName, addlQueries=[], addlLegends=[])::
     local title = 'Replicas';
     local componentTitle = std.strReplace(componentName, '_', '-');
 
@@ -660,12 +660,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
           hpa_name: $._config.autoscaling[componentName].hpa_name,
           cluster_labels: std.join(', ', $._config.cluster_labels),
         },
-      ],
+      ] + addlQueries,
       [
         'Max {{ scaletargetref_name }}',
         'Current {{ scaletargetref_name }}',
         'Min {{ scaletargetref_name }}',
-      ],
+      ] + addlLegends,
     ) +
     $.panelDescription(
       title,

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -415,7 +415,7 @@ local filename = 'mimir-writes.json';
         ) + $.queryPanel(
           [
             'sum by (%s) (up{%s})' % [$._config.per_job_label, $.jobMatcher($._config.job_names.ingester)],
-            'sum by (%s) (cortex_lifecycler_read_only{%s}) unless on (%s) (cortex_partition_ring_partitions{name="ingester-partitions"})' % [$._config.per_job_label, $.jobMatcher($._config.job_names.ingester), $._config.per_job_label],  // TODO: need to not show this if using ingest storage
+            'sum by (%s) (cortex_lifecycler_read_only{%s}) unless on (%s) (cortex_partition_ring_partitions{name="ingester-partitions"})' % [$._config.per_job_label, $.jobMatcher($._config.job_names.ingester), $._config.per_job_label],
             'max by (name) (cortex_partition_ring_partitions{%s,name="ingester-partitions",state="Inactive"})' % [$.namespaceMatcher()],
           ],
           [

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -371,19 +371,11 @@ local filename = 'mimir-writes.json';
       $.row('Ingester – autoscaling')
       .addPanel(
         local replicaTemplateQueries = [
-          |||
-            max by (name) (
-              kube_customresource_replicatemplate_spec_replicas{%(namespace_matcher)s, name=~"%(replica_template_name)s"}
-            )
-          ||| % {
+          'max(kube_customresource_replicatemplate_spec_replicas{%(namespace_matcher)s, name=~"%(replica_template_name)s"})' % {
             namespace_matcher: $.namespaceMatcher(),
             replica_template_name: $._config.autoscaling.ingester.replica_template_name,
           },
-          |||
-            max by (name) (
-              kube_customresource_replicatemplate_status_replicas{%(namespace_matcher)s, name=~"%(replica_template_name)s"}
-            )
-          ||| % {
+          'max(kube_customresource_replicatemplate_status_replicas{%(namespace_matcher)s, name=~"%(replica_template_name)s"})' % {
             namespace_matcher: $.namespaceMatcher(),
             replica_template_name: $._config.autoscaling.ingester.replica_template_name,
           },
@@ -416,7 +408,7 @@ local filename = 'mimir-writes.json';
           [
             'sum by (%s) (up{%s})' % [$._config.per_job_label, $.jobMatcher($._config.job_names.ingester)],
             'sum by (%s) (cortex_lifecycler_read_only{%s}) unless on (%s) (cortex_partition_ring_partitions{name="ingester-partitions"})' % [$._config.per_job_label, $.jobMatcher($._config.job_names.ingester), $._config.per_job_label],
-            'max by (name) (cortex_partition_ring_partitions{%s,name="ingester-partitions",state="Inactive"})' % [$.namespaceMatcher()],
+            'max(cortex_partition_ring_partitions{%s,name="ingester-partitions",state="Inactive"})' % [$.namespaceMatcher()],
           ],
           [
             'up ({{ %(per_job_label)s }})' % $._config.per_job_label,

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -390,8 +390,8 @@ local filename = 'mimir-writes.json';
         ];
 
         local replicaTemplateLegends = [
-          'Tmpl spec replicas',
-          'Tmpl status replicas',
+          'Template spec replicas',
+          'Template status replicas',
         ];
 
         $.autoScalingActualReplicas('ingester', replicaTemplateQueries, replicaTemplateLegends) + { title: 'Replicas (HPA + ReplicaTemplate)' } +

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -368,38 +368,6 @@ local filename = 'mimir-writes.json';
     )
     .addRowIf(
       $._config.autoscaling.ingester.enabled,
-      $.row('Ingester – autoscaling')
-      .addPanel(
-        $.autoScalingActualReplicas('ingester') + { title: 'Replicas (leader zone)' } +
-        $.panelDescription(
-          'Replicas (leader zone)',
-          |||
-            The minimum, maximum, and current number of replicas for the leader zone of ingesters.
-            Other zones scale to follow this zone (with delay for downscale).
-          |||
-        )
-      )
-      .addPanel(
-        $.timeseriesPanel('Replicas') +
-        $.panelDescription('Replicas', 'Number of ingester replicas per zone.') +
-        $.queryPanel(
-          [
-            'sum by (%s) (up{%s})' % [$._config.per_job_label, $.jobMatcher($._config.job_names.ingester)],
-          ],
-          [
-            '{{ %(per_job_label)s }}' % $._config.per_job_label,
-          ],
-        ),
-      )
-      .addPanel(
-        $.autoScalingDesiredReplicasByValueScalingMetricPanel('ingester', '', '') + { title: 'Desired replicas (leader zone)' }
-      )
-      .addPanel(
-        $.autoScalingFailuresPanel('ingester') + { title: 'Autoscaler failures rate' }
-      ),
-    )
-    .addRowIf(
-      $._config.show_ingest_storage_panels && $._config.autoscaling.ingester.enabled,
       $.row('Ingester – autoscaling (ingest storage)')
       .addPanel(
         $.autoScalingActualReplicas('ingester') + { title: 'Replicas (ReplicaTemplate)' } +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Use a single set of panels on the "Mimir / Writes" dashboard for ingest-storage and standard ingester autoscaling.

Regular autoscaling:
![Screenshot 2024-10-15 at 2 00 19 AM](https://github.com/user-attachments/assets/b9fcaade-d16f-4e37-b1b4-0a67ef2e4255)

Ingest storage:
![Screenshot 2024-10-15 at 2 00 48 AM](https://github.com/user-attachments/assets/121f7a5c-31b1-4a1f-a09e-4b985fea3264)

#### Which issue(s) this PR fixes or relates to

Fixes #N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
