### PR TITLE
Update splitblocks tool to handle partially outside chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@
 
 ### Tools
 
-* [FEATURE] `splitblocks`: add new tool to split blocks larger than a specified duration into multiple blocks. #9517
+* [FEATURE] `splitblocks`: add new tool to split blocks larger than a specified duration into multiple blocks. #9517, #9779
 * [ENHANCEMENT] `copyblocks`: Added `--skip-no-compact-block-duration-check`, which defaults to `false`, to simplify targeting blocks that are not awaiting compaction. #9439
 * [ENHANCEMENT] `kafkatool`: add SASL plain authentication support. The following new CLI flags have been added: #9584
   * `--kafka-sasl-username`

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -616,7 +616,7 @@ func repairIssue347(ctx context.Context, logger log.Logger, bkt objstore.Bucket,
 		return errors.Wrapf(err, "read meta from %s", bdir)
 	}
 
-	resid, err := block.Repair(ctx, logger, tmpdir, ie.id, block.CompactorRepairSource, block.IgnoreIssue347OutsideChunk)
+	resid, err := block.Repair(ctx, logger, tmpdir, ie.id, block.CompactorRepairSource, false, block.IgnoreIssue347OutsideChunk)
 	if err != nil {
 		return errors.Wrapf(err, "repair failed for block %s", ie.id)
 	}

