### PR TITLE
Improve MimirGossipMembersEndpointsOutOfSync runbook command

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -936,7 +936,7 @@ How to **investigate**:
 
 - Check the number of endpoints matching the `gossip-ring` service:
   ```
-  kubectl --namespace <namespace> get endpoints gossip-ring
+  kubectl --namespace <namespace> get endpoints gossip-ring -ojson | jq '.subsets[].addresses | length'
   ```
 - If the number of endpoints is 1000 then it means you reached the Kubernetes limit, the endpoints get truncated and
   you could be hit by [this bug](https://github.com/kubernetes/kubernetes/issues/127370). Having more than 1000 pods


### PR DESCRIPTION
#### What this PR does

Improves the command in the runbook to reduce the time to identify the issue.

I ran the previous command and the output is:

```
$ kubectl get endpoints gossip-ring
NAME          ENDPOINTS                                                                 AGE
gossip-ring   10.200.100.64:7946,10.200.100.65:7946,10.200.101.201:7946 + 979 more...   462d
```

While the new one just prints:

```
$ kubectl get endpoints gossip-ring -ojson | jq '.subsets[].addresses | length'
982
```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
