### PR TITLE
Backport #9998 to r316

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [CHANGE] Ingester: Change `-initial-delay` for circuit breakers to begin when the first request is received, rather than at breaker activation. #9842
 * [CHANGE] Query-frontend: apply query pruning before query sharding instead of after. #9913
 * [CHANGE] Ingester: remove experimental flags `-ingest-storage.kafka.ongoing-records-per-fetch` and `-ingest-storage.kafka.startup-records-per-fetch`. They are removed in favour of `-ingest-storage.kafka.max-buffered-bytes`. #9906
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642 #9651 #9664 #9681 #9717 #9719 #9724 #9874
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642 #9651 #9664 #9681 #9717 #9719 #9724 #9874 #9998
 * [FEATURE] Distributor: Add support for `lz4` OTLP compression. #9763
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] Query-frontend: add middleware to control access to specific PromQL experimental functions on a per-tenant basis. #9798

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -905,6 +905,22 @@ func TestSubqueries(t *testing.T) {
 			Start: time.Unix(10, 0),
 		},
 		{
+			// A query where SeriesMetadata returns some series but evaluates to no samples should not return anything.
+			Query: `(metric > Inf)[20s:10s]`,
+			Start: time.Unix(30, 0),
+			Result: promql.Result{
+				Value: promql.Matrix{},
+			},
+		},
+		{
+			// A nested subquery with the same properties as above.
+			Query: `last_over_time((metric > Inf)[20s:10s])[30s:5s]`,
+			Start: time.Unix(30, 0),
+			Result: promql.Result{
+				Value: promql.Matrix{},
+			},
+		},
+		{
 			Query: "metric[20s:5s]",
 			Result: promql.Result{
 				Value: promql.Matrix{

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -740,6 +740,12 @@ func (q *Query) populateMatrixFromRangeVectorOperator(ctx context.Context, o typ
 			return nil, err
 		}
 
+		if len(floats) == 0 && len(histograms) == 0 {
+			types.FPointSlicePool.Put(floats, q.memoryConsumptionTracker)
+			types.HPointSlicePool.Put(histograms, q.memoryConsumptionTracker)
+			continue
+		}
+
 		m = append(m, promql.Series{
 			Metric:     s.Labels,
 			Floats:     floats,

--- a/pkg/streamingpromql/testdata/ours/subqueries.test
+++ b/pkg/streamingpromql/testdata/ours/subqueries.test
@@ -127,3 +127,9 @@ eval range from 0 to 4m step 20s sum_over_time(sum_over_time(metric[2m:30s])[3m:
 
 eval range from 0 to 4m step 3m sum_over_time(sum_over_time(sum_over_time(metric[2m:30s])[3m:15s])[4m:20s])
   {} 0 86
+
+eval range from 0 to 4m step 15s last_over_time((metric > Inf)[20s:10s])
+  # Should produce no results.
+
+eval instant at 3m last_over_time((metric > Inf)[20s:10s])
+  # Should produce no results.


### PR DESCRIPTION
Manually backporting https://github.com/grafana/mimir/pull/9998 to r317.