### PR TITLE
test(histograms): do not ignore native histogram counter reset hint in tests

### DIFF
--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -99,7 +99,11 @@ func testIter(t require.TestingT, points int, iter chunkenc.Iterator, encoding c
 			require.Equal(t, chunkenc.ValHistogram, iter.Next(), strconv.Itoa(i))
 			ts, h := iter.AtHistogram(nil)
 			require.EqualValues(t, int64(nextExpectedTS), ts, strconv.Itoa(i))
-			test.RequireHistogramEqual(t, test.GenerateTestHistogram(int(nextExpectedTS)), h, strconv.Itoa(i))
+			expH := test.GenerateTestHistogram(int(nextExpectedTS))
+			if nextExpectedTS > 0 {
+				expH.CounterResetHint = histogram.NotCounterReset
+			}
+			test.RequireHistogramEqual(t, expH, h, strconv.Itoa(i))
 			nextExpectedTS = nextExpectedTS.Add(step)
 		}
 	case chunk.PrometheusFloatHistogramChunk:
@@ -107,7 +111,11 @@ func testIter(t require.TestingT, points int, iter chunkenc.Iterator, encoding c
 			require.Equal(t, chunkenc.ValFloatHistogram, iter.Next(), strconv.Itoa(i))
 			ts, fh := iter.AtFloatHistogram(nil)
 			require.EqualValues(t, int64(nextExpectedTS), ts, strconv.Itoa(i))
-			test.RequireFloatHistogramEqual(t, test.GenerateTestFloatHistogram(int(nextExpectedTS)), fh, strconv.Itoa(i))
+			expFH := test.GenerateTestFloatHistogram(int(nextExpectedTS))
+			if nextExpectedTS > 0 {
+				expFH.CounterResetHint = histogram.NotCounterReset
+			}
+			test.RequireFloatHistogramEqual(t, expFH, fh, strconv.Itoa(i))
 			nextExpectedTS = nextExpectedTS.Add(step)
 		}
 	default:
@@ -135,7 +143,11 @@ func testSeek(t require.TestingT, points int, iter chunkenc.Iterator, encoding c
 			require.Equal(t, chunkenc.ValHistogram, valType)
 			ts, h := iter.AtHistogram(nil)
 			require.EqualValues(t, expectedTS, ts)
-			test.RequireHistogramEqual(t, test.GenerateTestHistogram(int(expectedTS)), h)
+			expH := test.GenerateTestHistogram(int(expectedTS))
+			if expectedTS > 0 {
+				expH.CounterResetHint = histogram.NotCounterReset
+			}
+			test.RequireHistogramEqual(t, expH, h)
 			require.NoError(t, iter.Err())
 		}
 	case chunk.PrometheusFloatHistogramChunk:
@@ -143,7 +155,11 @@ func testSeek(t require.TestingT, points int, iter chunkenc.Iterator, encoding c
 			require.Equal(t, chunkenc.ValFloatHistogram, valType)
 			ts, fh := iter.AtFloatHistogram(nil)
 			require.EqualValues(t, expectedTS, ts)
-			test.RequireFloatHistogramEqual(t, test.GenerateTestFloatHistogram(int(expectedTS)), fh)
+			expFH := test.GenerateTestFloatHistogram(int(expectedTS))
+			if expectedTS > 0 {
+				expFH.CounterResetHint = histogram.NotCounterReset
+			}
+			test.RequireFloatHistogramEqual(t, expFH, fh)
 			require.NoError(t, iter.Err())
 		}
 	default:

