### PR TITLE
Increase timeout in ingester downscaling tests

### DIFF
--- a/pkg/ingester/downscale_test.go
+++ b/pkg/ingester/downscale_test.go
@@ -54,7 +54,7 @@ func TestIngester_PrepareInstanceRingDownscaleHandler(t *testing.T) {
 		ingester, r := setup(true)
 
 		// Pre-condition: entry is not read-only.
-		test.Poll(t, 5*time.Second, false, func() interface{} {
+		test.Poll(t, 10*time.Second, false, func() interface{} {
 			inst, err := r.GetInstance(ingester.lifecycler.ID)
 			require.NoError(t, err)
 			return inst.ReadOnly
@@ -69,7 +69,7 @@ func TestIngester_PrepareInstanceRingDownscaleHandler(t *testing.T) {
 		require.InDelta(t, time.Now().Unix(), resp.Timestamp, 10)
 
 		// Post-condition: entry is read only.
-		test.Poll(t, 5*time.Second, true, func() interface{} {
+		test.Poll(t, 10*time.Second, true, func() interface{} {
 			inst, err := r.GetInstance(ingester.lifecycler.ID)
 			require.NoError(t, err)
 			return inst.ReadOnly && inst.ReadOnlyUpdatedTimestamp == resp.Timestamp
@@ -95,7 +95,7 @@ func TestIngester_PrepareInstanceRingDownscaleHandler(t *testing.T) {
 		// Switch entry to read-only.
 		ingester.PrepareInstanceRingDownscaleHandler(res, httptest.NewRequest(http.MethodPost, target, nil))
 		require.Equal(t, http.StatusOK, res.Code)
-		test.Poll(t, 5*time.Second, true, func() interface{} {
+		test.Poll(t, 10*time.Second, true, func() interface{} {
 			inst, err := r.GetInstance(ingester.lifecycler.ID)
 			require.NoError(t, err)
 			return inst.ReadOnly
@@ -111,7 +111,7 @@ func TestIngester_PrepareInstanceRingDownscaleHandler(t *testing.T) {
 		require.Equal(t, int64(0), resp.Timestamp)
 
 		// Post-condition: entry is not read only.
-		test.Poll(t, 5*time.Second, false, func() interface{} {
+		test.Poll(t, 10*time.Second, false, func() interface{} {
 			inst, err := r.GetInstance(ingester.lifecycler.ID)
 			require.NoError(t, err)
 			return inst.ReadOnly


### PR DESCRIPTION
This change increases the polling timeout while waiting for ring state to converge after in the downscaling tests.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Increases polling timeout in flaky unit tests.

#### Which issue(s) this PR fixes or relates to

Fixes #9494

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
