### PR TITLE
fix(histograms): inflated counter resets on merge

### DIFF
--- a/pkg/ingester/client/chunkcompat.go
+++ b/pkg/ingester/client/chunkcompat.go
@@ -197,6 +197,7 @@ func seriesChunksToMatrix(from, through model.Time, lbls labels.Labels, metric m
 // FromChunks converts []client.Chunk to []chunk.Chunk.
 func FromChunks(metric labels.Labels, in []Chunk) ([]chunk.Chunk, error) {
 	out := make([]chunk.Chunk, 0, len(in))
+	prevMaxTime := int64(0)
 	for _, i := range in {
 		o, err := chunk.NewForEncoding(chunk.Encoding(byte(i.Encoding)))
 		if err != nil {
@@ -210,7 +211,8 @@ func FromChunks(metric labels.Labels, in []Chunk) ([]chunk.Chunk, error) {
 		firstTime, lastTime := model.Time(i.StartTimestampMs), model.Time(i.EndTimestampMs)
 		// As the lifetime of this chunk is scopes to this request, we don't need
 		// to supply a fingerprint.
-		out = append(out, chunk.NewChunk(metric, o, firstTime, lastTime))
+		out = append(out, chunk.NewChunk(metric, o, firstTime, lastTime, prevMaxTime))
+		prevMaxTime = int64(lastTime)
 	}
 	return out, nil
 }

--- a/pkg/ingester/client/streaming_test.go
+++ b/pkg/ingester/client/streaming_test.go
@@ -382,7 +382,7 @@ func createTestChunk(t *testing.T, time int64, value float64) Chunk {
 	_, err = promChunk.Add(model.SamplePair{Timestamp: model.Time(time), Value: model.SampleValue(value)})
 	require.NoError(t, err)
 
-	chunks, err := ToChunks([]chunk.Chunk{chunk.NewChunk(labels.EmptyLabels(), promChunk, model.Earliest, model.Latest)})
+	chunks, err := ToChunks([]chunk.Chunk{chunk.NewChunk(labels.EmptyLabels(), promChunk, model.Earliest, model.Latest, 0)})
 	require.NoError(t, err)
 
 	return chunks[0]

--- a/pkg/querier/batch/batch.go
+++ b/pkg/querier/batch/batch.go
@@ -20,15 +20,18 @@ import (
 type GenericChunk struct {
 	MinTime int64
 	MaxTime int64
+	// The maximum time of the previous chunk from the same stream/array.
+	PrevMaxTime int64
 
 	iterator func(reuse chunk.Iterator) chunk.Iterator
 }
 
-func NewGenericChunk(minTime, maxTime int64, iterator func(reuse chunk.Iterator) chunk.Iterator) GenericChunk {
+func NewGenericChunk(minTime, maxTime, prevMaxTime int64, iterator func(reuse chunk.Iterator) chunk.Iterator) GenericChunk {
 	return GenericChunk{
-		MinTime:  minTime,
-		MaxTime:  maxTime,
-		iterator: iterator,
+		MinTime:     minTime,
+		MaxTime:     maxTime,
+		PrevMaxTime: prevMaxTime,
+		iterator:    iterator,
 	}
 }
 
@@ -62,7 +65,7 @@ type iterator interface {
 func NewChunkMergeIterator(it chunkenc.Iterator, lbls labels.Labels, chunks []chunk.Chunk) chunkenc.Iterator {
 	converted := make([]GenericChunk, len(chunks))
 	for i, c := range chunks {
-		converted[i] = NewGenericChunk(int64(c.From), int64(c.Through), c.Data.NewIterator)
+		converted[i] = NewGenericChunk(int64(c.From), int64(c.Through), c.PrevMaxTime, c.Data.NewIterator)
 	}
 
 	return NewGenericChunkMergeIterator(it, lbls, converted)

--- a/pkg/querier/batch/chunk.go
+++ b/pkg/querier/batch/chunk.go
@@ -48,6 +48,9 @@ func (i *chunkIterator) Seek(t int64, size int) chunkenc.ValueType {
 			i.batch.Index++
 		}
 		if i.batch.Index+size < i.batch.Length {
+			// Set the previous timestamp to 0 (unknown) to be consistent with the
+			// non-fast path Seek below.
+			i.batch.SetPrevT(0)
 			return i.batch.ValueType
 		}
 	}

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -74,12 +74,12 @@ func mkChunk(t require.TestingT, from model.Time, points int, encoding chunk.Enc
 		ts = ts.Add(step)
 	}
 	ts = ts.Add(-step) // undo the add that we did just before exiting the loop
-	return chunk.NewChunk(metric, pc, from, ts)
+	return chunk.NewChunk(metric, pc, from, ts, 0)
 }
 
 func mkGenericChunk(t require.TestingT, from model.Time, points int, encoding chunk.Encoding) GenericChunk {
 	ck := mkChunk(t, from, points, encoding)
-	return NewGenericChunk(int64(ck.From), int64(ck.Through), ck.Data.NewIterator)
+	return NewGenericChunk(int64(ck.From), int64(ck.Through), 0, ck.Data.NewIterator)
 }
 
 func testIter(t require.TestingT, points int, iter chunkenc.Iterator, encoding chunk.Encoding) {
@@ -253,7 +253,7 @@ func TestChunkIterator_SeekBeforeCurrentBatch(t *testing.T) {
 		app.Append(ts, float64(ts))
 	}
 
-	genericChunk := NewGenericChunk(chunkTimestamps[0], chunkTimestamps[len(chunkTimestamps)-1], func(reuse chunk.Iterator) chunk.Iterator {
+	genericChunk := NewGenericChunk(chunkTimestamps[0], chunkTimestamps[len(chunkTimestamps)-1], 0, func(reuse chunk.Iterator) chunk.Iterator {
 		chk, err := chunk.NewForEncoding(chunk.PrometheusXorChunk)
 		require.NoError(t, err)
 		require.NoError(t, chk.UnmarshalFromBuf(ch.Bytes()))

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -38,9 +38,8 @@ func testChunkIter(t *testing.T, encoding chunk.Encoding) {
 	expectReset := func(ts model.Time, atSeek bool) histogram.CounterResetHint {
 		if ts == 0 || atSeek {
 			return histogram.UnknownCounterReset
-		} else {
-			return histogram.NotCounterReset
 		}
+		return histogram.NotCounterReset
 	}
 
 	iter.reset(chunk)
@@ -100,9 +99,8 @@ func testIter(t require.TestingT, points int, iter chunkenc.Iterator, encoding c
 				// This test is usually used for samples after merge, where
 				// samples at 0 and 1 have a 0 previous sample time, which means reset.
 				return histogram.UnknownCounterReset
-			} else {
-				return histogram.NotCounterReset
 			}
+			return histogram.NotCounterReset
 		}
 	}
 	nextExpectedTS := model.TimeFromUnix(0)
@@ -155,9 +153,8 @@ func testSeek(t require.TestingT, points int, iter chunkenc.Iterator, encoding c
 				// This test is usually used for samples after merge, where
 				// samples at 0 and 1 have a 0 previous sample time, which means reset.
 				return histogram.UnknownCounterReset
-			} else {
-				return histogram.NotCounterReset
 			}
+			return histogram.NotCounterReset
 		}
 	}
 	var assertPoint func(expectedTS int64, valType chunkenc.ValueType, atSeek bool)

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -236,10 +236,7 @@ func (i *mockIterator) Batch(_ int, valueType chunkenc.ValueType, _ int64, _ *ze
 }
 
 func (i *mockIterator) BatchFloats(_ int) chunk.Batch {
-	return chunk.Batch{
-		Length:    chunk.BatchSize,
-		ValueType: chunkenc.ValFloat,
-	}
+	return i.Batch(0, chunkenc.ValFloat, 0, nil, nil)
 }
 
 func (i *mockIterator) Err() error {

--- a/pkg/querier/batch/chunk_test.go
+++ b/pkg/querier/batch/chunk_test.go
@@ -224,7 +224,7 @@ func (i *mockIterator) Timestamp() int64 {
 	return 0
 }
 
-func (i *mockIterator) Batch(_ int, valueType chunkenc.ValueType, _ *zeropool.Pool[*histogram.Histogram], _ *zeropool.Pool[*histogram.FloatHistogram]) chunk.Batch {
+func (i *mockIterator) Batch(_ int, valueType chunkenc.ValueType, _ int64, _ *zeropool.Pool[*histogram.Histogram], _ *zeropool.Pool[*histogram.FloatHistogram]) chunk.Batch {
 	batch := chunk.Batch{
 		Length:    chunk.BatchSize,
 		ValueType: valueType,
@@ -233,6 +233,13 @@ func (i *mockIterator) Batch(_ int, valueType chunkenc.ValueType, _ *zeropool.Po
 		batch.Timestamps[i] = int64(i)
 	}
 	return batch
+}
+
+func (i *mockIterator) BatchFloats(_ int) chunk.Batch {
+	return chunk.Batch{
+		Length:    chunk.BatchSize,
+		ValueType: chunkenc.ValFloat,
+	}
 }
 
 func (i *mockIterator) Err() error {

--- a/pkg/querier/batch/merge_test.go
+++ b/pkg/querier/batch/merge_test.go
@@ -154,14 +154,14 @@ func TestMergeIteratorCounterResets(t *testing.T) {
 			overFlow, err := pc.AddHistogram(s.t, s.h)
 			require.NoError(t, err)
 			if overFlow != nil {
-				chunks = append(chunks, chunk.NewChunk(nil, pc, model.Time(mint), model.Time(maxt), prevMaxT))
+				chunks = append(chunks, chunk.NewChunk(labels.EmptyLabels(), pc, model.Time(mint), model.Time(maxt), prevMaxT))
 				prevMaxT = maxt
 				mint = s.t
 				pc = overFlow
 			}
 			maxt = s.t
 		}
-		chunks = append(chunks, chunk.NewChunk(nil, pc, model.Time(mint), model.Time(maxt), prevMaxT))
+		chunks = append(chunks, chunk.NewChunk(labels.EmptyLabels(), pc, model.Time(mint), model.Time(maxt), prevMaxT))
 		return chunks
 	}
 

--- a/pkg/querier/batch/non_overlapping_test.go
+++ b/pkg/querier/batch/non_overlapping_test.go
@@ -19,18 +19,18 @@ func TestNonOverlappingIter(t *testing.T) {
 	for i := int64(0); i < 100; i++ {
 		cs = append(cs, mkGenericChunk(t, model.TimeFromUnix(i*10), 10, chunk.PrometheusXorChunk))
 	}
-	testIter(t, 10*100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil), labels.EmptyLabels()), chunk.PrometheusXorChunk)
+	testIter(t, 10*100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil), labels.EmptyLabels()), chunk.PrometheusXorChunk, nil)
 	it := newNonOverlappingIterator(nil, cs, nil, nil)
 	adapter := newIteratorAdapter(nil, it, labels.EmptyLabels())
-	testSeek(t, 10*100, adapter, chunk.PrometheusXorChunk)
+	testSeek(t, 10*100, adapter, chunk.PrometheusXorChunk, nil)
 
 	// Do the same operations while re-using the iterators.
 	it = newNonOverlappingIterator(it, cs, nil, nil)
 	adapter = newIteratorAdapter(adapter.(*iteratorAdapter), it, labels.EmptyLabels())
-	testIter(t, 10*100, adapter, chunk.PrometheusXorChunk)
+	testIter(t, 10*100, adapter, chunk.PrometheusXorChunk, nil)
 	it = newNonOverlappingIterator(it, cs, nil, nil)
 	adapter = newIteratorAdapter(adapter.(*iteratorAdapter), it, labels.EmptyLabels())
-	testSeek(t, 10*100, adapter, chunk.PrometheusXorChunk)
+	testSeek(t, 10*100, adapter, chunk.PrometheusXorChunk, nil)
 }
 
 func TestNonOverlappingIterSparse(t *testing.T) {
@@ -42,6 +42,6 @@ func TestNonOverlappingIterSparse(t *testing.T) {
 		mkGenericChunk(t, model.TimeFromUnix(95), 1, chunk.PrometheusXorChunk),
 		mkGenericChunk(t, model.TimeFromUnix(96), 4, chunk.PrometheusXorChunk),
 	}
-	testIter(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil), labels.EmptyLabels()), chunk.PrometheusXorChunk)
-	testSeek(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil), labels.EmptyLabels()), chunk.PrometheusXorChunk)
+	testIter(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil), labels.EmptyLabels()), chunk.PrometheusXorChunk, nil)
+	testSeek(t, 100, newIteratorAdapter(nil, newNonOverlappingIterator(nil, cs, nil, nil), labels.EmptyLabels()), chunk.PrometheusXorChunk, nil)
 }

--- a/pkg/querier/batch/stream.go
+++ b/pkg/querier/batch/stream.go
@@ -182,6 +182,9 @@ func (bs *batchStream) merge(batch *chunk.Batch, size int) {
 		if lt != chunkenc.ValFloat && bs.lastTimeStamp < t1 {
 			// This histogram sample falls after the last sample in the merge.
 			if prevT := bs.curr().PrevT(); prevT != 0 && prevT < bs.lastTimeStamp {
+				// There are now samples in the merge that are newer than the previous
+				// sample in the merge stream, meaning that it was missing samples,
+				// we cannot trust its counter reset hint.
 				bs.curr().SetPrevT(0)
 			}
 		}
@@ -249,6 +252,9 @@ func (bs *batchStream) merge(batch *chunk.Batch, size int) {
 		if t != chunkenc.ValFloat {
 			// This histogram sample falls after the last sample in the merge.
 			if prevT := bs.curr().PrevT(); prevT != 0 && prevT < bs.lastTimeStamp {
+				// There are now samples in the merge that are newer than the previous
+				// sample in the merge stream, meaning that it was missing samples,
+				// we cannot trust its counter reset hint.
 				bs.curr().SetPrevT(0)
 			}
 		}

--- a/pkg/querier/batch/stream.go
+++ b/pkg/querier/batch/stream.go
@@ -179,15 +179,11 @@ func (bs *batchStream) merge(batch *chunk.Batch, size int) {
 		}
 
 		if t1 < t2 {
-			// We have a definite next sample in the left stream.
-			// Reset the counter hint if the previous sample was unknown.
 			populate(bs.curr(), lt)
 			bs.next()
 			continue
 		}
 		if t2 < t1 {
-			// We have a definite next sample in the right stream.
-			// Reset the counter hint if the previous sample was unknown.
 			populate(batch, rt)
 			batch.Next()
 			continue

--- a/pkg/querier/block.go
+++ b/pkg/querier/block.go
@@ -123,7 +123,7 @@ func newBlockQuerierSeriesIterator(reuse chunkenc.Iterator, lbls labels.Labels, 
 	genericChunks := make([]batch.GenericChunk, 0, len(chunks))
 
 	for _, c := range chunks {
-		genericChunk := batch.NewGenericChunk(c.MinTime, c.MaxTime, func(reuse chunk.Iterator) chunk.Iterator {
+		genericChunk := batch.NewGenericChunk(c.MinTime, c.MaxTime, 0, func(reuse chunk.Iterator) chunk.Iterator {
 			encoding, ok := c.GetChunkEncoding()
 			if !ok {
 				return chunk.ErrorIterator(fmt.Sprintf("cannot create new chunk for series %s: unknown encoded raw data type %v", lbls, c.Raw.Type))

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -138,7 +138,7 @@ func createTestChunk(t *testing.T, time int64, value float64) client.Chunk {
 	_, err = promChunk.Add(model.SamplePair{Timestamp: model.Time(time), Value: model.SampleValue(value)})
 	require.NoError(t, err)
 
-	chunks, err := client.ToChunks([]chunk.Chunk{chunk.NewChunk(labels.EmptyLabels(), promChunk, model.Earliest, model.Latest)})
+	chunks, err := client.ToChunks([]chunk.Chunk{chunk.NewChunk(labels.EmptyLabels(), promChunk, model.Earliest, model.Latest, 0)})
 	require.NoError(t, err)
 
 	return chunks[0]

--- a/pkg/querier/distributor_queryable_test.go
+++ b/pkg/querier/distributor_queryable_test.go
@@ -523,7 +523,7 @@ func TestDistributorQuerier_Select_MixedHistogramsAndFloatSamples(t *testing.T) 
 
 func TestDistributorQuerier_Select_FixedInflatedCounterResets(t *testing.T) {
 	var (
-		queryStart int64 = 0
+		queryStart int64
 		queryEnd   int64 = 1000
 	)
 

--- a/pkg/querier/partitioner_test.go
+++ b/pkg/querier/partitioner_test.go
@@ -51,7 +51,7 @@ func mkChunk(t require.TestingT, mint, maxt model.Time, step time.Duration, enco
 		require.NoError(t, err)
 		require.Nil(t, npc)
 	}
-	return chunk.NewChunk(metric, pc, mint, maxt)
+	return chunk.NewChunk(metric, pc, mint, maxt, 0)
 }
 
 func TestPartitionChunksOutputIsSortedByLabels(t *testing.T) {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -283,7 +283,7 @@ func TestQuerier_QueryableReturnsChunksOutsideQueriedRange(t *testing.T) {
 						mimirpb.Sample{TimestampMs: queryStart.Add(-9*time.Minute).Unix() * 1000, Value: 1},
 						mimirpb.Sample{TimestampMs: queryStart.Add(-8*time.Minute).Unix() * 1000, Value: 1},
 						mimirpb.Sample{TimestampMs: queryStart.Add(-7*time.Minute).Unix() * 1000, Value: 1},
-					}),
+					}, false),
 				},
 				// Series with data points before and after queryStart, but before queryEnd.
 				{
@@ -301,7 +301,7 @@ func TestQuerier_QueryableReturnsChunksOutsideQueriedRange(t *testing.T) {
 						mimirpb.Sample{TimestampMs: queryStart.Add(+0*time.Minute).Unix() * 1000, Value: 29},
 						mimirpb.Sample{TimestampMs: queryStart.Add(+1*time.Minute).Unix() * 1000, Value: 31},
 						mimirpb.Sample{TimestampMs: queryStart.Add(+2*time.Minute).Unix() * 1000, Value: 37},
-					}),
+					}, false),
 				},
 				// Series with data points after queryEnd.
 				{
@@ -311,7 +311,7 @@ func TestQuerier_QueryableReturnsChunksOutsideQueriedRange(t *testing.T) {
 						mimirpb.Sample{TimestampMs: queryStart.Add(+5*time.Minute).Unix() * 1000, Value: 43},
 						mimirpb.Sample{TimestampMs: queryStart.Add(+6*time.Minute).Unix() * 1000, Value: 47},
 						mimirpb.Sample{TimestampMs: queryStart.Add(+7*time.Minute).Unix() * 1000, Value: 53},
-					}),
+					}, false),
 				},
 			},
 		},
@@ -380,8 +380,8 @@ func TestBatchMergeChunks(t *testing.T) {
 		}
 	}
 
