### PR TITLE
Revert "query-tee: don't bother comparing responses for cancelled requests"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,6 @@
 
 ### Query-tee
 
-* [CHANGE] Don't compare responses for cancelled requests. #9640
 * [FEATURE] Added `-proxy.compare-skip-samples-before` to skip samples before the given time when comparing responses. The time can be in RFC3339 format (or) RFC3339 without the timezone and seconds (or) date only. #9515
 * [ENHANCEMENT] Added human-readable timestamps to comparison failure messages. #9665
 

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -259,7 +259,7 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, backends []Pro
 			expectedResponse, actualResponse = actualResponse, expectedResponse
 		}
 
-		result, err := p.compareResponses(ctx, expectedResponse, actualResponse, evaluationTime)
+		result, err := p.compareResponses(expectedResponse, actualResponse, evaluationTime)
 		if result == ComparisonFailed {
 			level.Error(logger).Log(
 				"msg", "response comparison failed",
@@ -315,17 +315,13 @@ func (p *ProxyEndpoint) waitBackendResponseForDownstream(resCh chan *backendResp
 	return firstResponse
 }
 
-func (p *ProxyEndpoint) compareResponses(ctx context.Context, expectedResponse, actualResponse *backendResponse, queryEvaluationTime time.Time) (ComparisonResult, error) {
+func (p *ProxyEndpoint) compareResponses(expectedResponse, actualResponse *backendResponse, queryEvaluationTime time.Time) (ComparisonResult, error) {
 	if expectedResponse.err != nil {
 		return ComparisonFailed, fmt.Errorf("skipped comparison of response because the request to the preferred backend failed: %w", expectedResponse.err)
 	}
 
 	if actualResponse.err != nil {
 		return ComparisonFailed, fmt.Errorf("skipped comparison of response because the request to the secondary backend failed: %w", actualResponse.err)
-	}
-
-	if ctx.Err() != nil {
-		return ComparisonSkipped, fmt.Errorf("skipped comparison of response because the incoming request to query-tee was cancelled: %w", context.Cause(ctx))
 	}
 
 	if expectedResponse.status != actualResponse.status {

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -363,57 +363,6 @@ func Test_ProxyEndpoint_Comparison(t *testing.T) {
 		})
 	}
 }
-func Test_ProxyEndpoint_ComparisonWithRequestCancellation(t *testing.T) {
-	testRoute := Route{RouteName: "test"}
-	ctx, cancel := context.WithCancelCause(context.Background())
-
-	preferredBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		cancel(errors.New("something cancelled this request"))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte("preferred response"))
-		require.NoError(t, err)
-	}))
-
-	defer preferredBackend.Close()
-	preferredBackendURL, err := url.Parse(preferredBackend.URL)
-	require.NoError(t, err)
-
-	secondaryBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		<-ctx.Done() // Wait until the incoming request has been cancelled.
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusTeapot)
-		_, err := w.Write([]byte("secondary response"))
-		require.NoError(t, err)
-	}))
-
-	defer secondaryBackend.Close()
-	secondaryBackendURL, err := url.Parse(secondaryBackend.URL)
-	require.NoError(t, err)
-
-	backends := []ProxyBackendInterface{
-		NewProxyBackend("preferred-backend", preferredBackendURL, time.Second, true, false),
-		NewProxyBackend("secondary-backend", secondaryBackendURL, time.Second, false, false),
-	}
-
-	logger := newMockLogger()
-	reg := prometheus.NewPedanticRegistry()
-	comparator := NewSamplesComparator(SampleComparisonOptions{})
-	endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(reg), logger, comparator, 0, 1.0)
-
-	resp := httptest.NewRecorder()
-	req, err := http.NewRequestWithContext(ctx, "GET", "http://test/api/v1/test", nil)
-	require.NoError(t, err)
-	endpoint.ServeHTTP(resp, req)
-	require.Equal(t, "preferred response", resp.Body.String())
-	require.Equal(t, http.StatusOK, resp.Code)
-
-	// The HTTP request above will return as soon as the primary response is received, but this doesn't guarantee that the response comparison has been completed.
-	// Wait for the response comparison to complete before checking the logged messages.
-	waitForResponseComparisonMetric(t, reg, ComparisonSkipped, 1)
-	requireLogMessageWithError(t, logger.messages, "response comparison skipped", "skipped comparison of response because the incoming request to query-tee was cancelled: something cancelled this request")
-}
 
 func Test_ProxyEndpoint_LogSlowQueries(t *testing.T) {
 	testRoute := Route{RouteName: "test"}


### PR DESCRIPTION
Reverts grafana/mimir#9640

This change was not quite right: the request context will be cancelled as soon as query-tee sends the response from the preferred backend.

I'll follow this up with a fix later, but for now, I'd like to revert this until I have time to fix it.