### PR TITLE
blockbuilder: Basic alerts

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1624,15 +1624,16 @@ How to **investigate**:
 
 - Check the block-builder logs to see what its pods have been busy with. The block-builder logs the `start consuming` and `done consuming` log messages, that mark per-partition conume-cycles. These log records include the details about the cycle, the Kafka topic's offsets, etc. Troubleshoot based on that.
 
-### MimirBlockBuilderLaging
+### MimirBlockBuilderLagging
 
-This alert fires when the block-builder instances report large lag values for the Kafka partitions.
+This alert fires when the block-builder instances report a large number of unprocessed records in the Kafka partitions.
 
 How it **works**:
 
-- When the block-builder starts a new consume cycle, it checks how many records the Kafka partition has in the backlog.
+- When the block-builder starts a new consume cycle, it checks how many records the Kafka partition has in the backlog. This number is tracked in the `cortex_blockbuilder_consumer_lag_records` metric.
 - The block-builder must consume and process these records into TSDB blocks.
-- If the block-builder reports high values in the lag, this could indicate that a block-builder instance cannot fully process and commit the Kafka records.
+- At the end of the processing, the block-builder commits the offset of the last fully processed record into Kafka.
+- If the block-builder reports high values in the lag, this could indicate that a block-builder instance cannot fully process and commit Kafka record.
 
 How to **investigate**:
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1618,11 +1618,11 @@ This alert fires when the block-builder stops reporting any processed cycles for
 How it **works**:
 
 - Block-builder periodically consumes a portion of the backlog from Kafka partition, and processes the consumed data into TSDB blocks. The block-buikder calls these periods "cycles".
-- If no cycles were processed during extended period of time, that can indicate that block-builder is stuck and cannot complete cycle processing.
+- If no cycles were processed during extended period of time, that can indicate that a block-builder instance is stuck and cannot complete cycle processing.
 
 How to **investigate**:
 
-- Check block-builder logs to see what block-builder is busy with, and troubleshoot based on that.
+- Check block-builder logs to see what its pods are busy with. Troubleshoot based on that.
 
 ### MimirBlockBuilderCompactAndUploadFailed
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1611,6 +1611,31 @@ How to **fix**:
 
   1. Once ingesters are stable, revert the temporarily config applied in the previous step.
 
+### MimirBlockBuilderNoCycleProcessing
+
+This alert fires when the block-builder stops reporting any processed cycles for an unexpectedly long time.
+
+How it **works**:
+
+- Block-builder periodically consumes a portion of the backlog from Kafka topic, and processes the consumed data into TSDB blocks. The block-buikder calls these periods "cycles".
+- If no cycles were processed during extended period of time, that can indicate that block-builder is stuck and cannot complete cycle processing.
+
+How to **investigate**:
+
+- Check block-builder logs to see what block-builder is busy with, and troubleshoot based on that.
+
+### MimirBlockBuilderCompactAndUploadFailed
+
+How it **works**:
+
+- Block-builder periodically consumes data from Kafka topic, and processes the consumed data into TSDB blocks.
+- It compacts and uploads the produced TSDB blocks to the object storage.
+- If block-builder encounters issues during compaction or uploading of the blocks if reports the failure metric, that triggers the alert.
+
+How to **investigate**:
+
+- Explore block-builder logs to check what errors are there.
+
 ## Errors catalog
 
 Mimir has some codified error IDs that you might see in HTTP responses or logs.

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1624,6 +1624,21 @@ How to **investigate**:
 
 - Check the block-builder logs to see what its pods have been busy with. The block-builder logs the `start consuming` and `done consuming` log messages, that mark per-partition conume-cycles. These log records include the details about the cycle, the Kafka topic's offsets, etc. Troubleshoot based on that.
 