-	c1 := convertToChunks(t, samplesToInterface(s1))
-	c2 := convertToChunks(t, samplesToInterface(s2))
+	c1 := convertToChunks(t, samplesToInterface(s1), false)
+	c2 := convertToChunks(t, samplesToInterface(s2), false)
 	chunks12 := []client.Chunk{}
 	chunks12 = append(chunks12, c1...)
 	chunks12 = append(chunks12, c2...)

--- a/pkg/storage/chunk/chunk.go
+++ b/pkg/storage/chunk/chunk.go
@@ -87,7 +87,7 @@ type Iterator interface {
 	// objects, the histogram.Histogram or histogram.FloatHistograms objects already present in
 	// the hPool or fhPool pool will be used instead of creating new ones.
 	Batch(size int, valueType chunkenc.ValueType, lastT int64, hPool *zeropool.Pool[*histogram.Histogram], fhPool *zeropool.Pool[*histogram.FloatHistogram]) Batch
-	// BatchFloats is a specialized Batch funtion for chunkenc.ValFloat values.
+	// BatchFloats is a specialized Batch function for chunkenc.ValFloat values.
 	BatchFloats(size int) Batch
 	// Returns the last error encountered. In general, an error signals data
 	// corruption in the chunk and requires quarantining.

--- a/pkg/storage/chunk/chunk.go
+++ b/pkg/storage/chunk/chunk.go
@@ -160,24 +160,9 @@ func (b *Batch) PrevT() int64 {
 	return 0
 }
 
-// LastTimes returns the last timestamp and previous timestamp of the batch.
-// Only meant for non float batches.
-func (b *Batch) LastT() int64 {
-	if b.Length > 0 {
-		return b.Timestamps[b.Length-1]
-	}
-	return 0
-}
-
 func (b *Batch) SetPrevT(t int64) {
 	if b.ValueType == chunkenc.ValHistogram || b.ValueType == chunkenc.ValFloatHistogram {
 		*(*int64)(unsafe.Pointer(&(b.Values[b.Index]))) = t
-	}
-}
-
-func (b *Batch) SetLastPrevT(t int64) {
-	if b.Length > 0 && (b.ValueType == chunkenc.ValHistogram || b.ValueType == chunkenc.ValFloatHistogram) {
-		*(*int64)(unsafe.Pointer(&(b.Values[b.Length-1]))) = t
 	}
 }
 

--- a/pkg/storage/chunk/chunk_test.go
+++ b/pkg/storage/chunk/chunk_test.go
@@ -329,7 +329,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 			}
 		case PrometheusHistogramChunk:
 			require.Equal(t, chunkenc.ValHistogram, chunkType)
