### PR TITLE
Add UsageTrackerClient to track series

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -322,3 +322,6 @@ replace github.com/twmb/franz-go => github.com/grafana/franz-go v0.0.0-202410091
 // Pin Google GRPC to v1.65.0 as v1.66.0 has API changes and also potentially performance regressions.
 // Following https://github.com/grafana/dskit/pull/581
 replace google.golang.org/grpc => google.golang.org/grpc v1.65.0
+
+// Vendoring the "usage-tracker" branch in dskit.
+replace github.com/grafana/dskit => github.com/grafana/dskit v0.0.0-20241202173007-390ebfd85697

--- a/go.sum
+++ b/go.sum
@@ -1267,8 +1267,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20241021123319-be61d61f71e7 h1:lsM/QscEX+ZDIJm48ynQscH+msETyGYV6ug8L4f2DtM=
 github.com/grafana/alerting v0.0.0-20241021123319-be61d61f71e7/go.mod h1:QsnoKX/iYZxA4Cv+H+wC7uxutBD8qi8ZW5UJvD2TYmU=
-github.com/grafana/dskit v0.0.0-20241125123840-77bb9ddddb0c h1:6P6ypl4cRRCOMHbvvppecSTe1e6+f185lXp53e9FsJU=
-github.com/grafana/dskit v0.0.0-20241125123840-77bb9ddddb0c/go.mod h1:SPLNCARd4xdjCkue0O6hvuoveuS1dGJjDnfxYe405YQ=
+github.com/grafana/dskit v0.0.0-20241202173007-390ebfd85697 h1:5tuWaJyq+EGwQp8/jjxxk3KFjc1j+h2aJe621AvocAA=
+github.com/grafana/dskit v0.0.0-20241202173007-390ebfd85697/go.mod h1:SPLNCARd4xdjCkue0O6hvuoveuS1dGJjDnfxYe405YQ=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc h1:BW+LjKJDz0So5LI8UZfW5neWeKpSkWqhmGjQFzcFfLM=
 github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/franz-go v0.0.0-20241009100846-782ba1442937 h1:fwwnG/NcygoS6XbAaEyK2QzMXI/BZIEJvQ3CD+7XZm8=

--- a/pkg/usagetracker/tracker.go
+++ b/pkg/usagetracker/tracker.go
@@ -87,8 +87,8 @@ func NewUsageTracker(cfg Config, overrides *validation.Overrides, logger log.Log
 		return nil, err
 	}
 
-	t.partitionWatcher = ring.NewPartitionRingWatcher(partitionRingName, partitionRingKey, partitionKVClient, logger, prometheus.WrapRegistererWithPrefix("cortex_", registerer))
-	t.partitionPageHandler = ring.NewPartitionRingPageHandler(t.partitionWatcher, ring.NewPartitionRingEditor(partitionRingKey, partitionKVClient))
+	t.partitionWatcher = NewPartitionRingWatcher(partitionKVClient, logger, registerer)
+	t.partitionPageHandler = ring.NewPartitionRingPageHandler(t.partitionWatcher, ring.NewPartitionRingEditor(PartitionRingKey, partitionKVClient))
 
 	t.store = newTrackerStore(cfg.IdleTimeout, logger, t, notImplementedEventsPublisher{logger: logger})
 

--- a/pkg/usagetracker/tracker_instance_ring.go
+++ b/pkg/usagetracker/tracker_instance_ring.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	instanceRingKey  = "usage-tracker-instances"
-	instanceRingName = "usage-tracker-instances"
+	InstanceRingKey  = "usage-tracker-instances"
+	InstanceRingName = "usage-tracker-instances"
 
 	// ringAutoForgetUnhealthyPeriods is how many consecutive timeout periods an unhealthy instance
 	// in the ring will be automatically removed after.
@@ -120,7 +120,7 @@ func NewInstanceRingLifecycler(cfg InstanceRingConfig, logger log.Logger, reg pr
 	delegate = ring.NewLeaveOnStoppingDelegate(delegate, logger)
 	delegate = ring.NewAutoForgetDelegate(ringAutoForgetUnhealthyPeriods*cfg.HeartbeatTimeout, delegate, logger)
 
-	lifecycler, err := ring.NewBasicLifecycler(lifecyclerCfg, instanceRingName, instanceRingKey, kvStore, delegate, logger, reg)
+	lifecycler, err := ring.NewBasicLifecycler(lifecyclerCfg, InstanceRingName, InstanceRingKey, kvStore, delegate, logger, reg)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize usage-trackers' lifecycler")
 	}
