### PR TITLE
Early Request Validation in Query Frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 * [ENHANCEMENT] Distributor: allow a different limit for info series (series ending in `_info`) label count, via `-validation.max-label-names-per-info-series`. #10028
 * [ENHANCEMENT] Ingester: do not reuse labels, samples and histograms slices in the write request if there are more entries than 10x the pre-allocated size. This should help to reduce the in-use memory in case of few requests with a very large number of labels, samples or histograms. #10040
 * [ENHANCEMENT] Query-Frontend: prune `<subquery> and on() (vector(x)==y)` style queries and stop pruning `<subquery> < -Inf`. Triggered by https://github.com/prometheus/prometheus/pull/15245. #10026
+* [ENHANCEMENT] Query-Frontend: perform request format validation before processing the request. #10093
 * [BUGFIX] Fix issue where functions such as `rate()` over native histograms could return incorrect values if a float stale marker was present in the selected range. #9508
 * [BUGFIX] Fix issue where negation of native histograms (eg. `-some_native_histogram_series`) did nothing. #9508
 * [BUGFIX] Fix issue where `metric might not be a counter, name does not end in _total/_sum/_count/_bucket` annotation would be emitted even if `rate` or `increase` did not have enough samples to compute a result. #9508

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -8,6 +8,7 @@ package querymiddleware
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -33,6 +34,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
+	"github.com/grafana/mimir/pkg/cardinality"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/querier/stats"
@@ -533,6 +535,39 @@ func DecodeLabelsQueryTimeParams(reqValues *url.Values, usePromDefaults bool) (s
 	}
 
 	return start, end, err
