### PR TITLE
Remove "track_sizes" option from Memcached in jsonnet and helm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 * [CHANGE] Remove support to set Redis as a cache backend from jsonnet. #9677
 * [CHANGE] Rollout-operator now defaults to storing scaling operation metadata in a Kubernetes ConfigMap. This avoids recursively invoking the admission webhook in some Kubernetes environments. #9699
 * [CHANGE] Update rollout-operator version to 0.20.0. #9995
+* [CHANGE] Remove the `track_sizes` feature for Memcached pods since it is unused. #10032
 * [FEATURE] Add support to deploy distributors in multi availability zones. #9548
 * [FEATURE] Add configuration settings to set the number of Memcached replicas for each type of cache (`memcached_frontend_replicas`, `memcached_index_queries_replicas`, `memcached_chunks_replicas`, `memcached_metadata_replicas`). #9679
 * [ENHANCEMENT] Add `ingest_storage_ingester_autoscaling_triggers` option to specify multiple triggers in ScaledObject created for ingest-store ingester autoscaling. #9422

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,6 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [BUGFIX] Update `serviceAccountName` in the `alertmanager-statefulset` template. #10016
 * [CHANGE] Update rollout-operator version to 0.20.0. #9995
+* [CHANGE] Remove the `track_sizes` feature for Memcached pods since it is unused. #10032
 * [FEATURE] Add support for GEM's federation-frontend. See the `federation_frontend` section in the values file. #9673
 * [ENHANCEMENT] Add support for setting type and internal traffic policy for Kubernetes service. Set `internalTrafficPolicy=Cluster` by default in all services with type `ClusterIP`. #9619
 * [ENHANCEMENT] Add the possibility to create a dedicated serviceAccount for the `alertmanager` component by setting `alertmanager.serviceAcount.create` to true in the values. #9781

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -105,7 +105,7 @@ spec:
               name: client
           args:
             - -m {{ .allocatedMemory }}
-            - --extended=modern,track_sizes{{ with .extraExtendedOptions }},{{ . }}{{ end }}
+            - --extended=modern{{ with .extraExtendedOptions }},{{ . }}{{ end }}
             - -I {{ .maxItemMemory }}m
             - -c {{ .connectionLimit }}
             - -v

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -63,7 +63,7 @@ spec:
               name: client
           args:
             - -m 8192
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -63,7 +63,7 @@ spec:
               name: client
           args:
             - -m 2048
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -63,7 +63,7 @@ spec:
               name: client
           args:
             - -m 512
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -63,7 +63,7 @@ spec:
               name: client
           args:
             - -m 512
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-aggregation-cache/graphite-aggregation-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 8192
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-metric-name-cache/graphite-metric-name-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 8192
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 8192
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 2048
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 512
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 1024
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 8192
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 2048
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 512
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 512
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-cache/admin-cache-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/admin-cache/admin-cache-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
               name: client
           args:
             - -m 64
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
               name: client
           args:
             - -m 8192
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
               name: client
           args:
             - -m 2048
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
               name: client
           args:
             - -m 512
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
               name: client
           args:
             - -m 512
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 8192
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 2048
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 512
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -60,7 +60,7 @@ spec:
               name: client
           args:
             - -m 512
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
               name: client
           args:
             - -m 10
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
               name: client
           args:
             - -m 30
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
               name: client
           args:
             - -m 10
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 1m
             - -c 16384
             - -v

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
               name: client
           args:
             - -m 10
