### PR TITLE
distributor: fix pool buffer reuse logic when `distributor.max-request-pool-buffer-size` is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [BUGFIX] Fix issue where sharded queries could return annotations with incorrect or confusing position information. #9536
 * [BUGFIX] Fix issue where downstream consumers may not generate correct cache keys for experimental error caching. #9644
 * [BUGFIX] Fix issue where active series requests error when encountering a stale posting. #9580
+* [BUGFIX] Fix pooling buffer reuse logic when `-distributor.max-request-pool-buffer-size` is set. #9666
 
 ### Mixin
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -324,12 +324,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 	subservices := []services.Service(nil)
 	subservices = append(subservices, haTracker)
 
-	var requestBufferPool util.Pool
-	if cfg.MaxRequestPoolBufferSize > 0 {
-		requestBufferPool = util.NewBucketedBufferPool(1<<10, cfg.MaxRequestPoolBufferSize, 4)
-	} else {
-		requestBufferPool = util.NewBufferPool()
-	}
+	requestBufferPool := util.NewBufferPool(cfg.MaxRequestPoolBufferSize)
 
 	d := &Distributor{
 		cfg:                   cfg,

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -1183,7 +1183,7 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 
 		return nil
 	}
-	h := OTLPHandler(200, util.NewBufferPool(), nil, otlpLimitsMock{}, RetryConfig{}, push, newPushMetrics(reg), reg, log.NewNopLogger())
+	h := OTLPHandler(200, util.NewBufferPool(0), nil, otlpLimitsMock{}, RetryConfig{}, push, newPushMetrics(reg), reg, log.NewNopLogger())
 	srv.HTTP.Handle("/otlp", h)
 
 	// start the server

--- a/tools/trafficdump/parser.go
+++ b/tools/trafficdump/parser.go
@@ -26,7 +26,7 @@ import (
 
 const maxBufferPoolSize = 1024 * 1024
 
-var bufferPool = util.NewBucketedBufferPool(1e3, maxBufferPoolSize, 2)
+var bufferPool = util.NewBufferPool(maxBufferPoolSize)
 
 type parser struct {
 	processorConfig processorConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adapts the distributor code to remove the bucketed pool implementation in `util.RequestBuffers` when a maximum pool buffer size is defined.

Instead, the code for the default `util.bufferPool` type has been adapted to allow defining a maximum pool capacity.

The reason is that with the current implementatiom, bucketed buffers are used to decompress the incoming request acquiring the buffer based on the specified request size. However, since these buffers eventually end up being resized during the decompression process, they can later end up in a different bucket when returned to the pool, thus preventing subsequent reuse and leading to higher GC pressure.

This behavior has been observed in our dev environments when enabling the config parameter `-distributor.max-request-pool-buffer-size`.

#### Which issue(s) this PR fixes or relates to

Fixes n/a

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
