### PR TITLE
Update mimir-prometheus to 5710f65f1444

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@
 * [BUGFIX] Fix issue when using the experimental `-ruler.max-independent-rule-evaluation-concurrency` feature, where the ruler could panic as it updates a running ruleset or shutdowns. #9726
 * [BUGFIX] Ingester: Fix race condition in per-tenant TSDB creation. #9708
 * [BUGFIX] Ingester: Fix race condition in exemplar adding. #9765
+* [BUGFIX] Ingester: Fix race condition in series adding. #9765
+* [BUGFIX] Ingester: Fix race condition in native histogram appending. #9765
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [BUGFIX] Fix pooling buffer reuse logic when `-distributor.max-request-pool-buffer-size` is set. #9666
 * [BUGFIX] Fix issue when using the experimental `-ruler.max-independent-rule-evaluation-concurrency` feature, where the ruler could panic as it updates a running ruleset or shutdowns. #9726
 * [BUGFIX] Ingester: Fix race condition in per-tenant TSDB creation. #9708
+* [BUGFIX] Ingester: Fix race condition in exemplar adding. #9765
 
 ### Mixin
 

--- a/go.mod
+++ b/go.mod
@@ -282,7 +282,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20241023201215-e8c852a65765
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20241029123536-5710f65f1444
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,8 @@ github.com/grafana/gomemcache v0.0.0-20241016125027-0a5bcc5aef40 h1:1TeKhyS+pvzO
 github.com/grafana/gomemcache v0.0.0-20241016125027-0a5bcc5aef40/go.mod h1:IGRj8oOoxwJbHBYl1+OhS9UjQR0dv6SQOep7HqmtyFU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20241023201215-e8c852a65765 h1:nOq2fEZviAcek/D7gRnNAOXSVMCq4Fyj7bScCXvGYEw=
-github.com/grafana/mimir-prometheus v0.0.0-20241023201215-e8c852a65765/go.mod h1:jw8nT+R1mhH4FdHRkYlht7cpilJCP0j0M83c5BWqYUg=
+github.com/grafana/mimir-prometheus v0.0.0-20241029123536-5710f65f1444 h1:o3Plh90SIbYgW6penf8BV3QUH0gwBJou+Cd2uCfamRk=
+github.com/grafana/mimir-prometheus v0.0.0-20241029123536-5710f65f1444/go.mod h1:7SuFBLahBoRY7KcgzWzK0p1n5QL+5dyr/Ysat6v1378=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20240930132144-b5e64e81e8d3 h1:6D2gGAwyQBElSrp3E+9lSr7k8gLuP3Aiy20rweLWeBw=

--- a/vendor/github.com/prometheus/prometheus/tsdb/exemplar.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/exemplar.go
@@ -152,12 +152,12 @@ func (ce *CircularExemplarStorage) Querier(_ context.Context) (storage.ExemplarQ
 func (ce *CircularExemplarStorage) Select(start, end int64, matchers ...[]*labels.Matcher) ([]exemplar.QueryResult, error) {
 	ret := make([]exemplar.QueryResult, 0)
 
+	ce.lock.RLock()
+	defer ce.lock.RUnlock()
+
 	if len(ce.exemplars) == 0 {
 		return ret, nil
 	}
-
-	ce.lock.RLock()
-	defer ce.lock.RUnlock()
 
 	// Loop through each index entry, which will point us to first/last exemplar for each series.
 	for _, idx := range ce.index {
@@ -281,12 +281,12 @@ func (ce *CircularExemplarStorage) Resize(l int64) int {
 		l = 0
 	}
 
+	ce.lock.Lock()
+	defer ce.lock.Unlock()
+
 	if l == int64(len(ce.exemplars)) {
 		return 0
 	}
-
-	ce.lock.Lock()
-	defer ce.lock.Unlock()
 
 	oldBuffer := ce.exemplars
 	oldNextIndex := int64(ce.nextIndex)
@@ -349,17 +349,17 @@ func (ce *CircularExemplarStorage) migrate(entry *circularBufferEntry, buf []byt
 }
 
 func (ce *CircularExemplarStorage) AddExemplar(l labels.Labels, e exemplar.Exemplar) error {
+	// TODO(bwplotka): This lock can lock all scrapers, there might high contention on this on scale.
+	// Optimize by moving the lock to be per series (& benchmark it).
+	ce.lock.Lock()
+	defer ce.lock.Unlock()
+
 	if len(ce.exemplars) == 0 {
 		return storage.ErrExemplarsDisabled
 	}
 
 	var buf [1024]byte
 	seriesLabels := l.Bytes(buf[:])
-
-	// TODO(bwplotka): This lock can lock all scrapers, there might high contention on this on scale.
-	// Optimize by moving the lock to be per series (& benchmark it).
-	ce.lock.Lock()
-	defer ce.lock.Unlock()
 
 	idx, ok := ce.index[string(seriesLabels)]
 	err := ce.validateExemplar(idx, e, true)

--- a/vendor/github.com/prometheus/prometheus/tsdb/index/postings.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/index/postings.go
@@ -345,13 +345,14 @@ func (p *MemPostings) Add(id storage.SeriesRef, lset labels.Labels) {
 	p.mtx.Unlock()
 }
 
-func appendWithExponentialGrowth[T any](a []T, v T) []T {
+func appendWithExponentialGrowth[T any](a []T, v T) (_ []T, copied bool) {
 	if cap(a) < len(a)+1 {
 		newList := make([]T, len(a), len(a)*2+1)
 		copy(newList, a)
 		a = newList
+		copied = true
 	}
-	return append(a, v)
+	return append(a, v), copied
 }
 
 func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
@@ -360,16 +361,26 @@ func (p *MemPostings) addFor(id storage.SeriesRef, l labels.Label) {
 		nm = map[string][]storage.SeriesRef{}
 		p.m[l.Name] = nm
 	}
-	list := appendWithExponentialGrowth(nm[l.Value], id)
+	list, copied := appendWithExponentialGrowth(nm[l.Value], id)
 	nm[l.Value] = list
 
-	if !p.ordered {
+	// Return if it shouldn't be ordered, if it only has one element or if it's already ordered.
+	// The invariant is that the first n-1 items in the list are already sorted.
+	if !p.ordered || len(list) == 1 || list[len(list)-1] >= list[len(list)-2] {
 		return
 	}
-	// There is no guarantee that no higher ID was inserted before as they may
-	// be generated independently before adding them to postings.
-	// We repair order violations on insert. The invariant is that the first n-1
-	// items in the list are already sorted.
+
+	if !copied {
+		// We have appended to the existing slice,
+		// and readers may already have a copy of this postings slice,
+		// so we need to copy it before sorting.
+		old := list
+		list = make([]storage.SeriesRef, len(old), cap(old))
+		copy(list, old)
+		nm[l.Value] = list
+	}
+
+	// Repair order violations.
 	for i := len(list) - 1; i >= 1; i-- {
 		if list[i] >= list[i-1] {
 			break

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1008,7 +1008,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20241023201215-e8c852a65765
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20241029123536-5710f65f1444
 ## explicit; go 1.22.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1676,7 +1676,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20241023201215-e8c852a65765
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20241029123536-5710f65f1444
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
#### What this PR does

Update mimir-prometheus to [5710f65f1444](https://github.com/grafana/mimir-prometheus/tree/5710f65f1444508a2d03d46e2db648ef2fa8d71f), brings in race condition fixes: 
* https://github.com/grafana/mimir-prometheus/pull/729
* https://github.com/grafana/mimir-prometheus/pull/730
* https://github.com/grafana/mimir-prometheus/pull/731

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