--- a/pkg/storage/tsdb/block/index.go
+++ b/pkg/storage/tsdb/block/index.go
@@ -771,6 +771,13 @@ func rewrite(
 // clampChunk returns a chunk that is clamped by the minT and maxT so that all samples fall within these,
 // else returns nil if no chunk clamping was needed.
 func clampChunk(input *chunks.Meta, minT, maxT int64) (*chunks.Meta, error) {
+	// Ignore chunks that are empty, all outside or all inside
+	outsideChunk := input.MinTime >= maxT || input.MaxTime < minT
+	insideChunk := minT <= input.MinTime && input.MaxTime < maxT
+	if input.Chunk.NumSamples() <= 0 || outsideChunk || insideChunk {
+		return nil, nil
+	}
+
 	newChunk, err := chunkenc.NewEmptyChunk(input.Chunk.Encoding())
 	if err != nil {
 		return nil, err

--- a/pkg/storage/tsdb/block/index.go
+++ b/pkg/storage/tsdb/block/index.go
@@ -561,7 +561,6 @@ OUTER:
 			} else {
 				continue
 			}
-			        
 		}
 
 		last = chk

--- a/pkg/storage/tsdb/block/index.go
+++ b/pkg/storage/tsdb/block/index.go
@@ -773,11 +773,13 @@ func rewrite(
 // clampChunk returns a chunk that contains only samples within [mint, maxt),
 // else nil if no samples were within that range.
 func clampChunk(input *chunks.Meta, minT, maxT int64) (*chunks.Meta, error) {
-	// Ignore chunks that are empty, all outside or all inside
-	outsideChunk := input.MinTime >= maxT || input.MaxTime < minT
-	insideChunk := minT <= input.MinTime && input.MaxTime < maxT
-	if input.Chunk.NumSamples() <= 0 || outsideChunk || insideChunk {
+	// Ignore chunks that are empty or all outside
+	if input.Chunk.NumSamples() <= 0 || input.MinTime >= maxT || input.MaxTime < minT {
 		return nil, nil
+	}
+	// Return chunks that are all inside
+	if minT <= input.MinTime && input.MaxTime < maxT {
+		return input, nil
 	}
 
 	newChunk, err := chunkenc.NewEmptyChunk(input.Chunk.Encoding())

--- a/pkg/storage/tsdb/block/index.go
+++ b/pkg/storage/tsdb/block/index.go
@@ -558,7 +558,10 @@ OUTER:
 				return nil, errors.Wrap(err, "clamping chunk")
 			} else if clampedChk != nil {
 				chk = clampedChk
+			} else {
+				continue
 			}
+			        
 		}
 
 		last = chk

--- a/pkg/storage/tsdb/block/index.go
+++ b/pkg/storage/tsdb/block/index.go
@@ -768,8 +768,8 @@ func rewrite(
 	return nil
 }
 
-// clampChunk returns a chunk that is clamped by the minT and maxT so that all samples fall within these,
-// else returns nil if no chunk clamping was needed.
+// clampChunk returns a chunk that contains only samples within [mint, maxt),
+// else nil if no samples were within that range.
 func clampChunk(input *chunks.Meta, minT, maxT int64) (*chunks.Meta, error) {
 	// Ignore chunks that are empty, all outside or all inside
 	outsideChunk := input.MinTime >= maxT || input.MaxTime < minT

--- a/pkg/storage/tsdb/block/index.go
+++ b/pkg/storage/tsdb/block/index.go
@@ -554,10 +554,10 @@ OUTER:
 		// Clamp chunk contents to be bounded by the mint and maxt
 		chk := &chks[i]
 		if clampChunks {
-			var err error
-			chk, err = clampChunk(chk, mint, maxt)
-			if err != nil {
+			if clampedChk, err := clampChunk(chk, mint, maxt); err != nil {
 				return nil, errors.Wrap(err, "clamping chunk")
+			} else if clampedChk != nil {
+				chk = clampedChk
 			}
 		}
 
@@ -768,8 +768,8 @@ func rewrite(
 	return nil
 }
 
-// clampChunk returns a chunk that is clamped by the minT and maxT, so that all samples fall within these,
-// else returns  the original chunk if no clamping was performed.
+// clampChunk returns a chunk that is clamped by the minT and maxT so that all samples fall within these,
+// else returns nil if no chunk clamping was needed.
 func clampChunk(input *chunks.Meta, minT, maxT int64) (*chunks.Meta, error) {
 	newChunk, err := chunkenc.NewEmptyChunk(input.Chunk.Encoding())
 	if err != nil {
@@ -799,7 +799,7 @@ func clampChunk(input *chunks.Meta, minT, maxT int64) (*chunks.Meta, error) {
 			Chunk:   newChunk,
 		}, nil
 	}
-	return input, nil
+	return nil, nil
 }
 
 type stringset map[string]struct{}

--- a/pkg/storage/tsdb/block/index_test.go
+++ b/pkg/storage/tsdb/block/index_test.go
@@ -63,7 +63,7 @@ func TestRewrite(t *testing.T) {
 
 	totalChunks := 0
 	ignoredChunks := 0
-	require.NoError(t, rewrite(ctx, log.NewNopLogger(), ir, cr, iw, cw, m, []ignoreFnType{func(_, _ int64, _ *chunks.Meta, curr *chunks.Meta) (bool, error) {
+	require.NoError(t, rewrite(ctx, log.NewNopLogger(), ir, cr, iw, cw, m, false, []ignoreFnType{func(_, _ int64, _ *chunks.Meta, curr *chunks.Meta) (bool, error) {
 		totalChunks++
 		if curr.OverlapsClosedInterval(excludeTime, excludeTime) {
 			// Ignores all chunks that overlap with the excludeTime. excludeTime was randomly selected inside the block.

--- a/tools/splitblocks/README.md
+++ b/tools/splitblocks/README.md
@@ -14,6 +14,7 @@ Source blocks can be read from either object storage or a local filesystem. Bloc
 - `--bucket-prefix` (optional) A prefix applied to the bucket path
 - `--max-block-duration` (optional, defaults to `24h`) Max block duration, blocks larger than this or crossing a duration boundary are split
 - `--full` (optional) If set, blocks that do not need to be split are included in the output directory
+- `--verify-blocks` (optional) Verifies blocks after splitting them
 - `--dry-run` (optional) If set, blocks are not downloaded (except metadata) and splits are not performed; only what would happen is logged
 
 ## Running

--- a/tools/splitblocks/main.go
+++ b/tools/splitblocks/main.go
@@ -219,7 +219,6 @@ func splitLocalBlock(ctx context.Context, parentDir, blockDir string, meta block
 		level.Info(logger).Log("msg", "splitting block", "minTime", timestamp.Time(minTime), "maxTime", timestamp.Time(maxTime))
 
 		// Inject a modified meta and abuse the repair into removing the now "outside" chunks.
-		// Chunks that cross boundaries are included in multiple blocks.
 		meta.MinTime = minTime
 		meta.MaxTime = maxTime
 		if err := meta.WriteToDir(logger, blockDir); err != nil {

--- a/tools/splitblocks/main.go
+++ b/tools/splitblocks/main.go
@@ -47,7 +47,7 @@ func (c *config) registerFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.full, "full", false, "If set blocks that do not need to be split are included in the output directory")
 	f.BoolVar(&c.dryRun, "dry-run", false, "If set blocks are not downloaded (except metadata) and splits are not performed; only what would happen is logged")
 	f.DurationVar(&c.maxBlockDuration, "max-block-duration", 24*time.Hour, "Max block duration, blocks larger than this or crossing a duration boundary are split")
-	f.BoolVar(&c.verifyBlocks, "verify-blocks", false, "Verifies blocks after performing repair")
+	f.BoolVar(&c.verifyBlocks, "verify-blocks", false, "Verifies blocks after splitting them")
 }
 
 func (c *config) validate() error {

--- a/tools/splitblocks/main.go
+++ b/tools/splitblocks/main.go
@@ -235,14 +235,13 @@ func splitLocalBlock(ctx context.Context, parentDir, blockDir string, meta block
 			return nil, errors.Wrap(err, "failed while splitting block")
 		}
 
+		splitDir := path.Join(parentDir, splitID.String())
 		if verifyBlocks {
-			blockPath := path.Join(parentDir, splitID.String())
-			if err := block.VerifyBlock(ctx, logger, blockPath, meta.MinTime, meta.MaxTime, true); err != nil {
+			if err := block.VerifyBlock(ctx, logger, splitDir, meta.MinTime, meta.MaxTime, true); err != nil {
 				return nil, errors.Wrap(err, "block verification failed")
 			}
 		}
 
-		splitDir := path.Join(parentDir, splitID.String())
 		splitMeta, err := block.ReadMetaFromDir(splitDir)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed while reading meta.json from split block")

--- a/tools/splitblocks/main_test.go
+++ b/tools/splitblocks/main_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/dskit/runutil"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -66,7 +67,7 @@ func TestSplitLocalBlock(t *testing.T) {
 	meta, err := block.GenerateBlockFromSpec(dir, specs)
 	require.NoError(t, err)
 
-	blocks, err := splitLocalBlock(context.Background(), dir, filepath.Join(dir, meta.ULID.String()), *meta, 24*time.Hour, log.NewNopLogger())
+	blocks, err := splitLocalBlock(context.Background(), dir, filepath.Join(dir, meta.ULID.String()), *meta, 24*time.Hour, true, log.NewNopLogger())
 	require.NoError(t, err)
 
 	// We expect 3 blocks
@@ -76,15 +77,17 @@ func TestSplitLocalBlock(t *testing.T) {
 	{
 		spec := listSeriesAndChunksFromBlock(t, filepath.Join(dir, blocks[0].String()))
 
-		// series 1 has its entire chunk in the first block
+		// Series 1 has 2 samples in this block
 		require.Equal(t, spec[0].Labels, labels.FromStrings("__name__", "1_series_with_one_chunk_with_samples_covering_multiple_days"))
 		require.Len(t, spec[0].Chunks, 1)
+		require.Equal(t, spec[0].Chunks[0].Chunk.NumSamples(), 2)
 		require.Equal(t, startOfDay.Add(10*time.Minute).UnixMilli(), spec[0].Chunks[0].MinTime)
-		require.Equal(t, startOfDay.Add(48*time.Hour).UnixMilli(), spec[0].Chunks[0].MaxTime)
+		require.Equal(t, startOfDay.Add(12*time.Hour).UnixMilli(), spec[0].Chunks[0].MaxTime)
 
-		// Series 2 has only first chunk in the first block
+		// Series 2 has 2 samples in this block
 		require.Equal(t, spec[1].Labels, labels.FromStrings("__name__", "2_series_with_multiple_chunks_not_crossing_24h_boundary"))
 		require.Len(t, spec[1].Chunks, 1)
+		require.Equal(t, spec[1].Chunks[0].Chunk.NumSamples(), 2)
 		require.Equal(t, startOfDay.UnixMilli(), spec[1].Chunks[0].MinTime)
 		require.Equal(t, startOfDay.Add(12*time.Hour).UnixMilli(), spec[1].Chunks[0].MaxTime)
 
@@ -96,21 +99,24 @@ func TestSplitLocalBlock(t *testing.T) {
 	{
 		spec := listSeriesAndChunksFromBlock(t, filepath.Join(dir, blocks[1].String()))
 
-		// series 1 has its entire chunk in the second block as well.
+		// series 1 has 2 samples in this block
 		require.Equal(t, spec[0].Labels, labels.FromStrings("__name__", "1_series_with_one_chunk_with_samples_covering_multiple_days"))
 		require.Len(t, spec[0].Chunks, 1)
-		require.Equal(t, startOfDay.Add(10*time.Minute).UnixMilli(), spec[0].Chunks[0].MinTime)
-		require.Equal(t, startOfDay.Add(48*time.Hour).UnixMilli(), spec[0].Chunks[0].MaxTime)
+		require.Equal(t, spec[0].Chunks[0].Chunk.NumSamples(), 2)
+		require.Equal(t, startOfDay.Add(24*time.Hour).UnixMilli(), spec[0].Chunks[0].MinTime)
+		require.Equal(t, startOfDay.Add(36*time.Hour).UnixMilli(), spec[0].Chunks[0].MaxTime)
 
-		// Series 2 has only second chunk in the first block
+		// Series 2 has 2 samples in this block
 		require.Equal(t, spec[1].Labels, labels.FromStrings("__name__", "2_series_with_multiple_chunks_not_crossing_24h_boundary"))
 		require.Len(t, spec[1].Chunks, 1)
+		require.Equal(t, spec[1].Chunks[0].Chunk.NumSamples(), 2)
 		require.Equal(t, startOfDay.Add(24*time.Hour).UnixMilli(), spec[1].Chunks[0].MinTime)
 		require.Equal(t, startOfDay.Add(36*time.Hour).UnixMilli(), spec[1].Chunks[0].MaxTime)
 
-		// Series 3 has its chunk in this block too
+		// Series 3 has 3 samples in this block
 		require.Equal(t, spec[2].Labels, labels.FromStrings("__name__", "3_series_with_samples_on_second_day"))
 		require.Len(t, spec[2].Chunks, 1)
+		require.Equal(t, spec[2].Chunks[0].Chunk.NumSamples(), 3)
 		require.Equal(t, startOfDay.Add(24*time.Hour).UnixMilli(), spec[2].Chunks[0].MinTime)
 		require.Equal(t, startOfDay.Add(26*time.Hour).UnixMilli(), spec[2].Chunks[0].MaxTime)
 
@@ -122,15 +128,17 @@ func TestSplitLocalBlock(t *testing.T) {
 	{
 		spec := listSeriesAndChunksFromBlock(t, filepath.Join(dir, blocks[2].String()))
 
-		// series 1 has its entire chunk in the last block too.
+		// series 1 has 1 sample in this block
 		require.Equal(t, spec[0].Labels, labels.FromStrings("__name__", "1_series_with_one_chunk_with_samples_covering_multiple_days"))
 		require.Len(t, spec[0].Chunks, 1)
-		require.Equal(t, startOfDay.Add(10*time.Minute).UnixMilli(), spec[0].Chunks[0].MinTime)
+		require.Equal(t, spec[0].Chunks[0].Chunk.NumSamples(), 1)
+		require.Equal(t, startOfDay.Add(48*time.Hour).UnixMilli(), spec[0].Chunks[0].MinTime)
 		require.Equal(t, startOfDay.Add(48*time.Hour).UnixMilli(), spec[0].Chunks[0].MaxTime)
 
-		// Series 2 has only last chunk in the last block
+		// Series 2 has 1 sample in this block
 		require.Equal(t, spec[1].Labels, labels.FromStrings("__name__", "2_series_with_multiple_chunks_not_crossing_24h_boundary"))
 		require.Len(t, spec[1].Chunks, 1)
+		require.Equal(t, spec[1].Chunks[0].Chunk.NumSamples(), 1)
 		require.Equal(t, startOfDay.Add(48*time.Hour).UnixMilli(), spec[1].Chunks[0].MinTime)
 		require.Equal(t, startOfDay.Add(48*time.Hour).UnixMilli(), spec[1].Chunks[0].MaxTime)
 
@@ -145,10 +153,13 @@ func buildSeriesSpec(startOfDay time.Time) []*block.SeriesSpec {
 			Labels: labels.FromStrings("__name__", "1_series_with_one_chunk_with_samples_covering_multiple_days"),
 			Chunks: []chunks.Meta{
 				must(chunks.ChunkFromSamples([]chunks.Sample{
+					// Ends up in block 1
 					newSample(startOfDay.Add(10*time.Minute).UnixMilli(), 1, nil, nil),
 					newSample(startOfDay.Add(12*time.Hour).UnixMilli(), 2, nil, nil),
+					// Ends up in block 2
 					newSample(startOfDay.Add(24*time.Hour).UnixMilli(), 3, nil, nil),
 					newSample(startOfDay.Add(36*time.Hour).UnixMilli(), 4, nil, nil),
+					// ENds up in block 3
 					newSample(startOfDay.Add(48*time.Hour).UnixMilli(), 5, nil, nil),
 				})),
 			},
@@ -157,14 +168,17 @@ func buildSeriesSpec(startOfDay time.Time) []*block.SeriesSpec {
 		{
 			Labels: labels.FromStrings("__name__", "2_series_with_multiple_chunks_not_crossing_24h_boundary"),
 			Chunks: []chunks.Meta{
+				// Ends up in block 1
 				must(chunks.ChunkFromSamples([]chunks.Sample{
 					newSample(startOfDay.UnixMilli(), 1, nil, nil),
 					newSample(startOfDay.Add(12*time.Hour).UnixMilli(), 2, nil, nil),
 				})),
+				// Ends up in block 2
 				must(chunks.ChunkFromSamples([]chunks.Sample{
 					newSample(startOfDay.Add(24*time.Hour).UnixMilli(), 3, nil, nil),
 					newSample(startOfDay.Add(36*time.Hour).UnixMilli(), 4, nil, nil),
 				})),
+				// Ends up in block 3
 				must(chunks.ChunkFromSamples([]chunks.Sample{
 					newSample(startOfDay.Add(48*time.Hour).UnixMilli(), 5, nil, nil),
 				})),
@@ -175,6 +189,7 @@ func buildSeriesSpec(startOfDay time.Time) []*block.SeriesSpec {
 			Labels: labels.FromStrings("__name__", "3_series_with_samples_on_second_day"),
 			Chunks: []chunks.Meta{
 				must(chunks.ChunkFromSamples([]chunks.Sample{
+					// Ends up in block 2
 					newSample(startOfDay.Add(24*time.Hour).UnixMilli(), 1, nil, nil),
 					newSample(startOfDay.Add(25*time.Hour).UnixMilli(), 2, nil, nil),
 					newSample(startOfDay.Add(26*time.Hour).UnixMilli(), 3, nil, nil),
@@ -193,6 +208,11 @@ func listSeriesAndChunksFromBlock(t *testing.T, blockDir string) []*block.Series
 	it, err := r.Postings(context.Background(), allKey, allValue)
 	require.NoError(t, err)
 
+	blk, err := tsdb.OpenBlock(log.NewNopLogger(), blockDir, nil)
+	require.NoError(t, err)
+	chunkReader, err := blk.Chunks()
+	require.NoError(t, err)
+	defer require.NoError(t, chunkReader.Close())
 	result := []*block.SeriesSpec(nil)
 
 	for it.Next() {
@@ -206,6 +226,11 @@ func listSeriesAndChunksFromBlock(t *testing.T, blockDir string) []*block.Series
 		ss := block.SeriesSpec{
 			Labels: lbls.Labels(),
 			Chunks: chks,
+		}
+		for i, c := range chks {
+			chunk, _, err := chunkReader.ChunkOrIterable(c)
+			require.NoError(t, err)
+			chks[i].Chunk = chunk
 		}
 		result = append(result, &ss)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

In #9517, a splitblocks tool was created to split blocks by time. But the tool doesn't rewrite chunks that are partially outside the time, causing block validation to complain.

This PR:
- Updates the splitblocks tool to rewrite chunks that are clamped to the block's time window
- Adds a `--verify-blocks` option to the splitblocks tool that runs block validation after each block is split
- Makes chunk "clamping" available for other block repair uses, though this PR doesn't enable it anywhere else for now (for example, in the compactor's usage of block repair)

#### Manual Testing

- Split a 48h block into 2h blocks and ran a sample counting script on all of them to confirm the number of samples in the split blocks equals the total from the original.
- Confirmed a 48h block split into 2h blocks passes verification via `--verify-blocks`.
  - Ensured that the split blocks have no outside chunks as shown by the tsdb-index-health tool.
- Confirmed that `--full` and `--verify-blocks` work as expected on blocks that do not need to be split.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
