### PR TITLE
query-tee: don't bother comparing responses for cancelled requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 
 ### Query-tee
 
+* [CHANGE] Don't compare responses for cancelled requests. #9640
 * [FEATURE] Added `-proxy.compare-skip-samples-before` to skip samples before the given time when comparing responses. The time can be in RFC3339 format (or) RFC3339 without the timezone and seconds (or) date only. #9515
 
 ### Documentation

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -259,7 +259,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, backends []Pro
 			expectedResponse, actualResponse = actualResponse, expectedResponse
 		}
 
-		result, err := p.compareResponses(expectedResponse, actualResponse, evaluationTime)
+		result, err := p.compareResponses(ctx, expectedResponse, actualResponse, evaluationTime)
 		if result == ComparisonFailed {
 			level.Error(logger).Log(
 				"msg", "response comparison failed",
@@ -315,13 +315,17 @@ func (p *ProxyEndpoint) waitBackendResponseForDownstream(resCh chan *backendResp
 	return firstResponse
 }
 
-func (p *ProxyEndpoint) compareResponses(expectedResponse, actualResponse *backendResponse, queryEvaluationTime time.Time) (ComparisonResult, error) {
+func (p *ProxyEndpoint) compareResponses(ctx context.Context, expectedResponse, actualResponse *backendResponse, queryEvaluationTime time.Time) (ComparisonResult, error) {
 	if expectedResponse.err != nil {
 		return ComparisonFailed, fmt.Errorf("skipped comparison of response because the request to the preferred backend failed: %w", expectedResponse.err)
 	}
 
 	if actualResponse.err != nil {
 		return ComparisonFailed, fmt.Errorf("skipped comparison of response because the request to the secondary backend failed: %w", actualResponse.err)
+	}
+
+	if ctx.Err() != nil {
+		return ComparisonSkipped, fmt.Errorf("skipped comparison of response because the incoming request to query-tee was cancelled: %w", context.Cause(ctx))
 	}
 
 	if expectedResponse.status != actualResponse.status {


### PR DESCRIPTION
#### What this PR does

This PR changes the behaviour of query-tee to not compare responses for cancelled requests.

If an incoming request is cancelled, that cancellation is propagated to the backends, but this is racy and can result in different responses from each backend. For example, one may finish processing the request before it observes the cancellation, and the other may observe the cancellation and abort processing. This then results in a response comparison failure, but this isn't interesting.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
