### PR TITLE
block-builder: Do not hard fail when native histogram is disabled and tried to ingest one

### DIFF
--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -122,6 +122,8 @@ func (b *TSDBBuilder) Process(ctx context.Context, rec *kgo.Record, lastBlockMax
 
 		allSamplesProcessed = true
 		discardedSamples    = 0
+
+		nativeHistogramsIngestionEnabled = b.limits.NativeHistogramsIngestionEnabled(userID)
 	)
 	for _, ts := range req.Timeseries {
 		mimirpb.FromLabelAdaptersOverwriteLabels(&labelsBuilder, ts.Labels, &nonCopiedLabels)
@@ -161,6 +163,10 @@ func (b *TSDBBuilder) Process(ctx context.Context, rec *kgo.Record, lastBlockMax
 				}
 				discardedSamples++
 			}
+		}
+
+		if !nativeHistogramsIngestionEnabled {
+			continue
 		}
 
 		for _, h := range ts.Histograms {

--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -454,6 +454,60 @@ func TestTSDBBuilderLimits(t *testing.T) {
 	require.Equal(t, uint64(100), db.Head().NumSeries())
 }
 
+// TestTSDBBuilderNativeHistogramEnabledError tests that when native histograms are disabled for a tenant,
+// the TSDB builder does not error out when trying to ingest native histogram for that tenant.
+func TestTSDBBuilderNativeHistogramEnabledError(t *testing.T) {
+	var (
+		user1 = "user1"
+		user2 = "user2"
+	)
+
+	limits := map[string]*validation.Limits{
+		user1: {
+			NativeHistogramsIngestionEnabled: true,
+		},
+		user2: {
+			NativeHistogramsIngestionEnabled: false,
+		},
+	}
+	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
+	require.NoError(t, err)
+
+	metrics := newTSDBBBuilderMetrics(prometheus.NewPedanticRegistry())
+	builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides, metrics, 0)
+	t.Cleanup(func() {
+		require.NoError(t, builder.Close())
+	})
+
+	var (
+		processingRange = time.Hour.Milliseconds()
+		lastEnd         = 2 * processingRange
+		currEnd         = 3 * processingRange
+		ts              = lastEnd + (processingRange / 2)
+	)
+	for seriesID := 1; seriesID <= 100; seriesID++ {
+		for userID := range limits {
+			rec := &kgo.Record{
+				Key:   []byte(userID),
+				Value: createWriteRequest(t, strconv.Itoa(seriesID), nil, histogramSample(ts)),
+			}
+			allProcessed, err := builder.Process(context.Background(), rec, lastEnd, currEnd, false)
+			require.NoError(t, err)
+			require.Equal(t, true, allProcessed)
+		}
+	}
+
+	// user1 had native histograms enabled. We should see it in the TSDB.
+	db, err := builder.getOrCreateTSDB(tsdbTenant{tenantID: user1})
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), db.Head().NumSeries())
+
+	// user2 had native histograms disabled. Nothing should be in the TSDB.
+	db, err = builder.getOrCreateTSDB(tsdbTenant{tenantID: user2})
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), db.Head().NumSeries())
+}
+
 func defaultLimitsTestConfig() validation.Limits {
 	limits := validation.Limits{}
 	flagext.DefaultValues(&limits)


### PR DESCRIPTION
#### What this PR does

As the title says. Else block builder will be stuck on that partition forever until the partition retention kicks in.

This is how ingesters handles it as well.


#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
