### PR TITLE
Jsonnet: replace multi_zone_distributor_availability_zones with multi_zone_availability_zones

### DIFF
--- a/operations/mimir-tests/test-multi-zone-distributor.jsonnet
+++ b/operations/mimir-tests/test-multi-zone-distributor.jsonnet
@@ -3,7 +3,7 @@
   _config+:: {
     local availabilityZones = ['us-east-2a', 'us-east-2b'],
     multi_zone_distributor_enabled: true,
-    multi_zone_distributor_availability_zones: availabilityZones,
+    multi_zone_availability_zones: availabilityZones,
 
     autoscaling_distributor_enabled: true,
     autoscaling_distributor_min_replicas: 3,

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -639,9 +639,9 @@
   local isDistributorMultiZoneEnabled = $._config.multi_zone_distributor_enabled,
   local isDistributorAutoscalingEnabled = $._config.autoscaling_distributor_enabled,
   local isDistributorAutoscalingSingleZoneEnabled = !isDistributorMultiZoneEnabled && isDistributorAutoscalingEnabled,
-  local isDistributorAutoscalingZoneAEnabled = isDistributorMultiZoneEnabled && isDistributorAutoscalingEnabled && std.length($._config.multi_zone_distributor_availability_zones) >= 1,
-  local isDistributorAutoscalingZoneBEnabled = isDistributorMultiZoneEnabled && isDistributorAutoscalingEnabled && std.length($._config.multi_zone_distributor_availability_zones) >= 2,
-  local isDistributorAutoscalingZoneCEnabled = isDistributorMultiZoneEnabled && isDistributorAutoscalingEnabled && std.length($._config.multi_zone_distributor_availability_zones) >= 3,
+  local isDistributorAutoscalingZoneAEnabled = isDistributorMultiZoneEnabled && isDistributorAutoscalingEnabled && std.length($._config.multi_zone_availability_zones) >= 1,
+  local isDistributorAutoscalingZoneBEnabled = isDistributorMultiZoneEnabled && isDistributorAutoscalingEnabled && std.length($._config.multi_zone_availability_zones) >= 2,
+  local isDistributorAutoscalingZoneCEnabled = isDistributorMultiZoneEnabled && isDistributorAutoscalingEnabled && std.length($._config.multi_zone_availability_zones) >= 3,
 
   distributor_scaled_object: if !isDistributorAutoscalingSingleZoneEnabled then null else
     $.newDistributorScaledObject('distributor'),

--- a/operations/mimir/multi-zone-distributor.libsonnet
+++ b/operations/mimir/multi-zone-distributor.libsonnet
@@ -1,8 +1,8 @@
 {
   _config+:: {
+    multi_zone_availability_zones: [],
     multi_zone_distributor_enabled: false,
-    multi_zone_distributor_availability_zones: [],
-    multi_zone_distributor_replicas: std.length($._config.multi_zone_distributor_availability_zones),
+    multi_zone_distributor_replicas: std.length($._config.multi_zone_availability_zones),
   },
 
   local container = $.core.v1.container,
@@ -10,9 +10,9 @@
   local service = $.core.v1.service,
 
   local isMultiZoneEnabled = $._config.multi_zone_distributor_enabled,
-  local isZoneAEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_distributor_availability_zones) >= 1,
-  local isZoneBEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_distributor_availability_zones) >= 2,
-  local isZoneCEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_distributor_availability_zones) >= 3,
+  local isZoneAEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 1,
+  local isZoneBEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 2,
+  local isZoneCEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 3,
 
   distributor_zone_a_args:: $.distributor_args,
   distributor_zone_b_args:: $.distributor_args,
@@ -22,9 +22,9 @@
   distributor_zone_b_env_map:: {},
   distributor_zone_c_env_map:: {},
 
-  distributor_zone_a_node_affinity_matchers:: $.distributor_node_affinity_matchers + [$.newMimirNodeAffinityMatcherAZ($._config.multi_zone_distributor_availability_zones[0])],
-  distributor_zone_b_node_affinity_matchers:: $.distributor_node_affinity_matchers + [$.newMimirNodeAffinityMatcherAZ($._config.multi_zone_distributor_availability_zones[1])],
-  distributor_zone_c_node_affinity_matchers:: $.distributor_node_affinity_matchers + [$.newMimirNodeAffinityMatcherAZ($._config.multi_zone_distributor_availability_zones[2])],
+  distributor_zone_a_node_affinity_matchers:: $.distributor_node_affinity_matchers + [$.newMimirNodeAffinityMatcherAZ($._config.multi_zone_availability_zones[0])],
+  distributor_zone_b_node_affinity_matchers:: $.distributor_node_affinity_matchers + [$.newMimirNodeAffinityMatcherAZ($._config.multi_zone_availability_zones[1])],
+  distributor_zone_c_node_affinity_matchers:: $.distributor_node_affinity_matchers + [$.newMimirNodeAffinityMatcherAZ($._config.multi_zone_availability_zones[2])],
 
   distributor_zone_a_container:: if !isZoneAEnabled then null else
     $.newDistributorZoneContainer('a', $.distributor_zone_a_args, $.distributor_zone_a_env_map),
@@ -74,7 +74,7 @@
     local name = 'distributor-zone-%s' % zone;
 
     $.newDistributorDeployment(name, container, nodeAffinityMatchers) +
-    deployment.mixin.spec.withReplicas(std.ceil($._config.multi_zone_distributor_replicas / std.length($._config.multi_zone_distributor_availability_zones))) +
+    deployment.mixin.spec.withReplicas(std.ceil($._config.multi_zone_distributor_replicas / std.length($._config.multi_zone_availability_zones))) +
     deployment.spec.template.spec.withTolerationsMixin([
       $.core.v1.toleration.withKey('topology') +
       $.core.v1.toleration.withOperator('Equal') +


### PR DESCRIPTION
#### What this PR does

This PR replaces the previously introduced configuration (#9548) for setting multi-AZs for distributor, `multi_zone_distributor_availability_zones`, with a more general one, that will be used for other components too, `multi_zone_availability_zones`

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
