### PR TITLE
Fix ordering of call to fetcher.Stop() and improve unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
 * [ENHANCEMENT] Ruler: Support `group_limit` and `group_next_token` parameters in the `<prometheus-http-prefix>/api/v1/rules` endpoint. #9563
 * [ENHANCEMENT] Ingester: improved lock contention affecting read and write latencies during TSDB head compaction. #9822
 * [ENHANCEMENT] Distributor: when a label value fails validation due to invalid UTF-8 characters, don't include the invalid characters in the returned error. #9828
-* [ENHANCEMENT] Ingester: when experimental ingest storage is enabled, do not buffer records in the Kafka client when fetch concurrency is in use. #9838
+* [ENHANCEMENT] Ingester: when experimental ingest storage is enabled, do not buffer records in the Kafka client when fetch concurrency is in use. #9838 #9850
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -111,9 +111,10 @@ func TestPartitionReader_ConsumerError(t *testing.T) {
 
 	// We want to run this test with different concurrency config.
 	concurrencyVariants := map[string][]readerTestCfgOpt{
-		"without concurrency":                  {withStartupConcurrency(0), withOngoingConcurrency(0)},
-		"with startup concurrency":             {withStartupConcurrency(2), withOngoingConcurrency(0)},
-		"with startup and ongoing concurrency": {withStartupConcurrency(2), withOngoingConcurrency(2)},
+		"without concurrency":                                       {withStartupConcurrency(0), withOngoingConcurrency(0)},
+		"with startup concurrency":                                  {withStartupConcurrency(2), withOngoingConcurrency(0)},
+		"with startup and ongoing concurrency (same settings)":      {withStartupConcurrency(2), withOngoingConcurrency(2)},
+		"with startup and ongoing concurrency (different settings)": {withStartupConcurrency(2), withOngoingConcurrency(4)},
 	}
 
 	for concurrencyName, concurrencyVariant := range concurrencyVariants {
@@ -166,9 +167,10 @@ func TestPartitionReader_ConsumerStopping(t *testing.T) {
 
 	// We want to run this test with different concurrency config.
 	concurrencyVariants := map[string][]readerTestCfgOpt{
-		"without concurrency":                  {withStartupConcurrency(0), withOngoingConcurrency(0)},
-		"with startup concurrency":             {withStartupConcurrency(2), withOngoingConcurrency(0)},
-		"with startup and ongoing concurrency": {withStartupConcurrency(2), withOngoingConcurrency(2)},
+		"without concurrency":                                       {withStartupConcurrency(0), withOngoingConcurrency(0)},
+		"with startup concurrency":                                  {withStartupConcurrency(2), withOngoingConcurrency(0)},
+		"with startup and ongoing concurrency (same settings)":      {withStartupConcurrency(2), withOngoingConcurrency(2)},
+		"with startup and ongoing concurrency (different settings)": {withStartupConcurrency(2), withOngoingConcurrency(4)},
 	}
 
 	for concurrencyName, concurrencyVariant := range concurrencyVariants {
@@ -513,9 +515,10 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 	// We want to run all these tests with different concurrency config.
 	concurrencyVariants := map[string][]readerTestCfgOpt{
-		"without concurrency":                  {withStartupConcurrency(0), withOngoingConcurrency(0)},
-		"with startup concurrency":             {withStartupConcurrency(2), withOngoingConcurrency(0)},
-		"with startup and ongoing concurrency": {withStartupConcurrency(2), withOngoingConcurrency(2)},
+		"without concurrency":                                       {withStartupConcurrency(0), withOngoingConcurrency(0)},
+		"with startup concurrency":                                  {withStartupConcurrency(2), withOngoingConcurrency(0)},
+		"with startup and ongoing concurrency (same settings)":      {withStartupConcurrency(2), withOngoingConcurrency(2)},
+		"with startup and ongoing concurrency (different settings)": {withStartupConcurrency(2), withOngoingConcurrency(4)},
 	}
 
 	t.Run("should immediately switch to Running state if partition is empty", func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

As discussed [here](https://github.com/grafana/mimir/pull/9838#discussion_r1832391875), in this PR I'm fixing the ordering of call to `fetcher.Stop()`. As of today, it's not a real bug because when `switchToOngoingFetcher()` is called multiple times, the 2nd time instance of `fetcher` is `PartitionReader` and its `Stop()` implementation is empty, but this could lead to future bugs.

I've also took the opportunity to improve the unit tests modified in https://github.com/grafana/mimir/pull/9838 to add one more variant: "with startup and ongoing concurrency (different settings)".

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