+### MimirBlockBuilderLaging
+
+This alert fires when the block-builder instances report large lag values for the Kafka partitions.
+
+How it **works**:
+
+- When the block-builder starts a new consume cycle, it checks how many records the Kafka partition has in the backlog.
+- The block-builder must consume and process these records into TSDB blocks.
+- If the block-builder reports high values in the lag, this could indicate that a block-builder instance cannot fully process and commit the Kafka records.
+
+How to **investigate**:
+
+- Check if the per-partition lag, reported by the `cortex_blockbuilder_consumer_lag_records` metric, has been growing over the past hours.
+- Explore the block-builder logs for any errors reported while it processed the partition.
+
 ### MimirBlockBuilderCompactAndUploadFailed
 
 How it **works**:

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1617,24 +1617,24 @@ This alert fires when the block-builder stops reporting any processed cycles for
 
 How it **works**:
 
-- Block-builder periodically consumes a portion of the backlog from Kafka partition, and processes the consumed data into TSDB blocks. The block-buikder calls these periods "cycles".
-- If no cycles were processed during extended period of time, that can indicate that a block-builder instance is stuck and cannot complete cycle processing.
+- The block-builder periodically consumes a portion of the backlog from Kafka partition, and processes the consumed data into TSDB blocks. The block-builder calls these periods "cycles".
+- If the block-builder doesn't process any cycles for an extended period of time, this could indicate that a block-builder instance is stuck and cannot complete cycle processing.
 
 How to **investigate**:
 
-- Check block-builder logs to see what its pods are busy with. Troubleshoot based on that.
+- Check the block-builder logs to see what its pods have been busy with. The block-builder logs the `start consuming` and `done consuming` log messages, that mark per-partition conume-cycles. These log records include the details about the cycle, the Kafka topic's offsets, etc. Troubleshoot based on that.
 
 ### MimirBlockBuilderCompactAndUploadFailed
 
 How it **works**:
 
-- Block-builder periodically consumes data from Kafka topic, and processes the consumed data into TSDB blocks.
-- It compacts and uploads the produced TSDB blocks to the object storage.
-- If block-builder encounters issues during compaction or uploading of the blocks if reports the failure metric, that triggers the alert.
+- The block-builder periodically consumes data from a Kafka topic and processes the consumed data into TSDB blocks.
+- It compacts and uploads the produced TSDB blocks to object storage.
+- If the block-builder encounters issues while compacting or uploading the blocks, it reports the failure metric, which then triggers the alert.
 
 How to **investigate**:
 
-- Explore block-builder logs to check what errors are there.
+- Explore the block-builder logs to check what errors are there.
 
 ## Errors catalog
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1617,7 +1617,7 @@ This alert fires when the block-builder stops reporting any processed cycles for
 
 How it **works**:
 
-- Block-builder periodically consumes a portion of the backlog from Kafka topic, and processes the consumed data into TSDB blocks. The block-buikder calls these periods "cycles".
+- Block-builder periodically consumes a portion of the backlog from Kafka partition, and processes the consumed data into TSDB blocks. The block-buikder calls these periods "cycles".
 - If no cycles were processed during extended period of time, that can indicate that block-builder is stuck and cannot complete cycle processing.
 
 How to **investigate**:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1172,6 +1172,15 @@ spec:
             for: 5m
             labels:
               severity: warning
+          - alert: MimirBlockBuilderLaging
+            annotations:
+              message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}%.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlaging
+            expr: |
+              max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[60m])) > 4e6
+            for: 1h
+            labels:
+              severity: warning
           - alert: MimirBlockBuilderCompactAndUploadFailed
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1165,11 +1165,11 @@ spec:
               severity: critical
           - alert: MimirBlockBuilderNoCycleProcessing
             annotations:
-              message: Mimir Block-builder {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
+              message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
             expr: |
-              max by(cluster, namespace) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[1h]))) == 0
-            for: 30m
+              max by(cluster, namespace, pod) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[60m]))) == 0
+            for: 5m
             labels:
               severity: warning
           - alert: MimirBlockBuilderCompactAndUploadFailed

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1163,6 +1163,24 @@ spec:
             for: 5m
             labels:
               severity: critical
