### PR TITLE
Ruler: Add support for arbitrary extra URL parameters to Alertmanager client's OAuth config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 * [ENHANCEMENT] Distributor: Initialize ha_tracker cache before ha_tracker and distributor reach running state and begin serving writes. #9826 #9976
 * [ENHANCEMENT] Ingester: `-ingest-storage.kafka.max-buffered-bytes` to limit the memory for buffered records when using concurrent fetching. #9892
 * [ENHANCEMENT] Querier: improve performance and memory consumption of queries that select many series. #9914
-* [ENHANCEMENT] Ruler: Support OAuth2 and proxies in Alertmanager client #9945
+* [ENHANCEMENT] Ruler: Support OAuth2 and proxies in Alertmanager client #9945 #10030
 * [ENHANCEMENT] Ingester: Add `-blocks-storage.tsdb.bigger-out-of-order-blocks-for-old-samples` to build 24h blocks for out-of-order data belonging to the previous days instead of building smaller 2h blocks. This reduces pressure on compactors and ingesters when the out-of-order samples span multiple days in the past. #9844 #10033 #10035
 * [ENHANCEMENT] Distributor: allow a different limit for info series (series ending in `_info`) label count, via `-validation.max-label-names-per-info-series`. #10028
 * [ENHANCEMENT] Ingester: do not reuse labels, samples and histograms slices in the write request if there are more entries than 10x the pre-allocated size. This should help to reduce the in-use memory in case of few requests with a very large number of labels, samples or histograms. #10040

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -12425,6 +12425,14 @@
                   "fieldDefaultValue": "",
                   "fieldFlag": "ruler.alertmanager-client.oauth.scopes",
                   "fieldType": "string"
+                },
+                {
+                  "kind": "block",
+                  "name": "endpoint_params",
+                  "required": false,
+                  "desc": "",
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
                 }
               ],
               "fieldValue": null,

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -12427,12 +12427,15 @@
                   "fieldType": "string"
                 },
                 {
-                  "kind": "block",
+                  "kind": "field",
                   "name": "endpoint_params",
                   "required": false,
-                  "desc": "",
+                  "desc": "Optional additional URL parameters to send to the token URL.",
                   "fieldValue": null,
-                  "fieldDefaultValue": null
+                  "fieldDefaultValue": {},
+                  "fieldFlag": "ruler.alertmanager-client.oauth.endpoint-params",
+                  "fieldType": "map of string to string",
+                  "fieldCategory": "advanced"
                 }
               ],
               "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2829,6 +2829,8 @@ Usage of ./cmd/mimir/mimir:
     	OAuth2 client ID. Enables the use of OAuth2 for authenticating with Alertmanager.
   -ruler.alertmanager-client.oauth.client_secret string
     	OAuth2 client secret.
+  -ruler.alertmanager-client.oauth.endpoint-params value
+    	Optional additional URL parameters to send to the token URL. (default {})
   -ruler.alertmanager-client.oauth.scopes comma-separated-list-of-strings
     	Optional scopes to include with the token request.
   -ruler.alertmanager-client.oauth.token_url string

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -715,6 +715,8 @@ Usage of ./cmd/mimir/mimir:
     	OAuth2 client ID. Enables the use of OAuth2 for authenticating with Alertmanager.
   -ruler.alertmanager-client.oauth.client_secret string
     	OAuth2 client secret.
+  -ruler.alertmanager-client.oauth.endpoint-params value
+    	Optional additional URL parameters to send to the token URL. (default {})
   -ruler.alertmanager-client.oauth.scopes comma-separated-list-of-strings
     	Optional scopes to include with the token request.
   -ruler.alertmanager-client.oauth.token_url string

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1972,6 +1972,8 @@ alertmanager_client:
     # CLI flag: -ruler.alertmanager-client.oauth.scopes
     [scopes: <string> | default = ""]
 
+    endpoint_params:
+
   # (advanced) Optional HTTP, HTTPS via CONNECT, or SOCKS5 proxy URL to route
   # requests through. Applies to all requests, including auxiliary traffic, such
   # as OAuth token requests.

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1972,7 +1972,9 @@ alertmanager_client:
     # CLI flag: -ruler.alertmanager-client.oauth.scopes
     [scopes: <string> | default = ""]
 
