### PR TITLE
[r314] compactor: concurrently get deletion marks for blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [ENHANCEMENT] Querier: Enable the optional querying of additional storage queryables. #9712
 * [ENHANCEMENT] Ingester: Disable the push circuit breaker when ingester is in read-only mode. #9760
 * [ENHANCEMENT] Distributor: when a label value fails validation due to invalid UTF-8 characters, don't include the invalid characters in the returned error. #9828
+* [ENHANCEMENT] Compactor: refresh deletion marks when updating the bucket index concurrently. This speeds up updating the bucket index by up to 16 times when there is a lot of blocks churn (thousands of blocks churning every cleanup cycle). #9881
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508

--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -33,17 +33,19 @@ import (
 )
 
 const (
-	defaultDeleteBlocksConcurrency = 16
+	defaultDeleteBlocksConcurrency       = 16
+	defaultGetDeletionMarkersConcurrency = 16
 )
 
 type BlocksCleanerConfig struct {
-	DeletionDelay              time.Duration
-	CleanupInterval            time.Duration
-	CleanupConcurrency         int
-	TenantCleanupDelay         time.Duration // Delay before removing tenant deletion mark and "debug".
-	DeleteBlocksConcurrency    int
-	NoBlocksFileCleanupEnabled bool
-	CompactionBlockRanges      mimir_tsdb.DurationList // Used for estimating compaction jobs.
+	DeletionDelay                 time.Duration
+	CleanupInterval               time.Duration
+	CleanupConcurrency            int
+	TenantCleanupDelay            time.Duration // Delay before removing tenant deletion mark and "debug".
+	DeleteBlocksConcurrency       int
+	GetDeletionMarkersConcurrency int
+	NoBlocksFileCleanupEnabled    bool
+	CompactionBlockRanges         mimir_tsdb.DurationList // Used for estimating compaction jobs.
 }
 
 type BlocksCleaner struct {
@@ -432,7 +434,7 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, userLogger
 	}
 
 	// Generate an updated in-memory version of the bucket index.
