### PR TITLE
fix(distributor-ha): init cache on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [ENHANCEMENT] Distributor: when a label value fails validation due to invalid UTF-8 characters, don't include the invalid characters in the returned error. #9828
 * [ENHANCEMENT] Ingester: when experimental ingest storage is enabled, do not buffer records in the Kafka client when fetch concurrency is in use. #9838 #9850
 * [ENHANCEMENT] PromQL: make `sort_by_label` stable. #9879
+* [ENHANCEMENT] Distributor: Initialize ha_tracker cache before ha_tracker and distributor reach running state and begin serving writes. #9826
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508

--- a/development/mimir-microservices-mode/config/mimir_override.yaml
+++ b/development/mimir-microservices-mode/config/mimir_override.yaml
@@ -1,0 +1,184 @@
+multitenancy_enabled: false
+
+distributor:
+  pool:
+    health_check_ingesters: true
+  ring:
+    kvstore:
+      store: memberlist
+
+ingester_client:
+  grpc_client_config:
+    # Configure the client to allow messages up to 100MB.
+    max_recv_msg_size: 104857600
+    max_send_msg_size: 104857600
+    grpc_compression: gzip
+
+ingester:
+  ring:
+    # We want to start immediately.
+    final_sleep: 0s
+    num_tokens: 512
+    kvstore:
+      store: memberlist
+
+# These memberlist options will be only used if memberlist is activated via CLI option.
+memberlist:
+  join_members:
+    - distributor-1:10000
+  rejoin_interval: 10s
+
+blocks_storage:
+  backend: s3
+
+  tsdb:
+    dir: /tmp/mimir-tsdb-ingester
+    # Note: this value is intentionally set low to create a faster feedback loop
+    # in development. However, setting this lower than 2m can cause the ruler's
+    # write requests to fail with out of bounds errors
+    block_ranges_period: ["2m"]
+    # retention_period must be larger than block_ranges_period and querier.query_store_after
+    retention_period: 15m
+    ship_interval: 1m
+
+    # Always use the PostingsForMatchers() cache in order to exercise it.
+    head_postings_for_matchers_cache_force: true
+    block_postings_for_matchers_cache_force: true
+    block_postings_for_matchers_cache_ttl: 1m
+
+  bucket_store:
+    sync_dir: /tmp/mimir-tsdb-querier
+    sync_interval: 1m
+    # ignore_blocks_within and sync_interval must be small enough for the store-gateways
+    # to discover & load new blocks shipped from the ingesters before they begin to be queried.
+    # With querier.query_store_after: 10m and sync_interval: 1m, anything larger than 2m causes issues.
+    # Slightly larger values for ignore_blocks_within work if sync_interval is reduced.
+    ignore_blocks_within: 2m
+
+    index_cache:
+    # Cache is configured via CLI flags. See docker-compose.jsonnet
+
+    chunks_cache:
+    # Cache is configured via CLI flags. See docker-compose.jsonnet
+
+    metadata_cache:
+    # Cache is configured via CLI flags. See docker-compose.jsonnet
+
+  s3:
+    endpoint:          minio:9000
+    bucket_name:       mimir-tsdb
+    access_key_id:     mimir
+    secret_access_key: supersecret
+    insecure:          true
+
+ruler:
+  ring:
+    heartbeat_period:   5s
+    heartbeat_timeout:  15s
+    kvstore:
+      store: memberlist
+
+  alertmanager_url: http://alertmanager-1:8031/alertmanager,http://alertmanager-2:8032/alertmanager,http://alertmanager-3:8033/alertmanager
+
+ruler_storage:
+  backend: s3
+
+  cache:
+  # Cache is configured via CLI flags. See docker-compose.jsonnet
+
+  s3:
+    bucket_name:       mimir-ruler
+    endpoint:          minio:9000
+    access_key_id:     mimir
+    secret_access_key: supersecret
+    insecure:          true
+
+alertmanager:
+  fallback_config_file: './config/alertmanager.yaml'
+  sharding_ring:
+    replication_factor: 3
+    heartbeat_period: 5s
+    heartbeat_timeout: 15s
+    kvstore:
+      store: memberlist
+
+alertmanager_storage:
+  backend: s3
+  s3:
+    bucket_name:       mimir-alertmanager
+    endpoint:          minio:9000
+    access_key_id:     mimir
+    secret_access_key: supersecret
+    insecure:          true
+
+compactor:
+  data_dir: "/tmp/mimir-compactor"
+  block_ranges: [ 2m, 4m, 8m, 16m ]
+  compaction_interval: 1m
+  compaction_concurrency: 2
+  cleanup_interval: 1m
+  tenant_cleanup_delay: 1m
+  sharding_ring:
+    kvstore:
+      store: memberlist
+
+store_gateway:
+  sharding_ring:
+    replication_factor: 1
+    heartbeat_period:   5s
+    heartbeat_timeout:  15s
+    wait_stability_min_duration: 0
+    kvstore:
+      store: memberlist
+
+frontend:
+  query_stats_enabled: true
+  parallelize_shardable_queries: true
+  cache_results: true
+  shard_active_series_queries: true
+
+  # Uncomment when using "dns" service discovery mode for query-scheduler.
+  # scheduler_address: "query-scheduler:9011"
+
+  results_cache:
+    # Cache is configured via CLI flags. See docker-compose.jsonnet
+    compression: snappy
+
+frontend_worker:
+  response_streaming_enabled: true
+
+  # Uncomment when using "dns" service discovery mode for query-scheduler.
+  # scheduler_address: "query-scheduler:9011"
+
+  # Uncomment to skip query-scheduler and enqueue queries directly in the query-frontend.
+  # frontend_address: "query-frontend:9007"
+
+querier:
+  # query_store_after must be smaller than blocks_storage.tsdb.retention_period
+  query_store_after: 10m
+
+query_scheduler:
+  # Change to "dns" to switch to query-scheduler DNS-based service discovery.
+  service_discovery_mode: "ring"
+
+limits:
+  # Limit max query time range to 31d
+  max_partial_query_length: 744h
+  max_global_exemplars_per_user: 5000
+  query_sharding_total_shards: 16
+  query_sharding_max_sharded_queries: 32
+  ingestion_rate: 50000
+  # expanded OOO window makes it easier to run continuous-test
+  # otherwise catch-up writes are rejected when metamonitoring is on
+  out_of_order_time_window: 1h
+  native_histograms_ingestion_enabled: true
+  cardinality_analysis_enabled: true
+  query_ingesters_within: 20m
+  # HA tracker configuration
+  accept_ha_samples: true
+  ha_cluster_label: ha_cluster
+  ha_replica_label: ha_replica
+  ha_max_clusters: 10
+
+runtime_config:
+  file: ./config/runtime.yaml

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -114,6 +114,7 @@ std.manifestYamlDoc({
         extraArguments:
           // Use of scheduler is activated by `-querier.scheduler-address` option and setting -querier.frontend-address option to nothing.
           if $._config.use_query_scheduler then '-querier.scheduler-address=query-scheduler:9011 -querier.frontend-address=' else '',
+        extraVolumes: ['./config/mimir_override.yaml:/mimir/config/mimir.yaml'],
       }),
 
       'query-frontend': mimirService({
@@ -152,6 +153,7 @@ std.manifestYamlDoc({
       httpPort: 8021 + id,
       jaegerApp: 'ruler-%d' % id,
       extraArguments: if $._config.ruler_use_remote_execution then '-ruler.query-frontend.address=dns:///query-frontend:9007' else '',
+      extraVolumes: ['./config/mimir_override.yaml:/mimir/config/mimir.yaml'],
     })
     for id in std.range(1, count)
   },

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -384,6 +384,7 @@
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
+      - "./config/mimir_override.yaml:/mimir/config/mimir.yaml"
   "query-frontend":
     "build":
       "context": "."
@@ -462,6 +463,7 @@
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
+      - "./config/mimir_override.yaml:/mimir/config/mimir.yaml"
   "ruler-2":
     "build":
       "context": "."
@@ -488,6 +490,7 @@
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
+      - "./config/mimir_override.yaml:/mimir/config/mimir.yaml"
   "store-gateway-1":
     "build":
       "context": "."

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -220,14 +220,15 @@ func (h *haTracker) syncHATrackerStateOnStart(ctx context.Context) error {
 	if !h.cfg.EnableHATracker {
 		return nil
 	}
-	// haTracker holds HATrackerConfig with the prefix.
+
 	keys, err := h.client.List(ctx, "")
 	if err != nil {
 		return err
 	}
 
 	if len(keys) == 0 {
-		level.Warn(h.logger).Log("msg", "sync HA state on start: no keys for HA tracker prefix", "err", err)
+		level.Warn(h.logger).Log("msg", "sync HA state on start: no keys for HA tracker prefix in the KV store."+
+			"Skipping cache sync")
 		return nil
 	}
 
@@ -241,10 +242,9 @@ func (h *haTracker) syncHATrackerStateOnStart(ctx context.Context) error {
 			level.Warn(h.logger).Log("msg", "sync HA state on start: failed to get replica value", "key", keys[i], "err", err)
 			return err
 		}
-
 		desc, ok := val.(*ReplicaDesc)
 		if !ok {
-			level.Error(h.logger).Log("msg", "sync HA state on start: got invalid replica descriptor", "key", keys[i])
+			level.Error(h.logger).Log("msg", "sync HA state on start: Skipping key: "+keys[i]+", got invalid ReplicaDesc")
 			continue
 		}
 		h.processKVStoreEntry(keys[i], desc)

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -240,7 +240,7 @@ func (h *haTracker) syncHATrackerStateOnStart(ctx context.Context) error {
 		val, err := h.client.Get(ctx, keys[i])
 		if err != nil {
 			level.Warn(h.logger).Log("msg", "sync HA state on start: failed to get replica value", "key", keys[i], "err", err)
-			return err
+			return nil
 		}
 		desc, ok := val.(*ReplicaDesc)
 		if !ok {

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -70,6 +70,53 @@ func checkReplicaTimestamp(t *testing.T, duration time.Duration, c *haTracker, u
 	})
 }
 
+func TestHATrackerCacheSyncOnStart(t *testing.T) {
+	cluster := "c1"
+	replica := "r1"
+	var c *haTracker
+	var err error
+	var now time.Time
+
+	codec := GetReplicaDescCodec()
+	kvStore, closer := consul.NewInMemoryClient(codec, log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	mock := kv.PrefixClient(kvStore, "prefix")
+	c, err = newHATracker(HATrackerConfig{
+		EnableHATracker:        true,
+		KVStore:                kv.Config{Mock: mock},
+		UpdateTimeout:          time.Second * 100,
+		UpdateTimeoutJitterMax: 0,
+		FailoverTimeout:        time.Millisecond * 2,
+	}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+
+	now = time.Now()
+	err = c.checkReplica(context.Background(), "user", cluster, replica, now)
+	assert.NoError(t, err)
+
+	err = services.StopAndAwaitTerminated(context.Background(), c)
+	assert.NoError(t, err)
+
+	replicaTwo := "r2"
+	c, err = newHATracker(HATrackerConfig{
+		EnableHATracker:        true,
+		KVStore:                kv.Config{Mock: mock},
+		UpdateTimeout:          1000 * time.Second,
+		UpdateTimeoutJitterMax: 0,
+		FailoverTimeout:        time.Millisecond * 2,
+	}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+	t.Cleanup(func() { assert.NoError(t, services.StopAndAwaitTerminated(context.Background(), c)) })
+
+	now = time.Now()
+	err = c.checkReplica(context.Background(), "user", cluster, replicaTwo, now)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, replicasDidNotMatchError{replica: "r2", elected: "r1"})
+}
+
 func TestHATrackerConfig_Validate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -71,8 +71,9 @@ func checkReplicaTimestamp(t *testing.T, duration time.Duration, c *haTracker, u
 }
 
 func TestHATrackerCacheSyncOnStart(t *testing.T) {
-	cluster := "c1"
-	replica := "r1"
+	const cluster = "c1"
+	const replica = "r1"
+
 	var c *haTracker
 	var err error
 	var now time.Time
@@ -85,7 +86,7 @@ func TestHATrackerCacheSyncOnStart(t *testing.T) {
 	c, err = newHATracker(HATrackerConfig{
 		EnableHATracker:        true,
 		KVStore:                kv.Config{Mock: mock},
-		UpdateTimeout:          time.Second * 100,
+		UpdateTimeout:          time.Millisecond * 100,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Millisecond * 2,
 	}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())
@@ -103,7 +104,7 @@ func TestHATrackerCacheSyncOnStart(t *testing.T) {
 	c, err = newHATracker(HATrackerConfig{
 		EnableHATracker:        true,
 		KVStore:                kv.Config{Mock: mock},
-		UpdateTimeout:          1000 * time.Second,
+		UpdateTimeout:          time.Millisecond * 100,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Millisecond * 2,
 	}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR adds the initialization of the local cache of the ha_tracker

The investigation if this is needed has been done in a separate PR https://github.com/grafana/mimir/pull/9853

Check [conclusion](https://github.com/grafana/mimir/pull/9853#issue-2643760579) for TLDR

#### Which issue(s) this PR fixes or relates to

Relates with: https://github.com/grafana/mimir/issues/5796

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
