### PR TITLE
(devel) Enable otel-collector containers to emit logs under docker-compose

### DIFF
--- a/development/mimir-monolithic-mode/config/otel-collector-otlp-push-config.yaml
+++ b/development/mimir-monolithic-mode/config/otel-collector-otlp-push-config.yaml
@@ -35,6 +35,8 @@ processors:
   batch:
 
 exporters:
+  debug:
+    verbosity: basic
   otlphttp:
     endpoint: http://mimir-1:8001/otlp
 
@@ -49,4 +51,4 @@ service:
     metrics:
       receivers: [otlp, prometheus]
       processors: [batch]
-      exporters: [otlphttp]
+      exporters: [debug, otlphttp]

--- a/development/mimir-monolithic-mode/config/otel-collector-remote-write-config.yaml
+++ b/development/mimir-monolithic-mode/config/otel-collector-remote-write-config.yaml
@@ -35,6 +35,8 @@ processors:
   batch:
 
 exporters:
+  debug:
+    verbosity: basic
   prometheusremotewrite:
     endpoint: http://mimir-1:8001/api/v1/push
 
@@ -49,4 +51,4 @@ service:
     metrics:
       receivers: [otlp, prometheus]
       processors: [batch]
-      exporters: [prometheusremotewrite]
+      exporters: [debug, prometheusremotewrite]


### PR DESCRIPTION
#### What this PR does
This allows the otel-collector containers available in monolithic development mode to write basic logs to the screen. With this, you begin to see output on the screen like this:

```
otel-otlp-1  | 2024-11-21T19:38:17.580Z	info	Metrics	{"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 1, "metrics": 20, "data points": 22}
```

... which is useful when testing locally. (Especially when writes are failing.)


#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
