### PR TITLE
Allow querying against an expandable number of storages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [ENHANCEMENT] Return server-side total bytes processed statistics as a header through query frontend. #9645
 * [ENHANCEMENT] Query-scheduler: Remove the experimental `query-scheduler.prioritize-query-components` flag. Request queues always prioritize query component dequeuing above tenant fairness. #9703
 * [ENHANCEMENT] Ingester: Emit traces for block syncing, to join up block-upload traces. #9656
+* [ENHANCEMENT] Querier: Enable the optional querying of additional storage queryables. #9712
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -720,6 +720,7 @@ type Mimir struct {
 	RuntimeConfig                   *runtimeconfig.Manager
 	QuerierQueryable                prom_storage.SampleAndChunkQueryable
 	ExemplarQueryable               prom_storage.ExemplarQueryable
+	AdditionalStorageQueryables     []querier.TimeRangeQueryable
 	MetadataSupplier                querier.MetadataSupplier
 	QuerierEngine                   promql.QueryEngine
 	QueryFrontendTripperware        querymiddleware.Tripperware
@@ -730,7 +731,6 @@ type Mimir struct {
 	Alertmanager                    *alertmanager.MultitenantAlertmanager
 	Compactor                       *compactor.MultitenantCompactor
 	StoreGateway                    *storegateway.StoreGateway
-	StoreQueryable                  prom_storage.Queryable
 	MemberlistKV                    *memberlist.KVInitService
 	ActivityTracker                 *activitytracker.ActivityTracker
 	Vault                           *vault.Vault

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -487,7 +487,7 @@ func (t *Mimir) initQueryable() (serv services.Service, err error) {
 
 	// Create a querier queryable and PromQL engine
 	t.QuerierQueryable, t.ExemplarQueryable, t.QuerierEngine, err = querier.New(
-		t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryable, registerer, util_log.Logger, t.ActivityTracker,
+		t.Cfg.Querier, t.Overrides, t.Distributor, t.AdditionalStorageQueryables, registerer, util_log.Logger, t.ActivityTracker,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not create queryable: %w", err)
@@ -635,7 +635,7 @@ func (t *Mimir) initStoreQueryable() (services.Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize block store queryable: %v", err)
 	}
-	t.StoreQueryable = q
+	t.AdditionalStorageQueryables = append(t.AdditionalStorageQueryables, querier.NewStoreGatewayTimeRangeQueryable(q, t.Cfg.Querier))
 	return q, nil
 }
 
@@ -868,7 +868,7 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 		// TODO: Consider wrapping logger to differentiate from querier module logger
 		rulerRegisterer := prometheus.WrapRegistererWith(rulerEngine, t.Registerer)
 
-		queryable, _, eng, err := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryable, rulerRegisterer, util_log.Logger, t.ActivityTracker)
+		queryable, _, eng, err := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.AdditionalStorageQueryables, rulerRegisterer, util_log.Logger, t.ActivityTracker)
 		if err != nil {
 			return nil, fmt.Errorf("could not create queryable for ruler: %w", err)
 		}


### PR DESCRIPTION
#### What this PR does

Currently the querier expects to run queries against two storages only:
  - Ingesters
  - Store gateways

The queriers know when each queryable was applicable and queries the appropriate queryables.

This commmit introduces the TimeRangeQueryable struct which is a wrapper around Queryable. It ties the Queryable to the logic that deems it applicable to an incoming query.

This, in conjunction with the newly-added AdditionalStorageQueryables property on the Mimir struct, enables the querier to query optionally against more storages than just the ingesters and store gateways in the future.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
