### PR TITLE
Log querier bucket index updates

### DIFF
--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -208,6 +208,12 @@ func (l *Loader) updateCachedIndex(ctx context.Context, userID string) {
 	// is when a tenant has rules configured but hasn't started remote writing yet. Rules will be evaluated and
 	// bucket index loaded by the ruler.
 	l.indexesMx.Lock()
+	userIdx := l.indexes[userID]
+	if idx != nil {
+		if userIdx == nil || (userIdx.index != nil && userIdx.index.UpdatedAt != idx.UpdatedAt) {
+			level.Debug(l.logger).Log("msg", "loaded bucket index", "user", userID, "updatedAt", idx.UpdatedAt)
+		}
+	}
 	l.indexes[userID].index = idx
 	l.indexes[userID].err = err
 	l.indexes[userID].setUpdatedAt(startTime)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds logging of querier bucket index updates so we can inspect exactly which bucket index version/timestamp a particular querier is working off of. This can help investigate situations where queriers and store gateways appear to be working off of different bucket indices.

Using DEBUG level since I suspect this might be noisy.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
