### PR TITLE
helm: don't quote container command args passed via *.extraArgs values

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -34,7 +34,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add support for setting type and internal traffic policy for Kubernetes service. Set `internalTrafficPolicy=Cluster` by default in all services with type `ClusterIP`. #9619
 * [ENHANCEMENT] Add the possibility to create a dedicated serviceAccount for the `alertmanager` component by setting `alertmanager.serviceAcount.create` to true in the values. #9781
 * [ENHANCEMENT] helm: add `enabled` field for admin-api, compactor, distributor, gateway, ingester, querier, query-frontend and store-gateway components. This helps when deploying the GEM federation-frontend on its own. #9734
-* [BUGFIX] Do not quote container command args passed via *.extraArgs values. #qqq
+* [BUGFIX] Do not quote container command args passed via *.extraArgs values. #10029
 * [BUGFIX] Update `serviceAccountName` in the `alertmanager-statefulset` template. #10016
 * [BUGFIX] Fix PVC template in AlertManager to not show diff in ArgoCD. #9774
 * [BUGFIX] Fix how `fullnameOverride` is reflected in generated manifests. #9564

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,12 +29,13 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [BUGFIX] Update `serviceAccountName` in the `alertmanager-statefulset` template. #10016
 * [CHANGE] Update rollout-operator version to 0.20.0. #9995
 * [FEATURE] Add support for GEM's federation-frontend. See the `federation_frontend` section in the values file. #9673
 * [ENHANCEMENT] Add support for setting type and internal traffic policy for Kubernetes service. Set `internalTrafficPolicy=Cluster` by default in all services with type `ClusterIP`. #9619
 * [ENHANCEMENT] Add the possibility to create a dedicated serviceAccount for the `alertmanager` component by setting `alertmanager.serviceAcount.create` to true in the values. #9781
 * [ENHANCEMENT] helm: add `enabled` field for admin-api, compactor, distributor, gateway, ingester, querier, query-frontend and store-gateway components. This helps when deploying the GEM federation-frontend on its own. #9734
+* [BUGFIX] Do not quote container command args passed via *.extraArgs values. #qqq
+* [BUGFIX] Update `serviceAccountName` in the `alertmanager-statefulset` template. #10016
 * [BUGFIX] Fix PVC template in AlertManager to not show diff in ArgoCD. #9774
 * [BUGFIX] Fix how `fullnameOverride` is reflected in generated manifests. #9564
 * [BUGFIX] Fix `extraObjects` linting with helm lint by padding with an extra new line. #9863

--- a/operations/helm/charts/mimir-distributed/ci/offline/test-extra-args-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/test-extra-args-values.yaml
@@ -1,0 +1,54 @@
+# Pin kube version so results are the same for running in CI and locally where the installed kube version may be different.
+kubeVersionOverride: "1.20"
+
+test_extra_args: &test_extra_args
+  extraArgs:
+    flag-empty: null
+    flag-string: hello
+    flag-bool: false
+    flag-float: 1.23
+    flag-json1: "{\"foo\":\"bar\"}"
+    flag-json2: '{"foo":"bar"}'
+    flag-number: 0
+
+admin_api:
+  <<: *test_extra_args
+
+alertmanager:
+  <<: *test_extra_args
+
+compactor:
+  <<: *test_extra_args
+
+continuous_test:
+  <<: *test_extra_args
+
+distributor:
+  <<: *test_extra_args
+
+gateway:
+  <<: *test_extra_args
+
+overrides_exporter:
+  <<: *test_extra_args
+
+query_frontend:
+  <<: *test_extra_args
+
+query_scheduler:
+  <<: *test_extra_args
+
+ruler:
+  <<: *test_extra_args
+
+ruler_querier:
+  <<: *test_extra_args
+
+ruler_query_scheduler:
+  <<: *test_extra_args
+
+smoke_test:
+  <<: *test_extra_args
+
+store_gateway:
+  <<: *test_extra_args

