### PR TITLE
helm: fix broken topology spread constraints in metamonitoring's GrafanaAgent

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [ENHANCEMENT] Add support for setting type and internal traffic policy for Kubernetes service. Set `internalTrafficPolicy=Cluster` by default in all services with type `ClusterIP`. #9619
+* [BUGFIX] Fix incorrect use of topology spread constraints in `GrafanaAgent` CRD of metamonitoring. #9669
 
 ## 5.5.0
 

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -64,7 +64,7 @@ spec:
   tolerations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- include "mimir.lib.topologySpreadConstraints" (dict "ctx" $ "component" "meta-monitoring") | nindent 6 }}
+  {{- include "mimir.lib.topologySpreadConstraints" (dict "ctx" $ "component" "meta-monitoring") | nindent 2 }}
   logs:
     instanceSelector:
       matchLabels:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -16,15 +16,15 @@ spec:
     # The container specs here are merged with the ones in the operator using a strategic merge patch.
     - name: config-reloader
     - name: grafana-agent
-      topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: mimir
-            app.kubernetes.io/instance: metamonitoring-values
-            app.kubernetes.io/component: meta-monitoring
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: metamonitoring-values
+        app.kubernetes.io/component: meta-monitoring
   logs:
     instanceSelector:
       matchLabels:


### PR DESCRIPTION
#### What this PR does

This PR fixes a broken indentation in the `topologySpreadConstraints` inside the `GrafanaAgent` CRD, introduced in #8670. The CRD's specification is defined [here](https://github.com/grafana/agent/blob/69e7872651069b20cf9b8b67d9d210c1db245885/operations/agent-static-operator/crds/monitoring.grafana.com_grafanaagents.yaml). It requires the field to be the direct child of the `spec` field.

#### Which issue(s) this PR fixes or relates to

Fixes #9638

Notes: this needs to be backported to the 5.5 release branch.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
