### PR TITLE
MQE: Fix handling of string results

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -251,10 +251,12 @@ func TestNewInstantQuery_Strings(t *testing.T) {
 	q, err := mimirEngine.NewInstantQuery(ctx, storage, nil, expr, time.Now())
 	require.NoError(t, err)
 	mimir := q.Exec(context.Background())
+	q.Close()
 
 	q, err = prometheusEngine.NewInstantQuery(ctx, storage, nil, expr, time.Now())
 	require.NoError(t, err)
 	prometheus := q.Exec(context.Background())
+	q.Close()
 
 	testutils.RequireEqualResults(t, expr, prometheus, mimir)
 }

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -795,6 +795,8 @@ func (q *Query) Close() {
 		types.VectorPool.Put(v, q.memoryConsumptionTracker)
 	case promql.Scalar:
 		// Nothing to do, we already returned the slice in populateScalarFromScalarOperator.
+	case promql.String:
+		// Nothing to do as strings don't come from a pool
 	default:
 		panic(fmt.Sprintf("unknown result value type %T", q.result.Value))
 	}


### PR DESCRIPTION
This would previously panic after the query was closed

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