-    endpoint_params:
+    # (advanced) Optional additional URL parameters to send to the token URL.
+    # CLI flag: -ruler.alertmanager-client.oauth.endpoint-params
+    [endpoint_params: <map of string to string> | default = {}]
 
   # (advanced) Optional HTTP, HTTPS via CONNECT, or SOCKS5 proxy URL to route
   # requests through. Applies to all requests, including auxiliary traffic, such

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -33,7 +33,6 @@ import (
 var (
 	errRulerNotifierStopped               = cancellation.NewErrorf("rulerNotifier stopped")
 	errRulerSimultaneousBasicAuthAndOAuth = errors.New("cannot use both Basic Auth and OAuth2 simultaneously")
-	errEmptyEndpointParamValue            = errors.New("endpoint params value cannot be empty")
 )
 
 type NotifierConfig struct {

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -52,13 +52,6 @@ func (cfg *NotifierConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.ProxyURL, "ruler.alertmanager-client.proxy-url", "", "Optional HTTP, HTTPS via CONNECT, or SOCKS5 proxy URL to route requests through. Applies to all requests, including auxiliary traffic, such as OAuth token requests.")
 }
 
-func validateOAuth2EndpointParam(_ string, v string) error {
-	if v == "" {
-		return errEmptyEndpointParamValue
-	}
-	return nil
-}
-
 type OAuth2Config struct {
 	ClientID       string                       `yaml:"client_id"`
 	ClientSecret   flagext.Secret               `yaml:"client_secret"`
@@ -73,7 +66,7 @@ func (cfg *OAuth2Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet)
 	f.StringVar(&cfg.TokenURL, prefix+"token_url", "", "Endpoint used to fetch access token.")
 	f.Var(&cfg.Scopes, prefix+"scopes", "Optional scopes to include with the token request.")
 	if !cfg.EndpointParams.IsInitialized() {
-		cfg.EndpointParams = validation.NewLimitsMap(validateOAuth2EndpointParam)
+		cfg.EndpointParams = validation.NewLimitsMap[string](nil)
 	}
 	f.Var(&cfg.EndpointParams, prefix+"endpoint-params", "Optional additional URL parameters to send to the token URL.")
 }

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -52,7 +52,7 @@ func (cfg *NotifierConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.ProxyURL, "ruler.alertmanager-client.proxy-url", "", "Optional HTTP, HTTPS via CONNECT, or SOCKS5 proxy URL to route requests through. Applies to all requests, including auxiliary traffic, such as OAuth token requests.")
 }
 
-func validateOAuth2EndpointParam(k string, v string) error {
+func validateOAuth2EndpointParam(_ string, v string) error {
 	if v == "" {
 		return errEmptyEndpointParamValue
 	}

--- a/pkg/ruler/notifier_test.go
+++ b/pkg/ruler/notifier_test.go
@@ -392,7 +392,7 @@ func TestBuildNotifierConfig(t *testing.T) {
 								"param1": "value1",
 								"param2": "value2",
 							},
-							validateOAuth2EndpointParam,
+							nil,
 						),
 					},
 				},
@@ -558,21 +558,15 @@ func TestOAuth2Config_ValidateEndpointParams(t *testing.T) {
 			args: []string{"-map-flag", "{\"param1\": \"value1\" }"},
 			expected: validation.NewLimitsMapWithData(map[string]string{
 				"param1": "value1",
-			}, validateOAuth2EndpointParam),
+			}, nil),
 		},
