### PR TITLE
fix(docs): update native histograms migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@
 
 ### Documentation
 
-* [BUGFIX] Send/Native Histograms: update the migration guide with the corrected dashboard query for switching between classic or native histograms queries.
+* [BUGFIX] Send/Native Histograms: update the migration guide with the corrected dashboard query for switching between classic or native histograms queries. #10052
 
 ### Tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,8 @@
 
 ### Documentation
 
+* [BUGFIX] Send/Native Histograms: update the migration guide with the corrected dashboard query for switching between classic or native histograms queries.
+
 ### Tools
 
 * [FEATURE] `splitblocks`: add new tool to split blocks larger than a specified duration into multiple blocks. #9517, #9779

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@
 
 ### Documentation
 
-* [BUGFIX] Send/Native Histograms: update the migration guide with the corrected dashboard query for switching between classic or native histograms queries. #10052
+* [BUGFIX] Send native histograms: update the migration guide with the corrected dashboard query for switching between classic and native histograms queries. #10052
 
 ### Tools
 

--- a/docs/sources/mimir/send/native-histograms/_index.md
+++ b/docs/sources/mimir/send/native-histograms/_index.md
@@ -257,7 +257,7 @@ To ease the migration process, you can keep the custom bucket definition of a cl
      (<native_query>) and on() (vector($latency_metrics) == -1)
      ```
 
-     Where `classic_query` is the original query and `native_query` is the same query using native histogram query syntax, placed inside a parenthesis. This technique is employed in Mimir's dashboards. For an example, refer to the [Overview dashboard](https://github.com/grafana/mimir/blob/main/operations/mimir-mixin-compiled/dashboards/mimir-overview.json) in the Mimir repository.
+     Where `classic_query` is the original query and `native_query` is the same query using native histogram query syntax placed inside parentheses. Mimir dashboards use this technique. For an example, refer to the [Overview dashboard](https://github.com/grafana/mimir/blob/main/operations/mimir-mixin-compiled/dashboards/mimir-overview.json) in the Mimir repository.
 
      This solution allows users to switch between the classic histogram and the native histogram without going to a different dashboard.
 

--- a/docs/sources/mimir/send/native-histograms/_index.md
+++ b/docs/sources/mimir/send/native-histograms/_index.md
@@ -250,14 +250,14 @@ To ease the migration process, you can keep the custom bucket definition of a cl
    - Add a dashboard variable to your dashboard to enable switching between classic histograms and native histograms. There isn't support for selectively enabling and disabling queries in Grafana ([issue 79848](https://github.com/grafana/grafana/issues/79848)). As a workaround, add the dashboard variable `latency_metrics`, for example, and assign it a value of either `-1` or `1`. Then, add the following two queries to the panel:
 
      ```
-     <classic_query> < ($latency_metrics * +Inf)
+     (<classic_query>) and on() (vector($latency_metrics) == 1)
      ```
 
      ```
-     <native_query> < ($latency_metrics * -Inf)
+     (<native_query>) and on() (vector($latency_metrics) == -1)
      ```
 
-     Where `classic_query` is the original query and `native_query` is the same query using native histogram query syntax. This technique is employed in Mimir's dashboards. For an example, refer to the [Overview dashboard](https://github.com/grafana/mimir/blob/main/operations/mimir-mixin-compiled/dashboards/mimir-overview.json) in the Mimir repository.
+     Where `classic_query` is the original query and `native_query` is the same query using native histogram query syntax, placed inside a parenthesis. This technique is employed in Mimir's dashboards. For an example, refer to the [Overview dashboard](https://github.com/grafana/mimir/blob/main/operations/mimir-mixin-compiled/dashboards/mimir-overview.json) in the Mimir repository.
 
      This solution allows users to switch between the classic histogram and the native histogram without going to a different dashboard.
 


### PR DESCRIPTION
#### What this PR does

Send/Native Histograms: update the migration guide with the corrected dashboard query for switching between classic or native histograms queries.

Due to https://github.com/prometheus/prometheus/pull/15245 invalidating the old method.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/prometheus/prometheus/pull/15245

#### Checklist

- N/A Tests updated. See #10026 
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
