### PR TITLE
tests(distributor): improve checks during ha_tracker sync cache on startup 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20241105154643-a6b453a88040
+	github.com/grafana/dskit v0.0.0-20241115082728-f2a7eb3aa0e9
 	github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -1260,8 +1260,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20241021123319-be61d61f71e7 h1:lsM/QscEX+ZDIJm48ynQscH+msETyGYV6ug8L4f2DtM=
 github.com/grafana/alerting v0.0.0-20241021123319-be61d61f71e7/go.mod h1:QsnoKX/iYZxA4Cv+H+wC7uxutBD8qi8ZW5UJvD2TYmU=
-github.com/grafana/dskit v0.0.0-20241105154643-a6b453a88040 h1:IR+UNYHqaU31t8/TArJk8K/GlDwOyxMpGNkWCXeZ28g=
-github.com/grafana/dskit v0.0.0-20241105154643-a6b453a88040/go.mod h1:SPLNCARd4xdjCkue0O6hvuoveuS1dGJjDnfxYe405YQ=
+github.com/grafana/dskit v0.0.0-20241115082728-f2a7eb3aa0e9 h1:Dx7+6aU/fhwD2vkMr0PUcyxGat1sjUssHAKQKaS7sDM=
+github.com/grafana/dskit v0.0.0-20241115082728-f2a7eb3aa0e9/go.mod h1:SPLNCARd4xdjCkue0O6hvuoveuS1dGJjDnfxYe405YQ=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc h1:BW+LjKJDz0So5LI8UZfW5neWeKpSkWqhmGjQFzcFfLM=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/franz-go v0.0.0-20241009100846-782ba1442937 h1:fwwnG/NcygoS6XbAaEyK2QzMXI/BZIEJvQ3CD+7XZm8=

--- a/vendor/github.com/grafana/dskit/kv/mock.go
+++ b/vendor/github.com/grafana/dskit/kv/mock.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"go.uber.org/atomic"
 )
 
 // The mockClient does not anything.
@@ -36,4 +37,64 @@ func (m mockClient) WatchKey(_ context.Context, _ string, _ func(interface{}) bo
 }
 
 func (m mockClient) WatchPrefix(_ context.Context, _ string, _ func(string, interface{}) bool) {
+}
+
+// MockCountingClient is a wrapper around the Client interface that counts the number of times its functions are called.
+// This is used for testing only.
+type MockCountingClient struct {
+	client Client
+
+	ListCalls        *atomic.Uint32
+	GetCalls         *atomic.Uint32
+	DeleteCalls      *atomic.Uint32
+	CASCalls         *atomic.Uint32
+	WatchKeyCalls    *atomic.Uint32
+	WatchPrefixCalls *atomic.Uint32
+}
+
+func NewMockCountingClient(client Client) *MockCountingClient {
+	return &MockCountingClient{
+		client:           client,
+		ListCalls:        atomic.NewUint32(0),
+		GetCalls:         atomic.NewUint32(0),
+		DeleteCalls:      atomic.NewUint32(0),
+		CASCalls:         atomic.NewUint32(0),
+		WatchKeyCalls:    atomic.NewUint32(0),
+		WatchPrefixCalls: atomic.NewUint32(0),
+	}
+}
+
+func (mc *MockCountingClient) List(ctx context.Context, prefix string) ([]string, error) {
+	mc.ListCalls.Inc()
+
+	return mc.client.List(ctx, prefix)
+}
+func (mc *MockCountingClient) Get(ctx context.Context, key string) (interface{}, error) {
+	mc.GetCalls.Inc()
+
+	return mc.client.Get(ctx, key)
+}
+
+func (mc *MockCountingClient) Delete(ctx context.Context, key string) error {
+	mc.DeleteCalls.Inc()
+
+	return mc.client.Delete(ctx, key)
+}
+
+func (mc *MockCountingClient) CAS(ctx context.Context, key string, f func(in interface{}) (out interface{}, retry bool, err error)) error {
+	mc.CASCalls.Inc()
+
+	return mc.client.CAS(ctx, key, f)
+}
+
+func (mc *MockCountingClient) WatchKey(ctx context.Context, key string, f func(interface{}) bool) {
+	mc.WatchKeyCalls.Inc()
+
+	mc.client.WatchKey(ctx, key, f)
+}
+
+func (mc *MockCountingClient) WatchPrefix(ctx context.Context, key string, f func(string, interface{}) bool) {
+	mc.WatchPrefixCalls.Inc()
+
+	mc.client.WatchPrefix(ctx, key, f)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -617,7 +617,7 @@ github.com/grafana/alerting/receivers/webex
 github.com/grafana/alerting/receivers/webhook
 github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
-# github.com/grafana/dskit v0.0.0-20241105154643-a6b453a88040
+# github.com/grafana/dskit v0.0.0-20241115082728-f2a7eb3aa0e9
 ## explicit; go 1.21
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR updates the `TestHATrackerCacheSyncOnStart` to use the `MockCountingClient` that was introduced in dskit ([Ref](https://github.com/grafana/dskit/pull/618)). This will allow us to better test if the sync happened during the ha_tracker creation

Follow up of this: #9826 

#### Which issue(s) this PR fixes or relates to

Improve testing scenarios

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