-
-		"empty value": {
-			args:  []string{"-map-flag", "{\"param1\": \"\" }"},
-			error: "invalid value \"{\\\"param1\\\": \\\"\\\" }\" for flag -map-flag: endpoint params value cannot be empty",
-		},
-
 		"parsing error": {
 			args:  []string{"-map-flag", "{\"hello\": ..."},
 			error: "invalid value \"{\\\"hello\\\": ...\" for flag -map-flag: invalid character '.' looking for beginning of value",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			v := validation.NewLimitsMap(validateOAuth2EndpointParam)
+			v := validation.NewLimitsMap[string](nil)
 
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			fs.SetOutput(&bytes.Buffer{}) // otherwise errors would go to stderr.

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -898,7 +898,7 @@ func (o *Overrides) RulerTenantShardSize(userID string) int {
 func (o *Overrides) RulerMaxRulesPerRuleGroup(userID, namespace string) int {
 	u := o.getOverridesForUser(userID)
 
-	if namespaceLimit, ok := u.RulerMaxRulesPerRuleGroupByNamespace.data[namespace]; ok {
+	if namespaceLimit, ok := u.RulerMaxRulesPerRuleGroupByNamespace.Read()[namespace]; ok {
 		return namespaceLimit
 	}
 
@@ -914,7 +914,7 @@ func (o *Overrides) RulerMaxRulesPerRuleGroup(userID, namespace string) int {
 func (o *Overrides) RulerMaxRuleGroupsPerTenant(userID, namespace string) int {
 	u := o.getOverridesForUser(userID)
 
-	if namespaceLimit, ok := u.RulerMaxRuleGroupsPerTenantByNamespace.data[namespace]; ok {
+	if namespaceLimit, ok := u.RulerMaxRuleGroupsPerTenantByNamespace.Read()[namespace]; ok {
 		return namespaceLimit
 	}
 
@@ -990,7 +990,7 @@ func (o *Overrides) AlertmanagerReceiversBlockPrivateAddresses(user string) bool
 // 4. default limits
 func (o *Overrides) getNotificationLimitForUser(user, integration string) float64 {
 	u := o.getOverridesForUser(user)
-	if n, ok := u.NotificationRateLimitPerIntegration.data[integration]; ok {
+	if n, ok := u.NotificationRateLimitPerIntegration.Read()[integration]; ok {
 		return n
 	}
 

--- a/pkg/util/validation/limits_map.go
+++ b/pkg/util/validation/limits_map.go
@@ -16,8 +16,12 @@ type LimitsMap[T float64 | int | string] struct {
 }
 
 func NewLimitsMap[T float64 | int | string](validator func(k string, v T) error) LimitsMap[T] {
+	return NewLimitsMapWithData(make(map[string]T), validator)
+}
+
+func NewLimitsMapWithData[T float64 | int | string](data map[string]T, validator func(k string, v T) error) LimitsMap[T] {
 	return LimitsMap[T]{
-		data:      make(map[string]T),
+		data:      data,
 		validator: validator,
 	}
 }

--- a/pkg/util/validation/limits_map.go
+++ b/pkg/util/validation/limits_map.go
@@ -73,6 +73,7 @@ func (m LimitsMap[T]) updateMap(newMap map[string]T) error {
 		}
 	}
 
+	clear(m.data)
 	for k, v := range newMap {
 		m.data[k] = v
 	}

--- a/pkg/util/validation/limits_map.go
+++ b/pkg/util/validation/limits_map.go
@@ -9,13 +9,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// LimitsMap is a generic map that can hold either float64 or int as values.
-type LimitsMap[T float64 | int] struct {
+// LimitsMap is a flag.Value implementation that looks like a generic map, holding float64s, ints, or strings as values.
+type LimitsMap[T float64 | int | string] struct {
 	data      map[string]T
 	validator func(k string, v T) error
 }
 
-func NewLimitsMap[T float64 | int](validator func(k string, v T) error) LimitsMap[T] {
+func NewLimitsMap[T float64 | int | string](validator func(k string, v T) error) LimitsMap[T] {
 	return LimitsMap[T]{
 		data:      make(map[string]T),
 		validator: validator,

--- a/pkg/util/validation/limits_map.go
+++ b/pkg/util/validation/limits_map.go
@@ -45,6 +45,10 @@ func (m LimitsMap[T]) Set(s string) error {
 	return m.updateMap(newMap)
 }
 
+func (m LimitsMap[T]) Read() map[string]T {
+	return m.data
+}
+
 // Clone returns a copy of the LimitsMap.
 func (m LimitsMap[T]) Clone() LimitsMap[T] {
 	newMap := make(map[string]T, len(m.data))

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -36,19 +36,19 @@ func TestNewLimitsMap(t *testing.T) {
 	t.Run("float64", func(t *testing.T) {
 		lm := NewLimitsMap(fakeFloat64Validator)
 		lm.data["key1"] = 10.6
-		require.Len(t, lm.data, 1)
+		require.Len(t, lm.Read(), 1)
 	})
 
 	t.Run("int", func(t *testing.T) {
 		lm := NewLimitsMap(fakeIntValidator)
 		lm.data["key1"] = 10
-		require.Len(t, lm.data, 1)
+		require.Len(t, lm.Read(), 1)
 	})
 
 	t.Run("string", func(t *testing.T) {
 		lm := NewLimitsMap(fakeStringValidator)
 		lm.data["key1"] = "test"
-		require.Len(t, lm.data, 1)
+		require.Len(t, lm.Read(), 1)
 	})
 }
 
@@ -110,7 +110,7 @@ func TestLimitsMap_SetAndString(t *testing.T) {
 					require.Equal(t, tt.error, err.Error())
 				} else {
 					require.NoError(t, err)
-					require.Equal(t, tt.expected, lm.data)
+					require.Equal(t, tt.expected, lm.Read())
 					require.Equal(t, tt.input, lm.String())
 				}
 			})
@@ -151,7 +151,7 @@ func TestLimitsMap_SetAndString(t *testing.T) {
 					require.Equal(t, tt.error, err.Error())
 				} else {
 					require.NoError(t, err)
-					require.Equal(t, tt.expected, lm.data)
+					require.Equal(t, tt.expected, lm.Read())
 					require.Equal(t, tt.input, lm.String())
 				}
 			})
@@ -416,7 +416,7 @@ func TestLimitsMap_updateMap(t *testing.T) {
 		// Verify that no partial updates were applied.
 		// Because maps in Go are accessed in random order, there's a chance that the validation will fail on the first invalid element of the map thus not asserting partial updates.
 		expectedData := map[string]float64{"a": 1.0, "b": 2.0}
-		require.Equal(t, expectedData, limitsMap.data)
+		require.Equal(t, expectedData, limitsMap.Read())
 	})
 
 	t.Run("updates totally replace all values", func(t *testing.T) {
@@ -428,6 +428,6 @@ func TestLimitsMap_updateMap(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedData := updateData
-		require.Equal(t, expectedData, limitsMap.data)
+		require.Equal(t, expectedData, limitsMap.Read())
 	})
 }

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -11,17 +11,45 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var fakeValidator = func(_ string, v float64) error {
+var fakeFloat64Validator = func(_ string, v float64) error {
 	if v < 0 {
 		return errors.New("value cannot be negative")
 	}
 	return nil
 }
 
+var fakeIntValidator = func(_ string, v int) error {
+	if v < 0 {
+		return errors.New("value cannot be negative")
+	}
+	return nil
+}
+
+var fakeStringValidator = func(_ string, v string) error {
+	if len(v) == 0 {
+		return errors.New("value cannot be empty")
+	}
+	return nil
+}
+
 func TestNewLimitsMap(t *testing.T) {
-	lm := NewLimitsMap(fakeValidator)
-	lm.data["key1"] = 10
-	require.Len(t, lm.data, 1)
+	t.Run("float64", func(t *testing.T) {
+		lm := NewLimitsMap(fakeFloat64Validator)
+		lm.data["key1"] = 10.6
+		require.Len(t, lm.data, 1)
+	})
+
+	t.Run("int", func(t *testing.T) {
+		lm := NewLimitsMap(fakeIntValidator)
+		lm.data["key1"] = 10
+		require.Len(t, lm.data, 1)
+	})
+
+	t.Run("string", func(t *testing.T) {
+		lm := NewLimitsMap(fakeStringValidator)
+		lm.data["key1"] = "test"
+		require.Len(t, lm.data, 1)
+	})
 }
 
 func TestLimitsMap_IsNil(t *testing.T) {
@@ -48,164 +76,338 @@ func TestLimitsMap_IsNil(t *testing.T) {
 }
 
 func TestLimitsMap_SetAndString(t *testing.T) {
-	tc := map[string]struct {
-		input    string
-		expected map[string]float64
-		error    string
-	}{
+	t.Run("numeric", func(t *testing.T) {
+		tc := map[string]struct {
+			input    string
+			expected map[string]float64
+			error    string
+		}{
 
-		"set without error": {
-			input:    `{"key1":10,"key2":20}`,
-			expected: map[string]float64{"key1": 10, "key2": 20},
-		},
-		"set with parsing error": {
-			input: `{"key1": 10, "key2": 20`,
-			error: "unexpected end of JSON input",
-		},
-		"set with validation error": {
-			input: `{"key1": -10, "key2": 20}`,
-			error: "value cannot be negative",
-		},
-	}
+			"set without error": {
+				input:    `{"key1":10,"key2":20}`,
+				expected: map[string]float64{"key1": 10, "key2": 20},
+			},
+			"set with parsing error": {
+				input: `{"key1": 10, "key2": 20`,
+				error: "unexpected end of JSON input",
+			},
+			"set with validation error": {
+				input: `{"key1": -10, "key2": 20}`,
+				error: "value cannot be negative",
+			},
+			"set with incompatible value type": {
+				input: `{"key1": "abc", "key2": "def"}`,
+				error: "json: cannot unmarshal string into Go value of type float64",
+			},
+		}
 
-	for name, tt := range tc {
-		t.Run(name, func(t *testing.T) {
-			lm := NewLimitsMap(fakeValidator)
-			err := lm.Set(tt.input)
-			if tt.error != "" {
-				require.Error(t, err)
-				require.Equal(t, tt.error, err.Error())
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expected, lm.data)
-				require.Equal(t, tt.input, lm.String())
-			}
-		})
-	}
+		for name, tt := range tc {
+			t.Run("numeric/"+name, func(t *testing.T) {
+				lm := NewLimitsMap(fakeFloat64Validator)
+				err := lm.Set(tt.input)
+				if tt.error != "" {
+					require.Error(t, err)
+					require.Equal(t, tt.error, err.Error())
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, lm.data)
+					require.Equal(t, tt.input, lm.String())
+				}
+			})
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		tc := map[string]struct {
+			input    string
+			expected map[string]string
+			error    string
+		}{
+
+			"set without error": {
+				input:    `{"key1":"abc","key2":"def"}`,
+				expected: map[string]string{"key1": "abc", "key2": "def"},
+			},
+			"set with parsing error": {
+				input: `{"key1": "abc", "key2": "def`,
+				error: "unexpected end of JSON input",
+			},
+			"set with validation error": {
+				input: `{"key1": "", "key2": "def"}`,
+				error: "value cannot be empty",
+			},
+			"set with incompatible value type": {
+				input: `{"key1": 10, "key2": 20}`,
+				error: "json: cannot unmarshal number into Go value of type string",
+			},
+		}
+
+		for name, tt := range tc {
+			t.Run("string/"+name, func(t *testing.T) {
+				lm := NewLimitsMap(fakeStringValidator)
+				err := lm.Set(tt.input)
+				if tt.error != "" {
+					require.Error(t, err)
+					require.Equal(t, tt.error, err.Error())
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, lm.data)
+					require.Equal(t, tt.input, lm.String())
+				}
+			})
+		}
+	})
 }
 
 func TestLimitsMap_UnmarshalYAML(t *testing.T) {
-	tc := []struct {
-		name     string
-		input    string
-		expected map[string]float64
-		error    string
-	}{
-		{
-			name: "unmarshal without error",
-			input: `
+	t.Run("numeric", func(t *testing.T) {
+		tc := []struct {
+			name     string
+			input    string
+			expected map[string]float64
+			error    string
+		}{
+			{
+				name: "unmarshal without error",
+				input: `
 key1: 10
 key2: 20
 `,
-			expected: map[string]float64{"key1": 10, "key2": 20},
-		},
-		{
-			name: "unmarshal with validation error",
-			input: `
+				expected: map[string]float64{"key1": 10, "key2": 20},
+			},
+			{
+				name: "unmarshal with validation error",
+				input: `
 key1: -10
 key2: 20
 `,
-			error: "value cannot be negative",
-		},
-		{
-			name: "unmarshal with parsing error",
-			input: `
+				error: "value cannot be negative",
+			},
+			{
+				name: "unmarshal with parsing error",
+				input: `
 key1: 10
 key2: 20
-			key3: 30
+	key3: 30
 `,
-			error: "yaml: line 3: found a tab character that violates indentation",
-		},
-	}
+				error: "yaml: line 3: found a tab character that violates indentation",
+			},
+		}
 
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			lm := NewLimitsMap(fakeValidator)
-			err := yaml.Unmarshal([]byte(tt.input), &lm)
-			if tt.error != "" {
-				require.Error(t, err)
-				require.Equal(t, tt.error, err.Error())
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expected, lm.data)
-			}
-		})
-	}
+		for _, tt := range tc {
+			t.Run(tt.name, func(t *testing.T) {
+				lm := NewLimitsMap(fakeFloat64Validator)
+				err := yaml.Unmarshal([]byte(tt.input), &lm)
+				if tt.error != "" {
+					require.Error(t, err)
+					require.Equal(t, tt.error, err.Error())
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, lm.data)
+				}
+			})
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		tc := []struct {
+			name     string
+			input    string
+			expected map[string]string
+			error    string
+		}{
+			{
+				name: "unmarshal without error",
+				input: `
+key1: abc
+key2: def
+`,
+				expected: map[string]string{"key1": "abc", "key2": "def"},
+			},
+			{
+				name: "unmarshal with validation error",
+				input: `
+key1: abc
+key2: ""
+`,
+				error: "value cannot be empty",
+			},
+			{
+				name: "unmarshal with parsing error",
+				input: `
+key1: abc
+key2: def
+	key3: ghi
+`,
+				error: "yaml: line 3: found a tab character that violates indentation",
+			},
+		}
+
+		for _, tt := range tc {
+			t.Run(tt.name, func(t *testing.T) {
+				lm := NewLimitsMap(fakeStringValidator)
+				err := yaml.Unmarshal([]byte(tt.input), &lm)
+				if tt.error != "" {
+					require.Error(t, err)
+					require.Equal(t, tt.error, err.Error())
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, lm.data)
+				}
+			})
+		}
+	})
+
 }
 
 func TestLimitsMap_MarshalYAML(t *testing.T) {
-	lm := NewLimitsMap(fakeValidator)
-	lm.data["key1"] = 10
-	lm.data["key2"] = 20
+	t.Run("numeric", func(t *testing.T) {
+		lm := NewLimitsMap(fakeFloat64Validator)
+		lm.data["key1"] = 10
+		lm.data["key2"] = 20
 
-	out, err := yaml.Marshal(&lm)
-	require.NoError(t, err)
-	require.Equal(t, "key1: 10\nkey2: 20\n", string(out))
+		out, err := yaml.Marshal(&lm)
+		require.NoError(t, err)
+		require.Equal(t, "key1: 10\nkey2: 20\n", string(out))
+	})
+
+	t.Run("string", func(t *testing.T) {
+		lm := NewLimitsMap(fakeStringValidator)
+		lm.data["key1"] = "abc"
+		lm.data["key2"] = "def"
+
+		out, err := yaml.Marshal(&lm)
+		require.NoError(t, err)
+		require.Equal(t, "key1: abc\nkey2: def\n", string(out))
+	})
 }
 
 func TestLimitsMap_Equal(t *testing.T) {
-	tc := map[string]struct {
-		map1     LimitsMap[float64]
-		map2     LimitsMap[float64]
-		expected bool
-	}{
-		"Equal maps with same key-value pairs": {
-			map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
-			map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
-			expected: true,
-		},
-		"Different maps with different lengths": {
-			map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
-			map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
-			expected: false,
-		},
-		"Different maps with same keys but different values": {
-			map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
-			map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.2}},
-			expected: false,
-		},
-		"Equal empty maps": {
-			map1:     LimitsMap[float64]{data: map[string]float64{}},
-			map2:     LimitsMap[float64]{data: map[string]float64{}},
-			expected: true,
-		},
-	}
+	t.Run("numeric", func(t *testing.T) {
+		tc := map[string]struct {
+			map1     LimitsMap[float64]
+			map2     LimitsMap[float64]
+			expected bool
+		}{
+			"Equal maps with same key-value pairs": {
+				map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
+				map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
+				expected: true,
+			},
+			"Different maps with different lengths": {
+				map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
+				map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1, "key2": 2.2}},
+				expected: false,
+			},
+			"Different maps with same keys but different values": {
+				map1:     LimitsMap[float64]{data: map[string]float64{"key1": 1.1}},
+				map2:     LimitsMap[float64]{data: map[string]float64{"key1": 1.2}},
+				expected: false,
+			},
+			"Equal empty maps": {
+				map1:     LimitsMap[float64]{data: map[string]float64{}},
+				map2:     LimitsMap[float64]{data: map[string]float64{}},
+				expected: true,
+			},
+		}
 
-	for name, tt := range tc {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, tt.expected, tt.map1.Equal(LimitsMap[float64]{data: tt.map2.data}))
-			require.Equal(t, tt.expected, cmp.Equal(tt.map1, tt.map2))
-		})
-	}
+		for name, tt := range tc {
+			t.Run(name, func(t *testing.T) {
+				require.Equal(t, tt.expected, tt.map1.Equal(LimitsMap[float64]{data: tt.map2.data}))
+				require.Equal(t, tt.expected, cmp.Equal(tt.map1, tt.map2))
+			})
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		tc := map[string]struct {
+			map1     LimitsMap[string]
+			map2     LimitsMap[string]
+			expected bool
+		}{
+			"Equal maps with same key-value pairs": {
+				map1:     LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
+				map2:     LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
+				expected: true,
+			},
+			"Different maps with different lengths": {
+				map1:     LimitsMap[string]{data: map[string]string{"key1": "abc"}},
+				map2:     LimitsMap[string]{data: map[string]string{"key1": "abc", "key2": "def"}},
+				expected: false,
+			},
+			"Different maps with same keys but different values": {
+				map1:     LimitsMap[string]{data: map[string]string{"key1": "abc"}},
+				map2:     LimitsMap[string]{data: map[string]string{"key1": "def"}},
+				expected: false,
+			},
+			"Equal empty maps": {
+				map1:     LimitsMap[string]{data: map[string]string{}},
+				map2:     LimitsMap[string]{data: map[string]string{}},
+				expected: true,
+			},
+		}
+
+		for name, tt := range tc {
+			t.Run(name, func(t *testing.T) {
+				require.Equal(t, tt.expected, tt.map1.Equal(LimitsMap[string]{data: tt.map2.data}))
+				require.Equal(t, tt.expected, cmp.Equal(tt.map1, tt.map2))
+			})
+		}
+	})
+
 }
 
 func TestLimitsMap_Clone(t *testing.T) {
-	// Create an initial LimitsMap with some data.
-	original := NewLimitsMap[float64](fakeValidator)
-	original.data["limit1"] = 1.0
-	original.data["limit2"] = 2.0
+	t.Run("numeric", func(t *testing.T) {
+		// Create an initial LimitsMap with some data.
+		original := NewLimitsMap[float64](nil)
+		original.data["limit1"] = 1.0
+		original.data["limit2"] = 2.0
 
-	// Clone the original LimitsMap.
-	cloned := original.Clone()
+		// Clone the original LimitsMap.
+		cloned := original.Clone()
 
-	// Check that the cloned LimitsMap is equal to the original.
-	require.True(t, original.Equal(cloned), "expected cloned LimitsMap to be different from original")
+		// Check that the cloned LimitsMap is equal to the original.
+		require.True(t, original.Equal(cloned), "expected cloned LimitsMap to be different from original")
 
-	// Modify the original LimitsMap and ensure the cloned map is not affected.
-	original.data["limit1"] = 10.0
-	require.False(t, cloned.data["limit1"] == 10.0, "expected cloned LimitsMap to be unaffected by changes to original")
+		// Modify the original LimitsMap and ensure the cloned map is not affected.
+		original.data["limit1"] = 10.0
+		require.False(t, cloned.data["limit1"] == 10.0, "expected cloned LimitsMap to be unaffected by changes to original")
 
-	// Modify the cloned LimitsMap and ensure the original map is not affected.
-	cloned.data["limit3"] = 3.0
-	_, exists := original.data["limit3"]
-	require.False(t, exists, "expected original LimitsMap to be unaffected by changes to cloned")
+		// Modify the cloned LimitsMap and ensure the original map is not affected.
+		cloned.data["limit3"] = 3.0
+		_, exists := original.data["limit3"]
+		require.False(t, exists, "expected original LimitsMap to be unaffected by changes to cloned")
+	})
+
+	t.Run("string", func(t *testing.T) {
+		// Create an initial LimitsMap with some data.
+		original := NewLimitsMap[string](nil)
+		original.data["limit1"] = "abc"
+		original.data["limit2"] = "def"
+
+		// Clone the original LimitsMap.
+		cloned := original.Clone()
+
+		// Check that the cloned LimitsMap is equal to the original.
+		require.True(t, original.Equal(cloned), "expected cloned LimitsMap to be different from original")
+
+		// Modify the original LimitsMap and ensure the cloned map is not affected.
+		original.data["limit1"] = "zxcv"
+		require.False(t, cloned.data["limit1"] == "zxcv", "expected cloned LimitsMap to be unaffected by changes to original")
+
+		// Modify the cloned LimitsMap and ensure the original map is not affected.
+		cloned.data["limit3"] = "test"
+		_, exists := original.data["limit3"]
+		require.False(t, exists, "expected original LimitsMap to be unaffected by changes to cloned")
+	})
 }
 
 func TestLimitsMap_updateMap(t *testing.T) {
 	initialData := map[string]float64{"a": 1.0, "b": 2.0}
 	updateData := map[string]float64{"a": 3.0, "b": -3.0, "c": 5.0}
 
-	limitsMap := LimitsMap[float64]{data: initialData, validator: fakeValidator}
+	limitsMap := LimitsMap[float64]{data: initialData, validator: fakeFloat64Validator}
 
 	err := limitsMap.updateMap(updateData)
 	require.Error(t, err)

--- a/pkg/util/validation/limits_map_test.go
+++ b/pkg/util/validation/limits_map_test.go
@@ -404,16 +404,30 @@ func TestLimitsMap_Clone(t *testing.T) {
 }
 
 func TestLimitsMap_updateMap(t *testing.T) {
-	initialData := map[string]float64{"a": 1.0, "b": 2.0}
-	updateData := map[string]float64{"a": 3.0, "b": -3.0, "c": 5.0}
+	t.Run("does not apply partial updates", func(t *testing.T) {
+		initialData := map[string]float64{"a": 1.0, "b": 2.0}
+		updateData := map[string]float64{"a": 3.0, "b": -3.0, "c": 5.0}
 
-	limitsMap := LimitsMap[float64]{data: initialData, validator: fakeFloat64Validator}
+		limitsMap := LimitsMap[float64]{data: initialData, validator: fakeFloat64Validator}
 
-	err := limitsMap.updateMap(updateData)
-	require.Error(t, err)
+		err := limitsMap.updateMap(updateData)
+		require.Error(t, err)
 
-	// Verify that no partial updates were applied.
-	// Because maps in Go are accessed in random order, there's a chance that the validation will fail on the first invalid element of the map thus not asserting partial updates.
-	expectedData := map[string]float64{"a": 1.0, "b": 2.0}
-	require.Equal(t, expectedData, limitsMap.data)
+		// Verify that no partial updates were applied.
+		// Because maps in Go are accessed in random order, there's a chance that the validation will fail on the first invalid element of the map thus not asserting partial updates.
+		expectedData := map[string]float64{"a": 1.0, "b": 2.0}
+		require.Equal(t, expectedData, limitsMap.data)
+	})
+
+	t.Run("updates totally replace all values", func(t *testing.T) {
+		initialData := map[string]float64{"a": 1.0, "b": 2.0}
+		updateData := map[string]float64{"b": 5.0, "c": 6.0}
+		limitsMap := LimitsMap[float64]{data: initialData, validator: fakeFloat64Validator}
+
+		err := limitsMap.updateMap(updateData)
+		require.NoError(t, err)
+
+		expectedData := updateData
+		require.Equal(t, expectedData, limitsMap.data)
+	})
 }

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -353,6 +353,8 @@ func getFieldCustomType(t reflect.Type) (string, bool) {
 		return "map of string to float64", true
 	case reflect.TypeOf(validation.LimitsMap[int]{}).String():
 		return "map of string to int", true
+	case reflect.TypeOf(validation.LimitsMap[string]{}).String():
+		return "map of string to string", true
 	case reflect.TypeOf(&url.URL{}).String():
 		return "url", true
 	case reflect.TypeOf(time.Duration(0)).String():
@@ -439,6 +441,8 @@ func getCustomFieldType(t reflect.Type) (string, bool) {
 		return "map of string to float64", true
 	case reflect.TypeOf(validation.LimitsMap[int]{}).String():
 		return "map of string to int", true
+	case reflect.TypeOf(validation.LimitsMap[string]{}).String():
+		return "map of string to string", true
 	case reflect.TypeOf(&url.URL{}).String():
 		return "url", true
 	case reflect.TypeOf(time.Duration(0)).String():


### PR DESCRIPTION
#### What this PR does

This PR allows you to specify arbitrary URL parameters to send alongside OAuth token requests, when the Alertmanager client is configured in OAuth mode.

Some OAuth providers require extra fields here that are not normally part of the spec - for example, `audience` is a common one. The Go stdlib followed a similar convention for such fields: https://github.com/golang/oauth2/issues/216 where arbitrary extra URL values are allowed.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