+          - alert: MimirBlockBuilderNoCycleProcessing
+            annotations:
+              message: Mimir Block-builder {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
+            expr: |
+              max by(cluster, namespace) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[1h]))) == 0
+            for: 30m
+            labels:
+              severity: warning
+          - alert: MimirBlockBuilderCompactAndUploadFailed
+            annotations:
+              message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
+            expr: |
+              sum by (cluster, namespace, pod) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
+            for: 5m
+            labels:
+              severity: warning
       - name: mimir_continuous_test
         rules:
           - alert: MimirContinuousTestNotRunningOnWrites

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1172,13 +1172,13 @@ spec:
             for: 5m
             labels:
               severity: warning
-          - alert: MimirBlockBuilderLaging
+          - alert: MimirBlockBuilderLagging
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}%.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlaging
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
             expr: |
-              max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[60m])) > 4e6
-            for: 1h
+              max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+            for: 75m
             labels:
               severity: warning
           - alert: MimirBlockBuilderCompactAndUploadFailed

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1139,11 +1139,11 @@ groups:
             severity: critical
         - alert: MimirBlockBuilderNoCycleProcessing
           annotations:
-            message: Mimir Block-builder {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
+            message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
           expr: |
-            max by(cluster, namespace) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[1h]))) == 0
-          for: 30m
+            max by(cluster, namespace, instance) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[60m]))) == 0
+          for: 5m
           labels:
             severity: warning
         - alert: MimirBlockBuilderCompactAndUploadFailed

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1146,13 +1146,13 @@ groups:
           for: 5m
           labels:
             severity: warning
-        - alert: MimirBlockBuilderLaging
+        - alert: MimirBlockBuilderLagging
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}%.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlaging
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
           expr: |
-            max by(cluster, namespace, instance) (max_over_time(cortex_blockbuilder_consumer_lag_records[60m])) > 4e6
-          for: 1h
+            max by(cluster, namespace, instance) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+          for: 75m
           labels:
             severity: warning
         - alert: MimirBlockBuilderCompactAndUploadFailed

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1146,6 +1146,15 @@ groups:
           for: 5m
           labels:
             severity: warning
+        - alert: MimirBlockBuilderLaging
+          annotations:
+            message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}%.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlaging
+          expr: |
+            max by(cluster, namespace, instance) (max_over_time(cortex_blockbuilder_consumer_lag_records[60m])) > 4e6
+          for: 1h
+          labels:
+            severity: warning
         - alert: MimirBlockBuilderCompactAndUploadFailed
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1137,6 +1137,24 @@ groups:
           for: 5m
           labels:
             severity: critical
+        - alert: MimirBlockBuilderNoCycleProcessing
+          annotations:
+            message: Mimir Block-builder {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
+          expr: |
+            max by(cluster, namespace) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[1h]))) == 0
+          for: 30m
+          labels:
+            severity: warning
+        - alert: MimirBlockBuilderCompactAndUploadFailed
+          annotations:
+            message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
+          expr: |
+            sum by (cluster, namespace, instance) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
+          for: 5m
+          labels:
+            severity: warning
     - name: mimir_continuous_test
       rules:
         - alert: MimirContinuousTestNotRunningOnWrites

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1160,13 +1160,13 @@ groups:
           for: 5m
           labels:
             severity: warning
-        - alert: MimirBlockBuilderLaging
+        - alert: MimirBlockBuilderLagging
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}%.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlaging
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
           expr: |
-            max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[60m])) > 4e6
-          for: 1h
+            max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+          for: 75m
           labels:
             severity: warning
         - alert: MimirBlockBuilderCompactAndUploadFailed

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1160,6 +1160,15 @@ groups:
           for: 5m
           labels:
             severity: warning
