### PR TITLE
query scheduler: optimize queueBroker.makeQueuePath to remove double slice allocation

### DIFF
--- a/pkg/scheduler/queue/queue_broker.go
+++ b/pkg/scheduler/queue/queue_broker.go
@@ -116,7 +116,7 @@ func (qb *queueBroker) makeQueuePath(request *tenantRequest) (tree.QueuePath, er
 	if schedulerRequest, ok := request.req.(*SchedulerRequest); ok {
 		queryComponent = schedulerRequest.ExpectedQueryComponentName()
 	}
-	return append([]string{queryComponent}, request.tenantID), nil
+	return []string{queryComponent, request.tenantID}, nil
 }
 
 func (qb *queueBroker) dequeueRequestForQuerier(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Fixes unneeded allocation seen during recent query-scheduler issues - this line was responsible for 1.3% of all allocations profiled.

This is a minor optimization compared to the [main fix](https://github.com/grafana/mimir/pull/9888), but the extra allocations contribute to main thread CPU usage as well as garbage collection pressure.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