--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -48,7 +48,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.admin_api.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             {{- if .Values.admin_api.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -52,7 +52,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
           {{- range $key, $value := .Values.alertmanager.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.alertmanager.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -153,7 +153,7 @@ spec:
             # needs to be higher to avoid connections being closed abruptly.
             - "-server.http-idle-timeout=6m"
             {{- range $key, $value := .Values.alertmanager.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             {{- if .Values.alertmanager.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -122,7 +122,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.compactor.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             {{- if .Values.compactor.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
@@ -65,7 +65,7 @@ spec:
             - "-tests.bearer-token={{ .Values.continuous_test.auth.bearerToken }}"
             {{- end }}
             {{- range $key, $value := .Values.continuous_test.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             - name: config

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -68,7 +68,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.distributor.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.distributor.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/federation-frontend/federation-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/federation-frontend/federation-frontend-dep.yaml
@@ -47,7 +47,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.federation_frontend.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             {{- if .Values.federation_frontend.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -59,7 +59,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             {{- with .extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-querier/graphite-querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-querier/graphite-querier-dep.yaml
@@ -50,7 +50,7 @@ spec:
             - -target=graphite-querier
             - -config.file=/etc/mimir/mimir.yaml
           {{- range $key, $value := .Values.graphite.querier.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.graphite.querier.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-write-proxy/graphite-write-proxy-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-write-proxy/graphite-write-proxy-dep.yaml
@@ -50,7 +50,7 @@ spec:
             - -target=graphite-write-proxy
             - -config.file=/etc/mimir/mimir.yaml
           {{- range $key, $value := .Values.graphite.write_proxy.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.graphite.write_proxy.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -142,7 +142,7 @@ spec:
             - "-server.grpc-max-concurrent-streams=500"
             {{- end }}
             {{- range $key, $value := .Values.ingester.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             {{- if .Values.ingester.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -48,7 +48,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.overrides_exporter.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             {{- if .Values.overrides_exporter.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -63,7 +63,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.querier.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.querier.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -56,7 +56,7 @@ spec:
             - "-server.grpc.keepalive.max-connection-age=30s"
             - "-shutdown-delay=90s"
           {{- range $key, $value := .Values.query_frontend.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.query_frontend.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -47,7 +47,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
           {{- range $key, $value := .Values.query_scheduler.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.query_scheduler.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
@@ -64,7 +64,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.ruler_querier.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.ruler_querier.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
@@ -58,7 +58,7 @@ spec:
             - "-server.grpc.keepalive.max-connection-age=30s"
             - "-shutdown-delay=90s"
           {{- range $key, $value := .Values.ruler_query_frontend.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.ruler_query_frontend.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-dep.yaml
@@ -47,7 +47,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
           {{- range $key, $value := .Values.ruler_query_scheduler.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.ruler_query_scheduler.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -65,7 +65,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.ruler.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
           {{- end }}
           volumeMounts:
             {{- if .Values.ruler.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -50,7 +50,7 @@ spec:
             - "-tests.write-read-series-test.max-query-age=48h"
             - "-server.http-listen-port={{ include "mimir.serverHttpListenPort" . }}"
             {{- range $key, $value := .Values.smoke_test.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             {{- if .Values.smoke_test.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -140,7 +140,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- range $key, $value := .Values.store_gateway.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             {{- if .Values.store_gateway.extraVolumeMounts }}

--- a/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -47,7 +47,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             {{- range $key, $value := .Values.tokengenJob.extraArgs }}
-            - "-{{ $key }}={{ $value }}"
+            - -{{ $key }}={{ $value }}
             {{- end }}
           volumeMounts:
             {{- if .Values.tokengenJob.extraVolumeMounts }}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/configmap.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/configmap.yaml
@@ -1,0 +1,405 @@
+---
+# Source: mimir-distributed/charts/minio/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-extra-args-values-minio
+  labels:
+    app: minio
+    chart: minio-5.3.0
+    release: test-extra-args-values
+    heritage: Helm
+data:
+  initialize: |-
+    #!/bin/sh
+    set -e # Have script exit in the event of a failed command.
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for MinIO service to be available
+    connectToMinio() {
+    	SCHEME=$1
+    	ATTEMPTS=0
+    	LIMIT=29 # Allow 30 attempts
+    	set -e   # fail if we can't read the keys.
+    	ACCESS=$(cat /config/rootUser)
+    	SECRET=$(cat /config/rootPassword)
+    	set +e # The connections to minio are allowed to fail.
+    	echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT"
+    	MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET"
+    	$MC_COMMAND
+    	STATUS=$?
+    	until [ $STATUS = 0 ]; do
+    		ATTEMPTS=$(expr $ATTEMPTS + 1)
+    		echo \"Failed attempts: $ATTEMPTS\"
+    		if [ $ATTEMPTS -gt $LIMIT ]; then
+    			exit 1
+    		fi
+    		sleep 2 # 1 second intervals between attempts
+    		$MC_COMMAND
+    		STATUS=$?
+    	done
+    	set -e # reset `e` as active
+    	return 0
+    }
+    
+    # checkBucketExists ($bucket)
+    # Check if the bucket exists, by using the exit code of `mc ls`
+    checkBucketExists() {
+    	BUCKET=$1
+    	CMD=$(${MC} stat myminio/$BUCKET >/dev/null 2>&1)
+    	return $?
+    }
+    
+    # createBucket ($bucket, $policy, $purge)
+    # Ensure bucket exists, purging if asked to
+    createBucket() {
+    	BUCKET=$1
+    	POLICY=$2
+    	PURGE=$3
+    	VERSIONING=$4
+    	OBJECTLOCKING=$5
+    
+    	# Purge the bucket, if set & exists
+    	# Since PURGE is user input, check explicitly for `true`
+    	if [ $PURGE = true ]; then
+    		if checkBucketExists $BUCKET; then
+    			echo "Purging bucket '$BUCKET'."
+    			set +e # don't exit if this fails
+    			${MC} rm -r --force myminio/$BUCKET
+    			set -e # reset `e` as active
+    		else
+    			echo "Bucket '$BUCKET' does not exist, skipping purge."
+    		fi
+    	fi
+    
+    	# Create the bucket if it does not exist and set objectlocking if enabled (NOTE: versioning will be not changed if OBJECTLOCKING is set because it enables versioning to the Buckets created)
+    	if ! checkBucketExists $BUCKET; then
+    		if [ ! -z $OBJECTLOCKING ]; then
+    			if [ $OBJECTLOCKING = true ]; then
+    				echo "Creating bucket with OBJECTLOCKING '$BUCKET'"
+    				${MC} mb --with-lock myminio/$BUCKET
+    			elif [ $OBJECTLOCKING = false ]; then
+    				echo "Creating bucket '$BUCKET'"
+    				${MC} mb myminio/$BUCKET
+    			fi
+    		elif [ -z $OBJECTLOCKING ]; then
+    			echo "Creating bucket '$BUCKET'"
+    			${MC} mb myminio/$BUCKET
+    		else
+    			echo "Bucket '$BUCKET' already exists."
+    		fi
+    	fi
+    
+    	# set versioning for bucket if objectlocking is disabled or not set
+    	if [ $OBJECTLOCKING = false ]; then
+    		if [ ! -z $VERSIONING ]; then
+    			if [ $VERSIONING = true ]; then
+    				echo "Enabling versioning for '$BUCKET'"
+    				${MC} version enable myminio/$BUCKET
+    			elif [ $VERSIONING = false ]; then
+    				echo "Suspending versioning for '$BUCKET'"
+    				${MC} version suspend myminio/$BUCKET
+    			fi
+    		fi
+    	else
+    		echo "Bucket '$BUCKET' versioning unchanged."
+    	fi
+    
+    	# At this point, the bucket should exist, skip checking for existence
+    	# Set policy on the bucket
+    	echo "Setting policy of bucket '$BUCKET' to '$POLICY'."
+    	${MC} anonymous set $POLICY myminio/$BUCKET
+    }
+    
+    # Try connecting to MinIO instance
+    scheme=http
+    connectToMinio $scheme
+    
+    
+    
+    # Create the buckets
+    createBucket mimir-tsdb "none" false false false
+    createBucket mimir-ruler "none" false false false
+    createBucket enterprise-metrics-tsdb "none" false false false
+    createBucket enterprise-metrics-admin "none" false false false
+    createBucket enterprise-metrics-ruler "none" false false false
+    
+  add-user: |-
+    #!/bin/sh
+    set -e ; # Have script exit in the event of a failed command.
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    
+    # AccessKey and secretkey credentials file are added to prevent shell execution errors caused by special characters.
+    # Special characters for example : ',",<,>,{,}
+    MINIO_ACCESSKEY_SECRETKEY_TMP="/tmp/accessKey_and_secretKey_tmp"
+    
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for MinIO service to be available
+    connectToMinio() {
+      SCHEME=$1
+      ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+      set -e ; # fail if we can't read the keys.
+      ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+      set +e ; # The connections to minio are allowed to fail.
+      echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+      MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+      $MC_COMMAND ;
+      STATUS=$? ;
+      until [ $STATUS = 0 ]
+      do
+        ATTEMPTS=`expr $ATTEMPTS + 1` ;
+        echo \"Failed attempts: $ATTEMPTS\" ;
+        if [ $ATTEMPTS -gt $LIMIT ]; then
+          exit 1 ;
+        fi ;
+        sleep 2 ; # 1 second intervals between attempts
+        $MC_COMMAND ;
+        STATUS=$? ;
+      done ;
+      set -e ; # reset `e` as active
+      return 0
+    }
+    
+    # checkUserExists ()
+    # Check if the user exists, by using the exit code of `mc admin user info`
+    checkUserExists() {
+      CMD=$(${MC} admin user info myminio $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) > /dev/null 2>&1)
+      return $?
+    }
+    
+    # createUser ($policy)
+    createUser() {
+      POLICY=$1
+      #check accessKey_and_secretKey_tmp file
+      if [[ ! -f $MINIO_ACCESSKEY_SECRETKEY_TMP ]];then
+        echo "credentials file does not exist"
+        return 1
+      fi
+      if [[ $(cat $MINIO_ACCESSKEY_SECRETKEY_TMP|wc -l) -ne 2 ]];then
+        echo "credentials file is invalid"
+        rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
+        return 1
+      fi
+      USER=$(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP)
+      # Create the user if it does not exist
+      if ! checkUserExists ; then
+        echo "Creating user '$USER'"
+        cat $MINIO_ACCESSKEY_SECRETKEY_TMP | ${MC} admin user add myminio
+      else
+        echo "User '$USER' already exists."
+      fi
+      #clean up credentials files.
+      rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
+    
+      # set policy for user
+      if [ ! -z $POLICY -a $POLICY != " " ] ; then
+          echo "Adding policy '$POLICY' for '$USER'"
+          set +e ; # policy already attach errors out, allow it.
+          ${MC} admin policy attach myminio $POLICY --user=$USER
+          set -e
+      else
+          echo "User '$USER' has no policy attached."
+      fi
+    }
+    
+    # Try connecting to MinIO instance
+    scheme=http
+    connectToMinio $scheme
+    
+    
+    
+    # Create the users
+    echo console > $MINIO_ACCESSKEY_SECRETKEY_TMP
+    echo console123 >> $MINIO_ACCESSKEY_SECRETKEY_TMP
+    createUser consoleAdmin
+    
+  add-policy: |-
+    #!/bin/sh
+    set -e ; # Have script exit in the event of a failed command.
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for MinIO service to be available
+    connectToMinio() {
+      SCHEME=$1
+      ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+      set -e ; # fail if we can't read the keys.
+      ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+      set +e ; # The connections to minio are allowed to fail.
+      echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+      MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+      $MC_COMMAND ;
+      STATUS=$? ;
+      until [ $STATUS = 0 ]
+      do
+        ATTEMPTS=`expr $ATTEMPTS + 1` ;
+        echo \"Failed attempts: $ATTEMPTS\" ;
+        if [ $ATTEMPTS -gt $LIMIT ]; then
+          exit 1 ;
+        fi ;
+        sleep 2 ; # 1 second intervals between attempts
+        $MC_COMMAND ;
+        STATUS=$? ;
+      done ;
+      set -e ; # reset `e` as active
+      return 0
+    }
+    
+    # checkPolicyExists ($policy)
+    # Check if the policy exists, by using the exit code of `mc admin policy info`
+    checkPolicyExists() {
+      POLICY=$1
+      CMD=$(${MC} admin policy info myminio $POLICY > /dev/null 2>&1)
+      return $?
+    }
+    
+    # createPolicy($name, $filename)
+    createPolicy () {
+      NAME=$1
+      FILENAME=$2
+    
+      # Create the name if it does not exist
+      echo "Checking policy: $NAME (in /config/$FILENAME.json)"
+      if ! checkPolicyExists $NAME ; then
+        echo "Creating policy '$NAME'"
+      else
+        echo "Policy '$NAME' already exists."
+      fi
+      ${MC} admin policy create myminio $NAME /config/$FILENAME.json
+    
+    }
+    
+    # Try connecting to MinIO instance
+    scheme=http
+    connectToMinio $scheme
+    
+    
+    
+  add-svcacct: |-
+    #!/bin/sh
+    set -e ; # Have script exit in the event of a failed command.
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    
+    # AccessKey and secretkey credentials file are added to prevent shell execution errors caused by special characters.
+    # Special characters for example : ',",<,>,{,}
+    MINIO_ACCESSKEY_SECRETKEY_TMP="/tmp/accessKey_and_secretKey_svcacct_tmp"
+    
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for MinIO service to be available
+    connectToMinio() {
+      SCHEME=$1
+      ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+      set -e ; # fail if we can't read the keys.
+      ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+      set +e ; # The connections to minio are allowed to fail.
+      echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+      MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+      $MC_COMMAND ;
+      STATUS=$? ;
+      until [ $STATUS = 0 ]
+      do
+        ATTEMPTS=`expr $ATTEMPTS + 1` ;
+        echo \"Failed attempts: $ATTEMPTS\" ;
+        if [ $ATTEMPTS -gt $LIMIT ]; then
+          exit 1 ;
+        fi ;
+        sleep 2 ; # 2 second intervals between attempts
+        $MC_COMMAND ;
+        STATUS=$? ;
+      done ;
+      set -e ; # reset `e` as active
+      return 0
+    }
+    
+    # checkSvcacctExists ()
+    # Check if the svcacct exists, by using the exit code of `mc admin user svcacct info`
+    checkSvcacctExists() {
+      CMD=$(${MC} admin user svcacct info myminio $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) > /dev/null 2>&1)
+      return $?
+    }
+    
+    # createSvcacct ($user)
+    createSvcacct () {
+      USER=$1
+      FILENAME=$2
+      #check accessKey_and_secretKey_tmp file
+      if [[ ! -f $MINIO_ACCESSKEY_SECRETKEY_TMP ]];then
+        echo "credentials file does not exist"
+        return 1
+      fi
+      if [[ $(cat $MINIO_ACCESSKEY_SECRETKEY_TMP|wc -l) -ne 2 ]];then
+        echo "credentials file is invalid"
+        rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
+        return 1
+      fi
+      SVCACCT=$(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP)
+      # Create the svcacct if it does not exist
+      if ! checkSvcacctExists ; then
+        echo "Creating svcacct '$SVCACCT'"
+        # Check if policy file is define
+        if [ -z $FILENAME ]; then
+          ${MC} admin user svcacct add --access-key $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --secret-key $(tail -n1 $MINIO_ACCESSKEY_SECRETKEY_TMP) myminio $USER
+        else
+          ${MC} admin user svcacct add --access-key $(head -1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --secret-key $(tail -n1 $MINIO_ACCESSKEY_SECRETKEY_TMP) --policy /config/$FILENAME.json myminio $USER
+        fi
+      else
+        echo "Svcacct '$SVCACCT' already exists."
+      fi
+      #clean up credentials files.
+      rm -f $MINIO_ACCESSKEY_SECRETKEY_TMP
+    }
+    
+    # Try connecting to MinIO instance
+    scheme=http
+    connectToMinio $scheme
+    
+    
+    
+  custom-command: |-
+    #!/bin/sh
+    set -e ; # Have script exit in the event of a failed command.
+    MC_CONFIG_DIR="/tmp/minio/mc/"
+    MC="/usr/bin/mc --insecure --config-dir ${MC_CONFIG_DIR}"
+    
+    # connectToMinio
+    # Use a check-sleep-check loop to wait for MinIO service to be available
+    connectToMinio() {
+      SCHEME=$1
+      ATTEMPTS=0 ; LIMIT=29 ; # Allow 30 attempts
+      set -e ; # fail if we can't read the keys.
+      ACCESS=$(cat /config/rootUser) ; SECRET=$(cat /config/rootPassword) ;
+      set +e ; # The connections to minio are allowed to fail.
+      echo "Connecting to MinIO server: $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT" ;
+      MC_COMMAND="${MC} alias set myminio $SCHEME://$MINIO_ENDPOINT:$MINIO_PORT $ACCESS $SECRET" ;
+      $MC_COMMAND ;
+      STATUS=$? ;
+      until [ $STATUS = 0 ]
+      do
+        ATTEMPTS=`expr $ATTEMPTS + 1` ;
+        echo \"Failed attempts: $ATTEMPTS\" ;
+        if [ $ATTEMPTS -gt $LIMIT ]; then
+          exit 1 ;
+        fi ;
+        sleep 2 ; # 1 second intervals between attempts
+        $MC_COMMAND ;
+        STATUS=$? ;
+      done ;
+      set -e ; # reset `e` as active
+      return 0
+    }
+    
+    # runCommand ($@)
+    # Run custom mc command
+    runCommand() {
+      ${MC} "$@"
+      return $?
+    }
+    
+    # Try connecting to MinIO instance
+    scheme=http
+    connectToMinio $scheme

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/console-service.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/console-service.yaml
@@ -1,0 +1,21 @@
+---
+# Source: mimir-distributed/charts/minio/templates/console-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-minio-console
+  labels:
+    app: minio
+    chart: minio-5.3.0
+    release: test-extra-args-values
+    heritage: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9001
+      protocol: TCP
+      targetPort: 9001
+  selector:
+    app: minio
+    release: test-extra-args-values

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/deployment.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/deployment.yaml
@@ -1,0 +1,85 @@
+---
+# Source: mimir-distributed/charts/minio/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-extra-args-values-minio
+  labels:
+    app: minio
+    chart: minio-5.3.0
+    release: test-extra-args-values
+    heritage: Helm
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+      release: test-extra-args-values
+  template:
+    metadata:
+      name: test-extra-args-values-minio
+      labels:
+        app: minio
+        release: test-extra-args-values
+      annotations:
+        checksum/secrets: 5cf9a2b331ff3c6793592f371e9acf102fa5918f4b412442425e0e2c95ff2cdb
+        checksum/config: 956c5b7448d778d78ed548aba2e68a8e48698e5c4dd4b859f966947f3dcf32fd
+    spec:
+      securityContext:
+        
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsUser: 1000
+      
+      serviceAccountName: minio-sa
+      containers:
+        - name: minio
+          image: "quay.io/minio/minio:RELEASE.2024-04-18T19-09-19Z"
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio server /export -S /etc/minio/certs/ --address :9000 --console-address :9001"
+          volumeMounts:
+            - name: minio-user
+              mountPath: "/tmp/credentials"
+              readOnly: true
+            - name: export
+              mountPath: /export            
+          ports:
+            - name: http
+              containerPort: 9000
+            - name: http-console
+              containerPort: 9001
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: test-extra-args-values-minio
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: test-extra-args-values-minio
+                  key: rootPassword
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: "public"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext: 
+            readOnlyRootFilesystem: false      
+      volumes:
+        - name: export
+          persistentVolumeClaim:
+            claimName: test-extra-args-values-minio
+        - name: minio-user
+          secret:
+            secretName: test-extra-args-values-minio

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/post-job.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/post-job.yaml
@@ -1,0 +1,74 @@
+---
+# Source: mimir-distributed/charts/minio/templates/post-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-extra-args-values-minio-post-job
+  labels:
+    app: minio-post-job
+    chart: minio-5.3.0
+    release: test-extra-args-values
+    heritage: Helm
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  template:
+    metadata:
+      labels:
+        app: minio-job
+        release: test-extra-args-values
+    spec:
+      restartPolicy: OnFailure      
+      volumes:
+        - name: etc-path
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: minio-configuration
+          projected:
+            sources:
+              - configMap:
+                  name: test-extra-args-values-minio
+              - secret:
+                  name: test-extra-args-values-minio
+      serviceAccountName: minio-sa
+      containers:
+        - name: minio-make-bucket
+          image: "quay.io/minio/mc:RELEASE.2024-04-18T16-45-29Z"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/sh", "/config/initialize" ]
+          env:
+            - name: MINIO_ENDPOINT
+              value: test-extra-args-values-minio
+            - name: MINIO_PORT
+              value: "9000"
+          volumeMounts:
+            - name: etc-path
+              mountPath: /etc/minio/mc
+            - name: tmp
+              mountPath: /tmp
+            - name: minio-configuration
+              mountPath: /config
+          resources:
+            requests:
+              memory: 128Mi
+        - name: minio-make-user
+          image: "quay.io/minio/mc:RELEASE.2024-04-18T16-45-29Z"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/sh", "/config/add-user" ]
+          env:
+            - name: MINIO_ENDPOINT
+              value: test-extra-args-values-minio
+            - name: MINIO_PORT
+              value: "9000"
+          volumeMounts:
+            - name: etc-path
+              mountPath: /etc/minio/mc
+            - name: tmp
+              mountPath: /tmp
+            - name: minio-configuration
+              mountPath: /config
+          resources:
+            requests:
+              memory: 128Mi

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/pvc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/pvc.yaml
@@ -1,0 +1,17 @@
+---
+# Source: mimir-distributed/charts/minio/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-extra-args-values-minio
+  labels:
+    app: minio
+    chart: minio-5.3.0
+    release: test-extra-args-values
+    heritage: Helm
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "5Gi"

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/secrets.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/secrets.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/minio/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-extra-args-values-minio
+  labels:
+    app: minio
+    chart: minio-5.3.0
+    release: test-extra-args-values
+    heritage: Helm
+type: Opaque
+data:
+  rootUser: "Z3JhZmFuYS1taW1pcg=="
+  rootPassword: "c3VwZXJzZWNyZXQ="

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/service.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/service.yaml
@@ -1,0 +1,22 @@
+---
+# Source: mimir-distributed/charts/minio/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-minio
+  labels:
+    app: minio
+    chart: minio-5.3.0
+    release: test-extra-args-values
+    heritage: Helm
+    monitoring: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app: minio
+    release: test-extra-args-values

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/minio/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+# Source: mimir-distributed/charts/minio/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "minio-sa"

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -1,0 +1,65 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-extra-args-values-rollout-operator
+  labels:
+    helm.sh/chart: rollout-operator-0.20.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rollout-operator
+      app.kubernetes.io/instance: test-extra-args-values
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rollout-operator
+        app.kubernetes.io/instance: test-extra-args-values
+    spec:
+      serviceAccountName: test-extra-args-values-rollout-operator
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: rollout-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          image: "grafana/rollout-operator:v0.20.0"
+          imagePullPolicy: IfNotPresent
+          args:
+          - -kubernetes.namespace=citestns
+          ports:
+            - name: http-metrics
+              containerPort: 8001
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -1,0 +1,36 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-extra-args-values-rollout-operator
+  labels:
+    helm.sh/chart: rollout-operator-0.20.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - watch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - update

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-extra-args-values-rollout-operator
+  labels:
+    helm.sh/chart: rollout-operator-0.20.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-extra-args-values-rollout-operator
+subjects:
+- kind: ServiceAccount
+  name: test-extra-args-values-rollout-operator

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-extra-args-values-rollout-operator
+  labels:
+    helm.sh/chart: rollout-operator-0.20.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/version: "v0.20.0"
+    app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
@@ -1,0 +1,21 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-extra-args-values-mimir-alertmanager-fallback-config
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {} 
+  namespace: "citestns"
+data:
+  alertmanager_fallback_config.yaml: |
+    receivers:
+        - name: default-receiver
+    route:
+        receiver: default-receiver

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-alertmanager
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: alertmanager
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -1,0 +1,140 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-extra-args-values-mimir-alertmanager
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: alertmanager
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-extra-args-values-mimir-alertmanager
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "1Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: alertmanager
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: alertmanager
+      terminationGracePeriodSeconds: 900
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: tmp
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}
+        - name: alertmanager-fallback-config
+          configMap:
+            name: test-extra-args-values-mimir-alertmanager-fallback-config
+      containers:
+        - name: alertmanager
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=alertmanager"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            # Prometheus HTTP client used to send alerts has a hard-coded idle
+            # timeout of 5 minutes, therefore the server timeout for Alertmanager
+            # needs to be higher to avoid connections being closed abruptly.
+            - "-server.http-idle-timeout=6m"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: alertmanager-fallback-config
+              mountPath: /configs/
+            - name: tmp
+              mountPath: /tmp
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -1,0 +1,36 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-alertmanager-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+    - port: 9094
+      protocol: TCP
+      name: cluster
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: alertmanager

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-alertmanager
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: alertmanager

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/compactor/compactor-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/compactor/compactor-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/compactor/compactor-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-compactor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: compactor
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -1,0 +1,128 @@
+---
+# Source: mimir-distributed/templates/compactor/compactor-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-extra-args-values-mimir-compactor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: compactor
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-extra-args-values-mimir-compactor
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: compactor
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: compactor
+      terminationGracePeriodSeconds: 900
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: compactor
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=compactor"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/compactor/compactor-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-compactor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: compactor

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -1,0 +1,133 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-extra-args-values-mimir-distributor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: distributor
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: distributor
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: distributor
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=distributor"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            # When write requests go through distributors via gRPC, we want gRPC clients to re-resolve the distributors DNS
+            # endpoint before the distributor process is terminated, in order to avoid any failures during graceful shutdown.
+            # To achieve it, we set a shutdown delay greater than the gRPC max connection age.
+            - "-server.grpc.keepalive.max-connection-age=60s"
+            - "-server.grpc.keepalive.max-connection-age-grace=5m"
+            - "-server.grpc.keepalive.max-connection-idle=1m"
+            - "-shutdown-delay=90s"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "8"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: distributor
+      terminationGracePeriodSeconds: 100
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-distributor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: distributor
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-distributor-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: distributor

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/distributor/distributor-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-distributor
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: distributor

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -1,0 +1,26 @@
+---
+# Source: mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-gossip-ring
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: gossip-ring
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: gossip-ring
+      port: 7946
+      appProtocol: tcp
+      protocol: TCP
+      targetPort: 7946
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/part-of: memberlist

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-ingester
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: ingester
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -1,0 +1,408 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-extra-args-values-mimir-ingester-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-a"
+    rollout-group: ingester
+    zone: zone-a
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: ingester
+      rollout-group: ingester
+      zone: zone-a
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-extra-args-values-mimir-ingester-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: memberlist
+        name: "ingester-zone-a"
+        rollout-group: ingester
+        zone: zone-a
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: ingester
+      terminationGracePeriodSeconds: 1200
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: ingester
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ingester"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-ingester.ring.instance-availability-zone=zone-a"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            
+            - name: "GOMAXPROCS"
+              value: "4"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+---
+# Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-extra-args-values-mimir-ingester-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-b"
+    rollout-group: ingester
+    zone: zone-b
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: ingester
+      rollout-group: ingester
+      zone: zone-b
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-extra-args-values-mimir-ingester-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: memberlist
+        name: "ingester-zone-b"
+        rollout-group: ingester
+        zone: zone-b
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: ingester
+      terminationGracePeriodSeconds: 1200
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: ingester
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ingester"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-ingester.ring.instance-availability-zone=zone-b"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            
+            - name: "GOMAXPROCS"
+              value: "4"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+---
+# Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-extra-args-values-mimir-ingester-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-c"
+    rollout-group: ingester
+    zone: zone-c
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: ingester
+      rollout-group: ingester
+      zone: zone-c
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-extra-args-values-mimir-ingester-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ingester
+        app.kubernetes.io/part-of: memberlist
+        name: "ingester-zone-c"
+        rollout-group: ingester
+        zone: zone-c
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: ingester
+      terminationGracePeriodSeconds: 1200
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: ingester
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ingester"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-ingester.ring.instance-availability-zone=zone-c"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            
+            - name: "GOMAXPROCS"
+              value: "4"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-ingester-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -1,0 +1,105 @@
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-ingester-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-a"
+    rollout-group: ingester
+    zone: zone-a
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    rollout-group: ingester
+    zone: zone-a
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-ingester-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-b"
+    rollout-group: ingester
+    zone: zone-b
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    rollout-group: ingester
+    zone: zone-b
+---
+# Source: mimir-distributed/templates/ingester/ingester-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-ingester-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "ingester-zone-c"
+    rollout-group: ingester
+    zone: zone-c
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ingester
+    rollout-group: ingester
+    zone: zone-c

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -1,0 +1,118 @@
+---
+# Source: mimir-distributed/templates/mimir-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-extra-args-values-mimir-config
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+data:
+  mimir.yaml: |
+    
+    activity_tracker:
+      filepath: /active-query-tracker/activity.log
+    alertmanager:
+      data_dir: /data
+      enable_api: true
+      external_url: /alertmanager
+      fallback_config_file: /configs/alertmanager_fallback_config.yaml
+    alertmanager_storage:
+      backend: s3
+      s3:
+        access_key_id: grafana-mimir
+        bucket_name: mimir-ruler
+        endpoint: test-extra-args-values-minio.citestns.svc:9000
+        insecure: true
+        secret_access_key: supersecret
+    blocks_storage:
+      backend: s3
+      bucket_store:
+        sync_dir: /data/tsdb-sync
+      s3:
+        access_key_id: grafana-mimir
+        bucket_name: mimir-tsdb
+        endpoint: test-extra-args-values-minio.citestns.svc:9000
+        insecure: true
+        secret_access_key: supersecret
+      tsdb:
+        dir: /data/tsdb
+        head_compaction_interval: 15m
+        wal_replay_concurrency: 3
+    compactor:
+      compaction_interval: 30m
+      data_dir: /data
+      deletion_delay: 2h
+      first_level_compaction_wait_period: 25m
+      max_closing_blocks_concurrency: 2
+      max_opening_blocks_concurrency: 4
+      sharding_ring:
+        heartbeat_period: 1m
+        heartbeat_timeout: 4m
+        wait_stability_min_duration: 1m
+      symbols_flushers_concurrency: 4
+    distributor:
+      ring:
+        heartbeat_period: 1m
+        heartbeat_timeout: 4m
+    frontend:
+      parallelize_shardable_queries: true
+      scheduler_address: test-extra-args-values-mimir-query-scheduler-headless.citestns.svc:9095
+    frontend_worker:
+      grpc_client_config:
+        max_send_msg_size: 419430400
+      scheduler_address: test-extra-args-values-mimir-query-scheduler-headless.citestns.svc:9095
+    ingester:
+      ring:
+        final_sleep: 0s
+        heartbeat_period: 2m
+        heartbeat_timeout: 10m
+        num_tokens: 512
+        tokens_file_path: /data/tokens
+        unregister_on_shutdown: false
+        zone_awareness_enabled: true
+    ingester_client:
+      grpc_client_config:
+        max_recv_msg_size: 104857600
+        max_send_msg_size: 104857600
+    limits:
+      max_cache_freshness: 10m
+      max_query_parallelism: 240
+      max_total_query_length: 12000h
+    memberlist:
+      abort_if_cluster_join_fails: false
+      compression_enabled: false
+      join_members:
+      - dns+test-extra-args-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
+    querier:
+      max_concurrent: 16
+    query_scheduler:
+      max_outstanding_requests_per_tenant: 800
+    ruler:
+      alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.test-extra-args-values-mimir-alertmanager-headless.citestns.svc.cluster.local./alertmanager
+      enable_api: true
+      rule_path: /data
+    ruler_storage:
+      backend: s3
+      s3:
+        access_key_id: grafana-mimir
+        bucket_name: mimir-ruler
+        endpoint: test-extra-args-values-minio.citestns.svc:9000
+        insecure: true
+        secret_access_key: supersecret
+    runtime_config:
+      file: /var/mimir/runtime.yaml
+    store_gateway:
+      sharding_ring:
+        heartbeat_period: 1m
+        heartbeat_timeout: 4m
+        kvstore:
+          prefix: multi-zone/
+        tokens_file_path: /data/tokens
+        unregister_on_shutdown: false
+        wait_stability_min_duration: 1m
+        zone_awareness_enabled: true
+    usage_stats:
+      installation_mode: helm

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/minio/create-bucket-job.yaml
@@ -1,0 +1,47 @@
+---
+# Source: mimir-distributed/templates/minio/create-bucket-job.yaml
+# Minio provides post-install hook to create bucket
+# however the hook won't be executed if helm install is run
+# with --wait flag. Hence this job is a workaround for that.
+# See https://github.com/grafana/mimir/issues/2464
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-extra-args-values-mimir-make-minio-buckets-5.3.0
+  namespace: "citestns"
+  labels:
+    app: mimir-distributed-make-bucket-job
+    release: test-extra-args-values
+    heritage: Helm
+spec:
+  template:
+    metadata:
+      labels:
+        app: mimir-distributed-job
+        release: test-extra-args-values
+    spec:
+      restartPolicy: OnFailure      
+      volumes:
+        - name: minio-configuration
+          projected:
+            sources:
+            - configMap:
+                name: test-extra-args-values-minio
+            - secret:
+                name: test-extra-args-values-minio
+      containers:
+      - name: minio-mc
+        image: "quay.io/minio/mc:RELEASE.2024-04-18T16-45-29Z"
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "/config/initialize"]
+        env:
+          - name: MINIO_ENDPOINT
+            value: test-extra-args-values-minio
+          - name: MINIO_PORT
+            value: "9000"
+        volumeMounts:
+          - name: minio-configuration
+            mountPath: /config
+        resources:
+          requests:
+            memory: 128Mi

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/nginx/nginx-configmap.yaml
@@ -1,0 +1,138 @@
+---
+# Source: mimir-distributed/templates/nginx/nginx-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-extra-args-values-mimir-nginx
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: nginx
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+data:
+  nginx.conf: |
+    worker_processes  5;  ## Default: 1
+    error_log  /dev/stderr error;
+    pid        /tmp/nginx.pid;
+    worker_rlimit_nofile 8192;
+    
+    events {
+      worker_connections  4096;  ## Default: 1024
+    }
+    
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+    
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+            '"$request" $body_bytes_sent "$http_referer" '
+            '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+    
+      sendfile           on;
+      tcp_nopush         on;
+      proxy_http_version 1.1;
+      resolver kube-dns.kube-system.svc.cluster.local.;
+    
+      # Ensure that X-Scope-OrgID is always present, default to the no_auth_tenant for backwards compatibility when multi-tenancy was turned off.
+      map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        "" "anonymous";
+      }
+    
+      map $http_x_scope_orgid $has_multiple_orgid_headers {
+        default 0;
+        "~^.+,.+$" 1;
+      }
+    
+      proxy_read_timeout 300;
+      server {
+        listen 8080;
+        listen [::]:8080;
+    
+        if ($has_multiple_orgid_headers = 1) {
+            return 400 'Sending multiple X-Scope-OrgID headers is not allowed. Use a single header with | as separator instead.';
+        }
+    
+        location = / {
+          return 200 'OK';
+          auth_basic off;
+        }
+    
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+    
+        # Distributor endpoints
+        location /distributor {
+          set $distributor test-extra-args-values-mimir-distributor-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$distributor:8080$request_uri;
+        }
+        location = /api/v1/push {
+          set $distributor test-extra-args-values-mimir-distributor-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$distributor:8080$request_uri;
+        }
+        location /otlp/v1/metrics {
+          set $distributor test-extra-args-values-mimir-distributor-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$distributor:8080$request_uri;
+        }
+    
+        # Alertmanager endpoints
+        location /alertmanager {
+          set $alertmanager test-extra-args-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+        location = /multitenant_alertmanager/status {
+          set $alertmanager test-extra-args-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+        location = /multitenant_alertmanager/configs {
+          set $alertmanager test-extra-args-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+        location = /api/v1/alerts {
+          set $alertmanager test-extra-args-values-mimir-alertmanager-headless.citestns.svc.cluster.local.;
+          proxy_pass      http://$alertmanager:8080$request_uri;
+        }
+    
+        # Ruler endpoints
+        location /prometheus/config/v1/rules {
+          set $ruler test-extra-args-values-mimir-ruler.citestns.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+        location /prometheus/api/v1/rules {
+          set $ruler test-extra-args-values-mimir-ruler.citestns.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+    
+        location /prometheus/api/v1/alerts {
+          set $ruler test-extra-args-values-mimir-ruler.citestns.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+        location = /ruler/ring {
+          set $ruler test-extra-args-values-mimir-ruler.citestns.svc.cluster.local.;
+          proxy_pass      http://$ruler:8080$request_uri;
+        }
+    
+        # Rest of /prometheus goes to the query frontend
+        location /prometheus {
+          set $query_frontend test-extra-args-values-mimir-query-frontend.citestns.svc.cluster.local.;
+          proxy_pass      http://$query_frontend:8080$request_uri;
+        }
+    
+        # Buildinfo endpoint can go to any component
+        location = /api/v1/status/buildinfo {
+          set $query_frontend test-extra-args-values-mimir-query-frontend.citestns.svc.cluster.local.;
+          proxy_pass      http://$query_frontend:8080$request_uri;
+        }
+    
+        # Compactor endpoint for uploading blocks
+        location /api/v1/upload/block/ {
+          set $compactor test-extra-args-values-mimir-compactor.citestns.svc.cluster.local.;
+          proxy_pass      http://$compactor:8080$request_uri;
+        }
+      }
+    }

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -1,0 +1,92 @@
+---
+# Source: mimir-distributed/templates/nginx/nginx-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-extra-args-values-mimir-nginx
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: nginx
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: nginx
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: nginx
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: nginx
+          image: docker.io/nginxinc/nginx-unprivileged:1.27-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http-metric
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http-metric
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: tmp
+              mountPath: /tmp
+            - name: docker-entrypoint-d-override
+              mountPath: /docker-entrypoint.d
+          resources:
+            {}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: nginx
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-nginx
+        - name: tmp
+          emptyDir: {}
+        - name: docker-entrypoint-d-override
+          emptyDir: {}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/nginx/nginx-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/nginx/nginx-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/nginx/nginx-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-nginx
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: nginx
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: nginx
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/nginx/nginx-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/nginx/nginx-svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: mimir-distributed/templates/nginx/nginx-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-nginx
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: nginx
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metric
+      port: 80
+      targetPort: http-metric
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: nginx

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -1,0 +1,110 @@
+---
+# Source: mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {}
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/managed-by: Helm
+  name: test-extra-args-values-mimir-overrides-exporter
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: overrides-exporter
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: overrides-exporter
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: overrides-exporter
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=overrides-exporter"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+      
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/overrides-exporter/overrides-exporter-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-overrides-exporter
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: overrides-exporter
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-overrides-exporter
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: overrides-exporter
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: overrides-exporter

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/templates/podsecuritypolicy.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: test-extra-args-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "seccomp.security.alpha.kubernetes.io/allowedProfileNames": runtime/default
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'persistentVolumeClaim'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -1,0 +1,118 @@
+---
+# Source: mimir-distributed/templates/querier/querier-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-extra-args-values-mimir-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: querier
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: querier
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: querier
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=querier"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "5000"
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: querier
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/querier/querier-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/querier/querier-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/querier/querier-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: querier
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/querier/querier-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/querier/querier-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: querier

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -1,0 +1,122 @@
+---
+# Source: mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-extra-args-values-mimir-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: query-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: query-frontend
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: query-frontend
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=query-frontend"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            # Reduce the likelihood of queries hitting terminated query-frontends.
+            - "-server.grpc.keepalive.max-connection-age=30s"
+            - "-shutdown-delay=90s"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: config
+              mountPath: /etc/mimir
+            - name: storage
+              mountPath: /data
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "5000"
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: query-frontend
+      terminationGracePeriodSeconds: 390
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/query-frontend/query-frontend-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: query-frontend
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: query-frontend

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -1,0 +1,114 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-extra-args-values-mimir-query-scheduler
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: query-scheduler
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: query-scheduler
+      annotations:
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: query-scheduler
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=query-scheduler"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: config
+              mountPath: /etc/mimir
+            - name: storage
+              mountPath: /data
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: query-scheduler
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-query-scheduler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: query-scheduler
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-query-scheduler-headless
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: query-scheduler

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-query-scheduler
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: query-scheduler

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/role.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/role.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-extra-args-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [test-extra-args-values-mimir]

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/rolebinding.yaml
@@ -1,0 +1,20 @@
+---
+# Source: mimir-distributed/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-extra-args-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-extra-args-values-mimir
+subjects:
+- kind: ServiceAccount
+  name: test-extra-args-values-mimir
+- kind: ServiceAccount
+  name: test-extra-args-values-mimir-distributed

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -1,0 +1,124 @@
+---
+# Source: mimir-distributed/templates/ruler/ruler-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-extra-args-values-mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: ruler
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ruler
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ruler
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=ruler"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-distributor.remote-timeout=10s"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: ruler
+      terminationGracePeriodSeconds: 600
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ruler/ruler-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ruler/ruler-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/ruler/ruler-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: ruler
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -1,0 +1,26 @@
+---
+# Source: mimir-distributed/templates/ruler/ruler-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-ruler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ruler
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: ruler

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/runtime-configmap.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/runtime-configmap.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/templates/runtime-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-extra-args-values-mimir-runtime
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+data:
+  runtime.yaml: |
+    
+    {}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: mimir-distributed/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-extra-args-values-mimir
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -1,0 +1,60 @@
+---
+# Source: mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-extra-args-values-mimir-smoke-test
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: smoke-test
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+  namespace: "citestns"
+spec:
+  backoffLimit: 5
+  completions: 1
+  parallelism: 1
+  selector:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: smoke-test
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        []
+      containers:
+        - name: smoke-test
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=continuous-test"
+            - "-activity-tracker.filepath="
+            - "-tests.smoke-test"
+            - "-tests.write-endpoint=http://test-extra-args-values-mimir-nginx.citestns.svc:80"
+            - "-tests.read-endpoint=http://test-extra-args-values-mimir-nginx.citestns.svc:80/prometheus"
+            - "-tests.tenant-id="
+            - "-tests.write-read-series-test.num-series=1000"
+            - "-tests.write-read-series-test.max-query-age=48h"
+            - "-server.http-listen-port=8080"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+      restartPolicy: OnFailure
+      volumes:

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: test-extra-args-values-mimir-store-gateway
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: store-gateway
+  maxUnavailable: 1

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -1,0 +1,432 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-extra-args-values-mimir-store-gateway-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-a"
+    rollout-group: store-gateway
+    zone: zone-a
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: store-gateway
+      rollout-group: store-gateway
+      zone: zone-a
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-extra-args-values-mimir-store-gateway-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: memberlist
+        name: "store-gateway-zone-a"
+        rollout-group: store-gateway
+        zone: zone-a
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: store-gateway
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: store-gateway
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=store-gateway"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-store-gateway.sharding-ring.instance-availability-zone=zone-a"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-extra-args-values-mimir-store-gateway-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-b"
+    rollout-group: store-gateway
+    zone: zone-b
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: store-gateway
+      rollout-group: store-gateway
+      zone: zone-b
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-extra-args-values-mimir-store-gateway-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: memberlist
+        name: "store-gateway-zone-b"
+        rollout-group: store-gateway
+        zone: zone-b
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: store-gateway
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: store-gateway
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=store-gateway"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-store-gateway.sharding-ring.instance-availability-zone=zone-b"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-extra-args-values-mimir-store-gateway-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-c"
+    rollout-group: store-gateway
+    zone: zone-c
+  annotations:
+    rollout-max-unavailable: "50"
+  namespace: "citestns"
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-extra-args-values
+      app.kubernetes.io/component: store-gateway
+      rollout-group: store-gateway
+      zone: zone-c
+  updateStrategy:
+    type: OnDelete
+  serviceName: test-extra-args-values-mimir-store-gateway-headless
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-extra-args-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: store-gateway
+        app.kubernetes.io/part-of: memberlist
+        name: "store-gateway-zone-c"
+        rollout-group: store-gateway
+        zone: zone-c
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-extra-args-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: test-extra-args-values
+            app.kubernetes.io/component: store-gateway
+      terminationGracePeriodSeconds: 120
+      volumes:
+        - name: config
+          configMap:
+            name: test-extra-args-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: test-extra-args-values-mimir-runtime
+        - name: active-queries
+          emptyDir: {}
+      containers:
+        - name: store-gateway
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=store-gateway"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-store-gateway.sharding-ring.instance-availability-zone=zone-c"
+            - -flag-bool=false
+            - -flag-empty=
+            - -flag-float=1.23
+            - -flag-json1={"foo":"bar"}
+            - -flag-json2={"foo":"bar"}
+            - -flag-number=0
+            - -flag-string=hello
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 60
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "GOMEMLIMIT"
+              value: "536870912"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "1000"

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-store-gateway-headless
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -1,0 +1,105 @@
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-store-gateway-zone-a
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-a"
+    rollout-group: store-gateway
+    zone: zone-a
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    rollout-group: store-gateway
+    zone: zone-a
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-store-gateway-zone-b
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-b"
+    rollout-group: store-gateway
+    zone: zone-b
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    rollout-group: store-gateway
+    zone: zone-b
+---
+# Source: mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-mimir-store-gateway-zone-c
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    name: "store-gateway-zone-c"
+    rollout-group: store-gateway
+    zone: zone-c
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/component: store-gateway
+    rollout-group: store-gateway
+    zone: zone-c


### PR DESCRIPTION
#### What this PR does

This PR fixes how the chart's templates handle `extraArgs` values. Right now the chart fails to render the manifests if the passed flag contains a JSON value. E.g. flags like `-ruler.max-rule-groups-per-tenant-by-namespace`, etc accept a JSON string. If a user sets the values via the `ruler.extraArgs` value — similar to how we use it in Jsonnet — the chart fails with an obscure error:

```
Error: YAML parse error on mimir-distributed/templates/ruler/ruler-dep.yaml: error converting YAML to JSON: yaml: line 61: did not find expected '-' indicator
```

_Note: I tried fairly hard to find a way how to handle that in better way but failed. After looking around for how other popular Helm charts solve it didn't help either. Everyone seem to just unquote the command args._

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