--- a/pkg/querier/block_test.go
+++ b/pkg/querier/block_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
@@ -80,7 +81,11 @@ func TestBlockQuerierSeries(t *testing.T) {
 			expectedMetric:  labels.FromStrings("foo", "bar"),
 			expectedSamples: 2,
 			assertSample: func(t *testing.T, i int64, iter chunkenc.Iterator, valueType chunkenc.ValueType) {
-				test.RequireIteratorHistogram(t, time.Unix(i, 0).UnixMilli(), test.GenerateTestHistogram(int(i)), iter, valueType)
+				expH := test.GenerateTestHistogram(int(i))
+				if i > 1 { // 1 because the chunk contains samples starting from timestamp 1, not 0
+					expH.CounterResetHint = histogram.NotCounterReset
+				}
+				test.RequireIteratorHistogram(t, time.Unix(i, 0).UnixMilli(), expH, iter, valueType)
 			},
 		},
 		"should return float histogram series on success": {
@@ -99,7 +104,11 @@ func TestBlockQuerierSeries(t *testing.T) {
 			expectedMetric:  labels.FromStrings("foo", "bar"),
 			expectedSamples: 2,
 			assertSample: func(t *testing.T, i int64, iter chunkenc.Iterator, valueType chunkenc.ValueType) {
-				test.RequireIteratorFloatHistogram(t, time.Unix(i, 0).UnixMilli(), test.GenerateTestFloatHistogram(int(i)), iter, valueType)
+				expFH := test.GenerateTestFloatHistogram(int(i))
+				if i > 1 { // 1 because the chunk contains samples starting from timestamp 1, not 0
+					expFH.CounterResetHint = histogram.NotCounterReset
+				}
+				test.RequireIteratorFloatHistogram(t, time.Unix(i, 0).UnixMilli(), expFH, iter, valueType)
 			},
 		},
 		"should return error on failure while reading encoded chunk data": {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -157,7 +157,6 @@ func TestQuerier(t *testing.T) {
 				// data doesn't have resets and is not a product of a merge.
 				point.H.CounterResetHint = histogram.UnknownCounterReset
 				test.RequireFloatHistogramEqual(t, test.GenerateTestHistogram(int(ts)).ToFloat(nil), point.H)
-
 			},
 		},
 

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/scrape"
@@ -150,7 +151,13 @@ func TestQuerier(t *testing.T) {
 			valueType: func(_ model.Time) chunkenc.ValueType { return chunkenc.ValFloatHistogram },
 			assertHPoint: func(t testing.TB, ts int64, point promql.HPoint) {
 				require.Equal(t, ts, point.T)
+				// The TSDB head uses heuristic to determine the chunk sizes, which
+				// can alter where chunks are started, which can alter where
+				// unknown and no reset hints are. We really don't care as the
+				// data doesn't have resets and is not a product of a merge.
+				point.H.CounterResetHint = histogram.UnknownCounterReset
 				test.RequireFloatHistogramEqual(t, test.GenerateTestHistogram(int(ts)).ToFloat(nil), point.H)
+
 			},
 		},
 
@@ -164,6 +171,11 @@ func TestQuerier(t *testing.T) {
 			valueType: func(_ model.Time) chunkenc.ValueType { return chunkenc.ValFloatHistogram },
 			assertHPoint: func(t testing.TB, ts int64, point promql.HPoint) {
 				require.Equal(t, ts, point.T)
+				// The TSDB head uses heuristic to determine the chunk sizes, which
+				// can alter where chunks are started, which can alter where
+				// unknown and no reset hints are. We really don't care as the
+				// data doesn't have resets and is not a product of a merge.
+				point.H.CounterResetHint = histogram.UnknownCounterReset
 				test.RequireFloatHistogramEqual(t, test.GenerateTestFloatHistogram(int(ts)), point.H)
 			},
 		},
@@ -178,6 +190,11 @@ func TestQuerier(t *testing.T) {
 			valueType: func(_ model.Time) chunkenc.ValueType { return chunkenc.ValFloatHistogram },
 			assertHPoint: func(t testing.TB, ts int64, point promql.HPoint) {
 				require.Equal(t, ts, point.T)
+				// The TSDB head uses heuristic to determine the chunk sizes, which
+				// can alter where chunks are started, which can alter where
+				// unknown and no reset hints are. We really don't care as the
+				// data doesn't have resets and is not a product of a merge.
+				point.H.CounterResetHint = histogram.UnknownCounterReset
 				test.RequireFloatHistogramEqual(t, test.GenerateTestFloatHistogram(int(ts)), point.H)
 			},
 		},
@@ -205,13 +222,18 @@ func TestQuerier(t *testing.T) {
 			assertHPoint: func(t testing.TB, ts int64, point promql.HPoint) {
 				require.True(t, ts > int64(secondChunkStart))
 				require.Equal(t, ts, point.T)
+				// The TSDB head uses heuristic to determine the chunk sizes, which
+				// can alter where chunks are started, which can alter where
+				// unknown and no reset hints are. We really don't care as the
+				// data doesn't have resets and is not a product of a merge.
+				point.H.CounterResetHint = histogram.UnknownCounterReset
 				test.RequireFloatHistogramEqual(t, test.GenerateTestFloatHistogram(int(ts)), point.H)
 			},
 		},
 	}
 
-	for _, q := range queries {
-		t.Run(q.query, func(t *testing.T) {
+	for qName, q := range queries {
+		t.Run(qName, func(t *testing.T) {
 			// Generate TSDB head used to simulate querying the long-term storage.
 			db, through := mockTSDB(t, model.Time(0), int(chunks*samplesPerChunk), sampleRate, chunkOffset, int(samplesPerChunk), q.valueType)
 			dbQueryable := TimeRangeQueryable{

--- a/pkg/util/test/histogram.go
+++ b/pkg/util/test/histogram.go
@@ -97,20 +97,12 @@ func GenerateTestSampleHistogram(i int) *model.SampleHistogram {
 	}
 }
 
-// RequireHistogramEqual ignores counter resets of non gauge histograms
+// RequireHistogramEqual requires the two histograms to be equal.
 func RequireHistogramEqual(t require.TestingT, expected, actual *histogram.Histogram, msgAndArgs ...interface{}) {
-	if expected.CounterResetHint != histogram.GaugeType {
-		// Ignore counter resets injected by tsdb
-		actual.CounterResetHint = histogram.UnknownCounterReset
-	}
 	require.EqualValues(t, expected, actual, msgAndArgs)
 }
 
-// RequireFloatHistogramEqual ignores counter resets of non gauge histograms
+// RequireFloatHistogramEqual requires the two float histograms to be equal.
 func RequireFloatHistogramEqual(t require.TestingT, expected, actual *histogram.FloatHistogram, msgAndArgs ...interface{}) {
-	if expected.CounterResetHint != histogram.GaugeType {
-		// Ignore counter resets injected by tsdb
-		actual.CounterResetHint = histogram.UnknownCounterReset
-	}
 	require.EqualValues(t, expected, actual, msgAndArgs)
 }


### PR DESCRIPTION
#### What this PR does

Do not ignore native histogram counter reset hint in tests

Ignoring the hint was convenient in the past, but we want to add a test case where the hint is actually calculated wrong. This commit simply updates the current tests to specify the expected output.

#### Which issue(s) this PR fixes or relates to

Related to #7175 

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
