### PR TITLE
Log an error if the Kafka partitions auto-creation fail with an error in the Kafka response

### DIFF
--- a/pkg/storage/ingest/util_test.go
+++ b/pkg/storage/ingest/util_test.go
@@ -10,8 +10,10 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/concurrency"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
@@ -129,32 +131,101 @@ func TestResultPromise(t *testing.T) {
 }
 
 func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
-	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
-	require.NoError(t, err)
-	t.Cleanup(cluster.Close)
+	createKafkaCluster := func(t *testing.T) (string, *kfake.Cluster) {
+		cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
+		require.NoError(t, err)
+		t.Cleanup(cluster.Close)
 
-	addrs := cluster.ListenAddrs()
-	require.Len(t, addrs, 1)
+		addrs := cluster.ListenAddrs()
+		require.Len(t, addrs, 1)
 
-	cfg := KafkaConfig{
-		Address:                          addrs[0],
-		AutoCreateTopicDefaultPartitions: 100,
+		return addrs[0], cluster
 	}
 
-	cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
-		r := request.(*kmsg.AlterConfigsRequest)
+	t.Run("should create the partitions", func(t *testing.T) {
+		var (
+			addr, cluster = createKafkaCluster(t)
+			cfg           = KafkaConfig{
+				Address:                          addr,
+				AutoCreateTopicDefaultPartitions: 100,
+			}
+		)
 
-		require.Len(t, r.Resources, 1)
-		res := r.Resources[0]
-		require.Equal(t, kmsg.ConfigResourceTypeBroker, res.ResourceType)
-		require.Len(t, res.Configs, 1)
-		cfg := res.Configs[0]
-		require.Equal(t, "num.partitions", cfg.Name)
-		require.NotNil(t, *cfg.Value)
-		require.Equal(t, "100", *cfg.Value)
+		cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			r := request.(*kmsg.AlterConfigsRequest)
 
-		return &kmsg.AlterConfigsResponse{}, nil, true
+			require.Len(t, r.Resources, 1)
+			res := r.Resources[0]
+			require.Equal(t, kmsg.ConfigResourceTypeBroker, res.ResourceType)
+			require.Len(t, res.Configs, 1)
+			cfg := res.Configs[0]
+			require.Equal(t, "num.partitions", cfg.Name)
+			require.NotNil(t, *cfg.Value)
+			require.Equal(t, "100", *cfg.Value)
+
+			return &kmsg.AlterConfigsResponse{
+				Version: r.Version,
+			}, nil, true
+		})
+
+		logs := concurrency.SyncBuffer{}
+		logger := log.NewLogfmtLogger(&logs)
+
+		setDefaultNumberOfPartitionsForAutocreatedTopics(cfg, logger)
+		require.NotContains(t, logs.String(), "err")
 	})
 
-	setDefaultNumberOfPartitionsForAutocreatedTopics(cfg, log.NewNopLogger())
+	t.Run("should log an error if the request fails", func(t *testing.T) {
+		var (
+			addr, cluster = createKafkaCluster(t)
+			cfg           = KafkaConfig{
+				Address:                          addr,
+				AutoCreateTopicDefaultPartitions: 100,
+			}
+		)
+
+		cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			return &kmsg.AlterConfigsResponse{}, errors.New("failed request"), true
+		})
+
+		logs := concurrency.SyncBuffer{}
+		logger := log.NewLogfmtLogger(&logs)
+
+		setDefaultNumberOfPartitionsForAutocreatedTopics(cfg, logger)
+		require.Contains(t, logs.String(), "err")
+	})
+
+	t.Run("should log an error if the request succeed but the response contains an error", func(t *testing.T) {
+		var (
+			addr, cluster = createKafkaCluster(t)
+			cfg           = KafkaConfig{
+				Address:                          addr,
+				AutoCreateTopicDefaultPartitions: 100,
+			}
+		)
+
+		cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(kReq kmsg.Request) (kmsg.Response, error, bool) {
+			req := kReq.(*kmsg.AlterConfigsRequest)
+			require.Len(t, req.Resources, 1)
+
+			return &kmsg.AlterConfigsResponse{
+				Version: req.Version,
+				Resources: []kmsg.AlterConfigsResponseResource{
+					{
+						ResourceType: req.Resources[0].ResourceType,
+						ResourceName: req.Resources[0].ResourceName,
+						ErrorCode:    kerr.InvalidRequest.Code,
+						ErrorMessage: pointerOf(kerr.InvalidRequest.Message),
+					},
+				},
+			}, nil, true
+		})
+
+		logs := concurrency.SyncBuffer{}
+		logger := log.NewLogfmtLogger(&logs)
+
+		setDefaultNumberOfPartitionsForAutocreatedTopics(cfg, logger)
+		require.Contains(t, logs.String(), "err")
+	})
+
 }

--- a/pkg/storage/ingest/util_test.go
+++ b/pkg/storage/ingest/util_test.go
@@ -184,7 +184,7 @@ func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
 			}
 		)
 
-		cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(_ kmsg.Request) (kmsg.Response, error, bool) {
 			return &kmsg.AlterConfigsResponse{}, errors.New("failed request"), true
 		})
 


### PR DESCRIPTION
#### What this PR does

This is a minor thing, but could be useful to get insights if partitions auto-creation fail. Previously we were only logging an error if the partitions creation request fail, but it could also succeed and contain an error in the response. Now we do log the error in the latter case too.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
