### PR TITLE
tracing: finish OTEL bridge span only once

### DIFF
--- a/pkg/util/tracing/tracing_test.go
+++ b/pkg/util/tracing/tracing_test.go
@@ -280,7 +280,7 @@ func TestOpenTelemetrySpanBridge_EndIdempotency(t *testing.T) {
 			// Create bridge
 			s := NewOpenTelemetrySpanBridge(m, nil)
 
-			// Call End multiple times
+			// Call End potentially multiple times
 			for i := 0; i < testData.endCalls; i++ {
 				if testData.withOptions {
 					s.End(trace.WithTimestamp(time.Now()))
@@ -290,12 +290,8 @@ func TestOpenTelemetrySpanBridge_EndIdempotency(t *testing.T) {
 			}
 
 			// Assert expectations
-			if testData.finishCalls > 0 {
-				m.AssertNumberOfCalls(t, "Finish", testData.finishCalls)
-			}
-			if testData.finishOpts > 0 {
-				m.AssertNumberOfCalls(t, "FinishWithOptions", testData.finishOpts)
-			}
+			m.AssertNumberOfCalls(t, "Finish", testData.finishCalls)
+			m.AssertNumberOfCalls(t, "FinishWithOptions", testData.finishOpts)
 		})
 	}
 }


### PR DESCRIPTION
#### Problem

The OTEL spec allows to close the span multiple times and that `End` should be idempotent. I think the jaeger implementation doesn't have the same guarantees, so we have to handle this in out bridge implementation.

Currently, we allow to call `Finish` multiple times and we end up reporting the span multiple times: once for exhausting the HTTP request body with `io.EOF` and once for `Close()`. For more details see https://github.com/open-telemetry/opentelemetry-go-contrib/pull/6391

#### The OTEL spec

https://github.com/open-telemetry/opentelemetry-specification/blob/50027a1036746dce293ee0a8592639f131fc1fb8/specification/trace/api.md#end

> Implementations SHOULD ignore all subsequent calls to End and any other Span methods, i.e. the Span becomes non-recording by being ended (there might be exceptions when Tracer is streaming events and has no mutable state associated with the Span).

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
