### PR TITLE
Docs/support escalations 11817

### DIFF
--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -20,7 +20,6 @@ Use each protocol's respective exporter and native Mimir endpoint. For example:
 - OTel data: `otlphttp`
 - Prometheus data: `prometheusremotewrite`
 
-
 ## OTLP
 
 Mimir supports native OTLP over HTTP. When possible, use this protocol to send OTLP data. To configure the collector to use the OTLP interface, use the [`otlphttp`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) exporter:

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -13,63 +13,17 @@ weight: 150
 To send OTel data to Grafana Cloud, refer to [Send data using OpenTelemetry Protocol (OTLP)](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/).
 {{% /admonition %}}
 
-When using the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), you can write metrics into Mimir via two options: `prometheusremotewrite` and `otlphttp`.
+When using the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), you can write metrics into Mimir using two options: `otlphttp` (preferred) and `prometheusremotewrite`.
 
-We recommend using each protocol's respective exporter and native Mimir endpoint:
+Use each protocol's respective exporter and native Mimir endpoint. For example:
 
-- Prometheus data: `prometheusremotewrite`
 - OTel data: `otlphttp`
+- Prometheus data: `prometheusremotewrite`
 
-## Prometheus Remote Write
-
-For the Remote Write, use the [`prometheusremotewrite`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter) exporter in the Collector:
-
-In the `exporters` section add:
-
-```yaml
-exporters:
-  prometheusremotewrite:
-    endpoint: http://<mimir-endpoint>/api/v1/push
-```
-
-And enable it in the `service.pipelines`:
-
-```yaml
-service:
-  pipelines:
-    metrics:
-      receivers: [...]
-      processors: [...]
-      exporters: [..., prometheusremotewrite]
-```
-
-If you want to authenticate using basic auth, we recommend the [`basicauth`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension) extension:
-
-```yaml
-extensions:
-  basicauth/prw:
-    client_auth:
-      username: username
-      password: password
-
-exporters:
-  prometheusremotewrite:
-    auth:
-      authenticator: basicauth/prw
-    endpoint: http://<mimir-endpoint>/api/v1/push
-
-service:
-  extensions: [basicauth/prw]
-  pipelines:
-    metrics:
-      receivers: [...]
-      processors: [...]
-      exporters: [..., prometheusremotewrite]
-```
 
 ## OTLP
 
-Mimir supports native OTLP over HTTP. To configure the collector to use the OTLP interface, you use the [`otlphttp`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) exporter:
+Mimir supports native OTLP over HTTP. When possible, use this protocol to send OTLP data. To configure the collector to use the OTLP interface, use the [`otlphttp`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) exporter:
 
 ```yaml
 exporters:
@@ -77,7 +31,7 @@ exporters:
     endpoint: http://<mimir-endpoint>/otlp
 ```
 
-And enable it in `service.pipelines`:
+Then, enable it in `service.pipelines`:
 
 ```yaml
 service:
@@ -88,7 +42,7 @@ service:
       exporters: [..., otlphttp]
 ```
 
-If you want to authenticate using basic auth, we recommend the [`basicauth`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension) extension:
+If you want to authenticate using basic auth, use the [`basicauth`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension) extension:
 
 ```yaml
 extensions:
@@ -110,6 +64,53 @@ service:
       receivers: [...]
       processors: [...]
       exporters: [..., otlphttp]
+```
+
+## Prometheus remote write
+
+For remote write, use the [`prometheusremotewrite`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter) exporter in the Collector:
+
+In the `exporters` section add:
+
+```yaml
+exporters:
+  prometheusremotewrite:
+    endpoint: http://<mimir-endpoint>/api/v1/push
+```
+
+Then, enable it in the `service.pipelines` block:
+
+```yaml
+service:
+  pipelines:
+    metrics:
+      receivers: [...]
+      processors: [...]
+      exporters: [..., prometheusremotewrite]
+```
+
+If you want to authenticate using basic auth, use the [`basicauth`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension) extension:
+
+```yaml
+extensions:
+  basicauth/prw:
+    client_auth:
+      username: username
+      password: password
+
+exporters:
+  prometheusremotewrite:
+    auth:
+      authenticator: basicauth/prw
+    endpoint: http://<mimir-endpoint>/api/v1/push
+
+service:
+  extensions: [basicauth/prw]
+  pipelines:
+    metrics:
+      receivers: [...]
+      processors: [...]
+      exporters: [..., prometheusremotewrite]
 ```
 
 ## Format considerations

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -68,9 +68,9 @@ service:
 
 ## Prometheus remote write
 
-For remote write, use the [`prometheusremotewrite`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter) exporter in the Collector:
+For remote write, use the [`prometheusremotewrite`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter) exporter in the Collector.
 
