### PR TITLE
MQE: create slices with capacity for number of steps remaining, not all possible steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   * `cortex_alertmanager_alerts`
   * `cortex_alertmanager_silences`
 * [CHANGE] Distributor: Drop experimental `-distributor.direct-otlp-translation-enabled` flag, since direct OTLP translation is well tested at this point. #9647
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642 #9651 #9664 #9681
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642 #9651 #9664 #9681 #9717
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] gRPC: Support S2 compression. #9322
   * `-alertmanager.alertmanager-client.grpc-compression=s2`

--- a/pkg/streamingpromql/testdata/ours/selectors.test
+++ b/pkg/streamingpromql/testdata/ours/selectors.test
@@ -60,3 +60,16 @@ eval range from 0 to 10m step 1m some_metric @ 20m
 # Range query with @ modifier before range of available data.
 eval range from 0 to 10m step 1m some_metric @ -5m
   # Should return no results.
+
+clear
+
+load 1m
+  some_metric{env="prod", cluster="eu"} _ _ _ 0+1x4
+  some_metric{env="prod", cluster="us"} _ _ _ 0+2x4
+  some_metric{env="prod", cluster="au"} _ _ _ {{count:5}}+{{count:5}}x4
+
+# Range query with instant vector selector with many steps at beginning of range with no samples.
+eval range from 0 to 7m step 1m some_metric
+  some_metric{env="prod", cluster="eu"} _ _ _ 0 1 2 3 4
+  some_metric{env="prod", cluster="us"} _ _ _ 0 2 4 6 8
+  some_metric{env="prod", cluster="au"} _ _ _ {{count:5}} {{count:10}} {{count:15}} {{count:20}} {{count:25}}


### PR DESCRIPTION
#### What this PR does

This PR is a small optimisation for instant vector selectors in MQE. 

Previously, instant vector selectors would always use a slice with capacity for the number of steps in the range query.

However, if a series only has samples beginning part-way through the query range, this is wasteful: we know the series can't have more samples than remain in the query range, so we don't need such a big slice.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
