### PR TITLE
Fix data loss bug in the experimental ingest storage when a Kafka Fetch is split into multiple requests and some of them return an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,8 @@
 * [BUGFIX] Ingester: Fix race condition in per-tenant TSDB creation. #9708
 * [BUGFIX] Ingester: Fix race condition in exemplar adding. #9765
 * [BUGFIX] Ingester: Fix race condition in native histogram appending. #9765
-* [BUGFIX] Ingester: fix bug in concurrent fetching where a failure to list topics on startup would cause to use an invalid topic ID (0x00000000000000000000000000000000). #9883
+* [BUGFIX] Ingester: Fix bug in concurrent fetching where a failure to list topics on startup would cause to use an invalid topic ID (0x00000000000000000000000000000000). #9883
+* [BUGFIX] Ingester: Fix data loss bug in the experimental ingest storage when a Kafka Fetch is split into multiple requests and some of them return an error. #9963
 * [BUGFIX] PromQL: `round` now removes the metric name again. #9879
 
 ### Mixin

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -658,11 +658,10 @@ func (r *concurrentFetchers) run(ctx context.Context, wants chan fetchWant, logg
 			}
 
 			if len(bufferedResult.Records) == 0 {
-				// Typically if we had an error, then there wouldn't be any records.
-				// But it's hard to verify this for all errors from the Kafka API docs, so just to be sure, we process any records we might have received.
+				// If we have no buffered records to try to send to the result channel then we retry with another
+				// Fetch attempt. However, before doing it, we check if we've been told to stop (if so, we should honor it).
 				attemptSpan.Finish()
 
-				// There is a chance we've been told to stop even when we have no records.
 				select {
 				case <-r.done:
 					wantSpan.Finish()

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -202,8 +202,10 @@ func (fr *fetchResult) Merge(older fetchResult) fetchResult {
 
 func newEmptyFetchResult(ctx context.Context, err error) fetchResult {
 	return fetchResult{
-		ctx:            ctx,
-		fetchedBytes:   0,
+		ctx:          ctx,
+		fetchedBytes: 0,
+
+		// TODO this is dangerous: we set Err and the Partition is the zero value, which is a valid partition ID
 		FetchPartition: kgo.FetchPartition{Err: err},
 	}
 }
@@ -578,7 +580,7 @@ func (r *concurrentFetchers) run(ctx context.Context, wants chan fetchWant, logg
 
 			f := r.fetchSingle(ctx, w)
 
-			// TODO f.Err could be valued!
+			// TODO f.Err could be valued, but then we merge previousResult on a response that has Err set
 
 			// We increase the count of buffered records as soon as we fetch them.
 			r.bufferedFetchedRecords.Add(int64(len(f.Records)))

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -578,6 +578,8 @@ func (r *concurrentFetchers) run(ctx context.Context, wants chan fetchWant, logg
 
 			f := r.fetchSingle(ctx, w)
 
+			// TODO f.Err could be valued!
+
 			// We increase the count of buffered records as soon as we fetch them.
 			r.bufferedFetchedRecords.Add(int64(len(f.Records)))
 

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -562,6 +562,10 @@ func (r *concurrentFetchers) run(ctx context.Context, wants chan fetchWant, logg
 	})
 
 	for w := range wants {
+		// TODO DEBUG
+		fmt.Println("fetchWant - startOffset:", w.startOffset, "endOffset:", w.endOffset)
+		//time.Sleep(time.Second)
+
 		// Start new span for each fetchWant. We want to record the lifecycle of a single record from being fetched to being ingested.
 		wantSpan, ctx := spanlogger.NewWithLogger(ctx, logger, "concurrentFetcher.fetch")
 		wantSpan.SetTag("start_offset", w.startOffset)

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -581,6 +581,9 @@ func (r *concurrentFetchers) run(ctx context.Context, wants chan fetchWant, logg
 			f := r.fetchSingle(ctx, w)
 
 			// TODO f.Err could be valued, but then we merge previousResult on a response that has Err set
+			if f.Err != nil {
+				fmt.Println("fetchSingle() returned err:", f.Err)
+			}
 
 			// We increase the count of buffered records as soon as we fetch them.
 			r.bufferedFetchedRecords.Add(int64(len(f.Records)))

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -5,10 +5,12 @@ package ingest
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
+	crypto_rand "crypto/rand"
 	"errors"
 	"fmt"
 	"math"
+	"math/rand"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -20,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -1143,218 +1146,195 @@ func TestConcurrentFetchers(t *testing.T) {
 
 		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
+}
 
-	t.Run("TODO", func(t *testing.T) {
-		t.Parallel()
+func TestTODO(t *testing.T) {
+	const (
+		topicName   = "test-topic"
+		partitionID = 1
+		concurrency = 5
+	)
 
-		const (
-			topicName   = "test-topic"
-			partitionID = 1
-			concurrency = 5
-		)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+	cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
+	client := newKafkaProduceClient(t, clusterAddr)
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+	const recordSizeBytes = 10_000  // TODO export initialBytesPerRecord and reuse it
+	const minFetchBytes = 1_000_000 // TODO set in fetchWant.MaxBytes() -> move it to a constant
+	const recordsPerFetch = minFetchBytes / recordSizeBytes
+	const maxInflightBytes = concurrency * recordsPerFetch * recordSizeBytes
 
-		fetchSingleRecordsBatch := func(topicName string, topicID [16]byte, partitionID int32, offset int64) (*kmsg.FetchResponse, error) {
-			req := kmsg.NewFetchRequest()
-			req.MinBytes = 1
-			req.Version = 13
-			req.MaxWaitMillis = 100
-			req.MaxBytes = math.MaxInt32 // TODO ?
+	// We expect that fetchers will fetch more than 50 records per Fetch request.
+	require.Greater(t, recordsPerFetch, 50)
 
-			reqTopic := kmsg.NewFetchRequestTopic()
-			reqTopic.Topic = topicName
-			reqTopic.TopicID = topicID
+	fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, int32(maxInflightBytes))
 
-			reqPartition := kmsg.NewFetchRequestTopicPartition()
-			reqPartition.Partition = partitionID
-			reqPartition.FetchOffset = offset
-			reqPartition.PartitionMaxBytes = 1
-			reqPartition.CurrentLeaderEpoch = 0 // TODO needed?
+	// Produce enough records so that we'll fetch concurrently.
+	const totalProducedRecords = concurrency * recordsPerFetch
 
-			reqTopic.Partitions = append(reqTopic.Partitions, reqPartition)
-			req.Topics = append(req.Topics, reqTopic)
+	for i := 0; i < totalProducedRecords; i++ {
+		// Fill the record with random data, in order to reduce the compression ratio and get the compressed
+		// record byte size as close as possible to the uncompressed one.
+		// TODO we should probably change all tests accordingly
+		randomData := make([]byte, recordSizeBytes)
+		_, err := crypto_rand.Read(randomData)
+		require.NoError(t, err)
 
-			kres, err := client.Request(context.Background(), &req)
-			if err != nil {
-				return nil, err
-			}
+		recordValue := append([]byte(fmt.Sprintf("record-%05d", i)), randomData...)
+		produceRecord(ctx, t, client, topicName, partitionID, recordValue)
+	}
 
-			res := kres.(*kmsg.FetchResponse)
-			if len(res.Topics) != 1 {
-				return nil, fmt.Errorf("expected 1 topic, got %d", len(res.Topics))
-			}
-			if len(res.Topics[0].Partitions) != 1 {
-				return nil, fmt.Errorf("expected 1 partition, got %d", len(res.Topics[0].Partitions))
-			}
-			// TODO check that we really read a single batch
+	t.Logf("Produced %d records", totalProducedRecords)
 
-			return res, nil
+	//
+	// Get topic ID.
+	//
+
+	topics, err := kadm.NewClient(client).ListTopics(ctx, topicName)
+	require.NoError(t, err)
+	require.NoError(t, topics.Error())
+	require.True(t, topics.Has(topicName))
+	topicID := topics[topicName].ID
+
+	t.Logf("Fetched topic ID")
+
+	//
+	// Fetch the raw record batches for each offset, so that it's easier to later mock the Kafka
+	// server and control the returned batches.
+	//
+
+	fetchResponseByRequestedOffset := map[int64]*kmsg.FetchResponse{}
+
+	for offset := int64(0); offset < totalProducedRecords; offset++ {
+		// Build a Fetch request.
+		req := kmsg.NewFetchRequest()
+		req.MinBytes = 1
+		req.Version = 13
+		req.MaxWaitMillis = 1000
+		req.MaxBytes = 1 // Request the minimum amount of bytes.
+
+		reqTopic := kmsg.NewFetchRequestTopic()
+		reqTopic.Topic = topicName
+		reqTopic.TopicID = topicID
+
+		reqPartition := kmsg.NewFetchRequestTopicPartition()
+		reqPartition.Partition = partitionID
+		reqPartition.FetchOffset = offset
+		reqPartition.PartitionMaxBytes = 1  // Request the minimum amount of bytes.
+		reqPartition.CurrentLeaderEpoch = 0 // Not needed here.
+
+		reqTopic.Partitions = append(reqTopic.Partitions, reqPartition)
+		req.Topics = append(req.Topics, reqTopic)
+
+		// Issue the Fetch request.
+		kres, err := client.Request(context.Background(), &req)
+		require.NoError(t, err)
+
+		res := kres.(*kmsg.FetchResponse)
+		require.Equal(t, int16(0), res.ErrorCode)
+		require.Equal(t, 1, len(res.Topics))
+		require.Equal(t, 1, len(res.Topics[0].Partitions))
+
+		// Parse the response, just to check how many records we got.
+		parseOptions := kgo.ProcessFetchPartitionOptions{
+			KeepControlRecords: false,
+			Offset:             offset,
+			IsolationLevel:     kgo.ReadUncommitted(),
+			Topic:              topicName,
+			Partition:          partitionID,
 		}
 
-		cluster.ControlKey(kmsg.Fetch.Int16(), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-			cluster.KeepControl()
+		rawPartitionResp := res.Topics[0].Partitions[0]
+		partition, _ := kgo.ProcessRespPartition(parseOptions, &rawPartitionResp, func(m kgo.FetchBatchMetrics) {})
 
-			req := kreq.(*kmsg.FetchRequest)
+		// Ensure we got a low number of records, otherwise the premise of this test is wrong
+		// because we want a single fetchWatch to be fulfilled in many Fetch requests.
+		require.LessOrEqual(t, len(partition.Records), 5)
 
-			// We expect only 1 partition.
-			if len(req.Topics) != 1 {
-				return nil, fmt.Errorf("expected 1 topic, got %d", len(req.Topics)), true
-			}
-			if len(req.Topics[0].Partitions) != 1 {
-				return nil, fmt.Errorf("expected 1 partition, got %d", len(req.Topics[0].Partitions)), true
-			}
-			// TODO add assertion to ensure PartitionMaxBytes is close to the expected one
+		// Keep track of the raw response.
+		fetchResponseByRequestedOffset[offset] = res
+	}
 
-			// TODO DEBUG
-			topicReq := req.Topics[0].Partitions[0]
-			fmt.Println("FetchOffset:", topicReq.FetchOffset, "max bytes:", topicReq.PartitionMaxBytes)
+	t.Logf("Collected raw Fetch responses for all expected offsets")
 
-			fmt.Println("fetchSingleRecordsBatch()")
-			batchRes, err := fetchSingleRecordsBatch(req.Topics[0].Topic, req.Topics[0].TopicID, topicReq.Partition, topicReq.FetchOffset)
-			fmt.Println("fetchSingleRecordsBatch() response > batchRes:", batchRes, "err:", err)
-			if err != nil {
-				return nil, err, true
-			}
+	//
+	// Mock the Kafka server to intercept Fetch requests, return less records than requested and
+	// inject random failures.
+	//
 
-			return batchRes, nil, true
-			/*
-				res := &kmsg.FetchResponse{
-					Version:        req.Version,
-					ThrottleMillis: 0,
-					ErrorCode:      0,
-					Topics: []kmsg.FetchResponseTopic{
-						{
-							Topic:   req.Topics[0].Topic,
-							TopicID: req.Topics[0].TopicID,
-							Partitions: []kmsg.FetchResponseTopicPartition{
-								{
-									Partition:        req.Topics[0].Partitions[0].Partition,
-									ErrorCode:        0,
-									HighWatermark:    2, // TODO
-									LastStableOffset: 2,
-									LogStartOffset:   -1,
-									RecordBatches:    []byte{},
-								},
-							},
-						},
-					},
-				}
-				return res, nil, true
-			*/
+	cluster.ControlKey(kmsg.Fetch.Int16(), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
 
-			return nil, nil, false
-		})
+		req := kreq.(*kmsg.FetchRequest)
 
-		const recordSizeBytes = 10_000  // TODO export initialBytesPerRecord and reuse it
-		const minFetchBytes = 1_000_000 // TODO set in fetchWant.MaxBytes() -> move it to a constant
-		const recordsPerFetch = minFetchBytes / recordSizeBytes
-		const maxInflightBytes = concurrency * recordsPerFetch * recordSizeBytes
-
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, int32(maxInflightBytes))
-
-		// Produce enough records so that we'll fetch concurrently.
-		const totalProducedRecords = concurrency * recordsPerFetch
-
-		for i := 0; i < totalProducedRecords; i++ {
-			// Fill the record with random data, in order to reduce the compression ratio and get the compressed
-			// record byte size as close as possible to the uncompressed one.
-			// TODO we should probably change all tests accordingly
-			randomData := make([]byte, recordSizeBytes)
-			_, err := rand.Read(randomData)
-			require.NoError(t, err)
-
-			recordValue := append([]byte(fmt.Sprintf("record-%05d", i)), randomData...)
-			produceRecord(ctx, t, client, topicName, partitionID, recordValue)
+		// We expect only 1 partition.
+		if len(req.Topics) != 1 {
+			return nil, fmt.Errorf("expected 1 topic, got %d", len(req.Topics)), true
 		}
-		t.Logf("Produced %d records", totalProducedRecords)
-
-		// Consume records.
-		totalConsumedRecords := 0
-		consumedOffsets := map[int64]struct{}{}
-
-		for totalConsumedRecords < totalProducedRecords {
-			fetches, _ := fetchers.PollFetches(ctx)
-			totalConsumedRecords += fetches.NumRecords()
-
-			fetches.EachRecord(func(record *kgo.Record) {
-				consumedOffsets[record.Offset] = struct{}{}
-			})
+		if len(req.Topics[0].Partitions) != 1 {
+			return nil, fmt.Errorf("expected 1 partition, got %d", len(req.Topics[0].Partitions)), true
 		}
 
-		require.Equal(t, totalProducedRecords, len(consumedOffsets), "Should have consumed all records")
+		// Simulate a 10% networking error rate.
+		if rand.Int()%10 == 0 {
+			return nil, errors.New("mocked error"), true
+		}
+
+		// Simulate a 10% Kafka error rate.
+		if rand.Int()%10 == 0 {
+			return &kmsg.FetchResponse{
+				Version:   req.Version,
+				ErrorCode: kerr.UnknownServerError.Code,
+				Topics: []kmsg.FetchResponseTopic{{
+					Topic:   req.Topics[0].Topic,
+					TopicID: req.Topics[0].TopicID,
+					Partitions: []kmsg.FetchResponseTopicPartition{{
+						Partition: req.Topics[0].Partitions[0].Partition,
+						ErrorCode: kerr.UnknownServerError.Code,
+					}},
+				}},
+			}, nil, true
+		}
+
+		// Lookup the response among the ones we previously fetched with a small "MaxBytes".
+		res := fetchResponseByRequestedOffset[req.Topics[0].Partitions[0].FetchOffset]
+		if res != nil {
+			return res, nil, true
+		}
+
+		return nil, errors.New("the offset requested has not been found among the ones we previously fetched"), true
 	})
 
-	/*
-		t.Run("TODO", func(t *testing.T) {
-			t.Parallel()
+	// Consume records.
+	totalConsumedRecords := 0
+	consumedOffsets := map[int64]struct{}{}
+	consumedRecordIDs := map[int64]struct{}{}
 
-			const (
-				topicName   = "test-topic"
-				partitionID = 1
-				concurrency = 3
+	for totalConsumedRecords < totalProducedRecords {
+		fetches, _ := fetchers.PollFetches(ctx)
+		totalConsumedRecords += fetches.NumRecords()
 
-				recordSizeBytes      = 1000
-				totalProducedRecords = 6000
-			)
+		// Filter out fetches that errored out, like the PartitionReader does.
+		fetches = filterOutErrFetches(fetches)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
+		fetches.EachRecord(func(record *kgo.Record) {
+			consumedOffsets[record.Offset] = struct{}{}
 
-			cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-			client := newKafkaProduceClient(t, clusterAddr)
-
-			cluster.ControlKey(kmsg.Fetch.Int16(), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-				req := kreq.(*kmsg.FetchRequest)
-
-				// TODO DEBUG
-				fmt.Println("FetchOffset:", req.Topics[0].Partitions[0].FetchOffset)
-
-				return nil, nil, false
-			})
-
-			fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
-
-			wg := sync.WaitGroup{}
-			wg.Add(2)
-
-			// Run a producer.
-			go func() {
-				defer wg.Done()
-
-				recordValue := bytes.Repeat([]byte{'a'}, recordSizeBytes)
-				for i := 0; i < totalProducedRecords; i++ {
-					produceRecord(ctx, t, client, topicName, partitionID, recordValue)
-				}
-			}()
-
-			// Run a consumer
-			totalConsumedRecords := 0
-			consumedOffsets := make(map[int64]struct{}, totalProducedRecords)
-
-			go func() {
-				defer wg.Done()
-
-				for totalConsumedRecords < totalProducedRecords {
-					fetches, _ := fetchers.PollFetches(ctx)
-					totalConsumedRecords += fetches.NumRecords()
-
-					fetches.EachRecord(func(record *kgo.Record) {
-						consumedOffsets[record.Offset] = struct{}{}
-					})
-				}
-			}()
-
-			// Wait until both producers and consumers have done.
-			wg.Wait()
-
-			require.Equal(t, totalProducedRecords, len(consumedOffsets), "Should have consumed all records")
+			// Parse the record ID from the actual record data.
+			recordID, err := strconv.ParseInt(string(record.Value[7:12]), 10, 64)
+			require.NoError(t, err)
+			consumedRecordIDs[recordID] = struct{}{}
 		})
-	*/
+	}
+
+	require.Equal(t, totalProducedRecords, len(consumedOffsets), "Should have consumed all records (offset check)")
+	require.Equal(t, totalProducedRecords, len(consumedRecordIDs), "Should have consumed all records (record IDs check)")
+	for i := int64(0); i < totalProducedRecords; i++ {
+		_, found := consumedRecordIDs[i]
+		require.Truef(t, found, "Expected to find a consumed record with ID %d", i)
+	}
 }
 
 func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Client, topic string, partition int32, startOffset int64, concurrency int, maxInflightBytes int32) *concurrentFetchers {

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -1422,6 +1422,29 @@ func TestConcurrentFetchers_parseFetchResponse(t *testing.T) {
 	})
 }
 
+func TestNewEmptyFetchResult(t *testing.T) {
+	t.Run("should have no error set", func(t *testing.T) {
+		res := newEmptyFetchResult(context.Background(), 1)
+		require.Equal(t, int32(1), res.Partition)
+		require.NoError(t, res.Err)
+	})
+}
+
+func TestNewErrorFetchResult(t *testing.T) {
+	t.Run("should have error set", func(t *testing.T) {
+		err := errors.New("test error")
+		res := newErrorFetchResult(context.Background(), 1, err)
+		require.Equal(t, int32(1), res.Partition)
+		require.Equal(t, err, res.Err)
+	})
+
+	t.Run("should panic if no error is provided", func(t *testing.T) {
+		require.Panics(t, func() {
+			newErrorFetchResult(context.Background(), 1, nil)
+		})
+	})
+}
+
 func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Client, topic string, partition int32, startOffset int64, concurrency int, maxInflightBytes int32) *concurrentFetchers {
 	logger := log.NewNopLogger()
 	reg := prometheus.NewPedanticRegistry()

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -1203,7 +1203,7 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 
 	t.Run("should return an error response if the Fetch request fails", func(t *testing.T) {
 		// Control only the next request, then drop it.
-		cluster.ControlKey(kmsg.Fetch.Int16(), func(req kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(kmsg.Fetch.Int16(), func(_ kmsg.Request) (kmsg.Response, error, bool) {
 			return nil, errors.New("failed request"), true
 		})
 

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -1257,6 +1257,7 @@ func TestTODO(t *testing.T) {
 		fetchResponseByRequestedOffset[offset] = res
 	}
 
+	require.Equal(t, totalProducedRecords, len(fetchResponseByRequestedOffset))
 	t.Logf("Collected raw Fetch responses for all expected offsets")
 
 	//

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -1207,7 +1207,7 @@ func TestTODO(t *testing.T) {
 
 	fetchResponseByRequestedOffset := map[int64]*kmsg.FetchResponse{}
 
-	for offset := int64(0); offset < totalProducedRecords; offset++ {
+	for offset := int64(0); offset < totalProducedRecords+1; offset++ {
 		// Build a Fetch request.
 		req := kmsg.NewFetchRequest()
 		req.MinBytes = 1
@@ -1257,7 +1257,6 @@ func TestTODO(t *testing.T) {
 		fetchResponseByRequestedOffset[offset] = res
 	}
 
-	require.Equal(t, totalProducedRecords, len(fetchResponseByRequestedOffset))
 	t.Logf("Collected raw Fetch responses for all expected offsets")
 
 	//
@@ -1305,7 +1304,11 @@ func TestTODO(t *testing.T) {
 			return res, nil, true
 		}
 
-		return nil, errors.New("the offset requested has not been found among the ones we previously fetched"), true
+		if req.Topics[0].Partitions[0].FetchOffset < totalProducedRecords {
+			return nil, errors.New("the offset requested has not been found among the ones we previously fetched"), true
+		}
+
+		return nil, nil, false
 	})
 
 	// Consume records.

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -242,7 +242,7 @@ func (r *PartitionReader) start(ctx context.Context) (returnErr error) {
 			r.kafkaCfg.Topic: {r.partitionID: kgo.NewOffset().At(startOffset)},
 		})
 
-		f, err := newConcurrentFetchers(ctx, r.client.Load(), r.logger, r.kafkaCfg.Topic, r.partitionID, startOffset, r.kafkaCfg.StartupFetchConcurrency, int32(r.kafkaCfg.MaxBufferedBytes), r.kafkaCfg.UseCompressedBytesAsFetchMaxBytes, r.concurrentFetchersMinBytesMaxWaitTime, offsetsClient, startOffsetReader, &r.metrics)
+		f, err := newConcurrentFetchers(ctx, r.client.Load(), r.logger, r.kafkaCfg.Topic, r.partitionID, startOffset, r.kafkaCfg.StartupFetchConcurrency, int32(r.kafkaCfg.MaxBufferedBytes), r.kafkaCfg.UseCompressedBytesAsFetchMaxBytes, r.concurrentFetchersMinBytesMaxWaitTime, offsetsClient, startOffsetReader, r.kafkaCfg.concurrentFetchersFetchBackoffConfig, &r.metrics)
 		if err != nil {
 			return errors.Wrap(err, "creating concurrent fetchers during startup")
 		}

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2025,7 +2025,7 @@ func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailure
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 	client := newKafkaProduceClient(t, clusterAddr)
@@ -2213,7 +2213,7 @@ func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailure
 	})
 
 	// Wait until all produced have been consumed.
-	test.Poll(t, 30*time.Second, totalProducedRecords, func() interface{} {
+	test.Poll(t, 30*time.Second, int64(totalProducedRecords), func() interface{} {
 		return totalConsumedRecords.Load()
 	})
 

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2200,7 +2200,7 @@ func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailure
 	readerOpts := append([]readerTestCfgOpt{
 		withConsumeFromPositionAtStartup(consumeFromStart),
 		withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
-		withLogger(testutil.NewLogger(t)),
+		withLogger(log.NewNopLogger()),
 		withMaxBufferedBytes(maxBufferedBytes),
 		withStartupConcurrency(concurrency),
 		withOngoingConcurrency(concurrency),
@@ -2213,7 +2213,7 @@ func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailure
 	})
 
 	// Wait until all produced have been consumed.
-	test.Poll(t, 10*time.Second, totalProducedRecords, func() interface{} {
+	test.Poll(t, 30*time.Second, totalProducedRecords, func() interface{} {
 		return totalConsumedRecords.Load()
 	})
 

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2115,7 +2115,7 @@ func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailure
 		}
 
 		rawPartitionResp := res.Topics[0].Partitions[0]
-		partition, _ := kgo.ProcessRespPartition(parseOptions, &rawPartitionResp, func(m kgo.FetchBatchMetrics) {})
+		partition, _ := kgo.ProcessRespPartition(parseOptions, &rawPartitionResp, func(_ kgo.FetchBatchMetrics) {})
 
 		// Ensure we got a low number of records, otherwise the premise of this test is wrong
 		// because we want a single fetchWatch to be fulfilled in many Fetch requests.
@@ -2202,14 +2202,14 @@ func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailure
 	})
 
 	// Create and start the reader.
-	readerOpts := append([]readerTestCfgOpt{
+	readerOpts := []readerTestCfgOpt{
 		withConsumeFromPositionAtStartup(consumeFromStart),
 		withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
 		withLogger(log.NewNopLogger()),
 		withMaxBufferedBytes(maxBufferedBytes),
 		withStartupConcurrency(concurrency),
 		withOngoingConcurrency(concurrency),
-	})
+	}
 
 	reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
 	require.NoError(t, reader.StartAsync(ctx))

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2074,7 +2074,7 @@ func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailure
 
 	fetchResponseByRequestedOffset := map[int64]*kmsg.FetchResponse{}
 
-	for offset := int64(0); offset < totalProducedRecords; offset++ {
+	for offset := int64(0); offset < totalProducedRecords+1; offset++ {
 		// Build a Fetch request.
 		req := kmsg.NewFetchRequest()
 		req.MinBytes = 1
@@ -2171,7 +2171,11 @@ func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailure
 			return res, nil, true
 		}
 
-		return nil, errors.New("the offset requested has not been found among the ones we previously fetched"), true
+		if req.Topics[0].Partitions[0].FetchOffset < totalProducedRecords {
+			return nil, errors.New("the offset requested has not been found among the ones we previously fetched"), true
+		}
+
+		return nil, nil, false
 	})
 
 	//

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -4,9 +4,12 @@ package ingest
 
 import (
 	"context"
+	crypto_rand "crypto/rand"
 	"errors"
 	"fmt"
+	"math/rand"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -2012,6 +2015,216 @@ func TestPartitionReader_ShouldNotPanicIfBufferedRecordsIsCalledBeforeStarting(t
 	reader := createReader(t, clusterAddr, topicName, partitionID, nil)
 
 	require.Zero(t, reader.BufferedRecords())
+}
+
+func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailuresWithConcurrentFetcherIsUsed(t *testing.T) {
+	const (
+		topicName   = "test-topic"
+		partitionID = 1
+		concurrency = 5
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
+	client := newKafkaProduceClient(t, clusterAddr)
+
+	const recordSizeBytes = 10_000  // TODO export initialBytesPerRecord and reuse it
+	const minFetchBytes = 1_000_000 // TODO set in fetchWant.MaxBytes() -> move it to a constant
+	const recordsPerFetch = minFetchBytes / recordSizeBytes
+	const maxBufferedBytes = concurrency * recordsPerFetch * recordSizeBytes
+
+	// We expect that fetchers will fetch more than 50 records per Fetch request.
+	require.Greater(t, recordsPerFetch, 50)
+
+	// Produce enough records so that we'll fetch concurrently.
+	const totalProducedRecords = concurrency * recordsPerFetch
+
+	for i := 0; i < totalProducedRecords; i++ {
+		// Fill the record with random data, in order to reduce the compression ratio and get the compressed
+		// record byte size as close as possible to the uncompressed one.
+		// TODO we should probably change all tests accordingly
+		randomData := make([]byte, recordSizeBytes)
+		_, err := crypto_rand.Read(randomData)
+		require.NoError(t, err)
+
+		recordValue := append([]byte(fmt.Sprintf("record-%05d", i)), randomData...)
+		produceRecord(ctx, t, client, topicName, partitionID, recordValue)
+	}
+
+	t.Logf("Produced %d records", totalProducedRecords)
+
+	//
+	// Get topic ID.
+	//
+
+	topics, err := kadm.NewClient(client).ListTopics(ctx, topicName)
+	require.NoError(t, err)
+	require.NoError(t, topics.Error())
+	require.True(t, topics.Has(topicName))
+	topicID := topics[topicName].ID
+
+	t.Logf("Fetched topic ID")
+
+	//
+	// Fetch the raw record batches for each offset, so that it's easier to later mock the Kafka
+	// server and control the returned batches.
+	//
+
+	fetchResponseByRequestedOffset := map[int64]*kmsg.FetchResponse{}
+
+	for offset := int64(0); offset < totalProducedRecords; offset++ {
+		// Build a Fetch request.
+		req := kmsg.NewFetchRequest()
+		req.MinBytes = 1
+		req.Version = 13
+		req.MaxWaitMillis = 1000
+		req.MaxBytes = 1 // Request the minimum amount of bytes.
+
+		reqTopic := kmsg.NewFetchRequestTopic()
+		reqTopic.Topic = topicName
+		reqTopic.TopicID = topicID
+
+		reqPartition := kmsg.NewFetchRequestTopicPartition()
+		reqPartition.Partition = partitionID
+		reqPartition.FetchOffset = offset
+		reqPartition.PartitionMaxBytes = 1  // Request the minimum amount of bytes.
+		reqPartition.CurrentLeaderEpoch = 0 // Not needed here.
+
+		reqTopic.Partitions = append(reqTopic.Partitions, reqPartition)
+		req.Topics = append(req.Topics, reqTopic)
+
+		// Issue the Fetch request.
+		kres, err := client.Request(context.Background(), &req)
+		require.NoError(t, err)
+
+		res := kres.(*kmsg.FetchResponse)
+		require.Equal(t, int16(0), res.ErrorCode)
+		require.Equal(t, 1, len(res.Topics))
+		require.Equal(t, 1, len(res.Topics[0].Partitions))
+
+		// Parse the response, just to check how many records we got.
+		parseOptions := kgo.ProcessFetchPartitionOptions{
+			KeepControlRecords: false,
+			Offset:             offset,
+			IsolationLevel:     kgo.ReadUncommitted(),
+			Topic:              topicName,
+			Partition:          partitionID,
+		}
+
+		rawPartitionResp := res.Topics[0].Partitions[0]
+		partition, _ := kgo.ProcessRespPartition(parseOptions, &rawPartitionResp, func(m kgo.FetchBatchMetrics) {})
+
+		// Ensure we got a low number of records, otherwise the premise of this test is wrong
+		// because we want a single fetchWatch to be fulfilled in many Fetch requests.
+		require.LessOrEqual(t, len(partition.Records), 5)
+
+		// Keep track of the raw response.
+		fetchResponseByRequestedOffset[offset] = res
+	}
+
+	t.Logf("Collected raw Fetch responses for all expected offsets")
+
+	//
+	// Mock the Kafka server to intercept Fetch requests, return less records than requested and
+	// inject random failures.
+	//
+
+	cluster.ControlKey(kmsg.Fetch.Int16(), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+
+		req := kreq.(*kmsg.FetchRequest)
+
+		// We expect only 1 partition.
+		if len(req.Topics) != 1 {
+			return nil, fmt.Errorf("expected 1 topic, got %d", len(req.Topics)), true
+		}
+		if len(req.Topics[0].Partitions) != 1 {
+			return nil, fmt.Errorf("expected 1 partition, got %d", len(req.Topics[0].Partitions)), true
+		}
+
+		// Simulate a 10% networking error rate.
+		if rand.Int()%10 == 0 {
+			return nil, errors.New("mocked error"), true
+		}
+
+		// Simulate a 10% Kafka error rate.
+		if rand.Int()%10 == 0 {
+			return &kmsg.FetchResponse{
+				Version:   req.Version,
+				ErrorCode: kerr.UnknownServerError.Code,
+				Topics: []kmsg.FetchResponseTopic{{
+					Topic:   req.Topics[0].Topic,
+					TopicID: req.Topics[0].TopicID,
+					Partitions: []kmsg.FetchResponseTopicPartition{{
+						Partition: req.Topics[0].Partitions[0].Partition,
+						ErrorCode: kerr.UnknownServerError.Code,
+					}},
+				}},
+			}, nil, true
+		}
+
+		// Lookup the response among the ones we previously fetched with a small "MaxBytes".
+		res := fetchResponseByRequestedOffset[req.Topics[0].Partitions[0].FetchOffset]
+		if res != nil {
+			return res, nil, true
+		}
+
+		return nil, errors.New("the offset requested has not been found among the ones we previously fetched"), true
+	})
+
+	//
+	// Consume all the records using the PartitionReader.
+	//
+
+	var (
+		totalConsumedRecords = atomic.NewInt64(0)
+		consumedRecordIDs    = map[int64]struct{}{}
+	)
+
+	consumer := consumerFunc(func(_ context.Context, records []record) error {
+		for _, rec := range records {
+			totalConsumedRecords.Inc()
+
+			// Parse the record ID from the actual record data.
+			recordID, err := strconv.ParseInt(string(rec.content[7:12]), 10, 64)
+			require.NoError(t, err)
+			consumedRecordIDs[recordID] = struct{}{}
+		}
+
+		return nil
+	})
+
+	// Create and start the reader.
+	readerOpts := append([]readerTestCfgOpt{
+		withConsumeFromPositionAtStartup(consumeFromStart),
+		withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
+		withLogger(testutil.NewLogger(t)),
+		withMaxBufferedBytes(maxBufferedBytes),
+		withStartupConcurrency(concurrency),
+		withOngoingConcurrency(concurrency),
+	})
+
+	reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+	require.NoError(t, reader.StartAsync(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+	})
+
+	// Wait until all produced have been consumed.
+	test.Poll(t, 10*time.Second, totalProducedRecords, func() interface{} {
+		return totalConsumedRecords.Load()
+	})
+
+	// Ensure that the actual records content match the expected one.
+	require.Equal(t, totalProducedRecords, len(consumedRecordIDs))
+	for i := int64(0); i < totalProducedRecords; i++ {
+		_, found := consumedRecordIDs[i]
+		require.Truef(t, found, "Expected to find a consumed record with ID %d", i)
+	}
+
+	// TODO assert no buffered records
 }
 
 func TestPartitionReader_fetchLastCommittedOffset(t *testing.T) {

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -1101,6 +1101,7 @@ func createTestKafkaConfig(clusterAddr, topicName string) KafkaConfig {
 	cfg.WriteTimeout = 2 * time.Second
 	cfg.StartupFetchConcurrency = 2
 	cfg.OngoingFetchConcurrency = 0
+	cfg.concurrentFetchersFetchBackoffConfig = fastFetchBackoffConfig
 
 	return cfg
 }


### PR DESCRIPTION
#### What this PR does

This PR fixed a data loss bug in the experimental ingest storage when a Kafka Fetch is split into multiple requests and some of them return an error.

**The bug**
Due to the `fetchResult.Merge()` we call in `concurrentFetchers.run()` we can merge records in a `kgo.Fetch` that also contains a `Err` (so it both has `Err` and some records). When this fetch is returned by `PollFetches()` to `PartitionReader`,  `PartitionReader` will filter out everything because of the `Err` set. We don't expect to both have an `Err` and some records set in the same `kgo.Fetch`, so I think `PartitionReader` is doing the right thing, and `concurrentFetchers` shouldn't mix `Err` with records.

**The fix**
A part from some small improvements / comments / new unit tests here and there, in this PR I address the issue doing two things:

1. `concurrentFetchers.parseFetchResponse()` checks for the error both at the `kmsg.FetchResponse` root and in the partition response
2. `concurrentFetchers.run()` doesn't merge `fetchResult` containing `Err`. To make the code a bit more robust and avoid mistakes in the future, I've explicitly introduced an `if` branch on the result from `r.fetchSingle()` with two different behaviours in case of err or no-err. I don't expect the logic to have been changed here, a part from not merging errors with records.

I intentionally introduced a couple of panics for invariants that, if violated, cause serious issues.

**The test**
I've locally run the new `TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailuresWithConcurrentFetcherIsUsed` 100 times with race and it looks both stable and fast (thanks to the custom backoff config the test time dropped from 50s to < 2s):

```
go test -v -race -failfast -count=100 -run 'TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailuresWithConcurrentFetcherIsUsed' ./pkg/storage/ingest
```

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
