### PR TITLE
Reduce 'skipped records because already returned' log frequency

### DIFF
--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -407,7 +407,7 @@ func (r *concurrentFetchers) recordOrderedFetchTelemetry(f fetchResult, firstRet
 
 	if skippedRecordsCount > 0 {
 		spanlogger.FromContext(f.Records[0].Context, r.logger).DebugLog(
-			"msg", "skipped records because already returned",
+			"msg", "skipped records because it is already returned",
 			"skipped_records_count", skippedRecordsCount,
 			"first_skipped_offset", firstSkippedRecordOffset,
 			"last_skipped_offset", lastSkippedRecordOffset)

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -1100,6 +1100,11 @@ func pollFetchesAndAssertNoRecords(t *testing.T, fetchers *concurrentFetchers) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
+	// If there are no buffered records, we can skip the polling at all.
+	if fetchers.BufferedRecords() == 0 {
+		return
+	}
+
 	for {
 		fetches, returnCtx := fetchers.PollFetches(ctx)
 		if errors.Is(returnCtx.Err(), context.DeadlineExceeded) {


### PR DESCRIPTION
#### What this PR does

I was looking at the flaky test reported in https://github.com/grafana/mimir/pull/9891. I actually reproduce it enabling the logging (and also increasing the number of records produced/consumed by the test). I personally think the main problem is that we log 'skipped records because already returned' for every single record, which looks a bit too much to me in case there are many skipped records.

In this PR I propose to just log the summary of all skipped records, logging the count, and the min/max offsets. With this change I can't get the test being flaky anymore. I also measured `'skipped records because already returned'()` timing and now it's in the order of microserconds when running the tests locally (with log enabled).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
