### PR TITLE
Close gzip readers after use

### DIFF
--- a/pkg/continuoustest/client_test.go
+++ b/pkg/continuoustest/client_test.go
@@ -37,6 +37,9 @@ func TestOTLPHttpClient_WriteSeries(t *testing.T) {
 		// Handle compression
 		reader, err := gzip.NewReader(request.Body)
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, reader.Close())
+		})
 
 		// Then Unmarshal
 		body, err := io.ReadAll(reader)

--- a/pkg/storegateway/indexheader/stream_binary_reader.go
+++ b/pkg/storegateway/indexheader/stream_binary_reader.go
@@ -197,8 +197,9 @@ func (r *StreamBinaryReader) loadFromSparseIndexHeader(logger *spanlogger.SpanLo
 	gzipped := bytes.NewReader(sparseData)
 	gzipReader, err := gzip.NewReader(gzipped)
 	if err != nil {
-		return fmt.Errorf("failed to create sparse index-header reader: %w", err)
+		return fmt.Errorf("failed to create sparse index-header gzip reader: %w", err)
 	}
+	defer runutil.CloseWithLogOnErr(logger, gzipReader, "close sparse index-header gzip reader")
 
 	sparseData, err = io.ReadAll(gzipReader)
 	if err != nil {

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -220,11 +220,15 @@ func decompressRequest(buffers *RequestBuffers, reader io.Reader, expectedSize, 
 			return decompressSnappyFromBuffer(buffers, buf, maxSize, sp)
 		}
 	case Gzip:
-		var err error
-		reader, err = gzip.NewReader(reader)
+		gzReader, err := gzip.NewReader(reader)
 		if err != nil {
 			return nil, errors.Wrap(err, "create gzip reader")
 		}
+
+		defer func() {
+			_ = gzReader.Close()
+		}()
+		reader = gzReader
 	case Lz4:
 		reader = lz4.NewReader(reader)
 	default:


### PR DESCRIPTION
#### What this PR does
I noticed that in most cases we don't close gzip readers after use, even though it's the [caller's responsibility](https://pkg.go.dev/compress/gzip#NewReader).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