+        - alert: MimirBlockBuilderLaging
+          annotations:
+            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}%.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlaging
+          expr: |
+            max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[60m])) > 4e6
+          for: 1h
+          labels:
+            severity: warning
         - alert: MimirBlockBuilderCompactAndUploadFailed
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1153,11 +1153,11 @@ groups:
             severity: critical
         - alert: MimirBlockBuilderNoCycleProcessing
           annotations:
-            message: Mimir Block-builder {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
+            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
           expr: |
-            max by(cluster, namespace) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[1h]))) == 0
-          for: 30m
+            max by(cluster, namespace, pod) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[60m]))) == 0
+          for: 5m
           labels:
             severity: warning
         - alert: MimirBlockBuilderCompactAndUploadFailed

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1151,6 +1151,24 @@ groups:
           for: 5m
           labels:
             severity: critical
+        - alert: MimirBlockBuilderNoCycleProcessing
+          annotations:
+            message: Mimir Block-builder {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
+          expr: |
+            max by(cluster, namespace) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[1h]))) == 0
+          for: 30m
+          labels:
+            severity: warning
+        - alert: MimirBlockBuilderCompactAndUploadFailed
+          annotations:
+            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
+          expr: |
+            sum by (cluster, namespace, pod) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
+          for: 5m
+          labels:
+            severity: warning
     - name: mimir_continuous_test
       rules:
         - alert: MimirContinuousTestNotRunningOnWrites

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -228,6 +228,21 @@
           },
         },
 
+        // Alert if block-builder per partition lag is higher than the threshhold.
+        {
+          alert: $.alertName('BlockBuilderLaging'),
+          'for': '1h',
+          expr: |||
+            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(cortex_blockbuilder_consumer_lag_records[60m])) > 4e6
+          ||| % $._config,
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s {{ $labels.%(per_instance_label)s }} in %(alert_aggregation_variables)s reports partition lag of {{ printf "%%.2f" $value }}%%.' % $._config,
+          },
+        },
+
         // Alert if block-builder is failing to compact and upload any blocks.
         {
           alert: $.alertName('BlockBuilderCompactAndUploadFailed'),

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -216,15 +216,15 @@
         // Alert if block-builder didn't process cycles in the past hour.
         {
           alert: $.alertName('BlockBuilderNoCycleProcessing'),
-          'for': '30m',
+          'for': '5m',
           expr: |||
-            max by(%(alert_aggregation_labels)s) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[1h]))) == 0
+            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[60m]))) == 0
           ||| % $._config,
           labels: {
             severity: 'warning',
           },
           annotations: {
-            message: '%(product)s Block-builder %(alert_instance_variable)s in %(alert_aggregation_variables)s has not processed cycles in the past hour.' % $._config,
+            message: '%(product)s {{ $labels.%(per_instance_label)s }} in %(alert_aggregation_variables)s has not processed cycles in the past hour.' % $._config,
           },
         },
 

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -229,11 +229,13 @@
         },
 
         // Alert if block-builder per partition lag is higher than the threshhold.
+        // The value of the threshhold is arbitary large for now. We will reconsider this alert after we get the block-builder-scheduler.
+        // Note on "for: 75m": we assume one cycle is 1hr; with 10m loopback we expect the warning to trigger only if the metric is above the threshold for more than one cycle.
         {
-          alert: $.alertName('BlockBuilderLaging'),
-          'for': '1h',
+          alert: $.alertName('BlockBuilderLagging'),
+          'for': '75m',
           expr: |||
-            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(cortex_blockbuilder_consumer_lag_records[60m])) > 4e6
+            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
           ||| % $._config,
           labels: {
             severity: 'warning',


### PR DESCRIPTION
#### What this PR does

This PR adds new alerts, that warns about possible scenarios, where the `block-builder` behaves abnormally. See the updated runbook for the details.

Note that I put the alert as warnings for now, since block-builder is still in its early experimental phase.