### PR TITLE
Jsonnet: change newResourceScaledObject() signature to allow to pass extra_matchers instead of pod_regex

### DIFF
--- a/operations/mimir-tests/test-new-resource-scaled-object.jsonnet
+++ b/operations/mimir-tests/test-new-resource-scaled-object.jsonnet
@@ -23,7 +23,7 @@ mimir {
       with_ready_trigger=with_ready_trigger,
       weight=weight,
       container_name=container,
-      pod_regex=pod_regex
+      extra_matchers=(if pod_regex != '' then 'pod=~"%s"' % pod_regex else '')
     )
   for with_cortex_prefix in [false, true]
   for with_ready_trigger in [false, true]


### PR DESCRIPTION
#### What this PR does

I have an use case where I need to add extra matchers to metrics used by `newResourceScaledObject()`. In this PR I'm replacing `pod_regex` with a generic `extra_matchers` to make it more flexible.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
