### PR TITLE
Adding renovate config for the mimir-mixin-tools/screenshots node project

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -33,6 +33,13 @@
         "matchDatasources": ["docker", "golang-version"],
         "matchPackageNames": ["go", "golang"],
         "allowedVersions": "<=1.22.5"
+      },
+      // Keep deps for the dashboard screenshotting tool up to date
+      {
+        "description": "Enable updating Node.js dependencies in operations/mimir-mixin-tools/screenshots",
+        "paths": ["operations/mimir-mixin-tools/screenshots"],
+        "managers": ["npm"],
+        "enabled": true
       }
     ],
     "branchPrefix": "deps-update/",


### PR DESCRIPTION
Updates the renovate config to include bumping changes to the small node project used to take screenshots of dashboards. The config validates but I'm not a renovate expert.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
