### PR TITLE
frontend: update query pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * [ENHANCEMENT] Ingester: Add `-blocks-storage.tsdb.bigger-out-of-order-blocks-for-old-samples` to build 24h blocks for out-of-order data belonging to the previous days instead of building smaller 2h blocks. This reduces pressure on compactors and ingesters when the out-of-order samples span multiple days in the past. #9844 #10033 #10035
 * [ENHANCEMENT] Distributor: allow a different limit for info series (series ending in `_info`) label count, via `-validation.max-label-names-per-info-series`. #10028
 * [ENHANCEMENT] Ingester: do not reuse labels, samples and histograms slices in the write request if there are more entries than 10x the pre-allocated size. This should help to reduce the in-use memory in case of few requests with a very large number of labels, samples or histograms. #10040
+* [ENHANCEMENT] Query-Frontend: prune `<subquery> and on() (vector(x)==y)` style queries and no longer prune `<subquery> < -Inf`. Triggered by https://github.com/prometheus/prometheus/pull/15245. #10026
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 * [ENHANCEMENT] Ingester: Add `-blocks-storage.tsdb.bigger-out-of-order-blocks-for-old-samples` to build 24h blocks for out-of-order data belonging to the previous days instead of building smaller 2h blocks. This reduces pressure on compactors and ingesters when the out-of-order samples span multiple days in the past. #9844 #10033 #10035
 * [ENHANCEMENT] Distributor: allow a different limit for info series (series ending in `_info`) label count, via `-validation.max-label-names-per-info-series`. #10028
 * [ENHANCEMENT] Ingester: do not reuse labels, samples and histograms slices in the write request if there are more entries than 10x the pre-allocated size. This should help to reduce the in-use memory in case of few requests with a very large number of labels, samples or histograms. #10040
-* [ENHANCEMENT] Query-Frontend: prune `<subquery> and on() (vector(x)==y)` style queries and no longer prune `<subquery> < -Inf`. Triggered by https://github.com/prometheus/prometheus/pull/15245. #10026
+* [ENHANCEMENT] Query-Frontend: prune `<subquery> and on() (vector(x)==y)` style queries and stop pruning `<subquery> < -Inf`. Triggered by https://github.com/prometheus/prometheus/pull/15245. #10026
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508

--- a/pkg/frontend/querymiddleware/astmapper/pruning.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning.go
@@ -71,10 +71,10 @@ func (pruner *queryPruner) isConst(expr parser.Expr) (isConst, isEmpty bool) {
 		return false, false
 	}
 
