### PR TITLE
query-tee: add per-backend request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
 ### Query-tee
 
 * [FEATURE] Added `-proxy.compare-skip-samples-before` to skip samples before the given time when comparing responses. The time can be in RFC3339 format (or) RFC3339 without the timezone and seconds (or) date only. #9515
+* [FEATURE] Add `-backend.config` JSON configuration for per-backend options. Currently, it only supports additional HTTP request headers. #10081
 * [ENHANCEMENT] Added human-readable timestamps to comparison failure messages. #9665
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@
 ### Query-tee
 
 * [FEATURE] Added `-proxy.compare-skip-samples-before` to skip samples before the given time when comparing responses. The time can be in RFC3339 format (or) RFC3339 without the timezone and seconds (or) date only. #9515
-* [FEATURE] Add `-backend.config` JSON configuration for per-backend options. Currently, it only supports additional HTTP request headers. #10081
+* [FEATURE] Add `-backend.config-file` for a YAML configuration file for per-backend options. Currently, it only supports additional HTTP request headers. #10081
 * [ENHANCEMENT] Added human-readable timestamps to comparison failure messages. #9665
 
 ### Documentation

--- a/tools/querytee/proxy.go
+++ b/tools/querytee/proxy.go
@@ -189,6 +189,9 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 
 		backendCfg := cfg.parsedBackendConfig[name]
 		if backendCfg == nil {
+			// In tests, we have the same hostname for all backends, so we also
+			// support a numeric preferred backend which is the index in the list
+			// of backends.
 			backendCfg = cfg.parsedBackendConfig[strconv.Itoa(idx)]
 			if backendCfg == nil {
 				backendCfg = &BackendConfig{}

--- a/tools/querytee/proxy_backend_test.go
+++ b/tools/querytee/proxy_backend_test.go
@@ -84,7 +84,7 @@ func Test_ProxyBackend_createBackendRequest_HTTPBasicAuthentication(t *testing.T
 				orig.Header.Set("X-Scope-OrgID", testData.clientTenant)
 			}
 
-			b := NewProxyBackend("test", u, time.Second, false, false, BackendConfig{})
+			b := NewProxyBackend("test", u, time.Second, false, false, defaultBackendConfig())
 			bp, ok := b.(*ProxyBackend)
 			if !ok {
 				t.Fatalf("Type assertion to *ProxyBackend failed")
@@ -97,4 +97,8 @@ func Test_ProxyBackend_createBackendRequest_HTTPBasicAuthentication(t *testing.T
 			assert.Equal(t, testData.expectedPass, actualPass)
 		})
 	}
+}
+
+func defaultBackendConfig() BackendConfig {
+	return BackendConfig{}
 }

--- a/tools/querytee/proxy_backend_test.go
+++ b/tools/querytee/proxy_backend_test.go
@@ -84,7 +84,7 @@ func Test_ProxyBackend_createBackendRequest_HTTPBasicAuthentication(t *testing.T
 				orig.Header.Set("X-Scope-OrgID", testData.clientTenant)
 			}
 
