### PR TITLE
ingest: move missed record tracking to PartitionReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@
 * [ENHANCEMENT] Alerts: Enable configuring job prefix for alerts to prevent clashes with metrics from Loki/Tempo. #9659
 * [ENHANCEMENT] Dashboards: visualize the age of source blocks in the "Mimir / Compactor" dashboard. #9697
 * [ENHANCEMENT] Dashboards: Include block compaction level on queried blocks in 'Mimir / Queries' dashboard. #9706
-
+* [ENHANCEMENT] Alerts: add `MimirIngesterMissedRecordsFromKafka` to detect gaps in consumed records in the ingester when using the experimental Kafka-based storage. #9921 #9972
 * [BUGFIX] Dashboards: Fix autoscaling metrics joins when series churn. #9412 #9450 #9432
 * [BUGFIX] Alerts: Fix autoscaling metrics joins in `MimirAutoscalerNotActive` when series churn. #9412
 * [BUGFIX] Alerts: Exclude failed cache "add" operations from alerting since failures are expected in normal operation. #9658

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -449,7 +449,6 @@ func instrumentGaps(gaps []offsetRange, records prometheus.Counter, logger log.L
 			"records_offset_gap_end_exclusive", gap.end,
 		)
 		records.Add(float64(gap.numOffsets()))
