### PR TITLE
support fallback configuration for KEDA autoscaling

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -33,6 +33,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add the possibility to create a dedicated serviceAccount for the `alertmanager` component by setting `alertmanager.serviceAcount.create` to true in the values. #9781
 * [BUGFIX] Fix PVC template in AlertManager to not show diff in ArgoCD. #9774
 * [BUGFIX] Fix how `fullnameOverride` is reflected in generated manifests. #9564
+* [ENHANCEMENT] Add support for `fallback` in kedaAutoscaling settings. #9846
 
 ## 5.5.1
 

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-so.yaml
@@ -17,6 +17,10 @@ spec:
       {{- end }}
   maxReplicaCount: {{ .Values.distributor.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.distributor.kedaAutoscaling.minReplicaCount }}
+  {{- with .Values.distributor.kedaAutoscaling.fallback }}
+  fallback:
+    {{ .toYaml . | nindent 4 }}
+  {{- end }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "distributor") }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-so.yaml
@@ -20,6 +20,10 @@ spec:
       {{- end }}
   maxReplicaCount: {{ .Values.querier.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.querier.kedaAutoscaling.minReplicaCount }}
+  {{- with .Values.querier.kedaAutoscaling.fallback }}
+  fallback:
+    {{ .toYaml . | nindent 4 }}
+  {{- end }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "querier") }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
@@ -17,6 +17,10 @@ spec:
       {{- end }}
   maxReplicaCount: {{ .Values.query_frontend.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.query_frontend.kedaAutoscaling.minReplicaCount }}
+  {{- with .Values.query_frontend.kedaAutoscaling.fallback }}
+  fallback:
+    {{ .toYaml . | nindent 4 }}
+  {{- end }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "query-frontend") }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
@@ -18,6 +18,10 @@ spec:
       {{- end }}
   maxReplicaCount: {{ .Values.ruler_querier.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.ruler_querier.kedaAutoscaling.minReplicaCount }}
+  {{- with .Values.query_frontend.kedaAutoscaling.fallback }}
+  fallback:
+    {{ .toYaml . | nindent 4 }}
+  {{- end }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-querier") }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
@@ -18,6 +18,10 @@ spec:
       {{- end }}
   maxReplicaCount: {{ .Values.ruler_query_frontend.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.ruler_query_frontend.kedaAutoscaling.minReplicaCount }}
+  {{- with .Values.ruler_query_frontend.kedaAutoscaling.fallback }}
+  fallback:
+    {{ .toYaml . | nindent 4 }}
+  {{- end }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-query-frontend") }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-so.yaml
@@ -16,6 +16,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   maxReplicaCount: {{ .Values.ruler.kedaAutoscaling.maxReplicaCount }}
+  {{- with .Values.ruler.kedaAutoscaling.fallback }}
+  fallback:
+    {{ .toYaml . | nindent 4 }}
+  {{- end }}
   minReplicaCount: {{ .Values.ruler.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
   scaleTargetRef:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1247,7 +1247,7 @@ ruler:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 100
     targetMemoryUtilizationPercentage: 100
-    #fallback:
+    # fallback:
     # -- Section to specify fallback options should the query for scaling metrics fail.
     # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
     #  failureThreshold: 3
@@ -1373,7 +1373,7 @@ ruler_querier:
     minReplicaCount: 1
     maxReplicaCount: 10
     querySchedulerInflightRequestsThreshold: 12
-    #fallback:
+    # fallback:
     # -- Section to specify fallback options should the query for scaling metrics fail.
     # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
     #  failureThreshold: 3
@@ -1498,7 +1498,7 @@ ruler_query_frontend:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 75
     targetMemoryUtilizationPercentage: 100
-    #fallback:
+    # fallback:
     # -- Section to specify fallback options should the query for scaling metrics fail.
     # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
     #  failureThreshold: 3
@@ -1708,7 +1708,7 @@ querier:
     # For example: if lookback is 30m and period is 6d23h30m,
     # the querier will scale based on the maximum inflight queries between 6d23h30m and 7d ago.
     predictiveScalingLookback: 30m
-    #fallback:
+    # fallback:
     # -- Section to specify fallback options should the query for scaling metrics fail.
     # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
     #  failureThreshold: 3
@@ -1832,7 +1832,7 @@ query_frontend:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 75
     targetMemoryUtilizationPercentage: 100
-    #fallback:
+    # fallback:
     # -- Section to specify fallback options should the query for scaling metrics fail.
     # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
     #  failureThreshold: 3

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -819,6 +819,11 @@ distributor:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 100
     targetMemoryUtilizationPercentage: 100
+    #fallback:
+    # -- Section to specify fallback options should the query for scaling metrics fail.
+    # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
+    #  failureThreshold: 3
+    #  replicas: 3
     behavior:
       scaleDown:
         policies:
@@ -1242,6 +1247,11 @@ ruler:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 100
     targetMemoryUtilizationPercentage: 100
+    #fallback:
+    # -- Section to specify fallback options should the query for scaling metrics fail.
+    # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
+    #  failureThreshold: 3
+    #  replicas: 3
     behavior:
       scaleDown:
         policies:
@@ -1363,6 +1373,11 @@ ruler_querier:
     minReplicaCount: 1
     maxReplicaCount: 10
     querySchedulerInflightRequestsThreshold: 12
+    #fallback:
+    # -- Section to specify fallback options should the query for scaling metrics fail.
+    # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
+    #  failureThreshold: 3
+    #  replicas: 3
     behavior:
       scaleDown:
         policies:
@@ -1483,6 +1498,11 @@ ruler_query_frontend:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 75
     targetMemoryUtilizationPercentage: 100
+    #fallback:
+    # -- Section to specify fallback options should the query for scaling metrics fail.
+    # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
+    #  failureThreshold: 3
+    #  replicas: 3
     behavior:
       scaleDown:
         policies:
@@ -1688,6 +1708,11 @@ querier:
     # For example: if lookback is 30m and period is 6d23h30m,
     # the querier will scale based on the maximum inflight queries between 6d23h30m and 7d ago.
     predictiveScalingLookback: 30m
+    #fallback:
+    # -- Section to specify fallback options should the query for scaling metrics fail.
+    # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
+    #  failureThreshold: 3
+    #  replicas: 3
     behavior:
       scaleDown:
         policies:
@@ -1807,6 +1832,11 @@ query_frontend:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 75
     targetMemoryUtilizationPercentage: 100
+    #fallback:
+    # -- Section to specify fallback options should the query for scaling metrics fail.
+    # More information here: https://keda.sh/docs/2.15/reference/scaledobject-spec/#fallback
+    #  failureThreshold: 3
+    #  replicas: 3
     behavior:
       scaleDown:
         policies:


### PR DESCRIPTION
#### What this PR does

Supports a fallback configuration for the KEDA autoscaling configuration in the `mimir-distributed` helm chart, so if/when the metrics endpoint being used to scale becomes unavailable, the ScaledObject will fallback to the configured replica count.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
