### PR TITLE
test(distributor): verify need of cache sync with memberlist KV in ha_tracker

### DIFF
--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -286,8 +286,46 @@ func newHATracker(cfg HATrackerConfig, limits haTrackerLimits, reg prometheus.Re
 		t.client = client
 	}
 
-	t.Service = services.NewBasicService(nil, t.loop, nil)
+	t.Service = services.NewBasicService(t.syncHATrackerStateOnStart, t.loop, nil)
 	return t, nil
+}
+
+func (h *haTracker) syncHATrackerStateOnStart(ctx context.Context) error {
+	if !h.cfg.EnableHATracker {
+		return nil
+	}
+	// haTracker holds HATrackerConfig with the prefix.
+	// This operation should wait until the underneath KV Store is at Running state
+	keys, err := h.client.List(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	if len(keys) == 0 {
+		level.Warn(h.logger).Log("msg", "sync HA state on start: no keys for HA tracker prefix", "err", err)
+		return nil
+	}
+
+	for i := 0; i < len(keys); i++ {
+		if ctx.Err() != nil {
+			return fmt.Errorf("syncing HA tracker state on startup: %w", context.Cause(ctx))
+		}
+
+		val, err := h.client.Get(ctx, keys[i])
+		if err != nil {
+			level.Warn(h.logger).Log("msg", "sync HA state on start: failed to get replica value", "key", keys[i], "err", err)
+			return err
+		}
+
+		desc, ok := val.(*ReplicaDesc)
+		if !ok {
+			level.Error(h.logger).Log("msg", "sync HA state on start: got invalid replica descriptor", "key", keys[i])
+			continue
+		}
+		h.processKVStoreEntry(keys[i], desc)
+	}
+	level.Info(h.logger).Log("msg", "sync HA state on start: HA cache sync finished successfully")
+	return nil
 }
 
 // Follows pattern used by ring for WatchKey.
@@ -310,45 +348,56 @@ func (h *haTracker) loop(ctx context.Context) error {
 	// The KVStore config we gave when creating h should have contained a prefix,
 	// which would have given us a prefixed KVStore client. So, we can pass an empty string here.
 	h.client.WatchPrefix(ctx, "", func(key string, value interface{}) bool {
-		replica := value.(*ReplicaDesc)
-		segments := strings.SplitN(key, "/", 2)
-
-		// Valid key would look like cluster/replica, and a key without a / such as `ring` would be invalid.
-		if len(segments) != 2 {
-			return true
+		replica, ok := value.(*ReplicaDesc)
+		if !ok {
+			return false
 		}
-
-		user := segments[0]
-		cluster := segments[1]
-
-		if replica.DeletedAt > 0 {
-			h.electedReplicaChanges.DeleteLabelValues(user, cluster)
-			h.electedReplicaTimestamp.DeleteLabelValues(user, cluster)
-			h.lastElectionTimestamp.DeleteLabelValues(user, cluster)
-			h.totalReelections.DeleteLabelValues(user, cluster)
-
-			h.electedLock.Lock()
-			defer h.electedLock.Unlock()
-			userClusters := h.clusters[user]
-			if userClusters != nil {
-				delete(userClusters, cluster)
-				if len(userClusters) == 0 {
-					delete(h.clusters, user)
-				}
-			}
-			return true
-		}
-
-		// Store the received information into our cache
-		h.electedLock.Lock()
-		h.updateCache(user, cluster, replica)
-		h.electedLock.Unlock()
-		h.electedReplicaPropagationTime.Observe(time.Since(timestamp.Time(replica.ReceivedAt)).Seconds())
+		h.processKVStoreEntry(key, replica)
 		return true
 	})
 
 	wg.Wait()
 	return nil
+}
+
+func (h *haTracker) processKVStoreEntry(key string, replica *ReplicaDesc) {
+	segments := strings.SplitN(key, "/", 2)
+
+	// Valid key would look like cluster/replica, and a key without a / such as `ring` would be invalid.
+	if len(segments) != 2 {
+		return
+	}
+
+	user := segments[0]
+	cluster := segments[1]
+
+	if replica.DeletedAt > 0 {
+		h.cleanupDeletedReplica(user, cluster)
+		return
+	}
+
+	// Store the received information into our cache
+	h.electedLock.Lock()
+	h.updateCache(user, cluster, replica)
+	h.electedLock.Unlock()
+	h.electedReplicaPropagationTime.Observe(time.Since(timestamp.Time(replica.ReceivedAt)).Seconds())
+}
+
+func (h *haTracker) cleanupDeletedReplica(user string, cluster string) {
+	h.electedReplicaChanges.DeleteLabelValues(user, cluster)
+	h.electedReplicaTimestamp.DeleteLabelValues(user, cluster)
+	h.lastElectionTimestamp.DeleteLabelValues(user, cluster)
+	h.totalReelections.DeleteLabelValues(user, cluster)
+
+	h.electedLock.Lock()
+	defer h.electedLock.Unlock()
+	userClusters := h.clusters[user]
+	if userClusters != nil {
+		delete(userClusters, cluster)
+		if len(userClusters) == 0 {
+			delete(h.clusters, user)
+		}
+	}
 }
 
 const (

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -255,7 +255,6 @@ func TestHaTrackerWithMemberListAndWithoutCacheSyncStart(t *testing.T) {
 
 	now = time.Now()
 	//check r2 - it should reject sample
-	//time.Sleep(time.Millisecond * 100)
 	replica2 := "r2"
 	err = c2.checkReplica(context.Background(), "user", cluster, replica2, now)
 	assert.Error(t, err)

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -205,7 +205,7 @@ func TestHaTrackerWithMemberListAndWithoutCacheSyncStart(t *testing.T) {
 		KVStore: kv.Config{Store: "memberlist", StoreConfig: kv.StoreConfig{
 			MemberlistKV: memberListSvc.GetMemberlistKV,
 		}},
-		UpdateTimeout:          time.Millisecond,
+		UpdateTimeout:          time.Millisecond * 100,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Millisecond * 2,
 	}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())
@@ -243,7 +243,7 @@ func TestHaTrackerWithMemberListAndWithoutCacheSyncStart(t *testing.T) {
 		KVStore: kv.Config{Store: "memberlist", StoreConfig: kv.StoreConfig{
 			MemberlistKV: memberListSvc2.GetMemberlistKV,
 		}},
-		UpdateTimeout:          time.Millisecond,
+		UpdateTimeout:          time.Millisecond * 100,
 		UpdateTimeoutJitterMax: 0,
 		FailoverTimeout:        time.Millisecond * 2,
 	}, trackerLimits{maxClusters: 100}, nil, log.NewNopLogger())

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -255,7 +255,7 @@ func TestHaTrackerWithMemberListAndWithoutCacheSyncStart(t *testing.T) {
 
 	now = time.Now()
 	//check r2 - it should reject sample
-	time.Sleep(time.Millisecond * 100)
+	//time.Sleep(time.Millisecond * 100)
 	replica2 := "r2"
 	err = c2.checkReplica(context.Background(), "user", cluster, replica2, now)
 	assert.Error(t, err)

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -255,7 +255,7 @@ func TestHaTrackerWithMemberListAndWithoutCacheSyncStart(t *testing.T) {
 
 	now = time.Now()
 	//check r2 - it should reject sample
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Millisecond * 100)
 	replica2 := "r2"
 	err = c2.checkReplica(context.Background(), "user", cluster, replica2, now)
 	assert.Error(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
In this PR we have added `TestHaTrackerWithMemberListAndWithoutCacheSyncStart`, in order to verify if the cache sync is needed when using [KV store with Memberlist](https://github.com/grafana/dskit/tree/main/kv/memberlist). 

##### Why
When a new KV is created in memberlist its performing the `fastJoinMembersOnStartup` ([Ref](https://github.com/grafana/dskit/blob/a6b453a88040c92083d1c733494e3b0f9bfa1746/kv/memberlist/memberlist_client.go#L552)), which should fill up the KV store based on the state of other Members in the cluster.

With this test we want to check if that function is enough to fill up the KV store of the ha_tracker and then the local cache should have the updated value.

##### Test Case

- Creates a basic `c` ha_tracker with memberlist KV store
- Invokes [checkReplica](https://github.com/grafana/mimir/blob/4195814f3816c48d0e92e14cb205c5b6d3214dbf/pkg/distributor/ha_tracker.go#L425) with r1, which should update the KV store and the local cache
- Creates a second ha_tracker with memberlist KV store
- **The fastJoinMembersOnStartup, should update the KV store state based on the other members, the c one.**
- checkReplica with r2, should fail with error `replicasDidNotMatchError`

### Conclusion

It seems that all the KV client operations are blocking until the underneath KV store is in running state ([Ref](https://github.com/grafana/dskit/blob/a6b453a88040c92083d1c733494e3b0f9bfa1746/kv/memberlist/memberlist_client.go#L111)), for that reason we are certain that when the first CAS operation is performed at [checkReplica](https://github.com/grafana/mimir/blob/e32b5e2531d40677f9793f8c72ed18aa79fcf50b/pkg/distributor/ha_tracker.go#L425). the fastJoinMembersOnStartup will have filled up the KV store and the cache will be updated.

In conclusion, the cache will have a valid state, even with Memberlist, before the first CAS operation. The main advantage of adding syncStart as a startingFn in ha_tracker is that it pre-populates the cache earlier. Additionally, the distributor and ha_tracker won’t be considered in a running state until the underlying KV store is fully operational

**By using the sync cache as the startingFn, we ensure that both the KV store is in a running state and the cache is initialized before ha_tracker enters the running state.**

#### Which issue(s) this PR fixes or relates to

Relates with  https://github.com/grafana/mimir/issues/5796



#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
