### PR TITLE
docs: adds deprecation notice for redis caching

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
+++ b/docs/sources/helm-charts/mimir-distributed/configure/configure-redis-cache.md
@@ -6,6 +6,10 @@ description: "Learn how to configure Grafana Mimir to use external Redis as cach
 
 # Configure Redis cache
 
+{{< admonition type="caution" >}}
+Starting with Mimir version 2.14, the experimental support for Redis caching is deprecated. It will be removed in a future release. You are encouraged to switch to Memcached.
+{{< /admonition >}}
+
 Besides support for Memcached, Mimir also supports Redis for the chunks-cache, index-cache, results-cache and metadata-cache. To use Redis, deploy Redis instances, disable the built-in Memcached configuration flag in values.yaml of `mimir-distributed` Helm chart, and then configure Mimir to use Redis.
 
 To disable Memcached, remove any `chunks-cache`, `index-cache`, `metadata-cache` and `results-cache` configuration from your Helm `values.yaml` file. Alternatively, explicitly disable each of the Memcached instances by setting `enabled` to `false`:


### PR DESCRIPTION

#### What this PR does

This PR adds a note to the 5.5 release branch of https://grafana.com/docs/helm-charts/mimir-distributed/latest/configure/configure-redis-cache/ to note the Redis caching is deprecated and set for removal in a future release.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/2552

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