-In the `exporters` section add:
+In the `exporters` section, add:
 
 ```yaml
 exporters:

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -17,7 +17,7 @@ When using the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector
 
 ## Use the OpenTelemetry protocol
 
-Mimir supports native OTLP over HTTP. To configure the collector to use the OTLP interface, use the [`otlphttp`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) exporter and native Mimir endpoint. For example:
+Mimir supports native OTLP over HTTP. To configure the collector to use the OTLP interface, use the [`otlphttp`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) exporter and the native Mimir endpoint. For example:
 
 ```yaml
 exporters:

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -10,19 +10,14 @@ weight: 150
 # Configure the OpenTelemetry Collector to write metrics into Mimir
 
 {{% admonition type="note" %}}
-To send OTel data to Grafana Cloud, refer to [Send data using OpenTelemetry Protocol (OTLP)](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/).
+To send OpenTelemetry data to Grafana Cloud, refer to [Send data using OpenTelemetry Protocol (OTLP)](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/).
 {{% /admonition %}}
 
-When using the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), you can write metrics into Mimir using two options: `otlphttp` (preferred) and `prometheusremotewrite`.
+When using the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), you can use the OpenTelemetry protocol (OTLP) or the Prometheus remote write protocol to write metrics into Mimir. It's recommended that you use the OpenTelemetry protocol.
 
-Use each protocol's respective exporter and native Mimir endpoint. For example:
+## Use the OpenTelemetry protocol
 
-- OTel data: `otlphttp`
-- Prometheus data: `prometheusremotewrite`
-
-## OTLP
-
-Mimir supports native OTLP over HTTP. When possible, use this protocol to send OTLP data. To configure the collector to use the OTLP interface, use the [`otlphttp`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) exporter:
+Mimir supports native OTLP over HTTP. To configure the collector to use the OTLP interface, use the [`otlphttp`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) exporter and native Mimir endpoint. For example:
 
 ```yaml
 exporters:
@@ -65,9 +60,13 @@ service:
       exporters: [..., otlphttp]
 ```
 
-## Prometheus remote write
+## Use the Prometheus remote write protocol
 
-For remote write, use the [`prometheusremotewrite`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter) exporter in the Collector.
+{{< admonition type="note" >}}
+Support for the Prometheus remote write protocol is an experimental feature in Mimir.
+{{< /admonition >}}
+
+To use the Prometheus remote write protocol to send metrics into Mimir, use the [`prometheusremotewrite`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter) exporter in the Collector and the native Mimir endpoint.
 
 In the `exporters` section, add:
 

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -17,7 +17,7 @@ When using the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector
 
 ## Use the OpenTelemetry protocol
 
-Mimir supports native OTLP over HTTP. To configure the collector to use the OTLP interface, use the [`otlphttp`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) exporter and the native Mimir endpoint. For example:
+Mimir supports native OTLP over HTTP. To configure the collector to use the OTLP interface, use the [`otlphttp` exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter) and the native Mimir endpoint. For example:
 
 ```yaml
 exporters:
@@ -25,7 +25,7 @@ exporters:
     endpoint: http://<mimir-endpoint>/otlp
 ```
 
-Then, enable it in `service.pipelines`:
+Then, enable it in the `service.pipelines` block:
 
 ```yaml
 service:
@@ -36,7 +36,7 @@ service:
       exporters: [..., otlphttp]
 ```
 
-If you want to authenticate using basic auth, use the [`basicauth`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension) extension:
+If you want to authenticate using basic auth, use the [`basicauth`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension) extension. For example:
 
 ```yaml
 extensions:
@@ -62,10 +62,6 @@ service:
 
 ## Use the Prometheus remote write protocol
 
-{{< admonition type="note" >}}
-Support for the Prometheus remote write protocol is an experimental feature in Mimir.
-{{< /admonition >}}
-
 To use the Prometheus remote write protocol to send metrics into Mimir, use the [`prometheusremotewrite`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter) exporter in the Collector and the native Mimir endpoint.
 
 In the `exporters` section, add:
@@ -87,7 +83,7 @@ service:
       exporters: [..., prometheusremotewrite]
 ```
 
-If you want to authenticate using basic auth, use the [`basicauth`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension) extension:
+If you want to authenticate using basic auth, use the [`basicauth`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension) extension. For example:
 
 ```yaml
 extensions:


### PR DESCRIPTION
#### What this PR does

This PR updates https://grafana.com/docs/mimir/next/configure/configure-otel-collector/ to explicitly recommend using the OTLP exporter, when possible, for sending OTLP data to Mimir.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/support-escalations/issues/11817

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
