### PR TITLE
feat(helm): add alertmanager specific service account

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [ENHANCEMENT] Add support for setting type and internal traffic policy for Kubernetes service. Set `internalTrafficPolicy=Cluster` by default in all services with type `ClusterIP`. #9619
+* [ENHANCEMENT] Add the possibility to create a dedicated serviceAccount for the `alertmanager` component by setting `alertmanager.serviceAcount.create` to true in the values. #9780
 * [BUGFIX] Fix PVC template in AlertManager to not show diff in ArgoCD. #9774
 
 ## 5.5.1

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -80,9 +80,23 @@ Create the name of the ruler service account
 {{- define "mimir.ruler.serviceAccountName" -}}
 {{- if and .Values.ruler.serviceAccount.create (eq .Values.ruler.serviceAccount.name "") -}}
 {{- $sa := default (include "mimir.fullname" .) .Values.serviceAccount.name }}
-{{- printf "%s-%s" $sa "ruler" }}
+{{- printf "%s-ruler" $sa }}
 {{- else if and .Values.ruler.serviceAccount.create (not (eq .Values.ruler.serviceAccount.name "")) -}}
 {{- .Values.ruler.serviceAccount.name -}}
+{{- else -}}
+{{- include "mimir.serviceAccountName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the alertmanager service account
+*/}}
+{{- define "mimir.alertmanager.serviceAccountName" -}}
+{{- if and .Values.alertmanager.serviceAccount.create (eq .Values.alertmanager.serviceAccount.name "") -}}
+{{- $sa := default (include "mimir.fullname" .) .Values.serviceAccount.name }}
+{{- printf "%s-alertmanager" $sa }}
+{{- else if and .Values.alertmanager.serviceAccount.create (not (eq .Values.alertmanager.serviceAccount.name "")) -}}
+{{- .Values.alertmanager.serviceAccount.name -}}
 {{- else -}}
 {{- include "mimir.serviceAccountName" . -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -27,7 +27,7 @@ spec:
         {{- end }}
       namespace: {{ .Release.Namespace | quote }}
     spec:
-      serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      serviceAccountName: {{ template "mimir.alertmanager.serviceAccountName" . }}
       {{- if .Values.alertmanager.priorityClassName }}
       priorityClassName: {{ .Values.query_frontend.priorityClassName }}
       {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-sa.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-sa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.alertmanager.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "mimir.alertmanager.serviceAccountName" . }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" .) | nindent 4 }}
+    {{- with .Values.alertmanager.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.alertmanager.serviceAccount.annotations | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/rolebinding.yaml
@@ -23,4 +23,8 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "mimir.ruler.serviceAccountName" . }}
 {{- end }}
+{{- if .Values.alertmanager.serviceAccount.create }}
+- kind: ServiceAccount
+  name: {{ template "mimir.alertmanager.serviceAccountName" . }}
+{{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -544,6 +544,17 @@ alertmanager:
   statefulSet:
     enabled: true
 
+  # -- Dedicated service account for alertmanager pods.
+  # If not set, the default service account defined at the begining of this file will be used.
+  # This service account can be used even if the default one is not set.
+  serviceAccount:
+    create: false
+    # -- Alertmanager specific service account name. If not set and create is set to true, the default
+    # name will be the default mimir service account's name with the "-alertmanager" suffix.
+    name: ""
+    annotations: {}
+    labels: {}
+
   service:
     annotations: {}
     labels: {}


### PR DESCRIPTION
#### What this PR does

This PR adds a specific service account for the alertmanager component so that different permissions/authorizations can be given to the component. This replicates what was done https://github.com/grafana/mimir/pull/7132 for the ruler.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


cc @dimitarvdimitrov if you have some time to review this one that would be amazing :) 