### PR TITLE
fix `MimirIngesterStuckProcessingRecordsFromKafka`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 ### Mixin
 
 * [CHANGE] Remove backwards compatibility for `thanos_memcached_` prefixed metrics in dashboards and alerts removed in 2.12. #9674 #9758
+* [CHANGE] Reworked the alert `MimirIngesterStuckProcessingRecordsFromKafka` to also work when concurrent fetching is enabled. #9855
 * [ENHANCEMENT] Unify ingester autoscaling panels on 'Mimir / Writes' dashboard to work for both ingest-storage and non-ingest-storage autoscaling. #9617
 * [ENHANCEMENT] Alerts: Enable configuring job prefix for alerts to prevent clashes with metrics from Loki/Tempo. #9659
 * [ENHANCEMENT] Dashboards: visualize the age of source blocks in the "Mimir / Compactor" dashboard. #9697

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1129,8 +1129,7 @@ spec:
                 rate(cortex_ingest_storage_reader_requests_total[5m])
               ) == 0)
               and
-              # NOTE: the cortex_ingest_storage_reader_buffered_fetch_records_total metric is a gauge showing the current number of buffered records.
-              (sum by (cluster, namespace, pod) (cortex_ingest_storage_reader_buffered_fetch_records_total) > 0)
+              (sum by (cluster, namespace, pod) (cortex_ingest_storage_reader_buffered_fetched_records) > 0)
             for: 5m
             labels:
               severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1103,8 +1103,7 @@ groups:
               rate(cortex_ingest_storage_reader_requests_total[5m])
             ) == 0)
             and
-            # NOTE: the cortex_ingest_storage_reader_buffered_fetch_records_total metric is a gauge showing the current number of buffered records.
-            (sum by (cluster, namespace, instance) (cortex_ingest_storage_reader_buffered_fetch_records_total) > 0)
+            (sum by (cluster, namespace, instance) (cortex_ingest_storage_reader_buffered_fetched_records) > 0)
           for: 5m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1117,8 +1117,7 @@ groups:
               rate(cortex_ingest_storage_reader_requests_total[5m])
             ) == 0)
             and
-            # NOTE: the cortex_ingest_storage_reader_buffered_fetch_records_total metric is a gauge showing the current number of buffered records.
-            (sum by (cluster, namespace, pod) (cortex_ingest_storage_reader_buffered_fetch_records_total) > 0)
+            (sum by (cluster, namespace, pod) (cortex_ingest_storage_reader_buffered_fetched_records) > 0)
           for: 5m
           labels:
             severity: critical

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -151,8 +151,7 @@
               rate(cortex_ingest_storage_reader_requests_total[5m])
             ) == 0)
             and
