### PR TITLE
query-frontend: propagate headers on labels requests

### DIFF
--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -328,12 +328,6 @@ func (c prometheusCodec) decodeRangeQueryRequest(r *http.Request) (MetricsQueryR
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
-	headers := make([]*PrometheusHeader, 0, len(r.Header))
-	for h, hv := range r.Header {
-		headers = append(headers, &PrometheusHeader{Name: h, Values: slices.Clone(hv)})
-	}
-	sort.Slice(headers, func(i, j int) bool { return headers[i].Name < headers[j].Name })
-
 	start, end, step, err := DecodeRangeQueryTimeParams(&reqValues)
 	if err != nil {
 		return nil, err
@@ -349,7 +343,7 @@ func (c prometheusCodec) decodeRangeQueryRequest(r *http.Request) (MetricsQueryR
 	decodeOptions(r, &options)
 
 	req := NewPrometheusRangeQueryRequest(
-		r.URL.Path, headers, start, end, step, c.lookbackDelta, queryExpr, options, nil,
+		r.URL.Path, httpHeadersToProm(r.Header), start, end, step, c.lookbackDelta, queryExpr, options, nil,
 	)
 	return req, nil
 }
@@ -359,12 +353,6 @@ func (c prometheusCodec) decodeInstantQueryRequest(r *http.Request) (MetricsQuer
 	if err != nil {
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
-
-	headers := make([]*PrometheusHeader, 0, len(r.Header))
-	for h, hv := range r.Header {
-		headers = append(headers, &PrometheusHeader{Name: h, Values: slices.Clone(hv)})
-	}
-	sort.Slice(headers, func(i, j int) bool { return headers[i].Name < headers[j].Name })
 
 	time, err := DecodeInstantQueryTimeParams(&reqValues, time.Now)
 	if err != nil {
@@ -381,9 +369,21 @@ func (c prometheusCodec) decodeInstantQueryRequest(r *http.Request) (MetricsQuer
 	decodeOptions(r, &options)
 
 	req := NewPrometheusInstantQueryRequest(
-		r.URL.Path, headers, time, c.lookbackDelta, queryExpr, options, nil,
+		r.URL.Path, httpHeadersToProm(r.Header), time, c.lookbackDelta, queryExpr, options, nil,
 	)
 	return req, nil
+}
+
+func httpHeadersToProm(httpH http.Header) []*PrometheusHeader {
+	if len(httpH) == 0 {
+		return nil
+	}
+	headers := make([]*PrometheusHeader, 0, len(httpH))
+	for h, hv := range httpH {
+		headers = append(headers, &PrometheusHeader{Name: h, Values: slices.Clone(hv)})
+	}
+	sort.Slice(headers, func(i, j int) bool { return headers[i].Name < headers[j].Name })
+	return headers
 }
 
 func (prometheusCodec) DecodeLabelsQueryRequest(_ context.Context, r *http.Request) (LabelsQueryRequest, error) {
@@ -409,10 +409,12 @@ func (prometheusCodec) DecodeLabelsQueryRequest(_ context.Context, r *http.Reque
 			return nil, apierror.New(apierror.TypeBadData, fmt.Sprintf("limit parameter must be a positive number: %s", limitStr))
 		}
 	}
+	headers := httpHeadersToProm(r.Header)
 
 	if IsSeriesQuery(r.URL.Path) {
 		return &PrometheusSeriesQueryRequest{
 			Path:             r.URL.Path,
+			Headers:          headers,
 			Start:            start,
 			End:              end,
 			LabelMatcherSets: labelMatcherSets,
@@ -422,6 +424,7 @@ func (prometheusCodec) DecodeLabelsQueryRequest(_ context.Context, r *http.Reque
 	if IsLabelNamesQuery(r.URL.Path) {
 		return &PrometheusLabelNamesQueryRequest{
 			Path:             r.URL.Path,
+			Headers:          headers,
 			Start:            start,
 			End:              end,
 			LabelMatcherSets: labelMatcherSets,
@@ -431,6 +434,7 @@ func (prometheusCodec) DecodeLabelsQueryRequest(_ context.Context, r *http.Reque
 	// else, must be Label Values Request due to IsLabelsQuery check at beginning of func
 	return &PrometheusLabelValuesQueryRequest{
 		Path:             r.URL.Path,
+		Headers:          headers,
 		LabelName:        labelValuesPathSuffix.FindStringSubmatch(r.URL.Path)[1],
 		Start:            start,
 		End:              end,

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -1721,6 +1721,10 @@ func TestPrometheusCodec_DecodeEncode_Metrics(t *testing.T) {
 // TestPrometheusCodec_DecodeEncodeMultipleTimes_Labels tests that decoding and re-encoding a
 // labels query request multiple times does not lose relevant information about the original request.
 func TestPrometheusCodec_DecodeEncodeMultipleTimes_Labels(t *testing.T) {
+
+	defaultHeaders := httpHeadersToProm(http.Header{
+		"Accept": {"application/json"},
+	})
 	codec := newTestPrometheusCodec().(prometheusCodec)
 	for _, tc := range []struct {
 		name     string
@@ -1731,18 +1735,20 @@ func TestPrometheusCodec_DecodeEncodeMultipleTimes_Labels(t *testing.T) {
 			name:     "label names - minimal",
 			queryURL: "/api/v1/labels?end=1708588800&start=1708502400",
 			request: &PrometheusLabelNamesQueryRequest{
-				Path:  "/api/v1/labels",
-				Start: 1708502400000,
-				End:   1708588800000,
+				Path:    "/api/v1/labels",
+				Headers: defaultHeaders,
+				Start:   1708502400000,
+				End:     1708588800000,
 			},
 		},
 		{
 			name:     "label names - all",
 			queryURL: "/api/v1/labels?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
 			request: &PrometheusLabelNamesQueryRequest{
-				Path:  "/api/v1/labels",
-				Start: 1708502400000,
-				End:   1708588800000,
+				Path:    "/api/v1/labels",
+				Headers: defaultHeaders,
+				Start:   1708502400000,
+				End:     1708588800000,
 				LabelMatcherSets: []string{
 					"go_goroutines{container=~\"quer.*\"}",
 					"go_goroutines{container!=\"query-scheduler\"}",
@@ -1755,6 +1761,7 @@ func TestPrometheusCodec_DecodeEncodeMultipleTimes_Labels(t *testing.T) {
 			queryURL: "/api/v1/label/job/values?end=1708588800&start=1708502400",
 			request: &PrometheusLabelValuesQueryRequest{
 				Path:      "/api/v1/label/job/values",
+				Headers:   defaultHeaders,
 				LabelName: "job",
 				Start:     1708502400000,
 				End:       1708588800000,
@@ -1765,6 +1772,7 @@ func TestPrometheusCodec_DecodeEncodeMultipleTimes_Labels(t *testing.T) {
 			queryURL: "/api/v1/label/job/values?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
 			request: &PrometheusLabelValuesQueryRequest{
 				Path:      "/api/v1/label/job/values",
+				Headers:   defaultHeaders,
 				LabelName: "job",
 				Start:     1708502400000,
 				End:       1708588800000,
@@ -1779,9 +1787,10 @@ func TestPrometheusCodec_DecodeEncodeMultipleTimes_Labels(t *testing.T) {
 			name:     "series - minimal",
 			queryURL: "/api/v1/series?end=1708588800&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
 			request: &PrometheusSeriesQueryRequest{
-				Path:  "/api/v1/series",
-				Start: 1708502400000,
-				End:   1708588800000,
+				Path:    "/api/v1/series",
+				Headers: defaultHeaders,
+				Start:   1708502400000,
+				End:     1708588800000,
 				LabelMatcherSets: []string{
 					"go_goroutines{container!=\"query-scheduler\"}",
 				},
@@ -1791,9 +1800,10 @@ func TestPrometheusCodec_DecodeEncodeMultipleTimes_Labels(t *testing.T) {
 			name:     "series - all",
 			queryURL: "/api/v1/series?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
 			request: &PrometheusSeriesQueryRequest{
-				Path:  "/api/v1/series",
-				Start: 1708502400000,
-				End:   1708588800000,
+				Path:    "/api/v1/series",
+				Headers: defaultHeaders,
+				Start:   1708502400000,
+				End:     1708588800000,
 				LabelMatcherSets: []string{
 					"go_goroutines{container=~\"quer.*\"}",
 					"go_goroutines{container!=\"query-scheduler\"}",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

We try to copy the headers from the internal request representation, but we never transfer it from the HTTP request to that representation  in the first place. This PR fixes that. 

https://github.com/grafana/mimir/blob/97f031939ce511e2d93a6e80634d9c5d9a5d8f90/pkg/frontend/querymiddleware/codec.go#L731-L741


Technically the list of headers to propagate is empty by default in Mimir, so there wasn't a bug for Mimir users, hence, not adding a changelog entry.

https://github.com/grafana/mimir/blob/451d592d6cd65171da4741564745ef105c1c475e/pkg/frontend/querymiddleware/codec.go#L53


> __Note to reviewers__: reviewing without whitespace is easier

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.



