### PR TITLE
MQE: subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * `cortex_alertmanager_alerts`
   * `cortex_alertmanager_silences`
 * [CHANGE] Distributor: Drop experimental `-distributor.direct-otlp-translation-enabled` flag, since direct OTLP translation is well tested at this point. #9647
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9664
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] gRPC: Support S2 compression. #9322
   * `-alertmanager.alertmanager-client.grpc-compression=s2`

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2032,6 +2032,17 @@
               "fieldFlag": "querier.mimir-query-engine.enable-scalars",
               "fieldType": "boolean",
               "fieldCategory": "experimental"
+            },
+            {
+              "kind": "field",
+              "name": "enable_subqueries",
+              "required": false,
+              "desc": "Enable support for subqueries in Mimir's query engine. Only applies if the Mimir query engine is in use.",
+              "fieldValue": null,
+              "fieldDefaultValue": true,
+              "fieldFlag": "querier.mimir-query-engine.enable-subqueries",
+              "fieldType": "boolean",
+              "fieldCategory": "experimental"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1957,6 +1957,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Enable support for binary comparison operations between two scalars in Mimir's query engine. Only applies if the Mimir query engine is in use. (default true)
   -querier.mimir-query-engine.enable-scalars
     	[experimental] Enable support for scalars in Mimir's query engine. Only applies if the Mimir query engine is in use. (default true)
+  -querier.mimir-query-engine.enable-subqueries
+    	[experimental] Enable support for subqueries in Mimir's query engine. Only applies if the Mimir query engine is in use. (default true)
   -querier.mimir-query-engine.enable-vector-scalar-binary-comparison-operations
     	[experimental] Enable support for binary comparison operations between a vector and a scalar in Mimir's query engine. Only applies if the Mimir query engine is in use. (default true)
   -querier.mimir-query-engine.enable-vector-vector-binary-comparison-operations

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1534,6 +1534,11 @@ mimir_query_engine:
   # applies if the Mimir query engine is in use.
   # CLI flag: -querier.mimir-query-engine.enable-scalars
   [enable_scalars: <boolean> | default = true]
+
+  # (experimental) Enable support for subqueries in Mimir's query engine. Only
+  # applies if the Mimir query engine is in use.
+  # CLI flag: -querier.mimir-query-engine.enable-subqueries
+  [enable_subqueries: <boolean> | default = true]
 ```
 
 ### frontend

--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -137,6 +137,9 @@ func TestCases(metricSizes []int) []BenchCase {
 		{
 			Expr: "sum_over_time(nh_X[10m:3m])",
 		},
+		{
+			Expr: "sum(sum_over_time(a_X[10m:3m]))",
+		},
 		//// Unary operators.
 		//{
 		//	Expr: "-a_X",

--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -130,6 +130,13 @@ func TestCases(metricSizes []int) []BenchCase {
 		//{
 		//	Expr: "absent_over_time(a_X[1d])",
 		//},
+		// Subqueries.
+		{
+			Expr: "sum_over_time(a_X[10m:3m])",
+		},
+		{
+			Expr: "sum_over_time(nh_X[10m:3m])",
+		},
 		//// Unary operators.
 		//{
 		//	Expr: "-a_X",

--- a/pkg/streamingpromql/config.go
+++ b/pkg/streamingpromql/config.go
@@ -24,11 +24,13 @@ type FeatureToggles struct {
 	EnableScalarScalarBinaryComparisonOperations bool `yaml:"enable_scalar_scalar_binary_comparison_operations" category:"experimental"`
 	EnableBinaryLogicalOperations                bool `yaml:"enable_binary_logical_operations" category:"experimental"`
 	EnableScalars                                bool `yaml:"enable_scalars" category:"experimental"`
+	EnableSubqueries                             bool `yaml:"enable_subqueries" category:"experimental"`
 }
 
 // EnableAllFeatures enables all features supported by MQE, including experimental or incomplete features.
 var EnableAllFeatures = FeatureToggles{
 	// Note that we deliberately use a keyless literal here to force a compilation error if we don't keep this in sync with new fields added to FeatureToggles.
+	true,
 	true,
 	true,
 	true,
@@ -44,4 +46,5 @@ func (t *FeatureToggles) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&t.EnableScalarScalarBinaryComparisonOperations, "querier.mimir-query-engine.enable-scalar-scalar-binary-comparison-operations", true, "Enable support for binary comparison operations between two scalars in Mimir's query engine. Only applies if the Mimir query engine is in use.")
 	f.BoolVar(&t.EnableBinaryLogicalOperations, "querier.mimir-query-engine.enable-binary-logical-operations", true, "Enable support for binary logical operations in Mimir's query engine. Only applies if the Mimir query engine is in use.")
 	f.BoolVar(&t.EnableScalars, "querier.mimir-query-engine.enable-scalars", true, "Enable support for scalars in Mimir's query engine. Only applies if the Mimir query engine is in use.")
+	f.BoolVar(&t.EnableSubqueries, "querier.mimir-query-engine.enable-subqueries", true, "Enable support for subqueries in Mimir's query engine. Only applies if the Mimir query engine is in use.")
 }

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -45,11 +45,12 @@ func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *sta
 	}
 
 	return &Engine{
-		lookbackDelta:      lookbackDelta,
-		timeout:            opts.CommonOpts.Timeout,
-		limitsProvider:     limitsProvider,
-		activeQueryTracker: opts.CommonOpts.ActiveQueryTracker,
-		featureToggles:     opts.FeatureToggles,
+		lookbackDelta:            lookbackDelta,
+		timeout:                  opts.CommonOpts.Timeout,
+		limitsProvider:           limitsProvider,
+		activeQueryTracker:       opts.CommonOpts.ActiveQueryTracker,
+		featureToggles:           opts.FeatureToggles,
+		noStepSubqueryIntervalFn: opts.CommonOpts.NoStepSubqueryIntervalFn,
 
 		logger: logger,
 		estimatedPeakMemoryConsumption: promauto.With(opts.CommonOpts.Reg).NewHistogram(prometheus.HistogramOpts{
@@ -64,11 +65,12 @@ func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *sta
 }
 
 type Engine struct {
-	lookbackDelta      time.Duration
-	timeout            time.Duration
-	limitsProvider     QueryLimitsProvider
-	activeQueryTracker promql.QueryTracker
-	featureToggles     FeatureToggles
+	lookbackDelta            time.Duration
+	timeout                  time.Duration
+	limitsProvider           QueryLimitsProvider
+	activeQueryTracker       promql.QueryTracker
+	featureToggles           FeatureToggles
+	noStepSubqueryIntervalFn func(rangeMillis int64) int64
 
 	logger                                    log.Logger
 	estimatedPeakMemoryConsumption            prometheus.Histogram

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -864,10 +864,10 @@ func TestSubqueries(t *testing.T) {
 	// This test is based on Prometheus' TestSubquerySelector.
 	data := `load 10s
 	           metric 1 2
-	           http_requests{job="api-server", instance="0", group="production"}	0+10x1000 100+30x1000
-	           http_requests{job="api-server", instance="1", group="production"}	0+20x1000 200+30x1000
-	           http_requests{job="api-server", instance="0", group="canary"}		0+30x1000 300+80x1000
-	           http_requests{job="api-server", instance="1", group="canary"}		0+40x2000`
+	           http_requests{job="api-server", instance="0", group="production"} 0+10x1000 100+30x1000
+	           http_requests{job="api-server", instance="1", group="production"} 0+20x1000 200+30x1000
+	           http_requests{job="api-server", instance="0", group="canary"}     0+30x1000 300+80x1000
+	           http_requests{job="api-server", instance="1", group="canary"}     0+40x2000`
 
 	opts := NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), log.NewNopLogger())

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -863,11 +863,16 @@ func TestRangeVectorSelectors(t *testing.T) {
 func TestSubqueries(t *testing.T) {
 	// This test is based on Prometheus' TestSubquerySelector.
 	data := `load 10s
-	           metric 1 2
+	           metric{type="floats"} 1 2
+	           metric{type="histograms"} {{count:1}} {{count:2}}
 	           http_requests{job="api-server", instance="0", group="production"} 0+10x1000 100+30x1000
 	           http_requests{job="api-server", instance="1", group="production"} 0+20x1000 200+30x1000
 	           http_requests{job="api-server", instance="0", group="canary"}     0+30x1000 300+80x1000
-	           http_requests{job="api-server", instance="1", group="canary"}     0+40x2000`
+	           http_requests{job="api-server", instance="1", group="canary"}     0+40x2000
+	           other_metric{type="floats"} 0 4 3 6 -1 10
+	           other_metric{type="histograms"} {{count:0}} {{count:4}} {{count:3}} {{count:6}} {{count:-1}} {{count:10}}
+	           other_metric{type="mixed"} 0 4 3 6 {{count:-1}} {{count:10}}
+	`
 
 	opts := NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), log.NewNopLogger())
@@ -886,7 +891,11 @@ func TestSubqueries(t *testing.T) {
 				Value: promql.Matrix{
 					promql.Series{
 						Floats: []promql.FPoint{{F: 1, T: 0}, {F: 2, T: 10000}},
-						Metric: labels.FromStrings("__name__", "metric"),
+						Metric: labels.FromStrings("__name__", "metric", "type", "floats"),
+					},
+					promql.Series{
+						Histograms: []promql.HPoint{{H: &histogram.FloatHistogram{Count: 1}, T: 0}, {H: &histogram.FloatHistogram{Count: 2}, T: 10000}},
+						Metric:     labels.FromStrings("__name__", "metric", "type", "histograms"),
 					},
 				},
 			},
@@ -898,7 +907,11 @@ func TestSubqueries(t *testing.T) {
 				Value: promql.Matrix{
 					promql.Series{
 						Floats: []promql.FPoint{{F: 1, T: 0}, {F: 1, T: 5000}, {F: 2, T: 10000}},
-						Metric: labels.FromStrings("__name__", "metric"),
+						Metric: labels.FromStrings("__name__", "metric", "type", "floats"),
+					},
+					promql.Series{
+						Histograms: []promql.HPoint{{H: &histogram.FloatHistogram{Count: 1}, T: 0}, {H: &histogram.FloatHistogram{Count: 1}, T: 5000}, {H: &histogram.FloatHistogram{Count: 2}, T: 10000}},
+						Metric:     labels.FromStrings("__name__", "metric", "type", "histograms"),
 					},
 				},
 			},
@@ -910,7 +923,11 @@ func TestSubqueries(t *testing.T) {
 				Value: promql.Matrix{
 					promql.Series{
 						Floats: []promql.FPoint{{F: 1, T: 0}, {F: 1, T: 5000}, {F: 2, T: 10000}},
-						Metric: labels.FromStrings("__name__", "metric"),
+						Metric: labels.FromStrings("__name__", "metric", "type", "floats"),
+					},
+					promql.Series{
+						Histograms: []promql.HPoint{{H: &histogram.FloatHistogram{Count: 1}, T: 0}, {H: &histogram.FloatHistogram{Count: 1}, T: 5000}, {H: &histogram.FloatHistogram{Count: 2}, T: 10000}},
+						Metric:     labels.FromStrings("__name__", "metric", "type", "histograms"),
 					},
 				},
 			},
@@ -922,7 +939,11 @@ func TestSubqueries(t *testing.T) {
 				Value: promql.Matrix{
 					promql.Series{
 						Floats: []promql.FPoint{{F: 1, T: 0}, {F: 1, T: 5000}, {F: 2, T: 10000}},
-						Metric: labels.FromStrings("__name__", "metric"),
+						Metric: labels.FromStrings("__name__", "metric", "type", "floats"),
+					},
+					promql.Series{
+						Histograms: []promql.HPoint{{H: &histogram.FloatHistogram{Count: 1}, T: 0}, {H: &histogram.FloatHistogram{Count: 1}, T: 5000}, {H: &histogram.FloatHistogram{Count: 2}, T: 10000}},
+						Metric:     labels.FromStrings("__name__", "metric", "type", "histograms"),
 					},
 				},
 			},
@@ -934,7 +955,11 @@ func TestSubqueries(t *testing.T) {
 				Value: promql.Matrix{
 					promql.Series{
 						Floats: []promql.FPoint{{F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}, {F: 2, T: 30000}},
-						Metric: labels.FromStrings("__name__", "metric"),
+						Metric: labels.FromStrings("__name__", "metric", "type", "floats"),
+					},
+					promql.Series{
+						Histograms: []promql.HPoint{{H: &histogram.FloatHistogram{Count: 2}, T: 15000}, {H: &histogram.FloatHistogram{Count: 2}, T: 20000}, {H: &histogram.FloatHistogram{Count: 2}, T: 25000}, {H: &histogram.FloatHistogram{Count: 2}, T: 30000}},
+						Metric:     labels.FromStrings("__name__", "metric", "type", "histograms"),
 					},
 				},
 			},
@@ -946,7 +971,11 @@ func TestSubqueries(t *testing.T) {
 				Value: promql.Matrix{
 					promql.Series{
 						Floats: []promql.FPoint{{F: 2, T: 10000}, {F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}, {F: 2, T: 30000}},
-						Metric: labels.FromStrings("__name__", "metric"),
+						Metric: labels.FromStrings("__name__", "metric", "type", "floats"),
+					},
+					promql.Series{
+						Histograms: []promql.HPoint{{H: &histogram.FloatHistogram{Count: 2}, T: 10000}, {H: &histogram.FloatHistogram{Count: 2}, T: 15000}, {H: &histogram.FloatHistogram{Count: 2}, T: 20000}, {H: &histogram.FloatHistogram{Count: 2}, T: 25000}, {H: &histogram.FloatHistogram{Count: 2}, T: 30000}},
+						Metric:     labels.FromStrings("__name__", "metric", "type", "histograms"),
 					},
 				},
 			},
@@ -958,7 +987,11 @@ func TestSubqueries(t *testing.T) {
 				Value: promql.Matrix{
 					promql.Series{
 						Floats: []promql.FPoint{{F: 2, T: 10000}, {F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}},
-						Metric: labels.FromStrings("__name__", "metric"),
+						Metric: labels.FromStrings("__name__", "metric", "type", "floats"),
+					},
+					promql.Series{
+						Histograms: []promql.HPoint{{H: &histogram.FloatHistogram{Count: 2}, T: 10000}, {H: &histogram.FloatHistogram{Count: 2}, T: 15000}, {H: &histogram.FloatHistogram{Count: 2}, T: 20000}, {H: &histogram.FloatHistogram{Count: 2}, T: 25000}},
+						Metric:     labels.FromStrings("__name__", "metric", "type", "histograms"),
 					},
 				},
 			},
@@ -970,7 +1003,11 @@ func TestSubqueries(t *testing.T) {
 				Value: promql.Matrix{
 					promql.Series{
 						Floats: []promql.FPoint{{F: 2, T: 10000}, {F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}},
-						Metric: labels.FromStrings("__name__", "metric"),
+						Metric: labels.FromStrings("__name__", "metric", "type", "floats"),
+					},
+					promql.Series{
+						Histograms: []promql.HPoint{{H: &histogram.FloatHistogram{Count: 2}, T: 10000}, {H: &histogram.FloatHistogram{Count: 2}, T: 15000}, {H: &histogram.FloatHistogram{Count: 2}, T: 20000}, {H: &histogram.FloatHistogram{Count: 2}, T: 25000}},
+						Metric:     labels.FromStrings("__name__", "metric", "type", "histograms"),
 					},
 				},
 			},
@@ -1076,6 +1113,54 @@ func TestSubqueries(t *testing.T) {
 				},
 			},
 			Start: time.Unix(120, 0),
+		},
+		// These tests exercise @ start() and @ end(), and use the same data as testdata/ours/subqueries.test, to
+		// mirror the range query tests there.
+		{
+			Query: `last_over_time(other_metric[20s:10s] @ start())`,
+			Result: promql.Result{
+				Value: promql.Vector{
+					{
+						F:      -1,
+						T:      40000,
+						Metric: labels.FromStrings(labels.MetricName, "other_metric", "type", "floats"),
+					},
+					{
+						H:      &histogram.FloatHistogram{Count: -1, CounterResetHint: histogram.CounterReset},
+						T:      40000,
+						Metric: labels.FromStrings(labels.MetricName, "other_metric", "type", "histograms"),
+					},
+					{
+						H:      &histogram.FloatHistogram{Count: -1, CounterResetHint: histogram.UnknownCounterReset},
+						T:      40000,
+						Metric: labels.FromStrings(labels.MetricName, "other_metric", "type", "mixed"),
+					},
+				},
+			},
+			Start: time.Unix(40, 0),
+		},
+		{
+			Query: `last_over_time(other_metric[20s:10s] @ end())`,
+			Result: promql.Result{
+				Value: promql.Vector{
+					{
+						F:      6,
+						T:      30000,
+						Metric: labels.FromStrings(labels.MetricName, "other_metric", "type", "floats"),
+					},
+					{
+						H:      &histogram.FloatHistogram{Count: 6, CounterResetHint: histogram.NotCounterReset},
+						T:      30000,
+						Metric: labels.FromStrings(labels.MetricName, "other_metric", "type", "histograms"),
+					},
+					{
+						F:      6,
+						T:      30000,
+						Metric: labels.FromStrings(labels.MetricName, "other_metric", "type", "mixed"),
+					},
+				},
+			},
+			Start: time.Unix(30, 0),
 		},
 	}
 

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
@@ -873,245 +874,231 @@ func TestRangeVectorSelectors(t *testing.T) {
 
 func TestSubqueries(t *testing.T) {
 	// This test is based on Prometheus' TestSubquerySelector.
-	type testCase struct {
+	data := `load 10s
+	           metric 1 2
+	           http_requests{job="api-server", instance="0", group="production"}	0+10x1000 100+30x1000
+	           http_requests{job="api-server", instance="1", group="production"}	0+20x1000 200+30x1000
+	           http_requests{job="api-server", instance="0", group="canary"}		0+30x1000 300+80x1000
+	           http_requests{job="api-server", instance="1", group="canary"}		0+40x2000`
+
+	opts := NewTestEngineOpts()
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), log.NewNopLogger())
+	require.NoError(t, err)
+	storage := promqltest.LoadedStorage(t, data)
+	t.Cleanup(func() { storage.Close() })
+
+	testCases := []struct {
 		Query  string
 		Result promql.Result
 		Start  time.Time
-	}
-
-	tests := []struct {
-		load  string
-		cases []testCase
 	}{
 		{
-			load: `load 10s
-			         metric 1 2`,
-			cases: []testCase{
-				{
-					Query: "metric[20s:10s]",
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 1, T: 0}, {F: 2, T: 10000}},
-								Metric: labels.FromStrings("__name__", "metric"),
-							},
-						},
+			Query: "metric[20s:10s]",
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 1, T: 0}, {F: 2, T: 10000}},
+						Metric: labels.FromStrings("__name__", "metric"),
 					},
-					Start: time.Unix(10, 0),
-				},
-				{
-					Query: "metric[20s:5s]",
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 1, T: 0}, {F: 1, T: 5000}, {F: 2, T: 10000}},
-								Metric: labels.FromStrings("__name__", "metric"),
-							},
-						},
-					},
-					Start: time.Unix(10, 0),
-				},
-				{
-					Query: "metric[20s:5s] offset 2s",
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 1, T: 0}, {F: 1, T: 5000}, {F: 2, T: 10000}},
-								Metric: labels.FromStrings("__name__", "metric"),
-							},
-						},
-					},
-					Start: time.Unix(12, 0),
-				},
-				{
-					Query: "metric[20s:5s] offset 6s",
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 1, T: 0}, {F: 1, T: 5000}, {F: 2, T: 10000}},
-								Metric: labels.FromStrings("__name__", "metric"),
-							},
-						},
-					},
-					Start: time.Unix(20, 0),
-				},
-				{
-					Query: "metric[20s:5s] offset 4s",
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}, {F: 2, T: 30000}},
-								Metric: labels.FromStrings("__name__", "metric"),
-							},
-						},
-					},
-					Start: time.Unix(35, 0),
-				},
-				{
-					Query: "metric[20s:5s] offset 5s",
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 2, T: 10000}, {F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}, {F: 2, T: 30000}},
-								Metric: labels.FromStrings("__name__", "metric"),
-							},
-						},
-					},
-					Start: time.Unix(35, 0),
-				},
-				{
-					Query: "metric[20s:5s] offset 6s",
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 2, T: 10000}, {F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}},
-								Metric: labels.FromStrings("__name__", "metric"),
-							},
-						},
-					},
-					Start: time.Unix(35, 0),
-				},
-				{
-					Query: "metric[20s:5s] offset 7s",
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 2, T: 10000}, {F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}},
-								Metric: labels.FromStrings("__name__", "metric"),
-							},
-						},
-					},
-					Start: time.Unix(35, 0),
 				},
 			},
+			Start: time.Unix(10, 0),
 		},
 		{
-			load: `load 10s
-			         http_requests{job="api-server", instance="0", group="production"}	0+10x1000 100+30x1000
-			         http_requests{job="api-server", instance="1", group="production"}	0+20x1000 200+30x1000
-			         http_requests{job="api-server", instance="0", group="canary"}		0+30x1000 300+80x1000
-			         http_requests{job="api-server", instance="1", group="canary"}		0+40x2000`,
-			cases: []testCase{
-				{ // Normal selector.
-					Query: `http_requests{group=~"pro.*",instance="0"}[30s:10s]`,
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 9990, T: 9990000}, {F: 10000, T: 10000000}, {F: 100, T: 10010000}, {F: 130, T: 10020000}},
-								Metric: labels.FromStrings("__name__", "http_requests", "job", "api-server", "instance", "0", "group", "production"),
-							},
-						},
+			Query: "metric[20s:5s]",
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 1, T: 0}, {F: 1, T: 5000}, {F: 2, T: 10000}},
+						Metric: labels.FromStrings("__name__", "metric"),
 					},
-					Start: time.Unix(10020, 0),
-				},
-				{ // Default step.
-					Query: `http_requests{group=~"pro.*",instance="0"}[5m:]`,
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 9840, T: 9840000}, {F: 9900, T: 9900000}, {F: 9960, T: 9960000}, {F: 130, T: 10020000}, {F: 310, T: 10080000}},
-								Metric: labels.FromStrings("__name__", "http_requests", "job", "api-server", "instance", "0", "group", "production"),
-							},
-						},
-					},
-					Start: time.Unix(10100, 0),
-				},
-				{ // Checking if high offset (>LookbackDelta) is being taken care of.
-					Query: `http_requests{group=~"pro.*",instance="0"}[5m:] offset 20m`,
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 8640, T: 8640000}, {F: 8700, T: 8700000}, {F: 8760, T: 8760000}, {F: 8820, T: 8820000}, {F: 8880, T: 8880000}},
-								Metric: labels.FromStrings("__name__", "http_requests", "job", "api-server", "instance", "0", "group", "production"),
-							},
-						},
-					},
-					Start: time.Unix(10100, 0),
-				},
-				{
-					Query: `rate(http_requests[1m])[15s:5s]`,
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats:   []promql.FPoint{{F: 3, T: 7985000}, {F: 3, T: 7990000}, {F: 3, T: 7995000}, {F: 3, T: 8000000}},
-								Metric:   labels.FromStrings("job", "api-server", "instance", "0", "group", "canary"),
-								DropName: true,
-							},
-							promql.Series{
-								Floats:   []promql.FPoint{{F: 4, T: 7985000}, {F: 4, T: 7990000}, {F: 4, T: 7995000}, {F: 4, T: 8000000}},
-								Metric:   labels.FromStrings("job", "api-server", "instance", "1", "group", "canary"),
-								DropName: true,
-							},
-							promql.Series{
-								Floats:   []promql.FPoint{{F: 1, T: 7985000}, {F: 1, T: 7990000}, {F: 1, T: 7995000}, {F: 1, T: 8000000}},
-								Metric:   labels.FromStrings("job", "api-server", "instance", "0", "group", "production"),
-								DropName: true,
-							},
-							promql.Series{
-								Floats:   []promql.FPoint{{F: 2, T: 7985000}, {F: 2, T: 7990000}, {F: 2, T: 7995000}, {F: 2, T: 8000000}},
-								Metric:   labels.FromStrings("job", "api-server", "instance", "1", "group", "production"),
-								DropName: true,
-							},
-						},
-					},
-					Start: time.Unix(8000, 0),
-				},
-				{
-					Query: `sum(http_requests{group=~"pro.*"})[30s:10s]`,
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 270, T: 90000}, {F: 300, T: 100000}, {F: 330, T: 110000}, {F: 360, T: 120000}},
-								Metric: labels.EmptyLabels(),
-							},
-						},
-					},
-					Start: time.Unix(120, 0),
-				},
-				{
-					Query: `sum(http_requests)[40s:10s]`,
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 800, T: 80000}, {F: 900, T: 90000}, {F: 1000, T: 100000}, {F: 1100, T: 110000}, {F: 1200, T: 120000}},
-								Metric: labels.EmptyLabels(),
-							},
-						},
-					},
-					Start: time.Unix(120, 0),
-				},
-				{
-					Query: `(sum(http_requests{group=~"p.*"})+sum(http_requests{group=~"c.*"}))[20s:5s]`,
-					Result: promql.Result{
-						Value: promql.Matrix{
-							promql.Series{
-								Floats: []promql.FPoint{{F: 1000, T: 100000}, {F: 1000, T: 105000}, {F: 1100, T: 110000}, {F: 1100, T: 115000}, {F: 1200, T: 120000}},
-								Metric: labels.EmptyLabels(),
-							},
-						},
-					},
-					Start: time.Unix(120, 0),
 				},
 			},
+			Start: time.Unix(10, 0),
+		},
+		{
+			Query: "metric[20s:5s] offset 2s",
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 1, T: 0}, {F: 1, T: 5000}, {F: 2, T: 10000}},
+						Metric: labels.FromStrings("__name__", "metric"),
+					},
+				},
+			},
+			Start: time.Unix(12, 0),
+		},
+		{
+			Query: "metric[20s:5s] offset 6s",
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 1, T: 0}, {F: 1, T: 5000}, {F: 2, T: 10000}},
+						Metric: labels.FromStrings("__name__", "metric"),
+					},
+				},
+			},
+			Start: time.Unix(20, 0),
+		},
+		{
+			Query: "metric[20s:5s] offset 4s",
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}, {F: 2, T: 30000}},
+						Metric: labels.FromStrings("__name__", "metric"),
+					},
+				},
+			},
+			Start: time.Unix(35, 0),
+		},
+		{
+			Query: "metric[20s:5s] offset 5s",
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 2, T: 10000}, {F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}, {F: 2, T: 30000}},
+						Metric: labels.FromStrings("__name__", "metric"),
+					},
+				},
+			},
+			Start: time.Unix(35, 0),
+		},
+		{
+			Query: "metric[20s:5s] offset 6s",
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 2, T: 10000}, {F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}},
+						Metric: labels.FromStrings("__name__", "metric"),
+					},
+				},
+			},
+			Start: time.Unix(35, 0),
+		},
+		{
+			Query: "metric[20s:5s] offset 7s",
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 2, T: 10000}, {F: 2, T: 15000}, {F: 2, T: 20000}, {F: 2, T: 25000}},
+						Metric: labels.FromStrings("__name__", "metric"),
+					},
+				},
+			},
+			Start: time.Unix(35, 0),
+		},
+		{ // Normal selector.
+			Query: `http_requests{group=~"pro.*",instance="0"}[30s:10s]`,
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 9990, T: 9990000}, {F: 10000, T: 10000000}, {F: 100, T: 10010000}, {F: 130, T: 10020000}},
+						Metric: labels.FromStrings("__name__", "http_requests", "job", "api-server", "instance", "0", "group", "production"),
+					},
+				},
+			},
+			Start: time.Unix(10020, 0),
+		},
+		{ // Default step.
+			Query: `http_requests{group=~"pro.*",instance="0"}[5m:]`,
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 9840, T: 9840000}, {F: 9900, T: 9900000}, {F: 9960, T: 9960000}, {F: 130, T: 10020000}, {F: 310, T: 10080000}},
+						Metric: labels.FromStrings("__name__", "http_requests", "job", "api-server", "instance", "0", "group", "production"),
+					},
+				},
+			},
+			Start: time.Unix(10100, 0),
+		},
+		{ // Checking if high offset (>LookbackDelta) is being taken care of.
+			Query: `http_requests{group=~"pro.*",instance="0"}[5m:] offset 20m`,
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 8640, T: 8640000}, {F: 8700, T: 8700000}, {F: 8760, T: 8760000}, {F: 8820, T: 8820000}, {F: 8880, T: 8880000}},
+						Metric: labels.FromStrings("__name__", "http_requests", "job", "api-server", "instance", "0", "group", "production"),
+					},
+				},
+			},
+			Start: time.Unix(10100, 0),
+		},
+		{
+			Query: `rate(http_requests[1m])[15s:5s]`,
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats:   []promql.FPoint{{F: 3, T: 7985000}, {F: 3, T: 7990000}, {F: 3, T: 7995000}, {F: 3, T: 8000000}},
+						Metric:   labels.FromStrings("job", "api-server", "instance", "0", "group", "canary"),
+						DropName: true,
+					},
+					promql.Series{
+						Floats:   []promql.FPoint{{F: 4, T: 7985000}, {F: 4, T: 7990000}, {F: 4, T: 7995000}, {F: 4, T: 8000000}},
+						Metric:   labels.FromStrings("job", "api-server", "instance", "1", "group", "canary"),
+						DropName: true,
+					},
+					promql.Series{
+						Floats:   []promql.FPoint{{F: 1, T: 7985000}, {F: 1, T: 7990000}, {F: 1, T: 7995000}, {F: 1, T: 8000000}},
+						Metric:   labels.FromStrings("job", "api-server", "instance", "0", "group", "production"),
+						DropName: true,
+					},
+					promql.Series{
+						Floats:   []promql.FPoint{{F: 2, T: 7985000}, {F: 2, T: 7990000}, {F: 2, T: 7995000}, {F: 2, T: 8000000}},
+						Metric:   labels.FromStrings("job", "api-server", "instance", "1", "group", "production"),
+						DropName: true,
+					},
+				},
+				Warnings: annotations.New().Add(annotations.NewPossibleNonCounterInfo("http_requests", posrange.PositionRange{Start: 5})),
+			},
+			Start: time.Unix(8000, 0),
+		},
+		{
+			Query: `sum(http_requests{group=~"pro.*"})[30s:10s]`,
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 270, T: 90000}, {F: 300, T: 100000}, {F: 330, T: 110000}, {F: 360, T: 120000}},
+						Metric: labels.EmptyLabels(),
+					},
+				},
+			},
+			Start: time.Unix(120, 0),
+		},
+		{
+			Query: `sum(http_requests)[40s:10s]`,
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 800, T: 80000}, {F: 900, T: 90000}, {F: 1000, T: 100000}, {F: 1100, T: 110000}, {F: 1200, T: 120000}},
+						Metric: labels.EmptyLabels(),
+					},
+				},
+			},
+			Start: time.Unix(120, 0),
+		},
+		{
+			Query: `(sum(http_requests{group=~"p.*"})+sum(http_requests{group=~"c.*"}))[20s:5s]`,
+			Result: promql.Result{
+				Value: promql.Matrix{
+					promql.Series{
+						Floats: []promql.FPoint{{F: 1000, T: 100000}, {F: 1000, T: 105000}, {F: 1100, T: 110000}, {F: 1100, T: 115000}, {F: 1200, T: 120000}},
+						Metric: labels.EmptyLabels(),
+					},
+				},
+			},
+			Start: time.Unix(120, 0),
 		},
 	}
 
-	for _, test := range tests {
-		opts := NewTestEngineOpts()
-		engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), log.NewNopLogger())
-		require.NoError(t, err)
-		storage := promqltest.LoadedStorage(t, test.load)
-		t.Cleanup(func() { storage.Close() })
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("%v evaluated at %v", testCase.Query, testCase.Start.Unix()), func(t *testing.T) {
+			qry, err := engine.NewInstantQuery(context.Background(), storage, nil, testCase.Query, testCase.Start)
+			require.NoError(t, err)
 
-		for _, testCase := range test.cases {
-			t.Run(testCase.Query, func(t *testing.T) {
-				qry, err := engine.NewInstantQuery(context.Background(), storage, nil, testCase.Query, testCase.Start)
-				require.NoError(t, err)
-
-				res := qry.Exec(context.Background())
-				testutils.RequireEqualResults(t, testCase.Query, &testCase.Result, res)
-			})
-		}
+			res := qry.Exec(context.Background())
+			testutils.RequireEqualResults(t, testCase.Query, &testCase.Result, res)
+		})
 	}
 }
 

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -50,7 +50,6 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 		"metric{} + on() group_right() other_metric{}": "binary expression with one-to-many matching",
 		"topk(5, metric{})":                            "'topk' aggregation with parameter",
 		`count_values("foo", metric{})`:                "'count_values' aggregation with parameter",
-		"rate(metric{}[5m:1m])":                        "subquery",
 		"quantile_over_time(0.4, metric{}[5m])":        "'quantile_over_time' function",
 		"quantile(0.95, metric{})":                     "'quantile' aggregation with parameter",
 	}
@@ -58,17 +57,6 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 	for expression, expectedError := range unsupportedExpressions {
 		t.Run(expression, func(t *testing.T) {
 			requireQueryIsUnsupported(t, featureToggles, expression, expectedError)
-		})
-	}
-
-	// These expressions are also unsupported, but are only valid as instant queries.
-	unsupportedInstantQueryExpressions := map[string]string{
-		"metric{}[5m:1m]": "subquery",
-	}
-
-	for expression, expectedError := range unsupportedInstantQueryExpressions {
-		t.Run(expression, func(t *testing.T) {
-			requireInstantQueryIsUnsupported(t, featureToggles, expression, expectedError)
 		})
 	}
 }

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -46,7 +46,7 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 		"metric{} + on() group_right() other_metric{}": "binary expression with one-to-many matching",
 		"topk(5, metric{})":                            "'topk' aggregation with parameter",
 		`count_values("foo", metric{})`:                "'count_values' aggregation with parameter",
-		"rate(metric{}[5m:1m])":                        "PromQL expression type *parser.SubqueryExpr for range vectors",
+		"rate(metric{}[5m:1m])":                        "subquery",
 		"quantile_over_time(0.4, metric{}[5m])":        "'quantile_over_time' function",
 		"quantile(0.95, metric{})":                     "'quantile' aggregation with parameter",
 	}
@@ -59,7 +59,7 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 
 	// These expressions are also unsupported, but are only valid as instant queries.
 	unsupportedInstantQueryExpressions := map[string]string{
-		"metric{}[5m:1m]": "PromQL expression type *parser.SubqueryExpr for range vectors",
+		"metric{}[5m:1m]": "subquery",
 	}
 
 	for expression, expectedError := range unsupportedInstantQueryExpressions {
@@ -152,6 +152,13 @@ func TestUnsupportedPromQLFeaturesWithFeatureToggles(t *testing.T) {
 		featureToggles.EnableScalars = false
 
 		requireQueryIsUnsupported(t, featureToggles, "2", "scalar values")
+	})
+
+	t.Run("subqueries", func(t *testing.T) {
+		featureToggles := EnableAllFeatures
+		featureToggles.EnableSubqueries = false
+
+		requireQueryIsUnsupported(t, featureToggles, "sum_over_time(metric[1m:10s])", "subquery")
 	})
 }
 

--- a/pkg/streamingpromql/functions/common.go
+++ b/pkg/streamingpromql/functions/common.go
@@ -73,8 +73,6 @@ func PassthroughData(seriesData types.InstantVectorSeriesData, _ []types.ScalarD
 type RangeVectorStepFunction func(
 	step types.RangeVectorStepData,
 	rangeSeconds float64,
-	floatBuffer *types.FPointRingBuffer,
-	histogramBuffer *types.HPointRingBuffer,
 	emitAnnotation EmitAnnotationFunc,
 ) (f float64, hasFloat bool, h *histogram.FloatHistogram, err error)
 

--- a/pkg/streamingpromql/functions/range_vectors.go
+++ b/pkg/streamingpromql/functions/range_vectors.go
@@ -21,9 +21,9 @@ var CountOverTime = FunctionOverRangeVector{
 	StepFunc:               countOverTime,
 }
 
-func countOverTime(step types.RangeVectorStepData, _ float64, fPoints *types.FPointRingBuffer, hPoints *types.HPointRingBuffer, _ EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	fPointCount := fPoints.CountAtOrBefore(step.RangeEnd)
-	hPointCount := hPoints.CountAtOrBefore(step.RangeEnd)
+func countOverTime(step types.RangeVectorStepData, _ float64, _ EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+	fPointCount := step.Floats.CountAtOrBefore(step.RangeEnd)
+	hPointCount := step.Histograms.CountAtOrBefore(step.RangeEnd)
 
 	if fPointCount == 0 && hPointCount == 0 {
 		return 0, false, nil, nil
@@ -37,9 +37,9 @@ var LastOverTime = FunctionOverRangeVector{
 	StepFunc: lastOverTime,
 }
 
-func lastOverTime(step types.RangeVectorStepData, _ float64, fPoints *types.FPointRingBuffer, hPoints *types.HPointRingBuffer, _ EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	lastFloat, floatAvailable := fPoints.LastAtOrBefore(step.RangeEnd)
-	lastHistogram, histogramAvailable := hPoints.LastAtOrBefore(step.RangeEnd)
+func lastOverTime(step types.RangeVectorStepData, _ float64, _ EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+	lastFloat, floatAvailable := step.Floats.LastAtOrBefore(step.RangeEnd)
+	lastHistogram, histogramAvailable := step.Histograms.LastAtOrBefore(step.RangeEnd)
 
 	if !floatAvailable && !histogramAvailable {
 		return 0, false, nil, nil
@@ -58,8 +58,8 @@ var PresentOverTime = FunctionOverRangeVector{
 	StepFunc:               presentOverTime,
 }
 
-func presentOverTime(step types.RangeVectorStepData, _ float64, fPoints *types.FPointRingBuffer, hPoints *types.HPointRingBuffer, _ EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	if fPoints.AnyAtOrBefore(step.RangeEnd) || hPoints.AnyAtOrBefore(step.RangeEnd) {
+func presentOverTime(step types.RangeVectorStepData, _ float64, _ EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+	if step.Floats.AnyAtOrBefore(step.RangeEnd) || step.Histograms.AnyAtOrBefore(step.RangeEnd) {
 		return 1, true, nil, nil
 	}
 
@@ -71,8 +71,8 @@ var MaxOverTime = FunctionOverRangeVector{
 	StepFunc:               maxOverTime,
 }
 
-func maxOverTime(step types.RangeVectorStepData, _ float64, fPoints *types.FPointRingBuffer, _ *types.HPointRingBuffer, _ EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	head, tail := fPoints.UnsafePoints(step.RangeEnd)
+func maxOverTime(step types.RangeVectorStepData, _ float64, _ EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+	head, tail := step.Floats.UnsafePoints(step.RangeEnd)
 
 	if len(head) == 0 && len(tail) == 0 {
 		return 0, false, nil, nil
@@ -108,8 +108,8 @@ var MinOverTime = FunctionOverRangeVector{
 	StepFunc:               minOverTime,
 }
 
-func minOverTime(step types.RangeVectorStepData, _ float64, fPoints *types.FPointRingBuffer, _ *types.HPointRingBuffer, _ EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	head, tail := fPoints.UnsafePoints(step.RangeEnd)
+func minOverTime(step types.RangeVectorStepData, _ float64, _ EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+	head, tail := step.Floats.UnsafePoints(step.RangeEnd)
 
 	if len(head) == 0 && len(tail) == 0 {
 		return 0, false, nil, nil
@@ -146,9 +146,9 @@ var SumOverTime = FunctionOverRangeVector{
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func sumOverTime(step types.RangeVectorStepData, _ float64, fPoints *types.FPointRingBuffer, hPoints *types.HPointRingBuffer, emitAnnotation EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	fHead, fTail := fPoints.UnsafePoints(step.RangeEnd)
-	hHead, hTail := hPoints.UnsafePoints(step.RangeEnd)
+func sumOverTime(step types.RangeVectorStepData, _ float64, emitAnnotation EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+	fHead, fTail := step.Floats.UnsafePoints(step.RangeEnd)
+	hHead, hTail := step.Histograms.UnsafePoints(step.RangeEnd)
 
 	haveFloats := len(fHead) > 0 || len(fTail) > 0
 	haveHistograms := len(hHead) > 0 || len(hTail) > 0
@@ -221,9 +221,9 @@ var AvgOverTime = FunctionOverRangeVector{
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func avgOverTime(step types.RangeVectorStepData, _ float64, fPoints *types.FPointRingBuffer, hPoints *types.HPointRingBuffer, emitAnnotation EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	fHead, fTail := fPoints.UnsafePoints(step.RangeEnd)
-	hHead, hTail := hPoints.UnsafePoints(step.RangeEnd)
+func avgOverTime(step types.RangeVectorStepData, _ float64, emitAnnotation EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+	fHead, fTail := step.Floats.UnsafePoints(step.RangeEnd)
+	hHead, hTail := step.Histograms.UnsafePoints(step.RangeEnd)
 
 	haveFloats := len(fHead) > 0 || len(fTail) > 0
 	haveHistograms := len(hHead) > 0 || len(hTail) > 0

--- a/pkg/streamingpromql/functions/rate_increase.go
+++ b/pkg/streamingpromql/functions/rate_increase.go
@@ -31,11 +31,11 @@ var Increase = FunctionOverRangeVector{
 
 // isRate is true for `rate` function, or false for `instant` function
 func rate(isRate bool) RangeVectorStepFunction {
-	return func(step types.RangeVectorStepData, rangeSeconds float64, floatBuffer *types.FPointRingBuffer, histogramBuffer *types.HPointRingBuffer, emitAnnotation EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-		fHead, fTail := floatBuffer.UnsafePoints(step.RangeEnd)
+	return func(step types.RangeVectorStepData, rangeSeconds float64, emitAnnotation EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+		fHead, fTail := step.Floats.UnsafePoints(step.RangeEnd)
 		fCount := len(fHead) + len(fTail)
 
-		hHead, hTail := histogramBuffer.UnsafePoints(step.RangeEnd)
+		hHead, hTail := step.Histograms.UnsafePoints(step.RangeEnd)
 		hCount := len(hHead) + len(hTail)
 
 		if fCount > 0 && hCount > 0 {
@@ -46,7 +46,7 @@ func rate(isRate bool) RangeVectorStepFunction {
 		}
 
 		if fCount >= 2 {
-			val := floatRate(isRate, fCount, floatBuffer, step, fHead, fTail, rangeSeconds)
+			val := floatRate(isRate, fCount, step.Floats, step, fHead, fTail, rangeSeconds)
 			return val, true, nil, nil
 		}
 

--- a/pkg/streamingpromql/operators/subquery.go
+++ b/pkg/streamingpromql/operators/subquery.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package operators
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+type Subquery struct {
+	Inner                types.InstantVectorOperator
+	ParentQueryTimeRange types.QueryTimeRange
+
+	SubqueryTimestamp *int64 // Milliseconds since Unix epoch, only set if selector uses @ modifier (eg. metric{...} @ 123)
+	SubqueryOffset    int64  // In milliseconds
+	SubqueryRange     time.Duration
+
+	expressionPosition posrange.PositionRange
+
+	nextStepT         int64
+	rangeMilliseconds int64
+	floats            *types.FPointRingBuffer
+	histograms        *types.HPointRingBuffer
+}
+
+var _ types.RangeVectorOperator = &Subquery{}
+
+func NewSubquery(
+	inner types.InstantVectorOperator,
+	parentQueryTimeRange types.QueryTimeRange,
+	subqueryTimestamp *int64,
+	subqueryOffset time.Duration,
+	subqueryRange time.Duration,
+	expressionPosition posrange.PositionRange,
+	memoryConsumptionTracker *limiting.MemoryConsumptionTracker,
+) *Subquery {
+	return &Subquery{
+		Inner:                inner,
+		ParentQueryTimeRange: parentQueryTimeRange,
+		SubqueryTimestamp:    subqueryTimestamp,
+		SubqueryOffset:       subqueryOffset.Milliseconds(),
+		SubqueryRange:        subqueryRange,
+		expressionPosition:   expressionPosition,
+		rangeMilliseconds:    subqueryRange.Milliseconds(),
+		floats:               types.NewFPointRingBuffer(memoryConsumptionTracker),
+		histograms:           types.NewHPointRingBuffer(memoryConsumptionTracker),
+	}
+}
+
+func (s *Subquery) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
+	return s.Inner.SeriesMetadata(ctx)
+}
+
+func (s *Subquery) NextSeries(ctx context.Context) error {
+	// Release the previous series' slices now, so we are likely to reuse the slices for the next series.
+	s.floats.Release()
+	s.histograms.Release()
+
+	data, err := s.Inner.NextSeries(ctx)
+	if err != nil {
+		return err
+	}
+
+	s.nextStepT = s.ParentQueryTimeRange.StartT
+	s.floats.Use(data.Floats)
+	s.histograms.Use(data.Histograms)
+	return nil
+}
+
+func (s *Subquery) NextStepSamples() (types.RangeVectorStepData, error) {
+	if s.nextStepT > s.ParentQueryTimeRange.EndT {
+		return types.RangeVectorStepData{}, types.EOS
+	}
+
+	stepT := s.nextStepT
+	rangeEnd := stepT
+
+	if s.SubqueryTimestamp != nil {
+		// Timestamp from @ modifier takes precedence over query evaluation timestamp.
+		rangeEnd = *s.SubqueryTimestamp
+	}
+
+	// Apply offset after adjusting for timestamp from @ modifier.
+	rangeEnd = rangeEnd - s.SubqueryOffset
+	rangeStart := rangeEnd - s.rangeMilliseconds
+	s.floats.DiscardPointsBefore(rangeStart)
+	s.histograms.DiscardPointsBefore(rangeStart)
+
+	s.nextStepT += s.ParentQueryTimeRange.IntervalMilliseconds
+
+	return types.RangeVectorStepData{
+		Floats:     s.floats,
+		Histograms: s.histograms,
+		StepT:      stepT,
+		RangeStart: rangeStart,
+		RangeEnd:   rangeEnd,
+	}, nil
+}
+
+func (s *Subquery) StepCount() int {
+	return s.ParentQueryTimeRange.StepCount
+}
+
+func (s *Subquery) Range() time.Duration {
+	return s.SubqueryRange
+}
+
+func (s *Subquery) ExpressionPosition() posrange.PositionRange {
+	return s.expressionPosition
+}
+
+func (s *Subquery) Close() {
+	s.Inner.Close()
+	s.histograms.Close()
+	s.floats.Close()
+}

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -326,6 +326,10 @@ func (q *Query) convertToRangeVectorOperator(expr parser.Expr) (types.RangeVecto
 				ExpressionPosition: e.PositionRange(),
 			},
 		}, nil
+
+	case *parser.SubqueryExpr:
+		return nil, compat.NewNotSupportedError("subquery")
+
 	case *parser.StepInvariantExpr:
 		// One day, we'll do something smarter here.
 		return q.convertToRangeVectorOperator(e.Expr)

--- a/pkg/streamingpromql/testdata/ours/subqueries.test
+++ b/pkg/streamingpromql/testdata/ours/subqueries.test
@@ -112,3 +112,18 @@ eval_warn range from 0 to 5m step 1m sum_over_time(last_over_time(metric[2m:1m])
   {type="histograms"} {{count:0}} {{count:0}} {{count:4}} {{count:10}} {{count:10}} {{count:9}}
   {type="mixed"} 0 0 4 10 10 _
   # Last sample for {type="mixed"} dropped due to mixture of floats and histograms
+
+clear
+
+# Test deeply nested subquery with changing step.
+load 1m
+  metric 0 1 2 3 4
+
+eval range from 0 to 4m step 15s sum_over_time(metric[2m:30s])
+  {} 0 0 0 0 1 1 2 2 4 4 6 6 9 8 11 10 14
+
+eval range from 0 to 4m step 20s sum_over_time(sum_over_time(metric[2m:30s])[3m:15s])
+  {} 0 0 0 1 2 4 10 14 20 35 43 54 78
+
+eval range from 0 to 4m step 3m sum_over_time(sum_over_time(sum_over_time(metric[2m:30s])[3m:15s])[4m:20s])
+  {} 0 86

--- a/pkg/streamingpromql/testdata/ours/subqueries.test
+++ b/pkg/streamingpromql/testdata/ours/subqueries.test
@@ -4,76 +4,111 @@
 # These test cases cover scenarios not covered by the upstream test cases, such as range queries, or edge cases that are uniquely likely to cause issues in the streaming engine.
 
 load 1m
-  metric 0 4 3 6 -1 10
+  metric{type="floats"} 0 4 3 6 -1 10
+  metric{type="histograms"} {{count:0}} {{count:4}} {{count:3}} {{count:6}} {{count:-1}} {{count:10}}
+  metric{type="mixed"} 0 4 3 6 {{count:-1}} {{count:10}}
 
 # Test that both ends of the time range selected are inclusive.
 eval instant at 4m59s count_over_time(metric[4m:30s])
-  {} 8
+  {type="floats"} 8
+  {type="histograms"} 8
+  {type="mixed"} 8
 
 eval instant at 5m count_over_time(metric[4m:30s])
-  {} 9
+  {type="floats"} 9
+  {type="histograms"} 9
+  {type="mixed"} 9
 
 eval instant at 5m count_over_time(metric[3m59s:30s])
-  {} 8
+  {type="floats"} 8
+  {type="histograms"} 8
+  {type="mixed"} 8
 
 eval range from 4m59s to 5m step 1s count_over_time(metric[4m:30s])
-  {} 8 9
+  {type="floats"} 8 9
+  {type="histograms"} 8 9
+  {type="mixed"} 8 9
 
 eval range from 5m to 5m1s step 1s count_over_time(metric[3m59s:30s])
-  {} 8 8
+  {type="floats"} 8 8
+  {type="histograms"} 8 8
+  {type="mixed"} 8 8
 
 # Evaluation step should be aligned to T=0, not the query evaluation time.
-eval instant at 5m max_over_time(metric[4m:3m])
-  {} 6
+eval instant at 5m last_over_time(metric[4m:3m])
+  metric{type="floats"} 6
+  metric{type="histograms"} {{count:6}}
+  metric{type="mixed"} 6
 
-eval range from 0 to 14m step 1m max_over_time(metric[4m:3m])
-  {} 0 0 0 6 6 6 10 10 10 10 10 10 10 10 _
+eval range from 0 to 14m step 1m last_over_time(metric[4m:3m])
+  metric{type="floats"} 0 0 0 6 6 6 10 10 10 10 10 10 10 10 _
+  metric{type="histograms"} {{count:0}} {{count:0}} {{count:0}} {{count:6}} {{count:6}} {{count:6}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} _
+  metric{type="mixed"} 0 0 0 6 6 6 {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} _
 
 # Subquery with @
-eval instant at 5m max_over_time(metric[2m:1m] @ 1m)
-  {} 4
+eval instant at 5m last_over_time(metric[2m:1m] @ 1m)
+  metric{type="floats"} 4
+  metric{type="histograms"} {{count:4}}
+  metric{type="mixed"} 4
 
-eval range from 0 to 5m step 1m max_over_time(metric[2m:1m] @ 1m)
-  {} 4 4 4 4 4 4
+eval range from 0 to 5m step 1m last_over_time(metric[2m:1m] @ 1m)
+  metric{type="floats"} 4 4 4 4 4 4
+  metric{type="histograms"} {{count:4}} {{count:4}} {{count:4}} {{count:4}} {{count:4}} {{count:4}}
+  metric{type="mixed"} 4 4 4 4 4 4
 
-eval instant at 4m max_over_time(metric[2m:1m] @ start())
-  {} 6
+# Instant queries with @ start() and @ end() are exercised in TestSubqueries, as the range mode of 'eval instant'
+# alters the start timestamp, making testing this here impossible.
+eval range from 0 to 5m step 1m last_over_time(metric[2m:1m] @ start())
+  metric{type="floats"} 0 0 0 0 0 0
+  metric{type="histograms"} {{count:0}} {{count:0}} {{count:0}} {{count:0}} {{count:0}} {{count:0}}
+  metric{type="mixed"} 0 0 0 0 0 0
 
-eval range from 0 to 5m step 1m max_over_time(metric[2m:1m] @ start())
-  {} 0 0 0 0 0 0
-
-eval instant at 3m max_over_time(metric[2m:1m] @ end())
-  {} 6
-
-eval range from 0 to 5m step 1m max_over_time(metric[2m:1m] @ end())
-  {} 10 10 10 10 10 10
+eval range from 0 to 5m step 1m last_over_time(metric[2m:1m] @ end())
+  metric{type="floats"} 10 10 10 10 10 10
+  metric{type="histograms"} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}}
+  metric{type="mixed"} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}} {{count:10}}
 
 # Subquery with 'offset'
 # Start with query without offset to show non-offset results
-eval range from 0 to 5m step 1m max_over_time(metric[2m:1m])
-  {} 0 4 4 6 6 10
+eval range from 0 to 5m step 1m last_over_time(metric[2m:1m])
+  metric{type="floats"} 0 4 3 6 -1 10
+  metric{type="histograms"} {{count:0}} {{count:4}} {{count:3}} {{count:6}} {{count:-1}} {{count:10}}
+  metric{type="mixed"} 0 4 3 6 {{count:-1}} {{count:10}}
 
-eval instant at 5m max_over_time(metric[2m:1m] offset 1m)
-  {} 6
+eval instant at 5m last_over_time(metric[2m:1m] offset 1m)
+  metric{type="floats"} -1
+  metric{type="histograms"} {{count:-1}}
+  metric{type="mixed"} {{count:-1}}
 
-eval range from 0 to 5m step 1m max_over_time(metric[2m:1m] offset 1m)
-  {} _ 0 4 4 6 6
+eval range from 0 to 5m step 1m last_over_time(metric[2m:1m] offset 1m)
+  metric{type="floats"} _ 0 4 3 6 -1
+  metric{type="histograms"} _ {{count:0}} {{count:4}} {{count:3}} {{count:6}} {{count:-1}}
+  metric{type="mixed"} _ 0 4 3 6 {{count:-1}}
 
 # Subquery range smaller than subquery step
-eval instant at 5m max_over_time(metric[1m:2m])
-  {} -1
+eval instant at 5m last_over_time(metric[1m:2m])
+  metric{type="floats"} -1
+  metric{type="histograms"} {{count:-1}}
+  metric{type="mixed"} {{count:-1}}
 
-eval range from 0 to 5m step 1m max_over_time(metric[1m:2m])
-  {} 0 0 3 3 -1 -1
+eval range from 0 to 5m step 1m last_over_time(metric[1m:2m])
+  metric{type="floats"} 0 0 3 3 -1 -1
+  metric{type="histograms"} {{count:0}} {{count:0}} {{count:3}} {{count:3}} {{count:-1}} {{count:-1}}
+  metric{type="mixed"} 0 0 3 3 {{count:-1}} {{count:-1}}
 
 # Nesting
 #
-# max_over_time[2m:1m] produces these results:
+# last_over_time[2m:1m] produces these results:
 # T=0m     T=1m     T=2m     T=3m     T=4m     T=5m
-# 0        4        4        6        6        10
+# 0        4        3        6        -1       10
 
-eval instant at 5m sum_over_time(max_over_time(metric[2m:1m])[5m:90s])
-  {} 16
+eval_warn instant at 5m sum_over_time(last_over_time(metric[2m:1m])[5m:90s])
+  {type="floats"} 9
+  {type="histograms"} {{count:9}}
+  # No results for {type="mixed"} due to mixture of floats and histograms
 
-eval range from 0 to 5m step 1m sum_over_time(max_over_time(metric[2m:1m])[5m:90s])
-  {} 0 0 4 10 10 16
+eval_warn range from 0 to 5m step 1m sum_over_time(last_over_time(metric[2m:1m])[5m:90s])
+  {type="floats"} 0 0 4 10 10 9
+  {type="histograms"} {{count:0}} {{count:0}} {{count:4}} {{count:10}} {{count:10}} {{count:9}}
+  {type="mixed"} 0 0 4 10 10 _
+  # Last sample for {type="mixed"} dropped due to mixture of floats and histograms

--- a/pkg/streamingpromql/testdata/ours/subqueries.test
+++ b/pkg/streamingpromql/testdata/ours/subqueries.test
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Most cases for functions are covered already in the upstream test cases.
+# These test cases cover scenarios not covered by the upstream test cases, such as range queries, or edge cases that are uniquely likely to cause issues in the streaming engine.
+
+load 1m
+  metric 0 4 3 6 -1 10
+
+# Test that both ends of the time range selected are inclusive.
+eval instant at 4m59s count_over_time(metric[4m:30s])
+  {} 8
+
+eval instant at 5m count_over_time(metric[4m:30s])
+  {} 9
+
+eval instant at 5m count_over_time(metric[3m59s:30s])
+  {} 8
+
+eval range from 4m59s to 5m step 1s count_over_time(metric[4m:30s])
+  {} 8 9
+
+eval range from 5m to 5m1s step 1s count_over_time(metric[3m59s:30s])
+  {} 8 8
+
+# Evaluation step should be aligned to T=0, not the query evaluation time.
+eval instant at 5m max_over_time(metric[4m:3m])
+  {} 6
+
+eval range from 0 to 14m step 1m max_over_time(metric[4m:3m])
+  {} 0 0 0 6 6 6 10 10 10 10 10 10 10 10 _
+
+# Subquery with @
+eval instant at 5m max_over_time(metric[2m:1m] @ 1m)
+  {} 4
+
+eval range from 0 to 5m step 1m max_over_time(metric[2m:1m] @ 1m)
+  {} 4 4 4 4 4 4
+
+eval instant at 4m max_over_time(metric[2m:1m] @ start())
+  {} 6
+
+eval range from 0 to 5m step 1m max_over_time(metric[2m:1m] @ start())
+  {} 0 0 0 0 0 0
+
+eval instant at 3m max_over_time(metric[2m:1m] @ end())
+  {} 6
+
+eval range from 0 to 5m step 1m max_over_time(metric[2m:1m] @ end())
+  {} 10 10 10 10 10 10
+
+# Subquery with 'offset'
+# Start with query without offset to show non-offset results
+eval range from 0 to 5m step 1m max_over_time(metric[2m:1m])
+  {} 0 4 4 6 6 10
+
+eval instant at 5m max_over_time(metric[2m:1m] offset 1m)
+  {} 6
+
+eval range from 0 to 5m step 1m max_over_time(metric[2m:1m] offset 1m)
+  {} _ 0 4 4 6 6
+
+# Subquery range smaller than subquery step
+eval instant at 5m max_over_time(metric[1m:2m])
+  {} -1
+
+eval range from 0 to 5m step 1m max_over_time(metric[1m:2m])
+  {} 0 0 3 3 -1 -1
+
+# Nesting
+#
+# max_over_time[2m:1m] produces these results:
+# T=0m     T=1m     T=2m     T=3m     T=4m     T=5m
+# 0        4        4        6        6        10
+
+eval instant at 5m sum_over_time(max_over_time(metric[2m:1m])[5m:90s])
+  {} 16
+
+eval range from 0 to 5m step 1m sum_over_time(max_over_time(metric[2m:1m])[5m:90s])
+  {} 0 0 4 10 10 16

--- a/pkg/streamingpromql/testdata/upstream/aggregators.test
+++ b/pkg/streamingpromql/testdata/upstream/aggregators.test
@@ -219,9 +219,8 @@ load 5m
   http_requests{job="api-server", instance="1", group="production"} 0+1.33x10
   http_requests{job="api-server", instance="0", group="canary"} 0+1.33x10
 
-# Unsupported by streaming engine.
-# eval instant at 50m stddev(http_requests)
-#   {} 0.0
+eval instant at 50m stddev(http_requests)
+  {} 0.0
 
 eval instant at 50m stdvar(http_requests)
   {} 0.0
@@ -458,11 +457,10 @@ load 10s
 	data{test="uneven samples",point="c"} 4
 	foo .8
 
-# Unsupported by streaming engine.
-# eval instant at 1m group without(point)(data)
-# 	{test="two samples"} 1
-# 	{test="three samples"} 1
-# 	{test="uneven samples"} 1
+eval instant at 1m group without(point)(data)
+	{test="two samples"} 1
+	{test="three samples"} 1
+	{test="uneven samples"} 1
 
 eval instant at 1m group(foo)
 	{} 1

--- a/pkg/streamingpromql/testdata/upstream/at_modifier.test
+++ b/pkg/streamingpromql/testdata/upstream/at_modifier.test
@@ -107,57 +107,49 @@ eval instant at 25s sum_over_time(metric{job="1"}[100] @ 100) + label_replace(su
 # Subqueries.
 
 # 10*(1+2+...+9) + 10.
-# Unsupported by streaming engine.
-# eval instant at 25s sum_over_time(metric{job="1"}[100s:1s] @ 100)
-#   {job="1"} 460
+eval instant at 25s sum_over_time(metric{job="1"}[100s:1s] @ 100)
+  {job="1"} 460
 
 # 10*(1+2+...+7) + 8.
-# Unsupported by streaming engine.
-# eval instant at 25s sum_over_time(metric{job="1"}[100s:1s] @ 100 offset 20s)
-#   {job="1"} 288
+eval instant at 25s sum_over_time(metric{job="1"}[100s:1s] @ 100 offset 20s)
+  {job="1"} 288
 
 # 10*(1+2+...+7) + 8.
-# Unsupported by streaming engine.
-# eval instant at 25s sum_over_time(metric{job="1"}[100s:1s] offset 20s @ 100)
-#   {job="1"} 288
+eval instant at 25s sum_over_time(metric{job="1"}[100s:1s] offset 20s @ 100)
+  {job="1"} 288
 
 # 10*(1+2+...+7) + 8.
-# Unsupported by streaming engine.
-# eval instant at 25s sum_over_time(metric{job="1"}[100:1] offset 20 @ 100)
-#   {job="1"} 288
+eval instant at 25s sum_over_time(metric{job="1"}[100:1] offset 20 @ 100)
+  {job="1"} 288
 
 # Subquery with different timestamps.
 
 # Since vector selector has timestamp, the result value does not depend on the timestamp of subqueries.
 # Inner most sum=1+2+...+10=55.
 # With [100s:25s] subquery, it's 55*5.
-# Unsupported by streaming engine.
-# eval instant at 100s sum_over_time(sum_over_time(metric{job="1"}[100s] @ 100)[100s:25s] @ 50)
-#   {job="1"} 275
+eval instant at 100s sum_over_time(sum_over_time(metric{job="1"}[100s] @ 100)[100s:25s] @ 50)
+  {job="1"} 275
 
 # Nested subqueries with different timestamps on both.
 
 # Since vector selector has timestamp, the result value does not depend on the timestamp of subqueries.
 # Sum of innermost subquery is 275 as above. The outer subquery repeats it 4 times.
-# Unsupported by streaming engine.
-# eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[100s] @ 100)[100s:25s] @ 50)[3s:1s] @ 3000)
-#   {job="1"} 1100
+eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[100s] @ 100)[100s:25s] @ 50)[3s:1s] @ 3000)
+  {job="1"} 1100
 
 # Testing the inner subquery timestamp since vector selector does not have @.
 
 # Inner sum for subquery [100s:25s] @ 50 are
 #   at -50 nothing, at -25 nothing, at 0=0, at 25=2, at 50=4+5=9.
 # This sum of 11 is repeated 4 times by outer subquery.
-# Unsupported by streaming engine.
-# eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[10s])[100s:25s] @ 50)[3s:1s] @ 200)
-#   {job="1"} 44
+eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[10s])[100s:25s] @ 50)[3s:1s] @ 200)
+  {job="1"} 44
 
 # Inner sum for subquery [100s:25s] @ 200 are
 #   at 100=9+10, at 125=12, at 150=14+15, at 175=17, at 200=19+20.
 # This sum of 116 is repeated 4 times by outer subquery.
-# Unsupported by streaming engine.
-# eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[10s])[100s:25s] @ 200)[3s:1s] @ 50)
-#   {job="1"} 464
+eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[10s])[100s:25s] @ 200)[3s:1s] @ 50)
+  {job="1"} 464
 
 # Nested subqueries with timestamp only on outer subquery.
 # Outer most subquery:
@@ -171,9 +163,8 @@ eval instant at 25s sum_over_time(metric{job="1"}[100] @ 100) + label_replace(su
 #     inner subquery: at 945=94+93, at 955=95+94, at 965=96+95
 #   at 1000=873
 #     inner subquery: at 970=97+96+95, at 980=98+97+96, at 990=99+98+97
-# Unsupported by streaming engine.
-# eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[20s])[20s:10s] offset 10s)[100s:25s] @ 1000)
-#   {job="1"} 3588
+eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[20s])[20s:10s] offset 10s)[100s:25s] @ 1000)
+  {job="1"} 3588
 
 # minute is counted on the value of the sample.
 # Unsupported by streaming engine.

--- a/pkg/streamingpromql/testdata/upstream/functions.test
+++ b/pkg/streamingpromql/testdata/upstream/functions.test
@@ -1249,8 +1249,7 @@ eval instant at 1m present_over_time(http_requests{handler!="/foo"}[5m])
 
 eval instant at 1m present_over_time(http_requests{handler="/foo", handler="/bar", handler="/foobar"}[5m])
 
-# Unsupported by streaming engine.
-# eval instant at 1m present_over_time(rate(nonexistant[5m])[5m:])
+eval instant at 1m present_over_time(rate(nonexistant[5m])[5m:])
 
 eval instant at 1m present_over_time(http_requests{handler="/foo", handler="/bar", instance="127.0.0.1"}[5m])
 
@@ -1265,10 +1264,9 @@ eval instant at 5m present_over_time(http_requests[5m])
     {instance="127.0.0.1", job="httpd", path="/bar"} 1
     {instance="127.0.0.1", job="httpd", path="/foo"} 1
 
-# Unsupported by streaming engine.
-# eval instant at 5m present_over_time(rate(http_requests[5m])[5m:1m])
-#     {instance="127.0.0.1", job="httpd", path="/bar"} 1
-#     {instance="127.0.0.1", job="httpd", path="/foo"} 1
+eval instant at 5m present_over_time(rate(http_requests[5m])[5m:1m])
+    {instance="127.0.0.1", job="httpd", path="/bar"} 1
+    {instance="127.0.0.1", job="httpd", path="/foo"} 1
 
 eval instant at 0m present_over_time(httpd_log_lines_total[30s])
     {instance="127.0.0.1",job="node"} 1
@@ -1293,8 +1291,7 @@ eval instant at 16m present_over_time({instance="127.0.0.1"}[5m])
 
 eval instant at 21m present_over_time({job="grok"}[20m])
 
-# Unsupported by streaming engine.
-# eval instant at 30m present_over_time({instance="127.0.0.1"}[5m:5s])
+eval instant at 30m present_over_time({instance="127.0.0.1"}[5m:5s])
 
 eval instant at 5m present_over_time({job="ingress"}[4m])
     {job="ingress"} 1

--- a/pkg/streamingpromql/testdata/upstream/native_histograms.test
+++ b/pkg/streamingpromql/testdata/upstream/native_histograms.test
@@ -1146,10 +1146,8 @@ clear
 load 1m
     histogram_sum_over_time {{schema:0 count:25 sum:1234.5 z_bucket:4 z_bucket_w:0.001 buckets:[1 2 0 1 1] n_buckets:[2 4 0 0 1 9]}} {{schema:0 count:41 sum:2345.6 z_bucket:5 z_bucket_w:0.001 buckets:[1 3 1 2 1 1 1] n_buckets:[0 1 4 2 7 0 0 0 0 5 5 2]}} {{schema:0 count:41 sum:1111.1 z_bucket:5 z_bucket_w:0.001 buckets:[1 3 1 2 1 1 1] n_buckets:[0 1 4 2 7 0 0 0 0 5 5 2]}} {{schema:1 count:0}}
 
-# Unsupported by streaming engine.
-# eval instant at 3m sum_over_time(histogram_sum_over_time[3m:1m])
-#     {} {{schema:0 count:107 sum:4691.2 z_bucket:14 z_bucket_w:0.001 buckets:[3 8 2 5 3 2 2] n_buckets:[2 6 8 4 15 9 0 0 0 10 10 4]}}
+eval instant at 3m sum_over_time(histogram_sum_over_time[3m:1m])
+    {} {{schema:0 count:107 sum:4691.2 z_bucket:14 z_bucket_w:0.001 buckets:[3 8 2 5 3 2 2] n_buckets:[2 6 8 4 15 9 0 0 0 10 10 4]}}
 
-# Unsupported by streaming engine.
-# eval instant at 3m avg_over_time(histogram_sum_over_time[3m:1m])
-#     {} {{schema:0 count:26.75 sum:1172.8 z_bucket:3.5 z_bucket_w:0.001 buckets:[0.75 2 0.5 1.25 0.75 0.5 0.5] n_buckets:[0.5 1.5 2 1 3.75 2.25 0 0 0 2.5 2.5 1]}}
+eval instant at 3m avg_over_time(histogram_sum_over_time[3m:1m])
+    {} {{schema:0 count:26.75 sum:1172.8 z_bucket:3.5 z_bucket_w:0.001 buckets:[0.75 2 0.5 1.25 0.75 0.5 0.5] n_buckets:[0.5 1.5 2 1 3.75 2.25 0 0 0 2.5 2.5 1]}}

--- a/pkg/streamingpromql/testdata/upstream/subquery.test
+++ b/pkg/streamingpromql/testdata/upstream/subquery.test
@@ -7,32 +7,26 @@ load 10s
   metric 1 2
 
 # Evaluation before 0s gets no sample.
-# Unsupported by streaming engine.
-# eval instant at 10s sum_over_time(metric[50s:10s])
-#   {} 3
+eval instant at 10s sum_over_time(metric[50s:10s])
+  {} 3
 
-# Unsupported by streaming engine.
-# eval instant at 10s sum_over_time(metric[50s:5s])
-#   {} 4
+eval instant at 10s sum_over_time(metric[50s:5s])
+  {} 4
 
 # Every evaluation yields the last value, i.e. 2
-# Unsupported by streaming engine.
-# eval instant at 5m sum_over_time(metric[50s:10s])
-#   {} 12
+eval instant at 5m sum_over_time(metric[50s:10s])
+  {} 12
 
 # Series becomes stale at 5m10s (5m after last sample)
 # Hence subquery gets a single sample at 6m-50s=5m10s.
-# Unsupported by streaming engine.
-# eval instant at 6m sum_over_time(metric[50s:10s])
-#   {} 2
+eval instant at 6m sum_over_time(metric[50s:10s])
+  {} 2
 
-# Unsupported by streaming engine.
-# eval instant at 10s rate(metric[20s:10s])
-#   {} 0.1
+eval instant at 10s rate(metric[20s:10s])
+  {} 0.1
 
-# Unsupported by streaming engine.
-# eval instant at 20s rate(metric[20s:5s])
-#   {} 0.05
+eval instant at 20s rate(metric[20s:5s])
+  {} 0.05
 
 clear
 
@@ -42,17 +36,15 @@ load 10s
   http_requests{job="api-server", instance="0", group="canary"}  0+30x1000 300+80x1000
   http_requests{job="api-server", instance="1", group="canary"}  0+40x2000
 
-# Unsupported by streaming engine.
-# eval instant at 8000s rate(http_requests{group=~"pro.*"}[1m:10s])
-#   {job="api-server", instance="0", group="production"} 1
-#   {job="api-server", instance="1", group="production"} 2
+eval instant at 8000s rate(http_requests{group=~"pro.*"}[1m:10s])
+  {job="api-server", instance="0", group="production"} 1
+  {job="api-server", instance="1", group="production"} 2
 
-# Unsupported by streaming engine.
-# eval instant at 20000s avg_over_time(rate(http_requests[1m])[1m:1s])
-#   {job="api-server", instance="0", group="canary"}     8
-#   {job="api-server", instance="1", group="canary"}     4
-#   {job="api-server", instance="1", group="production"} 3
-#   {job="api-server", instance="0", group="production"} 3
+eval instant at 20000s avg_over_time(rate(http_requests[1m])[1m:1s])
+  {job="api-server", instance="0", group="canary"}     8
+  {job="api-server", instance="1", group="canary"}     4
+  {job="api-server", instance="1", group="production"} 3
+  {job="api-server", instance="0", group="production"} 3
 
 clear
 
@@ -61,78 +53,61 @@ load 10s
   metric2 0+2x1000
   metric3 0+3x1000
 
-# Unsupported by streaming engine.
-# eval instant at 1000s sum_over_time(metric1[30s:10s])
-#   {} 394
+eval instant at 1000s sum_over_time(metric1[30s:10s])
+  {} 394
 
 # This is (394*2 - 100), because other than the last 100 at 1000s,
 # everything else is repeated with the 5s step.
-# Unsupported by streaming engine.
-# eval instant at 1000s sum_over_time(metric1[30s:5s])
-#   {} 688
+eval instant at 1000s sum_over_time(metric1[30s:5s])
+  {} 688
 
 # Offset is aligned with the step.
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time(metric1[30s:10s] offset 10s)
-#   {} 394
+eval instant at 1010s sum_over_time(metric1[30s:10s] offset 10s)
+  {} 394
 
 # Same result for different offsets due to step alignment.
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time(metric1[30s:10s] offset 9s)
-#   {} 297
+eval instant at 1010s sum_over_time(metric1[30s:10s] offset 9s)
+  {} 297
 
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time(metric1[30s:10s] offset 7s)
-#   {} 297
+eval instant at 1010s sum_over_time(metric1[30s:10s] offset 7s)
+  {} 297
 
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time(metric1[30s:10s] offset 5s)
-#   {} 297
+eval instant at 1010s sum_over_time(metric1[30s:10s] offset 5s)
+  {} 297
 
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time(metric1[30s:10s] offset 3s)
-#   {} 297
+eval instant at 1010s sum_over_time(metric1[30s:10s] offset 3s)
+  {} 297
 
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time((metric1)[30s:10s] offset 3s)
-#   {} 297
+eval instant at 1010s sum_over_time((metric1)[30s:10s] offset 3s)
+  {} 297
 
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time(metric1[30:10] offset 3)
-#   {} 297
+eval instant at 1010s sum_over_time(metric1[30:10] offset 3)
+  {} 297
 
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time((metric1)[30:10s] offset 3s)
-#   {} 297
+eval instant at 1010s sum_over_time((metric1)[30:10s] offset 3s)
+  {} 297
 
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time((metric1)[30:10s] offset 3s)
-#   {} 297
+eval instant at 1010s sum_over_time((metric1)[30:10s] offset 3s)
+  {} 297
 
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time((metric1)[30:10] offset 3s)
-#   {} 297
+eval instant at 1010s sum_over_time((metric1)[30:10] offset 3s)
+  {} 297
 
-# Unsupported by streaming engine.
-# eval instant at 1010s sum_over_time((metric1)[30:10] offset 3)
-#   {} 297
+eval instant at 1010s sum_over_time((metric1)[30:10] offset 3)
+  {} 297
 
 # Nested subqueries
-# Unsupported by streaming engine.
-# eval instant at 1000s rate(sum_over_time(metric1[30s:10s])[50s:10s])
-#   {} 0.4
+eval instant at 1000s rate(sum_over_time(metric1[30s:10s])[50s:10s])
+  {} 0.4
 
-# Unsupported by streaming engine.
-# eval instant at 1000s rate(sum_over_time(metric2[30s:10s])[50s:10s])
-#   {} 0.8
+eval instant at 1000s rate(sum_over_time(metric2[30s:10s])[50s:10s])
+  {} 0.8
 
-# Unsupported by streaming engine.
-# eval instant at 1000s rate(sum_over_time(metric3[30s:10s])[50s:10s])
-#   {} 1.2
+eval instant at 1000s rate(sum_over_time(metric3[30s:10s])[50s:10s])
+  {} 1.2
 
-# Unsupported by streaming engine.
-# eval instant at 1000s rate(sum_over_time((metric1+metric2+metric3)[30s:10s])[30s:10s])
-#   {} 2.4
+eval instant at 1000s rate(sum_over_time((metric1+metric2+metric3)[30s:10s])[30s:10s])
+  {} 2.4
 
 clear
 
@@ -146,20 +121,17 @@ eval instant at 80s rate(metric[1m])
   {} 2.517857143
 
 # No extrapolation, [2@20, 144@80]: (144 - 2) / 60
-# Unsupported by streaming engine.
-# eval instant at 80s rate(metric[1m:10s])
-#   {} 2.366666667
+eval instant at 80s rate(metric[1m:10s])
+  {} 2.366666667
 
 # Only one value between 10s and 20s, 2@14
 eval instant at 20s min_over_time(metric[10s])
   {} 2
 
 # min(1@10, 2@20)
-# Unsupported by streaming engine.
-# eval instant at 20s min_over_time(metric[10s:10s])
-#   {} 1
+eval instant at 20s min_over_time(metric[10s:10s])
+  {} 1
 
-# Unsupported by streaming engine.
-# eval instant at 20m min_over_time(rate(metric[5m])[20m:1m])
-#   {} 0.12119047619047618
+eval instant at 20m min_over_time(rate(metric[5m])[20m:1m])
+  {} 0.12119047619047618
 

--- a/pkg/streamingpromql/testing.go
+++ b/pkg/streamingpromql/testing.go
@@ -12,12 +12,13 @@ import (
 func NewTestEngineOpts() EngineOpts {
 	return EngineOpts{
 		CommonOpts: promql.EngineOpts{
-			Logger:               nil,
-			Reg:                  nil,
-			MaxSamples:           math.MaxInt,
-			Timeout:              100 * time.Second,
-			EnableAtModifier:     true,
-			EnableNegativeOffset: true,
+			Logger:                   nil,
+			Reg:                      nil,
+			MaxSamples:               math.MaxInt,
+			Timeout:                  100 * time.Second,
+			EnableAtModifier:         true,
+			EnableNegativeOffset:     true,
+			NoStepSubqueryIntervalFn: func(int64) int64 { return time.Minute.Milliseconds() },
 		},
 
 		FeatureToggles: EnableAllFeatures,

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -166,7 +166,7 @@ func (b *FPointRingBuffer) Release() {
 
 // Use replaces the contents of this buffer with s.
 // The points in s must be in time order, not contain duplicate timestamps and start at index 0.
-// s will be modified in place when the buffer is modified, and callers should not modify s after calling Use.
+// s will be modified in place when the buffer is modified, and callers should not modify s after passing it off to the ring buffer via Use.
 // s will be returned to the pool when Close is called, Use is called again, or the buffer needs to expand, so callers
 // should not return s to the pool themselves.
 func (b *FPointRingBuffer) Use(s []promql.FPoint) {

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -150,10 +150,18 @@ func (b *FPointRingBuffer) Append(p promql.FPoint) error {
 	return nil
 }
 
-// Reset clears the contents of this buffer.
+// Reset clears the contents of this buffer, but retains the underlying point slice for future reuse.
 func (b *FPointRingBuffer) Reset() {
 	b.firstIndex = 0
 	b.size = 0
+}
+
+// Release clears the contents of this buffer and releases the underlying point slice.
+// The buffer can be used again and will acquire a new slice when required.
+func (b *FPointRingBuffer) Release() {
+	b.Reset()
+	putFPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+	b.points = nil
 }
 
 // Use replaces the contents of this buffer with s.

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -156,6 +156,19 @@ func (b *FPointRingBuffer) Reset() {
 	b.size = 0
 }
 
+// Use replaces the contents of this buffer with s.
+// The points in s must be in time order, not contain duplicate timestamps and start at index 0.
+// s will be modified in place when the buffer is modified, and callers should not modify s after calling Use.
+// s will be returned to the pool when Close is called, Use is called again, or the buffer needs to expand, so callers
+// should not return s to the pool themselves.
+func (b *FPointRingBuffer) Use(s []promql.FPoint) {
+	putFPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+
+	b.points = s
+	b.firstIndex = 0
+	b.size = len(s)
+}
+
 // Close releases any resources associated with this buffer.
 func (b *FPointRingBuffer) Close() {
 	putFPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -217,7 +217,7 @@ func (b *HPointRingBuffer) Release() {
 
 // Use replaces the contents of this buffer with s.
 // The points in s must be in time order, not contain duplicate timestamps and start at index 0.
-// s will be modified in place when the buffer is modified, and callers should not modify s after calling Use.
+// s will be modified in place when the buffer is modified, and callers should not modify s after passing it off to the ring buffer via Use.
 // s will be returned to the pool when Close is called, Use is called again, or the buffer needs to expand, so callers
 // should not return s to the pool themselves.
 func (b *HPointRingBuffer) Use(s []promql.HPoint) {

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -207,6 +207,19 @@ func (b *HPointRingBuffer) Reset() {
 	b.size = 0
 }
 
+// Use replaces the contents of this buffer with s.
+// The points in s must be in time order, not contain duplicate timestamps and start at index 0.
+// s will be modified in place when the buffer is modified, and callers should not modify s after calling Use.
+// s will be returned to the pool when Close is called, Use is called again, or the buffer needs to expand, so callers
+// should not return s to the pool themselves.
+func (b *HPointRingBuffer) Use(s []promql.HPoint) {
+	putHPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+
+	b.points = s
+	b.firstIndex = 0
+	b.size = len(s)
+}
+
 // Close releases any resources associated with this buffer.
 func (b *HPointRingBuffer) Close() {
 	putHPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -201,10 +201,18 @@ func (b *HPointRingBuffer) RemoveLastPoint() {
 	}
 }
 
-// Reset clears the contents of this buffer.
+// Reset clears the contents of this buffer, but retains the underlying point slice for future reuse.
 func (b *HPointRingBuffer) Reset() {
 	b.firstIndex = 0
 	b.size = 0
+}
+
+// Release clears the contents of this buffer and releases the underlying point slice.
+// The buffer can be used again and will acquire a new slice when required.
+func (b *HPointRingBuffer) Release() {
+	b.Reset()
+	putHPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+	b.points = nil
 }
 
 // Use replaces the contents of this buffer with s.

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -60,8 +60,8 @@ type RangeVectorOperator interface {
 	// SeriesMetadata must be called exactly once before calling NextSeries.
 	NextSeries(ctx context.Context) error
 
-	// NextStepSamples populates the provided RingBuffers with the samples for the next time step for the
-	// current series and returns the timestamps of the next time step, or returns EOS if no more time
+	// NextStepSamples returns populated RingBuffers with the samples for the next time step for the
+	// current series and the timestamps of the next time step, or returns EOS if no more time
 	// steps are available.
 	NextStepSamples() (RangeVectorStepData, error)
 }

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -63,14 +63,7 @@ type RangeVectorOperator interface {
 	// NextStepSamples populates the provided RingBuffers with the samples for the next time step for the
 	// current series and returns the timestamps of the next time step, or returns EOS if no more time
 	// steps are available.
-	// The provided RingBuffers are expected to only contain points for the current series, and the same
-	// RingBuffers should be passed to subsequent NextStepSamples calls for the same series.
-	// The provided RingBuffers may be populated with points beyond the end of the expected time range, and
-	// callers should compare returned points' timestamps to the returned RangeVectorStepData.RangeEnd.
-	// Next must be called at least once before calling NextStepSamples.
-	// Keep in mind that HPoint contains a pointer to a histogram, so it is generally not safe to
-	// modify directly as the histogram may be used for other HPoint values, such as when lookback has occurred.
-	NextStepSamples(floats *FPointRingBuffer, histograms *HPointRingBuffer) (RangeVectorStepData, error)
+	NextStepSamples() (RangeVectorStepData, error)
 }
 
 // ScalarOperator represents all operators that produce scalars.

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -26,6 +26,7 @@ type ringBuffer[T any] interface {
 	AnyAtOrBefore(maxT int64) bool
 	First() T
 	Reset()
+	Use(s []T)
 	GetPoints() []T
 	GetFirstIndex() int
 	GetTimestamp(point T) int64
@@ -110,6 +111,12 @@ func testRingBuffer[T any](t *testing.T, buf ringBuffer[T], points []T) {
 
 	require.NoError(t, buf.Append(points[8]))
 	shouldHavePoints(t, buf, points[8])
+
+	buf.Use(points)
+	shouldHavePoints(t, buf, points...)
+
+	buf.DiscardPointsBefore(5)
+	shouldHavePoints(t, buf, points[4:]...)
 }
 
 func TestRingBuffer_DiscardPointsBefore_ThroughWrapAround(t *testing.T) {

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -27,6 +27,7 @@ type ringBuffer[T any] interface {
 	First() T
 	Reset()
 	Use(s []T)
+	Release()
 	GetPoints() []T
 	GetFirstIndex() int
 	GetTimestamp(point T) int64
@@ -116,6 +117,12 @@ func testRingBuffer[T any](t *testing.T, buf ringBuffer[T], points []T) {
 	shouldHavePoints(t, buf, points...)
 
 	buf.DiscardPointsBefore(5)
+	shouldHavePoints(t, buf, points[4:]...)
+
+	buf.Release()
+	shouldHaveNoPoints(t, buf)
+
+	buf.Use(points[4:])
 	shouldHavePoints(t, buf, points[4:]...)
 }
 


### PR DESCRIPTION
#### What this PR does

This PR adds support for subqueries to MQE.

Our benchmarks show mild latency improvements in most cases over Prometheus' engine, and improvements in peak memory utilisation in most cases:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/streamingpromql/benchmarks
cpu: Apple M1 Pro
                                                                         │ Prometheus  │               Mimir                │
                                                                         │   sec/op    │   sec/op     vs base               │
Query/sum_over_time(a_1[10m:3m]),_instant_query-10                         156.0µ ± 4%   152.3µ ± 4%   -2.36% (p=0.015 n=6)
Query/sum_over_time(a_1[10m:3m]),_range_query_with_100_steps-10            165.6µ ± 2%   154.6µ ± 1%   -6.63% (p=0.002 n=6)
Query/sum_over_time(a_1[10m:3m]),_range_query_with_1000_steps-10           250.2µ ± 1%   245.1µ ± 2%   -2.03% (p=0.041 n=6)
Query/sum_over_time(a_100[10m:3m]),_instant_query-10                       1.116m ± 2%   1.075m ± 8%        ~ (p=0.065 n=6)
Query/sum_over_time(a_100[10m:3m]),_range_query_with_100_steps-10          1.882m ± 4%   1.691m ± 1%  -10.18% (p=0.002 n=6)
Query/sum_over_time(a_100[10m:3m]),_range_query_with_1000_steps-10         8.662m ± 0%   9.212m ± 1%   +6.36% (p=0.002 n=6)
Query/sum_over_time(a_2000[10m:3m]),_instant_query-10                      16.02m ± 1%   15.38m ± 1%   -3.99% (p=0.002 n=6)
Query/sum_over_time(a_2000[10m:3m]),_range_query_with_100_steps-10         30.11m ± 1%   26.48m ± 1%  -12.06% (p=0.002 n=6)
Query/sum_over_time(a_2000[10m:3m]),_range_query_with_1000_steps-10        160.5m ± 7%   171.7m ± 3%   +6.95% (p=0.015 n=6)
Query/sum_over_time(nh_1[10m:3m]),_instant_query-10                        202.3µ ± 1%   193.9µ ± 1%   -4.18% (p=0.002 n=6)
Query/sum_over_time(nh_1[10m:3m]),_range_query_with_100_steps-10           260.3µ ± 5%   246.1µ ± 2%   -5.45% (p=0.002 n=6)
Query/sum_over_time(nh_1[10m:3m]),_range_query_with_1000_steps-10          829.5µ ± 0%   800.1µ ± 2%   -3.54% (p=0.002 n=6)
Query/sum_over_time(nh_100[10m:3m]),_instant_query-10                      5.656m ± 3%   5.558m ± 3%   -1.73% (p=0.041 n=6)
Query/sum_over_time(nh_100[10m:3m]),_range_query_with_100_steps-10         10.78m ± 1%   10.32m ± 0%   -4.29% (p=0.002 n=6)
Query/sum_over_time(nh_100[10m:3m]),_range_query_with_1000_steps-10        62.86m ± 1%   58.10m ± 4%   -7.57% (p=0.002 n=6)
Query/sum_over_time(nh_2000[10m:3m]),_instant_query-10                     105.3m ± 0%   103.4m ± 0%   -1.77% (p=0.002 n=6)
Query/sum_over_time(nh_2000[10m:3m]),_range_query_with_100_steps-10        204.7m ± 1%   194.1m ± 5%   -5.21% (p=0.015 n=6)
Query/sum_over_time(nh_2000[10m:3m]),_range_query_with_1000_steps-10        1.265 ± 3%    1.154 ± 1%   -8.81% (p=0.002 n=6)
Query/sum(sum_over_time(a_1[10m:3m])),_instant_query-10                    158.2µ ± 2%   150.4µ ± 2%   -4.93% (p=0.002 n=6)
Query/sum(sum_over_time(a_1[10m:3m])),_range_query_with_100_steps-10       169.8µ ± 2%   157.0µ ± 2%   -7.53% (p=0.002 n=6)
Query/sum(sum_over_time(a_1[10m:3m])),_range_query_with_1000_steps-10      279.2µ ± 1%   250.4µ ± 2%  -10.33% (p=0.002 n=6)
Query/sum(sum_over_time(a_100[10m:3m])),_instant_query-10                  1.135m ± 2%   1.071m ± 3%   -5.63% (p=0.002 n=6)
Query/sum(sum_over_time(a_100[10m:3m])),_range_query_with_100_steps-10     1.929m ± 1%   1.688m ± 3%  -12.50% (p=0.002 n=6)
Query/sum(sum_over_time(a_100[10m:3m])),_range_query_with_1000_steps-10    9.272m ± 1%   9.539m ± 1%   +2.88% (p=0.002 n=6)
Query/sum(sum_over_time(a_2000[10m:3m])),_instant_query-10                 16.19m ± 4%   15.58m ± 3%   -3.75% (p=0.002 n=6)
Query/sum(sum_over_time(a_2000[10m:3m])),_range_query_with_100_steps-10    31.18m ± 1%   27.01m ± 1%  -13.36% (p=0.002 n=6)
Query/sum(sum_over_time(a_2000[10m:3m])),_range_query_with_1000_steps-10   183.2m ± 1%   178.0m ± 1%   -2.82% (p=0.002 n=6)
geomean                                                                    4.550m        4.329m        -4.87%

                                                                         │  Prometheus   │                Mimir                │
                                                                         │       B       │      B        vs base               │
Query/sum_over_time(a_1[10m:3m]),_instant_query-10                          73.68Mi ± 1%   73.67Mi ± 1%        ~ (p=0.784 n=6)
Query/sum_over_time(a_1[10m:3m]),_range_query_with_100_steps-10             73.23Mi ± 1%   73.53Mi ± 1%        ~ (p=0.132 n=6)
Query/sum_over_time(a_1[10m:3m]),_range_query_with_1000_steps-10            70.84Mi ± 1%   71.88Mi ± 1%   +1.48% (p=0.009 n=6)
Query/sum_over_time(a_100[10m:3m]),_instant_query-10                        67.51Mi ± 1%   66.95Mi ± 1%        ~ (p=0.132 n=6)
Query/sum_over_time(a_100[10m:3m]),_range_query_with_100_steps-10           67.80Mi ± 1%   67.02Mi ± 0%   -1.15% (p=0.002 n=6)
Query/sum_over_time(a_100[10m:3m]),_range_query_with_1000_steps-10          69.89Mi ± 1%   69.70Mi ± 1%        ~ (p=1.000 n=6)
Query/sum_over_time(a_2000[10m:3m]),_instant_query-10                       68.45Mi ± 2%   69.11Mi ± 1%        ~ (p=0.132 n=6)
Query/sum_over_time(a_2000[10m:3m]),_range_query_with_100_steps-10          75.21Mi ± 1%   77.66Mi ± 1%   +3.26% (p=0.002 n=6)
Query/sum_over_time(a_2000[10m:3m]),_range_query_with_1000_steps-10         133.3Mi ± 1%   127.6Mi ± 0%   -4.26% (p=0.002 n=6)
Query/sum_over_time(nh_1[10m:3m]),_instant_query-10                         78.29Mi ± 1%   78.73Mi ± 1%        ~ (p=0.394 n=6)
Query/sum_over_time(nh_1[10m:3m]),_range_query_with_100_steps-10            73.31Mi ± 1%   72.88Mi ± 0%        ~ (p=0.065 n=6)
Query/sum_over_time(nh_1[10m:3m]),_range_query_with_1000_steps-10           72.63Mi ± 1%   71.93Mi ± 1%   -0.97% (p=0.015 n=6)
Query/sum_over_time(nh_100[10m:3m]),_instant_query-10                       70.20Mi ± 1%   70.10Mi ± 1%        ~ (p=1.000 n=6)
Query/sum_over_time(nh_100[10m:3m]),_range_query_with_100_steps-10          73.68Mi ± 1%   73.95Mi ± 1%        ~ (p=0.180 n=6)
Query/sum_over_time(nh_100[10m:3m]),_range_query_with_1000_steps-10         120.0Mi ± 1%   121.8Mi ± 1%   +1.44% (p=0.004 n=6)
Query/sum_over_time(nh_2000[10m:3m]),_instant_query-10                      76.34Mi ± 1%   73.81Mi ± 1%   -3.31% (p=0.002 n=6)
Query/sum_over_time(nh_2000[10m:3m]),_range_query_with_100_steps-10         180.4Mi ± 1%   184.1Mi ± 1%   +2.09% (p=0.002 n=6)
Query/sum_over_time(nh_2000[10m:3m]),_range_query_with_1000_steps-10        630.1Mi ± 0%   726.8Mi ± 7%  +15.35% (p=0.002 n=6)
Query/sum(sum_over_time(a_1[10m:3m])),_instant_query-10                     73.16Mi ± 1%   73.48Mi ± 1%        ~ (p=0.485 n=6)
Query/sum(sum_over_time(a_1[10m:3m])),_range_query_with_100_steps-10        72.80Mi ± 2%   73.14Mi ± 1%        ~ (p=0.394 n=6)
Query/sum(sum_over_time(a_1[10m:3m])),_range_query_with_1000_steps-10       70.45Mi ± 0%   71.66Mi ± 1%   +1.72% (p=0.004 n=6)
Query/sum(sum_over_time(a_100[10m:3m])),_instant_query-10                   67.38Mi ± 2%   66.86Mi ± 1%        ~ (p=0.260 n=6)
Query/sum(sum_over_time(a_100[10m:3m])),_range_query_with_100_steps-10      67.45Mi ± 1%   66.66Mi ± 1%   -1.17% (p=0.026 n=6)
Query/sum(sum_over_time(a_100[10m:3m])),_range_query_with_1000_steps-10     69.45Mi ± 2%   66.91Mi ± 1%   -3.66% (p=0.002 n=6)
Query/sum(sum_over_time(a_2000[10m:3m])),_instant_query-10                  69.12Mi ± 1%   68.40Mi ± 2%        ~ (p=0.065 n=6)
Query/sum(sum_over_time(a_2000[10m:3m])),_range_query_with_100_steps-10     76.16Mi ± 1%   68.52Mi ± 2%  -10.03% (p=0.002 n=6)
Query/sum(sum_over_time(a_2000[10m:3m])),_range_query_with_1000_steps-10   132.88Mi ± 2%   71.20Mi ± 1%  -46.41% (p=0.002 n=6)
geomean                                                                     85.72Mi        83.71Mi        -2.34%
```

It is possible to improve the performance of the 1000 step cases, however to do this without affecting the performance of range vector selectors requires a bit of refactoring I'd prefer to do in a separate PR.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
