### PR TITLE
IngesterInstanceHasNoTenants alert: exclude read only replicas

### DIFF
--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -164,7 +164,11 @@ groups:
             message: Mimir ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no tenants assigned.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
           expr: |
-            (min by(cluster, namespace, instance) (cortex_ingester_memory_users) == 0)
+            (
+              (min by(cluster, namespace, instance) (cortex_ingester_memory_users) == 0)
+              unless
+              (max by(cluster, namespace, instance) (cortex_lifecycler_read_only) > 0)
+            )
             and on (cluster, namespace)
             # Only if there are more timeseries than would be expected due to continuous testing load
             (

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -164,7 +164,11 @@ groups:
             message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no tenants assigned.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
           expr: |
-            (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
+            (
+              (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
+              unless
+              (max by(cluster, namespace, pod) (cortex_lifecycler_read_only) > 0)
+            )
             and on (cluster, namespace)
             # Only if there are more timeseries than would be expected due to continuous testing load
             (

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -296,7 +296,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('IngesterInstanceHasNoTenants'),
           'for': '1h',
           expr: |||
-            (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_memory_users) == 0)
+            (
+              (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_memory_users) == 0)
+              unless
+              (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_lifecycler_read_only) > 0)
+            )
             and on (%(alert_aggregation_labels)s)
             # Only if there are more timeseries than would be expected due to continuous testing load
             (


### PR DESCRIPTION
#### What this PR does

It's expected that read-only ingesters might not have tenants, there's no need to alert on that.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
