### PR TITLE
Querier and query-frontend test changes for Prometheus 3 upgrade

### DIFF
--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -205,74 +205,74 @@ func TestMetricsQuery_MinMaxTime(t *testing.T) {
 		{
 			name:         "range query: without range vector, without offset",
 			metricsQuery: rangeRequest,
-			expectedMinT: startTime.UnixMilli() - lookbackDurationMS,
+			expectedMinT: startTime.UnixMilli() - lookbackDurationMS + 1,
 			expectedMaxT: endTime.UnixMilli(),
 		},
 		{
 			name:         "instant query: without range vector, without offset",
 			metricsQuery: instantRequest,
-			expectedMinT: endTime.UnixMilli() - lookbackDurationMS,
+			expectedMinT: endTime.UnixMilli() - lookbackDurationMS + 1,
 			expectedMaxT: endTime.UnixMilli(),
 		},
 		{
 			name:         "range query: with range vector, without offset",
 			metricsQuery: withQuery(t, rangeRequest, fmt.Sprintf("rate(go_goroutines{}[%s])", rangeVectorDurationStr)),
-			expectedMinT: startTime.UnixMilli() - rangeVectorDurationMS, // lookback duration not used with range vectors
+			expectedMinT: startTime.UnixMilli() - rangeVectorDurationMS + 1, // lookback duration not used with range vectors
 			expectedMaxT: endTime.UnixMilli(),
 		},
 		{
 			name:         "instant query: with range vector, without offset",
 			metricsQuery: withQuery(t, instantRequest, fmt.Sprintf("rate(go_goroutines{}[%s])", rangeVectorDurationStr)),
-			expectedMinT: endTime.UnixMilli() - rangeVectorDurationMS, // lookback duration not used with range vectors
+			expectedMinT: endTime.UnixMilli() - rangeVectorDurationMS + 1, // lookback duration not used with range vectors
 			expectedMaxT: endTime.UnixMilli(),
 		},
 		{
 			name:         "range query: without range vector, with offset",
 			metricsQuery: withQuery(t, rangeRequest, fmt.Sprintf("go_goroutines{} offset %s", offsetDurationStr)),
-			expectedMinT: startTime.UnixMilli() - offsetDurationMS - lookbackDurationMS,
+			expectedMinT: startTime.UnixMilli() - offsetDurationMS - lookbackDurationMS + 1,
 			expectedMaxT: endTime.UnixMilli() - offsetDurationMS,
 		},
 		{
 			name:         "instant query: without range vector, with offset",
 			metricsQuery: withQuery(t, instantRequest, fmt.Sprintf("go_goroutines{} offset %s", offsetDurationStr)),
-			expectedMinT: endTime.UnixMilli() - offsetDurationMS - lookbackDurationMS,
+			expectedMinT: endTime.UnixMilli() - offsetDurationMS - lookbackDurationMS + 1,
 			expectedMaxT: endTime.UnixMilli() - offsetDurationMS,
 		},
 		{
 			name:         "range query: with range vector, with offset",
 			metricsQuery: withQuery(t, rangeRequest, fmt.Sprintf("rate(go_goroutines{}[%s] offset %s)", rangeVectorDurationStr, offsetDurationStr)),
-			expectedMinT: startTime.UnixMilli() - rangeVectorDurationMS - offsetDurationMS, // lookback duration not used with range vectors
+			expectedMinT: startTime.UnixMilli() - rangeVectorDurationMS - offsetDurationMS + 1, // lookback duration not used with range vectors
 			expectedMaxT: endTime.UnixMilli() - offsetDurationMS,
 		},
 		{
 			name:         "instant query: with range vector, with offset",
 			metricsQuery: withQuery(t, instantRequest, fmt.Sprintf("rate(go_goroutines{}[%s] offset %s)", rangeVectorDurationStr, offsetDurationStr)),
-			expectedMinT: endTime.UnixMilli() - rangeVectorDurationMS - offsetDurationMS, // lookback duration not used with range vectors
+			expectedMinT: endTime.UnixMilli() - rangeVectorDurationMS - offsetDurationMS + 1, // lookback duration not used with range vectors
 			expectedMaxT: endTime.UnixMilli() - offsetDurationMS,
 		},
 		// permutations with and without range vectors and @ modifiers
 		{
 			name:         "range query: with @ modifer",
 			metricsQuery: withQuery(t, rangeRequest, fmt.Sprintf("go_goroutines{} @ %d", endTime.Add(-atModifierDuration).Unix())),
-			expectedMinT: endTime.Add(-atModifierDuration).UnixMilli() - lookbackDurationMS,
+			expectedMinT: endTime.Add(-atModifierDuration).UnixMilli() - lookbackDurationMS + 1,
 			expectedMaxT: endTime.Add(-atModifierDuration).UnixMilli(),
 		},
 		{
 			name:         "instant query: with @ modifer",
 			metricsQuery: withQuery(t, instantRequest, fmt.Sprintf("go_goroutines{} @ %d", endTime.Add(-atModifierDuration).Unix())),
-			expectedMinT: endTime.Add(-atModifierDuration).UnixMilli() - lookbackDurationMS, // lookback duration not used with range vectors
+			expectedMinT: endTime.Add(-atModifierDuration).UnixMilli() - lookbackDurationMS + 1,
 			expectedMaxT: endTime.Add(-atModifierDuration).UnixMilli(),
 		},
 		{
 			name:         "range query: with range vector, with @ modifer",
 			metricsQuery: withQuery(t, rangeRequest, fmt.Sprintf("go_goroutines{}[%s] @ %d", rangeVectorDurationStr, endTime.Add(-atModifierDuration).Unix())),
-			expectedMinT: endTime.Add(-(atModifierDuration + rangeVectorDuration)).UnixMilli(), // lookback duration not used with range vectors
+			expectedMinT: endTime.Add(-(atModifierDuration + rangeVectorDuration)).UnixMilli() + 1, // lookback duration not used with range vectors
 			expectedMaxT: endTime.Add(-atModifierDuration).UnixMilli(),
 		},
 		{
 			name:         "instant query: with range vector, with @ modifer",
 			metricsQuery: withQuery(t, instantRequest, fmt.Sprintf("go_goroutines{}[%s] @ %d", rangeVectorDurationStr, endTime.Add(-atModifierDuration).Unix())),
-			expectedMinT: endTime.Add(-(atModifierDuration + rangeVectorDuration)).UnixMilli(), // lookback duration not used with range vectors
+			expectedMinT: endTime.Add(-(atModifierDuration + rangeVectorDuration)).UnixMilli() + 1, // lookback duration not used with range vectors
 			expectedMaxT: endTime.Add(-atModifierDuration).UnixMilli(),
 		},
 	} {
@@ -338,7 +338,7 @@ func TestMetricsQuery_WithStartEnd_TransformConsistency(t *testing.T) {
 			updatedStartTime:    updatedStartTime,
 			updatedEndTime:      updatedEndTime,
 
-			expectedUpdatedMinT: updatedStartTime.UnixMilli(),
+			expectedUpdatedMinT: updatedStartTime.UnixMilli() + 1, // query range is left-open, but minT is inclusive
 			expectedUpdatedMaxT: updatedEndTime.UnixMilli(),
 		},
 		{
@@ -347,7 +347,7 @@ func TestMetricsQuery_WithStartEnd_TransformConsistency(t *testing.T) {
 			updatedStartTime:    updatedEndTime,
 			updatedEndTime:      updatedEndTime,
 
-			expectedUpdatedMinT: updatedEndTime.UnixMilli(),
+			expectedUpdatedMinT: updatedEndTime.UnixMilli() + 1, // query range is left-open, but minT is inclusive
 			expectedUpdatedMaxT: updatedEndTime.UnixMilli(),
 		},
 	} {
@@ -418,7 +418,7 @@ func TestMetricsQuery_WithQuery_WithExpr_TransformConsistency(t *testing.T) {
 			initialMetricsQuery: rangeRequest,
 			updatedQuery:        fmt.Sprintf("rate(go_goroutines{}[%s] offset %s)", rangeVectorDurationStr, offsetDurationStr),
 
-			expectedUpdatedMinT: startTime.UnixMilli() - rangeVectorDurationMS - offsetDurationMS,
+			expectedUpdatedMinT: startTime.UnixMilli() - rangeVectorDurationMS - offsetDurationMS + 1,
 			expectedUpdatedMaxT: endTime.UnixMilli() - offsetDurationMS,
 			expectedErr:         nil,
 		},
@@ -427,7 +427,7 @@ func TestMetricsQuery_WithQuery_WithExpr_TransformConsistency(t *testing.T) {
 			initialMetricsQuery: instantRequest,
 			updatedQuery:        fmt.Sprintf("rate(go_goroutines{}[%s] offset %s)", rangeVectorDurationStr, offsetDurationStr),
 
-			expectedUpdatedMinT: endTime.UnixMilli() - rangeVectorDurationMS - offsetDurationMS,
+			expectedUpdatedMinT: endTime.UnixMilli() - rangeVectorDurationMS - offsetDurationMS + 1,
 			expectedUpdatedMaxT: endTime.UnixMilli() - offsetDurationMS,
 			expectedErr:         nil,
 		},

--- a/pkg/frontend/querymiddleware/model_extra_test.go
+++ b/pkg/frontend/querymiddleware/model_extra_test.go
@@ -185,13 +185,13 @@ func TestPrometheusRangeQueryRequest_MinTMaxT(t *testing.T) {
 		"instant vector selector, not modified": {
 			query:        "some_metric{}",
 			withFn:       func(req MetricsQueryRequest) (MetricsQueryRequest, error) { return req, nil },
-			expectedMinT: start.Add(-1 * defaultLookback).UnixMilli(), // Default lookback.
+			expectedMinT: start.Add(-1*defaultLookback).UnixMilli() + 1, // Default lookback.
 			expectedMaxT: end.UnixMilli(),
 		},
 		"range vector selector, not modified": {
 			query:        "some_metric{}[10m]",
 			withFn:       func(req MetricsQueryRequest) (MetricsQueryRequest, error) { return req, nil },
-			expectedMinT: start.Add(-10 * time.Minute).UnixMilli(), // Lookback is overridden by the range.
+			expectedMinT: start.Add(-10*time.Minute).UnixMilli() + 1, // Lookback is overridden by the range.
 			expectedMaxT: end.UnixMilli(),
 		},
 		"instant vector query, WithStartEnd": {
@@ -199,7 +199,7 @@ func TestPrometheusRangeQueryRequest_MinTMaxT(t *testing.T) {
 			withFn: func(req MetricsQueryRequest) (MetricsQueryRequest, error) {
 				return req.WithStartEnd(start.Add(-1*time.Hour).UnixMilli(), end.Add(5*time.Minute).UnixMilli())
 			},
-			expectedMinT: start.Add(-1 * time.Hour).Add(-1 * defaultLookback).UnixMilli(),
+			expectedMinT: start.Add(-1*time.Hour).Add(-1*defaultLookback).UnixMilli() + 1,
 			expectedMaxT: end.Add(5 * time.Minute).UnixMilli(),
 		},
 		"range vector query, WithStartEnd": {
@@ -207,7 +207,7 @@ func TestPrometheusRangeQueryRequest_MinTMaxT(t *testing.T) {
 			withFn: func(req MetricsQueryRequest) (MetricsQueryRequest, error) {
 				return req.WithStartEnd(start.Add(-1*time.Hour).UnixMilli(), end.Add(5*time.Minute).UnixMilli())
 			},
-			expectedMinT: start.Add(-1 * time.Hour).Add(-10 * time.Minute).UnixMilli(),
+			expectedMinT: start.Add(-1*time.Hour).Add(-10*time.Minute).UnixMilli() + 1,
 			expectedMaxT: end.Add(5 * time.Minute).UnixMilli(),
 		},
 		"instant vector query, WithQuery": {
@@ -215,7 +215,7 @@ func TestPrometheusRangeQueryRequest_MinTMaxT(t *testing.T) {
 			withFn: func(req MetricsQueryRequest) (MetricsQueryRequest, error) {
 				return req.WithQuery("other_metric{}")
 			},
-			expectedMinT: start.Add(-1 * defaultLookback).UnixMilli(), // Default lookback.
+			expectedMinT: start.Add(-1*defaultLookback).UnixMilli() + 1, // Default lookback.
 			expectedMaxT: end.UnixMilli(),
 		},
 		"range vector query, WithQuery": {
@@ -223,7 +223,7 @@ func TestPrometheusRangeQueryRequest_MinTMaxT(t *testing.T) {
 			withFn: func(req MetricsQueryRequest) (MetricsQueryRequest, error) {
 				return req.WithQuery("some_metric{}[20m]")
 			},
-			expectedMinT: start.Add(-20 * time.Minute).UnixMilli(), // Lookback is overridden by the range.
+			expectedMinT: start.Add(-20*time.Minute).UnixMilli() + 1, // Lookback is overridden by the range.
 			expectedMaxT: end.UnixMilli(),
 		},
 		"instant vector query, WithExpr": {
@@ -235,7 +235,7 @@ func TestPrometheusRangeQueryRequest_MinTMaxT(t *testing.T) {
 				}
 				return req.WithExpr(newExpr)
 			},
-			expectedMinT: start.Add(-1 * defaultLookback).UnixMilli(), // Default lookback.
+			expectedMinT: start.Add(-1*defaultLookback).UnixMilli() + 1, // Default lookback.
 			expectedMaxT: end.UnixMilli(),
 		},
 		"range vector query, WithExpr": {
@@ -247,7 +247,7 @@ func TestPrometheusRangeQueryRequest_MinTMaxT(t *testing.T) {
 				}
 				return req.WithExpr(newExpr)
 			},
-			expectedMinT: start.Add(-20 * time.Minute).UnixMilli(), // Lookback is overridden by the range.
+			expectedMinT: start.Add(-20*time.Minute).UnixMilli() + 1, // Lookback is overridden by the range.
 			expectedMaxT: end.UnixMilli(),
 		},
 	}
@@ -289,13 +289,13 @@ func TestPrometheusInstantQueryRequest_MinTMaxT(t *testing.T) {
 		"instant vector selector, not modified": {
 			query:        "some_metric{}",
 			withFn:       func(req MetricsQueryRequest) (MetricsQueryRequest, error) { return req, nil },
-			expectedMinT: now.Add(-1 * defaultLookback).UnixMilli(), // Default lookback.
+			expectedMinT: now.Add(-1*defaultLookback).UnixMilli() + 1, // Default lookback.
 			expectedMaxT: now.UnixMilli(),
 		},
 		"range vector selector, not modified": {
 			query:        "some_metric{}[10m]",
 			withFn:       func(req MetricsQueryRequest) (MetricsQueryRequest, error) { return req, nil },
-			expectedMinT: now.Add(-10 * time.Minute).UnixMilli(), // Lookback is overridden by the range.
+			expectedMinT: now.Add(-10*time.Minute).UnixMilli() + 1, // Lookback is overridden by the range.
 			expectedMaxT: now.UnixMilli(),
 		},
 		"instant vector selector, WithStartEnd": {
@@ -303,7 +303,7 @@ func TestPrometheusInstantQueryRequest_MinTMaxT(t *testing.T) {
 			withFn: func(req MetricsQueryRequest) (MetricsQueryRequest, error) {
 				return req.WithStartEnd(now.Add(-1*time.Hour).UnixMilli(), 42) // 42 is ignored.
 			},
-			expectedMinT: now.Add(-1 * time.Hour).Add(-1 * defaultLookback).UnixMilli(),
+			expectedMinT: now.Add(-1*time.Hour).Add(-1*defaultLookback).UnixMilli() + 1,
 			expectedMaxT: now.Add(-1 * time.Hour).UnixMilli(),
 		},
 		"range vector selector, WithStartEnd": {
@@ -311,7 +311,7 @@ func TestPrometheusInstantQueryRequest_MinTMaxT(t *testing.T) {
 			withFn: func(req MetricsQueryRequest) (MetricsQueryRequest, error) {
 				return req.WithStartEnd(now.Add(-1*time.Hour).UnixMilli(), 42) // 42 is ignored.
 			},
-			expectedMinT: now.Add(-1 * time.Hour).Add(-10 * time.Minute).UnixMilli(),
+			expectedMinT: now.Add(-1*time.Hour).Add(-10*time.Minute).UnixMilli() + 1,
 			expectedMaxT: now.Add(-1 * time.Hour).UnixMilli(),
 		},
 		"instant vector selector, WithQuery": {
@@ -319,7 +319,7 @@ func TestPrometheusInstantQueryRequest_MinTMaxT(t *testing.T) {
 			withFn: func(req MetricsQueryRequest) (MetricsQueryRequest, error) {
 				return req.WithQuery("other_metric{}")
 			},
-			expectedMinT: now.Add(-1 * defaultLookback).UnixMilli(), // Default lookback.
+			expectedMinT: now.Add(-1*defaultLookback).UnixMilli() + 1, // Default lookback.
 			expectedMaxT: now.UnixMilli(),
 		},
 		"range vector selector, WithQuery": {
@@ -327,7 +327,7 @@ func TestPrometheusInstantQueryRequest_MinTMaxT(t *testing.T) {
 			withFn: func(req MetricsQueryRequest) (MetricsQueryRequest, error) {
 				return req.WithQuery("some_metric{}[20m]")
 			},
-			expectedMinT: now.Add(-20 * time.Minute).UnixMilli(), // Lookback is overridden by the range.
+			expectedMinT: now.Add(-20*time.Minute).UnixMilli() + 1, // Lookback is overridden by the range.
 			expectedMaxT: now.UnixMilli(),
 		},
 		"instant vector selector, WithExpr": {
@@ -339,7 +339,7 @@ func TestPrometheusInstantQueryRequest_MinTMaxT(t *testing.T) {
 				}
 				return req.WithExpr(newExpr)
 			},
-			expectedMinT: now.Add(-1 * defaultLookback).UnixMilli(), // Default lookback.
+			expectedMinT: now.Add(-1*defaultLookback).UnixMilli() + 1, // Default lookback.
 			expectedMaxT: now.UnixMilli(),
 		},
 		"range vector selector, WithExpr": {
@@ -351,7 +351,7 @@ func TestPrometheusInstantQueryRequest_MinTMaxT(t *testing.T) {
 				}
 				return req.WithExpr(newExpr)
 			},
-			expectedMinT: now.Add(-20 * time.Minute).UnixMilli(), // Lookback is overridden by the range.
+			expectedMinT: now.Add(-20*time.Minute).UnixMilli() + 1, // Lookback is overridden by the range.
 			expectedMaxT: now.UnixMilli(),
 		},
 	}

--- a/pkg/frontend/querymiddleware/prune_test.go
+++ b/pkg/frontend/querymiddleware/prune_test.go
@@ -46,17 +46,17 @@ func TestQueryPruning(t *testing.T) {
 	}
 
 	templates := []template{
-		{`avg(rate(%s[1m])) < (-1 * +Inf)`, true},
-		{`avg(rate(%s[1m])) < (+1 * +Inf)`, false},
-		{`avg(rate(%s[1m])) < (-1 * -Inf)`, false},
-		{`avg(rate(%s[1m])) < (+1 * -Inf)`, true},
-		{`(-1 * -Inf) < avg(rate(%s[1m]))`, true},
-		{`((-1 * -Inf) < avg(rate(foo[2m]))) or avg(rate(%s[1m]))`, false},
-		{`((-1 * -Inf) < avg(rate(foo[2m]))) and avg(rate(%s[1m]))`, true},
-		{`((-1 * -Inf) < avg(rate(foo[2m]))) unless avg(rate(%s[1m]))`, true},
-		{`avg(rate(%s[1m])) unless ((-1 * -Inf) < avg(rate(foo[2m])))`, false},
-		{`(((-1 * -Inf) < avg(rate(foo[3m]))) unless avg(rate(foo[2m]))) or avg(rate(%s[1m]))`, true},
-		{`((((-1 * -Inf) < avg(rate(foo[4m]))) unless avg(rate(foo[3m]))) and avg(rate(foo[2m]))) or avg(rate(%s[1m]))`, true},
+		{`avg(rate(%s[1m1s])) < (-1 * +Inf)`, true},
+		{`avg(rate(%s[1m1s])) < (+1 * +Inf)`, false},
+		{`avg(rate(%s[1m1s])) < (-1 * -Inf)`, false},
+		{`avg(rate(%s[1m1s])) < (+1 * -Inf)`, true},
+		{`(-1 * -Inf) < avg(rate(%s[1m1s]))`, true},
+		{`((-1 * -Inf) < avg(rate(foo[2m1s]))) or avg(rate(%s[1m1s]))`, false},
+		{`((-1 * -Inf) < avg(rate(foo[2m1s]))) and avg(rate(%s[1m1s]))`, true},
+		{`((-1 * -Inf) < avg(rate(foo[2m1s]))) unless avg(rate(%s[1m1s]))`, true},
+		{`avg(rate(%s[1m1s])) unless ((-1 * -Inf) < avg(rate(foo[2m1s])))`, false},
+		{`(((-1 * -Inf) < avg(rate(foo[3m1s]))) unless avg(rate(foo[2m1s]))) or avg(rate(%s[1m1s]))`, true},
+		{`((((-1 * -Inf) < avg(rate(foo[4m1s]))) unless avg(rate(foo[3m1s]))) and avg(rate(foo[2m1s]))) or avg(rate(%s[1m1s]))`, true},
 	}
 	for _, template := range templates {
 		t.Run(template.query, func(t *testing.T) {

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1006,7 +1006,6 @@ func TestQuerySharding_FunctionCorrectness(t *testing.T) {
 		{fn: "clamp", args: []string{"5", "10"}},
 		{fn: "clamp_max", args: []string{"5"}},
 		{fn: "clamp_min", args: []string{"5"}},
-		{fn: "round", args: []string{"20"}},
 		{fn: "label_replace", args: []string{`"fuzz"`, `"$1"`, `"foo"`, `"b(.*)"`}},
 		{fn: "label_join", args: []string{`"fuzz"`, `","`, `"foo"`, `"bar"`}},
 	}
@@ -1025,6 +1024,7 @@ func TestQuerySharding_FunctionCorrectness(t *testing.T) {
 		{fn: "log2"},
 		{fn: "max_over_time", rangeQuery: true},
 		{fn: "min_over_time", rangeQuery: true},
+		{fn: "round", args: []string{"20"}},
 		{fn: "sqrt"},
 		{fn: "deg"},
 		{fn: "asinh"},

--- a/pkg/frontend/querymiddleware/stats_test.go
+++ b/pkg/frontend/querymiddleware/stats_test.go
@@ -56,7 +56,7 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				QuerierStats: &querier_stats.Stats{},
 				Start:        start.Truncate(time.Millisecond),
 				End:          end.Truncate(time.Millisecond),
-				MinT:         start.Truncate(time.Millisecond).Add(-5 * time.Minute),
+				MinT:         start.Truncate(time.Millisecond).Add(-5 * time.Minute).Add(time.Millisecond), // query range is left-open, but minT is inclusive
 				MaxT:         end.Truncate(time.Millisecond),
 				Step:         step,
 			},
@@ -90,7 +90,7 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				QuerierStats: &querier_stats.Stats{},
 				Start:        start.Truncate(time.Millisecond),
 				End:          end.Truncate(time.Millisecond),
-				MinT:         start.Truncate(time.Millisecond).Add(-5 * time.Minute),
+				MinT:         start.Truncate(time.Millisecond).Add(-5 * time.Minute).Add(time.Millisecond), // query range is left-open, but minT is inclusive
 				MaxT:         end.Truncate(time.Millisecond),
 				Step:         step,
 			},
@@ -122,7 +122,7 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				QuerierStats: &querier_stats.Stats{},
 				Start:        start.Truncate(time.Millisecond),
 				End:          start.Truncate(time.Millisecond),
-				MinT:         start.Truncate(time.Millisecond).Add(-5 * time.Minute),
+				MinT:         start.Truncate(time.Millisecond).Add(-5 * time.Minute).Add(time.Millisecond), // query range is left-open, but minT is inclusive
 				MaxT:         start.Truncate(time.Millisecond),
 			},
 		},
@@ -174,7 +174,7 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				QuerierStats: &querier_stats.Stats{},
 				Start:        start.Truncate(time.Millisecond).Add(-30 * time.Minute),
 				End:          end.Truncate(time.Millisecond).Add(10 * time.Minute),
-				MinT:         start.Truncate(time.Millisecond).Add(-30 * time.Minute),
+				MinT:         start.Truncate(time.Millisecond).Add(-30 * time.Minute).Add(time.Millisecond), // query range is left-open, but minT is inclusive
 				MaxT:         end.Truncate(time.Millisecond).Add(10 * time.Minute),
 			},
 		},
@@ -217,7 +217,7 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				QuerierStats: &querier_stats.Stats{},
 				Start:        start.Truncate(time.Millisecond),
 				End:          end.Truncate(time.Millisecond).Add(10 * time.Minute),
-				MinT:         start.Truncate(time.Millisecond),
+				MinT:         start.Truncate(time.Millisecond).Add(time.Millisecond), // query range is left-open, but minT is inclusive
 				MaxT:         end.Truncate(time.Millisecond).Add(10 * time.Minute),
 			},
 		},

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -56,7 +56,7 @@ func TestStreamingChunkSeries_HappyPath(t *testing.T) {
 	require.Equal(t, 1.0, m.SumCounters("cortex_distributor_query_ingester_chunks_deduped_total"))
 
 	require.Equal(t, uint64(3), queryStats.FetchedChunksCount)
-	require.Equal(t, uint64(114), queryStats.FetchedChunkBytes)
+	require.Equal(t, uint64(111), queryStats.FetchedChunkBytes)
 }
 
 func assertChunkIteratorsEqual(t testing.TB, c1, c2 chunkenc.Iterator) {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -758,13 +758,13 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 			query:          "rate(foo[31d])",
 			queryStartTime: time.Now().Add(-time.Hour),
 			queryEndTime:   time.Now(),
-			expected:       errors.Errorf("expanding series: %s", NewMaxQueryLengthError(745*time.Hour, 720*time.Hour)),
+			expected:       errors.Errorf("expanding series: %s", NewMaxQueryLengthError(745*time.Hour-time.Millisecond, 720*time.Hour)),
 		},
 		"should forbid query on large time range over the limit and short rate time window": {
 			query:          "rate(foo[1m])",
 			queryStartTime: time.Now().Add(-maxQueryLength).Add(-time.Hour),
 			queryEndTime:   time.Now(),
-			expected:       errors.Errorf("expanding series: %s", NewMaxQueryLengthError((721*time.Hour)+time.Minute, 720*time.Hour)),
+			expected:       errors.Errorf("expanding series: %s", NewMaxQueryLengthError((721*time.Hour)+time.Minute-time.Millisecond, 720*time.Hour)),
 		},
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR includes the changes to querier and query-frontend tests to mirror the left-open interval change in Prometheus 3.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
