### PR TITLE
MQE: mangle native histograms in returned slices to catch use-after-return bugs + fix issues found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * [CHANGE] Ingester: remove experimental flags `-ingest-storage.kafka.ongoing-records-per-fetch` and `-ingest-storage.kafka.startup-records-per-fetch`. They are removed in favour of `-ingest-storage.kafka.max-buffered-bytes`. #9906
 * [CHANGE] Ingester: Replace `cortex_discarded_samples_total` label from `sample-out-of-bounds` to `sample-timestamp-too-old`. #9885
 * [CHANGE] Ruler: the `/prometheus/config/v1/rules` does not return an error anymore if a rule group is missing in the object storage after been successfully returned by listing the storage, because it could have been deleted in the meanwhile. #9936
-* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642 #9651 #9664 #9681 #9717 #9719 #9724 #9874 #9998 #10007
+* [FEATURE] Querier: add experimental streaming PromQL engine, enabled with `-querier.query-engine=mimir`. #9367 #9368 #9398 #9399 #9403 #9417 #9418 #9419 #9420 #9482 #9504 #9505 #9507 #9518 #9531 #9532 #9533 #9553 #9558 #9588 #9589 #9639 #9641 #9642 #9651 #9664 #9681 #9717 #9719 #9724 #9874 #9998 #10007 #10010
 * [FEATURE] Distributor: Add support for `lz4` OTLP compression. #9763
 * [FEATURE] Query-frontend: added experimental configuration options `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` to allow non-transient responses to be cached. When set to `true` error responses from hitting limits or bad data are cached for a short TTL. #9028
 * [FEATURE] Query-frontend: add middleware to control access to specific PromQL experimental functions on a per-tenant basis. #9798

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1195,6 +1195,7 @@ func TestSubqueries(t *testing.T) {
 
 				res := qry.Exec(context.Background())
 				testutils.RequireEqualResults(t, testCase.Query, &testCase.Result, res)
+				qry.Close()
 			}
 
 			// Ensure our test cases are correct by running them against Prometheus' engine too.

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -40,6 +40,10 @@ import (
 	"github.com/grafana/mimir/pkg/util/globalerror"
 )
 
+func init() {
+	types.EnableManglingReturnedSlices = true
+}
+
 func TestUnsupportedPromQLFeatures(t *testing.T) {
 	featureToggles := EnableAllFeatures
 

--- a/pkg/streamingpromql/operators/aggregations/avg.go
+++ b/pkg/streamingpromql/operators/aggregations/avg.go
@@ -292,6 +292,9 @@ func (g *AvgAggregationGroup) ComputeOutputSeries(timeRange types.QueryTimeRange
 			if h != nil && h != invalidCombinationOfHistograms {
 				t := timeRange.StartT + int64(i)*timeRange.IntervalMilliseconds
 				histogramPoints = append(histogramPoints, promql.HPoint{T: t, H: h.Compact(0)})
+
+				// Remove histogram from slice to ensure it's not mutated when the slice is reused.
+				g.histograms[i] = nil
 			}
 		}
 	}

--- a/pkg/streamingpromql/operators/aggregations/sum.go
+++ b/pkg/streamingpromql/operators/aggregations/sum.go
@@ -194,6 +194,9 @@ func (g *SumAggregationGroup) ComputeOutputSeries(timeRange types.QueryTimeRange
 			if h != nil && h != invalidCombinationOfHistograms {
 				t := timeRange.StartT + int64(i)*timeRange.IntervalMilliseconds
 				histogramPoints = append(histogramPoints, promql.HPoint{T: t, H: h.Compact(0)})
+
+				// Remove histogram from slice to ensure it's not mutated when the slice is reused.
+				g.histogramSums[i] = nil
 			}
 		}
 	}

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -659,6 +659,9 @@ func (q *Query) populateVectorFromInstantVectorOperator(ctx context.Context, o t
 				T:      ts,
 				H:      point.H,
 			})
+
+			// Remove histogram from slice to ensure it's not mutated when the slice is reused.
+			d.Histograms[0].H = nil
 		} else {
 			types.PutInstantVectorSeriesData(d, q.memoryConsumptionTracker)
 

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -193,9 +193,10 @@ func TestLimitingPool_ClearsReturnedSlices(t *testing.T) {
 }
 
 func TestLimitingPool_Mangling(t *testing.T) {
+	currentEnableManglingReturnedSlices := EnableManglingReturnedSlices
 	defer func() {
 		// Ensure we reset this back to the default state given it applies globally.
-		EnableManglingReturnedSlices = false
+		EnableManglingReturnedSlices = currentEnableManglingReturnedSlices
 	}()
 
 	_, metric := createRejectedMetric()
@@ -208,6 +209,8 @@ func TestLimitingPool_Mangling(t *testing.T) {
 		func(_ int) int { return 123 },
 	)
 
+	// Test with mangling disabled.
+	EnableManglingReturnedSlices = false
 	s, err := p.Get(4, tracker)
 	require.NoError(t, err)
 	s = append(s, 1000, 2000, 3000, 4000)
@@ -215,8 +218,8 @@ func TestLimitingPool_Mangling(t *testing.T) {
 	p.Put(s, tracker)
 	require.Equal(t, []int{1000, 2000, 3000, 4000}, s, "returned slice should not be mangled when mangling is disabled")
 
+	// Test with mangling enabled.
 	EnableManglingReturnedSlices = true
-
 	s, err = p.Get(4, tracker)
 	require.NoError(t, err)
 	s = append(s, 1000, 2000, 3000, 4000)

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -28,6 +28,7 @@ func TestLimitingBucketedPool_Unlimited(t *testing.T) {
 		pool.NewBucketedPool(1, 1000, 2, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
 		FPointSize,
 		false,
+		nil,
 	)
 
 	// Get a slice from the pool, the current and peak stats should be updated based on the capacity of the slice returned, not the size requested.
@@ -80,6 +81,7 @@ func TestLimitingPool_Limited(t *testing.T) {
 		pool.NewBucketedPool(1, 1000, 2, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
 		FPointSize,
 		false,
+		nil,
 	)
 
 	// Get a slice from the pool beneath the limit.


### PR DESCRIPTION
#### What this PR does

This PR extends MQE's tests to aid in catching native histogram use-after-return bugs, and fixes some issues they've uncovered.

Now, during tests in the `streamingpromql` package, any histograms in slices returned to the `HPoint` or `FloatHistogram` pools will immediately be mutated. This ensures that any possible use-after-return bugs are triggered deterministically.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
