### PR TITLE
mimir-mixin: add dashboard for experimental block-builder

### DIFF
--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -36,6 +36,7 @@
       alertmanager: 'alertmanager',
       alertmanager_im: 'alertmanager-im',
       ingester: 'ingester',
+      block_builder: 'block-builder',
       distributor: 'distributor',
       querier: 'querier',
       query_frontend: 'query-frontend',
@@ -73,6 +74,7 @@
     job_names: {
       ingester: ['ingester.*', 'cortex', 'mimir', 'mimir-write.*'],  // Match also custom and per-zone ingester deployments.
       ingester_partition: ['ingester.*-partition'],  // Match exclusively temporarily partition ingesters run during the migration to ingest storage.
+      block_builder: ['block-builder.*'],
       distributor: ['distributor.*', 'cortex', 'mimir', 'mimir-write.*'],  // Match also per-zone distributor deployments.
       querier: ['querier.*', 'cortex', 'mimir', 'mimir-read.*'],  // Match also custom querier deployments.
       ruler_querier: ['ruler-querier.*'],  // Match also custom querier deployments.
@@ -110,6 +112,7 @@
       // the instance when deployed in microservices mode (e.g. "distributor"
       // matcher shouldn't match "mimir-write" too).
       compactor: instanceMatcher(componentNameRegexp.compactor),
+      block_builder: instanceMatcher(componentNameRegexp.block_builder),
       alertmanager: instanceMatcher(componentNameRegexp.alertmanager),
       alertmanager_im: instanceMatcher(componentNameRegexp.alertmanager_im),
       ingester: instanceMatcher(componentNameRegexp.ingester),
@@ -148,6 +151,7 @@
       // Microservices deployment mode. The following matchers MUST match only
       // the instance when deployed in microservices mode (e.g. "distributor"
       // matcher shouldn't match "mimir-write" too).
+      block_builder: componentNameRegexp.block_builder,
       gateway: componentNameRegexp.gateway,
       distributor: componentNameRegexp.distributor,
       ingester: componentNameRegexp.ingester,
@@ -210,6 +214,9 @@
 
     // Whether resources dashboards are enabled (based on cAdvisor metrics).
     resources_dashboards_enabled: true,
+
+    // Whether mimir block-builder is enabled (experimental)
+    block_builder_enabled: false,
 
     // Whether mimir gateway is enabled
     gateway_enabled: false,

--- a/operations/mimir-mixin/dashboards.libsonnet
+++ b/operations/mimir-mixin/dashboards.libsonnet
@@ -18,6 +18,9 @@
     (import 'dashboards/top-tenants.libsonnet') +
     (import 'dashboards/overview.libsonnet') +
 
+    (if !$._config.block_builder_enabled then {} else
+       (import 'dashboards/block-builder.libsonnet')) +
+
     (if !$._config.resources_dashboards_enabled then {} else
        (import 'dashboards/overview-resources.libsonnet') +
        (import 'dashboards/overview-networking.libsonnet') +

--- a/operations/mimir-mixin/dashboards/block-builder.libsonnet
+++ b/operations/mimir-mixin/dashboards/block-builder.libsonnet
@@ -1,0 +1,95 @@
+local filename = 'mimir-block-builder.json';
+
+(import 'dashboard-utils.libsonnet') +
+{
+  [filename]:
+    assert std.md5(filename) == 'c565e768420d79d0a632b3135d47cb30' : 'UID of the dashboard has changed, please update references to dashboard.';
+    ($.dashboard('Block-builder') + { uid: std.md5(filename) })
+    .addClusterSelectorTemplates()
+    .addRow(
+      $.row('Summary')
+      .addPanel(
+        $.timeseriesPanel('Overall consumption / sec') +
+        $.panelDescription(
+          'Overall consumption / sec',
+          'Overview of per-second rate of records consumed from Kafka.',
+        ) +
+        $.queryPanel(
+          [
+            'sum (rate(cortex_ingest_storage_reader_fetch_records_total{%(job)s}[$__rate_interval]))' % { job: $.jobMatcher($._config.job_names.block_builder) },
+            'sum (rate(cortex_ingest_storage_reader_read_errors_total{%(job)s}[$__rate_interval]))' % { job: $.jobMatcher($._config.job_names.block_builder) },
+          ],
+          [
+            'successful',
+            'read errors',
+          ],
+        ) +
+        $.stack,
+      )
+      .addPanel(
+        $.timeseriesPanel('Per-instance consumption / sec') +
+        $.panelDescription(
+          'Per-instance consumption / sec',
+          '',
+        ) +
+        $.queryPanel(
+          'rate(cortex_ingest_storage_reader_fetch_records_total{%(job)s}[$__rate_interval])' % { job: $.jobMatcher($._config.job_names.block_builder) },
+          '{{pod}}'
+        ) +
+        $.stack,
+      )
+    )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.timeseriesPanel('Partition processing / sec') +
+        $.panelDescription(
+          'Partition processing / sec',
+          'Per-partition rate of consumption cycles',
+        ) +
+        $.queryPanel(
+          'sum by (partition) (histogram_count(rate(cortex_blockbuilder_process_partition_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
+          '{{partition}}'
+        ) +
+        $.bars,
+      )
+      .addPanel(
+        $.timeseriesPanel('Lag records') +
+        $.panelDescription(
+          'Lag records',
+          |||
+            Number of records in the partition's backlog, as seen when starting a consumption cycle.
+          |||
+        ) +
+        $.queryPanel(
+          'max by (partition) (cortex_blockbuilder_consumer_lag_records{%(job)s}) > 0' % [$.jobMatcher($._config.job_names.block_builder)],
+          '{{partition}}',
+        )
+      )
+      .addPanel(
+        $.timeseriesPanel('Partition processing duration') +
+        $.queryPanel(
+          [
+            'histogram_quantile(0.50, sum (rate(cortex_blockbuilder_process_partition_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
+            'histogram_quantile(0.99, sum (rate(cortex_blockbuilder_process_partition_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
+            'histogram_avg(sum (rate(cortex_blockbuilder_process_partition_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
+          ],
+          [
+            '50th percentile',
+            '99th percentile',
+            'average',
+          ],
+        ) +
+        { fieldConfig+: { defaults+: { unit: 's' } } },
+      )
+    )
+    .addRow(
+      $.row('Resources')
+      .addPanel(
+        $.containerCPUUsagePanelByComponent('block_builder'),
+      )
+      .addPanel(
+        $.containerMemoryWorkingSetPanelByComponent('block_builder'),
+      )
+    ),
+}

