### PR TITLE
Distributor: Restore use of spanLogger in OTLP code

### DIFF
--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -181,7 +181,7 @@ func OTLPHandler(
 		pushMetrics.ObserveUncompressedBodySize(tenantID, float64(uncompressedBodySize))
 
 		var metrics []mimirpb.PreallocTimeseries
-		metrics, err = otelMetricsToTimeseries(ctx, tenantID, addSuffixes, enableCTZeroIngestion, promoteResourceAttributes, discardedDueToOtelParseError, logger, otlpReq.Metrics())
+		metrics, err = otelMetricsToTimeseries(ctx, tenantID, addSuffixes, enableCTZeroIngestion, promoteResourceAttributes, discardedDueToOtelParseError, spanLogger, otlpReq.Metrics())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What this PR does

I noticed that I in a [previous PR](https://github.com/grafana/mimir/pull/8271/files#diff-14e8ab607c4c17393fbe8a314df6f1f2119867f5e121e5d41752b0b317d8c223R184) replaced the use of `spanLogger` with `logger` by accident in the call to `otelMetricsToTimeseries` in the distributor's OTLP endpoint. This PR restores the use of `spanLogger`.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
