### PR TITLE
MQE: fix GOOS values in `tools/benchmark-query-engine`

### DIFF
--- a/tools/benchmark-query-engine/main.go
+++ b/tools/benchmark-query-engine/main.go
@@ -351,9 +351,9 @@ func (a *app) runTestCase(name string, printBenchmarkHeader bool) error {
 
 func maxRSSInBytes(usage *syscall.Rusage) int64 {
 	switch runtime.GOOS {
-	case "Linux":
+	case "linux":
 		return usage.Maxrss * 1024 // Maxrss is returned in kilobytes on Linux.
-	case "Darwin":
+	case "darwin":
 		return usage.Maxrss // Maxrss is already in bytes on macOS.
 	default:
 		panic(fmt.Sprintf("unknown GOOS '%v'", runtime.GOOS))


### PR DESCRIPTION
#### What this PR does

This PR fixes some typos in the GOOS values in `tools/benchmark-query-engine`.

I'm not adding a changelog entry given this is a development tool.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/10031

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
