### PR TITLE
ingester: shortcut fetchWants that have already been satisfied

### DIFF
--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -702,6 +702,10 @@ func (r *concurrentFetchers) start(ctx context.Context, startOffset int64, concu
 			}
 			nextFetch = nextFetch.UpdateBytesPerRecord(result.fetchedBytes, len(result.Records))
 
+			for recs := result.Records; len(recs) > 0 && recs[len(recs)-1].Offset >= nextFetch.endOffset; {
+				// We just received some records. If the nextFetch is already covered by these, then we can avoid fetching it.
+				nextFetch = nextFetch.Next(recordsPerFetch)
+			}
 			// We have some ordered records ready to be sent to PollFetches(). We store the fetch
 			// result in bufferedResult, and we flip readyBufferedResults to the channel used by
 			// PollFetches().


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

After #9855 and the assertions in `pollFetchesAndAssertNoRecords` there were some flaky tests (`TestConcurrentFetchers/consume_from_end_and_update_immediately` in particular). This happened because some fetch would satisfy the future fetchWants. Future fetchWantes would only end up buffering records and then discarding them at PollFetches.

The tests are more obviously flaky if you make consuming records a bit more expensive, for example, but changing the logger with 


```diff
diff --git a/pkg/storage/ingest/fetcher_test.go b/pkg/storage/ingest/fetcher_test.go
index f96f27d5b4..b1d5df9aa9 100644
--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -1057,7 +1058,7 @@ func TestConcurrentFetchers(t *testing.T) {
 }
 
 func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Client, topic string, partition int32, startOffset int64, concurrency, recordsPerFetch int) *concurrentFetchers {
-	logger := log.NewNopLogger()
+	logger := log.NewLogfmtLogger(os.Stdout)
 	reg := prometheus.NewPedanticRegistry()
 	metrics := newReaderMetrics(partition, reg, func() float64 { return 1 })
```

#### The fix


This PR shortcuts this, so the tests are less likely to be flaky. Now we can still make a request for a fetchWants that's been satisfied, but it's less likely and there will only be up to `concurrency` of these.


#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