+}
+
+// DecodeCardinalityQueryParams strictly handles validation for cardinality API endpoint parameters.
+// The current decoding of the cardinality requests is handled in the cardinality package
+// which is not yet compatible with the codec's approach of using interfaces
+// and multiple concrete proto implementations to represent different query types.
+func DecodeCardinalityQueryParams(r *http.Request) (any, error) {
+	var err error
+
+	reqValues, err := util.ParseRequestFormWithoutConsumingBody(r)
+	if err != nil {
+		return nil, apierror.New(apierror.TypeBadData, err.Error())
+	}
+
+	var parsedReq any
+	switch {
+	case strings.HasSuffix(r.URL.Path, cardinalityLabelNamesPathSuffix):
+		parsedReq, err = cardinality.DecodeLabelNamesRequestFromValues(reqValues)
+
+	case strings.HasSuffix(r.URL.Path, cardinalityLabelValuesPathSuffix):
+		parsedReq, err = cardinality.DecodeLabelValuesRequestFromValues(reqValues)
+
+	case strings.HasSuffix(r.URL.Path, cardinalityActiveSeriesPathSuffix):
+		parsedReq, err = cardinality.DecodeActiveSeriesRequestFromValues(reqValues)
+
+	default:
+		return nil, errors.New("unknown cardinality API endpoint")
+	}
+
+	if err != nil {
+		return nil, apierror.New(apierror.TypeBadData, err.Error())
+	}
+	return parsedReq, nil
 }
 
 func decodeQueryMinMaxTime(queryExpr parser.Expr, start, end, step int64, lookbackDelta time.Duration) (minTime, maxTime int64) {

--- a/pkg/frontend/querymiddleware/request_validation.go
+++ b/pkg/frontend/querymiddleware/request_validation.go
@@ -17,6 +17,9 @@ var errMetricsQueryRequestValidationFailed = cancellation.NewErrorf(
 var errLabelsQueryRequestValidationFailed = cancellation.NewErrorf(
 	requestValidationFailedFmt + "labels query",
 )
+var errCardinalityQueryRequestValidationFailed = cancellation.NewErrorf(
+	requestValidationFailedFmt + "cardinality query",
+)
 
 type MetricsQueryRequestValidationRoundTripper struct {
 	codec Codec
@@ -33,6 +36,7 @@ func NewMetricsQueryRequestValidationRoundTripper(codec Codec, next http.RoundTr
 func (rt MetricsQueryRequestValidationRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	ctx, cancel := context.WithCancelCause(r.Context())
 	defer cancel(errMetricsQueryRequestValidationFailed)
+	r = r.WithContext(ctx)
 
 	_, err := rt.codec.DecodeMetricsQueryRequest(ctx, r)
 	if err != nil {
@@ -56,8 +60,31 @@ func NewLabelsQueryRequestValidationRoundTripper(codec Codec, next http.RoundTri
 func (rt LabelsQueryRequestValidationRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	ctx, cancel := context.WithCancelCause(r.Context())
 	defer cancel(errLabelsQueryRequestValidationFailed)
+	r = r.WithContext(ctx)
 
 	_, err := rt.codec.DecodeLabelsQueryRequest(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return rt.next.RoundTrip(r)
+}
+
+type CardinalityQueryRequestValidationRoundTripper struct {
+	next http.RoundTripper
+}
+
+func NewCardinalityQueryRequestValidationRoundTripper(next http.RoundTripper) http.RoundTripper {
+	return CardinalityQueryRequestValidationRoundTripper{
+		next: next,
+	}
+}
+
+func (rt CardinalityQueryRequestValidationRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	ctx, cancel := context.WithCancelCause(r.Context())
+	defer cancel(errCardinalityQueryRequestValidationFailed)
+	r = r.WithContext(ctx)
+
+	_, err := DecodeCardinalityQueryParams(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/querymiddleware/request_validation.go
+++ b/pkg/frontend/querymiddleware/request_validation.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package querymiddleware
 
 import (

--- a/pkg/frontend/querymiddleware/request_validation.go
+++ b/pkg/frontend/querymiddleware/request_validation.go
@@ -1,0 +1,63 @@
+package querymiddleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/grafana/dskit/cancellation"
+)
+
+const requestValidationFailedFmt = "request validation failed for "
+
+var errMetricsQueryRequestValidationFailed = cancellation.NewErrorf(
+	requestValidationFailedFmt + "metrics query",
+)
+var errLabelsQueryRequestValidationFailed = cancellation.NewErrorf(
+	requestValidationFailedFmt + "labels query",
+)
+
+type MetricsQueryRequestValidationRoundTripper struct {
+	codec Codec
+	next  http.RoundTripper
+}
+
+func NewMetricsQueryRequestValidationRoundTripper(codec Codec, next http.RoundTripper) http.RoundTripper {
+	return MetricsQueryRequestValidationRoundTripper{
+		codec: codec,
+		next:  next,
+	}
+}
+
+func (rt MetricsQueryRequestValidationRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	ctx, cancel := context.WithCancelCause(r.Context())
+	defer cancel(errMetricsQueryRequestValidationFailed)
+
+	_, err := rt.codec.DecodeMetricsQueryRequest(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return rt.next.RoundTrip(r)
+}
+
+type LabelsQueryRequestValidationRoundTripper struct {
+	codec Codec
+	next  http.RoundTripper
+}
+
+func NewLabelsQueryRequestValidationRoundTripper(codec Codec, next http.RoundTripper) http.RoundTripper {
+	return LabelsQueryRequestValidationRoundTripper{
+		codec: codec,
+		next:  next,
+	}
+}
+
+func (rt LabelsQueryRequestValidationRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	ctx, cancel := context.WithCancelCause(r.Context())
+	defer cancel(errLabelsQueryRequestValidationFailed)
+
+	_, err := rt.codec.DecodeLabelsQueryRequest(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return rt.next.RoundTrip(r)
+}

--- a/pkg/frontend/querymiddleware/request_validation_test.go
+++ b/pkg/frontend/querymiddleware/request_validation_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/dskit/middleware"
+	apierror "github.com/grafana/mimir/pkg/api/error"
+)
+
+// TestMetricsQueryRequestValidationRoundTripper only checks for expected API error types being returned,
+// as the goal is to apply codec parsing early in the request cycle and return 400 errors for invalid requests.
+// The exact error message for each different parse failure is tested extensively in the codec tests.
+func TestMetricsQueryRequestValidationRoundTripper(t *testing.T) {
+	srv := httptest.NewServer(
+		middleware.AuthenticateUser.Wrap(
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				var err error
+				_, err = w.Write(nil)
+
+				if err != nil {
+					t.Fatal(err)
+				}
+			}),
+		),
+	)
+	defer srv.Close()
+
+	rt := NewMetricsQueryRequestValidationRoundTripper(newTestPrometheusCodec(), http.DefaultTransport)
+
+	for i, tc := range []struct {
+		url             string
+		expected        MetricsQueryRequest
+		expectedErrType apierror.Type
+	}{
+		{
+			url:             "/api/v1/query_range?query=up{&start=123&end=456&step=60s",
+			expectedErrType: apierror.TypeBadData,
+		},
+		{
+			url:             "/api/v1/query_range?query=up{}&start=foo&end=456&step=60s",
+			expectedErrType: apierror.TypeBadData,
+		},
+		{
+			url:             "/api/v1/query_range?query=up&start=123&end=bar&step=60s",
+			expectedErrType: apierror.TypeBadData,
+		},
+		{
+			url:             "/api/v1/query_range?query=up&start=123&end=456&step=baz",
+			expectedErrType: apierror.TypeBadData,
+		},
+		{
+			url:             "/api/v1/query_range?query=up&start=123&end=456&step=60s",
+			expectedErrType: "",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, srv.URL+tc.url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = rt.RoundTrip(req)
+			if tc.expectedErrType == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			apiErr := &apierror.APIError{}
+
+			assert.ErrorAs(t, err, &apiErr)
+			assert.Equal(t, tc.expectedErrType, apiErr.Type)
+
+		})
+	}
+}
+
+// TestLabelsQueryRequestValidationRoundTripper only checks for expected API error types being returned,
+// as the goal is to apply codec parsing early in the request cycle and return 400 errors for invalid requests.
+// The exact error message for each different parse failure is tested extensively in the codec tests.
+func TestLabelsQueryRequestValidationRoundTripper(t *testing.T) {
+	srv := httptest.NewServer(
+		middleware.AuthenticateUser.Wrap(
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				var err error
+				_, err = w.Write(nil)
+
+				if err != nil {
+					t.Fatal(err)
+				}
+			}),
+		),
+	)
+	defer srv.Close()
+
+	rt := NewLabelsQueryRequestValidationRoundTripper(newTestPrometheusCodec(), http.DefaultTransport)
+
+	for i, tc := range []struct {
+		url             string
+		expected        MetricsQueryRequest
+		expectedErrType apierror.Type
+	}{
+		{
+			url:             "/api/v1/labels?start=foo",
+			expectedErrType: apierror.TypeBadData,
+		},
+		{
+			url:             "/api/v1/labels?end=foo",
+			expectedErrType: apierror.TypeBadData,
+		},
+		{
+			url:             "/api/v1/labels?limit=foo",
+			expectedErrType: apierror.TypeBadData,
+		},
+		{
+			url:             "/api/v1/labels",
+			expectedErrType: "",
+		},
+		{
+			url:             "/api/v1/labels?match=up{}&start=123&end=456&limit=100",
+			expectedErrType: "",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, srv.URL+tc.url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = rt.RoundTrip(req)
+			if tc.expectedErrType == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			apiErr := &apierror.APIError{}
+
+			assert.ErrorAs(t, err, &apiErr)
+			assert.Equal(t, tc.expectedErrType, apiErr.Type)
+
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/request_validation_test.go
+++ b/pkg/frontend/querymiddleware/request_validation_test.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/grafana/dskit/middleware"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/grafana/dskit/middleware"
 	apierror "github.com/grafana/mimir/pkg/api/error"
 )
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -293,11 +293,17 @@ func newQueryTripperware(
 			next = newReadConsistencyRoundTripper(next, ingestStorageTopicOffsetsReader, limits, log, metrics)
 		}
 
-		// Look up cache as first thing.
+		// Look up cache as first thing after validation.
 		if cfg.CacheResults {
 			cardinality = newCardinalityQueryCacheRoundTripper(c, cacheKeyGenerator, limits, cardinality, log, registerer)
 			labels = newLabelsQueryCacheRoundTripper(c, cacheKeyGenerator, limits, labels, log, registerer)
 		}
+
+		// Validate the request before any processing.
+		queryrange = NewMetricsQueryRequestValidationRoundTripper(codec, queryrange)
+		instant = NewMetricsQueryRequestValidationRoundTripper(codec, instant)
+
+		labels = NewLabelsQueryRequestValidationRoundTripper(codec, labels)
 
 		return RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 			switch {

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -273,6 +273,7 @@ func newQueryTripperware(
 		activeSeries := next
 		activeNativeHistogramMetrics := next
 		labels := next
+		series := next
 
 		if cfg.ShardActiveSeriesQueries {
 			activeSeries = newShardActiveSeriesMiddleware(activeSeries, cfg.UseActiveSeriesDecoder, limits, log)
@@ -289,6 +290,7 @@ func newQueryTripperware(
 			activeSeries = newReadConsistencyRoundTripper(activeSeries, ingestStorageTopicOffsetsReader, limits, log, metrics)
 			activeNativeHistogramMetrics = newReadConsistencyRoundTripper(activeNativeHistogramMetrics, ingestStorageTopicOffsetsReader, limits, log, metrics)
 			labels = newReadConsistencyRoundTripper(labels, ingestStorageTopicOffsetsReader, limits, log, metrics)
+			series = newReadConsistencyRoundTripper(series, ingestStorageTopicOffsetsReader, limits, log, metrics)
 			remoteRead = newReadConsistencyRoundTripper(remoteRead, ingestStorageTopicOffsetsReader, limits, log, metrics)
 			next = newReadConsistencyRoundTripper(next, ingestStorageTopicOffsetsReader, limits, log, metrics)
 		}
@@ -319,6 +321,8 @@ func newQueryTripperware(
 				return activeNativeHistogramMetrics.RoundTrip(r)
 			case IsLabelsQuery(r.URL.Path):
 				return labels.RoundTrip(r)
+			case IsSeriesQuery(r.URL.Path):
+				return series.RoundTrip(r)
 			case IsRemoteReadQuery(r.URL.Path):
 				return remoteRead.RoundTrip(r)
 			default:

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -304,8 +304,9 @@ func newQueryTripperware(
 		// Validate the request before any processing.
 		queryrange = NewMetricsQueryRequestValidationRoundTripper(codec, queryrange)
 		instant = NewMetricsQueryRequestValidationRoundTripper(codec, instant)
-
 		labels = NewLabelsQueryRequestValidationRoundTripper(codec, labels)
+		series = NewLabelsQueryRequestValidationRoundTripper(codec, series)
+		cardinality = NewCardinalityQueryRequestValidationRoundTripper(cardinality)
 
 		return RoundTripFunc(func(r *http.Request) (*http.Response, error) {
 			switch {

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -186,46 +186,8 @@ func TestTripperware_InstantQuery(t *testing.T) {
 		}, res)
 	})
 
-	t.Run("specific time param with form being already parsed", func(t *testing.T) {
-		ts := time.Date(2021, 1, 2, 3, 4, 5, 0, time.UTC)
-
-		formParserRoundTripper := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
-			assert.NoError(t, r.ParseForm())
-			return tripper.RoundTrip(r)
-		})
-		queryClient, err := api.NewClient(api.Config{Address: "http://localhost", RoundTripper: formParserRoundTripper})
-		require.NoError(t, err)
-		api := v1.NewAPI(queryClient)
-
-		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, ts)
-		require.NoError(t, err)
-		require.IsType(t, model.Vector{}, res)
-		require.NotEmpty(t, res.(model.Vector))
-
-		resultTime := res.(model.Vector)[0].Timestamp.Time()
-		require.Equal(t, ts.Unix(), resultTime.Unix())
-	})
-
 	t.Run("default time param happy case", func(t *testing.T) {
 		queryClient, err := api.NewClient(api.Config{Address: "http://localhost", RoundTripper: tripper})
-		require.NoError(t, err)
-		api := v1.NewAPI(queryClient)
-
-		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, time.Time{})
-		require.NoError(t, err)
-		require.IsType(t, model.Vector{}, res)
-		require.NotEmpty(t, res.(model.Vector))
-
-		resultTime := res.(model.Vector)[0].Timestamp.Time()
-		require.InDelta(t, time.Now().Unix(), resultTime.Unix(), 1)
-	})
-
-	t.Run("default time param with form being already parsed", func(t *testing.T) {
-		formParserRoundTripper := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
-			assert.NoError(t, r.ParseForm())
-			return tripper.RoundTrip(r)
-		})
-		queryClient, err := api.NewClient(api.Config{Address: "http://localhost", RoundTripper: formParserRoundTripper})
 		require.NoError(t, err)
 		api := v1.NewAPI(queryClient)
 

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -796,7 +796,7 @@ func TestTripperware_ShouldSupportReadConsistencyOffsetsInjection(t *testing.T) 
 		},
 		"cardinality label values": {
 			makeRequest: func() *http.Request {
-				return httptest.NewRequest("GET", cardinalityLabelValuesPathSuffix, nil)
+				return httptest.NewRequest("GET", cardinalityLabelValuesPathSuffix+"?label_names[]=foo", nil)
 			},
 		},
 		"cardinality active series": {


### PR DESCRIPTION
#### What this PR does

This PR introduces early request validation for the majority of request types supported by the query-frontend.
This specifically does not introduce any new request parsing or validation logic, but it ensures that the validation that does exist is called in the first roundtripper, before any other work is done _and_ that a standardized 400 Bad Request APIError is returned.

The tests are largely focused on making sure we get a status 400 API Error when we expect one - each request validator roundtripper relies on existing validation codecs which have their own extensive test suites.

**Done so far** are the ones that have clearly defined validation code already in Mimir:
* instant query
* range query
* label names query
* label values query
* series query
* label names cardinality
* label values cardinality
* active series cardinality

Still to be done, likely saved for a subsequent PR are:
* metadata
* query exemplars
* active native histogram metrics cardinality requests

#### Which issue(s) this PR fixes or relates to

In previous incidents we have seen unexpected issues when parsing an invalid requests errors out in a part of the stack which is not set up to  propagate the errors properly back up the stack and prevent breaking connections or crashing goroutines.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
