### PR TITLE
Ruler: do not return an error if a rule group is missing after founding it when listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [CHANGE] Ingester: Change `-initial-delay` for circuit breakers to begin when the first request is received, rather than at breaker activation. #9842
 * [CHANGE] Query-frontend: apply query pruning before query sharding instead of after. #9913
 * [CHANGE] Ingester: remove experimental flags `-ingest-storage.kafka.ongoing-records-per-fetch` and `-ingest-storage.kafka.startup-records-per-fetch`. They are removed in favour of `-ingest-storage.kafka.max-buffered-bytes`. #9906
+* [CHANGE] Ruler: the `/prometheus/config/v1/rules` does not return an error anymore is a rule group is missing in the object storage after been successfully returned by listing the storage, because it could have been deleted in the meanwhile. #9936
 * [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642 #9651 #9664 #9681 #9717 #9719 #9724 #9874
 * [FEATURE] Distributor: Add support for `lz4` OTLP compression. #9763
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -920,7 +920,7 @@ func filterRuleGroupsByNotMissing(configs map[string]rulespb.RuleGroupList, miss
 
 			if _, isMissing := missingLookup[lookupKey]; isMissing {
 				level.Info(logger).Log(
-					"msg", "filtered out rule group because not found in the object storage (may be temporarily caused by ruler storage caching)",
+					"msg", "filtered out rule group because not found in the object storage (may be temporarily caused by ruler storage caching or the rule group being deleted after listing the storage)",
 					"user", group.GetUser(),
 					"namespace", group.GetNamespace(),
 					"group", group.GetName())

--- a/pkg/ruler/rulestore/store.go
+++ b/pkg/ruler/rulestore/store.go
@@ -72,6 +72,8 @@ type RuleStore interface {
 	//   not populated the rule groups with their actual rules.
 	// - If, and only if, a rule group can't be loaded because missing in the storage
 	//   then LoadRuleGroups() *MUST* not return error but return the missing rule groups.
+	//   This means that missing list *MUST* contain only rule groups that don't exist
+	//   in the storage, and not that we failed loading for other reasons.
 	LoadRuleGroups(ctx context.Context, groupsToLoad map[string]rulespb.RuleGroupList) (missing rulespb.RuleGroupList, err error)
 
 	GetRuleGroup(ctx context.Context, userID, namespace, group string) (*rulespb.RuleGroupDesc, error)


### PR DESCRIPTION
#### What this PR does

Over the weekend we've paged because of some ruler failures with log message:
```
an error occurred while loading 1 rule groups
```

After some investigation we've found that the issue is caused by concurrent `ListRules()` and other CRUD operations on rule groups config. If a rule group is deleted after being listed but before getting loaded, the `ListRules()` API will fail because of them missing rule group.

This behaviour was introduced to guarantee the API is strongly consistent. This is a property we still want to preserve. However, in Mimir we also assume that the object storage is strongly consistent (the API can't be strongly consistent anyway if the object storage isn't), so I don't think we have to error out if the object storage returns a 404 when loading a rule group (but we should still error out for any other type of error).

In this PR I propose to change the `/prometheus/config/v1/rules` behaviour, to not return an error anymore if a rule group is missing in the object storage after been successfully returned by listing the storage, because it could have been deleted in the meanwhile. It's important to note that the `missing` list only contains rule groups that failed to load because they don't exist in the object storage, and not because of other reasons.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