-		level.Error(logger).Log("msg", "found gap in records", "start", gap.start, "end", gap.end)
 	}
 }
 

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -468,7 +468,7 @@ func (g offsetRange) numOffsets() int64 {
 func findGapsInRecords(records kgo.Fetches, lastReturnedOffset int64) []offsetRange {
 	var gaps []offsetRange
 	records.EachRecord(func(r *kgo.Record) {
-		if r.Offset != lastReturnedOffset+1 {
+		if r.Offset > lastReturnedOffset+1 {
 			gaps = append(gaps, offsetRange{start: lastReturnedOffset + 1, end: r.Offset})
 		}
 		lastReturnedOffset = r.Offset

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -466,6 +466,10 @@ func (g offsetRange) numOffsets() int64 {
 
 func findGapsInRecords(records kgo.Fetches, lastSeenOffset int64) []offsetRange {
 	var gaps []offsetRange
+	if lastSeenOffset < 0 {
+		firstRecord := records.RecordIter().Next()
+		lastSeenOffset = firstRecord.Offset
+	}
 	records.EachRecord(func(r *kgo.Record) {
 		if r.Offset > lastSeenOffset+1 {
 			gaps = append(gaps, offsetRange{start: lastSeenOffset + 1, end: r.Offset})

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -466,7 +466,7 @@ func (g offsetRange) numOffsets() int64 {
 
 func findGapsInRecords(records kgo.Fetches, lastSeenOffset int64) []offsetRange {
 	var gaps []offsetRange
-	if lastSeenOffset < 0 {
+	if lastSeenOffset < 0 && records.NumRecords() > 0 {
 		// The offset may be -1 when we haven't seen ANY offsets. In this case we don't know what's the first available offset.
 		// So we assume that the first record is the first offset from the ones we're being passed.
 		firstRecord := records.RecordIter().Next()

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -467,6 +467,8 @@ func (g offsetRange) numOffsets() int64 {
 func findGapsInRecords(records kgo.Fetches, lastSeenOffset int64) []offsetRange {
 	var gaps []offsetRange
 	if lastSeenOffset < 0 {
+		// The offset may be -1 when we haven't seen ANY offsets. In this case we don't know what's the first available offset.
+		// So we assume that the first record is the first offset from the ones we're being passed.
 		firstRecord := records.RecordIter().Next()
 		lastSeenOffset = firstRecord.Offset
 	}

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -465,13 +465,13 @@ func (g offsetRange) numOffsets() int64 {
 	return g.end - g.start
 }
 
-func findGapsInRecords(records kgo.Fetches, lastReturnedOffset int64) []offsetRange {
+func findGapsInRecords(records kgo.Fetches, lastSeenOffset int64) []offsetRange {
 	var gaps []offsetRange
 	records.EachRecord(func(r *kgo.Record) {
-		if r.Offset > lastReturnedOffset+1 {
-			gaps = append(gaps, offsetRange{start: lastReturnedOffset + 1, end: r.Offset})
+		if r.Offset > lastSeenOffset+1 {
+			gaps = append(gaps, offsetRange{start: lastSeenOffset + 1, end: r.Offset})
 		}
-		lastReturnedOffset = r.Offset
+		lastSeenOffset = r.Offset
 	})
 	return gaps
 }

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -1631,7 +1631,17 @@ func TestFindGapsInRecords(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := findGapsInRecords(tc.records, tc.lastReturnedOffset)
+			fetches := kgo.Fetches{{
+				Topics: []kgo.FetchTopic{{
+					Topic: "t1",
+					Partitions: []kgo.FetchPartition{{
+						Partition: 1,
+						Records:   tc.records,
+					}},
+				}},
+			}}
+
+			got := findGapsInRecords(fetches, tc.lastReturnedOffset)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -1616,6 +1616,33 @@ func TestFindGapsInRecords(t *testing.T) {
 				{start: 12, end: 15},
 			},
 		},
+		"negative gap at start is ignored": {
+			records: []*kgo.Record{
+				{Offset: 5},
+				{Offset: 6},
+			},
+			lastReturnedOffset: 10,
+			want:               []offsetRange{},
+		},
+		"-1 start offset is ignored": {
+			records: []*kgo.Record{
+				{Offset: 5},
+				{Offset: 6},
+			},
+			lastReturnedOffset: -1,
+			want:               []offsetRange{},
+		},
+		"-1 start offset is ignored, but not the rest of the gaps": {
+			records: []*kgo.Record{
+				{Offset: 5},
+				{Offset: 6},
+				{Offset: 10},
+			},
+			lastReturnedOffset: -1,
+			want: []offsetRange{
+				{start: 7, end: 10},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -19,7 +18,6 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/test"
 	"github.com/prometheus/client_golang/prometheus"
-	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kerr"
@@ -1377,15 +1375,6 @@ func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Cli
 	logger := log.NewNopLogger()
 	reg := prometheus.NewPedanticRegistry()
 	metrics := newReaderMetrics(partition, reg, noopReaderMetricsSource{})
-
-	t.Cleanup(func() {
-		// Assuming none of the tests intentionally create gaps in offsets, there should be no missed records.
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-			# HELP cortex_ingest_storage_reader_missed_records_total The number of offsets that were never consumed by the reader because they weren't fetched.
-        	# TYPE cortex_ingest_storage_reader_missed_records_total counter
-        	cortex_ingest_storage_reader_missed_records_total 0
-		`), "cortex_ingest_storage_reader_missed_records_total"))
-	})
 
 	// This instantiates the fields of kprom.
 	// This is usually done by franz-go, but since now we use the metrics ourselves, we need to instantiate the metrics ourselves.

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -1622,7 +1622,7 @@ func TestFindGapsInRecords(t *testing.T) {
 				{Offset: 6},
 			},
 			lastReturnedOffset: 10,
-			want:               []offsetRange{},
+			want:               []offsetRange(nil),
 		},
 		"-1 start offset is ignored": {
 			records: []*kgo.Record{
@@ -1630,7 +1630,7 @@ func TestFindGapsInRecords(t *testing.T) {
 				{Offset: 6},
 			},
 			lastReturnedOffset: -1,
-			want:               []offsetRange{},
+			want:               []offsetRange(nil),
 		},
 		"-1 start offset is ignored, but not the rest of the gaps": {
 			records: []*kgo.Record{

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -189,6 +189,7 @@ func (r *PartitionReader) start(ctx context.Context) (returnErr error) {
 		return err
 	}
 
+	// lastConsumedOffset could be a special negative offset (e.g. partition start, or partition end).
 	r.lastSeenOffset = lastConsumedOffset
 	// Initialise the last consumed offset only if we've got an actual offset from the consumer group.
 	if lastConsumedOffset >= 0 {

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -95,8 +95,9 @@ type PartitionReader struct {
 	consumedOffsetWatcher *partitionOffsetWatcher
 	offsetReader          *partitionOffsetReader
 
-	logger log.Logger
-	reg    prometheus.Registerer
+	logger         log.Logger
+	reg            prometheus.Registerer
+	lastSeenOffset int64
 }
 
 func NewPartitionReaderForPusher(kafkaCfg KafkaConfig, partitionID int32, instanceID string, pusher Pusher, logger log.Logger, reg prometheus.Registerer) (*PartitionReader, error) {
@@ -188,6 +189,7 @@ func (r *PartitionReader) start(ctx context.Context) (returnErr error) {
 		return err
 	}
 
+	r.lastSeenOffset = lastConsumedOffset
 	// Initialise the last consumed offset only if we've got an actual offset from the consumer group.
 	if lastConsumedOffset >= 0 {
 		r.consumedOffsetWatcher.Notify(lastConsumedOffset)
@@ -375,6 +377,10 @@ func (r *PartitionReader) processNextFetches(ctx context.Context, delayObserver 
 	r.logFetchErrors(fetches)
 	fetches = filterOutErrFetches(fetches)
 
+	// instrument only after we've done all pre-processing of records. We don't expect the set of records to change beyond this point.
+	instrumentGaps(findGapsInRecords(fetches, r.lastSeenOffset), r.metrics.missedRecords, r.logger)
+	r.lastSeenOffset = max(r.lastSeenOffset, lastOffset(fetches))
+
 	err := r.consumeFetches(ctx, fetches)
 	if err != nil {
 		return fmt.Errorf("consume %d records: %w", fetches.NumRecords(), err)
@@ -382,6 +388,14 @@ func (r *PartitionReader) processNextFetches(ctx context.Context, delayObserver 
 	r.enqueueCommit(fetches)
 	r.notifyLastConsumedOffset(fetches)
 	return nil
+}
+
+func lastOffset(fetches kgo.Fetches) int64 {
+	var o int64
+	fetches.EachRecord(func(record *kgo.Record) {
+		o = record.Offset
+	})
+	return o
 }
 
 // processNextFetchesUntilTargetOrMaxLagHonored process records from Kafka until at least the maxLag is honored.

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -886,7 +886,11 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 						# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
 						# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
 						cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-					`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+
+						# HELP cortex_ingest_storage_reader_missed_records_total The number of offsets that were never consumed by the reader because they weren't fetched.
+						# TYPE cortex_ingest_storage_reader_missed_records_total counter
+						cortex_ingest_storage_reader_missed_records_total 2
+					`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_missed_records_total")
 				})
 			})
 		}

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -841,7 +841,6 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 					withConsumeFromPositionAtStartup(consumeFromEnd),
 					withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
 					withRegistry(reg),
-					withSkipMissedRecordsVerification(),
 				}, concurrencyVariant...)
 
 				reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
@@ -886,11 +885,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 						# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
 						# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
 						cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-
-						# HELP cortex_ingest_storage_reader_missed_records_total The number of offsets that were never consumed by the reader because they weren't fetched.
-						# TYPE cortex_ingest_storage_reader_missed_records_total counter
-						cortex_ingest_storage_reader_missed_records_total 2
-					`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_missed_records_total")
+					`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
 				})
 			})
 		}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

follow-up to #9921 

The idea is to catch gaps as close as possible to where we consume fetches. With the previous alert we wouldn't have caught the bug fixed in #9963


#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
