### PR TITLE
MQE: fix incorrect peak memory consumption value reported for benchmarks run on Linux

### DIFF
--- a/tools/benchmark-query-engine/main.go
+++ b/tools/benchmark-query-engine/main.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"syscall"
@@ -339,11 +340,22 @@ func (a *app) runTestCase(name string, printBenchmarkHeader bool) error {
 			}
 		} else if isBenchmarkLine {
 			fmt.Print(l)
-			fmt.Printf("     %v B\n", usage.Maxrss)
+			fmt.Printf("     %v B\n", maxRSSInBytes(usage))
 		} else if !isPassLine {
 			fmt.Println(l)
 		}
 	}
 
 	return nil
+}
+
+func maxRSSInBytes(usage *syscall.Rusage) int64 {
+	switch runtime.GOOS {
+	case "Linux":
+		return usage.Maxrss * 1024 // Maxrss is returned in kilobytes on Linux.
+	case "Darwin":
+		return usage.Maxrss // Maxrss is already in bytes on macOS.
+	default:
+		panic(fmt.Sprintf("unknown GOOS '%v'", runtime.GOOS))
+	}
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where the peak memory consumption of benchmarks run on Linux is off by a factor of 1024x.

I haven't added a changelog entry given this is not a user-facing change.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
