### PR TITLE
Add partition and instance rings support to usage-tracker

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -18120,6 +18120,754 @@
     },
     {
       "kind": "block",
+      "name": "usage_tracker",
+      "required": false,
+      "desc": "",
+      "blockEntries": [
+        {
+          "kind": "block",
+          "name": "ring",
+          "required": false,
+          "desc": "",
+          "blockEntries": [
+            {
+              "kind": "block",
+              "name": "kvstore",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "store",
+                  "required": false,
+                  "desc": "Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "memberlist",
+                  "fieldFlag": "usage-tracker.ring.store",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "prefix",
+                  "required": false,
+                  "desc": "The prefix for the keys in the store. Should end with a /.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "collectors/",
+                  "fieldFlag": "usage-tracker.ring.prefix",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "block",
+                  "name": "consul",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "host",
+                      "required": false,
+                      "desc": "Hostname and port of Consul.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "localhost:8500",
+                      "fieldFlag": "usage-tracker.ring.consul.hostname",
+                      "fieldType": "string"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "acl_token",
+                      "required": false,
+                      "desc": "ACL Token used to interact with Consul.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.consul.acl-token",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "http_client_timeout",
+                      "required": false,
+                      "desc": "HTTP timeout when talking to Consul",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 20000000000,
+                      "fieldFlag": "usage-tracker.ring.consul.client-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "consistent_reads",
+                      "required": false,
+                      "desc": "Enable consistent reads to Consul.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.ring.consul.consistent-reads",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "watch_rate_limit",
+                      "required": false,
+                      "desc": "Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 1,
+                      "fieldFlag": "usage-tracker.ring.consul.watch-rate-limit",
+                      "fieldType": "float",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "watch_burst_size",
+                      "required": false,
+                      "desc": "Burst size used in rate limit. Values less than 1 are treated as 1.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 1,
+                      "fieldFlag": "usage-tracker.ring.consul.watch-burst-size",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "cas_retry_delay",
+                      "required": false,
+                      "desc": "Maximum duration to wait before retrying a Compare And Swap (CAS) operation.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 1000000000,
+                      "fieldFlag": "usage-tracker.ring.consul.cas-retry-delay",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                },
+                {
+                  "kind": "block",
+                  "name": "etcd",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "endpoints",
+                      "required": false,
+                      "desc": "The etcd endpoints to connect to.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": [],
+                      "fieldFlag": "usage-tracker.ring.etcd.endpoints",
+                      "fieldType": "list of strings"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "dial_timeout",
+                      "required": false,
+                      "desc": "The dial timeout for the etcd connection.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 10000000000,
+                      "fieldFlag": "usage-tracker.ring.etcd.dial-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_retries",
+                      "required": false,
+                      "desc": "The maximum number of retries to do for failed ops.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 10,
+                      "fieldFlag": "usage-tracker.ring.etcd.max-retries",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_enabled",
+                      "required": false,
+                      "desc": "Enable TLS.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.ring.etcd.tls-enabled",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_cert_path",
+                      "required": false,
+                      "desc": "Path to the client certificate, which will be used for authenticating with the server. Also requires the key path to be configured.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.etcd.tls-cert-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_key_path",
+                      "required": false,
+                      "desc": "Path to the key for the client certificate. Also requires the client certificate to be configured.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.etcd.tls-key-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_ca_path",
+                      "required": false,
+                      "desc": "Path to the CA certificates to validate server certificate against. If not set, the host's root CA certificates are used.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.etcd.tls-ca-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_server_name",
+                      "required": false,
+                      "desc": "Override the expected name on the server certificate.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.etcd.tls-server-name",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_insecure_skip_verify",
+                      "required": false,
+                      "desc": "Skip validating server certificate.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.ring.etcd.tls-insecure-skip-verify",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_cipher_suites",
+                      "required": false,
+                      "desc": "Override the default cipher suite list (separated by commas). Allowed values:\n\nSecure Ciphers:\n- TLS_AES_128_GCM_SHA256\n- TLS_AES_256_GCM_SHA384\n- TLS_CHACHA20_POLY1305_SHA256\n- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA\n- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA\n- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA\n- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA\n- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\n- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\n- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\n- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\n- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\n- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\n\nInsecure Ciphers:\n- TLS_RSA_WITH_RC4_128_SHA\n- TLS_RSA_WITH_3DES_EDE_CBC_SHA\n- TLS_RSA_WITH_AES_128_CBC_SHA\n- TLS_RSA_WITH_AES_256_CBC_SHA\n- TLS_RSA_WITH_AES_128_CBC_SHA256\n- TLS_RSA_WITH_AES_128_GCM_SHA256\n- TLS_RSA_WITH_AES_256_GCM_SHA384\n- TLS_ECDHE_ECDSA_WITH_RC4_128_SHA\n- TLS_ECDHE_RSA_WITH_RC4_128_SHA\n- TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA\n- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256\n- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256\n",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.etcd.tls-cipher-suites",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_min_version",
+                      "required": false,
+                      "desc": "Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.etcd.tls-min-version",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "username",
+                      "required": false,
+                      "desc": "Etcd username.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.etcd.username",
+                      "fieldType": "string"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "password",
+                      "required": false,
+                      "desc": "Etcd password.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.etcd.password",
+                      "fieldType": "string"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                },
+                {
+                  "kind": "block",
+                  "name": "multi",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "primary",
+                      "required": false,
+                      "desc": "Primary backend storage used by multi-client.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.multi.primary",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "secondary",
+                      "required": false,
+                      "desc": "Secondary backend storage used by multi-client.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.ring.multi.secondary",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "mirror_enabled",
+                      "required": false,
+                      "desc": "Mirror writes to secondary store.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.ring.multi.mirror-enabled",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "mirror_timeout",
+                      "required": false,
+                      "desc": "Timeout for storing value to secondary store.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 2000000000,
+                      "fieldFlag": "usage-tracker.ring.multi.mirror-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
+            },
+            {
+              "kind": "field",
+              "name": "heartbeat_period",
+              "required": false,
+              "desc": "Period at which to heartbeat to the ring. 0 = disabled.",
+              "fieldValue": null,
+              "fieldDefaultValue": 15000000000,
+              "fieldFlag": "usage-tracker.ring.heartbeat-period",
+              "fieldType": "duration",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "heartbeat_timeout",
+              "required": false,
+              "desc": "The heartbeat timeout after which usage-trackers are considered unhealthy within the ring.",
+              "fieldValue": null,
+              "fieldDefaultValue": 60000000000,
+              "fieldFlag": "usage-tracker.ring.heartbeat-timeout",
+              "fieldType": "duration",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "instance_id",
+              "required": false,
+              "desc": "Instance ID to register in the ring.",
+              "fieldValue": null,
+              "fieldDefaultValue": "\u003chostname\u003e",
+              "fieldFlag": "usage-tracker.ring.instance-id",
+              "fieldType": "string",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "instance_interface_names",
+              "required": false,
+              "desc": "List of network interface names to look up when finding the instance IP address.",
+              "fieldValue": null,
+              "fieldDefaultValue": [],
+              "fieldFlag": "usage-tracker.ring.instance-interface-names",
+              "fieldType": "list of strings"
+            },
+            {
+              "kind": "field",
+              "name": "instance_port",
+              "required": false,
+              "desc": "Port to advertise in the ring (defaults to -server.grpc-listen-port).",
+              "fieldValue": null,
+              "fieldDefaultValue": 0,
+              "fieldFlag": "usage-tracker.ring.instance-port",
+              "fieldType": "int",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "instance_addr",
+              "required": false,
+              "desc": "IP address to advertise in the ring. Default is auto-detected.",
+              "fieldValue": null,
+              "fieldDefaultValue": "",
+              "fieldFlag": "usage-tracker.ring.instance-addr",
+              "fieldType": "string",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "instance_enable_ipv6",
+              "required": false,
+              "desc": "Enable using a IPv6 instance address. (default false)",
+              "fieldValue": null,
+              "fieldDefaultValue": false,
+              "fieldFlag": "usage-tracker.ring.instance-enable-ipv6",
+              "fieldType": "boolean",
+              "fieldCategory": "advanced"
+            }
+          ],
+          "fieldValue": null,
+          "fieldDefaultValue": null
+        },
+        {
+          "kind": "block",
+          "name": "partition_ring",
+          "required": false,
+          "desc": "",
+          "blockEntries": [
+            {
+              "kind": "block",
+              "name": "kvstore",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "store",
+                  "required": false,
+                  "desc": "Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "memberlist",
+                  "fieldFlag": "usage-tracker.partition-ring.store",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "prefix",
+                  "required": false,
+                  "desc": "The prefix for the keys in the store. Should end with a /.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "collectors/",
+                  "fieldFlag": "usage-tracker.partition-ring.prefix",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "block",
+                  "name": "consul",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "host",
+                      "required": false,
+                      "desc": "Hostname and port of Consul.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "localhost:8500",
+                      "fieldFlag": "usage-tracker.partition-ring.consul.hostname",
+                      "fieldType": "string"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "acl_token",
+                      "required": false,
+                      "desc": "ACL Token used to interact with Consul.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.consul.acl-token",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "http_client_timeout",
+                      "required": false,
+                      "desc": "HTTP timeout when talking to Consul",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 20000000000,
+                      "fieldFlag": "usage-tracker.partition-ring.consul.client-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "consistent_reads",
+                      "required": false,
+                      "desc": "Enable consistent reads to Consul.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.partition-ring.consul.consistent-reads",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "watch_rate_limit",
+                      "required": false,
+                      "desc": "Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 1,
+                      "fieldFlag": "usage-tracker.partition-ring.consul.watch-rate-limit",
+                      "fieldType": "float",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "watch_burst_size",
+                      "required": false,
+                      "desc": "Burst size used in rate limit. Values less than 1 are treated as 1.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 1,
+                      "fieldFlag": "usage-tracker.partition-ring.consul.watch-burst-size",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "cas_retry_delay",
+                      "required": false,
+                      "desc": "Maximum duration to wait before retrying a Compare And Swap (CAS) operation.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 1000000000,
+                      "fieldFlag": "usage-tracker.partition-ring.consul.cas-retry-delay",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                },
+                {
+                  "kind": "block",
+                  "name": "etcd",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "endpoints",
+                      "required": false,
+                      "desc": "The etcd endpoints to connect to.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": [],
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.endpoints",
+                      "fieldType": "list of strings"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "dial_timeout",
+                      "required": false,
+                      "desc": "The dial timeout for the etcd connection.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 10000000000,
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.dial-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_retries",
+                      "required": false,
+                      "desc": "The maximum number of retries to do for failed ops.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 10,
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.max-retries",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_enabled",
+                      "required": false,
+                      "desc": "Enable TLS.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.tls-enabled",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_cert_path",
+                      "required": false,
+                      "desc": "Path to the client certificate, which will be used for authenticating with the server. Also requires the key path to be configured.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.tls-cert-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_key_path",
+                      "required": false,
+                      "desc": "Path to the key for the client certificate. Also requires the client certificate to be configured.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.tls-key-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_ca_path",
+                      "required": false,
+                      "desc": "Path to the CA certificates to validate server certificate against. If not set, the host's root CA certificates are used.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.tls-ca-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_server_name",
+                      "required": false,
+                      "desc": "Override the expected name on the server certificate.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.tls-server-name",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_insecure_skip_verify",
+                      "required": false,
+                      "desc": "Skip validating server certificate.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.tls-insecure-skip-verify",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_cipher_suites",
+                      "required": false,
+                      "desc": "Override the default cipher suite list (separated by commas). Allowed values:\n\nSecure Ciphers:\n- TLS_AES_128_GCM_SHA256\n- TLS_AES_256_GCM_SHA384\n- TLS_CHACHA20_POLY1305_SHA256\n- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA\n- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA\n- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA\n- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA\n- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\n- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\n- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\n- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\n- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\n- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\n\nInsecure Ciphers:\n- TLS_RSA_WITH_RC4_128_SHA\n- TLS_RSA_WITH_3DES_EDE_CBC_SHA\n- TLS_RSA_WITH_AES_128_CBC_SHA\n- TLS_RSA_WITH_AES_256_CBC_SHA\n- TLS_RSA_WITH_AES_128_CBC_SHA256\n- TLS_RSA_WITH_AES_128_GCM_SHA256\n- TLS_RSA_WITH_AES_256_GCM_SHA384\n- TLS_ECDHE_ECDSA_WITH_RC4_128_SHA\n- TLS_ECDHE_RSA_WITH_RC4_128_SHA\n- TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA\n- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256\n- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256\n",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.tls-cipher-suites",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_min_version",
+                      "required": false,
+                      "desc": "Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.tls-min-version",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "username",
+                      "required": false,
+                      "desc": "Etcd username.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.username",
+                      "fieldType": "string"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "password",
+                      "required": false,
+                      "desc": "Etcd password.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.etcd.password",
+                      "fieldType": "string"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                },
+                {
+                  "kind": "block",
+                  "name": "multi",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "primary",
+                      "required": false,
+                      "desc": "Primary backend storage used by multi-client.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.multi.primary",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "secondary",
+                      "required": false,
+                      "desc": "Secondary backend storage used by multi-client.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.partition-ring.multi.secondary",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "mirror_enabled",
+                      "required": false,
+                      "desc": "Mirror writes to secondary store.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.partition-ring.multi.mirror-enabled",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "mirror_timeout",
+                      "required": false,
+                      "desc": "Timeout for storing value to secondary store.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 2000000000,
+                      "fieldFlag": "usage-tracker.partition-ring.multi.mirror-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
+            }
+          ],
+          "fieldValue": null,
+          "fieldDefaultValue": null
+        }
+      ],
+      "fieldValue": null,
+      "fieldDefaultValue": null
+    },
+    {
+      "kind": "block",
       "name": "overrides_exporter",
       "required": false,
       "desc": "",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3317,6 +3317,124 @@ Usage of ./cmd/mimir/mimir:
     	Enable anonymous usage reporting. (default true)
   -usage-stats.installation-mode string
     	Installation mode. Supported values: custom, helm, jsonnet. (default "custom")
+  -usage-tracker.partition-ring.consul.acl-token string
+    	ACL Token used to interact with Consul.
+  -usage-tracker.partition-ring.consul.cas-retry-delay duration
+    	Maximum duration to wait before retrying a Compare And Swap (CAS) operation. (default 1s)
+  -usage-tracker.partition-ring.consul.client-timeout duration
+    	HTTP timeout when talking to Consul (default 20s)
+  -usage-tracker.partition-ring.consul.consistent-reads
+    	Enable consistent reads to Consul.
+  -usage-tracker.partition-ring.consul.hostname string
+    	Hostname and port of Consul. (default "localhost:8500")
+  -usage-tracker.partition-ring.consul.watch-burst-size int
+    	Burst size used in rate limit. Values less than 1 are treated as 1. (default 1)
+  -usage-tracker.partition-ring.consul.watch-rate-limit float
+    	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
+  -usage-tracker.partition-ring.etcd.dial-timeout duration
+    	The dial timeout for the etcd connection. (default 10s)
+  -usage-tracker.partition-ring.etcd.endpoints string
+    	The etcd endpoints to connect to.
+  -usage-tracker.partition-ring.etcd.max-retries int
+    	The maximum number of retries to do for failed ops. (default 10)
+  -usage-tracker.partition-ring.etcd.password string
+    	Etcd password.
+  -usage-tracker.partition-ring.etcd.tls-ca-path string
+    	Path to the CA certificates to validate server certificate against. If not set, the host's root CA certificates are used.
+  -usage-tracker.partition-ring.etcd.tls-cert-path string
+    	Path to the client certificate, which will be used for authenticating with the server. Also requires the key path to be configured.
+  -usage-tracker.partition-ring.etcd.tls-cipher-suites string
+    	Override the default cipher suite list (separated by commas).
+  -usage-tracker.partition-ring.etcd.tls-enabled
+    	Enable TLS.
+  -usage-tracker.partition-ring.etcd.tls-insecure-skip-verify
+    	Skip validating server certificate.
+  -usage-tracker.partition-ring.etcd.tls-key-path string
+    	Path to the key for the client certificate. Also requires the client certificate to be configured.
+  -usage-tracker.partition-ring.etcd.tls-min-version string
+    	Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
+  -usage-tracker.partition-ring.etcd.tls-server-name string
+    	Override the expected name on the server certificate.
+  -usage-tracker.partition-ring.etcd.username string
+    	Etcd username.
+  -usage-tracker.partition-ring.multi.mirror-enabled
+    	Mirror writes to secondary store.
+  -usage-tracker.partition-ring.multi.mirror-timeout duration
+    	Timeout for storing value to secondary store. (default 2s)
+  -usage-tracker.partition-ring.multi.primary string
+    	Primary backend storage used by multi-client.
+  -usage-tracker.partition-ring.multi.secondary string
+    	Secondary backend storage used by multi-client.
+  -usage-tracker.partition-ring.prefix string
+    	The prefix for the keys in the store. Should end with a /. (default "collectors/")
+  -usage-tracker.partition-ring.store string
+    	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+  -usage-tracker.ring.consul.acl-token string
+    	ACL Token used to interact with Consul.
+  -usage-tracker.ring.consul.cas-retry-delay duration
+    	Maximum duration to wait before retrying a Compare And Swap (CAS) operation. (default 1s)
+  -usage-tracker.ring.consul.client-timeout duration
+    	HTTP timeout when talking to Consul (default 20s)
+  -usage-tracker.ring.consul.consistent-reads
+    	Enable consistent reads to Consul.
+  -usage-tracker.ring.consul.hostname string
+    	Hostname and port of Consul. (default "localhost:8500")
+  -usage-tracker.ring.consul.watch-burst-size int
+    	Burst size used in rate limit. Values less than 1 are treated as 1. (default 1)
+  -usage-tracker.ring.consul.watch-rate-limit float
+    	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
+  -usage-tracker.ring.etcd.dial-timeout duration
+    	The dial timeout for the etcd connection. (default 10s)
+  -usage-tracker.ring.etcd.endpoints string
+    	The etcd endpoints to connect to.
+  -usage-tracker.ring.etcd.max-retries int
+    	The maximum number of retries to do for failed ops. (default 10)
+  -usage-tracker.ring.etcd.password string
+    	Etcd password.
+  -usage-tracker.ring.etcd.tls-ca-path string
+    	Path to the CA certificates to validate server certificate against. If not set, the host's root CA certificates are used.
+  -usage-tracker.ring.etcd.tls-cert-path string
+    	Path to the client certificate, which will be used for authenticating with the server. Also requires the key path to be configured.
+  -usage-tracker.ring.etcd.tls-cipher-suites string
+    	Override the default cipher suite list (separated by commas).
+  -usage-tracker.ring.etcd.tls-enabled
+    	Enable TLS.
+  -usage-tracker.ring.etcd.tls-insecure-skip-verify
+    	Skip validating server certificate.
+  -usage-tracker.ring.etcd.tls-key-path string
+    	Path to the key for the client certificate. Also requires the client certificate to be configured.
+  -usage-tracker.ring.etcd.tls-min-version string
+    	Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
+  -usage-tracker.ring.etcd.tls-server-name string
+    	Override the expected name on the server certificate.
+  -usage-tracker.ring.etcd.username string
+    	Etcd username.
+  -usage-tracker.ring.heartbeat-period duration
+    	Period at which to heartbeat to the ring. 0 = disabled. (default 15s)
+  -usage-tracker.ring.heartbeat-timeout duration
+    	The heartbeat timeout after which usage-trackers are considered unhealthy within the ring. (default 1m0s)
+  -usage-tracker.ring.instance-addr string
+    	IP address to advertise in the ring. Default is auto-detected.
+  -usage-tracker.ring.instance-enable-ipv6
+    	Enable using a IPv6 instance address. (default false)
+  -usage-tracker.ring.instance-id string
+    	Instance ID to register in the ring. (default "<hostname>")
+  -usage-tracker.ring.instance-interface-names string
+    	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
+  -usage-tracker.ring.instance-port int
+    	Port to advertise in the ring (defaults to -server.grpc-listen-port).
+  -usage-tracker.ring.multi.mirror-enabled
+    	Mirror writes to secondary store.
+  -usage-tracker.ring.multi.mirror-timeout duration
+    	Timeout for storing value to secondary store. (default 2s)
+  -usage-tracker.ring.multi.primary string
+    	Primary backend storage used by multi-client.
+  -usage-tracker.ring.multi.secondary string
+    	Secondary backend storage used by multi-client.
+  -usage-tracker.ring.prefix string
+    	The prefix for the keys in the store. Should end with a /. (default "collectors/")
+  -usage-tracker.ring.store string
+    	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -validation.create-grace-period duration
     	Controls how far into the future incoming samples and exemplars are accepted compared to the wall clock. Any sample or exemplar will be rejected if its timestamp is greater than '(now + creation_grace_period)'. This configuration is enforced in the distributor and ingester. (default 10m)
   -validation.enforce-metadata-metric-name

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -861,6 +861,28 @@ Usage of ./cmd/mimir/mimir:
     	Enable anonymous usage reporting. (default true)
   -usage-stats.installation-mode string
     	Installation mode. Supported values: custom, helm, jsonnet. (default "custom")
+  -usage-tracker.partition-ring.consul.hostname string
+    	Hostname and port of Consul. (default "localhost:8500")
+  -usage-tracker.partition-ring.etcd.endpoints string
+    	The etcd endpoints to connect to.
+  -usage-tracker.partition-ring.etcd.password string
+    	Etcd password.
+  -usage-tracker.partition-ring.etcd.username string
+    	Etcd username.
+  -usage-tracker.partition-ring.store string
+    	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+  -usage-tracker.ring.consul.hostname string
+    	Hostname and port of Consul. (default "localhost:8500")
+  -usage-tracker.ring.etcd.endpoints string
+    	The etcd endpoints to connect to.
+  -usage-tracker.ring.etcd.password string
+    	Etcd password.
+  -usage-tracker.ring.etcd.username string
+    	Etcd username.
+  -usage-tracker.ring.instance-interface-names string
+    	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
+  -usage-tracker.ring.store string
+    	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -validation.max-label-names-per-info-series int
     	Maximum number of label names per info series. Has no effect if less than the value of the maximum number of label names per series option (-validation.max-label-names-per-series) (default 80)
   -validation.max-label-names-per-series int

--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -91,8 +91,8 @@ std.manifestYamlDoc({
   },
 
   usage_tracker:: {
-    'usage-tracker': mimirService({
-      name: 'usage-tracker',
+    'usage-tracker-1': mimirService({
+      name: 'usage-tracker-1',
       target: 'usage-tracker',
       publishedHttpPort: 8008,
     }),

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -375,14 +375,14 @@
       - "8080:8080"
     "volumes":
       - "../common/config:/etc/nginx/templates"
-  "usage-tracker":
+  "usage-tracker-1":
     "build":
       "context": "."
       "dockerfile": "dev.dockerfile"
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=usage-tracker -activity-tracker.filepath=/activity/usage-tracker"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=usage-tracker -activity-tracker.filepath=/activity/usage-tracker-1"
     "depends_on":
       "kafka_1":
         "condition": "service_healthy"
@@ -397,7 +397,7 @@
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=usage-tracker"
-    "hostname": "usage-tracker"
+    "hostname": "usage-tracker-1"
     "image": "mimir"
     "ports":
       - "8008:8080"

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -354,6 +354,116 @@ usage_stats:
   # CLI flag: -usage-stats.installation-mode
   [installation_mode: <string> | default = "custom"]
 
+usage_tracker:
+  ring:
+    # The key-value store used to share the hash ring across multiple instances.
+    # When usage-tracker is enabled, this option needs be set on usage-trackers
+    # and distributors.
+    kvstore:
+      # Backend storage to use for the ring. Supported values are: consul, etcd,
+      # inmemory, memberlist, multi.
+      # CLI flag: -usage-tracker.ring.store
+      [store: <string> | default = "memberlist"]
+
+      # (advanced) The prefix for the keys in the store. Should end with a /.
+      # CLI flag: -usage-tracker.ring.prefix
+      [prefix: <string> | default = "collectors/"]
+
+      # The consul block configures the consul client.
+      # The CLI flags prefix for this block configuration is: usage-tracker.ring
+      [consul: <consul>]
+
+      # The etcd block configures the etcd client.
+      # The CLI flags prefix for this block configuration is: usage-tracker.ring
+      [etcd: <etcd>]
+
+      multi:
+        # (advanced) Primary backend storage used by multi-client.
+        # CLI flag: -usage-tracker.ring.multi.primary
+        [primary: <string> | default = ""]
+
+        # (advanced) Secondary backend storage used by multi-client.
+        # CLI flag: -usage-tracker.ring.multi.secondary
+        [secondary: <string> | default = ""]
+
+        # (advanced) Mirror writes to secondary store.
+        # CLI flag: -usage-tracker.ring.multi.mirror-enabled
+        [mirror_enabled: <boolean> | default = false]
+
+        # (advanced) Timeout for storing value to secondary store.
+        # CLI flag: -usage-tracker.ring.multi.mirror-timeout
+        [mirror_timeout: <duration> | default = 2s]
+
+    # (advanced) Period at which to heartbeat to the ring. 0 = disabled.
+    # CLI flag: -usage-tracker.ring.heartbeat-period
+    [heartbeat_period: <duration> | default = 15s]
+
+    # (advanced) The heartbeat timeout after which usage-trackers are considered
+    # unhealthy within the ring.
+    # CLI flag: -usage-tracker.ring.heartbeat-timeout
+    [heartbeat_timeout: <duration> | default = 1m]
+
+    # (advanced) Instance ID to register in the ring.
+    # CLI flag: -usage-tracker.ring.instance-id
+    [instance_id: <string> | default = "<hostname>"]
+
+    # List of network interface names to look up when finding the instance IP
+    # address.
+    # CLI flag: -usage-tracker.ring.instance-interface-names
+    [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
+
+    # (advanced) Port to advertise in the ring (defaults to
+    # -server.grpc-listen-port).
+    # CLI flag: -usage-tracker.ring.instance-port
+    [instance_port: <int> | default = 0]
+
+    # (advanced) IP address to advertise in the ring. Default is auto-detected.
+    # CLI flag: -usage-tracker.ring.instance-addr
+    [instance_addr: <string> | default = ""]
+
+    # (advanced) Enable using a IPv6 instance address. (default false)
+    # CLI flag: -usage-tracker.ring.instance-enable-ipv6
+    [instance_enable_ipv6: <boolean> | default = false]
+
+  partition_ring:
+    # The key-value store used to share the hash ring across multiple instances.
+    kvstore:
+      # Backend storage to use for the ring. Supported values are: consul, etcd,
+      # inmemory, memberlist, multi.
+      # CLI flag: -usage-tracker.partition-ring.store
+      [store: <string> | default = "memberlist"]
+
+      # (advanced) The prefix for the keys in the store. Should end with a /.
+      # CLI flag: -usage-tracker.partition-ring.prefix
+      [prefix: <string> | default = "collectors/"]
+
+      # The consul block configures the consul client.
+      # The CLI flags prefix for this block configuration is:
+      # usage-tracker.partition-ring
+      [consul: <consul>]
+
+      # The etcd block configures the etcd client.
+      # The CLI flags prefix for this block configuration is:
+      # usage-tracker.partition-ring
+      [etcd: <etcd>]
+
+      multi:
+        # (advanced) Primary backend storage used by multi-client.
+        # CLI flag: -usage-tracker.partition-ring.multi.primary
+        [primary: <string> | default = ""]
+
+        # (advanced) Secondary backend storage used by multi-client.
+        # CLI flag: -usage-tracker.partition-ring.multi.secondary
+        [secondary: <string> | default = ""]
+
+        # (advanced) Mirror writes to secondary store.
+        # CLI flag: -usage-tracker.partition-ring.multi.mirror-enabled
+        [mirror_enabled: <boolean> | default = false]
+
+        # (advanced) Timeout for storing value to secondary store.
+        # CLI flag: -usage-tracker.partition-ring.multi.mirror-timeout
+        [mirror_timeout: <duration> | default = 2s]
+
 overrides_exporter:
   ring:
     # Enable the ring used by override-exporters to deduplicate exported limit
@@ -2807,6 +2917,8 @@ The `etcd` block configures the etcd client. The supported CLI flags `<prefix>` 
 - `query-scheduler.ring`
 - `ruler.ring`
 - `store-gateway.sharding-ring`
+- `usage-tracker.partition-ring`
+- `usage-tracker.ring`
 
 &nbsp;
 
@@ -2912,6 +3024,8 @@ The `consul` block configures the consul client. The supported CLI flags `<prefi
 - `query-scheduler.ring`
 - `ruler.ring`
 - `store-gateway.sharding-ring`
+- `usage-tracker.partition-ring`
+- `usage-tracker.ring`
 
 &nbsp;
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -493,6 +493,14 @@ func (a *API) RegisterOverridesExporter(oe *exporter.OverridesExporter) {
 }
 
 func (a *API) RegisterUsageTracker(t *usagetracker.UsageTracker) {
+	a.indexPage.AddLinks(defaultWeight, "Usage-tracker", []IndexPageLink{
+		{Desc: "Instance ring status", Path: "/usage-tracker/instance-ring"},
+		{Desc: "Partition ring status", Path: "/usage-tracker/partition-ring"},
+	})
+
+	a.RegisterRoute("/usage-tracker/instance-ring", http.HandlerFunc(t.InstanceRingHandler), false, true, "GET", "POST")
+	a.RegisterRoute("/usage-tracker/partition-ring", http.HandlerFunc(t.PartitionRingHandler), false, true, "GET", "POST")
+
 	usagetrackerpb.RegisterUsageTrackerServer(a.server.GRPC, t)
 }
 

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -143,6 +143,7 @@ type Config struct {
 	MemberlistKV        memberlist.KVConfig                        `yaml:"memberlist"`
 	QueryScheduler      scheduler.Config                           `yaml:"query_scheduler"`
 	UsageStats          usagestats.Config                          `yaml:"usage_stats"`
+	UsageTracker        usagetracker.Config                        `yaml:"usage_tracker"`
 	ContinuousTest      continuoustest.Config                      `yaml:"-"`
 	OverridesExporter   exporter.Config                            `yaml:"overrides_exporter"`
 
@@ -203,6 +204,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.ActivityTracker.RegisterFlags(f)
 	c.QueryScheduler.RegisterFlags(f, logger)
 	c.UsageStats.RegisterFlags(f)
+	c.UsageTracker.RegisterFlags(f, logger)
 	c.ContinuousTest.RegisterFlags(f)
 	c.OverridesExporter.RegisterFlags(f, logger)
 

--- a/pkg/usagetracker/tracker.go
+++ b/pkg/usagetracker/tracker.go
@@ -4,53 +4,135 @@ package usagetracker
 
 import (
 	"context"
+	"flag"
+	"net/http"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/mimir/pkg/usagetracker/usagetrackerpb"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
+type Config struct {
+	InstanceRing  InstanceRingConfig  `yaml:"ring"`
+	PartitionRing PartitionRingConfig `yaml:"partition_ring"`
+}
+
+func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
+	c.InstanceRing.RegisterFlags(f, logger)
+	c.PartitionRing.RegisterFlags(f)
+}
+
 type UsageTracker struct {
 	services.Service
 
 	overrides *validation.Overrides
 	logger    log.Logger
+
+	partitionID          int32
+	partitionLifecycler  *ring.PartitionInstanceLifecycler
+	partitionWatcher     *ring.PartitionRingWatcher
+	partitionPageHandler *ring.PartitionRingPageHandler
+
+	instanceLifecycler *ring.BasicLifecycler
+
+	// Dependencies.
+	subservices        *services.Manager
+	subservicesWatcher *services.FailureWatcher
 }
 
-func NewUsageTracker(overrides *validation.Overrides, logger log.Logger, _ prometheus.Registerer) *UsageTracker {
+func NewUsageTracker(cfg Config, overrides *validation.Overrides, logger log.Logger, registerer prometheus.Registerer) (*UsageTracker, error) {
 	t := &UsageTracker{
 		overrides: overrides,
 		logger:    logger,
 	}
 
+	// Get the partition ID.
+	var err error
+	t.partitionID, err = partitionIDFromInstanceID(cfg.InstanceRing.InstanceID)
+	if err != nil {
+		return nil, errors.Wrap(err, "calculating usage-tracker partition ID")
+	}
+
+	// Init instance ring.
+	t.instanceLifecycler, err = NewInstanceRingLifecycler(cfg.InstanceRing, logger, registerer)
+	if err != nil {
+		return nil, err
+	}
+
+	// Init the partition ring.
+	partitionKVClient, err := NewPartitionRingKVClient(cfg.PartitionRing, logger, registerer)
+	if err != nil {
+		return nil, err
+	}
+
+	t.partitionLifecycler, err = NewPartitionRingLifecycler(cfg.PartitionRing, t.partitionID, cfg.InstanceRing.InstanceID, partitionKVClient, logger, registerer)
+	if err != nil {
+		return nil, err
+	}
+
+	t.partitionWatcher = ring.NewPartitionRingWatcher(partitionRingName, partitionRingKey, partitionKVClient, logger, prometheus.WrapRegistererWithPrefix("cortex_", registerer))
+	t.partitionPageHandler = ring.NewPartitionRingPageHandler(t.partitionWatcher, ring.NewPartitionRingEditor(partitionRingKey, partitionKVClient))
+
 	t.Service = services.NewBasicService(t.start, t.run, t.stop)
 
-	return t
+	return t, nil
 }
 
 // start implements services.StartingFn.
-func (t *UsageTracker) start(_ context.Context) error {
+func (t *UsageTracker) start(ctx context.Context) error {
+	var err error
+
+	// Start dependencies.
+	if t.subservices, err = services.NewManager(t.instanceLifecycler, t.partitionLifecycler, t.partitionWatcher); err != nil {
+		return errors.Wrap(err, "unable to start usage-tracker dependencies")
+	}
+
+	t.subservicesWatcher = services.NewFailureWatcher()
+	t.subservicesWatcher.WatchManager(t.subservices)
+
+	if err = services.StartManagerAndAwaitHealthy(ctx, t.subservices); err != nil {
+		return errors.Wrap(err, "unable to start usage-tracker subservices")
+	}
+
 	return nil
 }
 
 // stop implements services.StoppingFn.
 func (t *UsageTracker) stop(_ error) error {
+	// Stop dependencies.
+	if t.subservices != nil {
+		_ = services.StopManagerAndAwaitStopped(context.Background(), t.subservices)
+	}
+
 	return nil
 }
 
 // run implements services.RunningFn.
 func (t *UsageTracker) run(ctx context.Context) error {
-	level.Info(t.logger).Log("msg", "Usage tracker service is running")
-
-	<-ctx.Done()
-	return nil
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-t.subservicesWatcher.Chan():
+			return errors.Wrap(err, "usage-tracker dependency failed")
+		}
+	}
 }
 
 // TrackSeries implements usagetrackerpb.UsageTrackerServer.
 func (t *UsageTracker) TrackSeries(_ context.Context, _ *usagetrackerpb.TrackSeriesRequest) (*usagetrackerpb.TrackSeriesResponse, error) {
 	return &usagetrackerpb.TrackSeriesResponse{}, nil
+}
+
+func (t *UsageTracker) InstanceRingHandler(w http.ResponseWriter, req *http.Request) {
+	t.instanceLifecycler.ServeHTTP(w, req)
+}
+
+func (t *UsageTracker) PartitionRingHandler(w http.ResponseWriter, req *http.Request) {
+	t.partitionPageHandler.ServeHTTP(w, req)
 }

--- a/pkg/usagetracker/tracker_instance_ring.go
+++ b/pkg/usagetracker/tracker_instance_ring.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagetracker
+
+import (
+	"flag"
+	"net"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/netutil"
+	"github.com/grafana/dskit/ring"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	instanceRingKey  = "usage-tracker-instances"
+	instanceRingName = "usage-tracker-instances"
+
+	// ringAutoForgetUnhealthyPeriods is how many consecutive timeout periods an unhealthy instance
+	// in the ring will be automatically removed after.
+	ringAutoForgetUnhealthyPeriods = 4
+)
+
+// InstanceRingConfig masks the ring lifecycler config which contains many options not really required by the usage-tracker ring.
+// This config is used to strip down the config to the minimum, and avoid confusion to the user.
+type InstanceRingConfig struct {
+	KVStore          kv.Config     `yaml:"kvstore" doc:"description=The key-value store used to share the hash ring across multiple instances. When usage-tracker is enabled, this option needs be set on usage-trackers and distributors."`
+	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period" category:"advanced"`
+	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout" category:"advanced"`
+
+	// Instance details
+	InstanceID             string   `yaml:"instance_id" doc:"default=<hostname>" category:"advanced"`
+	InstanceInterfaceNames []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
+	InstancePort           int      `yaml:"instance_port" category:"advanced"`
+	InstanceAddr           string   `yaml:"instance_addr" category:"advanced"`
+	EnableIPv6             bool     `yaml:"instance_enable_ipv6" category:"advanced"`
+
+	// Injected internally
+	ListenPort int `yaml:"-"`
+}
+
+// RegisterFlags adds the flags required to config this to the given flag.FlagSet.
+func (cfg *InstanceRingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to get hostname", "err", err)
+		os.Exit(1)
+	}
+
+	// Ring flags
+	cfg.KVStore.Store = "memberlist" // Override default value.
+	cfg.KVStore.RegisterFlagsWithPrefix("usage-tracker.ring.", "collectors/", f)
+	f.DurationVar(&cfg.HeartbeatPeriod, "usage-tracker.ring.heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
+	f.DurationVar(&cfg.HeartbeatTimeout, "usage-tracker.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which usage-trackers are considered unhealthy within the ring.")
+
+	// Instance flags
+	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, logger)
+	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), "usage-tracker.ring.instance-interface-names", "List of network interface names to look up when finding the instance IP address.")
+	f.StringVar(&cfg.InstanceAddr, "usage-tracker.ring.instance-addr", "", "IP address to advertise in the ring. Default is auto-detected.")
+	f.IntVar(&cfg.InstancePort, "usage-tracker.ring.instance-port", 0, "Port to advertise in the ring (defaults to -server.grpc-listen-port).")
+	f.StringVar(&cfg.InstanceID, "usage-tracker.ring.instance-id", hostname, "Instance ID to register in the ring.")
+	f.BoolVar(&cfg.EnableIPv6, "usage-tracker.ring.instance-enable-ipv6", false, "Enable using a IPv6 instance address. (default false)")
+}
+
+// ToBasicLifecyclerConfig returns a ring.BasicLifecyclerConfig based on the usage-tracker ring config.
+func (cfg *InstanceRingConfig) ToBasicLifecyclerConfig(logger log.Logger) (ring.BasicLifecyclerConfig, error) {
+	instanceAddr, err := ring.GetInstanceAddr(cfg.InstanceAddr, cfg.InstanceInterfaceNames, logger, cfg.EnableIPv6)
+	if err != nil {
+		return ring.BasicLifecyclerConfig{}, err
+	}
+
+	instancePort := ring.GetInstancePort(cfg.InstancePort, cfg.ListenPort)
+
+	return ring.BasicLifecyclerConfig{
+		ID:                              cfg.InstanceID,
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
+		HeartbeatPeriod:                 cfg.HeartbeatPeriod,
+		HeartbeatTimeout:                cfg.HeartbeatTimeout,
+		TokensObservePeriod:             0,
+		NumTokens:                       1, // We just use the instance ring for service discovery.
+		KeepInstanceInTheRingOnShutdown: false,
+	}, nil
+}
+
+// ToRingConfig returns a ring.Config based on the usage-tracker ring config.
+func (cfg *InstanceRingConfig) ToRingConfig() ring.Config {
+	rc := ring.Config{}
+	flagext.DefaultValues(&rc)
+
+	rc.KVStore = cfg.KVStore
+	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
+	rc.ReplicationFactor = 1
+	rc.SubringCacheDisabled = true
+
+	return rc
+}
+
+// NewInstanceRingLifecycler creates a new usage-tracker ring lifecycler with all required lifecycler delegates.
+func NewInstanceRingLifecycler(cfg InstanceRingConfig, logger log.Logger, reg prometheus.Registerer) (*ring.BasicLifecycler, error) {
+	reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
+	kvStore, err := kv.NewClient(cfg.KVStore, ring.GetCodec(), kv.RegistererWithKVName(reg, "usage-tracker-lifecycler"), logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to initialize usage-trackers' KV store")
+	}
+
+	lifecyclerCfg, err := cfg.ToBasicLifecyclerConfig(logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build usage-trackers' lifecycler config")
+	}
+
+	var delegate ring.BasicLifecyclerDelegate
+	delegate = ring.NewInstanceRegisterDelegate(ring.ACTIVE, 1)
+	delegate = ring.NewLeaveOnStoppingDelegate(delegate, logger)
+	delegate = ring.NewAutoForgetDelegate(ringAutoForgetUnhealthyPeriods*cfg.HeartbeatTimeout, delegate, logger)
+
+	lifecycler, err := ring.NewBasicLifecycler(lifecyclerCfg, instanceRingName, instanceRingKey, kvStore, delegate, logger, reg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to initialize usage-trackers' lifecycler")
+	}
+
+	return lifecycler, nil
+}
+
+// NewInstanceRingClient creates a client for the usage-trackers instance ring.
+func NewInstanceRingClient(cfg InstanceRingConfig, component string, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, error) {
+	client, err := ring.New(cfg.ToRingConfig(), component, instanceRingKey, logger, prometheus.WrapRegistererWithPrefix("cortex_", reg))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to initialize usage-trackers' ring client")
+	}
+
+	return client, err
+}

--- a/pkg/usagetracker/tracker_partition_ring.go
+++ b/pkg/usagetracker/tracker_partition_ring.go
@@ -5,13 +5,13 @@ package usagetracker
 import (
 	"flag"
 	"fmt"
-	"regexp"
 	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/ring"
+	"github.com/grafana/regexp"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/pkg/usagetracker/tracker_partition_ring.go
+++ b/pkg/usagetracker/tracker_partition_ring.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagetracker
+
+import (
+	"flag"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/ring"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	partitionRingKey  = "usage-tracker-partitions"
+	partitionRingName = "usage-tracker-partitions"
+)
+
+var (
+	// Regular expression used to parse the numeric ID from instance ID.
+	instanceIDRegexp = regexp.MustCompile("-([0-9]+)$")
+)
+
+type PartitionRingConfig struct {
+	KVStore kv.Config `yaml:"kvstore" doc:"description=The key-value store used to share the hash ring across multiple instances."`
+
+	// lifecyclerPollingInterval is the lifecycler polling interval. This setting is used to lower it in tests.
+	lifecyclerPollingInterval time.Duration
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet
+func (cfg *PartitionRingConfig) RegisterFlags(f *flag.FlagSet) {
+	cfg.KVStore.Store = "memberlist" // Override default value.
+	cfg.KVStore.RegisterFlagsWithPrefix("usage-tracker.partition-ring.", "collectors/", f)
+}
+
+func (cfg *PartitionRingConfig) ToLifecyclerConfig(partitionID int32, instanceID string) ring.PartitionInstanceLifecyclerConfig {
+	return ring.PartitionInstanceLifecyclerConfig{
+		PartitionID:                          partitionID,
+		InstanceID:                           instanceID,
+		WaitOwnersCountOnPending:             1,
+		WaitOwnersDurationOnPending:          10 * time.Second,
+		DeleteInactivePartitionAfterDuration: 1 * time.Hour,
+		PollingInterval:                      cfg.lifecyclerPollingInterval,
+	}
+}
+
+func NewPartitionRingKVClient(cfg PartitionRingConfig, logger log.Logger, registerer prometheus.Registerer) (kv.Client, error) {
+	if cfg.KVStore.Mock != nil {
+		return cfg.KVStore.Mock, nil
+	}
+
+	client, err := kv.NewClient(cfg.KVStore, ring.GetPartitionRingCodec(), kv.RegistererWithKVName(registerer, partitionRingName+"-lifecycler"), logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating KV store for usage-tracker partition ring")
+	}
+
+	return client, nil
+}
+
+func NewPartitionRingLifecycler(cfg PartitionRingConfig, partitionID int32, instanceID string, partitionRingKV kv.Client, logger log.Logger, registerer prometheus.Registerer) (*ring.PartitionInstanceLifecycler, error) {
+	return ring.NewPartitionInstanceLifecycler(
+		cfg.ToLifecyclerConfig(partitionID, instanceID),
+		partitionRingName,
+		partitionRingKey,
+		partitionRingKV,
+		logger,
+		prometheus.WrapRegistererWithPrefix("cortex_", registerer)), nil
+}
+
+// partitionIDFromInstanceID returns the partition ID from the instance ID.
+func partitionIDFromInstanceID(instanceID string) (int32, error) {
+	match := instanceIDRegexp.FindStringSubmatch(instanceID)
+	if len(match) == 0 {
+		return 0, fmt.Errorf("instance ID %s doesn't match regular expression %q", instanceID, instanceIDRegexp.String())
+	}
+
+	// Parse the instance sequence number.
+	seq, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, fmt.Errorf("no sequence number in instance ID %s", instanceID)
+	}
+
+	return int32(seq), nil
+}

--- a/pkg/usagetracker/tracker_partition_ring_test.go
+++ b/pkg/usagetracker/tracker_partition_ring_test.go
@@ -1,0 +1,57 @@
+package usagetracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionIDFromInstanceID(t *testing.T) {
+	t.Run("with zones", func(t *testing.T) {
+		actual, err := partitionIDFromInstanceID("usage-tracker-zone-a-0")
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, actual)
+
+		actual, err = partitionIDFromInstanceID("usage-tracker-zone-b-0")
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, actual)
+
+		actual, err = partitionIDFromInstanceID("usage-tracker-zone-a-1")
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, actual)
+
+		actual, err = partitionIDFromInstanceID("usage-tracker-zone-b-1")
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, actual)
+
+		actual, err = partitionIDFromInstanceID("mimir-backend-zone-c-2")
+		require.NoError(t, err)
+		assert.EqualValues(t, 2, actual)
+	})
+
+	t.Run("without zones", func(t *testing.T) {
+		actual, err := partitionIDFromInstanceID("usage-tracker-0")
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, actual)
+
+		actual, err = partitionIDFromInstanceID("usage-tracker-1")
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, actual)
+
+		actual, err = partitionIDFromInstanceID("mimir-backend-2")
+		require.NoError(t, err)
+		assert.EqualValues(t, 2, actual)
+	})
+
+	t.Run("should return error if the instance ID has a non supported format", func(t *testing.T) {
+		_, err := partitionIDFromInstanceID("unknown")
+		require.Error(t, err)
+
+		_, err = partitionIDFromInstanceID("usage-tracker-zone-a-")
+		require.Error(t, err)
+
+		_, err = partitionIDFromInstanceID("usage-tracker-zone-a")
+		require.Error(t, err)
+	})
+}

--- a/pkg/usagetracker/tracker_partition_ring_test.go
+++ b/pkg/usagetracker/tracker_partition_ring_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package usagetracker
 
 import (


### PR DESCRIPTION
#### What this PR does

Add partition and instance rings support to usage-tracker.

#### Homepage screenshot

![Screenshot 2024-12-02 at 16 12 47](https://github.com/user-attachments/assets/154e7b94-81f0-45f3-b4be-08ae1e88c32f)

#### Instance ring screenshot

![Screenshot 2024-12-02 at 16 16 54](https://github.com/user-attachments/assets/2ed1b6fd-1a17-4e13-9bdc-8d39f7b6884d)

#### Partition ring screenshot

![Screenshot 2024-12-02 at 16 12 51](https://github.com/user-attachments/assets/af3d4adb-5f07-4e87-9673-d9541e569724)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
