### PR TITLE
[mimir-distributed-release-5.5] helm: fix broken topology spread constraints in metamonitoring's GrafanaAgent

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,10 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+## 5.5.1
+
+* [BUGFIX] Fix incorrect use of topology spread constraints in `GrafanaAgent` CRD of metamonitoring. #9669
+
 ## 5.5.0
 
 * [ENHANCEMENT] Dashboards: allow switching between using classic or native histograms in dashboards.

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -64,7 +64,7 @@ spec:
   tolerations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- include "mimir.lib.topologySpreadConstraints" (dict "ctx" $ "component" "meta-monitoring") | nindent 6 }}
+  {{- include "mimir.lib.topologySpreadConstraints" (dict "ctx" $ "component" "meta-monitoring") | nindent 2 }}
   logs:
     instanceSelector:
       matchLabels:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-agent.yaml
@@ -16,15 +16,15 @@ spec:
     # The container specs here are merged with the ones in the operator using a strategic merge patch.
     - name: config-reloader
     - name: grafana-agent
-      topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: mimir
-            app.kubernetes.io/instance: metamonitoring-values
-            app.kubernetes.io/component: meta-monitoring
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: metamonitoring-values
+        app.kubernetes.io/component: meta-monitoring
   logs:
     instanceSelector:
       matchLabels:


### PR DESCRIPTION
Backport 0d3f52f74245d6ee1e20e5a6b8453000108b6543 from #9669

Relates to https://github.com/grafana/mimir/issues/9638