### PR TITLE
continuous-test: make debugging easier in docker compose env

### DIFF
--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -172,6 +172,9 @@ limits:
   query_sharding_total_shards: 16
   query_sharding_max_sharded_queries: 32
   ingestion_rate: 50000
+  # expanded OOO window makes it easier to run continuous-test
+  # otherwise catch-up writes are rejected when metamonitoring is on
+  out_of_order_time_window: 1h
   native_histograms_ingestion_enabled: true
   cardinality_analysis_enabled: true
   query_ingesters_within: 20m

--- a/pkg/continuoustest/manager.go
+++ b/pkg/continuoustest/manager.go
@@ -55,7 +55,7 @@ func (m *Manager) AddTest(t Test) {
 func (m *Manager) Run(ctx context.Context) error {
 	// Initialize all tests.
 	for _, t := range m.tests {
-		if err := t.Init(ctx, time.Now()); err != nil {
+		if err := t.Init(ctx, time.Now().UTC()); err != nil {
 			return err
 		}
 	}
@@ -68,7 +68,7 @@ func (m *Manager) Run(ctx context.Context) error {
 		group.Go(func() error {
 
 			// Run it immediately, and then every configured period.
-			err := t.Run(ctx, time.Now())
+			err := t.Run(ctx, time.Now().UTC())
 			if m.cfg.SmokeTest {
 				if err != nil {
 					level.Info(m.logger).Log("msg", "Test failed", "test", t.Name(), "err", err)
@@ -85,7 +85,7 @@ func (m *Manager) Run(ctx context.Context) error {
 				case <-ticker.C:
 					// This error is intentionally ignored because we want to
 					// continue running the tests forever.
-					_ = t.Run(ctx, time.Now())
+					_ = t.Run(ctx, time.Now().UTC())
 				case <-ctx.Done():
 					return nil
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Converts the timestamps fed into the runner to be in UTC, since all other timestamps encountered when attaching a breakpoint are in UTC.

Also expands OOO window config so the catchup writes from read-write continuous test don't all fail when you bring it up when metamonitoring is on.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
