### PR TITLE
Return server-side total bytes processed statistics as a header through query frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
   * `-memberlist.max-concurrent-writes`
   * `-memberlist.acquire-writer-timeout`
 * [ENHANCEMENT] memberlist: Notifications can now be processed once per interval specified by `-memberlist.notify-interval` to reduce notify storm CPU activity in large clusters. #9594
-* [ENHANCEMENT] Return server-side total bytes processed statistics as a header through query frontend. #9645 
+* [ENHANCEMENT] Return server-side total bytes processed statistics as a header through query frontend. #9645
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
   * `-memberlist.max-concurrent-writes`
   * `-memberlist.acquire-writer-timeout`
 * [ENHANCEMENT] memberlist: Notifications can now be processed once per interval specified by `-memberlist.notify-interval` to reduce notify storm CPU activity in large clusters. #9594
+* [ENHANCEMENT] Return server-side total bytes processed statistics as a header through query frontend. #9645 
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -383,7 +383,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 		if userID == 0 && cfg.queryStatsEnabled {
 			res, _, err := c.QueryRaw("{instance=~\"hello.*\"}")
 			require.NoError(t, err)
-			require.Regexp(t, "querier_wall_time;dur=[0-9.]*, response_time;dur=[0-9.]*$", res.Header.Values("Server-Timing")[0])
+			require.Regexp(t, "querier_wall_time;dur=[0-9.]*, response_time;dur=[0-9.]*, bytes_processed=[0-9.]*$", res.Header.Values("Server-Timing")[0])
 		}
 
 		// Beyond the range of -querier.query-ingesters-within should return nothing. No need to repeat it for each user.

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -286,7 +286,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			expectedReadConsistency: "",
 		},
 		{
-			name: "handler with stats enabled, check ServiceTotalBytesProcessed header",
+			name: "handler with stats enabled, check ServiceTimingHeader",
 			cfg:  HandlerConfig{QueryStatsEnabled: true, MaxBodySize: 1024},
 			request: func() *http.Request {
 				req := httptest.NewRequest(http.MethodPost, "/api/v1/query", strings.NewReader("query=some_metric&time=42"))
@@ -303,7 +303,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			expectedActivity:        "user:12345 UA: req:POST /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 			assertHeaders: func(t *testing.T, headers http.Header) {
-				assert.Equal(t, "0", headers.Get(ServiceTotalBytesProcessed))
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "bytes_processed=0")
 			},
 		},
 	} {


### PR DESCRIPTION
#### What this PR does
This pull request adds bytes-processed statistics to the existing `Server-Timing` HTTP header in the query frontend. It provides information about the total bytes processed by Mimir for a query request that passes through the query frontend. This information will be useful for assessing user behaviour and applying rate limiting when users run expensive, long-range Mimir queries. It will help mitigate slow performance or occasional downtime in Mimir.

#### Which issue(s) this PR fixes or relates to
None

#### Checklist

- [x] Tests updated.
- [x] `CHANGELOG.md` updated