-			b := NewProxyBackend("test", u, time.Second, false, false)
+			b := NewProxyBackend("test", u, time.Second, false, false, BackendConfig{})
 			bp, ok := b.(*ProxyBackend)
 			if !ok {
 				t.Fatalf("Type assertion to *ProxyBackend failed")

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -37,9 +37,9 @@ func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
 	backendURL3, err := url.Parse("http://backend-3/")
 	require.NoError(t, err)
 
-	backendPref := NewProxyBackend("backend-1", backendURL1, time.Second, true, false)
-	backendOther1 := NewProxyBackend("backend-2", backendURL2, time.Second, false, false)
-	backendOther2 := NewProxyBackend("backend-3", backendURL3, time.Second, false, false)
+	backendPref := NewProxyBackend("backend-1", backendURL1, time.Second, true, false, BackendConfig{})
+	backendOther1 := NewProxyBackend("backend-2", backendURL2, time.Second, false, false, BackendConfig{})
+	backendOther2 := NewProxyBackend("backend-3", backendURL3, time.Second, false, false, BackendConfig{})
 
 	tests := map[string]struct {
 		backends  []ProxyBackendInterface
@@ -157,8 +157,8 @@ func Test_ProxyEndpoint_Requests(t *testing.T) {
 	require.NoError(t, err)
 
 	backends := []ProxyBackendInterface{
-		NewProxyBackend("backend-1", backendURL1, time.Second, true, false),
-		NewProxyBackend("backend-2", backendURL2, time.Second, false, false),
+		NewProxyBackend("backend-1", backendURL1, time.Second, true, false, BackendConfig{}),
+		NewProxyBackend("backend-2", backendURL2, time.Second, false, false, BackendConfig{}),
 	}
 	endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(nil), log.NewNopLogger(), nil, 0, 1.0)
 
@@ -325,8 +325,8 @@ func Test_ProxyEndpoint_Comparison(t *testing.T) {
 			require.NoError(t, err)
 
 			backends := []ProxyBackendInterface{
-				NewProxyBackend("preferred-backend", preferredBackendURL, time.Second, true, false),
-				NewProxyBackend("secondary-backend", secondaryBackendURL, time.Second, false, false),
+				NewProxyBackend("preferred-backend", preferredBackendURL, time.Second, true, false, BackendConfig{}),
+				NewProxyBackend("secondary-backend", secondaryBackendURL, time.Second, false, false, BackendConfig{}),
 			}
 
 			logger := newMockLogger()

--- a/tools/querytee/proxy_endpoint_test.go
+++ b/tools/querytee/proxy_endpoint_test.go
@@ -37,9 +37,9 @@ func Test_ProxyEndpoint_waitBackendResponseForDownstream(t *testing.T) {
 	backendURL3, err := url.Parse("http://backend-3/")
 	require.NoError(t, err)
 
-	backendPref := NewProxyBackend("backend-1", backendURL1, time.Second, true, false, BackendConfig{})
-	backendOther1 := NewProxyBackend("backend-2", backendURL2, time.Second, false, false, BackendConfig{})
-	backendOther2 := NewProxyBackend("backend-3", backendURL3, time.Second, false, false, BackendConfig{})
+	backendPref := NewProxyBackend("backend-1", backendURL1, time.Second, true, false, defaultBackendConfig())
+	backendOther1 := NewProxyBackend("backend-2", backendURL2, time.Second, false, false, defaultBackendConfig())
+	backendOther2 := NewProxyBackend("backend-3", backendURL3, time.Second, false, false, defaultBackendConfig())
 
 	tests := map[string]struct {
 		backends  []ProxyBackendInterface
@@ -157,8 +157,8 @@ func Test_ProxyEndpoint_Requests(t *testing.T) {
 	require.NoError(t, err)
 
 	backends := []ProxyBackendInterface{
-		NewProxyBackend("backend-1", backendURL1, time.Second, true, false, BackendConfig{}),
-		NewProxyBackend("backend-2", backendURL2, time.Second, false, false, BackendConfig{}),
+		NewProxyBackend("backend-1", backendURL1, time.Second, true, false, defaultBackendConfig()),
+		NewProxyBackend("backend-2", backendURL2, time.Second, false, false, defaultBackendConfig()),
 	}
 	endpoint := NewProxyEndpoint(backends, testRoute, NewProxyMetrics(nil), log.NewNopLogger(), nil, 0, 1.0)
 
@@ -325,8 +325,8 @@ func Test_ProxyEndpoint_Comparison(t *testing.T) {
 			require.NoError(t, err)
 
 			backends := []ProxyBackendInterface{
-				NewProxyBackend("preferred-backend", preferredBackendURL, time.Second, true, false, BackendConfig{}),
-				NewProxyBackend("secondary-backend", secondaryBackendURL, time.Second, false, false, BackendConfig{}),
+				NewProxyBackend("preferred-backend", preferredBackendURL, time.Second, true, false, defaultBackendConfig()),
+				NewProxyBackend("secondary-backend", secondaryBackendURL, time.Second, false, false, defaultBackendConfig()),
 			}
 
 			logger := newMockLogger()

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -203,7 +203,7 @@ func Test_Proxy_RequestsForwarding(t *testing.T) {
 		requestPath         string
 		requestMethod       string
 		backends            []mockedBackend
-		backendConfig       map[string]BackendConfig
+		backendConfig       map[string]*BackendConfig
 		preferredBackendIdx int
 		expectedStatus      int
 		expectedRes         string
@@ -328,7 +328,7 @@ func Test_Proxy_RequestsForwarding(t *testing.T) {
 			requestPath:         "/api/v1/query",
 			requestMethod:       http.MethodGet,
 			preferredBackendIdx: 0,
-			backendConfig: map[string]BackendConfig{
+			backendConfig: map[string]*BackendConfig{
 				"0": {
 					RequestHeaders: map[string][]string{
 						"X-Test-Header": {"test-value"},

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -756,6 +756,35 @@ func Test_NewProxy_BackendConfigPath(t *testing.T) {
 				},
 			},
 		},
+		"configured backend which doesn't exist": {
+			createFile: true,
+			configContent: `
+              backend1:
+                request_headers:
+                  X-Custom-Header: ["value1", "value2"]
+                  Cache-Control: ["no-store"]
+              backend2:
+                request_headers:
+                  Authorization: ["Bearer token123"]
+              backend3:
+                request_headers:
+                  Authorization: ["Bearer token123"]
+            `,
+			expectedError: "backend3 does not exist in the list of actual backends",
+			expectedConfig: map[string]*BackendConfig{
+				"backend1": {
+					RequestHeaders: http.Header{
+						"X-Custom-Header": {"value1", "value2"},
+						"Cache-Control":   {"no-store"},
+					},
+				},
+				"backend2": {
+					RequestHeaders: http.Header{
+						"Authorization": {"Bearer token123"},
+					},
+				},
+			},
+		},
 	}
 
 	for testName, testCase := range tests {

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -694,6 +695,101 @@ func TestProxyHTTPGRPC(t *testing.T) {
 		assert.Equal(t, int32(200), res.Code)
 		assert.Equal(t, querySingleMetric1, string(res.Body))
 	})
+}
+
+func Test_NewProxy_BackendConfigPath(t *testing.T) {
+	// Helper to create a temporary file with content
+	createTempFile := func(t *testing.T, content string) string {
+		tmpfile, err := os.CreateTemp("", "backend-config-*.yaml")
+		require.NoError(t, err)
+
+		defer tmpfile.Close()
+
+		_, err = tmpfile.Write([]byte(content))
+		require.NoError(t, err)
+
+		return tmpfile.Name()
+	}
+
+	tests := map[string]struct {
+		configContent  string
+		createFile     bool
+		expectedError  string
+		expectedConfig map[string]*BackendConfig
+	}{
+		"missing file": {
+			createFile:    false,
+			expectedError: "failed to read backend config file (/nonexistent/path): open /nonexistent/path: no such file or directory",
+		},
+		"empty file": {
+			createFile:     true,
+			configContent:  "",
+			expectedConfig: map[string]*BackendConfig(nil),
+		},
+		"invalid YAML structure (not a map)": {
+			createFile:    true,
+			configContent: "- item1\n- item2",
+			expectedError: "failed to parse backend YAML config:",
+		},
+		"valid configuration": {
+			createFile: true,
+			configContent: `
+              backend1:
+                request_headers:
+                  X-Custom-Header: ["value1", "value2"]
+                  Cache-Control: ["no-store"]
+              backend2:
+                request_headers:
+                  Authorization: ["Bearer token123"]
+            `,
+			expectedConfig: map[string]*BackendConfig{
+				"backend1": {
+					RequestHeaders: http.Header{
+						"X-Custom-Header": {"value1", "value2"},
+						"Cache-Control":   {"no-store"},
+					},
+				},
+				"backend2": {
+					RequestHeaders: http.Header{
+						"Authorization": {"Bearer token123"},
+					},
+				},
+			},
+		},
+	}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			// Base config that's valid except for the backend config path
+			cfg := ProxyConfig{
+				BackendEndpoints:                   "http://backend1:9090,http://backend2:9090",
+				ServerHTTPServiceAddress:           "localhost",
+				ServerHTTPServicePort:              0,
+				ServerGRPCServiceAddress:           "localhost",
+				ServerGRPCServicePort:              0,
+				SecondaryBackendsRequestProportion: 1.0,
+			}
+
+			if !testCase.createFile {
+				cfg.BackendConfigFile = "/nonexistent/path"
+			} else {
+				tmpPath := createTempFile(t, testCase.configContent)
+				cfg.BackendConfigFile = tmpPath
+				defer os.Remove(tmpPath)
+			}
+
+			p, err := NewProxy(cfg, log.NewNopLogger(), testRoutes, nil)
+
+			if testCase.expectedError != "" {
+				assert.ErrorContains(t, err, testCase.expectedError)
+				assert.Nil(t, p)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, p)
+				assert.Equal(t, testCase.expectedConfig, p.cfg.parsedBackendConfig)
+			}
+		})
+	}
 }
 
 func mockQueryResponse(path string, status int, res string) http.HandlerFunc {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

One of my backends needs a specific header so that it returns "correct" results.

Currently we don't have a way to add per-backend configuration. This PR introduces a new flag which takes JSON and allows to configure each backend separately. It will be used like so

```
-backend.config='{"mimir.com": {"request_headers": "X-Some-Header": ["value1", "value2"]}}'
```

I'm open to suggestions in case this is not a route we want to go on.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
