### PR TITLE
Dashboards: clarify write requests processed from Kafka

### DIFF
--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -240,11 +240,15 @@ local filename = 'mimir-writes.json';
         ) + $.aliasColors({ successful: $._colors.success, failed: $._colors.failed, 'read errors': $._colors.failed }) + $.stack,
       )
       .addPanel(
-        $.timeseriesPanel('Kafka records / sec') +
+        $.timeseriesPanel('Write request batches processed / sec') +
         $.panelDescription(
-          'Kafka records / sec',
+          'Write request batches processed / sec',
           |||
-            Rate of processed records from Kafka. Failed records are categorized as "client" errors (e.g. per-tenant limits) or server errors.
+            Rate of write requests processed from Kafka. When concurrent fetcher is enabled, this panel shows the rate
+            of write request batches processed: multiple requests could get batched together and so the resulting number
+            batches processed may be lower than the number of write requests received in the distributor.
+
+            Failed records are categorized as "client" errors (e.g. per-tenant limits) or server errors.
           |||
         ) +
         $.queryPanel(
@@ -285,11 +289,11 @@ local filename = 'mimir-writes.json';
         ) + $.aliasColors({ successful: $._colors.success, 'failed (client)': $._colors.clientError, 'failed (server)': $._colors.failed }) + $.stack,
       )
       .addPanel(
-        $.timeseriesPanel('Kafka record processing latency') +
+        $.timeseriesPanel('Kafka records batch processing latency') +
         $.panelDescription(
-          'Kafka record processing latency',
+          'Kafka records batch processing latency',
           |||
-            Time used to process a single record (write request). This time is spent by appending data to per-tenant TSDB.
+            Time taken to process a batch of Kafka records (each record contains a write request).
           |||
         ) +
         $.queryPanel(


### PR DESCRIPTION
#### What this PR does

With https://github.com/grafana/mimir/pull/9654, the `cortex_ingest_storage_reader_requests_total` metric has changed meaning. When concurrent fetch is enabled, it's no more the number of records / write requests processed, but number of write request **batches** processed.

This caused some confusion to me when we recently rolled out concurrent fetch and I observed this change at the time of the rollout:

![Screenshot 2024-11-14 at 15 50 53](https://github.com/user-attachments/assets/3a114876-3a0b-449d-95ea-adb16ca23f81)

In this PR I propose to change the panel title / description to something which is more accurate to the current state of the metric tracking.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
