### PR TITLE
Alerting: add new type to support both primitive and string ints

### DIFF
--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -251,9 +251,9 @@ Usage of ./cmd/mimir/mimir:
     	Maximum size of the Alertmanager configuration for a tenant. 0 = no limit.
   -alertmanager.max-dispatcher-aggregation-groups int
     	Maximum number of aggregation groups in Alertmanager's dispatcher that a tenant can have. Each active aggregation group uses single goroutine. When the limit is reached, dispatcher will not dispatch alerts that belong to additional aggregation groups, but existing groups will keep working properly. 0 = no limit.
-  -alertmanager.max-grafana-config-size-bytes int
+  -alertmanager.max-grafana-config-size-bytes value
     	Maximum size of the Grafana Alertmanager configuration for a tenant. 0 = no limit.
-  -alertmanager.max-grafana-state-size-bytes int
+  -alertmanager.max-grafana-state-size-bytes value
     	Maximum size of the Grafana Alertmanager state for a tenant. 0 = no limit.
   -alertmanager.max-recv-msg-size int
     	Maximum size (bytes) of an accepted HTTP request body. (default 104857600)

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -89,9 +89,9 @@ Usage of ./cmd/mimir/mimir:
     	Maximum size of the Alertmanager configuration for a tenant. 0 = no limit.
   -alertmanager.max-dispatcher-aggregation-groups int
     	Maximum number of aggregation groups in Alertmanager's dispatcher that a tenant can have. Each active aggregation group uses single goroutine. When the limit is reached, dispatcher will not dispatch alerts that belong to additional aggregation groups, but existing groups will keep working properly. 0 = no limit.
-  -alertmanager.max-grafana-config-size-bytes int
+  -alertmanager.max-grafana-config-size-bytes value
     	Maximum size of the Grafana Alertmanager configuration for a tenant. 0 = no limit.
-  -alertmanager.max-grafana-state-size-bytes int
+  -alertmanager.max-grafana-state-size-bytes value
     	Maximum size of the Grafana Alertmanager state for a tenant. 0 = no limit.
   -alertmanager.max-silence-size-bytes int
     	Maximum silence size in bytes. 0 = no limit.

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -1429,7 +1429,7 @@ func TestIntStringJSONAMLAlertmanagerSizeLimits(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			limitsJSON := Limits{}
 			err := json.Unmarshal([]byte(tc.inputJSON), &limitsJSON)
-			require.NoError(t, err, "expected to be able to unmarshal from YAML")
+			require.NoError(t, err, "expected to be able to unmarshal from JSON")
 
 			ov, err := NewOverrides(limitsJSON, nil)
 			require.NoError(t, err)


### PR DESCRIPTION
#### Context
- Helm doesn't handle big ints well - we should support using strings
- Some tenants are already hitting the new config limits we've added but now we can't increase them using configmaps because helm will convert them to scientific notation
- For flags this is not an issue
- I've merged this PR earlier, but it caused AM pods to crash since the go-yaml doesn't handle the string conversion automatically: https://github.com/grafana/deployment_tools/pull/189045
- `IntString` should allow us to use both a string or an integer
- Use that for config/state size limits
- Tested the flag parsing is working by running locally (we don't have a unit test for that setup and doing so requires a bit tinkering)
![Screenshot 2024-11-05 at 19 26 47](https://github.com/user-attachments/assets/84259008-3527-4102-839d-341c7735dae7)

