### PR TITLE
Jsonnet: rename autoscaling_distributor_[min|max]_replicas to autoscaling_distributor_[min|max]_replicas_per_zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
 * [CHANGE] Rollout-operator now defaults to storing scaling operation metadata in a Kubernetes ConfigMap. This avoids recursively invoking the admission webhook in some Kubernetes environments. #9699
 * [CHANGE] Update rollout-operator version to 0.20.0. #9995
 * [CHANGE] Remove the `track_sizes` feature for Memcached pods since it is unused. #10032
+* [CHANGE] The configuration options `autoscaling_distributor_min_replicas` and `autoscaling_distributor_max_replicas` has been renamed to `autoscaling_distributor_min_replicas_per_zone` and `autoscaling_distributor_max_replicas_per_zone` respectively. #10019
 * [FEATURE] Add support to deploy distributors in multi availability zones. #9548
 * [FEATURE] Add configuration settings to set the number of Memcached replicas for each type of cache (`memcached_frontend_replicas`, `memcached_index_queries_replicas`, `memcached_chunks_replicas`, `memcached_metadata_replicas`). #9679
 * [ENHANCEMENT] Add `ingest_storage_ingester_autoscaling_triggers` option to specify multiple triggers in ScaledObject created for ingest-store ingester autoscaling. #9422

--- a/operations/mimir-tests/test-autoscaling.jsonnet
+++ b/operations/mimir-tests/test-autoscaling.jsonnet
@@ -29,8 +29,8 @@ mimir {
     autoscaling_ruler_querier_max_replicas: 30,
 
     autoscaling_distributor_enabled: true,
-    autoscaling_distributor_min_replicas: 3,
-    autoscaling_distributor_max_replicas: 30,
+    autoscaling_distributor_min_replicas_per_zone: 3,
+    autoscaling_distributor_max_replicas_per_zone: 30,
 
     autoscaling_query_frontend_enabled: true,
     autoscaling_query_frontend_min_replicas: 3,

--- a/operations/mimir-tests/test-multi-zone-distributor.jsonnet
+++ b/operations/mimir-tests/test-multi-zone-distributor.jsonnet
@@ -6,7 +6,7 @@
     multi_zone_availability_zones: availabilityZones,
 
     autoscaling_distributor_enabled: true,
-    autoscaling_distributor_min_replicas: 3,
-    autoscaling_distributor_max_replicas: 30,
+    autoscaling_distributor_min_replicas_per_zone: 3,
+    autoscaling_distributor_max_replicas_per_zone: 30,
   },
 }

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -18,8 +18,8 @@
     autoscaling_ruler_querier_workers_target_utilization: 0.75,  // Target to utilize 75% ruler-querier workers on peak traffic, so we have 25% room for higher peaks.
 
     autoscaling_distributor_enabled: false,
-    autoscaling_distributor_min_replicas: error 'you must set autoscaling_distributor_min_replicas in the _config',
-    autoscaling_distributor_max_replicas: error 'you must set autoscaling_distributor_max_replicas in the _config',
+    autoscaling_distributor_min_replicas_per_zone: error 'you must set autoscaling_distributor_min_replicas_per_zone in the _config',
+    autoscaling_distributor_max_replicas_per_zone: error 'you must set autoscaling_distributor_max_replicas_per_zone in the _config',
     autoscaling_distributor_cpu_target_utilization: 1,
     autoscaling_distributor_memory_target_utilization: 1,
 
@@ -551,8 +551,8 @@
       container_name='distributor',
       cpu_requests=$.distributor_container.resources.requests.cpu,
       memory_requests=$.distributor_container.resources.requests.memory,
-      min_replicas=$._config.autoscaling_distributor_min_replicas,
-      max_replicas=$._config.autoscaling_distributor_max_replicas,
+      min_replicas=$._config.autoscaling_distributor_min_replicas_per_zone,
+      max_replicas=$._config.autoscaling_distributor_max_replicas_per_zone,
       cpu_target_utilization=$._config.autoscaling_distributor_cpu_target_utilization,
       memory_target_utilization=$._config.autoscaling_distributor_memory_target_utilization,
       with_cortex_prefix=true,


### PR DESCRIPTION
#### What this PR does

Similarly to https://github.com/grafana/mimir/pull/8874, in this PR I propose to rename `autoscaling_distributor_[min|max]_replicas` to `autoscaling_distributor_[min|max]_replicas_per_zone` to clarify that it's a per-zone setting when distributor is deployed multi-zone.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
