### PR TITLE
query-frontend: Do not break scheduler connection on malformed queries

### DIFF
--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -144,6 +144,9 @@ const (
 
 type enqueueResult struct {
 	status enqueueStatus
+	// If the status is failed and if it was because of a client error on the frontend,
+	// the clientErr should be updated with the appropriate error.
+	clientErr error
 
 	cancelCh chan<- uint64 // Channel that can be used for request cancellation. If nil, cancellation is not possible.
 }
@@ -285,6 +288,11 @@ enqueueAgain:
 			cancelCh = enqRes.cancelCh
 			break // go wait for response.
 		} else if enqRes.status == failed {
+			if enqRes.clientErr != nil {
+				// It failed because of a client error. No need to retry.
+				return nil, nil, httpgrpc.Errorf(http.StatusBadRequest, "failed to enqueue request: %s", enqRes.clientErr.Error())
+			}
+
 			retries--
 			if retries > 0 {
 				spanLogger.DebugLog("msg", "enqueuing request failed, will retry")

--- a/pkg/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/frontend/v2/frontend_scheduler_worker.go
@@ -412,8 +412,8 @@ func (w *frontendSchedulerWorker) enqueueRequest(loop schedulerpb.SchedulerForFr
 	frontendToSchedulerRequest, err := w.toSchedulerAdapter.frontendToSchedulerEnqueueRequest(req, w.frontendAddr)
 	if err != nil {
 		level.Warn(spanLogger).Log("msg", "error converting frontend request to scheduler request", "err", err)
-		req.enqueue <- enqueueResult{status: failed}
-		return err
+		req.enqueue <- enqueueResult{status: failed, clientErr: err}
+		return nil
 	}
 
 	err = loop.Send(frontendToSchedulerRequest)

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -242,17 +242,57 @@ func TestFrontendTooManyRequests(t *testing.T) {
 	require.Equal(t, int32(http.StatusTooManyRequests), resp.Code)
 }
 
-func TestFrontendEnqueueFailure(t *testing.T) {
-	f, _ := setupFrontend(t, nil, func(*Frontend, *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
-		return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.SHUTTING_DOWN}
+func TestFrontendEnqueueFailures(t *testing.T) {
+	const (
+		body   = "all fine here"
+		userID = "test"
+	)
+
+	f, _ := setupFrontend(t, nil, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
+		// We cannot call QueryResult directly, as Frontend is not yet waiting for the response.
+		// It first needs to be told that enqueuing has succeeded.
+		go sendResponseWithDelay(f, 100*time.Millisecond, userID, msg.QueryID, &httpgrpc.HTTPResponse{
+			Code: 200,
+			Body: []byte(body),
+		})
+
+		return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
 	})
 
-	req := &httpgrpc.HTTPRequest{
-		Url: "/api/v1/query_range?start=946684800&end=946771200&step=60",
+	cases := []struct {
+		name, url, error string
+	}{
+		{
+			name:  "start time is wrong",
+			url:   "/api/v1/query_range?start=9466camnsd84800&end=946771200&step=60&query=up{}",
+			error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "start": cannot parse "9466camnsd84800" to a valid timestamp`,
+		},
+		{
+			name:  "end time is wrong",
+			url:   "/api/v1/query_range?start=946684800&end=946771200dgiu&step=60&query=up{}",
+			error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "end": cannot parse "946771200dgiu" to a valid timestamp`,
+		},
+		{
+			name:  "query time is wrong",
+			url:   "/api/v1/query_range?start=946684800&end=946771200&step=60&query=up{",
+			error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "query": 1:4: parse error: unexpected end of input inside braces`,
+		},
+		{
+			name:  "no query provided",
+			url:   "/api/v1/query_range?start=946684800&end=946771200&step=60",
+			error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "query": unknown position: parse error: no expression found in input`,
+		},
 	}
-	_, _, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), "test"), req)
-	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "failed to enqueue request"))
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := &httpgrpc.HTTPRequest{
+				Url: c.url,
+			}
+			_, _, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), userID), req)
+			require.Error(t, err)
+			require.Equal(t, c.error, err.Error())
+		})
+	}
 }
 
 func TestFrontendCancellation(t *testing.T) {

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -256,7 +256,7 @@ func TestFrontendEnqueueFailures(t *testing.T) {
 		require.True(t, strings.Contains(err.Error(), "failed to enqueue request"))
 	})
 	t.Run("scheduler is running fine", func(t *testing.T) {
-		f, _ := setupFrontend(t, nil, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
+		f, _ := setupFrontend(t, nil, func(*Frontend, *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
 			return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
 		})
 

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -243,56 +243,58 @@ func TestFrontendTooManyRequests(t *testing.T) {
 }
 
 func TestFrontendEnqueueFailures(t *testing.T) {
-	const (
-		body   = "all fine here"
-		userID = "test"
-	)
-
-	f, _ := setupFrontend(t, nil, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
-		// We cannot call QueryResult directly, as Frontend is not yet waiting for the response.
-		// It first needs to be told that enqueuing has succeeded.
-		go sendResponseWithDelay(f, 100*time.Millisecond, userID, msg.QueryID, &httpgrpc.HTTPResponse{
-			Code: 200,
-			Body: []byte(body),
+	t.Run("scheduler is shutting down with valid query", func(t *testing.T) {
+		f, _ := setupFrontend(t, nil, func(*Frontend, *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
+			return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.SHUTTING_DOWN}
 		})
 
-		return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
+		req := &httpgrpc.HTTPRequest{
+			Url: "/api/v1/query_range?start=946684800&end=946771200&step=60&query=up",
+		}
+		_, _, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), "test"), req)
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "failed to enqueue request"))
 	})
-
-	cases := []struct {
-		name, url, error string
-	}{
-		{
-			name:  "start time is wrong",
-			url:   "/api/v1/query_range?start=9466camnsd84800&end=946771200&step=60&query=up{}",
-			error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "start": cannot parse "9466camnsd84800" to a valid timestamp`,
-		},
-		{
-			name:  "end time is wrong",
-			url:   "/api/v1/query_range?start=946684800&end=946771200dgiu&step=60&query=up{}",
-			error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "end": cannot parse "946771200dgiu" to a valid timestamp`,
-		},
-		{
-			name:  "query time is wrong",
-			url:   "/api/v1/query_range?start=946684800&end=946771200&step=60&query=up{",
-			error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "query": 1:4: parse error: unexpected end of input inside braces`,
-		},
-		{
-			name:  "no query provided",
-			url:   "/api/v1/query_range?start=946684800&end=946771200&step=60",
-			error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "query": unknown position: parse error: no expression found in input`,
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			req := &httpgrpc.HTTPRequest{
-				Url: c.url,
-			}
-			_, _, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), userID), req)
-			require.Error(t, err)
-			require.Equal(t, c.error, err.Error())
+	t.Run("scheduler is running fine", func(t *testing.T) {
+		f, _ := setupFrontend(t, nil, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
+			return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
 		})
-	}
+
+		cases := []struct {
+			name, url, error string
+		}{
+			{
+				name:  "start time is wrong",
+				url:   "/api/v1/query_range?start=9466camnsd84800&end=946771200&step=60&query=up{}",
+				error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "start": cannot parse "9466camnsd84800" to a valid timestamp`,
+			},
+			{
+				name:  "end time is wrong",
+				url:   "/api/v1/query_range?start=946684800&end=946771200dgiu&step=60&query=up{}",
+				error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "end": cannot parse "946771200dgiu" to a valid timestamp`,
+			},
+			{
+				name:  "query time is wrong",
+				url:   "/api/v1/query_range?start=946684800&end=946771200&step=60&query=up{",
+				error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "query": 1:4: parse error: unexpected end of input inside braces`,
+			},
+			{
+				name:  "no query provided",
+				url:   "/api/v1/query_range?start=946684800&end=946771200&step=60",
+				error: `rpc error: code = Code(400) desc = failed to enqueue request: invalid parameter "query": unknown position: parse error: no expression found in input`,
+			},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				req := &httpgrpc.HTTPRequest{
+					Url: c.url,
+				}
+				_, _, err := f.RoundTripGRPC(user.InjectOrgID(context.Background(), "test"), req)
+				require.Error(t, err)
+				require.Equal(t, c.error, err.Error())
+			})
+		}
+	})
 }
 
 func TestFrontendCancellation(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Instead of breaking the scheduler connection for malformed queries and eventually sending 500, instead send 400 and do not break the scheduler connection.

This is another version of what https://github.com/grafana/mimir/pull/9782 was trying to do.

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
