### PR TITLE
ruler: Register custom discovery config

### DIFF
--- a/pkg/ruler/service_discovery.go
+++ b/pkg/ruler/service_discovery.go
@@ -22,6 +22,10 @@ const (
 	mechanismName = "dns_sd"
 )
 
+func init() {
+	discovery.RegisterConfig(dnsServiceDiscovery{})
+}
+
 type dnsServiceDiscovery struct {
 	refreshMetrics discovery.RefreshMetricsInstantiator
 


### PR DESCRIPTION
#### What this PR does

With Prometheus 3, it's required to register custom `discovery.Config` implementations, otherwise they [cannot be marshaled](https://github.com/prometheus/prometheus/blob/main/discovery/registry.go#L244). This currently causes Grafana Enterprise Metrics test failures in PRs to re-vendor Mimir.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