@@ -130,7 +130,7 @@ func NewInstanceRingLifecycler(cfg InstanceRingConfig, logger log.Logger, reg pr
 
 // NewInstanceRingClient creates a client for the usage-trackers instance ring.
 func NewInstanceRingClient(cfg InstanceRingConfig, component string, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, error) {
-	client, err := ring.New(cfg.ToRingConfig(), component, instanceRingKey, logger, prometheus.WrapRegistererWithPrefix("cortex_", reg))
+	client, err := ring.New(cfg.ToRingConfig(), component, InstanceRingKey, logger, prometheus.WrapRegistererWithPrefix("cortex_", reg))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize usage-trackers' ring client")
 	}

--- a/pkg/usagetracker/usagetrackerclient/client.go
+++ b/pkg/usagetracker/usagetrackerclient/client.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagetrackerclient
+
+import (
+	"context"
+	"flag"
+	"math/rand/v2"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/concurrency"
+	"github.com/grafana/dskit/crypto/tls"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/ring/client"
+	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/mimir/pkg/usagetracker/usagetrackerpb"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+)
+
+var (
+	// The ring operation used to track series.
+	trackSeriesOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
+)
+
+type Config struct {
+	PreferAvailabilityZone string        `yaml:"prefer_availability_zone"`
+	RequestsHedgingDelay   time.Duration `yaml:"requests_hedging_delay" category:"advanced"`
+	ReusableWorkers        int           `yaml:"reusable_workers" category:"advanced"`
+
+	TLSEnabled bool             `yaml:"tls_enabled" category:"advanced"`
+	TLS        tls.ClientConfig `yaml:",inline"`
+
+	// Allow to inject custom client factory in tests.
+	clientFactory client.PoolFactory `yaml:"-"`
+}
+
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("", f)
+}
+
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&cfg.PreferAvailabilityZone, prefix+".prefer-availability-zone", "", "Preferred availability zone to query usage-trackers.")
+	f.DurationVar(&cfg.RequestsHedgingDelay, prefix+".requests-hedging-delay", 100*time.Millisecond, "Delay before initiating requests to further usage-trackers (e.g. in other zones).")
+	f.IntVar(&cfg.ReusableWorkers, prefix+".reusable-workers", 500, "Number of pre-allocated workers used to send requests to usage-trackers. If 0, no workers pool will be used and a new goroutine will be spawned for each request.")
+
+	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", cfg.TLSEnabled, "Enable TLS for gRPC client connecting to usage-tracker.")
+	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
+}
+
+type UsageTrackerClient struct {
+	services.Service
+
+	cfg    Config
+	logger log.Logger
+
+	partitionRing      *ring.PartitionInstanceRing
+	partitionBatchRing *ring.ActivePartitionBatchRing
+
+	clientsPool *client.Pool
+
+	// trackSeriesWorkersPool is the pool of workers used to send requests to usage-tracker instances.
+	trackSeriesWorkersPool *concurrency.ReusableGoroutinesPool
+}
+
+func NewUsageTrackerClient(clientName string, clientCfg Config, partitionRing *ring.PartitionInstanceRing, instanceRing *ring.Ring, logger log.Logger, registerer prometheus.Registerer) *UsageTrackerClient {
+	c := &UsageTrackerClient{
+		cfg:                    clientCfg,
+		logger:                 logger,
+		partitionRing:          partitionRing,
+		partitionBatchRing:     ring.NewActivePartitionBatchRing(partitionRing.PartitionRing()),
+		clientsPool:            newUsageTrackerClientPool(client.NewRingServiceDiscovery(instanceRing), clientName, clientCfg, logger, registerer),
+		trackSeriesWorkersPool: concurrency.NewReusableGoroutinesPool(clientCfg.ReusableWorkers),
+	}
+
+	c.Service = services.NewIdleService(nil, c.stop)
+	return c
+}
+
+// stop implements services.StoppingFn.
+func (c *UsageTrackerClient) stop(_ error) error {
+	c.trackSeriesWorkersPool.Close()
+
+	return nil
+}
+
+func (c *UsageTrackerClient) TrackSeries(ctx context.Context, userID string, series []uint64) ([]uint64, error) {
+	var (
+		batchOptions = ring.DoBatchOptions{
+			Cleanup:       nil,
+			IsClientError: func(error) bool { return false },
+			Go:            c.trackSeriesWorkersPool.Go,
+		}
+
+		rejectedMx sync.Mutex
+		rejected   []uint64
+	)
+
+	// Series hashes are 64bit but the hash ring tokens are 32bit, so we truncate
+	// hashes to 32bit to get keys to lookup in the ring.
+	keys := make([]uint32, len(series))
+	for i, hash := range series {
+		keys[i] = uint32(hash)
+	}
+
+	err := ring.DoBatchWithOptions(ctx, ring.WriteNoExtend, c.partitionBatchRing, keys,
+		func(partition ring.InstanceDesc, indexes []int) error {
+			// The partition ID is stored in the ring.InstanceDesc.Id.
+			partitionID, err := strconv.ParseUint(partition.Id, 10, 31)
+			if err != nil {
+				return err
+			}
+
+			// Build the list of series hashes that belong to this partition.
+			partitionSeries := make([]uint64, len(indexes))
+			for i, idx := range indexes {
+				partitionSeries[i] = series[idx]
+			}
+
+			// Track the series for this partition.
+			partitionRejected, err := c.trackSeriesPerPartition(ctx, userID, int32(partitionID), partitionSeries)
+			if err != nil {
+				return errors.Wrapf(err, "partition %d", partitionID)
+			}
+
+			if len(partitionRejected) > 0 {
+				rejectedMx.Lock()
+				rejected = append(rejected, partitionRejected...)
+				rejectedMx.Unlock()
+			}
+
+			return nil
+		}, batchOptions,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// It should never happen that a response arrives at this point, but better to protect
+	// from bugs that could cause panics.
+	rejectedMx.Lock()
+	rejectedCopy := rejected
+	rejectedMx.Unlock()
+
+	return rejectedCopy, nil
+}
+
+func (c *UsageTrackerClient) trackSeriesPerPartition(ctx context.Context, userID string, partitionID int32, series []uint64) ([]uint64, error) {
+	// Get the usage-tracker instances for the input partition.
+	set, err := c.partitionRing.GetReplicationSetForPartitionAndOperation(partitionID, trackSeriesOp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare the request.
+	req := &usagetrackerpb.TrackSeriesRequest{
+		UserID:       userID,
+		SeriesHashes: series,
+	}
+
+	cfg := ring.DoUntilQuorumConfig{
+		Logger: spanlogger.FromContext(ctx, c.logger),
+
+		MinimizeRequests: true,
+		HedgingDelay:     c.cfg.RequestsHedgingDelay,
+
+		// Give precedence to the client's zone.
+		ZoneSorter: c.sortZones,
+
+		// No error is a terminal error, and a failing request should be retried on another usage-tracker
+		// replica for the same partition (if available).
+		IsTerminalError: func(_ error) bool { return false },
+	}
+
+	res, err := ring.DoUntilQuorum[[]uint64](ctx, set, cfg, func(ctx context.Context, instance *ring.InstanceDesc) ([]uint64, error) {
+		if instance == nil {
+			// This should never happen.
+			return nil, errors.New("instance is nil")
+		}
+
+		poolClient, err := c.clientsPool.GetClientForInstance(*instance)
+		if err != nil {
+			return nil, errors.Errorf("usage-tracker instance %s (%s)", instance.Id, instance.Addr)
+		}
+
+		trackerClient := poolClient.(usagetrackerpb.UsageTrackerClient)
+		trackerRes, err := trackerClient.TrackSeries(ctx, req)
+		if err != nil {
+			return nil, errors.Wrapf(err, "usage-tracker instance %s (%s)", instance.Id, instance.Addr)
+		}
+
+		return trackerRes.RejectedSeriesHashes, nil
+	}, func(_ []uint64) {
+		// No cleanup.
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if len(res) == 0 {
+		return nil, errors.Errorf("unexpected no responses from usage-tracker for partition %d", partitionID)
+	}
+
+	return res[0], nil
+}
+
+func (c *UsageTrackerClient) sortZones(zones []string) []string {
+	// Shuffle the zones to distribute load evenly.
+	if len(zones) > 2 || (c.cfg.PreferAvailabilityZone == "" && len(zones) > 1) {
+		rand.Shuffle(len(zones), func(i, j int) {
+			zones[i], zones[j] = zones[j], zones[i]
+		})
+	}
+
+	if c.cfg.PreferAvailabilityZone != "" {
+		// Give priority to the preferred zone.
+		for i, z := range zones {
+			if z == c.cfg.PreferAvailabilityZone {
+				zones[0], zones[i] = zones[i], zones[0]
+				break
+			}
+		}
+	}
+
+	return zones
+}

--- a/pkg/usagetracker/usagetrackerclient/client.go
+++ b/pkg/usagetracker/usagetrackerclient/client.go
@@ -108,7 +108,7 @@ func (c *UsageTrackerClient) TrackSeries(ctx context.Context, userID string, ser
 		keys[i] = uint32(hash)
 	}
 
-	err := ring.DoBatchWithOptions(ctx, ring.WriteNoExtend, c.partitionBatchRing, keys,
+	err := ring.DoBatchWithOptions(ctx, trackSeriesOp, c.partitionBatchRing, keys,
 		func(partition ring.InstanceDesc, indexes []int) error {
 			// The partition ID is stored in the ring.InstanceDesc.Id.
 			partitionID, err := strconv.ParseUint(partition.Id, 10, 31)

--- a/pkg/usagetracker/usagetrackerclient/client_test.go
+++ b/pkg/usagetracker/usagetrackerclient/client_test.go
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagetrackerclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/kv/consul"
+	"github.com/grafana/dskit/ring"
+	ring_client "github.com/grafana/dskit/ring/client"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/grafana/mimir/pkg/usagetracker"
+	"github.com/grafana/mimir/pkg/usagetracker/usagetrackerpb"
+)
+
+func TestUsageTrackerClient_TrackSeries(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		logger = log.NewNopLogger()
+		userID = "user-1"
+	)
+
+	prepareTest := func() (*ring.PartitionInstanceRing, *ring.Ring, prometheus.Registerer) {
+		registerer := prometheus.NewPedanticRegistry()
+
+		// Setup the in-memory KV store used for the ring.
+		instanceRingStore, instanceRingCloser := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+		t.Cleanup(func() { assert.NoError(t, instanceRingCloser.Close()) })
+
+		partitionRingStore, partitionRingCloser := consul.NewInMemoryClient(ring.GetPartitionRingCodec(), log.NewNopLogger(), nil)
+		t.Cleanup(func() { assert.NoError(t, partitionRingCloser.Close()) })
+
+		// Add few usage-tracker instances to the instance ring.
+		require.NoError(t, instanceRingStore.CAS(ctx, usagetracker.InstanceRingKey, func(interface{}) (interface{}, bool, error) {
+			d := ring.NewDesc()
+			d.AddIngester("usage-tracker-zone-a-1", "1.1.1.1", "zone-a", []uint32{1}, ring.ACTIVE, time.Now(), false, time.Time{})
+			d.AddIngester("usage-tracker-zone-a-2", "2.2.2.2", "zone-a", []uint32{2}, ring.ACTIVE, time.Now(), false, time.Time{})
+			d.AddIngester("usage-tracker-zone-b-1", "3.3.3.3", "zone-b", []uint32{3}, ring.ACTIVE, time.Now(), false, time.Time{})
+			d.AddIngester("usage-tracker-zone-b-2", "4.4.4.4", "zone-b", []uint32{4}, ring.ACTIVE, time.Now(), false, time.Time{})
+
+			return d, true, nil
+		}))
+
+		// Add partitions to the partition ring.
+		require.NoError(t, partitionRingStore.CAS(ctx, usagetracker.PartitionRingKey, func(interface{}) (interface{}, bool, error) {
+			d := ring.NewPartitionRingDesc()
+			d.AddPartition(1, ring.PartitionActive, time.Now())
+			d.AddPartition(2, ring.PartitionActive, time.Now())
+			d.AddOrUpdateOwner("usage-tracker-zone-a-1", ring.OwnerActive, 1, time.Now())
+			d.AddOrUpdateOwner("usage-tracker-zone-a-2", ring.OwnerActive, 2, time.Now())
+			d.AddOrUpdateOwner("usage-tracker-zone-b-1", ring.OwnerActive, 1, time.Now())
+			d.AddOrUpdateOwner("usage-tracker-zone-b-2", ring.OwnerActive, 2, time.Now())
+
+			return d, true, nil
+		}))
+
+		serverCfg := createTestServerConfig()
+		serverCfg.InstanceRing.KVStore.Mock = instanceRingStore
+		serverCfg.PartitionRing.KVStore.Mock = partitionRingStore
+
+		// Create the instance ring.
+		instanceRing, err := usagetracker.NewInstanceRingClient(serverCfg.InstanceRing, "test", logger, registerer)
+		require.NoError(t, err)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, instanceRing))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, instanceRing))
+		})
+
+		// Pre-condition check: all instances should be healthy.
+		set, err := instanceRing.GetAllHealthy(trackSeriesOp)
+		require.NoError(t, err)
+		require.Len(t, set.Instances, 4)
+
+		// Create the partition ring.
+		partitionRingWatcher := usagetracker.NewPartitionRingWatcher(partitionRingStore, logger, registerer)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, partitionRingWatcher))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, partitionRingWatcher))
+		})
+
+		partitionRing := ring.NewPartitionInstanceRing(partitionRingWatcher, instanceRing, serverCfg.InstanceRing.HeartbeatTimeout)
+
+		// Pre-condition check: all partitions should be active.
+		require.Equal(t, []int32{1, 2}, partitionRingWatcher.PartitionRing().ActivePartitionIDs())
+
+		return partitionRing, instanceRing, registerer
+	}
+
+	t.Run("should track series to usage-trackers running in the preferred zone if available", func(t *testing.T) {
+		t.Parallel()
+
+		partitionRing, instanceRing, registerer := prepareTest()
+
+		// Mock the usage-tracker server.
+		instances := map[string]*usageTrackerMock{
+			"usage-tracker-zone-a-1": newUsageTrackerMockWithSuccessfulResponse(),
+			"usage-tracker-zone-a-2": newUsageTrackerMockWithSuccessfulResponse(),
+			"usage-tracker-zone-b-1": newUsageTrackerMockWithSuccessfulResponse(),
+			"usage-tracker-zone-b-2": newUsageTrackerMockWithSuccessfulResponse(),
+		}
+
+		clientCfg := createTestClientConfig()
+		clientCfg.PreferAvailabilityZone = "zone-b"
+
+		clientCfg.clientFactory = ring_client.PoolInstFunc(func(instance ring.InstanceDesc) (ring_client.PoolClient, error) {
+			mock, ok := instances[instance.Id]
+			if ok {
+				return mock, nil
+			}
+
+			return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
+		})
+
+		c := NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, c))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
+		})
+
+		// Generate the series hashes so that we can predict in which partition they're sharded to.
+		partitions := partitionRing.PartitionRing().Partitions()
+		require.Len(t, partitions, 2)
+		slices.SortFunc(partitions, func(a, b ring.PartitionDesc) int { return int(a.Id - b.Id) })
+
+		require.Equal(t, int32(1), partitions[0].Id)
+		require.Equal(t, int32(2), partitions[1].Id)
+
+		series1Partition1 := uint64(partitions[0].Tokens[0] - 1)
+		series2Partition1 := uint64(partitions[0].Tokens[1] - 1)
+		series3Partition1 := uint64(partitions[0].Tokens[2] - 1)
+		series4Partition2 := uint64(partitions[1].Tokens[0] - 1)
+		series5Partition2 := uint64(partitions[1].Tokens[1] - 1)
+
+		rejected, err := c.TrackSeries(user.InjectOrgID(ctx, userID), userID, []uint64{series1Partition1, series2Partition1, series3Partition1, series4Partition2, series5Partition2})
+		require.NoError(t, err)
+		require.Empty(t, rejected)
+
+		// Should have tracked series only to usage-tracker replicas in the preferred zone.
+		instances["usage-tracker-zone-a-1"].AssertNumberOfCalls(t, "TrackSeries", 0)
+		instances["usage-tracker-zone-a-2"].AssertNumberOfCalls(t, "TrackSeries", 0)
+		instances["usage-tracker-zone-b-1"].AssertNumberOfCalls(t, "TrackSeries", 1)
+		instances["usage-tracker-zone-b-2"].AssertNumberOfCalls(t, "TrackSeries", 1)
+
+		req := instances["usage-tracker-zone-b-1"].Calls[0].Arguments.Get(1)
+		require.ElementsMatch(t, []uint64{series1Partition1, series2Partition1, series3Partition1}, req.(*usagetrackerpb.TrackSeriesRequest).SeriesHashes)
+
+		req = instances["usage-tracker-zone-b-2"].Calls[0].Arguments.Get(1)
+		require.ElementsMatch(t, []uint64{series4Partition2, series5Partition2}, req.(*usagetrackerpb.TrackSeriesRequest).SeriesHashes)
+	})
+
+	t.Run("should fallback to the other zone if a usage-tracker instance in the preferred zone is failing", func(t *testing.T) {
+		t.Parallel()
+
+		partitionRing, instanceRing, registerer := prepareTest()
+
+		// Mock the usage-tracker server.
+		instances := map[string]*usageTrackerMock{
+			"usage-tracker-zone-a-1": newUsageTrackerMockWithSuccessfulResponse(),
+			"usage-tracker-zone-a-2": newUsageTrackerMockWithSuccessfulResponse(),
+			"usage-tracker-zone-b-1": newUsageTrackerMockWithResponse(nil, errors.New("failing instance")),
+			"usage-tracker-zone-b-2": newUsageTrackerMockWithSuccessfulResponse(),
+		}
+
+		clientCfg := createTestClientConfig()
+		clientCfg.PreferAvailabilityZone = "zone-b"
+
+		clientCfg.clientFactory = ring_client.PoolInstFunc(func(instance ring.InstanceDesc) (ring_client.PoolClient, error) {
+			mock, ok := instances[instance.Id]
+			if ok {
+				return mock, nil
+			}
+
+			return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
+		})
+
+		c := NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, c))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
+		})
+
+		// Generate the series hashes so that we can predict in which partition they're sharded to.
+		partitions := partitionRing.PartitionRing().Partitions()
+		require.Len(t, partitions, 2)
+		slices.SortFunc(partitions, func(a, b ring.PartitionDesc) int { return int(a.Id - b.Id) })
+
+		require.Equal(t, int32(1), partitions[0].Id)
+		require.Equal(t, int32(2), partitions[1].Id)
+
+		series1Partition1 := uint64(partitions[0].Tokens[0] - 1)
+		series2Partition1 := uint64(partitions[0].Tokens[1] - 1)
+		series3Partition1 := uint64(partitions[0].Tokens[2] - 1)
+		series4Partition2 := uint64(partitions[1].Tokens[0] - 1)
+		series5Partition2 := uint64(partitions[1].Tokens[1] - 1)
+
+		rejected, err := c.TrackSeries(user.InjectOrgID(ctx, userID), userID, []uint64{series1Partition1, series2Partition1, series3Partition1, series4Partition2, series5Partition2})
+		require.NoError(t, err)
+		require.Empty(t, rejected)
+
+		// Should have tracked series only to usage-tracker replicas in the preferred zone.
+		instances["usage-tracker-zone-a-1"].AssertNumberOfCalls(t, "TrackSeries", 1)
+		instances["usage-tracker-zone-a-2"].AssertNumberOfCalls(t, "TrackSeries", 0)
+		instances["usage-tracker-zone-b-1"].AssertNumberOfCalls(t, "TrackSeries", 1)
+		instances["usage-tracker-zone-b-2"].AssertNumberOfCalls(t, "TrackSeries", 1)
+
+		req := instances["usage-tracker-zone-b-1"].Calls[0].Arguments.Get(1)
+		require.ElementsMatch(t, []uint64{series1Partition1, series2Partition1, series3Partition1}, req.(*usagetrackerpb.TrackSeriesRequest).SeriesHashes)
+
+		req = instances["usage-tracker-zone-b-2"].Calls[0].Arguments.Get(1)
+		require.ElementsMatch(t, []uint64{series4Partition2, series5Partition2}, req.(*usagetrackerpb.TrackSeriesRequest).SeriesHashes)
+
+		// Fallback.
+		req = instances["usage-tracker-zone-a-1"].Calls[0].Arguments.Get(1)
+		require.ElementsMatch(t, []uint64{series1Partition1, series2Partition1, series3Partition1}, req.(*usagetrackerpb.TrackSeriesRequest).SeriesHashes)
+	})
+
+	t.Run("should return rejected series", func(t *testing.T) {
+		t.Parallel()
+
+		partitionRing, instanceRing, registerer := prepareTest()
+
+		// Generate the series hashes so that we can predict in which partition they're sharded to.
+		partitions := partitionRing.PartitionRing().Partitions()
+		require.Len(t, partitions, 2)
+		slices.SortFunc(partitions, func(a, b ring.PartitionDesc) int { return int(a.Id - b.Id) })
+
+		require.Equal(t, int32(1), partitions[0].Id)
+		require.Equal(t, int32(2), partitions[1].Id)
+
+		series1Partition1 := uint64(partitions[0].Tokens[0] - 1)
+		series2Partition1 := uint64(partitions[0].Tokens[1] - 1)
+		series3Partition1 := uint64(partitions[0].Tokens[2] - 1)
+		series4Partition2 := uint64(partitions[1].Tokens[0] - 1)
+		series5Partition2 := uint64(partitions[1].Tokens[1] - 1)
+
+		// Mock the usage-tracker server.
+		instances := map[string]*usageTrackerMock{
+			"usage-tracker-zone-a-1": newUsageTrackerMockWithSuccessfulResponse(),
+			"usage-tracker-zone-a-2": newUsageTrackerMockWithSuccessfulResponse(),
+
+			// Return rejected series only from zone-b to ensure the response is picked up from this zone.
+			"usage-tracker-zone-b-1": newUsageTrackerMockWithResponse(&usagetrackerpb.TrackSeriesResponse{RejectedSeriesHashes: []uint64{series2Partition1}}, nil),
+			"usage-tracker-zone-b-2": newUsageTrackerMockWithResponse(&usagetrackerpb.TrackSeriesResponse{RejectedSeriesHashes: []uint64{series4Partition2, series5Partition2}}, nil),
+		}
+
+		clientCfg := createTestClientConfig()
+		clientCfg.PreferAvailabilityZone = "zone-b"
+
+		clientCfg.clientFactory = ring_client.PoolInstFunc(func(instance ring.InstanceDesc) (ring_client.PoolClient, error) {
+			mock, ok := instances[instance.Id]
+			if ok {
+				return mock, nil
+			}
+
+			return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
+		})
+
+		c := NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, c))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
+		})
+
+		rejected, err := c.TrackSeries(user.InjectOrgID(ctx, userID), userID, []uint64{series1Partition1, series2Partition1, series3Partition1, series4Partition2, series5Partition2})
+		require.NoError(t, err)
+		require.ElementsMatch(t, []uint64{series2Partition1, series4Partition2, series5Partition2}, rejected)
+
+		// Should have tracked series only to usage-tracker replicas in the preferred zone.
+		instances["usage-tracker-zone-a-1"].AssertNumberOfCalls(t, "TrackSeries", 0)
+		instances["usage-tracker-zone-a-2"].AssertNumberOfCalls(t, "TrackSeries", 0)
+		instances["usage-tracker-zone-b-1"].AssertNumberOfCalls(t, "TrackSeries", 1)
+		instances["usage-tracker-zone-b-2"].AssertNumberOfCalls(t, "TrackSeries", 1)
+
+		req := instances["usage-tracker-zone-b-1"].Calls[0].Arguments.Get(1)
+		require.ElementsMatch(t, []uint64{series1Partition1, series2Partition1, series3Partition1}, req.(*usagetrackerpb.TrackSeriesRequest).SeriesHashes)
+
+		req = instances["usage-tracker-zone-b-2"].Calls[0].Arguments.Get(1)
+		require.ElementsMatch(t, []uint64{series4Partition2, series5Partition2}, req.(*usagetrackerpb.TrackSeriesRequest).SeriesHashes)
+	})
+
+	t.Run("should hedge requests to the other zone if a usage-tracker instance in the preferred zone is slow", func(t *testing.T) {
+		t.Parallel()
+
+		partitionRing, instanceRing, registerer := prepareTest()
+
+		clientCfg := createTestClientConfig()
+		clientCfg.PreferAvailabilityZone = "zone-b"
+		clientCfg.RequestsHedgingDelay = 250 * time.Millisecond
+
+		// Generate the series hashes so that we can predict in which partition they're sharded to.
+		partitions := partitionRing.PartitionRing().Partitions()
+		require.Len(t, partitions, 2)
+		slices.SortFunc(partitions, func(a, b ring.PartitionDesc) int { return int(a.Id - b.Id) })
+
+		require.Equal(t, int32(1), partitions[0].Id)
+		require.Equal(t, int32(2), partitions[1].Id)
+
+		series1Partition1 := uint64(partitions[0].Tokens[0] - 1)
+		series2Partition1 := uint64(partitions[0].Tokens[1] - 1)
+		series3Partition1 := uint64(partitions[0].Tokens[2] - 1)
+		series4Partition2 := uint64(partitions[1].Tokens[0] - 1)
+		series5Partition2 := uint64(partitions[1].Tokens[1] - 1)
+
+		// Mock the usage-tracker server.
+		instances := map[string]*usageTrackerMock{
+			// Return rejected series only from this instance, to ensure the response comes from here.
+			"usage-tracker-zone-a-1": newUsageTrackerMockWithResponse(&usagetrackerpb.TrackSeriesResponse{RejectedSeriesHashes: []uint64{series2Partition1}}, nil),
+
+			"usage-tracker-zone-a-2": newUsageTrackerMockWithSuccessfulResponse(),
+			"usage-tracker-zone-b-1": newUsageTrackerMockWithSlowSuccessfulResponse(clientCfg.RequestsHedgingDelay * 2),
+			"usage-tracker-zone-b-2": newUsageTrackerMockWithSuccessfulResponse(),
+		}
+
+		clientCfg.clientFactory = ring_client.PoolInstFunc(func(instance ring.InstanceDesc) (ring_client.PoolClient, error) {
+			mock, ok := instances[instance.Id]
+			if ok {
+				return mock, nil
+			}
+
+			return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
+		})
+
+		c := NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, c))
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
+		})
+
+		rejected, err := c.TrackSeries(user.InjectOrgID(ctx, userID), userID, []uint64{series1Partition1, series2Partition1, series3Partition1, series4Partition2, series5Partition2})
+		require.NoError(t, err)
+		require.ElementsMatch(t, []uint64{series2Partition1}, rejected)
+
+		// Should have tracked series only to usage-tracker replicas in the preferred zone.
+		instances["usage-tracker-zone-a-1"].AssertNumberOfCalls(t, "TrackSeries", 1)
+		instances["usage-tracker-zone-a-2"].AssertNumberOfCalls(t, "TrackSeries", 0)
+		instances["usage-tracker-zone-b-1"].AssertNumberOfCalls(t, "TrackSeries", 1)
+		instances["usage-tracker-zone-b-2"].AssertNumberOfCalls(t, "TrackSeries", 1)
+
+		req := instances["usage-tracker-zone-b-1"].Calls[0].Arguments.Get(1)
+		require.ElementsMatch(t, []uint64{series1Partition1, series2Partition1, series3Partition1}, req.(*usagetrackerpb.TrackSeriesRequest).SeriesHashes)
+
+		req = instances["usage-tracker-zone-b-2"].Calls[0].Arguments.Get(1)
+		require.ElementsMatch(t, []uint64{series4Partition2, series5Partition2}, req.(*usagetrackerpb.TrackSeriesRequest).SeriesHashes)
+
+		// Hedged request.
+		req = instances["usage-tracker-zone-b-1"].Calls[0].Arguments.Get(1)
+		require.ElementsMatch(t, []uint64{series1Partition1, series2Partition1, series3Partition1}, req.(*usagetrackerpb.TrackSeriesRequest).SeriesHashes)
+	})
+}
+
+func createTestClientConfig() Config {
+	cfg := Config{}
+	flagext.DefaultValues(&cfg)
+
+	// No hedging in tests by default.
+	cfg.RequestsHedgingDelay = time.Hour
+
+	return cfg
+}
+
+func createTestServerConfig() usagetracker.Config {
+	cfg := usagetracker.Config{}
+	flagext.DefaultValues(&cfg)
+
+	return cfg
+}
+
+type usageTrackerMock struct {
+	mock.Mock
+
+	usagetrackerpb.UsageTrackerClient
+	grpc_health_v1.HealthClient
+}
+
+func newUsageTrackerMockWithSuccessfulResponse() *usageTrackerMock {
+	return newUsageTrackerMockWithResponse(&usagetrackerpb.TrackSeriesResponse{}, nil)
+}
+
+func newUsageTrackerMockWithSlowSuccessfulResponse(delay time.Duration) *usageTrackerMock {
+	m := &usageTrackerMock{}
+	m.On("TrackSeries", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
+		time.Sleep(delay)
+	}).Return(&usagetrackerpb.TrackSeriesResponse{}, nil)
+
+	return m
+}
+
+func newUsageTrackerMockWithResponse(res *usagetrackerpb.TrackSeriesResponse, err error) *usageTrackerMock {
+	m := &usageTrackerMock{}
+	m.On("TrackSeries", mock.Anything, mock.Anything).Return(res, err)
+
+	return m
+}
+
+func (m *usageTrackerMock) TrackSeries(ctx context.Context, req *usagetrackerpb.TrackSeriesRequest, _ ...grpc.CallOption) (*usagetrackerpb.TrackSeriesResponse, error) {
+	args := m.Called(ctx, req)
+
+	if args.Get(0) != nil {
+		return args.Get(0).(*usagetrackerpb.TrackSeriesResponse), args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}
+
+func (m *usageTrackerMock) Close() error {
+	return nil
+}

--- a/pkg/usagetracker/usagetrackerclient/grpc_client_pool.go
+++ b/pkg/usagetracker/usagetrackerclient/grpc_client_pool.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagetrackerclient
+
+import (
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/grpcclient"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/ring/client"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/grafana/mimir/pkg/usagetracker/usagetrackerpb"
+)
+
+func newUsageTrackerClientPool(discovery client.PoolServiceDiscovery, clientName string, clientConfig Config, logger log.Logger, registerer prometheus.Registerer) *client.Pool {
+	// We prefer sane defaults instead of exposing further config options.
+	clientCfg := grpcclient.Config{
+		MaxRecvMsgSize:      100 << 20,
+		MaxSendMsgSize:      16 << 20,
+		GRPCCompression:     "",
+		RateLimit:           0,
+		RateLimitBurst:      0,
+		BackoffOnRatelimits: false,
+		TLSEnabled:          clientConfig.TLSEnabled,
+		TLS:                 clientConfig.TLS,
+	}
+
+	poolCfg := client.PoolConfig{
+		CheckInterval:      10 * time.Second,
+		HealthCheckEnabled: true,
+		HealthCheckTimeout: 10 * time.Second,
+	}
+
+	clientsCount := promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+		Namespace:   "cortex",
+		Name:        "usage_tracker_clients",
+		Help:        "The current number of usage-tracker clients in the pool.",
+		ConstLabels: map[string]string{"client": clientName},
+	})
+
+	var factory client.PoolFactory
+	if clientConfig.clientFactory != nil {
+		factory = clientConfig.clientFactory
+	} else {
+		factory = newUsageTrackerClientFactory(clientName, clientCfg, registerer)
+	}
+
+	return client.NewPool("usage-tracker", poolCfg, discovery, factory, clientsCount, logger)
+}
+
+func newUsageTrackerClientFactory(clientName string, clientCfg grpcclient.Config, reg prometheus.Registerer) client.PoolFactory {
+	requestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:   "cortex",
+		Name:        "usage_tracker_client_request_duration_seconds",
+		Help:        "Time spent executing requests to the usage-tracker.",
+		Buckets:     prometheus.ExponentialBuckets(0.008, 4, 7),
+		ConstLabels: prometheus.Labels{"client": clientName},
+	}, []string{"operation", "status_code"})
+
+	return client.PoolInstFunc(func(inst ring.InstanceDesc) (client.PoolClient, error) {
+		return dialUsageTracker(clientCfg, inst, requestDuration)
+	})
+}
+
+func dialUsageTracker(clientCfg grpcclient.Config, instance ring.InstanceDesc, requestDuration *prometheus.HistogramVec) (*usageTrackerClient, error) {
+	opts, err := clientCfg.DialOption(grpcclient.Instrument(requestDuration))
+	if err != nil {
+		return nil, err
+	}
+
+	// nolint:staticcheck // grpc.Dial() has been deprecated; we'll address it before upgrading to gRPC 2.
+	conn, err := grpc.Dial(instance.Addr, opts...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to dial usage-tracker %s %s", instance.Id, instance.Addr)
+	}
+
+	return &usageTrackerClient{
+		UsageTrackerClient: usagetrackerpb.NewUsageTrackerClient(conn),
+		HealthClient:       grpc_health_v1.NewHealthClient(conn),
+		conn:               conn,
+	}, nil
+}
+
+type usageTrackerClient struct {
+	usagetrackerpb.UsageTrackerClient
+	grpc_health_v1.HealthClient
+	conn *grpc.ClientConn
+}
+
+func (c *usageTrackerClient) Close() error {
+	return c.conn.Close()
+}
+
+func (c *usageTrackerClient) String() string {
+	return c.RemoteAddress()
+}
+
+func (c *usageTrackerClient) RemoteAddress() string {
+	return c.conn.Target()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -620,7 +620,7 @@ github.com/grafana/alerting/receivers/webex
 github.com/grafana/alerting/receivers/webhook
 github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
-# github.com/grafana/dskit v0.0.0-20241125123840-77bb9ddddb0c
+# github.com/grafana/dskit v0.0.0-20241125123840-77bb9ddddb0c => github.com/grafana/dskit v0.0.0-20241202173007-390ebfd85697
 ## explicit; go 1.21
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast
@@ -1695,3 +1695,4 @@ sigs.k8s.io/yaml/goyaml.v3
 # github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20240930132144-b5e64e81e8d3
 # github.com/twmb/franz-go => github.com/grafana/franz-go v0.0.0-20241009100846-782ba1442937
 # google.golang.org/grpc => google.golang.org/grpc v1.65.0
+# github.com/grafana/dskit => github.com/grafana/dskit v0.0.0-20241202173007-390ebfd85697


### PR DESCRIPTION
#### What this PR does

Add UsageTrackerClient to track series. It will be used by distributor in a follow up PR.

UsageTrackerClient features:
- Preferred zone
- Hedge to other zone instances after 100ms (configurable) or on failure

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