-			batch = iter.Batch(BatchSize, chunkenc.ValHistogram, 42, nil, nil)
+			batch = iter.Batch(BatchSize, chunkenc.ValHistogram, 0, nil, nil)
 			require.Equal(t, chunkenc.ValHistogram, batch.ValueType, "Batch contains histograms")
 			for j := 0; j < batch.Length; j++ {
 				require.Equal(t, int64((i+j)*step), batch.AtTime())
@@ -337,7 +337,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 				require.EqualValues(t, expectedHistogram(i+j), (*histogram.Histogram)(h))
 				require.Equal(t, int64((i+j)*step), ts)
 				if j == 0 {
-					require.Equal(t, int64(42), batch.PrevT())
+					require.Equal(t, int64(0), batch.PrevT())
 				} else {
 					require.Equal(t, int64((i+j-1)*step), batch.PrevT())
 				}
@@ -345,7 +345,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 			}
 		case PrometheusFloatHistogramChunk:
 			require.Equal(t, chunkenc.ValFloatHistogram, chunkType)
-			batch = iter.Batch(BatchSize, chunkenc.ValFloatHistogram, 42, nil, nil)
+			batch = iter.Batch(BatchSize, chunkenc.ValFloatHistogram, 0, nil, nil)
 			require.Equal(t, chunkenc.ValFloatHistogram, batch.ValueType, "Batch contains float histograms")
 			for j := 0; j < batch.Length; j++ {
 				require.Equal(t, int64((i+j)*step), batch.AtTime())
@@ -353,7 +353,7 @@ func testChunkBatch(t *testing.T, encoding Encoding, samples int) {
 				require.EqualValues(t, expectedFloatHistogram(i+j), (*histogram.FloatHistogram)(fh))
 				require.Equal(t, int64((i+j)*step), ts)
 				if j == 0 {
-					require.Equal(t, int64(42), batch.PrevT())
+					require.Equal(t, int64(0), batch.PrevT())
 				} else {
 					require.Equal(t, int64((i+j-1)*step), batch.PrevT())
 				}

--- a/pkg/storage/chunk/prometheus_chunk.go
+++ b/pkg/storage/chunk/prometheus_chunk.go
@@ -246,7 +246,6 @@ func (p *prometheusChunkIterator) Timestamp() int64 {
 // Batch fills the batch with the next size samples from the iterator.
 // Only meant for histogram and float histogram values.
 // lastT is the last timestamp from the previous batch (or 0).
-// lastPrevT is the previous timestamp recorded for the last sample in the previous batch (or 0)
 func (p *prometheusChunkIterator) Batch(size int, valueType chunkenc.ValueType, lastT int64, hPool *zeropool.Pool[*histogram.Histogram], fhPool *zeropool.Pool[*histogram.FloatHistogram]) Batch {
 	var batch Batch
 	batch.ValueType = valueType

--- a/pkg/streamingpromql/testutils/utils.go
+++ b/pkg/streamingpromql/testutils/utils.go
@@ -44,6 +44,12 @@ func RequireEqualResults(t testing.TB, expr string, expected, actual *promql.Res
 
 			require.Equal(t, expectedSample.Metric, actualSample.Metric)
 			require.Equal(t, expectedSample.T, actualSample.T)
+			if expectedSample.H != nil && actualSample.H != nil && (expectedSample.H.CounterResetHint == histogram.UnknownCounterReset || actualSample.H.CounterResetHint == histogram.UnknownCounterReset) {
+				// Differences in iterator usage can result in different counter reset
+				// hints. Unknown is always a valid value and not comparable.
+				expectedSample.H.CounterResetHint = histogram.UnknownCounterReset
+				actualSample.H.CounterResetHint = histogram.UnknownCounterReset
+			}
 			require.Equal(t, expectedSample.H, actualSample.H)
 			requireInEpsilonIfNotZero(t, expectedSample.F, actualSample.F)
 		}


### PR DESCRIPTION
Credit to @fionaliao for discovering this.

6th Nov 2024: currently **on hold** as it needs support from Prometheus  (chunks.Meta) and agreement on the algorithm proposed in https://github.com/prometheus/prometheus/issues/15346.

Let ingester A receive native histograms samples (T=1, C=40) and (T=3, C=20), where C is count. Let ingester B receive samples (T=1, C=40), (T=2, C=10) and (T=3, C=20). In this case the distributor querier should merge the results and clear the counter reset detected by A at T=3.

Modified convertToChunks test function to be able to handle chunks created due to counter reset - optionally to keep compatibility.

Modified Add(Float)Histogram test functions to handle chunks created due to counter reset. The signature already supported it.

The solution needs to know if a stream of chunks is missing samples compared to the other streams.
To achieve this, I'm encoding the timestamp of the previous histogram sample next to each histogram in the `Batch` in the float values (hard cast). The float value is not used when the value is a histogram, I'm reusing it to save memory.

I'll also use this previous timestamp to indicate if the histogram needs to have its counter reset cleared by writing 0 in it.

To detect missing samples , we need to check if a new Batch added to the merge has a sample newer than the merged samples, but its previous timestamp is before the last timestamp in the merge => has obviously missing samples.

The tricky part is making sure that we have the previous timestamp correctly set between chunks coming from the same stream. This means the sources here: https://github.com/grafana/mimir/blob/502885720fcd76f45b711a0f7ff7f388771a1283/pkg/ingester/client/client.go#L82

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
