### PR TITLE
Add internalTrafficPolicy setting to both ingester and distributor services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [FEATURE] Ingester/Distributor: Allow users to set internalTrafficPolicy setting on Kubernetes services
 * [CHANGE] Alertmanager: the following metrics are not exported for a given `user` when the metric value is zero: #9359
   * `cortex_alertmanager_alerts_received_total`
   * `cortex_alertmanager_alerts_invalid_total`

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -12,6 +12,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: ClusterIP
+  internalTrafficPolicy: {{ .Values.distributor.service.internalTrafficPolicy }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -21,6 +21,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: ClusterIP
+  internalTrafficPolicy: {{ .Values.ingester.service.internalTrafficPolicy }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -815,6 +815,8 @@ distributor:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
 
   resources:
     requests:
@@ -906,6 +908,8 @@ ingester:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
 
   # -- Optionally set the scheduler for pods of the ingester
   schedulerName: ""


### PR DESCRIPTION
#### What this PR does

Adds the possibility for users to change the internalTrafficPolicy setting on ingester/distributor services.

#### Checklist

- [N/A] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