-	if vectorAndConst, equals := pruner.isVectorAndNumberEqual(lhs, rhs); vectorAndConst {
+	if vectorAndNumber, equals := pruner.isVectorAndNumberEqual(lhs, rhs); vectorAndNumber {
 		return true, !equals
 	}
-	if vectorAndConst, equals := pruner.isVectorAndNumberEqual(rhs, lhs); vectorAndConst {
+	if vectorAndNumber, equals := pruner.isVectorAndNumberEqual(rhs, lhs); vectorAndNumber {
 		return true, !equals
 	}
 	return false, false

--- a/pkg/frontend/querymiddleware/astmapper/pruning.go
+++ b/pkg/frontend/querymiddleware/astmapper/pruning.go
@@ -4,8 +4,6 @@ package astmapper
 
 import (
 	"context"
-	"math"
-	"strconv"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -33,185 +31,89 @@ func (pruner *queryPruner) MapExpr(expr parser.Expr) (mapped parser.Expr, finish
 		return nil, false, err
 	}
 
-	switch e := expr.(type) {
-	case *parser.ParenExpr:
-		mapped, finished, err = pruner.MapExpr(e.Expr)
-		if err != nil {
-			return e, false, err
-		}
-		return &parser.ParenExpr{Expr: mapped, PosRange: e.PosRange}, finished, nil
-	case *parser.BinaryExpr:
-		return pruner.pruneBinOp(e)
-	default:
-		return e, false, nil
-	}
-}
-
-func (pruner *queryPruner) pruneBinOp(expr *parser.BinaryExpr) (mapped parser.Expr, finished bool, err error) {
-	switch expr.Op {
-	case parser.MUL:
-		return pruner.handleMultiplyOp(expr), false, nil
-	case parser.GTR, parser.LSS:
-		return pruner.handleCompOp(expr), false, nil
-	case parser.LOR:
-		return pruner.handleOrOp(expr), false, nil
-	case parser.LAND:
-		return pruner.handleAndOp(expr), false, nil
-	case parser.LUNLESS:
-		return pruner.handleUnlessOp(expr), false, nil
-	default:
+	e, ok := expr.(*parser.BinaryExpr)
+	if !ok {
 		return expr, false, nil
 	}
+
+	if e.Op != parser.LAND || e.VectorMatching == nil ||
+		!e.VectorMatching.On || len(e.VectorMatching.MatchingLabels) != 0 {
+		// Return if not "<lhs> and on() <rhs>"
+		return expr, false, nil
+	}
+
+	isConst, isEmpty := pruner.isConst(e.RHS)
+	if !isConst {
+		return expr, false, nil
+	}
+	if isEmpty {
+		// The right hand side is empty, so the whole expression is empty due to
+		// "and on()", return the right hand side.
+		return e.RHS, false, nil
+	}
+	// The right hand side is const no empty, so the whole expression is just the
+	// left side.
+	return e.LHS, false, nil
 }
 
-// The bool signifies if the number evaluates to infinity, and if it does
-// we return the infinity of the correct sign.
-func calcInf(isPositive bool, num string) (*parser.NumberLiteral, bool) {
-	coeff, err := strconv.Atoi(num)
-	if err != nil || coeff == 0 {
-		return nil, false
-	}
-	switch {
-	case isPositive && coeff > 0:
-		return &parser.NumberLiteral{Val: math.Inf(1)}, true
-	case isPositive && coeff < 0:
-		return &parser.NumberLiteral{Val: math.Inf(-1)}, true
-	case !isPositive && coeff > 0:
-		return &parser.NumberLiteral{Val: math.Inf(-1)}, true
-	case !isPositive && coeff < 0:
-		return &parser.NumberLiteral{Val: math.Inf(1)}, true
-	default:
-		return nil, false
-	}
-}
-
-func (pruner *queryPruner) handleMultiplyOp(expr *parser.BinaryExpr) parser.Expr {
-	isInfR, signR := pruner.isInfinite(expr.RHS)
-	if isInfR {
-		newExpr, ok := calcInf(signR, expr.LHS.String())
-		if ok {
-			return newExpr
-		}
-	}
-	isInfL, signL := pruner.isInfinite(expr.LHS)
-	if isInfL {
-		newExpr, ok := calcInf(signL, expr.RHS.String())
-		if ok {
-			return newExpr
-		}
-	}
-	return expr
-}
-
-func (pruner *queryPruner) handleCompOp(expr *parser.BinaryExpr) parser.Expr {
-	var refNeg, refPos parser.Expr
-	switch expr.Op {
-	case parser.LSS:
-		refNeg = expr.RHS
-		refPos = expr.LHS
-	case parser.GTR:
-		refNeg = expr.LHS
-		refPos = expr.RHS
-	default:
-		return expr
-	}
-
-	// foo < -Inf or -Inf > foo => vector(0) < -Inf
-	isInf, sign := pruner.isInfinite(refNeg)
-	if isInf && !sign {
-		return &parser.BinaryExpr{
-			LHS: &parser.Call{
-				Func: parser.Functions["vector"],
-				Args: []parser.Expr{&parser.NumberLiteral{Val: 0}},
-			},
-			Op:         parser.LSS,
-			RHS:        &parser.NumberLiteral{Val: math.Inf(-1)},
-			ReturnBool: false,
-		}
-	}
-
-	// foo > +Inf or +Inf < foo => vector(0) > +Inf => vector(0) < -Inf
-	isInf, sign = pruner.isInfinite(refPos)
-	if isInf && sign {
-		return &parser.BinaryExpr{
-			LHS: &parser.Call{
-				Func: parser.Functions["vector"],
-				Args: []parser.Expr{&parser.NumberLiteral{Val: 0}},
-			},
-			Op:         parser.LSS,
-			RHS:        &parser.NumberLiteral{Val: math.Inf(-1)},
-			ReturnBool: false,
-		}
-	}
-
-	return expr
-}
-
-// 1st bool is true if the number is infinite.
-// 2nd bool is true if the number is positive infinity.
-func (pruner *queryPruner) isInfinite(expr parser.Expr) (bool, bool) {
-	mapped, _, err := pruner.MapExpr(expr)
-	if err == nil {
-		expr = mapped
-	}
+func (pruner *queryPruner) isConst(expr parser.Expr) (isConst, isEmpty bool) {
+	var lhs, rhs parser.Expr
 	switch e := expr.(type) {
 	case *parser.ParenExpr:
-		return pruner.isInfinite(e.Expr)
+		return pruner.isConst(e.Expr)
+	case *parser.BinaryExpr:
+		if e.Op != parser.EQLC || e.ReturnBool {
+			return false, false
+		}
+		lhs = e.LHS
+		rhs = e.RHS
+	default:
+		return false, false
+	}
+
+	lIsVector, lValue := pruner.isConstVector(lhs)
+	if lIsVector {
+		rIsConst, rValue := pruner.isNumber(rhs)
+		if rIsConst {
+			return true, rValue != lValue
+		}
+		return false, false
+	}
+	var lIsConst bool
+	lIsConst, lValue = pruner.isNumber(lhs)
+	if !lIsConst {
+		return false, false
+	}
+	rIsVector, rValue := pruner.isConstVector(rhs)
+	if !rIsVector {
+		return false, false
+	}
+	return true, lValue != rValue
+}
+
+func (pruner *queryPruner) isConstVector(expr parser.Expr) (isVector bool, value float64) {
+	switch e := expr.(type) {
+	case *parser.ParenExpr:
+		return pruner.isConstVector(e.Expr)
+	case *parser.Call:
+		if e.Func.Name != "vector" || len(e.Args) != 1 {
+			return false, 0
+		}
+		lit, ok := e.Args[0].(*parser.NumberLiteral)
+		if !ok {
+			return false, 0
+		}
+		return true, lit.Val
+	}
+	return false, 0
+}
+
+func (pruner *queryPruner) isNumber(expr parser.Expr) (isNumber bool, value float64) {
+	switch e := expr.(type) {
+	case *parser.ParenExpr:
+		return pruner.isNumber(e.Expr)
 	case *parser.NumberLiteral:
-		if math.IsInf(e.Val, 1) {
-			return true, true
-		}
-		if math.IsInf(e.Val, -1) {
-			return true, false
-		}
-		return false, false
-	default:
-		return false, false
+		return true, e.Val
 	}
-}
-
-func (pruner *queryPruner) handleOrOp(expr *parser.BinaryExpr) parser.Expr {
-	switch {
-	case pruner.isEmpty(expr.LHS):
-		return expr.RHS
-	case pruner.isEmpty(expr.RHS):
-		return expr.LHS
-	}
-	return expr
-}
-
-func (pruner *queryPruner) handleAndOp(expr *parser.BinaryExpr) parser.Expr {
-	switch {
-	case pruner.isEmpty(expr.LHS):
-		return expr.LHS
-	case pruner.isEmpty(expr.RHS):
-		return expr.RHS
-	}
-	return expr
-}
-
-func (pruner *queryPruner) handleUnlessOp(expr *parser.BinaryExpr) parser.Expr {
-	switch {
-	case pruner.isEmpty(expr.LHS):
-		return expr.LHS
-	case pruner.isEmpty(expr.RHS):
-		return expr.LHS
-	}
-	return expr
-}
-
-func (pruner *queryPruner) isEmpty(expr parser.Expr) bool {
-	mapped, _, err := pruner.MapExpr(expr)
-	if err == nil {
-		expr = mapped
-	}
-	switch e := expr.(type) {
-	case *parser.ParenExpr:
-		return pruner.isEmpty(e.Expr)
-	default:
-		if e.String() == `vector(0) < -Inf` {
-			return true
-		}
-		return false
-	}
+	return false, 0
 }

--- a/pkg/frontend/querymiddleware/prune_test.go
+++ b/pkg/frontend/querymiddleware/prune_test.go
@@ -69,7 +69,6 @@ func TestQueryPruning(t *testing.T) {
 			require.Nil(t, err)
 
 			if !template.IsEmpty {
-				fmt.Printf("query1: %s\n", query)
 				// Ensure the query produces some results.
 				require.NotEmpty(t, expectedRes.(*PrometheusResponse).Data.Result)
 				requireValidSamples(t, expectedRes.(*PrometheusResponse).Data.Result)
@@ -81,7 +80,6 @@ func TestQueryPruning(t *testing.T) {
 
 			if !template.IsEmpty {
 				// Ensure the query produces some results.
-				fmt.Printf("query2: %s\n", query)
 				require.NotEmpty(t, prunedRes.(*PrometheusResponse).Data.Result)
 				requireValidSamples(t, prunedRes.(*PrometheusResponse).Data.Result)
 			}


### PR DESCRIPTION
#### What this PR does

The current method of excluding/including sub query results in PromQL by comparing to -Inf or +Inf is no longer valid after https://github.com/prometheus/prometheus/pull/15245 due to comparison of native histograms to a float with < or > result in Jeanette's warning, not empty set.

To ease migration away from the old wrong logic, I'm adding the new logic first.

The new method uses logical AND operation to intersect the sub query with either a const vector() or an empty vector(). E.g.

```
subquery and on() (vector(1)==1)
```

which becomes:

```
subquery
```

and conversely 

```
subquery and on() (vector(-1)==1)
```
becomes
```
(vector(-1)==1)
```

#### Note

We cannot just drop `(vector(-1)==1)` altogether , because of this example:
```
(other_subquery) and (subquery and on() (vector(-1)==1))
```
removal of the whole right side would allow results from the `other_subquery` which is not correct. Solving this is out of scope.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