--- a/operations/mimir-mixin/dashboards/block-builder.libsonnet
+++ b/operations/mimir-mixin/dashboards/block-builder.libsonnet
@@ -11,7 +11,7 @@ local filename = 'mimir-block-builder.json';
       .addPanel(
         $.timeseriesPanel('Kafka fetched records / sec') +
         $.panelDescription(
-          'Overall consumption / sec',
+          'Kafka fetched records / sec',
           'Overview of per-second rate of records fetched from Kafka.',
         ) +
         $.queryPanel(
@@ -29,11 +29,11 @@ local filename = 'mimir-block-builder.json';
       .addPanel(
         $.timeseriesPanel('Per pod Kafka fetched records / sec') +
         $.panelDescription(
-          'Per-instance consumption / sec',
-          '',
+          'Per pod Kafka fetched records / sec',
+          'Overview of per-second rate of records fetched from Kafka split by pods.',
         ) +
         $.queryPanel(
-          'sum by(pod) (rate(cortex_ingest_storage_reader_fetch_records_total{%(job)s}[$__rate_interval]))' % { job: $.jobMatcher($._config.job_names.block_builder) },
+          'sum by (pod) (rate(cortex_ingest_storage_reader_fetch_records_total{%(job)s}[$__rate_interval]))' % { job: $.jobMatcher($._config.job_names.block_builder) },
           '{{pod}}'
         ) +
         $.stack,
@@ -45,21 +45,18 @@ local filename = 'mimir-block-builder.json';
         $.timeseriesPanel('Partition processing / sec') +
         $.panelDescription(
           'Partition processing / sec',
-          'Per-partition rate of consumption cycles',
+          'Per-partition rate of consumption cycles.',
         ) +
         $.queryPanel(
-          'sum by (partition) (histogram_count(rate(cortex_blockbuilder_process_partition_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
+          'sum by (partition) (histogram_count(increase(cortex_blockbuilder_process_partition_duration_seconds{%(job)s}[1m])))' % [$.jobMatcher($._config.job_names.block_builder)],
           '{{partition}}'
-        ) +
-        $.bars,
+        )
       )
       .addPanel(
         $.timeseriesPanel('Lag records') +
         $.panelDescription(
           'Per partition records lag',
-          |||
-            Number of records in the partition's backlog, as seen when starting a consumption cycle.
-          |||
+          'Number of records in the backlog of a partition, as seen when starting a consumption cycle.'
         ) +
         $.queryPanel(
           'max by (partition) (cortex_blockbuilder_consumer_lag_records{%(job)s}) > 0' % [$.jobMatcher($._config.job_names.block_builder)],
@@ -68,11 +65,56 @@ local filename = 'mimir-block-builder.json';
       )
       .addPanel(
         $.timeseriesPanel('Partition processing duration') +
+        $.panelDescription(
+          'Partition processing duration',
+          'Amount of time that it takes to process a partition.'
+        ) +
         $.queryPanel(
           [
             'histogram_quantile(0.50, sum (rate(cortex_blockbuilder_process_partition_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
             'histogram_quantile(0.99, sum (rate(cortex_blockbuilder_process_partition_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
             'histogram_avg(sum (rate(cortex_blockbuilder_process_partition_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
+          ],
+          [
+            '50th percentile',
+            '99th percentile',
+            'average',
+          ],
+        ) +
+        { fieldConfig+: { defaults+: { unit: 's' } } },
+      )
+    )
+    .addRow(
+      $.row('TSDB')
+      .addPanel(
+        $.timeseriesPanel('Partition compactios / sec') +
+        $.panelDescription(
+          'Partition compactios / sec',
+          'Per-second rate of compact and upload operattions for blocks of the processed partitions.'
+        ) +
+        $.queryPanel(
+          [
+            'sum (histogram_count(rate(cortex_blockbuilder_tsdb_compact_and_upload_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
+            'sum (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total{%(job)s}[$__rate_interval]))' % [$.jobMatcher($._config.job_names.block_builder)],
+          ],
+          [
+            'successful',
+            'failed',
+          ],
+        ) +
+        $.stack,
+      )
+      .addPanel(
+        $.timeseriesPanel('Partition compaction duration') +
+        $.panelDescription(
+          'Partition compaction duration',
+          'Amount of time that it takes to compact and upload blocks of the processed partitions.'
+        ) +
+        $.queryPanel(
+          [
+            'histogram_quantile(0.50, sum (rate(cortex_blockbuilder_tsdb_compact_and_upload_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
+            'histogram_quantile(0.99, sum (rate(cortex_blockbuilder_tsdb_compact_and_upload_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
+            'histogram_avg(sum (rate(cortex_blockbuilder_tsdb_compact_and_upload_duration_seconds{%(job)s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.block_builder)],
           ],
           [
             '50th percentile',

--- a/operations/mimir-mixin/dashboards/block-builder.libsonnet
+++ b/operations/mimir-mixin/dashboards/block-builder.libsonnet
@@ -9,10 +9,10 @@ local filename = 'mimir-block-builder.json';
     .addRow(
       $.row('Summary')
       .addPanel(
-        $.timeseriesPanel('Overall consumption / sec') +
+        $.timeseriesPanel('Kafka fetched records / sec') +
         $.panelDescription(
           'Overall consumption / sec',
-          'Overview of per-second rate of records consumed from Kafka.',
+          'Overview of per-second rate of records fetched from Kafka.',
         ) +
         $.queryPanel(
           [
@@ -27,13 +27,13 @@ local filename = 'mimir-block-builder.json';
         $.stack,
       )
       .addPanel(
-        $.timeseriesPanel('Per-instance consumption / sec') +
+        $.timeseriesPanel('Per pod Kafka fetched records / sec') +
         $.panelDescription(
           'Per-instance consumption / sec',
           '',
         ) +
         $.queryPanel(
-          'rate(cortex_ingest_storage_reader_fetch_records_total{%(job)s}[$__rate_interval])' % { job: $.jobMatcher($._config.job_names.block_builder) },
+          'sum by(pod) (rate(cortex_ingest_storage_reader_fetch_records_total{%(job)s}[$__rate_interval]))' % { job: $.jobMatcher($._config.job_names.block_builder) },
           '{{pod}}'
         ) +
         $.stack,
@@ -56,7 +56,7 @@ local filename = 'mimir-block-builder.json';
       .addPanel(
         $.timeseriesPanel('Lag records') +
         $.panelDescription(
-          'Lag records',
+          'Per partition records lag',
           |||
             Number of records in the partition's backlog, as seen when starting a consumption cycle.
           |||


### PR DESCRIPTION
#### What this PR does

The PR is the first iteration of a new experimental dashboard, with basic monitoring for the block-builder. The dashboard is disabled by default. It must be enabled via the `$._config.block_builder_enabled` config in jsonnet.

<img width="1512" alt="Screenshot 2024-10-21 at 19 31 28" src="https://github.com/user-attachments/assets/6b0d09e4-af8e-43c0-900c-c73735f67634">