-            - --extended=modern,track_sizes
+            - --extended=modern
             - -I 5m
             - -c 16384
             - -v

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -1243,7 +1243,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1297,7 +1296,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1351,7 +1349,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1405,7 +1402,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
@@ -1243,7 +1243,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1297,7 +1296,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1351,7 +1349,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1405,7 +1402,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
@@ -1252,7 +1252,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1306,7 +1305,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1360,7 +1358,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1414,7 +1411,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -1245,7 +1245,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1299,7 +1298,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1353,7 +1351,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1407,7 +1404,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -1244,7 +1244,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1298,7 +1297,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1352,7 +1350,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1406,7 +1403,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1751,7 +1751,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1805,7 +1804,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1859,7 +1857,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1913,7 +1910,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -1824,7 +1824,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1878,7 +1877,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1932,7 +1930,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1986,7 +1983,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1597,7 +1597,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1651,7 +1650,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1705,7 +1703,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1759,7 +1756,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1597,7 +1597,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1651,7 +1650,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1705,7 +1703,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1759,7 +1756,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -1111,7 +1111,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1165,7 +1164,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1219,7 +1217,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1273,7 +1270,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -1111,7 +1111,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1165,7 +1164,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1219,7 +1217,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1273,7 +1270,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1614,7 +1614,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1668,7 +1667,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1722,7 +1720,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1776,7 +1773,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -2090,7 +2090,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2144,7 +2143,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2198,7 +2196,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2252,7 +2249,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1482,7 +1482,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1536,7 +1535,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1590,7 +1588,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1644,7 +1641,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -1041,7 +1041,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1095,7 +1094,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1149,7 +1147,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1203,7 +1200,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -987,7 +987,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1041,7 +1040,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1095,7 +1093,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1149,7 +1146,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -2140,7 +2140,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2194,7 +2193,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2248,7 +2246,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2302,7 +2299,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1247,7 +1247,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1301,7 +1300,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1355,7 +1353,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1409,7 +1406,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -987,7 +987,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1041,7 +1040,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1095,7 +1093,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1149,7 +1146,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1291,7 +1291,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1345,7 +1344,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1399,7 +1397,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1453,7 +1450,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1350,7 +1350,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1404,7 +1403,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1458,7 +1456,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1512,7 +1509,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -2284,7 +2284,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2338,7 +2337,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2392,7 +2390,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2446,7 +2443,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -2284,7 +2284,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2338,7 +2337,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2392,7 +2390,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2446,7 +2443,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -2284,7 +2284,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2338,7 +2337,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2392,7 +2390,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2446,7 +2443,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -2141,7 +2141,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2195,7 +2194,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2249,7 +2247,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2303,7 +2300,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -2643,7 +2643,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2697,7 +2696,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2751,7 +2749,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2805,7 +2802,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -2117,7 +2117,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2171,7 +2170,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2225,7 +2223,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2279,7 +2276,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -2121,7 +2121,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2175,7 +2174,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2229,7 +2227,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2283,7 +2280,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -2656,7 +2656,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2710,7 +2709,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2764,7 +2762,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2818,7 +2815,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -2678,7 +2678,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2732,7 +2731,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2786,7 +2784,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2840,7 +2837,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -2676,7 +2676,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2730,7 +2729,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2784,7 +2782,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2838,7 +2835,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -2676,7 +2676,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2730,7 +2729,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2784,7 +2782,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2838,7 +2835,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -2676,7 +2676,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2730,7 +2729,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2784,7 +2782,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2838,7 +2835,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -2205,7 +2205,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2259,7 +2258,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2313,7 +2311,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2367,7 +2364,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -2221,7 +2221,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2275,7 +2274,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2329,7 +2327,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2383,7 +2380,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -2221,7 +2221,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2275,7 +2274,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2329,7 +2327,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2383,7 +2380,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -2058,7 +2058,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2112,7 +2111,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2166,7 +2164,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2220,7 +2217,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -2284,7 +2284,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2338,7 +2337,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2392,7 +2390,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2446,7 +2443,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1243,7 +1243,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1297,7 +1296,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1351,7 +1349,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1405,7 +1402,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1249,7 +1249,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1303,7 +1302,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1357,7 +1355,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1411,7 +1408,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1255,7 +1255,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1309,7 +1308,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1363,7 +1361,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1417,7 +1414,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1249,7 +1249,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1303,7 +1302,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1357,7 +1355,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1411,7 +1408,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1614,7 +1614,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1668,7 +1667,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1722,7 +1720,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1776,7 +1773,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1699,7 +1699,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1753,7 +1752,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1807,7 +1805,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1861,7 +1858,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1699,7 +1699,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1753,7 +1752,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1807,7 +1805,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1861,7 +1858,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1699,7 +1699,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1753,7 +1752,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1807,7 +1805,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1861,7 +1858,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1699,7 +1699,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1753,7 +1752,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1807,7 +1805,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1861,7 +1858,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1246,7 +1246,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1300,7 +1299,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1354,7 +1352,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1408,7 +1405,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1243,7 +1243,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1297,7 +1296,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1351,7 +1349,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1405,7 +1402,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -1303,7 +1303,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
@@ -1380,7 +1379,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
@@ -1457,7 +1455,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2
@@ -1534,7 +1531,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         - --listen=notls:127.0.0.1:11211,0.0.0.0:11212
         - --enable-ssl
         - --extended=ssl_ca_cert=/var/secrets/memcached-ca-cert/memcached-ca-cert.pem,ssl_chain_cert=/var/secrets/memcached-server-cert/memcached-server-cert.pem,ssl_key=/var/secrets/memcached-server-key/memcached-server-key.pem,ssl_kernel_tls,ssl_verify_mode=2