-	w := bucketindex.NewUpdater(c.bucketClient, userID, c.cfgProvider, userLogger)
+	w := bucketindex.NewUpdater(c.bucketClient, userID, c.cfgProvider, c.cfg.GetDeletionMarkersConcurrency, userLogger)
 	idx, partials, err := w.UpdateIndex(ctx, idx)
 	if err != nil {
 		return err

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -521,13 +521,14 @@ func (c *MultitenantCompactor) starting(ctx context.Context) error {
 
 	// Create the blocks cleaner (service).
 	c.blocksCleaner = NewBlocksCleaner(BlocksCleanerConfig{
-		DeletionDelay:              c.compactorCfg.DeletionDelay,
-		CleanupInterval:            util.DurationWithJitter(c.compactorCfg.CleanupInterval, 0.1),
-		CleanupConcurrency:         c.compactorCfg.CleanupConcurrency,
-		TenantCleanupDelay:         c.compactorCfg.TenantCleanupDelay,
-		DeleteBlocksConcurrency:    defaultDeleteBlocksConcurrency,
-		NoBlocksFileCleanupEnabled: c.compactorCfg.NoBlocksFileCleanupEnabled,
-		CompactionBlockRanges:      c.compactorCfg.BlockRanges,
+		DeletionDelay:                 c.compactorCfg.DeletionDelay,
+		CleanupInterval:               util.DurationWithJitter(c.compactorCfg.CleanupInterval, 0.1),
+		CleanupConcurrency:            c.compactorCfg.CleanupConcurrency,
+		TenantCleanupDelay:            c.compactorCfg.TenantCleanupDelay,
+		DeleteBlocksConcurrency:       defaultDeleteBlocksConcurrency,
+		GetDeletionMarkersConcurrency: defaultGetDeletionMarkersConcurrency,
+		NoBlocksFileCleanupEnabled:    c.compactorCfg.NoBlocksFileCleanupEnabled,
+		CompactionBlockRanges:         c.compactorCfg.BlockRanges,
 	}, c.bucketClient, c.shardingStrategy.blocksCleanerOwnsUser, c.cfgProvider, c.parentLogger, c.registerer)
 
 	// Start blocks cleaner asynchronously, don't wait until initial cleanup is finished.

--- a/pkg/storage/tsdb/bucketindex/storage_test.go
+++ b/pkg/storage/tsdb/bucketindex/storage_test.go
@@ -56,7 +56,7 @@ func TestReadIndex_ShouldReturnTheParsedIndexOnSuccess(t *testing.T) {
 	block.MockStorageDeletionMark(t, bkt, userID, block.MockStorageBlock(t, bkt, userID, 30, 40))
 
 	// Write the index.
-	u := NewUpdater(bkt, userID, nil, logger)
+	u := NewUpdater(bkt, userID, nil, 16, logger)
 	expectedIdx, _, err := u.UpdateIndex(ctx, nil)
 	require.NoError(t, err)
 	require.NoError(t, WriteIndex(ctx, bkt, userID, nil, expectedIdx))
@@ -93,7 +93,7 @@ func BenchmarkReadIndex(b *testing.B) {
 	}
 
 	// Write the index.
-	u := NewUpdater(bkt, userID, nil, logger)
+	u := NewUpdater(bkt, userID, nil, 16, logger)
 	idx, _, err := u.UpdateIndex(ctx, nil)
 	require.NoError(b, err)
 	require.NoError(b, WriteIndex(ctx, bkt, userID, nil, idx))

--- a/pkg/storage/tsdb/bucketindex/updater.go
+++ b/pkg/storage/tsdb/bucketindex/updater.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/runutil"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
@@ -32,14 +33,16 @@ var (
 
 // Updater is responsible to generate an update in-memory bucket index.
 type Updater struct {
-	bkt    objstore.InstrumentedBucket
-	logger log.Logger
+	bkt                           objstore.InstrumentedBucket
+	logger                        log.Logger
+	getDeletionMarkersConcurrency int
 }
 
-func NewUpdater(bkt objstore.Bucket, userID string, cfgProvider bucket.TenantConfigProvider, logger log.Logger) *Updater {
+func NewUpdater(bkt objstore.Bucket, userID string, cfgProvider bucket.TenantConfigProvider, getDeletionMarkersConcurrency int, logger log.Logger) *Updater {
 	return &Updater{
-		bkt:    bucket.NewUserBucketClient(userID, bkt, cfgProvider),
-		logger: logger,
+		bkt:                           bucket.NewUserBucketClient(userID, bkt, cfgProvider),
+		getDeletionMarkersConcurrency: getDeletionMarkersConcurrency,
+		logger:                        logger,
 	}
 }
 
@@ -209,23 +212,32 @@ func (w *Updater) updateBlockDeletionMarks(ctx context.Context, old []*BlockDele
 	}
 
 	// Remaining markers are new ones and we have to fetch them.
+	discoveredSlice := make([]ulid.ULID, 0, len(discovered))
 	for id := range discovered {
+		discoveredSlice = append(discoveredSlice, id)
+	}
+
+	updatedMarks, err := concurrency.ForEachJobMergeResults(ctx, discoveredSlice, w.getDeletionMarkersConcurrency, func(ctx context.Context, id ulid.ULID) ([]*BlockDeletionMark, error) {
 		m, err := w.updateBlockDeletionMarkIndexEntry(ctx, id)
 		if errors.Is(err, ErrBlockDeletionMarkNotFound) {
 			// This could happen if the block is permanently deleted between the "list objects" and now.
 			level.Warn(w.logger).Log("msg", "skipped missing block deletion mark when updating bucket index", "block", id.String())
-			continue
+			return nil, nil
 		}
 		if errors.Is(err, ErrBlockDeletionMarkCorrupted) {
 			level.Error(w.logger).Log("msg", "skipped corrupted block deletion mark when updating bucket index", "block", id.String(), "err", err)
-			continue
+			return nil, nil
 		}
 		if err != nil {
 			return nil, err
 		}
 
-		out = append(out, m)
+		return BlockDeletionMarks{m}, nil
+	})
+	if err != nil {
+		return nil, err
 	}
+	out = append(out, updatedMarks...)
 
 	level.Info(w.logger).Log("msg", "updated deletion markers for recently marked blocks", "count", len(discovered), "total_deletion_markers", len(out))
 

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1710,7 +1710,7 @@ func (m *mockShardingStrategy) FilterBlocks(ctx context.Context, userID string, 
 }
 
 func createBucketIndex(t *testing.T, bkt objstore.Bucket, userID string) *bucketindex.Index {
-	updater := bucketindex.NewUpdater(bkt, userID, nil, log.NewNopLogger())
+	updater := bucketindex.NewUpdater(bkt, userID, nil, 16, log.NewNopLogger())
 	idx, _, err := updater.UpdateIndex(context.Background(), nil)
 	require.NoError(t, err)
 	require.NoError(t, bucketindex.WriteIndex(context.Background(), bkt, userID, nil, idx))

--- a/pkg/storegateway/metadata_fetcher_filters_test.go
+++ b/pkg/storegateway/metadata_fetcher_filters_test.go
@@ -74,7 +74,7 @@ func testIgnoreDeletionMarkFilter(t *testing.T, bucketIndexEnabled bool) {
 	if bucketIndexEnabled {
 		var err error
 
-		u := bucketindex.NewUpdater(bkt, userID, nil, logger)
+		u := bucketindex.NewUpdater(bkt, userID, nil, 16, logger)
 		idx, _, err = u.UpdateIndex(ctx, nil)
 		require.NoError(t, err)
 		require.NoError(t, bucketindex.WriteIndex(ctx, bkt, userID, nil, idx))


### PR DESCRIPTION
* compactor: concurrently get deletion marks for blocks

With a lot of blocks churn (for example a lot of OOO blocks) getting the deletion marks for newly discovered blocks can take a long time (13 minutes).

This PR introduces changes the bucket index updater to request 16 deletions marks concurrently (same as the number of block deleted in parallel).

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>
Co-authored-by: Ganesh Vernekar <ganeshvern@gmail.com>
(cherry picked from commit 94255ac58ccfb68a82963d45ba912e17f3c784d0, #9881)
