### PR TITLE
Hash object names used as cache keys for CachingBucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 * [FEATURE] Alertmanager: limit added for maximum size of the Grafana configuration (`-alertmanager.max-config-size-bytes`). #9402
 * [FEATURE] Ingester: Experimental support for ingesting out-of-order native histograms. This is disabled by default and can be enabled by setting `-ingester.ooo-native-histograms-ingestion-enabled` to `true`. #7175
 * [FEATURE] Distributor: Added `-api.skip-label-count-validation-header-enabled` option to allow skipping label count validation on the HTTP write path based on `X-Mimir-SkipLabelCountValidation` header being `true` or not. #9576
-* [FEATURE] Ruler: Add experimental support for caching the contents of rule groups. This is disabled by default and can be enabled by setting `-ruler-storage.cache.rule-group-enabled`. #9595
+* [FEATURE] Ruler: Add experimental support for caching the contents of rule groups. This is disabled by default and can be enabled by setting `-ruler-storage.cache.rule-group-enabled`. #9595 #9968
 * [FEATURE] PromQL: Add experimental `info` function. Experimental functions are disabled by default, but can be enabled setting `-querier.promql-experimental-functions-enabled=true` in the query-frontend and querier. #9879
 * [FEATURE] Distributor: Support promotion of OTel resource attributes to labels. #8271
 * [ENHANCEMENT] mimirtool: Adds bearer token support for mimirtool's analyze ruler/prometheus commands. #9587

--- a/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
@@ -40,6 +40,7 @@ func TestChunksCaching(t *testing.T) {
 	}
 
 	name := "/test/chunks/000001"
+	hashedName := cachingKeyHash(name)
 
 	inmem := objstore.NewInMemBucket()
 	assert.NoError(t, inmem.Upload(context.Background(), name, bytes.NewReader(data)))
@@ -149,9 +150,9 @@ func TestChunksCaching(t *testing.T) {
 			init: func() {
 				ctx := context.Background()
 				// Delete first 3 subranges.
-				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, name, 0*subrangeSize, 1*subrangeSize)))
-				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, name, 1*subrangeSize, 2*subrangeSize)))
-				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, name, 2*subrangeSize, 3*subrangeSize)))
+				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, hashedName, 0*subrangeSize, 1*subrangeSize)))
+				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, hashedName, 1*subrangeSize, 2*subrangeSize)))
+				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, hashedName, 2*subrangeSize, 3*subrangeSize)))
 			},
 		},
 
@@ -167,9 +168,9 @@ func TestChunksCaching(t *testing.T) {
 			init: func() {
 				ctx := context.Background()
 				// Delete last 3 subranges.
-				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, name, 7*subrangeSize, 8*subrangeSize)))
-				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, name, 8*subrangeSize, 9*subrangeSize)))
-				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, name, 9*subrangeSize, 10*subrangeSize)))
+				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, hashedName, 7*subrangeSize, 8*subrangeSize)))
+				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, hashedName, 8*subrangeSize, 9*subrangeSize)))
+				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, hashedName, 9*subrangeSize, 10*subrangeSize)))
 			},
 		},
 
@@ -185,9 +186,9 @@ func TestChunksCaching(t *testing.T) {
 			init: func() {
 				ctx := context.Background()
 				// Delete 3 subranges in the middle.
-				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, name, 3*subrangeSize, 4*subrangeSize)))
-				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, name, 4*subrangeSize, 5*subrangeSize)))
-				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, name, 5*subrangeSize, 6*subrangeSize)))
+				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, hashedName, 3*subrangeSize, 4*subrangeSize)))
+				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, hashedName, 4*subrangeSize, 5*subrangeSize)))
+				require.NoError(t, cache.Delete(ctx, cachingKeyObjectSubrange(bucketID, hashedName, 5*subrangeSize, 6*subrangeSize)))
 			},
 		},
 
@@ -206,7 +207,7 @@ func TestChunksCaching(t *testing.T) {
 					if i > 0 && i%3 == 0 {
 						continue
 					}
-					require.NoError(t, cache.Delete(context.Background(), cachingKeyObjectSubrange(bucketID, name, i*subrangeSize, (i+1)*subrangeSize)))
+					require.NoError(t, cache.Delete(context.Background(), cachingKeyObjectSubrange(bucketID, hashedName, i*subrangeSize, (i+1)*subrangeSize)))
 				}
 			},
 		},
@@ -228,7 +229,7 @@ func TestChunksCaching(t *testing.T) {
 					if i == 3 || i == 5 || i == 7 {
 						continue
 					}
-					require.NoError(t, cache.Delete(context.Background(), cachingKeyObjectSubrange(bucketID, name, i*subrangeSize, (i+1)*subrangeSize)))
+					require.NoError(t, cache.Delete(context.Background(), cachingKeyObjectSubrange(bucketID, hashedName, i*subrangeSize, (i+1)*subrangeSize)))
 				}
 			},
 		},
@@ -249,7 +250,7 @@ func TestChunksCaching(t *testing.T) {
 					if i == 5 || i == 6 || i == 7 {
 						continue
 					}
-					require.NoError(t, cache.Delete(context.Background(), cachingKeyObjectSubrange(bucketID, name, i*subrangeSize, (i+1)*subrangeSize)))
+					require.NoError(t, cache.Delete(context.Background(), cachingKeyObjectSubrange(bucketID, hashedName, i*subrangeSize, (i+1)*subrangeSize)))
 				}
 			},
 		},

--- a/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket_test.go
@@ -1012,9 +1012,19 @@ func BenchmarkCachingKey(b *testing.B) {
 				cachingKeyAttributes(bucketID, "/object")
 			},
 		},
+		"cachingKeyAttributes() hashed": {
+			run: func(bucketID string) {
+				cachingKeyAttributes(bucketID, cachingKeyHash("/object"))
+			},
+		},
 		"cachingKeyObjectSubrange()": {
 			run: func(bucketID string) {
 				cachingKeyObjectSubrange(bucketID, "/object", 10, 20)
+			},
+		},
+		"cachingKeyObjectSubrange() hashed": {
+			run: func(bucketID string) {
+				cachingKeyObjectSubrange(bucketID, cachingKeyHash("/object"), 10, 20)
 			},
 		},
 		"cachingKeyIter()": {
@@ -1032,9 +1042,19 @@ func BenchmarkCachingKey(b *testing.B) {
 				cachingKeyExists(bucketID, "/object")
 			},
 		},
+		"cachingKeyExists() hashed": {
+			run: func(bucketID string) {
+				cachingKeyExists(bucketID, cachingKeyHash("/object"))
+			},
+		},
 		"cachingKeyContent()": {
 			run: func(bucketID string) {
 				cachingKeyContent(bucketID, "/object")
+			},
+		},
+		"cachingKeyContent() hashed": {
+			run: func(bucketID string) {
+				cachingKeyContent(bucketID, cachingKeyHash("/object"))
 			},
 		},
 	}


### PR DESCRIPTION
#### What this PR does

When caching rule groups, the base64 encoded name of the rule group is used as part of the key for caching its contents. For long rule group names, this can exceed the max key length of Memcached. To solve this we use the sha256 of the object name in the cache key instead of the object name itself.

#### Which issue(s) this PR fixes or relates to

Related #9386

#### Notes for reviewers

We're using a SHA3 hash for this since we don't want collisions and I didn't want to use the approach we take in the query-frontend: storing a "results" object with a key to disambiguate collisions. I ~haven't run benchmarks but I~ did take care to make sure that we're only doing a single hash per object storage operation.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