--- a/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
@@ -1909,7 +1909,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1963,7 +1962,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2017,7 +2015,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2071,7 +2068,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
@@ -1751,7 +1751,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1805,7 +1804,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1859,7 +1857,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1913,7 +1910,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1751,7 +1751,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1805,7 +1804,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1859,7 +1857,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1913,7 +1910,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1918,7 +1918,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1972,7 +1971,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2026,7 +2024,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2080,7 +2077,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1829,7 +1829,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1883,7 +1882,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1937,7 +1935,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1991,7 +1988,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -987,7 +987,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1041,7 +1040,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1095,7 +1093,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1149,7 +1146,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
+++ b/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
@@ -1081,7 +1081,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1137,7 +1136,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1193,7 +1191,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1249,7 +1246,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -1489,7 +1489,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1543,7 +1542,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1597,7 +1595,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1651,7 +1648,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1624,7 +1624,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1678,7 +1677,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1732,7 +1730,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1786,7 +1783,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1662,7 +1662,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1716,7 +1715,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1770,7 +1768,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1824,7 +1821,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1274,7 +1274,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1328,7 +1327,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1382,7 +1380,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1436,7 +1433,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1262,7 +1262,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1316,7 +1315,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1370,7 +1368,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1424,7 +1421,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1248,7 +1248,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1302,7 +1301,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1356,7 +1354,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1410,7 +1407,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -678,7 +678,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -732,7 +731,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -786,7 +784,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -840,7 +837,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -679,7 +679,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -733,7 +732,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -787,7 +785,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -841,7 +838,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1604,7 +1604,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1658,7 +1657,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1712,7 +1710,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1766,7 +1763,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1602,7 +1602,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1656,7 +1655,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1710,7 +1708,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1764,7 +1761,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1252,7 +1252,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1306,7 +1305,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1360,7 +1358,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1414,7 +1411,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
@@ -1256,7 +1256,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1310,7 +1309,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1364,7 +1362,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1418,7 +1415,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1253,7 +1253,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1307,7 +1306,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1361,7 +1359,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1415,7 +1412,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
+++ b/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
@@ -2040,7 +2040,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2094,7 +2093,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2148,7 +2146,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -2202,7 +2199,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1253,7 +1253,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1307,7 +1306,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1361,7 +1359,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1415,7 +1412,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1243,7 +1243,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1297,7 +1296,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1351,7 +1349,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1405,7 +1402,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1248,7 +1248,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1302,7 +1301,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1356,7 +1354,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1410,7 +1407,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -890,7 +890,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -944,7 +943,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -998,7 +996,6 @@ spec:
         - -I 5m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached
@@ -1052,7 +1049,6 @@ spec:
         - -I 1m
         - -c 16384
         - -v
-        - --extended=track_sizes
         image: memcached:1.6.28-alpine
         imagePullPolicy: IfNotPresent
         name: memcached

--- a/operations/mimir/memcached.libsonnet
+++ b/operations/mimir/memcached.libsonnet
@@ -53,7 +53,6 @@ memcached {
         max_item_size: '%dm' % [$._config.cache_frontend_max_item_size_mb],
         overprovision_factor: 1.05,
         connection_limit: std.toString($._config.cache_frontend_connection_limit),
-        extended_options: ['track_sizes'],
 
         statefulSet+:
           statefulSet.mixin.spec.withReplicas($._config.memcached_frontend_replicas),
@@ -68,7 +67,6 @@ memcached {
         max_item_size: '%dm' % [$._config.cache_index_queries_max_item_size_mb],
         overprovision_factor: 1.05,
         connection_limit: std.toString($._config.cache_index_queries_connection_limit),
-        extended_options: ['track_sizes'],
 
         statefulSet+:
           statefulSet.mixin.spec.withReplicas($._config.memcached_index_queries_replicas),
@@ -86,7 +84,6 @@ memcached {
         memory_limit_mb: 6 * 1024,
         overprovision_factor: 1.05,
         connection_limit: std.toString($._config.cache_chunks_connection_limit),
-        extended_options: ['track_sizes'],
 
         statefulSet+:
           statefulSet.mixin.spec.withReplicas($._config.memcached_chunks_replicas),
@@ -100,7 +97,6 @@ memcached {
         name: 'memcached-metadata',
         max_item_size: '%dm' % [$._config.cache_metadata_max_item_size_mb],
         connection_limit: std.toString($._config.cache_metadata_connection_limit),
-        extended_options: ['track_sizes'],
 
         // Metadata cache doesn't need much memory.
         memory_limit_mb: 512,


### PR DESCRIPTION
#### What this PR does

The option tracks the size of items in the cache in a histogram. We don't use this information for anything or monitor it in any way so remove it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