-            # NOTE: the cortex_ingest_storage_reader_buffered_fetch_records_total metric is a gauge showing the current number of buffered records.
-            (sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingest_storage_reader_buffered_fetch_records_total) > 0)
+            (sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingest_storage_reader_buffered_fetched_records) > 0)
           ||| % $._config,
           labels: {
             severity: 'critical',

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -307,6 +307,7 @@ func (r *concurrentFetchers) Stop() {
 	close(r.done)
 
 	r.wg.Wait()
+	r.bufferedFetchedRecords.Store(0)
 
 	level.Info(r.logger).Log("msg", "stopped concurrent fetchers", "last_returned_record", r.lastReturnedRecord)
 }

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -685,9 +685,9 @@ func (r *concurrentFetchers) start(ctx context.Context, startOffset int64, concu
 			bufferedResult = result
 			readyBufferedResults = r.orderedFetches
 
-			// We increase the count of buffered records only for ordered records that we're sure
-			// will not be discarded later, so that we can get an accurate tracking of the records
-			// ready to be polled by PollFetches() but not polled yet.
+			// We increase the count of buffered records only for ordered records, so that we can
+			// get an accurate tracking of the records ready to be polled by PollFetches() but not
+			// polled yet. This mimics the similar tracking done by the franz-go library.
 			r.bufferedFetchedRecords.Add(int64(len(result.Records)))
 
 		case readyBufferedResults <- bufferedResult:

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -225,8 +225,7 @@ type concurrentFetchers struct {
 
 	// orderedFetches is a channel where we write fetches that are ready to be polled by PollFetches().
 	// Since all records must be polled in order, the fetches written to this channel are after
-	// ordering and "deduplication" (in case the same record is fetched multiple times from different
-	// routines).
+	// ordering.
 	orderedFetches chan fetchResult
 
 	lastReturnedRecord int64

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -463,7 +463,7 @@ func (r *concurrentFetchers) parseFetchResponse(ctx context.Context, startOffset
 	}
 
 	nv := r.bufferedFetchedRecords.Add(int64(len(partition.Records)))
-	level.Info(r.logger).Log("msg", "buffered fetched records", "num_records", len(partition.Records), "total_records", nv)
+	level.Debug(r.logger).Log("msg", "buffered fetched records", "num_records", len(partition.Records), "total_records", nv)
 
 	return fetchResult{
 		ctx:            ctx,

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -460,7 +460,6 @@ func (r *concurrentFetchers) parseFetchResponse(ctx context.Context, startOffset
 		fetchedBytes = sumRecordLengths(partition.Records)
 	}
 
-	r.bufferedFetchedRecords.Add(int64(len(partition.Records)))
 	return fetchResult{
 		ctx:            ctx,
 		FetchPartition: partition,
@@ -514,6 +513,7 @@ func (r *concurrentFetchers) run(ctx context.Context, wants chan fetchWant, logg
 			attemptSpan.SetTag("attempt", attempt)
 
 			f := r.fetchSingle(ctx, w)
+			r.bufferedFetchedRecords.Add(int64(len(f.FetchPartition.Records)))
 			f = f.Merge(previousResult)
 			previousResult = f
 			if f.Err != nil {

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -923,7 +923,9 @@ func TestConcurrentFetchers(t *testing.T) {
 
 		logger := log.NewNopLogger()
 		reg := prometheus.NewPedanticRegistry()
-		metrics := newReaderMetrics(partitionID, reg)
+		metrics := newReaderMetrics(partitionID, reg, func() float64 {
+			return 0
+		})
 
 		client := newKafkaProduceClient(t, clusterAddr)
 

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/test"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -303,9 +304,12 @@ func TestConcurrentFetchers(t *testing.T) {
 
 		assert.Zero(t, fetches.NumRecords())
 		assert.Error(t, fetchCtx.Err(), "Expected context to be cancelled")
+		assert.Zero(t, fetchers.BufferedRecords())
 	})
 
 	t.Run("cold replay", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -321,9 +325,14 @@ func TestConcurrentFetchers(t *testing.T) {
 
 		fetches, _ := fetchers.PollFetches(ctx)
 		assert.Equal(t, fetches.NumRecords(), 5)
+
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("fetch records produced after startup", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -339,6 +348,9 @@ func TestConcurrentFetchers(t *testing.T) {
 
 		fetches, _ := fetchers.PollFetches(ctx)
 		assert.Equal(t, fetches.NumRecords(), 3)
+
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("slow processing of fetches", func(t *testing.T) {
@@ -357,26 +369,42 @@ func TestConcurrentFetchers(t *testing.T) {
 
 		var wg sync.WaitGroup
 		wg.Add(1)
+
 		go func() {
 			defer wg.Done()
 			consumedRecords := 0
 			for consumedRecords < 10 {
 				fetches, _ := fetchers.PollFetches(ctx)
-				time.Sleep(1000 * time.Millisecond) // Simulate slow processing
 				consumedRecords += fetches.NumRecords()
+
+				// Simulate slow processing.
+				time.Sleep(200 * time.Millisecond)
 			}
 			assert.Equal(t, 10, consumedRecords)
 		}()
 
-		// Produce more records while processing is slow
-		for i := 5; i < 10; i++ {
-			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
-		}
+		// Slowly produce more records while processing is slow too. This increase the chances
+		// of progressive fetches done by the consumer.
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for i := 5; i < 10; i++ {
+				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
+				time.Sleep(200 * time.Millisecond)
+			}
+		}()
 
 		wg.Wait()
+
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("fast processing of fetches", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -390,25 +418,27 @@ func TestConcurrentFetchers(t *testing.T) {
 			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 		}
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			consumedRecords := 0
-			for consumedRecords < 10 {
-				fetches, _ := fetchers.PollFetches(ctx)
-				consumedRecords += fetches.NumRecords()
-				// no processing delay
-			}
-			assert.Equal(t, 10, consumedRecords)
-		}()
+		// Consume all expected records.
+		consumedRecords := 0
+		for consumedRecords < 10 {
+			fetches, _ := fetchers.PollFetches(ctx)
+			consumedRecords += fetches.NumRecords()
+		}
+		assert.Equal(t, 10, consumedRecords)
 
-		wg.Wait()
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("fetch with different concurrency levels", func(t *testing.T) {
+		t.Parallel()
+
 		for _, concurrency := range []int{1, 2, 4} {
+			concurrency := concurrency
+
 			t.Run(fmt.Sprintf("concurrency-%d", concurrency), func(t *testing.T) {
+				t.Parallel()
+
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
@@ -429,11 +459,16 @@ func TestConcurrentFetchers(t *testing.T) {
 				}
 
 				assert.Equal(t, 20, totalRecords)
+
+				// We expect no more records returned by PollFetches() and no buffered records.
+				pollFetchesAndAssertNoRecords(t, fetchers)
 			})
 		}
 	})
 
 	t.Run("start from mid-stream offset", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -472,9 +507,14 @@ func TestConcurrentFetchers(t *testing.T) {
 			"new-record-1",
 			"new-record-2",
 		}, fetchedRecordsContents)
+
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("synchronous produce and fetch", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -507,10 +547,15 @@ func TestConcurrentFetchers(t *testing.T) {
 
 			// Verify fetched records
 			assert.Equal(t, expectedRecords, fetchedRecords, "Fetched records in round %d do not match expected", round)
+
+			// We expect no more records returned by PollFetches() and no buffered records.
+			pollFetchesAndAssertNoRecords(t, fetchers)
 		}
 	})
 
 	t.Run("concurrency can be updated", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		rec1 := []byte("record-1")
@@ -548,10 +593,13 @@ func TestConcurrentFetchers(t *testing.T) {
 		fetchers.Update(ctx, 10, 10)
 		produceRecordAndAssert(rec3)
 
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("update concurrency with continuous production", func(t *testing.T) {
 		t.Parallel()
+
 		const (
 			testDuration       = 10 * time.Second
 			produceInterval    = 10 * time.Millisecond
@@ -633,6 +681,9 @@ func TestConcurrentFetchers(t *testing.T) {
 				"Record %d has unexpected content: %s", i, string(record.Value))
 		}
 
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
+
 		// Log some statistics
 		t.Logf("Total produced: %d, Total fetched: %d", totalProduced, totalFetched)
 		t.Logf("Fetched with initial concurrency: %d", initialFetched)
@@ -642,6 +693,7 @@ func TestConcurrentFetchers(t *testing.T) {
 
 	t.Run("consume from end and update immediately", func(t *testing.T) {
 		t.Parallel()
+
 		const (
 			initialRecords     = 100
 			additionalRecords  = 50
@@ -693,6 +745,9 @@ func TestConcurrentFetchers(t *testing.T) {
 			assert.Equal(t, expectedContent, string(record.Value),
 				"Record %d has unexpected content: %s", i, string(record.Value))
 		}
+
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
 
 		// Log some statistics
 		t.Logf("Total records produced: %d", initialRecords+additionalRecords)
@@ -756,6 +811,9 @@ func TestConcurrentFetchers(t *testing.T) {
 		}
 
 		assert.Equal(t, producedRecordsBytes, fetchedRecordsBytes)
+
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("staggered production with one less than multiple of concurrency and records per fetch", func(t *testing.T) {
@@ -823,6 +881,9 @@ func TestConcurrentFetchers(t *testing.T) {
 
 			return nil, errors.New("mocked error"), true
 		})
+
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("fetchers do not request offset beyond high watermark", func(t *testing.T) {
@@ -898,9 +959,14 @@ func TestConcurrentFetchers(t *testing.T) {
 
 		// Verify the number and content of fetched records
 		assert.Equal(t, producedRecordsBytes, fetchedRecordsBytes, "Should fetch all produced records")
+
+		// We expect no more records returned by PollFetches() and no buffered records.
+		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("starting to run against a broken broker fails creating the fetchers", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -957,6 +1023,37 @@ func TestConcurrentFetchers(t *testing.T) {
 		assert.ErrorContains(t, err, "failed to find topic ID")
 		assert.ErrorIs(t, err, mockErr)
 	})
+
+	t.Run("should reset the buffered records count when stopping", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
+		client := newKafkaProduceClient(t, clusterAddr)
+
+		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, recordsPerFetch)
+
+		// Produce some records.
+		for i := 0; i < 10; i++ {
+			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
+		}
+
+		// We are not consuming the records, so we expect the count of buffered records to increase.
+		// The actual number of buffered records may change due to concurrency, so we just check
+		// that there are some buffered records.
+		test.Poll(t, time.Second, true, func() interface{} {
+			return fetchers.BufferedRecords() > 0
+		})
+
+		// Stop the fetchers.
+		fetchers.Stop()
+
+		// Even if there were some buffered records we expect the count to be reset to 0 when stopping
+		// because the Stop() intentionally discard any buffered record.
+		require.Zero(t, fetchers.BufferedRecords())
+	})
 }
 
 func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Client, topic string, partition int32, startOffset int64, concurrency, recordsPerFetch int) *concurrentFetchers {
@@ -993,6 +1090,33 @@ func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Cli
 	t.Cleanup(f.Stop)
 
 	return f
+}
+
+// pollFetchesAndAssertNoRecords ensures that PollFetches() returns 0 records and there are
+// no buffered records in fetchers. Since some records are discarded in the PollFetches(),
+// we may have to call it multiple times to process all buffered records that need to be
+// discarded.
+func pollFetchesAndAssertNoRecords(t *testing.T, fetchers *concurrentFetchers) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	for {
+		fetches, returnCtx := fetchers.PollFetches(ctx)
+		if errors.Is(returnCtx.Err(), context.DeadlineExceeded) {
+			break
+		}
+
+		// We always expect that PollFetches() returns zero records.
+		require.Len(t, fetches.Records(), 0)
+
+		// If there are no buffered records, we're good. We can end the assertion.
+		if fetchers.BufferedRecords() == 0 {
+			return
+		}
+	}
+
+	// We stopped polling fetches. We have to make sure there are no buffered records.
+	require.Zero(t, fetchers.BufferedRecords())
 }
 
 type waiterFunc func()

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -960,7 +960,7 @@ func TestConcurrentFetchers(t *testing.T) {
 func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Client, topic string, partition int32, startOffset int64, concurrency, recordsPerFetch int) *concurrentFetchers {
 	logger := log.NewNopLogger()
 	reg := prometheus.NewPedanticRegistry()
-	metrics := newReaderMetrics(partition, reg)
+	metrics := newReaderMetrics(partition, reg, func() float64 { return 1 })
 
 	// This instantiates the fields of kprom.
 	// This is usually done by franz-go, but since now we use the metrics ourselves, we need to instantiate the metrics ourselves.

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -119,7 +119,7 @@ func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, instanceID stri
 		reg:                                   reg,
 	}
 
-	r.metrics = newReaderMetrics(partitionID, reg, func() float64 { return r.BufferedRecords() })
+	r.metrics = newReaderMetrics(partitionID, reg, func() float64 { return float64(r.BufferedRecords()) })
 
 	r.Service = services.NewBasicService(r.start, r.run, r.stop)
 	return r, nil
@@ -135,16 +135,16 @@ func (r *PartitionReader) Update(_ context.Context, _, _ int) {
 	// Given the partition reader has no concurrency it doesn't support updates.
 }
 
-func (r *PartitionReader) BufferedRecords() float64 {
+func (r *PartitionReader) BufferedRecords() int64 {
 	r.fetcherMtx.Lock()
 	defer r.fetcherMtx.Unlock()
-	var fcount, ccount float64
+	var fcount, ccount int64
 	if r.fetcher != nil && r.fetcher != r {
 		fcount = r.fetcher.BufferedRecords()
 	}
 
 	if r.client != nil {
-		ccount = float64(r.client.BufferedFetchRecords())
+		ccount = r.client.BufferedFetchRecords()
 	}
 
 	return fcount + ccount

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -951,8 +951,6 @@ func (r *partitionCommitter) stop(error) error {
 }
 
 type readerMetrics struct {
-	reg prometheus.Registerer
-
 	bufferedFetchedRecords           prometheus.GaugeFunc
 	receiveDelayWhenStarting         prometheus.Observer
 	receiveDelayWhenRunning          prometheus.Observer

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1986,6 +1986,18 @@ func TestPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhenDone(t *testi
 	}
 }
 
+func TestPartitionReader_ShouldNotPanicIfBufferedRecordsIsCalledBeforeStarting(t *testing.T) {
+	const (
+		topicName   = "test"
+		partitionID = 1
+	)
+
+	_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
+	reader := createReader(t, clusterAddr, topicName, partitionID, nil)
+
+	require.Zero(t, reader.BufferedRecords())
+}
+
 func TestPartitionReader_fetchLastCommittedOffset(t *testing.T) {
 	const (
 		topicName   = "test"

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1793,74 +1793,87 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 	})
 }
 
-func TestPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhenConcurrentFetchIsEnabled(t *testing.T) {
+func TestPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhenDone(t *testing.T) {
 	const (
 		topicName   = "test"
 		partitionID = 1
 	)
 
-	var (
-		ctx               = context.Background()
-		_, clusterAddr    = testkafka.CreateCluster(t, partitionID+1, topicName)
-		consumedRecordsMx sync.Mutex
-		consumedRecords   []string
-	)
+	concurrencyVariants := map[string][]readerTestCfgOpt{
+		"without concurrency":                                       {withStartupConcurrency(0), withOngoingConcurrency(0)},
+		"with startup concurrency":                                  {withStartupConcurrency(2), withOngoingConcurrency(0)},
+		"with startup and ongoing concurrency (same settings)":      {withStartupConcurrency(2), withOngoingConcurrency(2)},
+		"with startup and ongoing concurrency (different settings)": {withStartupConcurrency(2), withOngoingConcurrency(4)},
+	}
 
-	consumer := consumerFunc(func(_ context.Context, records []record) error {
-		consumedRecordsMx.Lock()
-		defer consumedRecordsMx.Unlock()
+	for concurrencyName, concurrencyVariant := range concurrencyVariants {
+		concurrencyVariant := concurrencyVariant
 
-		for _, r := range records {
-			consumedRecords = append(consumedRecords, string(r.content))
-		}
-		return nil
-	})
+		t.Run(concurrencyName, func(t *testing.T) {
+			t.Parallel()
 
-	// Produce some records.
-	writeClient := newKafkaProduceClient(t, clusterAddr)
-	produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-	produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-	t.Log("produced 2 records")
+			var (
+				ctx               = context.Background()
+				_, clusterAddr    = testkafka.CreateCluster(t, partitionID+1, topicName)
+				consumedRecordsMx sync.Mutex
+				consumedRecords   []string
+			)
 
-	// Create and start the reader.
-	reg := prometheus.NewPedanticRegistry()
-	logs := &concurrency.SyncBuffer{}
-	reader := createReader(t, clusterAddr, topicName, partitionID, consumer,
-		withConsumeFromPositionAtStartup(consumeFromStart),
-		withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
-		withRegistry(reg),
-		withLogger(log.NewLogfmtLogger(logs)),
-		// Enable both startup and ongoing fetch concurrency.
-		withStartupConcurrency(2),
-		withOngoingConcurrency(2))
+			consumer := consumerFunc(func(_ context.Context, records []record) error {
+				consumedRecordsMx.Lock()
+				defer consumedRecordsMx.Unlock()
 
-	require.NoError(t, reader.StartAsync(ctx))
-	t.Cleanup(func() {
-		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-	})
+				for _, r := range records {
+					consumedRecords = append(consumedRecords, string(r.content))
+				}
+				return nil
+			})
 
-	// We expect the reader to catch up, and then switch to Running state.
-	test.Poll(t, 5*time.Second, services.Running, func() interface{} {
-		return reader.State()
-	})
+			// Produce some records.
+			writeClient := newKafkaProduceClient(t, clusterAddr)
+			produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+			produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+			t.Log("produced 2 records")
 
-	// We expect the reader to have switched to running because target consumer lag has been honored.
-	assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
+			// Create and start the reader.
+			reg := prometheus.NewPedanticRegistry()
+			logs := &concurrency.SyncBuffer{}
 
-	// We expect the reader to have consumed the partition from start.
-	test.Poll(t, time.Second, []string{"record-1", "record-2"}, func() interface{} {
-		consumedRecordsMx.Lock()
-		defer consumedRecordsMx.Unlock()
-		return slices.Clone(consumedRecords)
-	})
+			readerOpts := append([]readerTestCfgOpt{
+				withConsumeFromPositionAtStartup(consumeFromStart),
+				withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
+				withRegistry(reg),
+				withLogger(log.NewLogfmtLogger(logs)),
+			}, concurrencyVariant...)
 
-	// Wait some time to give some time for the Kafka client to eventually read and buffer records.
-	// We don't expect it, but to make sure it's not happening we have to give it some time.
-	time.Sleep(time.Second)
+			reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+			require.NoError(t, reader.StartAsync(ctx))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+			})
 
-	// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
-	test.Poll(t, time.Second, nil, func() interface{} {
-		return promtest.GatherAndCompare(reg, strings.NewReader(`
+			// We expect the reader to catch up, and then switch to Running state.
+			test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+				return reader.State()
+			})
+
+			// We expect the reader to have switched to running because target consumer lag has been honored.
+			assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
+
+			// We expect the reader to have consumed the partition from start.
+			test.Poll(t, time.Second, []string{"record-1", "record-2"}, func() interface{} {
+				consumedRecordsMx.Lock()
+				defer consumedRecordsMx.Unlock()
+				return slices.Clone(consumedRecords)
+			})
+
+			// Wait some time to give some time for the Kafka client to eventually read and buffer records.
+			// We don't expect it, but to make sure it's not happening we have to give it some time.
+			time.Sleep(time.Second)
+
+			// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
+			test.Poll(t, time.Second, nil, func() interface{} {
+				return promtest.GatherAndCompare(reg, strings.NewReader(`
 				# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
 				# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
 				cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
@@ -1868,28 +1881,32 @@ func TestPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhenConcurrentFet
 				# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
 				# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
 				cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-			`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
-	})
 
-	// Produce more records after the reader has started.
-	produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
-	produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-4"))
-	t.Log("produced 2 records")
+        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the kafka client but not yet processed.
+        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
+        		cortex_ingest_storage_reader_buffered_fetched_records 0
+			`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records")
+			})
 
-	// We expect the reader to consume subsequent records too.
-	test.Poll(t, time.Second, []string{"record-1", "record-2", "record-3", "record-4"}, func() interface{} {
-		consumedRecordsMx.Lock()
-		defer consumedRecordsMx.Unlock()
-		return slices.Clone(consumedRecords)
-	})
+			// Produce more records after the reader has started.
+			produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
+			produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-4"))
+			t.Log("produced 2 records")
 
-	// Wait some time to give some time for the Kafka client to eventually read and buffer records.
-	// We don't expect it, but to make sure it's not happening we have to give it some time.
-	time.Sleep(time.Second)
+			// We expect the reader to consume subsequent records too.
+			test.Poll(t, time.Second, []string{"record-1", "record-2", "record-3", "record-4"}, func() interface{} {
+				consumedRecordsMx.Lock()
+				defer consumedRecordsMx.Unlock()
+				return slices.Clone(consumedRecords)
+			})
 
-	// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
-	test.Poll(t, time.Second, nil, func() interface{} {
-		return promtest.GatherAndCompare(reg, strings.NewReader(`
+			// Wait some time to give some time for the Kafka client to eventually read and buffer records.
+			// We don't expect it, but to make sure it's not happening we have to give it some time.
+			time.Sleep(time.Second)
+
+			// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
+			test.Poll(t, time.Second, nil, func() interface{} {
+				return promtest.GatherAndCompare(reg, strings.NewReader(`
 				# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
 				# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
 				cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 3
@@ -1897,8 +1914,14 @@ func TestPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhenConcurrentFet
 				# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
 				# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
 				cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-			`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
-	})
+
+        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the kafka client but not yet processed.
+        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
+        		cortex_ingest_storage_reader_buffered_fetched_records 0
+			`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records")
+			})
+		})
+	}
 }
 
 func TestPartitionReader_fetchLastCommittedOffset(t *testing.T) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The alert `MimirIngesterStuckProcessingRecordsFromKafka` relied on the metric `cortex_ingest_storage_reader_buffered_fetch_records_total ` provided by the Kafka client to identify wether we had stuck buffers or not.

Now that we've implemented concurrent fetching from Kafka and bypass the client's polling function we needed an equivalent metric when using concurrent fetching. This PR does that; In addition to that - the metric also takes the client's buffered records In case we do use a mixture of non-concurrent fetching and concurrent fetching.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
