### PR TITLE
Log fetched bucket index timestamps

### DIFF
--- a/pkg/querier/blocks_finder_bucket_index.go
+++ b/pkg/querier/blocks_finder_bucket_index.go
@@ -40,6 +40,7 @@ type BucketIndexBlocksFinder struct {
 
 	cfg    BucketIndexBlocksFinderConfig
 	loader *bucketindex.Loader
+	logger log.Logger
 }
 
 func NewBucketIndexBlocksFinder(cfg BucketIndexBlocksFinderConfig, bkt objstore.Bucket, cfgProvider bucket.TenantConfigProvider, logger log.Logger, reg prometheus.Registerer) *BucketIndexBlocksFinder {
@@ -49,6 +50,7 @@ func NewBucketIndexBlocksFinder(cfg BucketIndexBlocksFinderConfig, bkt objstore.
 		cfg:     cfg,
 		loader:  loader,
 		Service: loader,
+		logger:  logger,
 	}
 }
 

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -133,7 +133,7 @@ func (l *Loader) GetIndex(ctx context.Context, userID string) (*Index, error) {
 
 	elapsedTime := time.Since(startTime)
 	l.loadDuration.Observe(elapsedTime.Seconds())
-	level.Info(l.logger).Log("msg", "loaded bucket index", "user", userID, "duration", elapsedTime)
+	level.Info(l.logger).Log("msg", "loaded bucket index", "user", userID, "updatedAt", idx.UpdatedAt, "duration", elapsedTime)
 	return idx, nil
 }
 

--- a/pkg/storegateway/bucket_index_metadata_fetcher.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher.go
@@ -94,7 +94,7 @@ func (f *BucketIndexMetadataFetcher) Fetch(ctx context.Context) (metas map[ulid.
 		return nil, nil, errors.Wrapf(err, "read bucket index")
 	}
 
-	level.Info(f.logger).Log("msg", "fetched bucket index", "userID", f.userID, "updatedAt", idx.UpdatedAt)
+	level.Info(f.logger).Log("msg", "loaded bucket index", "user", f.userID, "updatedAt", idx.UpdatedAt)
 
 	// Build block metas out of the index.
 	metas = make(map[ulid.ULID]*block.Meta, len(idx.Blocks))

--- a/pkg/storegateway/bucket_index_metadata_fetcher.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher.go
@@ -94,6 +94,8 @@ func (f *BucketIndexMetadataFetcher) Fetch(ctx context.Context) (metas map[ulid.
 		return nil, nil, errors.Wrapf(err, "read bucket index")
 	}
 
+	level.Info(f.logger).Log("msg", "fetched bucket index", "userID", f.userID, "updatedAt", idx.UpdatedAt)
+
 	// Build block metas out of the index.
 	metas = make(map[ulid.ULID]*block.Meta, len(idx.Blocks))
 	for _, b := range idx.Blocks {

--- a/pkg/storegateway/bucket_index_metadata_fetcher_test.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher_test.go
@@ -68,7 +68,6 @@ func TestBucketIndexMetadataFetcher_Fetch(t *testing.T) {
 		block3.ID: block3.ThanosMeta(),
 	}, metas)
 	assert.Empty(t, partials)
-	assert.Empty(t, logs)
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 		# HELP blocks_meta_sync_failures_total Total blocks metadata synchronization failures


### PR DESCRIPTION
#### What this PR does

Adds logging of bucket index timestamps (updatedAt) after they're fetched, in queriers and store gateways. This allows better understanding of which exact bucket index queriers and store gateways are working off of.

#### Which issue(s) this PR fixes or relates to



#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
