### PR TITLE
MQE: enable supported upstream tests

### DIFF
--- a/pkg/streamingpromql/testdata/upstream/functions.test
+++ b/pkg/streamingpromql/testdata/upstream/functions.test
@@ -1056,8 +1056,7 @@ load 5m
   testmetric1{src="a",dst="b"} 0
   testmetric2{src="a",dst="b"} 1
 
-# Unsupported by streaming engine.
-# eval_fail instant at 0m changes({__name__=~'testmetric1|testmetric2'}[5m])
+eval_fail instant at 0m changes({__name__=~'testmetric1|testmetric2'}[5m])
 
 # Tests for *_over_time
 clear

--- a/pkg/streamingpromql/testdata/upstream/histograms.test
+++ b/pkg/streamingpromql/testdata/upstream/histograms.test
@@ -638,9 +638,8 @@ load_with_nhcb 5m
 eval instant at 10m increase(histogram_with_reset[15m])
     {} {{schema:-53 count:27 sum:91.5 custom_values:[1 2 4 8] counter_reset_hint:gauge buckets:[13.5 0 4.5 9]}}
 
-# Unsupported by streaming engine.
-# eval instant at 10m resets(histogram_with_reset[15m])
-#      {} 1
+eval instant at 10m resets(histogram_with_reset[15m])
+     {} 1
 
 eval instant at 10m histogram_count(increase(histogram_with_reset[15m]))
      {} 27

--- a/pkg/streamingpromql/testdata/upstream/operators.test
+++ b/pkg/streamingpromql/testdata/upstream/operators.test
@@ -31,9 +31,8 @@ eval instant at 50m 2 - SUM(http_requests) BY (job)
 eval instant at 50m -http_requests{job="api-server",instance="0",group="production"}
   {job="api-server",instance="0",group="production"} -100
 
-# Unsupported by streaming engine.
-# eval instant at 50m +http_requests{job="api-server",instance="0",group="production"}
-#   http_requests{job="api-server",instance="0",group="production"} 100
+eval instant at 50m +http_requests{job="api-server",instance="0",group="production"}
+  http_requests{job="api-server",instance="0",group="production"} 100
 
 eval instant at 50m - - - SUM(http_requests) BY (job)
 	{job="api-server"} -1000

--- a/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
+++ b/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
@@ -28,8 +28,8 @@ import (
 
 var (
 	// These expressions are taken directly from the promqltest package, and are what it uses to parse eval commands.
-	patEvalInstant = regexp.MustCompile(`^eval(?:_(fail|warn|ordered))?\s+instant\s+(?:at\s+(.+?))?\s+(.+)$`)
-	patEvalRange   = regexp.MustCompile(`^eval(?:_(fail|warn))?\s+range\s+from\s+(.+)\s+to\s+(.+)\s+step\s+(.+?)\s+(.+)$`)
+	patEvalInstant = regexp.MustCompile(`^eval(?:_(fail|warn|info|ordered))?\s+instant\s+(?:at\s+(.+?))?\s+(.+)$`)
+	patEvalRange   = regexp.MustCompile(`^eval(?:_(fail|warn|info))?\s+range\s+from\s+(.+)\s+to\s+(.+)\s+step\s+(.+?)\s+(.+)$`)
 )
 
 func main() {


### PR DESCRIPTION
#### What this PR does

This PR enables some upstream test cases that were previously disabled because they were not supported, but are now supported by MQE.

It also fixes an issue running `tools/check-for-disabled-but-supported-mqe-test-cases` when a test file uses the new `eval_info` command.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
