### PR TITLE
Jsonnet: add ingest_storage_kafka_client_id_settings config option

### DIFF
--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -47,8 +47,9 @@
 
   // The default Kafka client ID settings to use for producers and consumers.
   // These key-value settings get serialised into a comma-separated string.
-  ingest_storage_kafka_producer_client_id_settings:: {},
-  ingest_storage_kafka_consumer_client_id_settings:: {},
+  ingest_storage_kafka_client_id_settings:: {},
+  ingest_storage_kafka_producer_client_id_settings:: $.ingest_storage_kafka_client_id_settings,
+  ingest_storage_kafka_consumer_client_id_settings:: $.ingest_storage_kafka_client_id_settings,
 
   // The per-component Kafka client ID settings overrides.
   ingest_storage_distributor_kafka_client_id_settings:: $.ingest_storage_kafka_producer_client_id_settings,


### PR DESCRIPTION
#### What this PR does

Adding a generic `ingest_storage_kafka_client_id_settings` config option to Jsonnet, and then having both `ingest_storage_kafka_producer_client_id_settings` and `ingest_storage_kafka_consumer_client_id_settings` inherit from it. This is useful if you want to set a client ID for every Kafka client, both producer and consumer.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
