### PR TITLE
query-tee: Filter samples for matrix before checking number of series

### DIFF
--- a/tools/querytee/response_comparator.go
+++ b/tools/querytee/response_comparator.go
@@ -246,16 +246,12 @@ func compareMatrix(expectedRaw, actualRaw json.RawMessage, queryEvaluationTime t
 		eChanged, aChanged := len(expected) != expLen, len(actual) != actLen
 		defer func() {
 			if retErr != nil {
-				warning := ""
 				if eChanged && aChanged {
-					warning = " (also, some series were completely filtered out from the expected and actual response due to the 'skip samples before')"
+					retErr = fmt.Errorf("%w (also, some series were completely filtered out from the expected and actual response due to the 'skip samples before')", retErr)
 				} else if aChanged {
-					warning = " (also, some series were completely filtered out from the actual response due to the 'skip samples before')"
+					retErr = fmt.Errorf("%w (also, some series were completely filtered out from the actual response due to the 'skip samples before')", retErr)
 				} else if eChanged {
-					warning = " (also, some series were completely filtered out from the expected response due to the 'skip samples before')"
-				}
-				if warning != "" {
-					retErr = fmt.Errorf("%w%s", retErr, warning)
+					retErr = fmt.Errorf("%w (also, some series were completely filtered out from the expected response due to the 'skip samples before')", retErr)
 				}
 			}
 		}()
@@ -467,16 +463,12 @@ func compareVector(expectedRaw, actualRaw json.RawMessage, queryEvaluationTime t
 		eChanged, aChanged := len(expected) != eOrgLen, len(actual) != aOrgLen
 		defer func() {
 			if retErr != nil {
-				warning := ""
 				if eChanged && aChanged {
-					warning = " (also, some samples were filtered out from the expected and actual response due to the 'skip samples before'; if all samples have been filtered out, this could cause the check on the expected number of metrics to fail)"
+					retErr = fmt.Errorf("%w (also, some samples were filtered out from the expected and actual response due to the 'skip samples before'; if all samples have been filtered out, this could cause the check on the expected number of metrics to fail)", retErr)
 				} else if aChanged {
-					warning = " (also, some samples were filtered out from the actual response due to the 'skip samples before'; if all samples have been filtered out, this could cause the check on the expected number of metrics to fail)"
+					retErr = fmt.Errorf("%w (also, some samples were filtered out from the actual response due to the 'skip samples before'; if all samples have been filtered out, this could cause the check on the expected number of metrics to fail)", retErr)
 				} else if eChanged {
-					warning = " (also, some samples were filtered out from the expected response due to the 'skip samples before'; if all samples have been filtered out, this could cause the check on the expected number of metrics to fail)"
-				}
-				if warning != "" {
-					retErr = fmt.Errorf("%w%s", retErr, warning)
+					retErr = fmt.Errorf("%w (also, some samples were filtered out from the expected response due to the 'skip samples before'; if all samples have been filtered out, this could cause the check on the expected number of metrics to fail)", retErr)
 				}
 			}
 		}()

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -2192,6 +2192,19 @@ func TestCompareSamplesResponse(t *testing.T) {
 			skipSamplesBefore: 95 * 1000,
 		},
 		{
+			name: "fail when all series from expected are filtered out - float",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[90,"9"], [93,"10"]]}, {"metric":{"foo":"bar2"},"values":[[90,"10"]]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[90,"10"], [93,"10"], [100,"10"]]}]}
+						}`),
+			skipSamplesBefore: 95 * 1000,
+			err:               errors.New(`expected 0 metrics but got 1 (also, some series were completely filtered out from the expected response due to the 'skip samples before')`),
+		},
+		{
 			name: "should not fail when we skip all samples starting from the beginning - float",
 			expected: json.RawMessage(`{
 							"status": "success",

--- a/tools/querytee/response_comparator_test.go
+++ b/tools/querytee/response_comparator_test.go
@@ -2180,6 +2180,18 @@ func TestCompareSamplesResponse(t *testing.T) {
 			skipSamplesBefore: 95 * 1000,
 		},
 		{
+			name: "should not fail when some series is entirely skipped and rest matches - float",
+			expected: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[90,"9"], [100,"10"]]}, {"metric":{"foo":"bar2"},"values":[[90,"10"]]}]}
+						}`),
+			actual: json.RawMessage(`{
+							"status": "success",
+							"data": {"resultType":"matrix","result":[{"metric":{"foo":"bar"},"values":[[100,"10"]]}]}
+						}`),
+			skipSamplesBefore: 95 * 1000,
+		},
+		{
 			name: "should not fail when we skip all samples starting from the beginning - float",
 			expected: json.RawMessage(`{
 							"status": "success",


### PR DESCRIPTION
#### What this PR does

This is a follow up of https://github.com/grafana/mimir/pull/9515

It fixes the case where if a series was completely removed from matrix and if the remaining part would match, we would still fail comparison saying there is a mismatch in series.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
