### PR TITLE
helm: support for setting internalTrafficPolicy in k8s services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [FEATURE] Allow users to set type and internalTrafficPolicy setting on Kubernetes services
 * [CHANGE] Alertmanager: the following metrics are not exported for a given `user` when the metric value is zero: #9359
   * `cortex_alertmanager_alerts_received_total`
   * `cortex_alertmanager_alerts_invalid_total`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Grafana Mimir
 
-* [FEATURE] Allow users to set type and internalTrafficPolicy setting on Kubernetes services
 * [CHANGE] Alertmanager: the following metrics are not exported for a given `user` when the metric value is zero: #9359
   * `cortex_alertmanager_alerts_received_total`
   * `cortex_alertmanager_alerts_invalid_total`

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Add support for setting type and internal traffic policy for Kubernetes service. Set `internalTrafficPolicy=Cluster` by default in all services with type `ClusterIP`. #9619
+
 ## 5.5.0
 
 * [ENHANCEMENT] Dashboards: allow switching between using classic or native histograms in dashboards.

--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-svc.yaml
@@ -12,7 +12,10 @@ metadata:
     {{- toYaml .Values.admin_api.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.admin_api.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.admin_api.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -21,7 +21,10 @@ metadata:
     {{- toYaml .Values.alertmanager.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.alertmanager.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.alertmanager.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -11,7 +11,10 @@ metadata:
     {{- toYaml .Values.compactor.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.compactor.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.compactor.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -11,7 +11,10 @@ metadata:
     {{- toYaml .Values.distributor.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.distributor.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.distributor.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -14,6 +14,9 @@ metadata:
   namespace: {{ $.Release.Namespace | quote }}
 spec:
   type: {{ .service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .service.internalTrafficPolicy }}
+  {{- end }}
   {{- with .service.clusterIP }}
   clusterIP: {{ . }}
   {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -1,37 +1,36 @@
 {{- if eq (include "mimir.gateway.isEnabled" .) "true" -}}
-{{- with .Values.gateway -}}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mimir.gateway.service.name" $ }}
   labels:
     {{- include "mimir.labels" (dict "ctx" $ "component" "gateway") | nindent 4 }}
-    {{- with .service.labels }}
+    {{- with .Values.gateway.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    {{- toYaml .service.annotations | nindent 4 }}
+    {{- toYaml .Values.gateway.service.annotations | nindent 4 }}
   namespace: {{ $.Release.Namespace | quote }}
 spec:
-  type: {{ .service.type }}
+  type: {{ .Values.gateway.service.type }}
   {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
-  internalTrafficPolicy: {{ .service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.gateway.service.internalTrafficPolicy }}
   {{- end }}
-  {{- with .service.clusterIP }}
+  {{- with .Values.gateway.service.clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
-  {{- if and (eq "LoadBalancer" .service.type) .service.loadBalancerIP }}
-  loadBalancerIP: {{ .service.loadBalancerIP }}
+  {{- if and (eq "LoadBalancer" .Values.gateway.service.type) .Values.gateway.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.gateway.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - port: {{ .service.port }}
+    - port: {{ .Values.gateway.service.port }}
       protocol: TCP
       name: http-metrics
       targetPort: http-metrics
-      {{- if and (eq "NodePort" .service.type) .service.nodePort }}
-      nodePort: {{ .service.nodePort }}
+      {{- if and (eq "NodePort" .Values.gateway.service.type) .Values.gateway.service.nodePort }}
+      nodePort: {{ .Values.gateway.service.nodePort }}
       {{- end }}
-    {{- with .service.legacyPort }}
+    {{- with .Values.gateway.service.legacyPort }}
     - port: {{ . }}
       protocol: TCP
       name: legacy-http-metrics
@@ -39,5 +38,4 @@ spec:
     {{- end }}
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" $ "component" "gateway") | nindent 4 }}
-{{- end -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -20,7 +20,10 @@ metadata:
     {{- toYaml .Values.ingester.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.ingester.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.ingester.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-svc.yaml
@@ -14,6 +14,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: {{ .Values.nginx.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.nginx.service.internalTrafficPolicy }}
+  {{- end }}
   {{- with .Values.nginx.service.clusterIP }}
   clusterIP: {{ . }}
   {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -12,7 +12,10 @@ metadata:
     {{- toYaml .Values.overrides_exporter.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.overrides_exporter.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.overrides_exporter.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
@@ -11,7 +11,10 @@ metadata:
     {{- toYaml .Values.querier.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.querier.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.querier.service.internalTrafficPolicy }}
+  {{- end}}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -11,7 +11,10 @@ metadata:
     {{- toYaml .Values.query_frontend.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.query_frontend.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.query_frontend.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
@@ -12,7 +12,10 @@ metadata:
   annotations:
     {{- toYaml .Values.query_scheduler.service.annotations | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.query_scheduler.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.query_scheduler.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-svc.yaml
@@ -12,7 +12,10 @@ metadata:
     {{- toYaml .Values.ruler_querier.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.ruler_querier.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.ruler_querier.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc.yaml
@@ -12,7 +12,10 @@ metadata:
     {{- toYaml .Values.ruler_query_frontend.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.ruler_query_frontend.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.ruler_query_frontend.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc.yaml
@@ -12,7 +12,10 @@ metadata:
   annotations:
     {{- toYaml .Values.ruler_query_scheduler.service.annotations | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.ruler_query_scheduler.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.ruler_query_scheduler.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -12,7 +12,10 @@ metadata:
     {{- toYaml .Values.ruler.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.ruler.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.ruler.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -20,7 +20,10 @@ metadata:
     {{- toYaml .Values.store_gateway.service.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.store_gateway.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.store_gateway.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -547,6 +547,9 @@ alertmanager:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   # -- Optionally set the scheduler for pods of the alertmanager
   schedulerName: ""
@@ -815,6 +818,9 @@ distributor:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   resources:
     requests:
@@ -906,6 +912,9 @@ ingester:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   # -- Optionally set the scheduler for pods of the ingester
   schedulerName: ""
@@ -1125,6 +1134,9 @@ overrides_exporter:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   strategy:
     type: RollingUpdate
@@ -1229,6 +1241,9 @@ ruler:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   # -- Dedicated service account for ruler pods.
   # If not set, the default service account defined at the begining of this file will be used.
@@ -1357,6 +1372,9 @@ ruler_querier:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   resources:
     requests:
@@ -1464,6 +1482,9 @@ ruler_query_frontend:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   resources:
     requests:
@@ -1548,6 +1569,9 @@ ruler_query_scheduler:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   resources:
     requests:
@@ -1673,6 +1697,9 @@ querier:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   resources:
     requests:
@@ -1779,6 +1806,9 @@ query_frontend:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   resources:
     requests:
@@ -1863,6 +1893,9 @@ query_scheduler:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   resources:
     requests:
@@ -1950,6 +1983,9 @@ store_gateway:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   # -- Optionally set the scheduler for pods of the store-gateway
   schedulerName: ""
@@ -2157,6 +2193,9 @@ compactor:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   # -- Optionally set the scheduler for pods of the compactor
   schedulerName: ""
@@ -2893,6 +2932,8 @@ nginx:
     annotations: {}
     # -- Labels for nginx service
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
   # Ingress configuration
   ingress:
     # -- Specifies whether an ingress for the nginx should be created
@@ -3288,6 +3329,8 @@ gateway:
     # Instead, it will update the existing one in place.
     # If left as an empty string, a name is generated.
     nameOverride: ""
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
 
   ingress:
     enabled: false
@@ -3906,6 +3949,9 @@ admin_api:
   service:
     annotations: {}
     labels: {}
+    # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    internalTrafficPolicy: Cluster
+    type: ClusterIP
 
   initContainers: []
 

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/admin-api/admin-api-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/admin-api/admin-api-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 80
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -18,6 +18,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP
@@ -53,6 +54,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP
@@ -88,6 +90,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -18,6 +18,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP
@@ -53,6 +54,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP
@@ -88,6 +90,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -18,6 +18,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP
@@ -53,6 +54,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP
@@ -88,6 +90,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/nginx/nginx-svc.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - name: http-metric
       port: 80

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
@@ -14,6 +14,7 @@ metadata:
     {}
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -18,6 +18,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP
@@ -53,6 +54,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP
@@ -88,6 +90,7 @@ metadata:
   namespace: "citestns"
 spec:
   type: ClusterIP
+  internalTrafficPolicy: Cluster
   ports:
     - port: 8080
       protocol: TCP


### PR DESCRIPTION
#### What this PR does

Allows users to add internalTrafficPolicy to the Kubernetes Service of Ingester and Distributor.

#### Checklist

- [N/A] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
