### PR TITLE
Docs: rename scrape_native_histograms setting based on prometheus update

### DIFF
--- a/docs/sources/mimir/send/native-histograms/_index.md
+++ b/docs/sources/mimir/send/native-histograms/_index.md
@@ -171,7 +171,7 @@ Use the latest version of [Grafana Alloy](https://grafana.com/docs/alloy/<ALLOY_
    scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
    always_scrape_classic_histograms = true
    ```
-   
+
    For more information, refer to [prometheus.scrape](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/prometheus/prometheus.scrape/) in the Grafana Alloy documentation.
 
    {{< admonition type="note" >}}

--- a/docs/sources/mimir/send/native-histograms/_index.md
+++ b/docs/sources/mimir/send/native-histograms/_index.md
@@ -106,7 +106,13 @@ Use Prometheus version 2.47 or later.
    prometheus --enable-feature=native-histograms
    ```
 
-1. This flag makes Prometheus detect and scrape native histograms but ignores the classic histogram version of those metrics that have native histograms defined as well. Classic histograms without native histogram definitions are not affected. To keep scraping the classic histogram version of native histogram metrics, you need to set `always_scrape_classic_histograms` to `true` in your scrape jobs.
+   This flag makes Prometheus detect and scrape native histograms and ignore the classic histogram version of metrics that have native histograms defined as well. Classic histograms without native histogram definitions are not affected.
+
+1. To keep scraping the classic histogram version of native histogram metrics, you need to set `always_scrape_classic_histograms` to `true` in your scrape jobs.
+
+   {{< admonition type="note" >}}
+   In Prometheus versions earlier than 3.0, the `always_scrape_classic_histograms` setting is called `scrape_classic_histograms`. Use the setting name that corresponds to the version of Prometheus you're using.
+   {{< /admonition >}}
 
    For example, to get both classic and native histograms, use the following configuration:
 
@@ -149,13 +155,23 @@ Use Prometheus version 2.47 or later.
 
 Use the latest version of [Grafana Alloy](https://grafana.com/docs/alloy/<ALLOY_VERSION>).
 
-1. To scrape native histograms, you need to set the `scrape_protocols` argument in the `prometheus.scrape` component to specify `PrometheusProto` as the first protocol to negotiate and `always_scrape_classic_histograms = true` in order to scrape both classic and native histograms.
+1. To scrape native histograms, set the `scrape_protocols` argument in the `prometheus.scrape` component to specify `PrometheusProto` as the first protocol to negotiate.
 
    ```
     scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
-    always_scrape_classic_histograms = true
    ```
 
+1. To scrape classic histograms in addition to native histograms, set `always_scrape_classic_histograms` to `true`.
+
+   {{< admonition type="note" >}}
+   In Prometheus versions earlier than 3.0, the `always_scrape_classic_histograms` setting is called `scrape_classic_histograms`. Use the setting name that corresponds to the version of Prometheus you're using.
+   {{< /admonition >}}
+
+   ```
+   scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+   always_scrape_classic_histograms = true
+   ```
+   
    For more information, refer to [prometheus.scrape](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/prometheus/prometheus.scrape/) in the Grafana Alloy documentation.
 
    {{< admonition type="note" >}}

--- a/docs/sources/mimir/send/native-histograms/_index.md
+++ b/docs/sources/mimir/send/native-histograms/_index.md
@@ -98,17 +98,17 @@ The duration in `NativeHistogramMinResetDuration`/`nativeResetDuration` will pro
 
 ## Scrape and send native histograms with Prometheus
 
-Use the latest version of Prometheus or at least version 2.47.
+Use Prometheus version 2.47 or later.
 
-1. To enable scraping native histograms from the application, you need to enable native histograms feature via a feature flag on the command line:
+1. To enable scraping native histograms from the application, you need to enable the native histograms feature via a feature flag on the command line:
 
    ```bash
    prometheus --enable-feature=native-histograms
    ```
 
-1. The above flag makes Prometheus detect and scrape native histograms, but ignores classic histogram version of those metrics that have native histogram defined as well. Classic histograms without native histogram definitions are not affected. To keep scraping the classic histogram version of native histogram metrics, you need to set `always_scrape_classic_histograms` to `true` in your scrape jobs.
+1. This flag makes Prometheus detect and scrape native histograms but ignores the classic histogram version of those metrics that have native histograms defined as well. Classic histograms without native histogram definitions are not affected. To keep scraping the classic histogram version of native histogram metrics, you need to set `always_scrape_classic_histograms` to `true` in your scrape jobs.
 
-For example, to get both classic and native histograms, use the following configuration.
+   For example, to get both classic and native histograms, use the following configuration:
 
    ```yaml
    scrape_configs:
@@ -119,20 +119,20 @@ For example, to get both classic and native histograms, use the following config
    {{< admonition type="note" >}}
    <!-- Issue: https://github.com/prometheus/prometheus/issues/11265 -->
 
-   Native histograms don't have a textual presentation at the moment on the application's `/metrics` endpoint, thus Prometheus negotiates a Protobuf protocol transfer in this case.
+   Native histograms don't have a textual presentation on the application's `/metrics` endpoint. Therefore, Prometheus negotiates a Protobuf protocol transfer in these cases.
    {{< /admonition >}}
 
    {{< admonition type="note" >}}
-   In certain situations, the protobuf parsing changes the number formatting of
+   In certain situations, the Protobuf parsing changes the number formatting of
    the `le` labels of conventional histograms and the `quantile` labels of
    summaries. Typically, this happens if the scraped target is instrumented with
    [client_golang](https://github.com/prometheus/client_golang), provided that
    [promhttp.HandlerOpts.EnableOpenMetrics](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus/promhttp#HandlerOpts)
    is set to `false`. In such cases, integer label values are represented
    as `quantile="1"` or `le="2"` omitting the zero fractional.
-   However, the protobuf parsing changes the representation to always include a fractional (following the OpenMetrics
+   However, the Protobuf parsing changes the representation to always include a fractional (following the OpenMetrics
    specification), so the examples above become `quantile="1.0"` and `le="2.0"` after
-   ingestion into Prometheus, which changes the identity of the metric from what was originally ingested.
+   ingestion into Prometheus. This changes the identity of the metric from what was originally ingested.
 
    For more information, refer to [Feature Flags Native Histograms](https://prometheus.io/docs/prometheus/latest/feature_flags/#native-histograms) in the Prometheus documentation.
    {{< /admonition >}}
@@ -159,16 +159,16 @@ Use the latest version of [Grafana Alloy](https://grafana.com/docs/alloy/<ALLOY_
    For more information, refer to [prometheus.scrape](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/prometheus/prometheus.scrape/) in the Grafana Alloy documentation.
 
    {{< admonition type="note" >}}
-   In certain situations, the protobuf parsing changes the number formatting of
+   In certain situations, the Protobuf parsing changes the number formatting of
    the `le` labels of conventional histograms and the `quantile` labels of
    summaries. Typically, this happens if the scraped target is instrumented with
    [client_golang](https://github.com/prometheus/client_golang), provided that
    [promhttp.HandlerOpts.EnableOpenMetrics](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus/promhttp#HandlerOpts)
    is set to `false`. In such cases, integer label values are represented
    as `quantile="1"` or `le="2"` omitting the zero fractional.
-   However, the protobuf parsing changes the representation to always include a fractional (following the OpenMetrics
+   However, the Protobuf parsing changes the representation to always include a fractional (following the OpenMetrics
    specification), so the examples above become `quantile="1.0"` and `le="2.0"` after
-   ingestion into Prometheus, which changes the identity of the metric from what was originally ingested.
+   ingestion into Prometheus. This changes the identity of the metric from what was originally ingested.
 
    For more information, refer to [Feature Flags Native Histograms](https://prometheus.io/docs/prometheus/latest/feature_flags/#native-histograms) in the Prometheus documentation.
    {{< /admonition >}}

--- a/docs/sources/mimir/send/native-histograms/_index.md
+++ b/docs/sources/mimir/send/native-histograms/_index.md
@@ -106,15 +106,15 @@ Use the latest version of Prometheus or at least version 2.47.
    prometheus --enable-feature=native-histograms
    ```
 
-1. The above flag will make Prometheus detect and scrape native histograms, but ignores classic histogram version of those metrics that have native histogram defined as well. Classic histograms without native histogram definitions are not effected. To keep scraping the classic histogram version of native histogram metrics you need to set `scrape_classic_histograms` to `true` in your scrape jobs, for example:
+1. The above flag makes Prometheus detect and scrape native histograms, but ignores classic histogram version of those metrics that have native histogram defined as well. Classic histograms without native histogram definitions are not affected. To keep scraping the classic histogram version of native histogram metrics, you need to set `always_scrape_classic_histograms` to `true` in your scrape jobs.
+
+For example, to get both classic and native histograms, use the following configuration.
 
    ```yaml
    scrape_configs:
      - job_name: myapp
-       scrape_classic_histograms: true
+       always_scrape_classic_histograms: true
    ```
-
-   in your scrape jobs, to get both histogram version.
 
    {{< admonition type="note" >}}
    <!-- Issue: https://github.com/prometheus/prometheus/issues/11265 -->
@@ -149,11 +149,11 @@ Use the latest version of Prometheus or at least version 2.47.
 
 Use the latest version of [Grafana Alloy](https://grafana.com/docs/alloy/<ALLOY_VERSION>).
 
-1. To scrape native histograms, you need to set the `scrape_protocols` argument in the `prometheus.scrape` component to specify `PrometheusProto` as the first protocol to negotiate and `scrape_classic_histograms = true` in order to scrape both classic and native histograms.
+1. To scrape native histograms, you need to set the `scrape_protocols` argument in the `prometheus.scrape` component to specify `PrometheusProto` as the first protocol to negotiate and `always_scrape_classic_histograms = true` in order to scrape both classic and native histograms.
 
    ```
     scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
-    scrape_classic_histograms = true
+    always_scrape_classic_histograms = true
    ```
 
    For more information, refer to [prometheus.scrape](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/prometheus/prometheus.scrape/) in the Grafana Alloy documentation.


### PR DESCRIPTION
#### What this PR does

This PR updates the `scrape_native_histograms` setting to `always_scrape_native_histograms` at https://grafana.com/docs/mimir/latest/send/native-histograms/. This update is based on a [change in Prometheus version 3.0](https://github.com/prometheus/prometheus/pull/15178).

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/9695

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
