### PR TITLE
Fix TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailuresWithConcurrentFetcherIsUsed flakyness

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2145,11 +2145,6 @@ func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailure
 			return nil, fmt.Errorf("expected 1 partition, got %d", len(req.Topics[0].Partitions)), true
 		}
 
-		// Simulate a 10% networking error rate.
-		if rand.Int()%10 == 0 {
-			return nil, errors.New("mocked error"), true
-		}
-
 		// Simulate a 10% Kafka error rate.
 		if rand.Int()%10 == 0 {
 			return &kmsg.FetchResponse{


### PR DESCRIPTION
#### What this PR does

In https://github.com/grafana/mimir/pull/9963 I've introduced `TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailuresWithConcurrentFetcherIsUsed`. After merging, I realised locally that sometimes the test hang.

I spent 1h debugging it and it's related to the case the kfake control return an `error` (not a response with error). I'm quite sure the issue has not been introduced with the changes in https://github.com/grafana/mimir/pull/9963, but I still haven't understood if the issue is in kfake (can't find a proof there) or an issue in the franz-go library.

I need more time to further investigate it. In the meanwhile I suggest to remove that type of error: the error still make sense due to the error injected by "Simulate a 10% Kafka error rate".

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
