### PR TITLE
Alertmanager: add missing version to email receiver config

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -486,6 +486,7 @@ func (am *Alertmanager) ApplyConfig(conf *definition.PostableApiAlertingConfig, 
 		KeyFile:       cfg.Global.HTTPConfig.TLSConfig.KeyFile,
 		SkipVerify:    !cfg.Global.SMTPRequireTLS,
 		StaticHeaders: staticHeaders,
+		Version:       version.Version,
 	}
 	am.emailCfgMtx.Unlock()
 
@@ -622,6 +623,7 @@ func (am *Alertmanager) buildIntegrationsMap(gCfg *config.GlobalConfig, nc []*de
 		KeyFile:       gCfg.HTTPConfig.TLSConfig.KeyFile,
 		SkipVerify:    !gCfg.SMTPRequireTLS,
 		StaticHeaders: staticHeaders,
+		Version:       version.Version,
 	}
 
 	var gTmpl *template.Template


### PR DESCRIPTION
Adds missing version to the email footer

<img width="382" alt="Screenshot 2024-11-22 at 13 59 46" src="https://github.com/user-attachments/assets/4a7e7103-5916-4023-968f-0f13792b0b7e">



Fixes: https://github.com/grafana/alerting-squad/issues/873

