### PR TITLE
MQE: add support for unary addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * `cortex_alertmanager_alerts`
   * `cortex_alertmanager_silences`
 * [CHANGE] Distributor: Drop experimental `-distributor.direct-otlp-translation-enabled` flag, since direct OTLP translation is well tested at this point. #9647
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642 #9681
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] gRPC: Support S2 compression. #9322
   * `-alertmanager.alertmanager-client.grpc-compression=s2`

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -266,6 +266,11 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr) (types.InstantV
 		}
 
 	case *parser.UnaryExpr:
+		if e.Op == parser.ADD {
+			// Unary addition (+value): there's nothing to do, just return the inner expression.
+			return q.convertToInstantVectorOperator(e.Expr)
+		}
+
 		if e.Op != parser.SUB {
 			return nil, compat.NewNotSupportedError(fmt.Sprintf("unary expression with '%s'", e.Op))
 		}
@@ -360,6 +365,11 @@ func (q *Query) convertToScalarOperator(expr parser.Expr) (types.ScalarOperator,
 		return q.convertFunctionCallToScalarOperator(e)
 
 	case *parser.UnaryExpr:
+		if e.Op == parser.ADD {
+			// Unary addition (+value): there's nothing to do, just return the inner expression.
+			return q.convertToScalarOperator(e.Expr)
+		}
+
 		if e.Op != parser.SUB {
 			return nil, compat.NewNotSupportedError(fmt.Sprintf("unary expression with '%s'", e.Op))
 		}

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -214,6 +214,7 @@ eval instant at 54m scalar(multiple_series)
 
 clear
 
+# Unary negation (-) and unary addition (+)
 load 6m
   metric{series="float"} 1 2 3 4 -5 0 NaN -NaN
   metric{series="histogram"} {{schema:3 sum:4 count:23 buckets:[1 2 4] n_buckets:[3 5 8]}} {{schema:3 sum:14 count:27 buckets:[1 2 6] n_buckets:[3 5 10]}}
@@ -225,6 +226,11 @@ eval range from 0 to 42m step 6m -metric
 # Ensure unary negation of histograms behaves correctly when lookback is involved.
 eval range from 0 to 1m step 1m -metric{series="histogram"}
   {series="histogram"} {{schema:3 sum:-4 count:-23 buckets:[-1 -2 -4] n_buckets:[-3 -5 -8]}} {{schema:3 sum:-4 count:-23 buckets:[-1 -2 -4] n_buckets:[-3 -5 -8]}}
+
+# Unary addition should do nothing.
+eval range from 0 to 42m step 6m +metric
+  metric{series="float"} 1 2 3 4 -5 0 NaN -NaN
+  metric{series="histogram"} {{schema:3 sum:4 count:23 buckets:[1 2 4] n_buckets:[3 5 8]}} {{schema:3 sum:14 count:27 buckets:[1 2 6] n_buckets:[3 5 10]}}
 
 clear
 

--- a/pkg/streamingpromql/testdata/ours/literals.test
+++ b/pkg/streamingpromql/testdata/ours/literals.test
@@ -25,3 +25,20 @@ eval range from 0m to 2m step 1m -(-Inf)
 
 eval range from 0m to 2m step 1m -(NaN)
   {} NaN NaN NaN
+
+# Same thing as above, with with unary addition.
+# Unary addition is a no-op.
+eval range from 0m to 2m step 1m +(2)
+  {} 2 2 2
+
+eval range from 0m to 2m step 1m +(-2)
+  {} -2 -2 -2
+
+eval range from 0m to 2m step 1m +(Inf)
+  {} Inf Inf Inf
+
+eval range from 0m to 2m step 1m +(-Inf)
+  {} -Inf -Inf -Inf
+
+eval range from 0m to 2m step 1m +(NaN)
+  {} NaN NaN NaN


### PR DESCRIPTION
#### What this PR does

This PR adds support for unary addition to MQE.

Unary addition is a no-op, but it's valid PromQL, so we have to support it too 🤷 

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
