### PR TITLE
Disable ingester push circuit breaker in read-only mode

### DIFF
--- a/pkg/ingester/downscale.go
+++ b/pkg/ingester/downscale.go
@@ -48,6 +48,8 @@ func (i *Ingester) PrepareInstanceRingDownscaleHandler(w http.ResponseWriter, r 
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// Deactivate the push circuit breaker in read-only mode. Calling this repeatedly is fine.
+		i.circuitBreaker.push.deactivate()
 
 	case http.MethodDelete:
 		// Clear the read-only status.
@@ -57,6 +59,8 @@ func (i *Ingester) PrepareInstanceRingDownscaleHandler(w http.ResponseWriter, r 
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// Activate the push circuit breaker when exiting read-only mode. Calling this repeatedly is fine.
+		i.circuitBreaker.push.activate()
 	}
 
 	ro, rots := i.lifecycler.GetReadOnlyState()

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -634,7 +634,11 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 		return errors.Wrap(err, "failed to start ingester subservices after ingester ring lifecycler")
 	}
 
-	i.circuitBreaker.activate()
+	i.circuitBreaker.read.activate()
+	if ro, _ := i.lifecycler.GetReadOnlyState(); !ro {
+		// If the ingester is not read-only, activate the push circuit breaker.
+		i.circuitBreaker.push.activate()
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

We ran across an issue where the ingester's push circuit breaker was getting tripped when first starting, or when leaving read-only mode. The `--initial-delay` option allows us to add a delay before the circuit breaker starts measuring request times and making decisions. This is a solution for the cold start case, but does not help us when a running ingester is leaving read-only mode.

This PR builds on https://github.com/grafana/mimir/pull/9743 to disable the ingester push circuit breaker when entering read-only mode, and enable it when leaving read-only mode. It also only enables the push breaker at start time if the ingester isn't starting in read-only mode.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
