### PR TITLE
Ingester circuit breaker deactivate() function

### DIFF
--- a/pkg/ingester/circuitbreaker.go
+++ b/pkg/ingester/circuitbreaker.go
@@ -192,10 +192,12 @@ func (cb *circuitBreaker) activate() {
 		return
 	}
 	if cb.cfg.InitialDelay == 0 {
+		level.Info(cb.logger).Log("msg", "activating circuit breaker", "requestType", cb.requestType)
 		cb.active.Store(true)
 		return
 	}
 	time.AfterFunc(cb.cfg.InitialDelay, func() {
+		level.Info(cb.logger).Log("msg", "activating circuit breaker", "requestType", cb.requestType)
 		cb.active.Store(true)
 	})
 }
@@ -204,6 +206,7 @@ func (cb *circuitBreaker) deactivate() {
 	if cb == nil {
 		return
 	}
+	level.Info(cb.logger).Log("msg", "deactivating circuit breaker", "requestType", cb.requestType)
 	cb.active.Store(false)
 }
 

--- a/pkg/ingester/circuitbreaker.go
+++ b/pkg/ingester/circuitbreaker.go
@@ -199,6 +199,13 @@ func (cb *circuitBreaker) activate() {
 	})
 }
 
+func (cb *circuitBreaker) deactivate() {
+	if cb == nil {
+		return
+	}
+	cb.active.Store(false)
+}
+
 func (cb *circuitBreaker) isOpen() bool {
 	if !cb.isActive() {
 		return false

--- a/pkg/ingester/circuitbreaker.go
+++ b/pkg/ingester/circuitbreaker.go
@@ -193,6 +193,7 @@ func (cb *circuitBreaker) activate() {
 	}
 	if cb.cfg.InitialDelay == 0 {
 		cb.active.Store(true)
+		return
 	}
 	time.AfterFunc(cb.cfg.InitialDelay, func() {
 		cb.active.Store(true)

--- a/pkg/ingester/circuitbreaker.go
+++ b/pkg/ingester/circuitbreaker.go
@@ -188,7 +188,7 @@ func (cb *circuitBreaker) isActive() bool {
 }
 
 func (cb *circuitBreaker) activate() {
-	if cb == nil {
+	if cb == nil || cb.active.Load() {
 		return
 	}
 	if cb.cfg.InitialDelay == 0 {
@@ -203,7 +203,7 @@ func (cb *circuitBreaker) activate() {
 }
 
 func (cb *circuitBreaker) deactivate() {
-	if cb == nil {
+	if cb == nil || !cb.active.Load() {
 		return
 	}
 	level.Info(cb.logger).Log("msg", "deactivating circuit breaker", "requestType", cb.requestType)

--- a/pkg/ingester/circuitbreaker.go
+++ b/pkg/ingester/circuitbreaker.go
@@ -133,15 +133,15 @@ func newCircuitBreaker(cfg CircuitBreakerConfig, registerer prometheus.Registere
 		WithDelay(cfg.CooldownPeriod).
 		OnClose(func(event circuitbreaker.StateChangedEvent) {
 			circuitBreakerTransitionsCounter(cb.metrics, circuitbreaker.ClosedState).Inc()
-			level.Info(logger).Log("msg", "circuit breaker is closed", "previous", event.OldState, "current", event.NewState)
+			level.Info(logger).Log("msg", "circuit breaker is closed", "previous", event.OldState, "current", event.NewState, "requestType", requestType)
 		}).
 		OnOpen(func(event circuitbreaker.StateChangedEvent) {
 			circuitBreakerTransitionsCounter(cb.metrics, circuitbreaker.OpenState).Inc()
-			level.Warn(logger).Log("msg", "circuit breaker is open", "previous", event.OldState, "current", event.NewState)
+			level.Warn(logger).Log("msg", "circuit breaker is open", "previous", event.OldState, "current", event.NewState, "requestType", requestType)
 		}).
 		OnHalfOpen(func(event circuitbreaker.StateChangedEvent) {
 			circuitBreakerTransitionsCounter(cb.metrics, circuitbreaker.HalfOpenState).Inc()
-			level.Info(logger).Log("msg", "circuit breaker is half-open", "previous", event.OldState, "current", event.NewState)
+			level.Info(logger).Log("msg", "circuit breaker is half-open", "previous", event.OldState, "current", event.NewState, "requestType", requestType)
 		})
 
 	if cfg.testModeEnabled {

--- a/pkg/ingester/circuitbreaker_test.go
+++ b/pkg/ingester/circuitbreaker_test.go
@@ -90,6 +90,10 @@ func TestCircuitBreaker_IsActive(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return cb.isActive()
 	}, time.Second, 10*time.Millisecond)
+
+	// deactivate() makes the circuit breaker inactive again.
+	cb.deactivate()
+	require.False(t, cb.isActive())
 }
 
 func TestCircuitBreaker_TryAcquirePermit(t *testing.T) {
@@ -107,7 +111,7 @@ func TestCircuitBreaker_TryAcquirePermit(t *testing.T) {
 		"if circuit breaker is not active, finish function and no error are returned": {
 			initialDelay: 1 * time.Minute,
 			circuitBreakerSetup: func(cb *circuitBreaker) {
-				cb.active.Store(false)
+				cb.deactivate()
 			},
 			expectedCircuitBreakerError: false,
 		},
@@ -1029,7 +1033,7 @@ func TestPRCircuitBreaker_TryPushAcquirePermit(t *testing.T) {
 	}{
 		"if push circuit breaker is not active, finish function and no error are returned": {
 			circuitBreakerSetup: func(cb ingesterCircuitBreaker) {
-				cb.push.active.Store(false)
+				cb.push.deactivate()
 			},
 			expectedCircuitBreakerError: false,
 			expectedMetrics: `
@@ -1184,8 +1188,8 @@ func TestPRCircuitBreaker_TryReadAcquirePermit(t *testing.T) {
 	}{
 		"if read circuit breaker is not active and push circuit breaker is not active, finish function and no error are returned": {
 			circuitBreakerSetup: func(cb ingesterCircuitBreaker) {
-				cb.read.active.Store(false)
-				cb.push.active.Store(false)
+				cb.read.deactivate()
+				cb.push.deactivate()
 			},
 			expectedCircuitBreakerError: false,
 			expectedMetrics: `
@@ -1217,7 +1221,7 @@ func TestPRCircuitBreaker_TryReadAcquirePermit(t *testing.T) {
 		},
 		"if read circuit breaker is not active and push circuit breaker is closed, finish function and no error are returned": {
 			circuitBreakerSetup: func(cb ingesterCircuitBreaker) {
-				cb.read.active.Store(false)
+				cb.read.deactivate()
 				cb.push.activate()
 				cb.push.cb.Close()
 			},
@@ -1251,7 +1255,7 @@ func TestPRCircuitBreaker_TryReadAcquirePermit(t *testing.T) {
 		},
 		"if read circuit breaker is not active and push circuit breaker is open, finish function and no error are returned": {
 			circuitBreakerSetup: func(cb ingesterCircuitBreaker) {
-				cb.read.active.Store(false)
+				cb.read.deactivate()
 				cb.push.activate()
 				cb.push.cb.Open()
 			},
@@ -1285,7 +1289,7 @@ func TestPRCircuitBreaker_TryReadAcquirePermit(t *testing.T) {
 		},
 		"if read circuit breaker is not active and push circuit breaker is half-open, finish function and no error are returned": {
 			circuitBreakerSetup: func(cb ingesterCircuitBreaker) {
-				cb.read.active.Store(false)
+				cb.read.deactivate()
 				cb.push.activate()
 				cb.push.cb.HalfOpen()
 			},
@@ -1321,7 +1325,7 @@ func TestPRCircuitBreaker_TryReadAcquirePermit(t *testing.T) {
 			circuitBreakerSetup: func(cb ingesterCircuitBreaker) {
 				cb.read.activate()
 				cb.read.cb.Close()
-				cb.push.active.Store(false)
+				cb.push.deactivate()
 			},
 			expectedCircuitBreakerError: false,
 			expectedMetrics: `
@@ -1460,7 +1464,7 @@ func TestPRCircuitBreaker_TryReadAcquirePermit(t *testing.T) {
 			circuitBreakerSetup: func(cb ingesterCircuitBreaker) {
 				cb.read.activate()
 				cb.read.cb.Open()
-				cb.push.active.Store(false)
+				cb.push.deactivate()
 			},
 			expectedCircuitBreakerError: true,
 			expectedMetrics: `
@@ -1599,7 +1603,7 @@ func TestPRCircuitBreaker_TryReadAcquirePermit(t *testing.T) {
 			circuitBreakerSetup: func(cb ingesterCircuitBreaker) {
 				cb.read.activate()
 				cb.read.cb.HalfOpen()
-				cb.push.active.Store(false)
+				cb.push.deactivate()
 			},
 			expectedCircuitBreakerError: false,
 			expectedMetrics: `

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -311,7 +311,7 @@ func TestIngester_StartReadRequest(t *testing.T) {
 		},
 		"do not fail if read circuit breaker is not active, and do not acquire a permit": {
 			setup: func(failingIng *failingIngester) {
-				failingIng.circuitBreaker.read.active.Store(false)
+				failingIng.circuitBreaker.read.deactivate()
 			},
 			expectedAcquiredPermitCount: 0,
 		},

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -248,6 +248,11 @@ func TestIngester_StartReadRequest(t *testing.T) {
 			CooldownPeriod: 10 * time.Second,
 			RequestTimeout: 30 * time.Second,
 		}
+		cfg.PushCircuitBreaker = CircuitBreakerConfig{
+			Enabled:        true,
+			CooldownPeriod: 10 * time.Second,
+			RequestTimeout: 2 * time.Second,
+		}
 		failingIng := newFailingIngester(t, cfg, nil, nil)
 		failingIng.startWaitAndCheck(context.Background(), t)
 		require.Equal(t, services.Running, failingIng.lifecycler.State())
@@ -286,7 +291,7 @@ func TestIngester_StartReadRequest(t *testing.T) {
 				require.ErrorIs(t, err, errTooBusy)
 			},
 		},
-		"fail if circuit breaker is open, and do not acquire a permit": {
+		"fail if read circuit breaker is open, and do not acquire a permit": {
 			setup: func(failingIng *failingIngester) {
 				failingIng.circuitBreaker.read.cb.Open()
 			},
@@ -295,7 +300,16 @@ func TestIngester_StartReadRequest(t *testing.T) {
 				require.ErrorAs(t, err, &circuitBreakerOpenError{})
 			},
 		},
-		"do not fail if circuit breaker is not active, and do not acquire a permit": {
+		"fail if push circuit breaker is open, and do not acquire a permit": {
+			setup: func(failingIng *failingIngester) {
+				failingIng.circuitBreaker.push.cb.Open()
+			},
+			expectedAcquiredPermitCount: 0,
+			verifyErr: func(err error) {
+				require.ErrorAs(t, err, &circuitBreakerOpenError{})
+			},
+		},
+		"do not fail if read circuit breaker is not active, and do not acquire a permit": {
 			setup: func(failingIng *failingIngester) {
 				failingIng.circuitBreaker.read.active.Store(false)
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Add a `deactivate()` method to the ingester circuit breakers to allow them to be disabled and re-enabled dynamically.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
