### PR TITLE
kafka replay speed: dont send requests for higher than the high watermark

### DIFF
--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -605,7 +605,7 @@ func (r *concurrentFetchers) start(ctx context.Context, startOffset int64, concu
 		dispatchNextWant := chan fetchWant(nil)
 		if nextResult == nil || nextFetch.startOffset <= highWatermark.Load() {
 			// In Warpstream fetching past the end induced more delays than MinBytesWaitTime.
-			// So we dispatch a fetch for only if it's fetching an existing offset.
+			// So we dispatch a fetch only if it's fetching an existing offset.
 			// This shouldn't noticeably affect performance with Apache Kafka, after all franz-go only has a concurrency of 1 per partition.
 			//
 			// At the same time we don't want to reach a deadlock where the HWM is not updated and there are no fetches in flight.

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -21,6 +21,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/plugin/kotel"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -474,7 +475,7 @@ func sumRecordLengths(records []*kgo.Record) (sum int) {
 	return sum
 }
 
-func (r *concurrentFetchers) run(ctx context.Context, wants chan fetchWant, logger log.Logger) {
+func (r *concurrentFetchers) run(ctx context.Context, wants chan fetchWant, logger log.Logger, highWatermark *atomic.Int64) {
 	defer r.wg.Done()
 
 	errBackoff := backoff.New(ctx, backoff.Config{
@@ -500,7 +501,9 @@ func (r *concurrentFetchers) run(ctx context.Context, wants chan fetchWant, logg
 			if f.Err != nil {
 				w = handleKafkaFetchErr(f.Err, w, errBackoff, r.startOffsets, r.client, attemptSpan)
 			}
-
+			if hwm := f.HighWatermark; hwm >= 0 {
+				casHWM(highWatermark, hwm)
+			}
 			if len(f.Records) == 0 {
 				// Typically if we had an error, then there wouldn't be any records.
 				// But it's hard to verify this for all errors from the Kafka API docs, so just to be sure, we process any records we might have received.
@@ -557,15 +560,27 @@ func (r *concurrentFetchers) run(ctx context.Context, wants chan fetchWant, logg
 	}
 }
 
+func casHWM(highWwatermark *atomic.Int64, newHWM int64) {
+	for hwm := highWwatermark.Load(); hwm < newHWM; hwm = highWwatermark.Load() {
+		if highWwatermark.CompareAndSwap(hwm, newHWM) {
+			break
+		}
+	}
+}
+
 func (r *concurrentFetchers) start(ctx context.Context, startOffset int64, concurrency, recordsPerFetch int) {
 	level.Info(r.logger).Log("msg", "starting concurrent fetchers", "start_offset", startOffset, "concurrency", concurrency, "recordsPerFetch", recordsPerFetch)
+
+	// HWM is updated by the fetchers. A value of 0 is the same as there not being any produced records.
+	// A value of 0 doesn't prevent progress because we ensure there is at least one dispatched fetchWant.
+	highWatermark := atomic.NewInt64(0)
 
 	wants := make(chan fetchWant)
 	defer close(wants)
 	r.wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {
 		logger := log.With(r.logger, "fetcher", i)
-		go r.run(ctx, wants, logger)
+		go r.run(ctx, wants, logger, highWatermark)
 	}
 
 	var (
@@ -587,13 +602,23 @@ func (r *concurrentFetchers) start(ctx context.Context, startOffset int64, concu
 			// So we don't try to get new results from the fetchers.
 			refillBufferedResult = nil
 		}
+		dispatchNextWant := chan fetchWant(nil)
+		if nextResult == nil || nextFetch.startOffset <= highWatermark.Load() {
+			// In Warpstream fetching past the end induced more delays than MinBytesWaitTime.
+			// So we dispatch a fetch for only if it's fetching an existing offset.
+			// This shouldn't noticeably affect performance with Apache Kafka, after all franz-go only has a concurrency of 1 per partition.
+			//
+			// At the same time we don't want to reach a deadlock where the HWM is not updated and there are no fetches in flight.
+			// When there isn't a fetch in flight the HWM will never be updated, we will dispatch the next fetchWant even if that means it's above the HWM.
+			dispatchNextWant = wants
+		}
 		select {
 		case <-r.done:
 			return
 		case <-ctx.Done():
 			return
 
-		case wants <- nextFetch:
+		case dispatchNextWant <- nextFetch:
 			pendingResults.PushBack(nextFetch.result)
 			if nextResult == nil {
 				// In case we previously exhausted pendingResults, we just created


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

### What this PR does

This is related to a problem we have: high e2e latency when fetching at the head of the partition. The current theory is that WS introduces extra delay when requesting an offset which doesn't exist.

Currently, we have two sets of flags: one for startup and one for ongoing fetching. This PR enables us to have just a single configuration which determines the max concurrency. We will limit concurrency by never requesting an offset which doesn't exist.


### Testing

#### Startup tests

I tested using the same concurrency and records-per-fetch settings for startup and ongoing fetching:

```
    'ingest-storage.kafka.startup-fetch-concurrency': '12',  
    'ingest-storage.kafka.startup-records-per-fetch': '1000',  
    'ingest-storage.kafka.ongoing-fetch-concurrency': '12',  
    'ingest-storage.kafka.ongoing-records-per-fetch': '1000',  
```

results looks pretty good:
1. cold replay speed remains high (variability is likely due to different data density in different partitions)
2. lag right after startup is on par with franz-go (previously our implementation struggled to get end-to-end latency below 2s and keep it there).
3. end-to-end latency while running is also on par with franz-go at ~400ms (first half of the screenshots)


| |  |
|--------|--------|
| ![Image](https://github.com/user-attachments/assets/b556f792-fe70-4893-b641-5ccbc46648c8) | ![Image](https://github.com/user-attachments/assets/1147431a-c0eb-462e-95c1-e0c55b237a9f) | 
|  ![Image](https://github.com/user-attachments/assets/f2f357b2-5183-4647-83a9-8c09a9e5cdce) | | 

#### Kafka outage tests

This also unlocks recovering from a Kafka outage. I tried to simulate that by scaling down the WS agents to from 40 replicas to 1. This ended up slowing down the path. The ingesters recovered with similar replay speed (admitedly the simulated "outage" was too short to be able to properly measure replay speed because the recovery was too fast)



| |  |
|--------|--------|
| ![Image](https://github.com/user-attachments/assets/b25942de-20d8-40d7-bf6b-a73c04857fff) | ![Image](https://github.com/user-attachments/assets/02c774e7-97b2-4d2a-a458-84bc29551065) |


#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
