### PR TITLE
MQE: add support for `group_left` and `group_right` (aka many-to-one and one-to-many matching)

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2043,6 +2043,17 @@
               "fieldFlag": "querier.mimir-query-engine.enable-histogram-quantile-function",
               "fieldType": "boolean",
               "fieldCategory": "experimental"
+            },
+            {
+              "kind": "field",
+              "name": "enable_one_to_many_and_many_to_one_binary_operations",
+              "required": false,
+              "desc": "Enable support for one-to-many and many-to-one binary operations (group_left/group_right) in the Mimir query engine. Only applies if the MQE is in use.",
+              "fieldValue": null,
+              "fieldDefaultValue": true,
+              "fieldFlag": "querier.mimir-query-engine.enable-one-to-many-and-many-to-one-binary-operations",
+              "fieldType": "boolean",
+              "fieldCategory": "experimental"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2105,6 +2105,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Enable support for binary logical operations in the Mimir query engine. Only applies if the MQE is in use. (default true)
   -querier.mimir-query-engine.enable-histogram-quantile-function
     	[experimental] Enable support for the histogram_quantile function in the Mimir query engine. Only applies if the MQE is in use. (default true)
+  -querier.mimir-query-engine.enable-one-to-many-and-many-to-one-binary-operations
+    	[experimental] Enable support for one-to-many and many-to-one binary operations (group_left/group_right) in the Mimir query engine. Only applies if the MQE is in use. (default true)
   -querier.mimir-query-engine.enable-scalar-scalar-binary-comparison-operations
     	[experimental] Enable support for binary comparison operations between two scalars in the Mimir query engine. Only applies if the MQE is in use. (default true)
   -querier.mimir-query-engine.enable-scalars

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1536,6 +1536,12 @@ mimir_query_engine:
   # Mimir query engine. Only applies if the MQE is in use.
   # CLI flag: -querier.mimir-query-engine.enable-histogram-quantile-function
   [enable_histogram_quantile_function: <boolean> | default = true]
+
+  # (experimental) Enable support for one-to-many and many-to-one binary
+  # operations (group_left/group_right) in the Mimir query engine. Only applies
+  # if the MQE is in use.
+  # CLI flag: -querier.mimir-query-engine.enable-one-to-many-and-many-to-one-binary-operations
+  [enable_one_to_many_and_many_to_one_binary_operations: <boolean> | default = true]
 ```
 
 ### frontend

--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -164,6 +164,9 @@ func TestCases(metricSizes []int) []BenchCase {
 		{
 			Expr: "nh_X / 2",
 		},
+		{
+			Expr: "h_X * on(l) group_left() a_X",
+		},
 		// Test the case where one side of a binary operation has many more series than the other.
 		{
 			Expr: `a_100{l=~"[13579]."} - b_100`,

--- a/pkg/streamingpromql/config.go
+++ b/pkg/streamingpromql/config.go
@@ -26,11 +26,13 @@ type FeatureToggles struct {
 	EnableScalars                                bool `yaml:"enable_scalars" category:"experimental"`
 	EnableSubqueries                             bool `yaml:"enable_subqueries" category:"experimental"`
 	EnableHistogramQuantileFunction              bool `yaml:"enable_histogram_quantile_function" category:"experimental"`
+	EnableOneToManyAndManyToOneBinaryOperations  bool `yaml:"enable_one_to_many_and_many_to_one_binary_operations" category:"experimental"`
 }
 
 // EnableAllFeatures enables all features supported by MQE, including experimental or incomplete features.
 var EnableAllFeatures = FeatureToggles{
 	// Note that we deliberately use a keyless literal here to force a compilation error if we don't keep this in sync with new fields added to FeatureToggles.
+	true,
 	true,
 	true,
 	true,
@@ -50,4 +52,5 @@ func (t *FeatureToggles) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&t.EnableScalars, "querier.mimir-query-engine.enable-scalars", true, "Enable support for scalars in the Mimir query engine. Only applies if the MQE is in use.")
 	f.BoolVar(&t.EnableSubqueries, "querier.mimir-query-engine.enable-subqueries", true, "Enable support for subqueries in the Mimir query engine. Only applies if the MQE is in use.")
 	f.BoolVar(&t.EnableHistogramQuantileFunction, "querier.mimir-query-engine.enable-histogram-quantile-function", true, "Enable support for the histogram_quantile function in the Mimir query engine. Only applies if the MQE is in use.")
+	f.BoolVar(&t.EnableOneToManyAndManyToOneBinaryOperations, "querier.mimir-query-engine.enable-one-to-many-and-many-to-one-binary-operations", true, "Enable support for one-to-many and many-to-one binary operations (group_left/group_right) in the Mimir query engine. Only applies if the MQE is in use.")
 }

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -2665,6 +2665,8 @@ func runMixedMetricsTests(t *testing.T, expressions []string, pointsPerSeries in
 }
 
 func TestCompareVariousMixedMetricsFunctions(t *testing.T) {
+	t.Parallel()
+
 	labelsToUse, pointsPerSeries, seriesData := getMixedMetricsForTests(true)
 
 	// Test each label individually to catch edge cases in with single series
@@ -2697,6 +2699,8 @@ func TestCompareVariousMixedMetricsFunctions(t *testing.T) {
 }
 
 func TestCompareVariousMixedMetricsBinaryOperations(t *testing.T) {
+	t.Parallel()
+
 	labelsToUse, pointsPerSeries, seriesData := getMixedMetricsForTests(false)
 
 	// Generate combinations of 2 and 3 labels. (e.g., "a,b", "e,f", "c,d,e" etc)
@@ -2737,6 +2741,8 @@ func TestCompareVariousMixedMetricsBinaryOperations(t *testing.T) {
 }
 
 func TestCompareVariousMixedMetricsAggregations(t *testing.T) {
+	t.Parallel()
+
 	labelsToUse, pointsPerSeries, seriesData := getMixedMetricsForTests(true)
 
 	// Test each label individually to catch edge cases in with single series
@@ -2765,6 +2771,8 @@ func TestCompareVariousMixedMetricsAggregations(t *testing.T) {
 }
 
 func TestCompareVariousMixedMetricsVectorSelectors(t *testing.T) {
+	t.Parallel()
+
 	labelsToUse, pointsPerSeries, seriesData := getMixedMetricsForTests(true)
 
 	// Test each label individually to catch edge cases in with single series
@@ -2790,6 +2798,8 @@ func TestCompareVariousMixedMetricsVectorSelectors(t *testing.T) {
 }
 
 func TestCompareVariousMixedMetricsComparisonOps(t *testing.T) {
+	t.Parallel()
+
 	labelsToUse, pointsPerSeries, seriesData := getMixedMetricsForTests(true)
 
 	// Test each label individually to catch edge cases in with single series

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -50,12 +50,10 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 	// The goal of this is not to list every conceivable expression that is unsupported, but to cover all the
 	// different cases and make sure we produce a reasonable error message when these cases are encountered.
 	unsupportedExpressions := map[string]string{
-		"metric{} + on() group_left() other_metric{}":  "binary expression with many-to-one matching",
-		"metric{} + on() group_right() other_metric{}": "binary expression with one-to-many matching",
-		"topk(5, metric{})":                            "'topk' aggregation with parameter",
-		`count_values("foo", metric{})`:                "'count_values' aggregation with parameter",
-		"quantile_over_time(0.4, metric{}[5m])":        "'quantile_over_time' function",
-		"quantile(0.95, metric{})":                     "'quantile' aggregation with parameter",
+		"topk(5, metric{})":                     "'topk' aggregation with parameter",
+		`count_values("foo", metric{})`:         "'count_values' aggregation with parameter",
+		"quantile_over_time(0.4, metric{}[5m])": "'quantile_over_time' function",
+		"quantile(0.95, metric{})":              "'quantile' aggregation with parameter",
 	}
 
 	for expression, expectedError := range unsupportedExpressions {
@@ -157,11 +155,19 @@ func TestUnsupportedPromQLFeaturesWithFeatureToggles(t *testing.T) {
 		requireQueryIsUnsupported(t, featureToggles, "sum_over_time(metric[1m:10s])", "subquery")
 	})
 
-	t.Run("classic histograms", func(t *testing.T) {
+	t.Run("histogram_quantile function", func(t *testing.T) {
 		featureToggles := EnableAllFeatures
 		featureToggles.EnableHistogramQuantileFunction = false
 
 		requireQueryIsUnsupported(t, featureToggles, "histogram_quantile(0.5, metric)", "'histogram_quantile' function")
+	})
+
+	t.Run("one-to-many and many-to-one binary operations", func(t *testing.T) {
+		featureToggles := EnableAllFeatures
+		featureToggles.EnableOneToManyAndManyToOneBinaryOperations = false
+
+		requireQueryIsUnsupported(t, featureToggles, "metric{} + on() group_left() other_metric{}", "binary expression with many-to-one matching")
+		requireQueryIsUnsupported(t, featureToggles, "metric{} + on() group_right() other_metric{}", "binary expression with one-to-many matching")
 	})
 }
 

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -2455,8 +2455,8 @@ func TestBinaryOperationAnnotations(t *testing.T) {
 		}
 
 		for _, expr := range expressions {
-			addBinopTestCase(op, fmt.Sprintf("binary %v between a scalar on the left side and a histogram on the right with", expr), fmt.Sprintf(`2 %v metric{type="histogram"}`, expr), "float", "histogram", binop.floatHistogramSupported)
-			addBinopTestCase(op, fmt.Sprintf("binary %v between a histogram on the left side and a scalar on the right with", expr), fmt.Sprintf(`metric{type="histogram"} %v 2`, expr), "histogram", "float", binop.histogramFloatSupported)
+			addBinopTestCase(op, fmt.Sprintf("binary %v between a scalar on the left side and a histogram on the right", expr), fmt.Sprintf(`2 %v metric{type="histogram"}`, expr), "float", "histogram", binop.floatHistogramSupported)
+			addBinopTestCase(op, fmt.Sprintf("binary %v between a histogram on the left side and a scalar on the right", expr), fmt.Sprintf(`metric{type="histogram"} %v 2`, expr), "histogram", "float", binop.histogramFloatSupported)
 
 			for cardinalityName, cardinalityModifier := range cardinalities {
 				addBinopTestCase(op, fmt.Sprintf("binary %v between two floats with %v matching", expr, cardinalityName), fmt.Sprintf(`metric{type="float"} %v ignoring(type) %v metric{type="float"}`, expr, cardinalityModifier), "float", "float", true)

--- a/pkg/streamingpromql/operators/aggregations/aggregation.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation.go
@@ -212,7 +212,8 @@ func (a *Aggregation) groupingWithoutLabelsSeriesToGroupFuncs() (seriesToGroupLa
 	// Why 1024 bytes? It's what labels.Labels.String() uses as a buffer size, so we use that as a sensible starting point too.
 	b := make([]byte, 0, 1024)
 	bytesFunc := func(l labels.Labels) []byte {
-		return l.BytesWithoutLabels(b, a.Grouping...) // NewAggregation will add __name__ to Grouping for 'without' aggregations, so no need to add it here.
+		b = l.BytesWithoutLabels(b, a.Grouping...) // NewAggregation will add __name__ to Grouping for 'without' aggregations, so no need to add it here.
+		return b
 	}
 
 	lb := labels.NewBuilder(labels.EmptyLabels())
@@ -231,7 +232,8 @@ func (a *Aggregation) groupingByLabelsSeriesToGroupFuncs() (seriesToGroupLabelsB
 	// Why 1024 bytes? It's what labels.Labels.String() uses as a buffer size, so we use that as a sensible starting point too.
 	b := make([]byte, 0, 1024)
 	bytesFunc := func(l labels.Labels) []byte {
-		return l.BytesWithLabels(b, a.Grouping...)
+		b = l.BytesWithLabels(b, a.Grouping...)
+		return b
 	}
 
 	lb := labels.NewBuilder(labels.EmptyLabels())

--- a/pkg/streamingpromql/operators/binops/binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation.go
@@ -51,7 +51,7 @@ func vectorMatchingGroupKeyFunc(vectorMatching parser.VectorMatching) func(label
 }
 
 // vectorMatchingGroupLabelsFunc returns a function that computes the labels of the output group a series belongs to.
-func groupLabelsFunc(vectorMatching parser.VectorMatching, returnBool bool) func(labels.Labels) labels.Labels {
+func groupLabelsFunc(vectorMatching parser.VectorMatching, op parser.ItemType, returnBool bool) func(labels.Labels) labels.Labels {
 	lb := labels.NewBuilder(labels.EmptyLabels())
 
 	if vectorMatching.On {
@@ -62,7 +62,7 @@ func groupLabelsFunc(vectorMatching parser.VectorMatching, returnBool bool) func
 		}
 	}
 
-	if returnBool {
+	if op.IsComparisonOperator() && !returnBool {
 		// If this is a comparison operator, we want to retain the metric name, as the comparison acts like a filter.
 		return func(l labels.Labels) labels.Labels {
 			lb.Reset(l)

--- a/pkg/streamingpromql/operators/binops/binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation.go
@@ -29,14 +29,16 @@ func vectorMatchingGroupKeyFunc(vectorMatching parser.VectorMatching) func(label
 		slices.Sort(vectorMatching.MatchingLabels)
 
 		return func(l labels.Labels) []byte {
-			return l.BytesWithLabels(buf, vectorMatching.MatchingLabels...)
+			buf = l.BytesWithLabels(buf, vectorMatching.MatchingLabels...)
+			return buf
 		}
 	}
 
 	if len(vectorMatching.MatchingLabels) == 0 {
 		// Fast path for common case for expressions like "a + b" with no 'on' or 'without' labels.
 		return func(l labels.Labels) []byte {
-			return l.BytesWithoutLabels(buf, labels.MetricName)
+			buf = l.BytesWithoutLabels(buf, labels.MetricName)
+			return buf
 		}
 	}
 
@@ -46,7 +48,8 @@ func vectorMatchingGroupKeyFunc(vectorMatching parser.VectorMatching) func(label
 	slices.Sort(lbls)
 
 	return func(l labels.Labels) []byte {
-		return l.BytesWithoutLabels(buf, lbls...)
+		buf = l.BytesWithoutLabels(buf, lbls...)
+		return buf
 	}
 }
 

--- a/pkg/streamingpromql/operators/binops/binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation.go
@@ -192,7 +192,7 @@ func (e *vectorVectorBinaryOperationEvaluator) computeResult(left types.InstantV
 	var fPoints []promql.FPoint
 	var hPoints []promql.HPoint
 
-	// For one-to-one matching for arithmetic operators, we'll never produce more points than the smaller input side.
+	// For arithmetic and comparison operators, we'll never produce more points than the smaller input side.
 	// Because floats and histograms can be multiplied together, we use the sum of both the float and histogram points.
 	// We also don't know if the output will be exclusively floats or histograms, so we'll use the same size slice for both.
 	// We only assign the slices once we see the associated point type so it shouldn't be common that we allocate both.

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package binops
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/prometheus/prometheus/util/annotations"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/compat"
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+// GroupedVectorVectorBinaryOperation represents a one-to-many or many-to-one binary operation between instant vectors such as "<expr> + group_left <expr>" or "<expr> - group_right <expr>".
+// One-to-one binary operations between instant vectors are not supported.
+type GroupedVectorVectorBinaryOperation struct {
+	Left                     types.InstantVectorOperator
+	Right                    types.InstantVectorOperator
+	Op                       parser.ItemType
+	ReturnBool               bool
+	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
+
+	VectorMatching parser.VectorMatching
+
+	// We need to retain these so that NextSeries() can return an error message with the series labels when
+	// multiple points match on a single side.
+	// Note that we don't retain the output series metadata: if we need to return an error message, we can compute
+	// the output series labels from these again.
+	leftMetadata  []types.SeriesMetadata
+	rightMetadata []types.SeriesMetadata
+
+	opFunc binaryOperationFunc
+
+	expressionPosition posrange.PositionRange
+	annotations        *annotations.Annotations
+}
+
+var _ types.InstantVectorOperator = &GroupedVectorVectorBinaryOperation{}
+
+func NewGroupedVectorVectorBinaryOperation(
+	left types.InstantVectorOperator,
+	right types.InstantVectorOperator,
+	vectorMatching parser.VectorMatching,
+	op parser.ItemType,
+	returnBool bool,
+	memoryConsumptionTracker *limiting.MemoryConsumptionTracker,
+	annotations *annotations.Annotations,
+	expressionPosition posrange.PositionRange,
+) (*GroupedVectorVectorBinaryOperation, error) {
+	b := &GroupedVectorVectorBinaryOperation{
+		Left:                     left,
+		Right:                    right,
+		VectorMatching:           vectorMatching,
+		Op:                       op,
+		ReturnBool:               returnBool,
+		MemoryConsumptionTracker: memoryConsumptionTracker,
+
+		expressionPosition: expressionPosition,
+		annotations:        annotations,
+	}
+
+	if returnBool {
+		b.opFunc = boolComparisonOperationFuncs[op]
+	} else {
+		b.opFunc = arithmeticAndComparisonOperationFuncs[op]
+	}
+
+	if b.opFunc == nil {
+		return nil, compat.NewNotSupportedError(fmt.Sprintf("binary expression with '%s'", op))
+	}
+
+	return b, nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
+	return nil, nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+	return types.InstantVectorSeriesData{}, nil
+}
+
+func (g *GroupedVectorVectorBinaryOperation) ExpressionPosition() posrange.PositionRange {
+	return g.expressionPosition
+}
+
+func (g *GroupedVectorVectorBinaryOperation) Close() {
+	g.Left.Close()
+	g.Right.Close()
+
+	if g.leftMetadata != nil {
+		types.PutSeriesMetadataSlice(g.leftMetadata)
+	}
+
+	if g.rightMetadata != nil {
+		types.PutSeriesMetadataSlice(g.rightMetadata)
+	}
+
+}

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -158,6 +158,8 @@ func NewGroupedVectorVectorBinaryOperation(
 		return nil, fmt.Errorf("unsupported cardinality '%v'", g.VectorMatching.Card)
 	}
 
+	slices.Sort(g.VectorMatching.Include)
+
 	return g, nil
 }
 

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -110,6 +110,10 @@ type matchGroup struct {
 	oneSideCount int
 }
 
+// updatePresence records the presence of a sample from the series with index seriesIdx at the timestamp with index timestampIdx.
+//
+// If there is already a sample present from another series at the same timestamp, updatePresence returns that series' index, or
+// -1 if there was no sample present at the same timestamp from another series.
 func (g *matchGroup) updatePresence(timestampIdx int64, seriesIdx int) int {
 	if existing := g.presence[timestampIdx]; existing != -1 {
 		return existing

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -357,7 +357,7 @@ func (g *GroupedVectorVectorBinaryOperation) additionalLabelsKeyFunc() func(oneS
 	buf := make([]byte, 0, 1024)
 
 	return func(oneSideLabels labels.Labels) []byte {
-		return oneSideLabels.BytesWithLabels(buf, g.VectorMatching.MatchingLabels...)
+		return oneSideLabels.BytesWithLabels(buf, g.VectorMatching.Include...)
 	}
 }
 

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -387,7 +387,8 @@ func (g *GroupedVectorVectorBinaryOperation) additionalLabelsKeyFunc() func(oneS
 	buf := make([]byte, 0, 1024)
 
 	return func(oneSideLabels labels.Labels) []byte {
-		return oneSideLabels.BytesWithLabels(buf, g.VectorMatching.Include...)
+		buf = oneSideLabels.BytesWithLabels(buf, g.VectorMatching.Include...)
+		return buf
 	}
 }
 
@@ -398,13 +399,15 @@ func (g *GroupedVectorVectorBinaryOperation) manySideGroupKeyFunc() func(manySid
 
 	if !g.shouldRemoveMetricNameFromManySide() && len(g.VectorMatching.Include) == 0 {
 		return func(manySideLabels labels.Labels) []byte {
-			return manySideLabels.Bytes(buf) // FIXME: it'd be nice if we could avoid copying the bytes here
+			buf = manySideLabels.Bytes(buf) // FIXME: it'd be nice if we could avoid Bytes() copying the slice here
+			return buf
 		}
 	}
 
 	if len(g.VectorMatching.Include) == 0 {
 		return func(manySideLabels labels.Labels) []byte {
-			return manySideLabels.BytesWithoutLabels(buf, labels.MetricName)
+			buf = manySideLabels.BytesWithoutLabels(buf, labels.MetricName)
+			return buf
 		}
 	}
 
@@ -416,7 +419,8 @@ func (g *GroupedVectorVectorBinaryOperation) manySideGroupKeyFunc() func(manySid
 	}
 
 	return func(manySideLabels labels.Labels) []byte {
-		return manySideLabels.BytesWithoutLabels(buf, labelsToRemove...)
+		buf = manySideLabels.BytesWithoutLabels(buf, labelsToRemove...)
+		return buf
 	}
 }
 

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/promql/engine.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors
 
 package binops
 

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -471,7 +471,7 @@ func (g *GroupedVectorVectorBinaryOperation) shouldRemoveMetricNameFromManySide(
 // At present, sortSeries uses a very basic heuristic to guess the best way to sort the output series, but we could make
 // this more sophisticated in the future.
 func (g *GroupedVectorVectorBinaryOperation) sortSeries(metadata []types.SeriesMetadata, series []*groupedBinaryOperationOutputSeries) {
-	// Each series from the "many" side is used for at most one output series, so sort the output series so that we buffer as little of the
+	// Each series from the "many" side is usually used for at most one output series, so sort the output series so that we buffer as little of the
 	// "many" side series as possible.
 	//
 	// This isn't necessarily perfect: it may be that this still requires us to buffer many series from the "many" side if many

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -685,7 +685,7 @@ func (g *GroupedVectorVectorBinaryOperation) formatConflictError(
 	side string,
 ) error {
 	firstConflictingSeriesLabels := sourceSeriesMetadata[firstConflictingSeriesIndex].Labels
-	groupLabels := groupLabelsFunc(g.VectorMatching, g.ReturnBool)(firstConflictingSeriesLabels)
+	groupLabels := groupLabelsFunc(g.VectorMatching, g.Op, g.ReturnBool)(firstConflictingSeriesLabels)
 
 	if secondConflictingSeriesIndex == -1 {
 		return fmt.Errorf(

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -77,10 +77,10 @@ type manySide struct {
 	outputSeriesCount int
 }
 
-// latestSeries returns the index of the last series from this side.
+// latestSeriesIndex returns the index of the last series from this side.
 //
 // It assumes that seriesIndices is sorted in ascending order.
-func (s manySide) latestSeries() int {
+func (s manySide) latestSeriesIndex() int {
 	return s.seriesIndices[len(s.seriesIndices)-1]
 }
 
@@ -95,10 +95,10 @@ type oneSide struct {
 	matchGroup *matchGroup // nil if this is the only "one" side in this group.
 }
 
-// latestSeries returns the index of the last series from this side.
+// latestSeriesIndex returns the index of the last series from this side.
 //
 // It assumes that seriesIndices is sorted in ascending order.
-func (s oneSide) latestSeries() int {
+func (s oneSide) latestSeriesIndex() int {
 	return s.seriesIndices[len(s.seriesIndices)-1]
 }
 
@@ -502,13 +502,13 @@ func (s favourManySideSorter) Len() int {
 }
 
 func (s favourManySideSorter) Less(i, j int) bool {
-	iMany := s.series[i].manySide.latestSeries()
-	jMany := s.series[j].manySide.latestSeries()
+	iMany := s.series[i].manySide.latestSeriesIndex()
+	jMany := s.series[j].manySide.latestSeriesIndex()
 	if iMany != jMany {
 		return iMany < jMany
 	}
 
-	return s.series[i].oneSide.latestSeries() < s.series[j].oneSide.latestSeries()
+	return s.series[i].oneSide.latestSeriesIndex() < s.series[j].oneSide.latestSeriesIndex()
 }
 
 func (s favourManySideSorter) Swap(i, j int) {

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -311,21 +311,19 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 			// so just create the series labels directly rather than trying to avoid their creation until we know for sure we'll
 			// need them.
 			l := outputSeriesLabelsFunc(g.oneSideMetadata[oneSide.seriesIndices[0]].Labels, s.Labels)
-			outputSeries, exists := outputSeriesMap[string(l.Bytes(buf))]
+			_, exists := outputSeriesMap[string(l.Bytes(buf))]
 
 			if !exists {
 				oneSide.outputSeriesCount++
 				thisManySide.outputSeriesCount++
 
-				outputSeries = groupedBinaryOperationOutputSeriesWithLabels{
+				outputSeriesMap[string(l.Bytes(buf))] = groupedBinaryOperationOutputSeriesWithLabels{
 					labels: l,
 					outputSeries: &groupedBinaryOperationOutputSeries{
 						manySide: thisManySide,
 						oneSide:  oneSide,
 					},
 				}
-
-				outputSeriesMap[string(l.Bytes(buf))] = outputSeries
 			}
 		}
 	}
@@ -374,7 +372,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 // be included in the final output series labels.
 func (g *GroupedVectorVectorBinaryOperation) additionalLabelsKeyFunc() func(oneSideLabels labels.Labels) []byte {
 	if len(g.VectorMatching.Include) == 0 {
-		return func(oneSideLabels labels.Labels) []byte {
+		return func(_ labels.Labels) []byte {
 			return nil
 		}
 	}
@@ -716,17 +714,6 @@ func (g *GroupedVectorVectorBinaryOperation) oneSideHandedness() string {
 		return "left"
 	case parser.CardManyToOne:
 		return "right"
-	default:
-		panic(fmt.Sprintf("unsupported cardinality '%v'", g.VectorMatching.Card))
-	}
-}
-
-func (g *GroupedVectorVectorBinaryOperation) manySideHandedness() string {
-	switch g.VectorMatching.Card {
-	case parser.CardOneToMany:
-		return "right"
-	case parser.CardManyToOne:
-		return "left"
 	default:
 		panic(fmt.Sprintf("unsupported cardinality '%v'", g.VectorMatching.Card))
 	}

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package binops
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/operators"
+	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func TestGroupedVectorVectorBinaryOperation_OutputSeriesSorting(t *testing.T) {
+	testCases := map[string]struct {
+		leftSeries  []labels.Labels
+		rightSeries []labels.Labels
+
+		matching   parser.VectorMatching
+		op         parser.ItemType
+		returnBool bool
+
+		expectedOutputSeries []labels.Labels
+	}{
+		"no series on either side": {
+			leftSeries:  []labels.Labels{},
+			rightSeries: []labels.Labels{},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardManyToOne},
+
+			expectedOutputSeries: []labels.Labels{},
+		},
+
+		"no series on left side": {
+			leftSeries: []labels.Labels{},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("series", "a"),
+			},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardManyToOne},
+
+			expectedOutputSeries: []labels.Labels{},
+		},
+
+		"no series on right side": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("series", "a"),
+			},
+			rightSeries: []labels.Labels{},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardManyToOne},
+
+			expectedOutputSeries: []labels.Labels{},
+		},
+
+		"single series on each side matched and both sides' series are in the same order": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "left", "group", "a"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "right", "group", "a"),
+				labels.FromStrings(labels.MetricName, "right", "group", "b"),
+			},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardManyToOne, MatchingLabels: []string{"group"}, On: true},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "a"),
+				labels.FromStrings("group", "b"),
+			},
+		},
+
+		"single series on each side matched and both sides' series are in different order with group_left": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "left", "group", "a"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "right", "group", "b"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a"),
+			},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardManyToOne, MatchingLabels: []string{"group"}, On: true},
+
+			// Should be sorted to avoid buffering "many" side.
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "a"),
+				labels.FromStrings("group", "b"),
+			},
+		},
+
+		"single series on each side matched and both sides' series are in different order with group_right": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "left", "group", "a"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "right", "group", "b"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a"),
+			},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardOneToMany, MatchingLabels: []string{"group"}, On: true},
+
+			// Should be sorted to avoid buffering "many" side.
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "b"),
+				labels.FromStrings("group", "a"),
+			},
+		},
+
+		"multiple series on left side match to a single series on right side with group_left": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx", "1"),
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx", "2"),
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx", "3"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx", "3"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx", "1"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "right", "group", "b"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a"),
+			},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardManyToOne, MatchingLabels: []string{"group"}, On: true},
+
+			// Should be sorted to avoid buffering "many" side.
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "a", "idx", "1"),
+				labels.FromStrings("group", "a", "idx", "2"),
+				labels.FromStrings("group", "a", "idx", "3"),
+				labels.FromStrings("group", "b", "idx", "3"),
+				labels.FromStrings("group", "b", "idx", "1"),
+				labels.FromStrings("group", "b", "idx", "2"),
+			},
+		},
+
+		"multiple series on left side match to a single series on right side with group_right": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx", "1"),
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx", "2"),
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx", "3"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx", "3"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx", "1"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "right", "group", "b"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a"),
+			},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardOneToMany, MatchingLabels: []string{"group"}, On: true},
+
+			// Should be sorted to avoid buffering "many" side.
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "b"),
+				labels.FromStrings("group", "a"),
+			},
+		},
+
+		"single series on left side match to multiple series on right side with group_left": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "left", "group", "a"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx", "1"),
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx", "2"),
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx", "3"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx", "3"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx", "1"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx", "2"),
+			},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardManyToOne, MatchingLabels: []string{"group"}, On: true},
+
+			// Should be sorted to avoid buffering "many" side.
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "a"),
+				labels.FromStrings("group", "b"),
+			},
+		},
+
+		"single series on left side match to multiple series on right side with group_right": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "left", "group", "a"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx", "1"),
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx", "2"),
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx", "3"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx", "3"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx", "1"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx", "2"),
+			},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardOneToMany, MatchingLabels: []string{"group"}, On: true},
+
+			// Should be sorted to avoid buffering "many" side.
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "b", "idx", "1"),
+				labels.FromStrings("group", "b", "idx", "2"),
+				labels.FromStrings("group", "b", "idx", "3"),
+				labels.FromStrings("group", "a", "idx", "3"),
+				labels.FromStrings("group", "a", "idx", "1"),
+				labels.FromStrings("group", "a", "idx", "2"),
+			},
+		},
+
+		"multiple series on left side match to multiple series on right side with group_left": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx_left", "1"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx_left", "3"),
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx_left", "2"),
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx_left", "3"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx_left", "1"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx_left", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx_right", "4"),
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx_right", "5"),
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx_right", "6"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx_right", "5"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx_right", "4"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx_right", "6"),
+			},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardManyToOne, MatchingLabels: []string{"group"}, On: true},
+
+			// Should be sorted to avoid buffering "many" side.
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "a", "idx_left", "1"),
+				labels.FromStrings("group", "b", "idx_left", "3"),
+				labels.FromStrings("group", "a", "idx_left", "2"),
+				labels.FromStrings("group", "a", "idx_left", "3"),
+				labels.FromStrings("group", "b", "idx_left", "1"),
+				labels.FromStrings("group", "b", "idx_left", "2"),
+			},
+		},
+
+		"multiple series on left side match to multiple series on right side with group_right": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx_left", "1"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx_left", "3"),
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx_left", "2"),
+				labels.FromStrings(labels.MetricName, "left", "group", "a", "idx_left", "3"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx_left", "1"),
+				labels.FromStrings(labels.MetricName, "left", "group", "b", "idx_left", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx_right", "4"),
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx_right", "5"),
+				labels.FromStrings(labels.MetricName, "right", "group", "b", "idx_right", "6"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx_right", "5"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx_right", "4"),
+				labels.FromStrings(labels.MetricName, "right", "group", "a", "idx_right", "6"),
+			},
+
+			op:       parser.ADD,
+			matching: parser.VectorMatching{Card: parser.CardOneToMany, MatchingLabels: []string{"group"}, On: true},
+
+			// Should be sorted to avoid buffering "many" side.
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "b", "idx_right", "4"),
+				labels.FromStrings("group", "b", "idx_right", "5"),
+				labels.FromStrings("group", "b", "idx_right", "6"),
+				labels.FromStrings("group", "a", "idx_right", "5"),
+				labels.FromStrings("group", "a", "idx_right", "4"),
+				labels.FromStrings("group", "a", "idx_right", "6"),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			left := &operators.TestOperator{Series: testCase.leftSeries}
+			right := &operators.TestOperator{Series: testCase.rightSeries}
+
+			o, err := NewGroupedVectorVectorBinaryOperation(
+				left,
+				right,
+				testCase.matching,
+				testCase.op,
+				testCase.returnBool,
+				limiting.NewMemoryConsumptionTracker(0, nil),
+				nil,
+				posrange.PositionRange{},
+				types.QueryTimeRange{},
+			)
+
+			require.NoError(t, err)
+
+			outputSeries, err := o.SeriesMetadata(context.Background())
+			require.NoError(t, err)
+
+			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
+		})
+	}
+}

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -182,7 +182,7 @@ func (b *OneToOneVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Con
 // - a list indicating which series from the left side are needed to compute the output
 // - a list indicating which series from the right side are needed to compute the output
 func (b *OneToOneVectorVectorBinaryOperation) computeOutputSeries() ([]types.SeriesMetadata, []*oneToOneBinaryOperationOutputSeries, []bool, []bool, error) {
-	labelsFunc := groupLabelsFunc(b.VectorMatching, b.ReturnBool)
+	labelsFunc := groupLabelsFunc(b.VectorMatching, b.Op, b.ReturnBool)
 	groupKeyFunc := vectorMatchingGroupKeyFunc(b.VectorMatching)
 	outputSeriesMap := map[string]*oneToOneBinaryOperationOutputSeries{}
 
@@ -403,7 +403,7 @@ func (b *OneToOneVectorVectorBinaryOperation) mergeSingleSide(data []types.Insta
 
 func (b *OneToOneVectorVectorBinaryOperation) mergeConflictToError(conflict *operators.MergeConflict, sourceSeriesMetadata []types.SeriesMetadata, side string) error {
 	firstConflictingSeriesLabels := sourceSeriesMetadata[conflict.FirstConflictingSeriesIndex].Labels
-	groupLabels := groupLabelsFunc(b.VectorMatching, b.ReturnBool)(firstConflictingSeriesLabels)
+	groupLabels := groupLabelsFunc(b.VectorMatching, b.Op, b.ReturnBool)(firstConflictingSeriesLabels)
 
 	if conflict.SecondConflictingSeriesIndex == -1 {
 		return fmt.Errorf(

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -282,11 +282,6 @@ func (b *OneToOneVectorVectorBinaryOperation) sortSeries(metadata []types.Series
 	// If we do this, then in the worst case, we'll have to buffer the whole of the lower cardinality side.
 	// (Compare this with sorting so that we read the lowest cardinality side in order: in the worst case, we'll have
 	// to buffer the whole of the higher cardinality side.)
-	//
-	// FIXME: this is reasonable for one-to-one matching, but likely not for one-to-many / many-to-one.
-	// For one-to-many / many-to-one, it would likely be best to buffer the side used for multiple output series (the "one" side),
-	// as we'll need to retain these series for multiple output series anyway.
-
 	var sortInterface sort.Interface
 
 	if len(b.leftMetadata) < len(b.rightMetadata) {

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -25,7 +25,7 @@ import (
 //
 // Most of the edge cases are already covered by TestMergeSeries, so we focus on the logic
 // unique to OneToOneVectorVectorBinaryOperation: converting conflicts to user-friendly error messages.
-func TestVectorVectorBinaryOperation_SeriesMerging(t *testing.T) {
+func TestOneToOneVectorVectorBinaryOperation_SeriesMerging(t *testing.T) {
 	testCases := map[string]struct {
 		input                []types.InstantVectorSeriesData
 		sourceSeriesIndices  []int
@@ -214,7 +214,7 @@ func TestVectorVectorBinaryOperation_SeriesMerging(t *testing.T) {
 	}
 }
 
-func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
+func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 	testCases := map[string]struct {
 		series []*oneToOneBinaryOperationOutputSeries
 

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -24,7 +24,7 @@ import (
 // The merging behaviour has many edge cases, so it's easier to test it directly from Go.
 //
 // Most of the edge cases are already covered by TestMergeSeries, so we focus on the logic
-// unique to VectorVectorBinaryOperation: converting conflicts to user-friendly error messages.
+// unique to OneToOneVectorVectorBinaryOperation: converting conflicts to user-friendly error messages.
 func TestVectorVectorBinaryOperation_SeriesMerging(t *testing.T) {
 	testCases := map[string]struct {
 		input                []types.InstantVectorSeriesData
@@ -188,7 +188,7 @@ func TestVectorVectorBinaryOperation_SeriesMerging(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
-			o := &VectorVectorBinaryOperation{
+			o := &OneToOneVectorVectorBinaryOperation{
 				// Simulate an expression with "on (env)".
 				// This is used to generate error messages.
 				VectorMatching: parser.VectorMatching{
@@ -216,19 +216,19 @@ func TestVectorVectorBinaryOperation_SeriesMerging(t *testing.T) {
 
 func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 	testCases := map[string]struct {
-		series []*binaryOperationOutputSeries
+		series []*oneToOneBinaryOperationOutputSeries
 
 		expectedOrderFavouringLeftSide  []int
 		expectedOrderFavouringRightSide []int
 	}{
 		"no output series": {
-			series: []*binaryOperationOutputSeries{},
+			series: []*oneToOneBinaryOperationOutputSeries{},
 
 			expectedOrderFavouringLeftSide:  []int{},
 			expectedOrderFavouringRightSide: []int{},
 		},
 		"single output series": {
-			series: []*binaryOperationOutputSeries{
+			series: []*oneToOneBinaryOperationOutputSeries{
 				{
 					leftSeriesIndices:  []int{4},
 					rightSeriesIndices: []int{1},
@@ -239,7 +239,7 @@ func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 			expectedOrderFavouringRightSide: []int{0},
 		},
 		"two output series, both with one input series, read from both sides in same order and already sorted correctly": {
-			series: []*binaryOperationOutputSeries{
+			series: []*oneToOneBinaryOperationOutputSeries{
 				{
 					leftSeriesIndices:  []int{1},
 					rightSeriesIndices: []int{1},
@@ -254,7 +254,7 @@ func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 			expectedOrderFavouringRightSide: []int{0, 1},
 		},
 		"two output series, both with one input series, read from both sides in same order but sorted incorrectly": {
-			series: []*binaryOperationOutputSeries{
+			series: []*oneToOneBinaryOperationOutputSeries{
 				{
 					leftSeriesIndices:  []int{2},
 					rightSeriesIndices: []int{2},
@@ -269,7 +269,7 @@ func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 			expectedOrderFavouringRightSide: []int{1, 0},
 		},
 		"two output series, both with one input series, read from both sides in different order": {
-			series: []*binaryOperationOutputSeries{
+			series: []*oneToOneBinaryOperationOutputSeries{
 				{
 					leftSeriesIndices:  []int{1},
 					rightSeriesIndices: []int{2},
@@ -284,7 +284,7 @@ func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 			expectedOrderFavouringRightSide: []int{1, 0},
 		},
 		"two output series, both with multiple input series": {
-			series: []*binaryOperationOutputSeries{
+			series: []*oneToOneBinaryOperationOutputSeries{
 				{
 					leftSeriesIndices:  []int{1, 2},
 					rightSeriesIndices: []int{0, 3},
@@ -299,7 +299,7 @@ func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 			expectedOrderFavouringRightSide: []int{1, 0},
 		},
 		"multiple output series, both with one input series, read from both sides in same order and already sorted correctly": {
-			series: []*binaryOperationOutputSeries{
+			series: []*oneToOneBinaryOperationOutputSeries{
 				{
 					leftSeriesIndices:  []int{1},
 					rightSeriesIndices: []int{1},
@@ -318,7 +318,7 @@ func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 			expectedOrderFavouringRightSide: []int{0, 1, 2},
 		},
 		"multiple output series, both with one input series, read from both sides in same order but sorted incorrectly": {
-			series: []*binaryOperationOutputSeries{
+			series: []*oneToOneBinaryOperationOutputSeries{
 				{
 					leftSeriesIndices:  []int{2},
 					rightSeriesIndices: []int{2},
@@ -337,7 +337,7 @@ func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 			expectedOrderFavouringRightSide: []int{2, 0, 1},
 		},
 		"multiple output series, both with one input series, read from both sides in different order": {
-			series: []*binaryOperationOutputSeries{
+			series: []*oneToOneBinaryOperationOutputSeries{
 				{
 					leftSeriesIndices:  []int{1},
 					rightSeriesIndices: []int{2},
@@ -356,7 +356,7 @@ func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 			expectedOrderFavouringRightSide: []int{2, 0, 1},
 		},
 		"multiple output series, with multiple input series each": {
-			series: []*binaryOperationOutputSeries{
+			series: []*oneToOneBinaryOperationOutputSeries{
 				{
 					leftSeriesIndices:  []int{4, 5, 10},
 					rightSeriesIndices: []int{2, 20},
@@ -375,7 +375,7 @@ func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 			expectedOrderFavouringRightSide: []int{0, 2, 1},
 		},
 		"multiple output series which depend on the same input series": {
-			series: []*binaryOperationOutputSeries{
+			series: []*oneToOneBinaryOperationOutputSeries{
 				{
 					leftSeriesIndices:  []int{1},
 					rightSeriesIndices: []int{2},
@@ -409,8 +409,8 @@ func TestVectorVectorBinaryOperation_Sorting(t *testing.T) {
 				metadata[i] = types.SeriesMetadata{Labels: labels.FromStrings("series", strconv.Itoa(i))}
 			}
 
-			test := func(t *testing.T, series []*binaryOperationOutputSeries, metadata []types.SeriesMetadata, sorter sort.Interface, expectedOrder []int) {
-				expectedSeriesOrder := make([]*binaryOperationOutputSeries, len(series))
+			test := func(t *testing.T, series []*oneToOneBinaryOperationOutputSeries, metadata []types.SeriesMetadata, sorter sort.Interface, expectedOrder []int) {
+				expectedSeriesOrder := make([]*oneToOneBinaryOperationOutputSeries, len(series))
 				expectedMetadataOrder := make([]types.SeriesMetadata, len(metadata))
 
 				for outputIndex, inputIndex := range expectedOrder {

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -202,7 +202,7 @@ func TestVectorVectorBinaryOperation_SeriesMerging(t *testing.T) {
 				require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*uint64(len(s.Floats))+types.HPointSize*uint64(len(s.Histograms))))
 			}
 
-			result, err := o.mergeOneSide(testCase.input, testCase.sourceSeriesIndices, testCase.sourceSeriesMetadata, "right")
+			result, err := o.mergeSingleSide(testCase.input, testCase.sourceSeriesIndices, testCase.sourceSeriesMetadata, "right")
 
 			if testCase.expectedError == "" {
 				require.NoError(t, err)

--- a/pkg/streamingpromql/operators/binops/vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/vector_vector_binary_operation.go
@@ -167,7 +167,6 @@ func (b *VectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Context) (b
 	}
 
 	if len(b.leftMetadata) == 0 {
-		// FIXME: this is incorrect for 'or'
 		// No series on left-hand side, we'll never have any output series.
 		return false, nil
 	}
@@ -178,7 +177,6 @@ func (b *VectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Context) (b
 	}
 
 	if len(b.rightMetadata) == 0 {
-		// FIXME: this is incorrect for 'or' and 'unless'
 		// No series on right-hand side, we'll never have any output series.
 		return false, nil
 	}
@@ -202,7 +200,6 @@ func (b *VectorVectorBinaryOperation) computeOutputSeries() ([]types.SeriesMetad
 	// Use the smaller side to populate the map of possible output series first.
 	// This should ensure we don't unnecessarily populate the output series map with series that will never match in most cases.
 	// (It's possible that all the series on the larger side all belong to the same group, but this is expected to be rare.)
-	// FIXME: this doesn't work as-is for 'unless'.
 	smallerSide := b.leftMetadata
 	largerSide := b.rightMetadata
 	smallerSideIsLeftSide := len(b.leftMetadata) < len(b.rightMetadata)
@@ -240,14 +237,11 @@ func (b *VectorVectorBinaryOperation) computeOutputSeries() ([]types.SeriesMetad
 				series.leftSeriesIndices = append(series.leftSeriesIndices, idx)
 			}
 		}
-
-		// FIXME: if this is an 'or' operation, then we need to create the right side even if the left doesn't exist (or vice-versa)
 	}
 
 	// Remove series that cannot produce samples.
 	for seriesLabels, outputSeries := range outputSeriesMap {
 		if len(outputSeries.leftSeriesIndices) == 0 || len(outputSeries.rightSeriesIndices) == 0 {
-			// FIXME: this is incorrect for 'or' and 'unless'
 			// No matching series on at least one side for this output series, so output series will have no samples. Remove it.
 			delete(outputSeriesMap, seriesLabels)
 		}

--- a/pkg/streamingpromql/operators/binops/vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/vector_vector_binary_operation.go
@@ -502,7 +502,7 @@ func (b *VectorVectorBinaryOperation) computeResult(left types.InstantVectorSeri
 	// at the end of series2 (also index 3).
 	// It should be pretty uncommon that metric contains both histograms and floats, so we will
 	// accept the cost of a new slice.
-	mixedPoints := len(left.Floats) > 0 && len(left.Histograms) > 0 || len(right.Floats) > 0 && len(right.Histograms) > 0
+	mixedPoints := (len(left.Floats) > 0 && len(left.Histograms) > 0) || (len(right.Floats) > 0 && len(right.Histograms) > 0)
 
 	prepareFSlice := func() error {
 		if !mixedPoints && maxPoints <= cap(left.Floats) && cap(left.Floats) < cap(right.Floats) {

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -249,7 +249,7 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr, timeRange types
 			return nil, compat.NewNotSupportedError(fmt.Sprintf("binary expression with '%v'", e.Op))
 		}
 
-		if !e.Op.IsSetOperator() && e.VectorMatching.Card != parser.CardOneToOne {
+		if !e.Op.IsSetOperator() && e.VectorMatching.Card != parser.CardOneToOne && !q.engine.featureToggles.EnableOneToManyAndManyToOneBinaryOperations {
 			return nil, compat.NewNotSupportedError(fmt.Sprintf("binary expression with %v matching", e.VectorMatching.Card))
 		}
 

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -269,7 +269,7 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr, timeRange types
 		case parser.LOR:
 			return binops.NewOrBinaryOperation(lhs, rhs, *e.VectorMatching, q.memoryConsumptionTracker, timeRange, e.PositionRange()), nil
 		default:
-			return binops.NewVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange())
+			return binops.NewOneToOneVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange())
 		}
 
 	case *parser.UnaryExpr:

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -271,7 +271,7 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr, timeRange types
 		default:
 			switch e.VectorMatching.Card {
 			case parser.CardOneToMany, parser.CardManyToOne:
-				return binops.NewGroupedVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange())
+				return binops.NewGroupedVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange(), timeRange)
 			case parser.CardOneToOne:
 				return binops.NewOneToOneVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange())
 			default:

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1269,9 +1269,10 @@ load 6m
   left_side_b{env="test", pod="a"} 5 6 7 8
   right_side{env="test", pod="a"}  2 2 7 7
 
-eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
-  left_side_a{pod="a"} _ 2 _ _
-  left_side_b{pod="a"} _ _ 7 _
+# FIXME: MQE currently does not correctly handle this case because it performs filtering after merging input series, whereas we should do it in the other order.
+#eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
+#  left_side_a{pod="a"} _ 2 _ _
+#  left_side_b{pod="a"} _ _ 7 _
 
 eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool ignoring(env) right_side
   expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the left side of the operation)
@@ -1287,8 +1288,9 @@ eval_fail range from 0 to 18m step 6m right_side == bool ignoring(env) {__name__
 #  left_side_b{pod="a"} _ _ 7 _
 # but instead both engines drop the metric names in the output.
 # This is accepted behaviour: https://github.com/prometheus/prometheus/issues/5326
-eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == on(pod) right_side
-  {pod="a"} _ 2 7 _
+# FIXME: MQE currently does not correctly handle this case because it performs filtering after merging input series, whereas we should do it in the other order.
+#eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == on(pod) right_side
+#  {pod="a"} _ 2 7 _
 
 eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool on(pod) right_side
   expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the left side of the operation)
@@ -1309,16 +1311,16 @@ load 6m
   right_side{env="test", pod="a"}  2 2 7 7
 
 eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
-  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the right side of the operation)
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the left side of the operation)
 
 eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool ignoring(env) right_side
-  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the right side of the operation)
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the left side of the operation)
 
 eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == on(pod) right_side
-  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the right side of the operation)
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the left side of the operation)
 
 eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool on(pod) right_side
-  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the right side of the operation)
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the left side of the operation)
 
 clear
 
@@ -1328,8 +1330,9 @@ load 6m
   left{pod="b"} 5 6 7 8
   right         2 2 7 7
 
-eval range from 0 to 18m step 6m left == ignoring(pod) right
-  left _ 2 7 _
+# FIXME: MQE currently does not correctly handle this case because it performs filtering after merging input series, whereas we should do it in the other order.
+# eval range from 0 to 18m step 6m left == ignoring(pod) right
+#   left _ 2 7 _
 
 clear
 
@@ -1339,9 +1342,10 @@ load 6m
   left_side_b{env="test", pod="a"} _ _ 7 8
   right_side{env="test", pod="a"}  2 2 7 7
 
-eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
-  left_side_a{pod="a"} _ 2 _ _
-  left_side_b{pod="a"} _ _ 7 _
+# FIXME: MQE currently does not correctly handle this case.
+#eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
+#  left_side_a{pod="a"} _ 2 _ _
+#  left_side_b{pod="a"} _ _ 7 _
 
 eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool ignoring(env) right_side
   {pod="a"} 0 1 1 0

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1315,3 +1315,64 @@ eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == on(pod) right_side
 
 eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool on(pod) right_side
   {pod="a"} 0 1 1 0
+
+clear
+
+# Comparison operations with group_left / group_right.
+
+load 6m
+  left_side{env="test", pod="a", region="au"} 1 2 3 9 10
+  left_side{env="test", pod="a", region="us"} 6 7 8 4 5
+  right_side{env="test", dc="1"}              2 _ _ 5 _
+  right_side{env="test", dc="2"}              _ 3 _ _ 6
+
+eval range from 0 to 24m step 6m left_side < on(env) group_left(dc) right_side
+  left_side{env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
+  left_side{env="test", pod="a", region="au", dc="2"} _ 2 _ _ _
+  left_side{env="test", pod="a", region="us", dc="1"} _ _ _ 4 _
+  left_side{env="test", pod="a", region="us", dc="2"} _ _ _ _ 5
+
+eval range from 0 to 24m step 6m left_side < bool on(env) group_left(dc) right_side
+  {env="test", pod="a", region="au", dc="1"} 1 _ _ 0 _
+  {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
+  {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
+  {env="test", pod="a", region="us", dc="2"} _ 0 _ _ 1
+
+eval range from 0 to 24m step 6m left_side < ignoring(pod, region, dc) group_left(dc) right_side
+  left_side{env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
+  left_side{env="test", pod="a", region="au", dc="2"} _ 2 _ _ _
+  left_side{env="test", pod="a", region="us", dc="1"} _ _ _ 4 _
+  left_side{env="test", pod="a", region="us", dc="2"} _ _ _ _ 5
+
+eval range from 0 to 24m step 6m left_side < bool ignoring(pod, region, dc) group_left(dc) right_side
+  {env="test", pod="a", region="au", dc="1"} 1 _ _ 0 _
+  {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
+  {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
+  {env="test", pod="a", region="us", dc="2"} _ 0 _ _ 1
+
+# FIXME: shouldn't this return series with name right_side?
+eval range from 0 to 24m step 6m right_side > on(env) group_right(dc) left_side
+  left_side{env="test", pod="a", region="au", dc="1"} 2 _ _ _ _
+  left_side{env="test", pod="a", region="au", dc="2"} _ 3 _ _ _
+  left_side{env="test", pod="a", region="us", dc="1"} _ _ _ 5 _
+  left_side{env="test", pod="a", region="us", dc="2"} _ _ _ _ 6
+
+eval range from 0 to 24m step 6m right_side > bool on(env) group_right(dc) left_side
+  {env="test", pod="a", region="au", dc="1"} 1 _ _ 0 _
+  {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
+  {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
+  {env="test", pod="a", region="us", dc="2"} _ 0 _ _ 1
+
+# FIXME: shouldn't this return series with name right_side?
+eval range from 0 to 24m step 6m right_side > ignoring(pod, region, dc) group_right(dc) left_side
+  left_side{env="test", pod="a", region="au", dc="1"} 2 _ _ _ _
+  left_side{env="test", pod="a", region="au", dc="2"} _ 3 _ _ _
+  left_side{env="test", pod="a", region="us", dc="1"} _ _ _ 5 _
+  left_side{env="test", pod="a", region="us", dc="2"} _ _ _ _ 6
+
+eval range from 0 to 24m step 6m right_side > bool ignoring(pod, region, dc) group_right(dc) left_side
+  {env="test", pod="a", region="au", dc="1"} 1 _ _ 0 _
+  {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
+  {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
+  {env="test", pod="a", region="us", dc="2"} _ 0 _ _ 1
+

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1358,6 +1358,39 @@ eval range from 0 to 18m step 6m one_side - on(group) group_right(pod, env) many
 
 clear
 
+# Binary operations on native histograms with group_left.
+# We don't bother testing all the combinations of label matching, group_right etc. given that's covered by floats above.
+load 5m
+  first_histogram{job="test"}    {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
+  second_histogram{job="test"}   {{schema:0 sum:10 count:6 buckets:[1 2 1]}}
+  metric{job="test"}             2
+
+eval instant at 0 first_histogram + on(job) group_left second_histogram
+  {job="test"} {{schema:0 sum:15 count:10 buckets:[2 4 2]}}
+
+eval instant at 0 second_histogram - on(job) group_left first_histogram
+  {job="test"} {{schema:0 sum:5 count:2 buckets:[0 0 0]}}
+
+# Cannot multiply two histograms
+eval_info instant at 0 first_histogram * on(job) group_left second_histogram
+
+# Cannot divide a histogram by a histogram
+eval_info instant at 0 first_histogram / on(job) group_left second_histogram
+
+# Histogram multiplied by float
+eval instant at 0 first_histogram * on(job) group_left metric
+  {job="test"} {{schema:0 count:8 sum:10 buckets:[2 4 2]}}
+
+# Works in either order
+eval instant at 0 metric * on(job) group_left first_histogram
+  {job="test"} {{schema:0 count:8 sum:10 buckets:[2 4 2]}}
+
+# Histogram divide by float
+eval instant at 0 first_histogram / on(job) group_left metric
+  {job="test"} {{schema:0 count:2 sum:2.5 buckets:[0.5 1 0.5]}}
+
+clear
+
 # Test comparison operator edge cases.
 load 6m
   left_side_a{env="test", pod="a"} 1 2 3 4

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1323,8 +1323,8 @@ clear
 load 6m
   side_a{env="test", pod="a", region="au"} 1 2 3 9 10
   side_a{env="test", pod="a", region="us"} 6 7 8 4 5
-  side_b{env="test", dc="1"}               2 _ _ 5 _
-  side_b{env="test", dc="2"}               _ 3 _ _ 6
+  side_b{env="test", dc="1", ignored="1"}  2 _ _ 5 _
+  side_b{env="test", dc="2", ignored="1"}  _ 3 _ _ 6
 
 eval range from 0 to 24m step 6m side_a < on(env) group_left(dc) side_b
   side_a{env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
@@ -1344,19 +1344,19 @@ eval range from 0 to 24m step 6m side_a < bool on(env) group_left(dc) side_b
   {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
   {env="test", pod="a", region="us", dc="2"} _ 0 _ _ 1
 
-eval range from 0 to 24m step 6m side_a < ignoring(pod, region, dc) group_left(dc) side_b
+eval range from 0 to 24m step 6m side_a < ignoring(pod, region, dc, ignored) group_left(dc) side_b
   side_a{env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
   side_a{env="test", pod="a", region="au", dc="2"} _ 2 _ _ _
   side_a{env="test", pod="a", region="us", dc="1"} _ _ _ 4 _
   side_a{env="test", pod="a", region="us", dc="2"} _ _ _ _ 5
 
-eval range from 0 to 24m step 6m sum without () (side_a) < ignoring(pod, region, dc) group_left(dc) side_b
+eval range from 0 to 24m step 6m sum without () (side_a) < ignoring(pod, region, dc, ignored) group_left(dc) side_b
   {env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
   {env="test", pod="a", region="au", dc="2"} _ 2 _ _ _
   {env="test", pod="a", region="us", dc="1"} _ _ _ 4 _
   {env="test", pod="a", region="us", dc="2"} _ _ _ _ 5
 
-eval range from 0 to 24m step 6m side_a < bool ignoring(pod, region, dc) group_left(dc) side_b
+eval range from 0 to 24m step 6m side_a < bool ignoring(pod, region, dc, ignored) group_left(dc) side_b
   {env="test", pod="a", region="au", dc="1"} 1 _ _ 0 _
   {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
   {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
@@ -1400,7 +1400,7 @@ eval range from 0 to 24m step 6m sum without () (side_b) > ignoring(pod, region,
   side_a{env="test", pod="a", region="us", dc="1"} _ _ _ 5 _
   side_a{env="test", pod="a", region="us", dc="2"} _ _ _ _ 6
 
-eval range from 0 to 24m step 6m side_b > bool ignoring(pod, region, dc) group_right(dc) side_a
+eval range from 0 to 24m step 6m side_b > bool ignoring(pod, region, dc, ignored) group_right(dc) side_a
   {env="test", pod="a", region="au", dc="1"} 1 _ _ 0 _
   {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
   {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -977,3 +977,245 @@ load 6m
 # Test the case where both sides of 'or' contain series with the same labels.
 eval range from 0 to 48m step 6m min(series_1) or min(series_2)
   {} 9 1 2 9 4 5 9 7 9
+
+clear
+
+# Many-to-one / one-to-many matching.
+load 6m
+  method_code:http_errors:rate5m{method="get", code="500"}  24  240  240  _
+  method_code:http_errors:rate5m{method="get", code="404"}  30  300  _    _
+  method_code:http_errors:rate5m{method="put", code="501"}  3   30   _    _
+  method_code:http_errors:rate5m{method="post", code="500"} 6   60   _    60
+  method_code:http_errors:rate5m{method="post", code="404"} 21  210  _    210
+  method:http_requests:rate5m{method="get", foo="bar"}      600 _    2400 2400
+  method:http_requests:rate5m{method="get", foo="bar2"}     _   1200 1200 1200
+  method:http_requests:rate5m{method="del", foo="baz"}      34  80   _    _
+  method:http_requests:rate5m{method="post", foo="blah"}    120 100  _    100
+
+eval instant at 0 method_code:http_errors:rate5m / ignoring(code, foo) group_left() method:http_requests:rate5m
+  {method="get", code="500"} 0.04
+  {method="get", code="404"} 0.05
+  {method="post", code="500"} 0.05
+  {method="post", code="404"} 0.175
+
+eval instant at 0 method_code:http_errors:rate5m / on(method) group_left() method:http_requests:rate5m
+  {method="get", code="500"} 0.04
+  {method="get", code="404"} 0.05
+  {method="post", code="500"} 0.05
+  {method="post", code="404"} 0.175
+
+eval instant at 0 method_code:http_errors:rate5m / ignoring(code, foo) group_left(foo) method:http_requests:rate5m
+  {method="get", code="500", foo="bar"} 0.04
+  {method="get", code="404", foo="bar"} 0.05
+  {method="post", code="500", foo="blah"} 0.05
+  {method="post", code="404", foo="blah"} 0.175
+
+eval instant at 0 method_code:http_errors:rate5m / on(method) group_left(foo) method:http_requests:rate5m
+  {method="get", code="500", foo="bar"} 0.04
+  {method="get", code="404", foo="bar"} 0.05
+  {method="post", code="500", foo="blah"} 0.05
+  {method="post", code="404", foo="blah"} 0.175
+
+eval instant at 6m method_code:http_errors:rate5m / ignoring(code, foo) group_left() method:http_requests:rate5m
+  {method="get", code="500"} 0.2
+  {method="get", code="404"} 0.25
+  {method="post", code="500"} 0.6
+  {method="post", code="404"} 2.1
+
+eval instant at 6m method_code:http_errors:rate5m / on(method) group_left() method:http_requests:rate5m
+  {method="get", code="500"} 0.2
+  {method="get", code="404"} 0.25
+  {method="post", code="500"} 0.6
+  {method="post", code="404"} 2.1
+
+eval instant at 6m method_code:http_errors:rate5m / ignoring(code, foo) group_left(foo) method:http_requests:rate5m
+  {method="get", code="500", foo="bar2"} 0.2
+  {method="get", code="404", foo="bar2"} 0.25
+  {method="post", code="500", foo="blah"} 0.6
+  {method="post", code="404", foo="blah"} 2.1
+
+eval instant at 6m method_code:http_errors:rate5m / on(method) group_left(foo) method:http_requests:rate5m
+  {method="get", code="500", foo="bar2"} 0.2
+  {method="get", code="404", foo="bar2"} 0.25
+  {method="post", code="500", foo="blah"} 0.6
+  {method="post", code="404", foo="blah"} 2.1
+
+eval range from 0 to 6m step 6m method_code:http_errors:rate5m / ignoring(code, foo) group_left() method:http_requests:rate5m
+  {method="get", code="500"}  0.04  0.2
+  {method="get", code="404"}  0.05  0.25
+  {method="post", code="500"} 0.05  0.6
+  {method="post", code="404"} 0.175 2.1
+
+eval range from 0 to 6m step 6m method_code:http_errors:rate5m / on(method) group_left() method:http_requests:rate5m
+  {method="get", code="500"}  0.04  0.2
+  {method="get", code="404"}  0.05  0.25
+  {method="post", code="500"} 0.05  0.6
+  {method="post", code="404"} 0.175 2.1
+
+eval range from 0 to 6m step 6m method_code:http_errors:rate5m / ignoring(code, foo) group_left(foo) method:http_requests:rate5m
+  {method="get", code="500", foo="bar"}   0.04  _
+  {method="get", code="404", foo="bar"}   0.05  _
+  {method="get", code="500", foo="bar2"}  _     0.2
+  {method="get", code="404", foo="bar2"}  _     0.25
+  {method="post", code="500", foo="blah"} 0.05  0.6
+  {method="post", code="404", foo="blah"} 0.175 2.1
+
+eval range from 0 to 6m step 6m method_code:http_errors:rate5m / on(method) group_left(foo) method:http_requests:rate5m
+  {method="get", code="500", foo="bar"}   0.04  _
+  {method="get", code="404", foo="bar"}   0.05  _
+  {method="get", code="500", foo="bar2"}  _     0.2
+  {method="get", code="404", foo="bar2"}  _     0.25
+  {method="post", code="500", foo="blah"} 0.05  0.6
+  {method="post", code="404", foo="blah"} 0.175 2.1
+
+# Fail if multiple series on "one" side, even if they differ on the additional labels
+eval_fail instant at 12m method_code:http_errors:rate5m / ignoring(code, foo) group_left() method:http_requests:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+eval_fail instant at 12m method_code:http_errors:rate5m / on(method) group_left() method:http_requests:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+eval_fail instant at 12m method_code:http_errors:rate5m / ignoring(code, foo) group_left(foo) method:http_requests:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+eval_fail instant at 12m method_code:http_errors:rate5m / on(method) group_left(foo) method:http_requests:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+# Fail if multiple series on "one" side, even if there is no matching point on the "many" side
+eval_fail instant at 18m method_code:http_errors:rate5m / ignoring(code, foo) group_left(foo) method:http_requests:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+eval_fail instant at 18m method_code:http_errors:rate5m / on(method) group_left(foo) method:http_requests:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+# Same cases as above, but with group_right and expressions swapped.
+eval instant at 0 method:http_requests:rate5m / ignoring(code, foo) group_right() method_code:http_errors:rate5m
+  {method="get", code="500"} 25
+  {method="get", code="404"} 20
+  {method="post", code="500"} 20
+  {method="post", code="404"} 5.7142857143
+
+eval instant at 0 method:http_requests:rate5m / on(method) group_right() method_code:http_errors:rate5m
+  {method="get", code="500"} 25
+  {method="get", code="404"} 20
+  {method="post", code="500"} 20
+  {method="post", code="404"} 5.7142857143
+
+eval instant at 0 method:http_requests:rate5m / ignoring(code, foo) group_right(foo) method_code:http_errors:rate5m
+  {method="get", code="500", foo="bar"} 25
+  {method="get", code="404", foo="bar"} 20
+  {method="post", code="500", foo="blah"} 20
+  {method="post", code="404", foo="blah"} 5.7142857143
+
+eval instant at 0 method:http_requests:rate5m / on(method) group_right(foo) method_code:http_errors:rate5m
+  {method="get", code="500", foo="bar"} 25
+  {method="get", code="404", foo="bar"} 20
+  {method="post", code="500", foo="blah"} 20
+  {method="post", code="404", foo="blah"} 5.7142857143
+
+eval instant at 6m method:http_requests:rate5m / ignoring(code, foo) group_right() method_code:http_errors:rate5m
+  {method="get", code="500"} 5
+  {method="get", code="404"} 4
+  {method="post", code="500"} 1.6666666667
+  {method="post", code="404"} 0.4761904762
+
+eval instant at 6m method:http_requests:rate5m / on(method) group_right() method_code:http_errors:rate5m
+  {method="get", code="500"} 5
+  {method="get", code="404"} 4
+  {method="post", code="500"} 1.6666666667
+  {method="post", code="404"} 0.4761904762
+
+eval instant at 6m method:http_requests:rate5m / ignoring(code, foo) group_right(foo) method_code:http_errors:rate5m
+  {method="get", code="500", foo="bar2"} 5
+  {method="get", code="404", foo="bar2"} 4
+  {method="post", code="500", foo="blah"} 1.6666666667
+  {method="post", code="404", foo="blah"} 0.4761904762
+
+eval instant at 6m method:http_requests:rate5m / on(method) group_right(foo) method_code:http_errors:rate5m
+  {method="get", code="500", foo="bar2"} 5
+  {method="get", code="404", foo="bar2"} 4
+  {method="post", code="500", foo="blah"} 1.6666666667
+  {method="post", code="404", foo="blah"} 0.4761904762
+
+eval range from 0 to 6m step 6m method:http_requests:rate5m / ignoring(code, foo) group_right() method_code:http_errors:rate5m
+  {method="get", code="500"}  25           5
+  {method="get", code="404"}  20           4
+  {method="post", code="500"} 20           1.6666666667
+  {method="post", code="404"} 5.7142857143 0.4761904762
+
+eval range from 0 to 6m step 6m method:http_requests:rate5m / on(method) group_right() method_code:http_errors:rate5m
+  {method="get", code="500"}  25           5
+  {method="get", code="404"}  20           4
+  {method="post", code="500"} 20           1.6666666667
+  {method="post", code="404"} 5.7142857143 0.4761904762
+
+eval range from 0 to 6m step 6m method:http_requests:rate5m / ignoring(code, foo) group_right(foo) method_code:http_errors:rate5m
+  {method="get", code="500", foo="bar"}   25           _
+  {method="get", code="404", foo="bar"}   20           _
+  {method="get", code="500", foo="bar2"}  _            5
+  {method="get", code="404", foo="bar2"}  _            4
+  {method="post", code="500", foo="blah"} 20           1.6666666667
+  {method="post", code="404", foo="blah"} 5.7142857143 0.4761904762
+
+eval range from 0 to 6m step 6m method:http_requests:rate5m / on(method) group_right(foo) method_code:http_errors:rate5m
+  {method="get", code="500", foo="bar"}   25           _
+  {method="get", code="404", foo="bar"}   20           _
+  {method="get", code="500", foo="bar2"}  _            5
+  {method="get", code="404", foo="bar2"}  _            4
+  {method="post", code="500", foo="blah"} 20           1.6666666667
+  {method="post", code="404", foo="blah"} 5.7142857143 0.4761904762
+
+# Fail if multiple series on "one" side, even if they differ on the additional labels
+eval_fail instant at 12m method:http_requests:rate5m / ignoring(code, foo) group_right() method_code:http_errors:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+eval_fail instant at 12m method:http_requests:rate5m / on(method) group_right() method_code:http_errors:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+eval_fail instant at 12m method:http_requests:rate5m / ignoring(code, foo) group_right(foo) method_code:http_errors:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+eval_fail instant at 12m method:http_requests:rate5m / on(method) group_right(foo) method_code:http_errors:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+# Fail if multiple series on "one" side, even if there is no matching point on the "many" side
+eval_fail instant at 18m method:http_requests:rate5m / ignoring(code, foo) group_right(foo) method_code:http_errors:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+eval_fail instant at 18m method:http_requests:rate5m / on(method) group_right(foo) method_code:http_errors:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+
+clear
+
+# Test group_left / group_right where the additional labels from "one" side replace labels with the same name from the the "many" side
+load 6m
+  left{method="get", code="500", foo="left-1"} 1
+  left{method="get", code="404", foo="left-2"} 2
+  right{method="get", foo="right-1"} 4
+
+eval instant at 0 left / on(method) group_left(foo) right
+  {method="get", code="500", foo="right-1"} 0.25
+  {method="get", code="404", foo="right-1"} 0.5
+
+eval instant at 0 right / on(method) group_right(foo) left
+  {method="get", code="500", foo="right-1"} 4
+  {method="get", code="404", foo="right-1"} 2
+
+clear
+
+load 6m
+  left{method="get", code="500", foo="left-1"}   1 _ 10
+  left{method="get", code="404", foo="left-2"}   _ 4 20
+  right{method="get", code="999", foo="right-1"} 4 8 40
+
+eval range from 0 to 6m step 6m left / on(method) group_left(foo, code) right
+  {method="get", code="999", foo="right-1"} 0.25 0.5
+
+eval range from 0 to 6m step 6m right / on(method) group_right(foo, code) left
+  {method="get", code="999", foo="right-1"} 4 2
+
+eval_fail instant at 12m left / on(method) group_left(foo, code) right
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+eval_fail instant at 12m right / on(method) group_right(foo, code) left
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1263,6 +1263,41 @@ eval_fail instant at 12m series_b / ignoring(code, foo) group_right(foo, code) s
 
 clear
 
+# Same as above, but this time the additional labels are not present on either side.
+load 6m
+  series_a{method="get", code="500"} 1 _ 10
+  series_a{method="get", code="404"} _ 4 20
+  series_b{method="get", code="999"}               4 8 40
+
+eval range from 0 to 6m step 6m series_a / on(method) group_left(foo, code) series_b
+  {method="get", code="999"} 0.25 0.5
+
+eval range from 0 to 6m step 6m series_b / on(method) group_right(foo, code) series_a
+  {method="get", code="999"} 4 2
+
+# Cannot have multiple matches from the "many" side.
+eval_fail instant at 12m series_a / on(method) group_left(foo, code) series_b
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+eval_fail instant at 12m series_b / on(method) group_right(foo, code) series_a
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+# Same thing, but with 'ignoring'.
+eval range from 0 to 6m step 6m series_a / ignoring(code, foo) group_left(foo, code) series_b
+  {method="get", code="999"} 0.25 0.5
+
+eval range from 0 to 6m step 6m series_b / ignoring(code, foo) group_right(foo, code) series_a
+  {method="get", code="999"} 4 2
+
+# Cannot have multiple matches from the "many" side.
+eval_fail instant at 12m series_a / ignoring(code, foo) group_left(foo, code) series_b
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+eval_fail instant at 12m series_b / ignoring(code, foo) group_right(foo, code) series_a
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+clear
+
 # Test comparison operator edge cases.
 load 6m
   left_side_a{env="test", pod="a"} 1 2 3 4

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1191,21 +1191,74 @@ eval instant at 0 right / on(method) group_right(foo) left
 
 clear
 
+# Test group_left / group_right where both sides contain the additional labels.
 load 6m
-  left{method="get", code="500", foo="left-1"}   1 _ 10
-  left{method="get", code="404", foo="left-2"}   _ 4 20
-  right{method="get", code="999", foo="right-1"} 4 8 40
+  series_a{method="get", code="500", foo="left-1"}   1 _ 10
+  series_a{method="get", code="404", foo="left-2"}   _ 4 20
+  series_b{method="get", code="999", foo="right-1"}  4 8 40
 
-eval range from 0 to 6m step 6m left / on(method) group_left(foo, code) right
+eval range from 0 to 6m step 6m series_a / on(method) group_left(foo, code) series_b
   {method="get", code="999", foo="right-1"} 0.25 0.5
 
-eval range from 0 to 6m step 6m right / on(method) group_right(foo, code) left
+eval range from 0 to 6m step 6m series_b / on(method) group_right(foo, code) series_a
   {method="get", code="999", foo="right-1"} 4 2
 
-eval_fail instant at 12m left / on(method) group_left(foo, code) right
+# Cannot have multiple matches from the "many" side.
+eval_fail instant at 12m series_a / on(method) group_left(foo, code) series_b
   expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
 
-eval_fail instant at 12m right / on(method) group_right(foo, code) left
+eval_fail instant at 12m series_b / on(method) group_right(foo, code) series_a
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+# Same thing, but with 'ignoring'.
+eval range from 0 to 6m step 6m series_a / ignoring(code, foo) group_left(foo, code) series_b
+  {method="get", code="999", foo="right-1"} 0.25 0.5
+
+eval range from 0 to 6m step 6m series_b / ignoring(code, foo) group_right(foo, code) series_a
+  {method="get", code="999", foo="right-1"} 4 2
+
+# Cannot have multiple matches from the "many" side.
+eval_fail instant at 12m series_a / ignoring(code, foo) group_left(foo, code) series_b
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+eval_fail instant at 12m series_b / ignoring(code, foo) group_right(foo, code) series_a
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+clear
+
+# Same as above, but this time where the additional labels are present on the "many" side but not the "one" side.
+# (They should be taken from the "one" side.)
+
+load 6m
+  series_a{method="get", code="500", foo="left-1"} 1 _ 10
+  series_a{method="get", code="404", foo="left-2"} _ 4 20
+  series_b{method="get", code="999"}               4 8 40
+
+eval range from 0 to 6m step 6m series_a / on(method) group_left(foo, code) series_b
+  {method="get", code="999"} 0.25 0.5
+
+eval range from 0 to 6m step 6m series_b / on(method) group_right(foo, code) series_a
+  {method="get", code="999"} 4 2
+
+# Cannot have multiple matches from the "many" side.
+eval_fail instant at 12m series_a / on(method) group_left(foo, code) series_b
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+eval_fail instant at 12m series_b / on(method) group_right(foo, code) series_a
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+# Same thing, but with 'ignoring'.
+eval range from 0 to 6m step 6m series_a / ignoring(code, foo) group_left(foo, code) series_b
+  {method="get", code="999"} 0.25 0.5
+
+eval range from 0 to 6m step 6m series_b / ignoring(code, foo) group_right(foo, code) series_a
+  {method="get", code="999"} 4 2
+
+# Cannot have multiple matches from the "many" side.
+eval_fail instant at 12m series_a / ignoring(code, foo) group_left(foo, code) series_b
+  expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+eval_fail instant at 12m series_b / ignoring(code, foo) group_right(foo, code) series_a
   expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
 
 clear

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1298,6 +1298,66 @@ eval_fail instant at 12m series_b / ignoring(code, foo) group_right(foo, code) s
 
 clear
 
+# Test group_left and group_right with label names in different orders in 'on' and 'ignoring'.
+load 6m
+  left_side{env="test", pod="a", group="foo"} 1 2 3
+  left_side{env="test", pod="b", group="bar"} 4 5 6
+  left_side{env="prod", pod="a", group="baz"} 7 8 9
+  right_side{env="test", pod="a", group="bar"} 10 20 30
+  right_side{env="test", pod="b", group="baz"} 40 50 60
+  right_side{env="prod", pod="a", group="foo"} 70 80 90
+
+eval range from 0 to 18m step 6m left_side - on(env, pod) group_left() right_side
+  {env="prod", pod="a", group="baz"} -63 -72 -81
+  {env="test", pod="a", group="foo"} -9 -18 -27
+  {env="test", pod="b", group="bar"} -36 -45 -54
+
+# Test the same thing again with the grouping labels in a different order.
+# (The implementation of binary operations relies on grouping labels being sorted in some places,
+# so this test exists to ensure this is done correctly.)
+eval range from 0 to 18m step 6m left_side - on(pod, env) group_left() right_side
+  {env="prod", pod="a", group="baz"} -63 -72 -81
+  {env="test", pod="a", group="foo"} -9 -18 -27
+  {env="test", pod="b", group="bar"} -36 -45 -54
+
+eval range from 0 to 18m step 6m left_side - ignoring(env, pod) group_left() right_side
+  {env="prod", pod="a", group="baz"} -33 -42 -51
+  {env="test", pod="b", group="bar"} -6 -15 -24
+  {env="test", pod="a", group="foo"} -69 -78 -87
+
+# Test the same thing again with the grouping labels in a different order.
+# (The implementation of binary operations relies on grouping labels being sorted in some places,
+# so this test exists to ensure this is done correctly.)
+eval range from 0 to 18m step 6m left_side - ignoring(pod, env) group_left() right_side
+  {env="prod", pod="a", group="baz"} -33 -42 -51
+  {env="test", pod="b", group="bar"} -6 -15 -24
+  {env="test", pod="a", group="foo"} -69 -78 -87
+
+# Same thing, but with the additional labels given in group_left / group_right in different orders.
+load 6m
+  many_side{group="a", idx="x"}            1 2 3
+  many_side{group="b", idx="y"}            4 5 6
+  one_side{group="a", env="test", pod="1"} 10 20 30
+  one_side{group="b", env="prod", pod="2"} 100 110 120
+
+eval range from 0 to 18m step 6m many_side - on(group) group_left(env, pod) one_side
+  {group="a", env="test", pod="1", idx="x"} -9 -18 -27
+  {group="b", env="prod", pod="2", idx="y"} -96 -105 -114
+
+eval range from 0 to 18m step 6m many_side - on(group) group_left(pod, env) one_side
+  {group="a", env="test", pod="1", idx="x"} -9 -18 -27
+  {group="b", env="prod", pod="2", idx="y"} -96 -105 -114
+
+eval range from 0 to 18m step 6m one_side - on(group) group_right(env, pod) many_side
+  {group="a", env="test", pod="1", idx="x"} 9 18 27
+  {group="b", env="prod", pod="2", idx="y"} 96 105 114
+
+eval range from 0 to 18m step 6m one_side - on(group) group_right(pod, env) many_side
+  {group="a", env="test", pod="1", idx="x"} 9 18 27
+  {group="b", env="prod", pod="2", idx="y"} 96 105 114
+
+clear
+
 # Test comparison operator edge cases.
 load 6m
   left_side_a{env="test", pod="a"} 1 2 3 4

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1068,25 +1068,19 @@ eval range from 0 to 6m step 6m method_code:http_errors:rate5m / on(method) grou
   {method="post", code="500", foo="blah"} 0.05  0.6
   {method="post", code="404", foo="blah"} 0.175 2.1
 
-# Fail if multiple series on "one" side, even if they differ on the additional labels
-eval_fail instant at 12m method_code:http_errors:rate5m / ignoring(code, foo) group_left() method:http_requests:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+# Fail if multiple series on "one" side, even if they differ on the additional labels.
+# We run these tests as range queries with a single step to avoid promqltest's instant query time shifting, which makes using an explicit error message pattern more difficult.
+eval_fail range from 12m to 12m step 1m method_code:http_errors:rate5m / ignoring(code, foo) group_left() method:http_requests:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right (hand-)?side of the operation( at timestamp 1970-01-01T00:12:00Z)?: \[?\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(,| and) \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(\];many-to-many matching not allowed: matching labels must be unique on one side)?
 
-eval_fail instant at 12m method_code:http_errors:rate5m / on(method) group_left() method:http_requests:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+eval_fail range from 12m to 12m step 1m method_code:http_errors:rate5m / on(method) group_left() method:http_requests:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right (hand-)?side of the operation( at timestamp 1970-01-01T00:12:00Z)?: \[?\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(,| and) \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(\];many-to-many matching not allowed: matching labels must be unique on one side)?
 
-eval_fail instant at 12m method_code:http_errors:rate5m / ignoring(code, foo) group_left(foo) method:http_requests:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+eval_fail range from 12m to 12m step 1m method_code:http_errors:rate5m / ignoring(code, foo) group_left(foo) method:http_requests:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right (hand-)?side of the operation( at timestamp 1970-01-01T00:12:00Z)?: \[?\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(,| and) \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(\];many-to-many matching not allowed: matching labels must be unique on one side)?
 
-eval_fail instant at 12m method_code:http_errors:rate5m / on(method) group_left(foo) method:http_requests:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
-
-# Fail if multiple series on "one" side, even if there is no matching point on the "many" side
-eval_fail instant at 18m method_code:http_errors:rate5m / ignoring(code, foo) group_left(foo) method:http_requests:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
-
-eval_fail instant at 18m method_code:http_errors:rate5m / on(method) group_left(foo) method:http_requests:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+eval_fail range from 12m to 12m step 1m method_code:http_errors:rate5m / on(method) group_left(foo) method:http_requests:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the right (hand-)?side of the operation( at timestamp 1970-01-01T00:12:00Z)?: \[?\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(,| and) \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(\];many-to-many matching not allowed: matching labels must be unique on one side)?
 
 # Same cases as above, but with group_right and expressions swapped.
 eval instant at 0 method:http_requests:rate5m / ignoring(code, foo) group_right() method_code:http_errors:rate5m
@@ -1166,24 +1160,18 @@ eval range from 0 to 6m step 6m method:http_requests:rate5m / on(method) group_r
   {method="post", code="404", foo="blah"} 5.7142857143 0.4761904762
 
 # Fail if multiple series on "one" side, even if they differ on the additional labels
-eval_fail instant at 12m method:http_requests:rate5m / ignoring(code, foo) group_right() method_code:http_errors:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+# We run these tests as range queries with a single step to avoid promqltest's instant query time shifting, which makes using an explicit error message pattern more difficult.
+eval_fail range from 12m to 12m step 1m method:http_requests:rate5m / ignoring(code, foo) group_right() method_code:http_errors:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left (hand-)?side of the operation( at timestamp 1970-01-01T00:12:00Z)?: \[?\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(,| and) \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(\];many-to-many matching not allowed: matching labels must be unique on one side)?
 
-eval_fail instant at 12m method:http_requests:rate5m / on(method) group_right() method_code:http_errors:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+eval_fail range from 12m to 12m step 1m method:http_requests:rate5m / on(method) group_right() method_code:http_errors:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left (hand-)?side of the operation( at timestamp 1970-01-01T00:12:00Z)?: \[?\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(,| and) \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(\];many-to-many matching not allowed: matching labels must be unique on one side)?
 
-eval_fail instant at 12m method:http_requests:rate5m / ignoring(code, foo) group_right(foo) method_code:http_errors:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+eval_fail range from 12m to 12m step 1m method:http_requests:rate5m / ignoring(code, foo) group_right(foo) method_code:http_errors:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left (hand-)?side of the operation( at timestamp 1970-01-01T00:12:00Z)?: \[?\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(,| and) \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(\];many-to-many matching not allowed: matching labels must be unique on one side)?
 
-eval_fail instant at 12m method:http_requests:rate5m / on(method) group_right(foo) method_code:http_errors:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
-
-# Fail if multiple series on "one" side, even if there is no matching point on the "many" side
-eval_fail instant at 18m method:http_requests:rate5m / ignoring(code, foo) group_right(foo) method_code:http_errors:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
-
-eval_fail instant at 18m method:http_requests:rate5m / on(method) group_right(foo) method_code:http_errors:rate5m
-  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left hand-side of the operation: \[\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}, \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}\];many-to-many matching not allowed: matching labels must be unique on one side
+eval_fail range from 12m to 12m step 1m method:http_requests:rate5m / on(method) group_right(foo) method_code:http_errors:rate5m
+  expected_fail_regexp found duplicate series for the match group \{method="get"\} on the left (hand-)?side of the operation( at timestamp 1970-01-01T00:12:00Z)?: \[?\{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(,| and) \{__name__="method:http_requests:rate5m", foo="(bar|bar2)", method="get"\}(\];many-to-many matching not allowed: matching labels must be unique on one side)?
 
 clear
 

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1321,58 +1321,87 @@ clear
 # Comparison operations with group_left / group_right.
 
 load 6m
-  left_side{env="test", pod="a", region="au"} 1 2 3 9 10
-  left_side{env="test", pod="a", region="us"} 6 7 8 4 5
-  right_side{env="test", dc="1"}              2 _ _ 5 _
-  right_side{env="test", dc="2"}              _ 3 _ _ 6
+  side_a{env="test", pod="a", region="au"} 1 2 3 9 10
+  side_a{env="test", pod="a", region="us"} 6 7 8 4 5
+  side_b{env="test", dc="1"}               2 _ _ 5 _
+  side_b{env="test", dc="2"}               _ 3 _ _ 6
 
-eval range from 0 to 24m step 6m left_side < on(env) group_left(dc) right_side
-  left_side{env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
-  left_side{env="test", pod="a", region="au", dc="2"} _ 2 _ _ _
-  left_side{env="test", pod="a", region="us", dc="1"} _ _ _ 4 _
-  left_side{env="test", pod="a", region="us", dc="2"} _ _ _ _ 5
+eval range from 0 to 24m step 6m side_a < on(env) group_left(dc) side_b
+  side_a{env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
+  side_a{env="test", pod="a", region="au", dc="2"} _ 2 _ _ _
+  side_a{env="test", pod="a", region="us", dc="1"} _ _ _ 4 _
+  side_a{env="test", pod="a", region="us", dc="2"} _ _ _ _ 5
 
-eval range from 0 to 24m step 6m left_side < bool on(env) group_left(dc) right_side
+eval range from 0 to 24m step 6m sum without () (side_a) < on(env) group_left(dc) side_b
+  {env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
+  {env="test", pod="a", region="au", dc="2"} _ 2 _ _ _
+  {env="test", pod="a", region="us", dc="1"} _ _ _ 4 _
+  {env="test", pod="a", region="us", dc="2"} _ _ _ _ 5
+
+eval range from 0 to 24m step 6m side_a < bool on(env) group_left(dc) side_b
   {env="test", pod="a", region="au", dc="1"} 1 _ _ 0 _
   {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
   {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
   {env="test", pod="a", region="us", dc="2"} _ 0 _ _ 1
 
-eval range from 0 to 24m step 6m left_side < ignoring(pod, region, dc) group_left(dc) right_side
-  left_side{env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
-  left_side{env="test", pod="a", region="au", dc="2"} _ 2 _ _ _
-  left_side{env="test", pod="a", region="us", dc="1"} _ _ _ 4 _
-  left_side{env="test", pod="a", region="us", dc="2"} _ _ _ _ 5
+eval range from 0 to 24m step 6m side_a < ignoring(pod, region, dc) group_left(dc) side_b
+  side_a{env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
+  side_a{env="test", pod="a", region="au", dc="2"} _ 2 _ _ _
+  side_a{env="test", pod="a", region="us", dc="1"} _ _ _ 4 _
+  side_a{env="test", pod="a", region="us", dc="2"} _ _ _ _ 5
 
-eval range from 0 to 24m step 6m left_side < bool ignoring(pod, region, dc) group_left(dc) right_side
+eval range from 0 to 24m step 6m sum without () (side_a) < ignoring(pod, region, dc) group_left(dc) side_b
+  {env="test", pod="a", region="au", dc="1"} 1 _ _ _ _
+  {env="test", pod="a", region="au", dc="2"} _ 2 _ _ _
+  {env="test", pod="a", region="us", dc="1"} _ _ _ 4 _
+  {env="test", pod="a", region="us", dc="2"} _ _ _ _ 5
+
+eval range from 0 to 24m step 6m side_a < bool ignoring(pod, region, dc) group_left(dc) side_b
   {env="test", pod="a", region="au", dc="1"} 1 _ _ 0 _
   {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
   {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
   {env="test", pod="a", region="us", dc="2"} _ 0 _ _ 1
 
-# FIXME: shouldn't this return series with name right_side?
-eval range from 0 to 24m step 6m right_side > on(env) group_right(dc) left_side
-  left_side{env="test", pod="a", region="au", dc="1"} 2 _ _ _ _
-  left_side{env="test", pod="a", region="au", dc="2"} _ 3 _ _ _
-  left_side{env="test", pod="a", region="us", dc="1"} _ _ _ 5 _
-  left_side{env="test", pod="a", region="us", dc="2"} _ _ _ _ 6
+# The docs say this should return series with name "side_b" from the left, but it is accepted that this will return
+# "side_a" from the right: see https://github.com/prometheus/prometheus/issues/15471.
+eval range from 0 to 24m step 6m side_b > on(env) group_right(dc) side_a
+  side_a{env="test", pod="a", region="au", dc="1"} 2 _ _ _ _
+  side_a{env="test", pod="a", region="au", dc="2"} _ 3 _ _ _
+  side_a{env="test", pod="a", region="us", dc="1"} _ _ _ 5 _
+  side_a{env="test", pod="a", region="us", dc="2"} _ _ _ _ 6
 
-eval range from 0 to 24m step 6m right_side > bool on(env) group_right(dc) left_side
+# The docs say this should return series with no name, but it is accepted that this will return
+# "side_a" from the right: see https://github.com/prometheus/prometheus/issues/15471.
+eval range from 0 to 24m step 6m sum without () (side_b) > on(env) group_right(dc) side_a
+  side_a{env="test", pod="a", region="au", dc="1"} 2 _ _ _ _
+  side_a{env="test", pod="a", region="au", dc="2"} _ 3 _ _ _
+  side_a{env="test", pod="a", region="us", dc="1"} _ _ _ 5 _
+  side_a{env="test", pod="a", region="us", dc="2"} _ _ _ _ 6
+
+eval range from 0 to 24m step 6m side_b > bool on(env) group_right(dc) side_a
   {env="test", pod="a", region="au", dc="1"} 1 _ _ 0 _
   {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
   {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
   {env="test", pod="a", region="us", dc="2"} _ 0 _ _ 1
 
-# FIXME: shouldn't this return series with name right_side?
-eval range from 0 to 24m step 6m right_side > ignoring(pod, region, dc) group_right(dc) left_side
-  left_side{env="test", pod="a", region="au", dc="1"} 2 _ _ _ _
-  left_side{env="test", pod="a", region="au", dc="2"} _ 3 _ _ _
-  left_side{env="test", pod="a", region="us", dc="1"} _ _ _ 5 _
-  left_side{env="test", pod="a", region="us", dc="2"} _ _ _ _ 6
+# The docs say this should return series with name "side_b" from the left, but it is accepted that this will return
+# "side_a" from the right: see https://github.com/prometheus/prometheus/issues/15471.
+eval range from 0 to 24m step 6m side_b > ignoring(pod, region, dc, ignored) group_right(dc) side_a
+  side_a{env="test", pod="a", region="au", dc="1"} 2 _ _ _ _
+  side_a{env="test", pod="a", region="au", dc="2"} _ 3 _ _ _
+  side_a{env="test", pod="a", region="us", dc="1"} _ _ _ 5 _
+  side_a{env="test", pod="a", region="us", dc="2"} _ _ _ _ 6
 
-eval range from 0 to 24m step 6m right_side > bool ignoring(pod, region, dc) group_right(dc) left_side
+# The docs say this should return series with no name (ie. the metric name from the left), but it is accepted that this will return
+# "side_a" from the right: see https://github.com/prometheus/prometheus/issues/15471.
+eval range from 0 to 24m step 6m sum without () (side_b) > ignoring(pod, region, dc, ignored) group_right(dc) side_a
+  side_a{env="test", pod="a", region="au", dc="1"} 2 _ _ _ _
+  side_a{env="test", pod="a", region="au", dc="2"} _ 3 _ _ _
+  side_a{env="test", pod="a", region="us", dc="1"} _ _ _ 5 _
+  side_a{env="test", pod="a", region="us", dc="2"} _ _ _ _ 6
+
+eval range from 0 to 24m step 6m side_b > bool ignoring(pod, region, dc) group_right(dc) side_a
   {env="test", pod="a", region="au", dc="1"} 1 _ _ 0 _
   {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
   {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
   {env="test", pod="a", region="us", dc="2"} _ 0 _ _ 1
-

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1219,3 +1219,99 @@ eval_fail instant at 12m left / on(method) group_left(foo, code) right
 
 eval_fail instant at 12m right / on(method) group_right(foo, code) left
   expected_fail_message multiple matches for labels: grouping labels must ensure unique matches
+
+clear
+
+# Test comparison operator edge cases.
+load 6m
+  left_side_a{env="test", pod="a"} 1 2 3 4
+  left_side_b{env="test", pod="a"} 5 6 7 8
+  right_side{env="test", pod="a"}  2 2 7 7
+
+eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
+  left_side_a{pod="a"} _ 2 _ _
+  left_side_b{pod="a"} _ _ 7 _
+
+eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool ignoring(env) right_side
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the left side of the operation)
+
+eval_fail range from 0 to 18m step 6m right_side == ignoring(env) {__name__=~"left_side.*"}
+  expected_fail_regexp found duplicate series for the match group .* on the right (hand-)?side of the operation
+
+eval_fail range from 0 to 18m step 6m right_side == bool ignoring(env) {__name__=~"left_side.*"}
+  expected_fail_regexp found duplicate series for the match group .* on the right (hand-)?side of the operation
+
+# This should return:
+#  left_side_a{pod="a"} _ 2 _ _
+#  left_side_b{pod="a"} _ _ 7 _
+# but instead both engines drop the metric names in the output.
+# This is accepted behaviour: https://github.com/prometheus/prometheus/issues/5326
+eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == on(pod) right_side
+  {pod="a"} _ 2 7 _
+
+eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool on(pod) right_side
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the left side of the operation)
+
+eval_fail range from 0 to 18m step 6m right_side == on(pod) {__name__=~"left_side.*"}
+  expected_fail_regexp found duplicate series for the match group .* on the right (hand-)?side of the operation
+
+eval_fail range from 0 to 18m step 6m right_side == bool on(pod) {__name__=~"left_side.*"}
+  expected_fail_regexp found duplicate series for the match group .* on the right (hand-)?side of the operation
+
+clear
+
+# If we change the data slightly... (note the second point for left_side_b is now 2)
+
+load 6m
+  left_side_a{env="test", pod="a"} 1 2 3 4
+  left_side_b{env="test", pod="a"} 5 2 7 8
+  right_side{env="test", pod="a"}  2 2 7 7
+
+eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the right side of the operation)
+
+eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool ignoring(env) right_side
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the right side of the operation)
+
+eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == on(pod) right_side
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the right side of the operation)
+
+eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool on(pod) right_side
+  expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the right side of the operation)
+
+clear
+
+# Same thing as above, but with the same metric name for all series on left side.
+load 6m
+  left{pod="a"} 1 2 3 4
+  left{pod="b"} 5 6 7 8
+  right         2 2 7 7
+
+eval range from 0 to 18m step 6m left == ignoring(pod) right
+  left _ 2 7 _
+
+clear
+
+# Same thing as above, but with no overlapping samples on left side.
+load 6m
+  left_side_a{env="test", pod="a"} 1 2 _ _
+  left_side_b{env="test", pod="a"} _ _ 7 8
+  right_side{env="test", pod="a"}  2 2 7 7
+
+eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
+  left_side_a{pod="a"} _ 2 _ _
+  left_side_b{pod="a"} _ _ 7 _
+
+eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool ignoring(env) right_side
+  {pod="a"} 0 1 1 0
+
+# This should return:
+#  left_side_a{pod="a"} _ 2 _ _
+#  left_side_b{pod="a"} _ _ 7 _
+# but instead both engines drop the metric names in the output.
+# This is accepted behaviour: https://github.com/prometheus/prometheus/issues/5326
+eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == on(pod) right_side
+  {pod="a"} _ 2 7 _
+
+eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool on(pod) right_side
+  {pod="a"} 0 1 1 0

--- a/pkg/streamingpromql/testdata/upstream/collision.test
+++ b/pkg/streamingpromql/testdata/upstream/collision.test
@@ -10,11 +10,10 @@ load 1s
       node_cpu_seconds_total{cpu="35",endpoint="https",instance="10.253.57.87:9100",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v",service="node-exporter"} 449
       node_cpu_seconds_total{cpu="89",endpoint="https",instance="10.253.57.87:9100",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v",service="node-exporter"} 449
 
-# Unsupported by streaming engine.
-# eval instant at 4s count by(namespace, pod, cpu) (node_cpu_seconds_total{cpu=~".*",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v"}) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{namespace="observability",pod="node-exporter-l454v"}
-#     {cpu="10",namespace="observability",node="gke-search-infra-custom-96-253440-fli-d135b119-jx00",pod="node-exporter-l454v"} 1
-#     {cpu="35",namespace="observability",node="gke-search-infra-custom-96-253440-fli-d135b119-jx00",pod="node-exporter-l454v"} 1
-#     {cpu="89",namespace="observability",node="gke-search-infra-custom-96-253440-fli-d135b119-jx00",pod="node-exporter-l454v"} 1
+eval instant at 4s count by(namespace, pod, cpu) (node_cpu_seconds_total{cpu=~".*",job="node-exporter",mode="idle",namespace="observability",pod="node-exporter-l454v"}) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{namespace="observability",pod="node-exporter-l454v"}
+    {cpu="10",namespace="observability",node="gke-search-infra-custom-96-253440-fli-d135b119-jx00",pod="node-exporter-l454v"} 1
+    {cpu="35",namespace="observability",node="gke-search-infra-custom-96-253440-fli-d135b119-jx00",pod="node-exporter-l454v"} 1
+    {cpu="89",namespace="observability",node="gke-search-infra-custom-96-253440-fli-d135b119-jx00",pod="node-exporter-l454v"} 1
 
 clear
 

--- a/pkg/streamingpromql/testdata/upstream/operators.test
+++ b/pkg/streamingpromql/testdata/upstream/operators.test
@@ -334,98 +334,82 @@ load 5m
   threshold{instance="abc",job="node",target="a@b.com"} 0
 
 # Copy machine role to node variable.
-# Unsupported by streaming engine.
-# eval instant at 1m node_role * on (instance) group_right (role) node_var
-#   {instance="abc",job="node",role="prometheus"} 2
+eval instant at 1m node_role * on (instance) group_right (role) node_var
+  {instance="abc",job="node",role="prometheus"} 2
 
-# Unsupported by streaming engine.
-# eval instant at 1m node_var * on (instance) group_left (role) node_role
-#   {instance="abc",job="node",role="prometheus"} 2
+eval instant at 1m node_var * on (instance) group_left (role) node_role
+  {instance="abc",job="node",role="prometheus"} 2
 
-# Unsupported by streaming engine.
-# eval instant at 1m node_var * ignoring (role) group_left (role) node_role
-#   {instance="abc",job="node",role="prometheus"} 2
+eval instant at 1m node_var * ignoring (role) group_left (role) node_role
+  {instance="abc",job="node",role="prometheus"} 2
 
-# Unsupported by streaming engine.
-# eval instant at 1m node_role * ignoring (role) group_right (role) node_var
-#   {instance="abc",job="node",role="prometheus"} 2
+eval instant at 1m node_role * ignoring (role) group_right (role) node_var
+  {instance="abc",job="node",role="prometheus"} 2
 
 # Copy machine role to node variable with instrumentation labels.
-# Unsupported by streaming engine.
-# eval instant at 1m node_cpu * ignoring (role, mode) group_left (role) node_role
-#   {instance="abc",job="node",mode="idle",role="prometheus"} 3
-#   {instance="abc",job="node",mode="user",role="prometheus"} 1
+eval instant at 1m node_cpu * ignoring (role, mode) group_left (role) node_role
+  {instance="abc",job="node",mode="idle",role="prometheus"} 3
+  {instance="abc",job="node",mode="user",role="prometheus"} 1
 
-# Unsupported by streaming engine.
-# eval instant at 1m node_cpu * on (instance) group_left (role) node_role
-#   {instance="abc",job="node",mode="idle",role="prometheus"} 3
-#   {instance="abc",job="node",mode="user",role="prometheus"} 1
+eval instant at 1m node_cpu * on (instance) group_left (role) node_role
+  {instance="abc",job="node",mode="idle",role="prometheus"} 3
+  {instance="abc",job="node",mode="user",role="prometheus"} 1
 
 
 # Ratio of total.
-# Unsupported by streaming engine.
-# eval instant at 1m node_cpu / on (instance) group_left sum by (instance,job)(node_cpu)
-#   {instance="abc",job="node",mode="idle"} .75
-#   {instance="abc",job="node",mode="user"} .25
-#   {instance="def",job="node",mode="idle"} .80
-#   {instance="def",job="node",mode="user"} .20
+eval instant at 1m node_cpu / on (instance) group_left sum by (instance,job)(node_cpu)
+  {instance="abc",job="node",mode="idle"} .75
+  {instance="abc",job="node",mode="user"} .25
+  {instance="def",job="node",mode="idle"} .80
+  {instance="def",job="node",mode="user"} .20
 
-# Unsupported by streaming engine.
-# eval instant at 1m sum by (mode, job)(node_cpu) / on (job) group_left sum by (job)(node_cpu)
-#   {job="node",mode="idle"} 0.7857142857142857
-#   {job="node",mode="user"} 0.21428571428571427
+eval instant at 1m sum by (mode, job)(node_cpu) / on (job) group_left sum by (job)(node_cpu)
+  {job="node",mode="idle"} 0.7857142857142857
+  {job="node",mode="user"} 0.21428571428571427
 
-# Unsupported by streaming engine.
-# eval instant at 1m sum(sum by (mode, job)(node_cpu) / on (job) group_left sum by (job)(node_cpu))
-#   {} 1.0
+eval instant at 1m sum(sum by (mode, job)(node_cpu) / on (job) group_left sum by (job)(node_cpu))
+  {} 1.0
 
 
-# Unsupported by streaming engine.
-# eval instant at 1m node_cpu / ignoring (mode) group_left sum without (mode)(node_cpu)
-#   {instance="abc",job="node",mode="idle"} .75
-#   {instance="abc",job="node",mode="user"} .25
-#   {instance="def",job="node",mode="idle"} .80
-#   {instance="def",job="node",mode="user"} .20
+eval instant at 1m node_cpu / ignoring (mode) group_left sum without (mode)(node_cpu)
+  {instance="abc",job="node",mode="idle"} .75
+  {instance="abc",job="node",mode="user"} .25
+  {instance="def",job="node",mode="idle"} .80
+  {instance="def",job="node",mode="user"} .20
 
-# Unsupported by streaming engine.
-# eval instant at 1m node_cpu / ignoring (mode) group_left(dummy) sum without (mode)(node_cpu)
-#   {instance="abc",job="node",mode="idle"} .75
-#   {instance="abc",job="node",mode="user"} .25
-#   {instance="def",job="node",mode="idle"} .80
-#   {instance="def",job="node",mode="user"} .20
+eval instant at 1m node_cpu / ignoring (mode) group_left(dummy) sum without (mode)(node_cpu)
+  {instance="abc",job="node",mode="idle"} .75
+  {instance="abc",job="node",mode="user"} .25
+  {instance="def",job="node",mode="idle"} .80
+  {instance="def",job="node",mode="user"} .20
 
-# Unsupported by streaming engine.
-# eval instant at 1m sum without (instance)(node_cpu) / ignoring (mode) group_left sum without (instance, mode)(node_cpu)
-#   {job="node",mode="idle"} 0.7857142857142857
-#   {job="node",mode="user"} 0.21428571428571427
+eval instant at 1m sum without (instance)(node_cpu) / ignoring (mode) group_left sum without (instance, mode)(node_cpu)
+  {job="node",mode="idle"} 0.7857142857142857
+  {job="node",mode="user"} 0.21428571428571427
 
-# Unsupported by streaming engine.
-# eval instant at 1m sum(sum without (instance)(node_cpu) / ignoring (mode) group_left sum without (instance, mode)(node_cpu))
-#   {} 1.0
+eval instant at 1m sum(sum without (instance)(node_cpu) / ignoring (mode) group_left sum without (instance, mode)(node_cpu))
+  {} 1.0
 
 
 # Copy over label from metric with no matching labels, without having to list cross-job target labels ('job' here).
-# Unsupported by streaming engine.
-# eval instant at 1m node_cpu + on(dummy) group_left(foo) random*0
-#   {instance="abc",job="node",mode="idle",foo="bar"} 3
-#   {instance="abc",job="node",mode="user",foo="bar"} 1
-#   {instance="def",job="node",mode="idle",foo="bar"} 8
-#   {instance="def",job="node",mode="user",foo="bar"} 2
+eval instant at 1m node_cpu + on(dummy) group_left(foo) random*0
+  {instance="abc",job="node",mode="idle",foo="bar"} 3
+  {instance="abc",job="node",mode="user",foo="bar"} 1
+  {instance="def",job="node",mode="idle",foo="bar"} 8
+  {instance="def",job="node",mode="user",foo="bar"} 2
 
 
 # Use threshold from metric, and copy over target.
-# Unsupported by streaming engine.
-# eval instant at 1m node_cpu > on(job, instance) group_left(target) threshold
-#   node_cpu{instance="abc",job="node",mode="idle",target="a@b.com"} 3
-#   node_cpu{instance="abc",job="node",mode="user",target="a@b.com"} 1
+eval instant at 1m node_cpu > on(job, instance) group_left(target) threshold
+  node_cpu{instance="abc",job="node",mode="idle",target="a@b.com"} 3
+  node_cpu{instance="abc",job="node",mode="user",target="a@b.com"} 1
 
 # Use threshold from metric, and a default (1) if it's not present.
-# Unsupported by streaming engine.
-# eval instant at 1m node_cpu > on(job, instance) group_left(target) (threshold or on (job, instance) (sum by (job, instance)(node_cpu) * 0 + 1))
-#   node_cpu{instance="abc",job="node",mode="idle",target="a@b.com"} 3
-#   node_cpu{instance="abc",job="node",mode="user",target="a@b.com"} 1
-#   node_cpu{instance="def",job="node",mode="idle"} 8
-#   node_cpu{instance="def",job="node",mode="user"} 2
+eval instant at 1m node_cpu > on(job, instance) group_left(target) (threshold or on (job, instance) (sum by (job, instance)(node_cpu) * 0 + 1))
+  node_cpu{instance="abc",job="node",mode="idle",target="a@b.com"} 3
+  node_cpu{instance="abc",job="node",mode="user",target="a@b.com"} 1
+  node_cpu{instance="def",job="node",mode="idle"} 8
+  node_cpu{instance="def",job="node",mode="user"} 2
 
 
 # Check that binops drop the metric name.

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -23,6 +23,7 @@ const (
 	HPointSize           = uint64(FPointSize * nativeHistogramSampleSizeFactor)
 	VectorSampleSize     = uint64(unsafe.Sizeof(promql.Sample{})) // This assumes each sample is a float sample, not a histogram.
 	Float64Size          = uint64(unsafe.Sizeof(float64(0)))
+	IntSize              = uint64(unsafe.Sizeof(int(0)))
 	BoolSize             = uint64(unsafe.Sizeof(false))
 	HistogramPointerSize = uint64(unsafe.Sizeof((*histogram.FloatHistogram)(nil)))
 	StringSize           = uint64(unsafe.Sizeof(""))
@@ -69,6 +70,15 @@ var (
 			return make([]float64, 0, size)
 		}),
 		Float64Size,
+		true,
+		nil,
+	)
+
+	IntSlicePool = NewLimitingBucketedPool(
+		pool.NewBucketedPool(MaxExpectedPointsPerSeries, func(size int) []int {
+			return make([]int, 0, size)
+		}),
+		IntSize,
 		true,
 		nil,
 	)


### PR DESCRIPTION
#### What this PR does

This PR adds support for `group_left` and `group_right` (aka many-to-one and one-to-many matching) in binary operations to MQE.

In our benchmarks, latency is up to 80% lower and peak memory utilisation is up to 30% lower with MQE compared to Prometheus' engine:

```
                                                                         │  Prometheus  │               Mimir                │
                                                                         │    sec/op    │   sec/op     vs base               │
Query/h_1_*_on(l)_group_left()_a_1,_instant_query-10                        321.8µ ± 2%   340.3µ ± 9%        ~ (p=0.065 n=6)
Query/h_1_*_on(l)_group_left()_a_1,_range_query_with_100_steps-10           452.3µ ± 1%   358.5µ ± 2%  -20.74% (p=0.002 n=6)
Query/h_1_*_on(l)_group_left()_a_1,_range_query_with_1000_steps-10         1651.5µ ± 0%   756.0µ ± 3%  -54.23% (p=0.002 n=6)
Query/h_100_*_on(l)_group_left()_a_100,_instant_query-10                    4.694m ± 1%   4.659m ± 2%        ~ (p=0.310 n=6)
Query/h_100_*_on(l)_group_left()_a_100,_range_query_with_100_steps-10      22.581m ± 1%   8.320m ± 1%  -63.16% (p=0.002 n=6)
Query/h_100_*_on(l)_group_left()_a_100,_range_query_with_1000_steps-10     185.37m ± 3%   39.77m ± 0%  -78.55% (p=0.002 n=6)
Query/h_2000_*_on(l)_group_left()_a_2000,_instant_query-10                  84.71m ± 1%   85.24m ± 2%        ~ (p=0.132 n=6)
Query/h_2000_*_on(l)_group_left()_a_2000,_range_query_with_100_steps-10     468.3m ± 1%   155.0m ± 4%  -66.90% (p=0.002 n=6)
Query/h_2000_*_on(l)_group_left()_a_2000,_range_query_with_1000_steps-10   4006.0m ± 2%   761.7m ± 1%  -80.99% (p=0.002 n=6)
geomean                                                                     20.87m        10.41m       -50.14%

                                                                         │   Prometheus   │                Mimir                │
                                                                         │       B        │      B        vs base               │
Query/h_1_*_on(l)_group_left()_a_1,_instant_query-10                        73.48Mi ±  1%   73.76Mi ± 1%        ~ (p=0.699 n=6)
Query/h_1_*_on(l)_group_left()_a_1,_range_query_with_100_steps-10           72.05Mi ±  1%   73.21Mi ± 1%   +1.62% (p=0.002 n=6)
Query/h_1_*_on(l)_group_left()_a_1,_range_query_with_1000_steps-10          70.13Mi ±  1%   70.78Mi ± 1%        ~ (p=0.087 n=6)
Query/h_100_*_on(l)_group_left()_a_100,_instant_query-10                    69.96Mi ±  1%   70.16Mi ± 1%   +0.29% (p=0.015 n=6)
Query/h_100_*_on(l)_group_left()_a_100,_range_query_with_100_steps-10       73.55Mi ±  1%   73.12Mi ± 1%        ~ (p=0.262 n=6)
Query/h_100_*_on(l)_group_left()_a_100,_range_query_with_1000_steps-10     107.05Mi ±  5%   90.28Mi ± 3%  -15.66% (p=0.002 n=6)
Query/h_2000_*_on(l)_group_left()_a_2000,_instant_query-10                  79.68Mi ±  3%   79.24Mi ± 4%        ~ (p=0.485 n=6)
Query/h_2000_*_on(l)_group_left()_a_2000,_range_query_with_100_steps-10     172.9Mi ±  6%   131.9Mi ± 2%  -23.73% (p=0.002 n=6)
Query/h_2000_*_on(l)_group_left()_a_2000,_range_query_with_1000_steps-10    651.3Mi ± 13%   438.1Mi ± 0%  -32.74% (p=0.002 n=6)
geomean                                                                     107.0Mi         97.69Mi        -8.68%
```

I am not adding a changelog entry given it is covered by the generic MQE changelog entry that links to https://github.com/grafana/mimir/issues/10067.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/10067

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
