### PR TITLE
[r311] MQE: Fix handling of string results

### DIFF
--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -689,6 +689,8 @@ func (q *Query) Close() {
 		types.VectorPool.Put(v, q.memoryConsumptionTracker)
 	case promql.Scalar:
 		// Nothing to do, we already returned the slice in populateScalarFromScalarOperator.
+	case promql.String:
+		// Nothing to do as strings don't come from a pool
 	default:
 		panic(fmt.Sprintf("unknown result value type %T", q.result.Value))
 	}


### PR DESCRIPTION
This would previously panic after the query was closed

(cherry picked from commit dcbf3f4b6e4caf1533247493baed68271a14a514)

Backport https://github.com/grafana/mimir/commit/dcbf3f4b6e4caf1533247493baed68271a14a514 from https://github.com/grafana/mimir/pull/9803

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
