### PR TITLE
MQE: improve performance of subqueries when the parent query is a range query with many steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   * `cortex_alertmanager_silences`
 * [CHANGE] Distributor: Drop experimental `-distributor.direct-otlp-translation-enabled` flag, since direct OTLP translation is well tested at this point. #9647
 * [FEATURE] Distributor: Add support for `lz4` OTLP compression. #9763
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642 #9651 #9664 #9681 #9717
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642 #9651 #9664 #9681 #9717 #9719
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] gRPC: Support S2 compression. #9322
   * `-alertmanager.alertmanager-client.grpc-compression=s2`

--- a/pkg/streamingpromql/operators/functions/common.go
+++ b/pkg/streamingpromql/operators/functions/common.go
@@ -70,7 +70,7 @@ func PassthroughData(seriesData types.InstantVectorSeriesData, _ []types.ScalarD
 //   - h *histogram.FloatHistogram: nil if no histogram is present.
 //   - err error.
 type RangeVectorStepFunction func(
-	step types.RangeVectorStepData,
+	step *types.RangeVectorStepData,
 	rangeSeconds float64,
 	emitAnnotation types.EmitAnnotationFunc,
 ) (f float64, hasFloat bool, h *histogram.FloatHistogram, err error)

--- a/pkg/streamingpromql/operators/functions/range_vectors.go
+++ b/pkg/streamingpromql/operators/functions/range_vectors.go
@@ -21,7 +21,7 @@ var CountOverTime = FunctionOverRangeVectorDefinition{
 	StepFunc:               countOverTime,
 }
 
-func countOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+func countOverTime(step *types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
 	fPointCount := step.Floats.Count()
 	hPointCount := step.Histograms.Count()
 
@@ -37,7 +37,7 @@ var LastOverTime = FunctionOverRangeVectorDefinition{
 	StepFunc: lastOverTime,
 }
 
-func lastOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+func lastOverTime(step *types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
 	lastFloat, floatAvailable := step.Floats.Last()
 	lastHistogram, histogramAvailable := step.Histograms.Last()
 
@@ -58,7 +58,7 @@ var PresentOverTime = FunctionOverRangeVectorDefinition{
 	StepFunc:               presentOverTime,
 }
 
-func presentOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+func presentOverTime(step *types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
 	if step.Floats.Any() || step.Histograms.Any() {
 		return 1, true, nil, nil
 	}
@@ -71,7 +71,7 @@ var MaxOverTime = FunctionOverRangeVectorDefinition{
 	StepFunc:               maxOverTime,
 }
 
-func maxOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+func maxOverTime(step *types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
 	head, tail := step.Floats.UnsafePoints()
 
 	if len(head) == 0 && len(tail) == 0 {
@@ -101,7 +101,7 @@ var MinOverTime = FunctionOverRangeVectorDefinition{
 	StepFunc:               minOverTime,
 }
 
-func minOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+func minOverTime(step *types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
 	head, tail := step.Floats.UnsafePoints()
 
 	if len(head) == 0 && len(tail) == 0 {
@@ -132,7 +132,7 @@ var SumOverTime = FunctionOverRangeVectorDefinition{
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func sumOverTime(step types.RangeVectorStepData, _ float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+func sumOverTime(step *types.RangeVectorStepData, _ float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
 	fHead, fTail := step.Floats.UnsafePoints()
 	hHead, hTail := step.Histograms.UnsafePoints()
 
@@ -197,7 +197,7 @@ var AvgOverTime = FunctionOverRangeVectorDefinition{
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func avgOverTime(step types.RangeVectorStepData, _ float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+func avgOverTime(step *types.RangeVectorStepData, _ float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
 	fHead, fTail := step.Floats.UnsafePoints()
 	hHead, hTail := step.Histograms.UnsafePoints()
 

--- a/pkg/streamingpromql/operators/functions/range_vectors.go
+++ b/pkg/streamingpromql/operators/functions/range_vectors.go
@@ -22,8 +22,8 @@ var CountOverTime = FunctionOverRangeVectorDefinition{
 }
 
 func countOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	fPointCount := step.Floats.CountAtOrBefore(step.RangeEnd)
-	hPointCount := step.Histograms.CountAtOrBefore(step.RangeEnd)
+	fPointCount := step.Floats.Count()
+	hPointCount := step.Histograms.Count()
 
 	if fPointCount == 0 && hPointCount == 0 {
 		return 0, false, nil, nil
@@ -38,8 +38,8 @@ var LastOverTime = FunctionOverRangeVectorDefinition{
 }
 
 func lastOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	lastFloat, floatAvailable := step.Floats.LastAtOrBefore(step.RangeEnd)
-	lastHistogram, histogramAvailable := step.Histograms.LastAtOrBefore(step.RangeEnd)
+	lastFloat, floatAvailable := step.Floats.Last()
+	lastHistogram, histogramAvailable := step.Histograms.Last()
 
 	if !floatAvailable && !histogramAvailable {
 		return 0, false, nil, nil
@@ -59,7 +59,7 @@ var PresentOverTime = FunctionOverRangeVectorDefinition{
 }
 
 func presentOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	if step.Floats.AnyAtOrBefore(step.RangeEnd) || step.Histograms.AnyAtOrBefore(step.RangeEnd) {
+	if step.Floats.Any() || step.Histograms.Any() {
 		return 1, true, nil, nil
 	}
 
@@ -72,7 +72,7 @@ var MaxOverTime = FunctionOverRangeVectorDefinition{
 }
 
 func maxOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	head, tail := step.Floats.UnsafePoints(step.RangeEnd)
+	head, tail := step.Floats.UnsafePoints()
 
 	if len(head) == 0 && len(tail) == 0 {
 		return 0, false, nil, nil
@@ -109,7 +109,7 @@ var MinOverTime = FunctionOverRangeVectorDefinition{
 }
 
 func minOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	head, tail := step.Floats.UnsafePoints(step.RangeEnd)
+	head, tail := step.Floats.UnsafePoints()
 
 	if len(head) == 0 && len(tail) == 0 {
 		return 0, false, nil, nil
@@ -147,8 +147,8 @@ var SumOverTime = FunctionOverRangeVectorDefinition{
 }
 
 func sumOverTime(step types.RangeVectorStepData, _ float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	fHead, fTail := step.Floats.UnsafePoints(step.RangeEnd)
-	hHead, hTail := step.Histograms.UnsafePoints(step.RangeEnd)
+	fHead, fTail := step.Floats.UnsafePoints()
+	hHead, hTail := step.Histograms.UnsafePoints()
 
 	haveFloats := len(fHead) > 0 || len(fTail) > 0
 	haveHistograms := len(hHead) > 0 || len(hTail) > 0
@@ -222,8 +222,8 @@ var AvgOverTime = FunctionOverRangeVectorDefinition{
 }
 
 func avgOverTime(step types.RangeVectorStepData, _ float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-	fHead, fTail := step.Floats.UnsafePoints(step.RangeEnd)
-	hHead, hTail := step.Histograms.UnsafePoints(step.RangeEnd)
+	fHead, fTail := step.Floats.UnsafePoints()
+	hHead, hTail := step.Histograms.UnsafePoints()
 
 	haveFloats := len(fHead) > 0 || len(fTail) > 0
 	haveHistograms := len(hHead) > 0 || len(hTail) > 0

--- a/pkg/streamingpromql/operators/functions/range_vectors.go
+++ b/pkg/streamingpromql/operators/functions/range_vectors.go
@@ -78,15 +78,8 @@ func maxOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotati
 		return 0, false, nil, nil
 	}
 
-	var maxSoFar float64
-
-	if len(head) > 0 {
-		maxSoFar = head[0].F
-		head = head[1:]
-	} else {
-		maxSoFar = tail[0].F
-		tail = tail[1:]
-	}
+	maxSoFar := head[0].F
+	head = head[1:]
 
 	for _, p := range head {
 		if p.F > maxSoFar || math.IsNaN(maxSoFar) {
@@ -115,15 +108,8 @@ func minOverTime(step types.RangeVectorStepData, _ float64, _ types.EmitAnnotati
 		return 0, false, nil, nil
 	}
 
-	var minSoFar float64
-
-	if len(head) > 0 {
-		minSoFar = head[0].F
-		head = head[1:]
-	} else {
-		minSoFar = tail[0].F
-		tail = tail[1:]
-	}
+	minSoFar := head[0].F
+	head = head[1:]
 
 	for _, p := range head {
 		if p.F < minSoFar || math.IsNaN(minSoFar) {
@@ -185,18 +171,8 @@ func sumFloats(head, tail []promql.FPoint) float64 {
 }
 
 func sumHistograms(head, tail []promql.HPoint, emitAnnotation types.EmitAnnotationFunc) (*histogram.FloatHistogram, error) {
-	var sum *histogram.FloatHistogram
-
-	if len(head) > 0 {
-		sum = head[0].H
-		head = head[1:]
-	} else {
-		sum = tail[0].H
-		tail = tail[1:]
-	}
-
-	// We must make a copy of the histogram, as the ring buffer may reuse the FloatHistogram instance on subsequent steps.
-	sum = sum.Copy()
+	sum := head[0].H.Copy() // We must make a copy of the histogram, as the ring buffer may reuse the FloatHistogram instance on subsequent steps.
+	head = head[1:]
 
 	for _, p := range head {
 		if _, err := sum.Add(p.H); err != nil {
@@ -306,19 +282,9 @@ func avgFloats(head, tail []promql.FPoint) float64 {
 }
 
 func avgHistograms(head, tail []promql.HPoint) (*histogram.FloatHistogram, error) {
-	var avgSoFar *histogram.FloatHistogram
+	avgSoFar := head[0].H.Copy() // We must make a copy of the histogram, as the ring buffer may reuse the FloatHistogram instance on subsequent steps.
+	head = head[1:]
 	count := 1.0
-
-	if len(head) > 0 {
-		avgSoFar = head[0].H
-		head = head[1:]
-	} else {
-		avgSoFar = tail[0].H
-		tail = tail[1:]
-	}
-
-	// We must make a copy of the histogram, as the ring buffer may reuse the FloatHistogram instance on subsequent steps.
-	avgSoFar = avgSoFar.Copy()
 
 	// Reuse these instances if we need them, to avoid allocating two FloatHistograms for every remaining histogram in the range.
 	var contributionByP *histogram.FloatHistogram

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -31,7 +31,7 @@ var Increase = FunctionOverRangeVectorDefinition{
 
 // isRate is true for `rate` function, or false for `instant` function
 func rate(isRate bool) RangeVectorStepFunction {
-	return func(step types.RangeVectorStepData, rangeSeconds float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+	return func(step *types.RangeVectorStepData, rangeSeconds float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
 		fHead, fTail := step.Floats.UnsafePoints()
 		fCount := len(fHead) + len(fTail)
 
@@ -46,6 +46,7 @@ func rate(isRate bool) RangeVectorStepFunction {
 		}
 
 		if fCount >= 2 {
+			// TODO: just pass step here? (and below)
 			val := floatRate(isRate, fCount, fHead, fTail, step.RangeStart, step.RangeEnd, rangeSeconds)
 			return val, true, nil, nil
 		}

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -146,7 +146,7 @@ func histogramRate(isRate bool, step types.RangeVectorStepData, hHead []promql.H
 	return val, err
 }
 
-func floatRate(isRate bool, fCount int, floatBuffer types.FPointRingBufferView, step types.RangeVectorStepData, fHead []promql.FPoint, fTail []promql.FPoint, rangeSeconds float64) float64 {
+func floatRate(isRate bool, fCount int, floatBuffer *types.FPointRingBufferView, step types.RangeVectorStepData, fHead []promql.FPoint, fTail []promql.FPoint, rangeSeconds float64) float64 {
 	firstPoint := floatBuffer.First()
 
 	var lastPoint promql.FPoint

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -46,7 +46,7 @@ func rate(isRate bool) RangeVectorStepFunction {
 		}
 
 		if fCount >= 2 {
-			val := floatRate(isRate, fCount, step.Floats, step, fHead, fTail, rangeSeconds)
+			val := floatRate(isRate, fCount, step, fHead, fTail, rangeSeconds)
 			return val, true, nil, nil
 		}
 
@@ -64,14 +64,8 @@ func rate(isRate bool) RangeVectorStepFunction {
 }
 
 func histogramRate(isRate bool, step types.RangeVectorStepData, hHead []promql.HPoint, hTail []promql.HPoint, rangeSeconds float64, hCount int, emitAnnotation types.EmitAnnotationFunc) (*histogram.FloatHistogram, error) {
-	var firstPoint promql.HPoint
-	if len(hHead) > 0 {
-		firstPoint = hHead[0]
-		hHead = hHead[1:]
-	} else {
-		firstPoint = hTail[0]
-		hTail = hTail[1:]
-	}
+	firstPoint := hHead[0]
+	hHead = hHead[1:]
 
 	var lastPoint promql.HPoint
 	if len(hTail) > 0 {
@@ -146,8 +140,9 @@ func histogramRate(isRate bool, step types.RangeVectorStepData, hHead []promql.H
 	return val, err
 }
 
-func floatRate(isRate bool, fCount int, floatBuffer *types.FPointRingBufferView, step types.RangeVectorStepData, fHead []promql.FPoint, fTail []promql.FPoint, rangeSeconds float64) float64 {
-	firstPoint := floatBuffer.First()
+func floatRate(isRate bool, fCount int, step types.RangeVectorStepData, fHead []promql.FPoint, fTail []promql.FPoint, rangeSeconds float64) float64 {
+	firstPoint := fHead[0]
+	fHead = fHead[1:]
 
 	var lastPoint promql.FPoint
 	if len(fTail) > 0 {

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -46,12 +46,12 @@ func rate(isRate bool) RangeVectorStepFunction {
 		}
 
 		if fCount >= 2 {
-			val := floatRate(isRate, fCount, step, fHead, fTail, rangeSeconds)
+			val := floatRate(isRate, fCount, fHead, fTail, step.RangeStart, step.RangeEnd, rangeSeconds)
 			return val, true, nil, nil
 		}
 
 		if hCount >= 2 {
-			val, err := histogramRate(isRate, step, hHead, hTail, rangeSeconds, hCount, emitAnnotation)
+			val, err := histogramRate(isRate, hCount, hHead, hTail, step.RangeStart, step.RangeEnd, rangeSeconds, emitAnnotation)
 			if err != nil {
 				err = NativeHistogramErrorToAnnotation(err, emitAnnotation)
 				return 0, false, nil, err
@@ -63,7 +63,7 @@ func rate(isRate bool) RangeVectorStepFunction {
 	}
 }
 
-func histogramRate(isRate bool, step types.RangeVectorStepData, hHead []promql.HPoint, hTail []promql.HPoint, rangeSeconds float64, hCount int, emitAnnotation types.EmitAnnotationFunc) (*histogram.FloatHistogram, error) {
+func histogramRate(isRate bool, hCount int, hHead []promql.HPoint, hTail []promql.HPoint, rangeStart int64, rangeEnd int64, rangeSeconds float64, emitAnnotation types.EmitAnnotationFunc) (*histogram.FloatHistogram, error) {
 	firstPoint := hHead[0]
 	hHead = hHead[1:]
 
@@ -136,11 +136,11 @@ func histogramRate(isRate bool, step types.RangeVectorStepData, hHead []promql.H
 		delta = delta.CopyToSchema(desiredSchema)
 	}
 
-	val := calculateHistogramRate(isRate, step.RangeStart, step.RangeEnd, rangeSeconds, firstPoint, lastPoint, delta, hCount)
+	val := calculateHistogramRate(isRate, rangeStart, rangeEnd, rangeSeconds, firstPoint, lastPoint, delta, hCount)
 	return val, err
 }
 
-func floatRate(isRate bool, fCount int, step types.RangeVectorStepData, fHead []promql.FPoint, fTail []promql.FPoint, rangeSeconds float64) float64 {
+func floatRate(isRate bool, fCount int, fHead []promql.FPoint, fTail []promql.FPoint, rangeStart int64, rangeEnd int64, rangeSeconds float64) float64 {
 	firstPoint := fHead[0]
 	fHead = fHead[1:]
 
@@ -168,7 +168,7 @@ func floatRate(isRate bool, fCount int, step types.RangeVectorStepData, fHead []
 	accumulate(fHead)
 	accumulate(fTail)
 
-	val := calculateFloatRate(isRate, step.RangeStart, step.RangeEnd, rangeSeconds, firstPoint, lastPoint, delta, fCount)
+	val := calculateFloatRate(isRate, rangeStart, rangeEnd, rangeSeconds, firstPoint, lastPoint, delta, fCount)
 	return val
 }
 

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -32,10 +32,10 @@ var Increase = FunctionOverRangeVectorDefinition{
 // isRate is true for `rate` function, or false for `instant` function
 func rate(isRate bool) RangeVectorStepFunction {
 	return func(step types.RangeVectorStepData, rangeSeconds float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
-		fHead, fTail := step.Floats.UnsafePoints(step.RangeEnd)
+		fHead, fTail := step.Floats.UnsafePoints()
 		fCount := len(fHead) + len(fTail)
 
-		hHead, hTail := step.Histograms.UnsafePoints(step.RangeEnd)
+		hHead, hTail := step.Histograms.UnsafePoints()
 		hCount := len(hHead) + len(hTail)
 
 		if fCount > 0 && hCount > 0 {
@@ -146,7 +146,7 @@ func histogramRate(isRate bool, step types.RangeVectorStepData, hHead []promql.H
 	return val, err
 }
 
-func floatRate(isRate bool, fCount int, floatBuffer *types.FPointRingBuffer, step types.RangeVectorStepData, fHead []promql.FPoint, fTail []promql.FPoint, rangeSeconds float64) float64 {
+func floatRate(isRate bool, fCount int, floatBuffer types.FPointRingBufferView, step types.RangeVectorStepData, fHead []promql.FPoint, fTail []promql.FPoint, rangeSeconds float64) float64 {
 	firstPoint := floatBuffer.First()
 
 	var lastPoint promql.FPoint

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -97,8 +97,8 @@ func (m *RangeVectorSelector) NextStepSamples() (types.RangeVectorStepData, erro
 	m.nextT += m.Selector.TimeRange.IntervalMilliseconds
 
 	return types.RangeVectorStepData{
-		Floats:     m.floats,
-		Histograms: m.histograms,
+		Floats:     m.floats.ViewUntil(rangeEnd, false),
+		Histograms: m.histograms.ViewUntil(rangeEnd, false),
 		StepT:      stepT,
 		RangeStart: rangeStart,
 		RangeEnd:   rangeEnd,

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -26,7 +26,9 @@ type RangeVectorSelector struct {
 	chunkIterator     chunkenc.Iterator
 	nextT             int64
 	floats            *types.FPointRingBuffer
+	floatView         *types.FPointRingBufferView
 	histograms        *types.HPointRingBuffer
+	histogramView     *types.HPointRingBufferView
 }
 
 var _ types.RangeVectorOperator = &RangeVectorSelector{}
@@ -95,10 +97,12 @@ func (m *RangeVectorSelector) NextStepSamples() (types.RangeVectorStepData, erro
 	}
 
 	m.nextT += m.Selector.TimeRange.IntervalMilliseconds
+	m.floatView = m.floats.ViewUntil(rangeEnd, false, m.floatView)
+	m.histogramView = m.histograms.ViewUntil(rangeEnd, false, m.histogramView)
 
 	return types.RangeVectorStepData{
-		Floats:     m.floats.ViewUntil(rangeEnd, false),
-		Histograms: m.histograms.ViewUntil(rangeEnd, false),
+		Floats:     m.floatView,
+		Histograms: m.histogramView,
 		StepT:      stepT,
 		RangeStart: rangeStart,
 		RangeEnd:   rangeEnd,

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -24,11 +24,10 @@ type RangeVectorSelector struct {
 
 	rangeMilliseconds int64
 	chunkIterator     chunkenc.Iterator
-	nextT             int64
+	nextStepT         int64
 	floats            *types.FPointRingBuffer
-	floatView         *types.FPointRingBufferView
 	histograms        *types.HPointRingBuffer
-	histogramView     *types.HPointRingBufferView
+	stepData          *types.RangeVectorStepData // Retain the last step data instance we used to avoid allocating it for every step.
 }
 
 var _ types.RangeVectorOperator = &RangeVectorSelector{}
@@ -38,6 +37,7 @@ func NewRangeVectorSelector(selector *Selector, memoryConsumptionTracker *limiti
 		Selector:   selector,
 		floats:     types.NewFPointRingBuffer(memoryConsumptionTracker),
 		histograms: types.NewHPointRingBuffer(memoryConsumptionTracker),
+		stepData:   &types.RangeVectorStepData{},
 	}
 }
 
@@ -67,19 +67,20 @@ func (m *RangeVectorSelector) NextSeries(ctx context.Context) error {
 		return err
 	}
 
-	m.nextT = m.Selector.TimeRange.StartT
+	m.nextStepT = m.Selector.TimeRange.StartT
 	m.floats.Reset()
 	m.histograms.Reset()
 	return nil
 }
 
-func (m *RangeVectorSelector) NextStepSamples() (types.RangeVectorStepData, error) {
-	if m.nextT > m.Selector.TimeRange.EndT {
-		return types.RangeVectorStepData{}, types.EOS
+func (m *RangeVectorSelector) NextStepSamples() (*types.RangeVectorStepData, error) {
+	if m.nextStepT > m.Selector.TimeRange.EndT {
+		return nil, types.EOS
 	}
 
-	stepT := m.nextT
-	rangeEnd := stepT
+	m.stepData.StepT = m.nextStepT
+	rangeEnd := m.nextStepT
+	m.nextStepT += m.Selector.TimeRange.IntervalMilliseconds
 
 	if m.Selector.Timestamp != nil {
 		// Timestamp from @ modifier takes precedence over query evaluation timestamp.
@@ -93,20 +94,15 @@ func (m *RangeVectorSelector) NextStepSamples() (types.RangeVectorStepData, erro
 	m.histograms.DiscardPointsBefore(rangeStart)
 
 	if err := m.fillBuffer(m.floats, m.histograms, rangeStart, rangeEnd); err != nil {
-		return types.RangeVectorStepData{}, err
+		return nil, err
 	}
 
-	m.nextT += m.Selector.TimeRange.IntervalMilliseconds
-	m.floatView = m.floats.ViewUntilSearchingBackwards(rangeEnd, m.floatView)
-	m.histogramView = m.histograms.ViewUntilSearchingBackwards(rangeEnd, m.histogramView)
+	m.stepData.Floats = m.floats.ViewUntilSearchingBackwards(rangeEnd, m.stepData.Floats)
+	m.stepData.Histograms = m.histograms.ViewUntilSearchingBackwards(rangeEnd, m.stepData.Histograms)
+	m.stepData.RangeStart = rangeStart
+	m.stepData.RangeEnd = rangeEnd
 
-	return types.RangeVectorStepData{
-		Floats:     m.floatView,
-		Histograms: m.histogramView,
-		StepT:      stepT,
-		RangeStart: rangeStart,
-		RangeEnd:   rangeEnd,
-	}, nil
+	return m.stepData, nil
 }
 
 func (m *RangeVectorSelector) fillBuffer(floats *types.FPointRingBuffer, histograms *types.HPointRingBuffer, rangeStart, rangeEnd int64) error {

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -97,8 +97,8 @@ func (m *RangeVectorSelector) NextStepSamples() (types.RangeVectorStepData, erro
 	}
 
 	m.nextT += m.Selector.TimeRange.IntervalMilliseconds
-	m.floatView = m.floats.ViewUntil(rangeEnd, false, m.floatView)
-	m.histogramView = m.histograms.ViewUntil(rangeEnd, false, m.histogramView)
+	m.floatView = m.floats.ViewUntilSearchingBackwards(rangeEnd, m.floatView)
+	m.histogramView = m.histograms.ViewUntilSearchingBackwards(rangeEnd, m.histogramView)
 
 	return types.RangeVectorStepData{
 		Floats:     m.floatView,

--- a/pkg/streamingpromql/operators/subquery.go
+++ b/pkg/streamingpromql/operators/subquery.go
@@ -94,8 +94,8 @@ func (s *Subquery) NextStepSamples() (types.RangeVectorStepData, error) {
 	s.nextStepT += s.ParentQueryTimeRange.IntervalMilliseconds
 
 	return types.RangeVectorStepData{
-		Floats:     s.floats,
-		Histograms: s.histograms,
+		Floats:     s.floats.ViewUntil(rangeEnd, true),
+		Histograms: s.histograms.ViewUntil(rangeEnd, true),
 		StepT:      stepT,
 		RangeStart: rangeStart,
 		RangeEnd:   rangeEnd,

--- a/pkg/streamingpromql/operators/subquery.go
+++ b/pkg/streamingpromql/operators/subquery.go
@@ -94,8 +94,8 @@ func (s *Subquery) NextStepSamples() (types.RangeVectorStepData, error) {
 	s.histograms.DiscardPointsBefore(rangeStart)
 
 	s.nextStepT += s.ParentQueryTimeRange.IntervalMilliseconds
-	s.floatView = s.floats.ViewUntil(rangeEnd, true, s.floatView)
-	s.histogramView = s.histograms.ViewUntil(rangeEnd, true, s.histogramView)
+	s.floatView = s.floats.ViewUntilSearchingForwards(rangeEnd, s.floatView)
+	s.histogramView = s.histograms.ViewUntilSearchingForwards(rangeEnd, s.histogramView)
 
 	return types.RangeVectorStepData{
 		Floats:     s.floatView,

--- a/pkg/streamingpromql/operators/subquery.go
+++ b/pkg/streamingpromql/operators/subquery.go
@@ -25,7 +25,9 @@ type Subquery struct {
 	nextStepT         int64
 	rangeMilliseconds int64
 	floats            *types.FPointRingBuffer
+	floatView         *types.FPointRingBufferView
 	histograms        *types.HPointRingBuffer
+	histogramView     *types.HPointRingBufferView
 }
 
 var _ types.RangeVectorOperator = &Subquery{}
@@ -92,10 +94,12 @@ func (s *Subquery) NextStepSamples() (types.RangeVectorStepData, error) {
 	s.histograms.DiscardPointsBefore(rangeStart)
 
 	s.nextStepT += s.ParentQueryTimeRange.IntervalMilliseconds
+	s.floatView = s.floats.ViewUntil(rangeEnd, true, s.floatView)
+	s.histogramView = s.histograms.ViewUntil(rangeEnd, true, s.histogramView)
 
 	return types.RangeVectorStepData{
-		Floats:     s.floats.ViewUntil(rangeEnd, true),
-		Histograms: s.histograms.ViewUntil(rangeEnd, true),
+		Floats:     s.floatView,
+		Histograms: s.histogramView,
 		StepT:      stepT,
 		RangeStart: rangeStart,
 		RangeEnd:   rangeEnd,

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -730,12 +730,12 @@ func (q *Query) populateMatrixFromRangeVectorOperator(ctx context.Context, o typ
 			return nil, err
 		}
 
-		floats, err := step.Floats.CopyPoints(step.RangeEnd)
+		floats, err := step.Floats.CopyPoints()
 		if err != nil {
 			return nil, err
 		}
 
-		histograms, err := step.Histograms.CopyPoints(step.RangeEnd)
+		histograms, err := step.Histograms.CopyPoints()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/streamingpromql/types/data.go
+++ b/pkg/streamingpromql/types/data.go
@@ -84,25 +84,15 @@ func (i *InstantVectorSeriesDataIterator) Next() (t int64, f float64, h *histogr
 //   - RangeStart is 1712015700000 (2024-04-01T23:55:00Z)
 //   - RangeEnd is 1712016000000 (2024-04-02T00:00:00Z)
 type RangeVectorStepData struct {
-	// Floats contains the float samples for this time step, and possibly points beyond the end of the
-	// selected range. Callers should compare points' timestamps to RangeEnd.
-	//
-	// The ring buffer must not be modified, including closing it, as RangeVectorOperator implementations
-	// may return the same ring buffer for subsequent steps and reuse the same points, if the ranges for
-	// both steps overlap.
-	Floats *FPointRingBuffer
+	// Floats contains the float samples for this time step.
+	Floats FPointRingBufferView
 
-	// Histograms contains the histogram samples for this time step, and possibly points beyond the end of the
-	// selected range. Callers should compare points' timestamps to RangeEnd.
-	//
-	// The ring buffer must not be modified, including closing it, as RangeVectorOperator implementations
-	// may return the same ring buffer for subsequent steps and reuse the same points, if the ranges for
-	// both steps overlap.
+	// Histograms contains the histogram samples for this time step.
 	//
 	// FloatHistogram instances in the buffer must not be modified as they may be returned for subsequent steps.
 	// FloatHistogram instances that are retained after the next call to NextStepSamples must be copied, as they
 	// may be modified on subsequent calls to NextStepSamples.
-	Histograms *HPointRingBuffer
+	Histograms HPointRingBufferView
 
 	// StepT is the timestamp of this time step.
 	StepT int64

--- a/pkg/streamingpromql/types/data.go
+++ b/pkg/streamingpromql/types/data.go
@@ -85,14 +85,14 @@ func (i *InstantVectorSeriesDataIterator) Next() (t int64, f float64, h *histogr
 //   - RangeEnd is 1712016000000 (2024-04-02T00:00:00Z)
 type RangeVectorStepData struct {
 	// Floats contains the float samples for this time step.
-	Floats FPointRingBufferView
+	Floats *FPointRingBufferView
 
 	// Histograms contains the histogram samples for this time step.
 	//
 	// FloatHistogram instances in the buffer must not be modified as they may be returned for subsequent steps.
 	// FloatHistogram instances that are retained after the next call to NextStepSamples must be copied, as they
 	// may be modified on subsequent calls to NextStepSamples.
-	Histograms HPointRingBufferView
+	Histograms *HPointRingBufferView
 
 	// StepT is the timestamp of this time step.
 	StepT int64

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -161,6 +161,10 @@ type FPointRingBufferView struct {
 // FIXME: the fact we have to expose this is a bit gross, but the overhead of calling a function with ForEach is terrible.
 // Perhaps we can use range-over function iterators (https://go.dev/wiki/RangefuncExperiment) once this is not experimental?
 func (v FPointRingBufferView) UnsafePoints() (head []promql.FPoint, tail []promql.FPoint) {
+	if v.size == 0 {
+		return nil, nil
+	}
+
 	endOfHeadSegment := v.buffer.firstIndex + v.size
 
 	if endOfHeadSegment > len(v.buffer.points) {

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -165,7 +165,7 @@ func (v FPointRingBufferView) UnsafePoints() (head []promql.FPoint, tail []promq
 
 	if endOfHeadSegment > len(v.buffer.points) {
 		// Need to wrap around.
-		endOfTailSegment := endOfHeadSegment % len(v.buffer.points)
+		endOfTailSegment := endOfHeadSegment - len(v.buffer.points)
 		endOfHeadSegment = len(v.buffer.points)
 		return v.buffer.points[v.buffer.firstIndex:endOfHeadSegment], v.buffer.points[0:endOfTailSegment]
 	}

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -173,7 +173,7 @@ type FPointRingBufferView struct {
 
 // UnsafePoints returns slices of the points in this buffer view.
 // Either or both slice could be empty.
-// Callers must not modify the values in the returned slices or return them to a pool.
+// Callers must not modify the values in the returned slices nor return them to a pool.
 // Calling UnsafePoints is more efficient than calling CopyPoints, as CopyPoints will create a new slice and copy all
 // points into the slice, whereas UnsafePoints returns a view into the internal state of the buffer.
 // The returned slices are no longer valid if this buffer is modified (eg. a point is added, or the buffer is reset or closed).

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -74,37 +74,41 @@ func (b *FPointRingBuffer) Append(p promql.FPoint) error {
 	return nil
 }
 
-// ViewUntil returns a view into this buffer, including only points with timestamps less than or equal to maxT.
-// searchForwards is a hint used to optimise the search for points satisfying the maxT condition, ViewUntil will return the
-// same result regardless of teh value.
-// Set searchForwards to true if it is expected that there are many points with timestamp greater than maxT, and few points with
+// ViewUntilSearchingForwards returns a view into this buffer, including only points with timestamps less than or equal to maxT.
+// ViewUntilSearchingForwards examines the points in the buffer starting from the front of the buffer, so is preferred over
+// ViewUntilSearchingBackwards if it is expected that there are many points with timestamp greater than maxT, and few points with
 // earlier timestamps.
-// Set searchForwards to false if it is expected that only a few of the points will have timestamp greater than maxT.
 // existing is an existing view instance for this buffer that is reused if provided. It can be nil.
 // The returned view is no longer valid if this buffer is modified (eg. a point is added, or the buffer is reset or closed).
-func (b *FPointRingBuffer) ViewUntil(maxT int64, searchForwards bool, existing *FPointRingBufferView) *FPointRingBufferView {
+func (b *FPointRingBuffer) ViewUntilSearchingForwards(maxT int64, existing *FPointRingBufferView) *FPointRingBufferView {
 	if existing == nil {
 		existing = &FPointRingBufferView{buffer: b}
 	}
 
-	if searchForwards {
-		size := 0
+	size := 0
 
-		for size < b.size && b.pointAt(size).T <= maxT {
-			size++
-		}
-
-		existing.size = size
-		return existing
-	}
-
-	size := b.size
-
-	for size > 0 && b.pointAt(size-1).T > maxT {
-		size--
+	for size < b.size && b.pointAt(size).T <= maxT {
+		size++
 	}
 
 	existing.size = size
+	return existing
+}
+
+// ViewUntilSearchingBackwards is like ViewUntilSearchingForwards, except it examines the points from the end of the buffer, so
+// is preferred over ViewUntilSearchingForwards if it is expected that only a few of the points will have timestamp greater than maxT.
+func (b *FPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *FPointRingBufferView) *FPointRingBufferView {
+	if existing == nil {
+		existing = &FPointRingBufferView{buffer: b}
+	}
+
+	nextPositionToCheck := b.size - 1
+
+	for nextPositionToCheck >= 0 && b.pointAt(nextPositionToCheck).T > maxT {
+		nextPositionToCheck--
+	}
+
+	existing.size = nextPositionToCheck + 1
 	return existing
 }
 

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -3,6 +3,8 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/prometheus/prometheus/promql"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
@@ -18,6 +20,7 @@ import (
 type FPointRingBuffer struct {
 	memoryConsumptionTracker *limiting.MemoryConsumptionTracker
 	points                   []promql.FPoint
+	pointsIndexMask          int // Bitmask used to calculate indices into points efficiently. Computing modulo is relatively expensive, but points is always sized as a power of two, so we can a bitmask to calculate remainders cheaply.
 	firstIndex               int // Index into 'points' of first point in this buffer.
 	size                     int // Number of points in this buffer.
 }
@@ -58,6 +61,11 @@ func (b *FPointRingBuffer) Append(p promql.FPoint) error {
 			return err
 		}
 
+		if !isPowerOfTwo(cap(newSlice)) {
+			// We rely on the capacity being a power of two for the pointsIndexMask optimisation below.
+			panic(fmt.Sprintf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize))
+		}
+
 		newSlice = newSlice[:cap(newSlice)]
 		pointsAtEnd := b.size - b.firstIndex
 		copy(newSlice, b.points[b.firstIndex:])
@@ -66,9 +74,10 @@ func (b *FPointRingBuffer) Append(p promql.FPoint) error {
 		putFPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
 		b.points = newSlice
 		b.firstIndex = 0
+		b.pointsIndexMask = cap(newSlice) - 1
 	}
 
-	nextIndex := (b.firstIndex + b.size) % len(b.points)
+	nextIndex := (b.firstIndex + b.size) & b.pointsIndexMask
 	b.points[nextIndex] = p
 	b.size++
 	return nil
@@ -114,7 +123,7 @@ func (b *FPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *FPo
 
 // pointAt returns the point at index 'position'.
 func (b *FPointRingBuffer) pointAt(position int) promql.FPoint {
-	return b.points[(b.firstIndex+position)%len(b.points)]
+	return b.points[(b.firstIndex+position)&b.pointsIndexMask]
 }
 
 // Reset clears the contents of this buffer, but retains the underlying point slice for future reuse.
@@ -136,12 +145,19 @@ func (b *FPointRingBuffer) Release() {
 // s will be modified in place when the buffer is modified, and callers should not modify s after passing it off to the ring buffer via Use.
 // s will be returned to the pool when Close is called, Use is called again, or the buffer needs to expand, so callers
 // should not return s to the pool themselves.
+// s must have a capacity that is a power of two.
 func (b *FPointRingBuffer) Use(s []promql.FPoint) {
+	if !isPowerOfTwo(cap(s)) {
+		// We rely on the capacity being a power of two for the pointsIndexMask optimisation below.
+		panic(fmt.Sprintf("slice capacity must be a power of two, but is %v", cap(s)))
+	}
+
 	putFPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
 
-	b.points = s
+	b.points = s[:cap(s)]
 	b.firstIndex = 0
 	b.size = len(s)
+	b.pointsIndexMask = cap(s) - 1
 }
 
 // Close releases any resources associated with this buffer.
@@ -243,3 +259,7 @@ func (v FPointRingBufferView) Any() bool {
 // These hooks exist so we can override them during unit tests.
 var getFPointSliceForRingBuffer = FPointSlicePool.Get
 var putFPointSliceForRingBuffer = FPointSlicePool.Put
+
+func isPowerOfTwo(n int) bool {
+	return (n & (n - 1)) == 0
+}

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -63,6 +63,7 @@ func (b *FPointRingBuffer) Append(p promql.FPoint) error {
 
 		if !isPowerOfTwo(cap(newSlice)) {
 			// We rely on the capacity being a power of two for the pointsIndexMask optimisation below.
+			// If we can guarantee that newSlice has a capacity that is a power of two in the future, then we can drop this check.
 			panic(fmt.Sprintf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize))
 		}
 

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -123,6 +123,7 @@ func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, error) {
 
 		if !isPowerOfTwo(cap(newSlice)) {
 			// We rely on the capacity being a power of two for the pointsIndexMask optimisation below.
+			// If we can guarantee that newSlice has a capacity that is a power of two in the future, then we can drop this check.
 			panic(fmt.Sprintf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize))
 		}
 

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -210,7 +210,7 @@ type HPointRingBufferView struct {
 
 // UnsafePoints returns slices of the points in this buffer view.
 // Either or both slice could be empty.
-// Callers must not modify the values in the returned slices or return them to a pool.
+// Callers must not modify the values in the returned slices nor return them to a pool.
 // Calling UnsafePoints is more efficient than calling CopyPoints, as CopyPoints will create a new slice and copy all
 // points into the slice, whereas UnsafePoints returns a view into the internal state of the buffer.
 // The returned slices are no longer valid if this buffer is modified (eg. a point is added, or the buffer is reset or closed).

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -198,6 +198,10 @@ type HPointRingBufferView struct {
 // FIXME: the fact we have to expose this is a bit gross, but the overhead of calling a function with ForEach is terrible.
 // Perhaps we can use range-over function iterators (https://go.dev/wiki/RangefuncExperiment) once this is not experimental?
 func (v HPointRingBufferView) UnsafePoints() (head []promql.HPoint, tail []promql.HPoint) {
+	if v.size == 0 {
+		return nil, nil
+	}
+
 	endOfHeadSegment := v.buffer.firstIndex + v.size
 
 	if endOfHeadSegment > len(v.buffer.points) {

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -202,7 +202,7 @@ func (v HPointRingBufferView) UnsafePoints() (head []promql.HPoint, tail []promq
 
 	if endOfHeadSegment > len(v.buffer.points) {
 		// Need to wrap around.
-		endOfTailSegment := endOfHeadSegment % len(v.buffer.points)
+		endOfTailSegment := endOfHeadSegment - len(v.buffer.points)
 		endOfHeadSegment = len(v.buffer.points)
 		return v.buffer.points[v.buffer.firstIndex:endOfHeadSegment], v.buffer.points[0:endOfTailSegment]
 	}

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	maxExpectedPointsPerSeries  = 100_000 // There's not too much science behind this number: 100000 points allows for a point per minute for just under 70 days.
-	pointsPerSeriesBucketFactor = 2.0
+	pointsPerSeriesBucketFactor = 2
 
 	// Treat a native histogram sample as equivalent to this many float samples when considering max in-memory bytes limit.
 	// Keep in mind that float sample = timestamp + float value, so 5x this is equivalent to five timestamps and five floats.

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -63,7 +63,7 @@ type RangeVectorOperator interface {
 	// NextStepSamples returns populated RingBuffers with the samples for the next time step for the
 	// current series and the timestamps of the next time step, or returns EOS if no more time
 	// steps are available.
-	NextStepSamples() (RangeVectorStepData, error)
+	NextStepSamples() (*RangeVectorStepData, error)
 }
 
 // ScalarOperator represents all operators that produce scalars.

--- a/pkg/streamingpromql/types/pool.go
+++ b/pkg/streamingpromql/types/pool.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	maxExpectedSeriesPerResult  = 10_000_000 // Likewise, there's not too much science behind this number: this is the based on examining the largest queries seen at Grafana Labs.
-	seriesPerResultBucketFactor = 2.0
+	seriesPerResultBucketFactor = 2
 )
 
 var (

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -342,6 +342,7 @@ func viewShouldHavePoints[T any](t *testing.T, view ringBufferView[T], expected 
 	} else {
 		require.Equal(t, expected, combinedPoints)
 		require.True(t, view.Any())
+		require.NotEmpty(t, head, "head slice should not be empty for non-empty view")
 	}
 
 	require.Equal(t, len(expected), view.Count())

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -370,7 +370,7 @@ type fPointRingBufferWrapper struct {
 }
 
 func (w *fPointRingBufferWrapper) ViewUntilForTesting(maxT int64, searchForwards bool) ringBufferView[promql.FPoint] {
-	return w.ViewUntil(maxT, searchForwards)
+	return w.ViewUntil(maxT, searchForwards, nil)
 }
 
 func (w *fPointRingBufferWrapper) GetPoints() []promql.FPoint {
@@ -391,7 +391,7 @@ type hPointRingBufferWrapper struct {
 }
 
 func (w *hPointRingBufferWrapper) ViewUntilForTesting(maxT int64, searchForwards bool) ringBufferView[promql.HPoint] {
-	return w.ViewUntil(maxT, searchForwards)
+	return w.ViewUntil(maxT, searchForwards, nil)
 }
 
 func (w *hPointRingBufferWrapper) GetPoints() []promql.HPoint {

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -117,7 +117,9 @@ func testRingBuffer[T any](t *testing.T, buf ringBuffer[T], points []T) {
 	require.NoError(t, buf.Append(points[8]))
 	shouldHavePoints(t, buf, points[8])
 
-	buf.Use(points)
+	pointsWithPowerOfTwoCapacity := make([]T, 0, 16) // Use must be passed a slice with a capacity that is equal to a power of 2.
+	pointsWithPowerOfTwoCapacity = append(pointsWithPowerOfTwoCapacity, points...)
+	buf.Use(pointsWithPowerOfTwoCapacity)
 	shouldHavePoints(t, buf, points...)
 
 	buf.DiscardPointsBefore(5)
@@ -126,7 +128,9 @@ func testRingBuffer[T any](t *testing.T, buf ringBuffer[T], points []T) {
 	buf.Release()
 	shouldHaveNoPoints(t, buf)
 
-	buf.Use(points[4:])
+	subsliceWithPowerOfTwoCapacity := make([]T, 0, 8) // Use must be passed a slice with a capacity that is equal to a power of 2.
+	subsliceWithPowerOfTwoCapacity = append(subsliceWithPowerOfTwoCapacity, points[4:]...)
+	buf.Use(subsliceWithPowerOfTwoCapacity)
 	shouldHavePoints(t, buf, points[4:]...)
 }
 

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -371,7 +371,11 @@ type fPointRingBufferWrapper struct {
 }
 
 func (w *fPointRingBufferWrapper) ViewUntilForTesting(maxT int64, searchForwards bool) ringBufferView[promql.FPoint] {
-	return w.ViewUntil(maxT, searchForwards, nil)
+	if searchForwards {
+		return w.ViewUntilSearchingForwards(maxT, nil)
+	}
+
+	return w.ViewUntilSearchingBackwards(maxT, nil)
 }
 
 func (w *fPointRingBufferWrapper) GetPoints() []promql.FPoint {
@@ -392,7 +396,11 @@ type hPointRingBufferWrapper struct {
 }
 
 func (w *hPointRingBufferWrapper) ViewUntilForTesting(maxT int64, searchForwards bool) ringBufferView[promql.HPoint] {
-	return w.ViewUntil(maxT, searchForwards, nil)
+	if searchForwards {
+		return w.ViewUntilSearchingForwards(maxT, nil)
+	}
+
+	return w.ViewUntilSearchingBackwards(maxT, nil)
 }
 
 func (w *hPointRingBufferWrapper) GetPoints() []promql.HPoint {

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -298,11 +298,13 @@ func TestRingBuffer_ViewUntilWithExistingView(t *testing.T) {
 		viewShouldHavePoints(t, view, promql.FPoint{T: 1, F: 100}, promql.FPoint{T: 2, F: 200})
 
 		// Test that reusing the view with ViewUntilSearchingForwards works correctly.
-		view = buf.ViewUntilSearchingForwards(1, view)
+		newView := buf.ViewUntilSearchingForwards(1, view)
+		require.Same(t, newView, view)
 		viewShouldHavePoints(t, view, promql.FPoint{T: 1, F: 100})
 
 		// Test that reusing the view with ViewUntilSearchingBackwards works correctly.
-		view = buf.ViewUntilSearchingBackwards(3, view)
+		newView = buf.ViewUntilSearchingBackwards(3, view)
+		require.Same(t, newView, view)
 		viewShouldHavePoints(t, view, promql.FPoint{T: 1, F: 100}, promql.FPoint{T: 2, F: 200}, promql.FPoint{T: 3, F: 300})
 	})
 
@@ -322,11 +324,13 @@ func TestRingBuffer_ViewUntilWithExistingView(t *testing.T) {
 		viewShouldHavePoints(t, view, promql.HPoint{T: 1, H: h1}, promql.HPoint{T: 2, H: h2})
 
 		// Test that reusing the view with ViewUntilSearchingForwards works correctly.
-		view = buf.ViewUntilSearchingForwards(1, view)
+		newView := buf.ViewUntilSearchingForwards(1, view)
+		require.Same(t, newView, view)
 		viewShouldHavePoints(t, view, promql.HPoint{T: 1, H: h1})
 
 		// Test that reusing the view with ViewUntilSearchingBackwards works correctly.
-		view = buf.ViewUntilSearchingBackwards(3, view)
+		newView = buf.ViewUntilSearchingBackwards(3, view)
+		require.Same(t, newView, view)
 		viewShouldHavePoints(t, view, promql.HPoint{T: 1, H: h1}, promql.HPoint{T: 2, H: h2}, promql.HPoint{T: 3, H: h3})
 	})
 }

--- a/pkg/util/pool/bucketed_pool.go
+++ b/pkg/util/pool/bucketed_pool.go
@@ -21,7 +21,7 @@ type BucketedPool[T ~[]E, E any] struct {
 
 // NewBucketedPool returns a new BucketedPool with size buckets for minSize to maxSize
 // increasing by the given factor.
-func NewBucketedPool[T ~[]E, E any](minSize, maxSize int, factor float64, makeFunc func(int) T) *BucketedPool[T, E] {
+func NewBucketedPool[T ~[]E, E any](minSize, maxSize int, factor int, makeFunc func(int) T) *BucketedPool[T, E] {
 	if minSize < 1 {
 		panic("invalid minimum pool size")
 	}
@@ -34,7 +34,7 @@ func NewBucketedPool[T ~[]E, E any](minSize, maxSize int, factor float64, makeFu
 
 	var sizes []int
 
-	for s := minSize; s <= maxSize; s = int(float64(s) * factor) {
+	for s := minSize; s <= maxSize; s = s * factor {
 		sizes = append(sizes, s)
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR is a follow-up PR to https://github.com/grafana/mimir/pull/9664.

This PR improves the performance of subqueries when the parent query is a range query with many steps.

It does this by changing the behaviour of the ring buffer implementations to search forwards through the buffer to find the end of the range when a subquery is being evaluated, rather than backwards. Searching backwards makes sense for range vector selectors, where there is expected to only be one point, if any, at the end of the buffer outside the range, but for subqueries in range queries it is expected that there will be many points at the end of the buffer outside the range, so it is usually faster to search from the beginning of the buffer.

I'd suggest reviewing each commit separately, as each builds on the previous one and incrementally improves things.

In benchmarking, peak memory consumption is unchanged, and latency is reduced for both subqueries and range vector selectors. For example:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/streamingpromql/benchmarks
cpu: Apple M1 Pro
                                                                                       │ original.txt │              final.txt              │
                                                                                       │    sec/op    │    sec/op     vs base               │
Query/rate(a_1[1m]),_range_query_with_1000_steps/engine=Mimir-10                         230.2µ ±  1%   218.0µ ±  2%   -5.30% (p=0.002 n=6)
Query/rate(a_100[1m]),_range_query_with_1000_steps/engine=Mimir-10                       7.707m ±  1%   7.086m ±  2%   -8.07% (p=0.002 n=6)
Query/rate(a_2000[1m]),_range_query_with_1000_steps/engine=Mimir-10                      134.3m ±  1%   124.3m ±  1%   -7.43% (p=0.002 n=6)
Query/rate(a_2000[1m]),_range_query_with_10000_steps/engine=Mimir-10                      1.356 ±  6%    1.253 ±  5%   -7.56% (p=0.002 n=6)
Query/rate(nh_1[1m]),_range_query_with_1000_steps/engine=Mimir-10                        705.2µ ±  1%   649.9µ ±  1%   -7.85% (p=0.002 n=6)
Query/rate(nh_100[1m]),_range_query_with_1000_steps/engine=Mimir-10                      44.71m ±  1%   43.46m ±  1%   -2.79% (p=0.002 n=6)
Query/rate(nh_2000[1m]),_range_query_with_1000_steps/engine=Mimir-10                     853.5m ±  1%   843.9m ±  4%        ~ (p=0.310 n=6)
Query/rate(nh_2000[1m]),_range_query_with_10000_steps/engine=Mimir-10                     8.723 ±  3%    8.573 ±  1%   -1.73% (p=0.002 n=6)
Query/sum_over_time(a_2000[10m:3m]),_range_query_with_1000_steps/engine=Mimir-10         172.4m ±  2%   129.6m ±  3%  -24.80% (p=0.002 n=6)
Query/sum_over_time(nh_2000[10m:3m]),_range_query_with_1000_steps/engine=Mimir-10         1.155 ±  2%    1.101 ±  1%   -4.68% (p=0.002 n=6)
Query/sum(sum_over_time(a_100[10m:3m])),_range_query_with_1000_steps/engine=Mimir-10     9.652m ±  1%   7.456m ±  1%  -22.75% (p=0.002 n=6)
Query/sum(sum_over_time(a_2000[10m:3m])),_range_query_with_1000_steps/engine=Mimir-10    177.2m ±  1%   133.6m ±  1%  -24.56% (p=0.002 n=6)

```

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/9664

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
