### PR TITLE
blockbuilder: add metrics for number of discarded samples due to non-terminal failures in kafka record processing

### DIFF
--- a/pkg/blockbuilder/metrics.go
+++ b/pkg/blockbuilder/metrics.go
@@ -44,12 +44,18 @@ func newBlockBuilderMetrics(reg prometheus.Registerer) blockBuilderMetrics {
 }
 
 type tsdbBuilderMetrics struct {
+	processSamplesDiscarded  *prometheus.CounterVec
 	compactAndUploadDuration *prometheus.HistogramVec
 	compactAndUploadFailed   *prometheus.CounterVec
 }
 
 func newTSDBBBuilderMetrics(reg prometheus.Registerer) tsdbBuilderMetrics {
 	var m tsdbBuilderMetrics
+
+	m.processSamplesDiscarded = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_blockbuilder_tsdb_process_samples_discarded_total",
+		Help: "The total number of samples that were discarded while processing records in one partition.",
+	}, []string{"partition"})
 
 	m.compactAndUploadDuration = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:                        "cortex_blockbuilder_tsdb_compact_and_upload_duration_seconds",

--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -106,9 +106,11 @@ func (b *TSDBBuilder) Process(ctx context.Context, rec *kgo.Record, lastBlockMax
 	}()
 
 	var (
-		labelsBuilder       labels.ScratchBuilder
-		nonCopiedLabels     labels.Labels
+		labelsBuilder   labels.ScratchBuilder
+		nonCopiedLabels labels.Labels
+
 		allSamplesProcessed = true
+		discardedSamples    = 0
 	)
 	for _, ts := range req.Timeseries {
 		mimirpb.FromLabelAdaptersOverwriteLabels(&labelsBuilder, ts.Labels, &nonCopiedLabels)
@@ -141,10 +143,12 @@ func (b *TSDBBuilder) Process(ctx context.Context, rec *kgo.Record, lastBlockMax
 				}
 			}
 
-			// Only abort the processing on a terminal error.
-			// TODO(v): add metrics for non-terminal errors
-			if err := checkTSDBAppendError(err); err != nil {
-				return false, err
+			if err != nil {
+				// Only abort the processing on a terminal error.
+				if err := checkTSDBAppendError(err); err != nil {
+					return false, err
+				}
+				discardedSamples++
 			}
 		}
 
@@ -183,14 +187,21 @@ func (b *TSDBBuilder) Process(ctx context.Context, rec *kgo.Record, lastBlockMax
 				}
 			}
 
-			// Only abort the processing on a terminal error.
-			// TODO(v): add metrics for non-terminal errors
-			if err := checkTSDBAppendError(err); err != nil {
-				return false, err
+			if err != nil {
+				// Only abort the processing on a terminal error.
+				if err := checkTSDBAppendError(err); err != nil {
+					return false, err
+				}
+				discardedSamples++
 			}
 		}
 
 		// Exemplars and metadata are not persisted in the block. So we skip them.
+	}
+
+	if discardedSamples > 0 {
+		partitionStr := fmt.Sprintf("%d", tenant.partitionID)
+		b.metrics.processSamplesDiscarded.WithLabelValues(partitionStr).Add(float64(discardedSamples))
 	}
 
 	return allSamplesProcessed, app.Commit()


### PR DESCRIPTION
#### What this PR does

This one addresses an old TODO in block-builder, by adding a metric, that counts the total number of discarded samples.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
