### PR TITLE
Modify docker compose ports so it's possible to run multiple different mimir networks in parallel

### DIFF
--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -4,17 +4,17 @@ services:
     image: consul:1.15  # latest tag not supported
     command: [ "agent", "-dev" ,"-client=0.0.0.0", "-log-level=info" ]
     ports:
-      - 8500:8500
+      - 8510:8500
 
   minio:
     image: minio/minio
-    command: [ "server", "--console-address", ":9001", "/data" ]
+    command: [ "server", "--console-address", ":9101", "/data" ]
     environment:
       - MINIO_ROOT_USER=mimir
       - MINIO_ROOT_PASSWORD=supersecret
     ports:
-      - 9000:9000
-      - 9001:9001
+      - 9100:9100
+      - 9101:9101
     volumes:
       - .data-minio:/data:delegated
 
@@ -26,7 +26,7 @@ services:
     volumes:
       - ./config:/etc/prometheus
     ports:
-      - 9090:9090
+      - 9190:9090
 
   grafana:
     environment:
@@ -48,7 +48,7 @@ services:
     volumes:
       - ./config:/etc/agent-config
     ports:
-      - 9091:9091
+      - 9191:9091
 
   grafana-alloy:
     profiles:
@@ -63,7 +63,7 @@ services:
   jaeger:
     image: jaegertracing/all-in-one
     ports:
-      - 16686:16686
+      - 16681:16686
       - "14268"
 
   mimir-1:
@@ -71,7 +71,7 @@ services:
       context:    .
       dockerfile: dev.dockerfile
     image: mimir
-    command: ["sh", "-c", "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=all -server.http-listen-port=8001 -server.grpc-listen-port=9001"]
+    command: ["sh", "-c", "sleep 3 && exec ./mimir -config.file=./config/mimir.yaml -target=all -server.http-listen-port=8001 -server.grpc-listen-port=9101"]
     depends_on:
       - consul
       - minio
@@ -83,7 +83,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
       - JAEGER_REPORTER_MAX_QUEUE_SIZE=1000
     ports:
-      - 8001:8001
+      - 8101:8001
     volumes:
       - ./config:/mimir/config
       - .data-mimir-1:/data:delegated
@@ -105,7 +105,7 @@ services:
       - JAEGER_SAMPLER_PARAM=1
       - JAEGER_REPORTER_MAX_QUEUE_SIZE=1000
     ports:
-      - 8002:8002
+      - 8102:8002
     volumes:
       - ./config:/mimir/config
       - .data-mimir-2:/data:delegated

--- a/development/mimir-read-write-mode/docker-compose.jsonnet
+++ b/development/mimir-read-write-mode/docker-compose.jsonnet
@@ -71,7 +71,7 @@ std.manifestYamlDoc({
         'QUERY_FRONTEND_HOST=mimir-read-1:8080',
         'COMPACTOR_HOST=mimir-backend-1:8080',
       ],
-      ports: ['8080:8080'],
+      ports: ['8780:8080'],
       volumes: ['../common/config:/etc/nginx/templates'],
     },
   },
@@ -79,11 +79,11 @@ std.manifestYamlDoc({
   minio:: {
     minio: {
       image: 'minio/minio',
-      command: ['server', '--console-address', ':9001', '/data'],
+      command: ['server', '--console-address', ':9701', '/data'],
       environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
       ports: [
-        '9000:9000',
-        '9001:9001',
+        '9700:9700',
+        '9701:9701',
       ],
       volumes: ['.data-minio:/data:delegated'],
     },
@@ -116,7 +116,7 @@ std.manifestYamlDoc({
       image: 'grafana/agent:v0.37.3',
       command: ['-config.file=/etc/agent-config/grafana-agent.yaml', '-metrics.wal-directory=/tmp', '-server.http.address=127.0.0.1:9091'],
       volumes: ['./config:/etc/agent-config'],
-      ports: ['9091:9091'],
+      ports: ['9791:9091'],
     },
   },
 
@@ -131,7 +131,7 @@ std.manifestYamlDoc({
       volumes: [
         './config:/etc/prometheus',
       ],
-      ports: ['9090:9090'],
+      ports: ['9790:9090'],
     },
   },
 
@@ -168,7 +168,7 @@ std.manifestYamlDoc({
     ],
     hostname: options.name,
     // Only publish HTTP port, but not gRPC one.
-    ports: ['%d:8080' % options.publishedHttpPort],
+    ports: ['%d:8080' % (options.publishedHttpPort + 700)],
     depends_on: options.dependsOn,
     volumes: ['./config:/mimir/config', './activity:/activity'] + options.extraVolumes,
   },

--- a/development/mimir-read-write-mode/docker-compose.yml
+++ b/development/mimir-read-write-mode/docker-compose.yml
@@ -15,7 +15,7 @@
       - "-server.http.address=127.0.0.1:9091"
     "image": "grafana/agent:v0.37.3"
     "ports":
-      - "9091:9091"
+      - "9791:9091"
     "volumes":
       - "./config:/etc/agent-config"
   "memcached":
@@ -35,7 +35,7 @@
     "hostname": "mimir-backend-1"
     "image": "mimir"
     "ports":
-      - "8006:8080"
+      - "8706:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -54,7 +54,7 @@
     "hostname": "mimir-backend-2"
     "image": "mimir"
     "ports":
-      - "8007:8080"
+      - "8707:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -73,7 +73,7 @@
     "hostname": "mimir-read-1"
     "image": "mimir"
     "ports":
-      - "8004:8080"
+      - "8704:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -92,7 +92,7 @@
     "hostname": "mimir-read-2"
     "image": "mimir"
     "ports":
-      - "8005:8080"
+      - "8705:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -111,7 +111,7 @@
     "hostname": "mimir-write-1"
     "image": "mimir"
     "ports":
-      - "8001:8080"
+      - "8701:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -131,7 +131,7 @@
     "hostname": "mimir-write-2"
     "image": "mimir"
     "ports":
-      - "8002:8080"
+      - "8702:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -151,7 +151,7 @@
     "hostname": "mimir-write-3"
     "image": "mimir"
     "ports":
-      - "8003:8080"
+      - "8703:8080"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
@@ -160,15 +160,15 @@
     "command":
       - "server"
       - "--console-address"
-      - ":9001"
+      - ":9701"
       - "/data"
     "environment":
       - "MINIO_ROOT_USER=mimir"
       - "MINIO_ROOT_PASSWORD=supersecret"
     "image": "minio/minio"
     "ports":
-      - "9000:9000"
-      - "9001:9001"
+      - "9700:9700"
+      - "9701:9701"
     "volumes":
       - ".data-minio:/data:delegated"
   "nginx":
@@ -182,7 +182,7 @@
     "hostname": "nginx"
     "image": "nginxinc/nginx-unprivileged:1.22-alpine"
     "ports":
-      - "8080:8080"
+      - "8780:8080"
     "volumes":
       - "../common/config:/etc/nginx/templates"
   "prometheus":
@@ -192,6 +192,6 @@
       - "--enable-feature=native-histograms"
     "image": "prom/prometheus:v2.53.0"
     "ports":
-      - "9090:9090"
+      - "9790:9090"
     "volumes":
       - "./config:/etc/prometheus"


### PR DESCRIPTION
#### What this PR does

Modify docker compose ports to avoid clashes between different mimir networks, making it possible to run them in parallel.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Only modifying docker-compose networks for dev.