### PR TITLE
jsonnet: Set replicas for each Memcached cluster via _config settings

### DIFF
--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -109,7 +109,10 @@
     store_gateway_lazy_loading_enabled: true,
 
     // Number of memcached replicas for each memcached statefulset
-    memcached_replicas: 3,
+    memcached_frontend_replicas: 3,
+    memcached_index_queries_replicas: 3,
+    memcached_chunks_replicas: 3,
+    memcached_metadata_replicas: 1,
 
     cache_frontend_enabled: true,
     cache_frontend_max_item_size_mb: 5,

--- a/operations/mimir/memcached.libsonnet
+++ b/operations/mimir/memcached.libsonnet
@@ -54,6 +54,9 @@ memcached {
         overprovision_factor: 1.05,
         connection_limit: std.toString($._config.cache_frontend_connection_limit),
         extended_options: ['track_sizes'],
+
+        statefulSet+:
+          statefulSet.mixin.spec.withReplicas($._config.memcached_frontend_replicas),
       } + if $._config.memcached_frontend_mtls_enabled then $.memcached_mtls else {}
     else {},
 
@@ -66,6 +69,9 @@ memcached {
         overprovision_factor: 1.05,
         connection_limit: std.toString($._config.cache_index_queries_connection_limit),
         extended_options: ['track_sizes'],
+
+        statefulSet+:
+          statefulSet.mixin.spec.withReplicas($._config.memcached_index_queries_replicas),
       } + if $._config.memcached_index_queries_mtls_enabled then $.memcached_mtls else {}
     else {},
 
@@ -81,6 +87,9 @@ memcached {
         overprovision_factor: 1.05,
         connection_limit: std.toString($._config.cache_chunks_connection_limit),
         extended_options: ['track_sizes'],
+
+        statefulSet+:
+          statefulSet.mixin.spec.withReplicas($._config.memcached_chunks_replicas),
       } + if $._config.memcached_chunks_mtls_enabled then $.memcached_mtls else {}
     else {},
 
@@ -98,7 +107,7 @@ memcached {
         overprovision_factor: 1.05,
 
         statefulSet+:
-          statefulSet.mixin.spec.withReplicas(1),
+          statefulSet.mixin.spec.withReplicas($._config.memcached_metadata_replicas),
       } + if $._config.memcached_metadata_mtls_enabled then $.memcached_mtls else {}
     else {},
 }


### PR DESCRIPTION
#### What this PR does

Instead of needing to modify each statefulset, create _config settings that can be used to adjust the replica count of each Memcached cluster.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
