### PR TITLE
Fix flaky TestIngester_Push_CircuitBreaker_DeadlineExceeded test

### DIFF
--- a/pkg/ingester/circuitbreaker_test.go
+++ b/pkg/ingester/circuitbreaker_test.go
@@ -922,7 +922,7 @@ func TestIngester_FinishPushRequest(t *testing.T) {
 }
 
 func TestIngester_Push_CircuitBreaker_DeadlineExceeded(t *testing.T) {
-	pushTimeout := 100 * time.Millisecond
+	pushTimeout := 1 * time.Second
 	for initialDelayEnabled, initialDelayStatus := range map[bool]string{false: "disabled", true: "enabled"} {
 		t.Run(fmt.Sprintf("test slow push with initial delay %s", initialDelayStatus), func(t *testing.T) {
 			metricLabelAdapters := [][]mimirpb.LabelAdapter{{{Name: labels.MetricName, Value: "test"}}}


### PR DESCRIPTION
This test would sometimes fail:
```
--- FAIL: TestIngester_Push_CircuitBreaker_DeadlineExceeded (2.00s)
    --- FAIL: TestIngester_Push_CircuitBreaker_DeadlineExceeded/test_slow_push_with_initial_delay_disabled (2.00s)
        circuitbreaker_test.go:1015: 
            	Error Trace:	/go/src/github.com/grafana/mimir/pkg/ingester/circuitbreaker_test.go:1015
            	Error:      	Received unexpected error:
            	           	circuit breaker open on push request type with remaining delay 9.999979667s
            	Test:       	TestIngester_Push_CircuitBreaker_DeadlineExceeded/test_slow_push_with_initial_delay_disabled
```

The test assumes that it will execute one successful request, and then 4 failing requests. However, sometimes the first request would take longer to execute than the configured `100ms` timeout, and the circuit breaker would close after the second overall request, rather than after the third.

The trivial fix is to increase the push timeout to a larger value, so that the initial request has time to complete successfully, even if the test runner is slow. This PR bumps it to `1s`.

With this change I was able to run this test 1000x without failure locally:
```
go test -timeout 300m ./pkg/ingester/... -run "TestIngester_Push_CircuitBreaker_DeadlineExceeded" -race -count 1000 -failfast
ok  	github.com/grafana/mimir/pkg/ingester	4026.572s
ok  	github.com/grafana/mimir/pkg/ingester/activeseries	1.018s [no tests to run]
ok  	github.com/grafana/mimir/pkg/ingester/activeseries/model	1.018s [no tests to run]
ok  	github.com/grafana/mimir/pkg/ingester/client	1.047s [no tests to run]
make: Leaving directory '/go/src/github.com/grafana/mimir'

real	67m16.581s
user	0m0.121s
sys	0m0.026s
```
