### PR TITLE
Vendor update mimir-prometheus at cb322705289fa0660f4c93df82dcd8815f4…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -284,7 +284,7 @@ require (
 )
 
 // Using a fork of Prometheus with Mimir-specific changes.
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20241203165959-320e9aa3985d
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20241204081021-cb322705289f
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -1279,8 +1279,8 @@ github.com/grafana/gomemcache v0.0.0-20241016125027-0a5bcc5aef40 h1:1TeKhyS+pvzO
 github.com/grafana/gomemcache v0.0.0-20241016125027-0a5bcc5aef40/go.mod h1:IGRj8oOoxwJbHBYl1+OhS9UjQR0dv6SQOep7HqmtyFU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20241203165959-320e9aa3985d h1:ia2JbmaZA2VUP9HoE5wDjNmR3ZyJYH1yAodg/KoX/IY=
-github.com/grafana/mimir-prometheus v0.0.0-20241203165959-320e9aa3985d/go.mod h1:SLFE244uZpIWNevAuaMLJmsy5QluDTSUwLKKGK3jkk0=
+github.com/grafana/mimir-prometheus v0.0.0-20241204081021-cb322705289f h1:osEg8aUQ8HtRV8fcJ1dliJ/pxDpBARJywkyOsgM6Rv8=
+github.com/grafana/mimir-prometheus v0.0.0-20241204081021-cb322705289f/go.mod h1:SLFE244uZpIWNevAuaMLJmsy5QluDTSUwLKKGK3jkk0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20240930132144-b5e64e81e8d3 h1:6D2gGAwyQBElSrp3E+9lSr7k8gLuP3Aiy20rweLWeBw=

--- a/integration/compactor_test.go
+++ b/integration/compactor_test.go
@@ -133,7 +133,7 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 		chkReader, err := chunks.NewDirReader(filepath.Join(outDir, blockID, block.ChunksDirname), nil)
 		require.NoError(t, err)
 
-		ixReader, err := index.NewFileReader(filepath.Join(outDir, blockID, block.IndexFilename))
+		ixReader, err := index.NewFileReader(filepath.Join(outDir, blockID, block.IndexFilename), index.DecodePostingsRaw)
 		require.NoError(t, err)
 
 		n, v := index.AllPostingsKey()

--- a/pkg/compactor/split_merge_compactor_test.go
+++ b/pkg/compactor/split_merge_compactor_test.go
@@ -775,7 +775,7 @@ func TestMultitenantCompactor_ShouldGuaranteeSeriesShardingConsistencyOverTheTim
 	for _, actualMeta := range actualMetas {
 		expectedSeriesIDs := expectedSeriesIDByShard[actualMeta.Thanos.Labels[mimir_tsdb.CompactorShardIDExternalLabel]]
 
-		b, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), filepath.Join(storageDir, userID, actualMeta.ULID.String()), nil)
+		b, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), filepath.Join(storageDir, userID, actualMeta.ULID.String()), nil, nil)
 		require.NoError(t, err)
 
 		indexReader, err := b.Index()

--- a/pkg/ingester/ingester_early_compaction_test.go
+++ b/pkg/ingester/ingester_early_compaction_test.go
@@ -692,7 +692,7 @@ func listBlocksInDir(t *testing.T, dir string) (ids []ulid.ULID) {
 }
 
 func readMetricSamplesFromBlockDir(t *testing.T, blockDir string, metricName string) (results model.Matrix) {
-	block, err := tsdb.OpenBlock(promslog.NewNopLogger(), blockDir, nil)
+	block, err := tsdb.OpenBlock(promslog.NewNopLogger(), blockDir, nil, nil)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, block.Close())

--- a/pkg/storage/tsdb/block/index.go
+++ b/pkg/storage/tsdb/block/index.go
@@ -218,7 +218,7 @@ func GatherBlockHealthStats(ctx context.Context, logger log.Logger, blockDir str
 	indexFn := filepath.Join(blockDir, IndexFilename)
 	chunkDir := filepath.Join(blockDir, ChunksDirname)
 	// index reader
-	r, err := index.NewFileReader(indexFn)
+	r, err := index.NewFileReader(indexFn, index.DecodePostingsRaw)
 	if err != nil {
 		return stats, errors.Wrap(err, "open index file")
 	}
@@ -423,7 +423,7 @@ func Repair(ctx context.Context, logger log.Logger, dir string, id ulid.ULID, so
 		return resid, errors.New("cannot repair downsampled block")
 	}
 
-	b, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), bdir, nil)
+	b, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), bdir, nil, nil)
 	if err != nil {
 		return resid, errors.Wrap(err, "open block")
 	}

--- a/pkg/storage/tsdb/block/index_test.go
+++ b/pkg/storage/tsdb/block/index_test.go
@@ -36,7 +36,7 @@ func TestRewrite(t *testing.T) {
 	}, 150, 0, 1000, labels.EmptyLabels())
 	require.NoError(t, err)
 
-	ir, err := index.NewFileReader(filepath.Join(tmpDir, b.String(), IndexFilename))
+	ir, err := index.NewFileReader(filepath.Join(tmpDir, b.String(), IndexFilename), index.DecodePostingsRaw)
 	require.NoError(t, err)
 
 	defer func() { require.NoError(t, ir.Close()) }()
@@ -78,7 +78,7 @@ func TestRewrite(t *testing.T) {
 	require.NoError(t, iw.Close())
 	require.NoError(t, cw.Close())
 
-	ir2, err := index.NewFileReader(filepath.Join(tmpDir, m.ULID.String(), IndexFilename))
+	ir2, err := index.NewFileReader(filepath.Join(tmpDir, m.ULID.String(), IndexFilename), index.DecodePostingsRaw)
 	require.NoError(t, err)
 
 	defer func() { require.NoError(t, ir2.Close()) }()

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -132,7 +132,7 @@ func TestReadersComparedToIndexHeader(t *testing.T) {
 func compareIndexToHeader(t *testing.T, indexByteSlice index.ByteSlice, headerReader Reader) {
 	ctx := context.Background()
 
-	indexReader, err := index.NewReader(indexByteSlice)
+	indexReader, err := index.NewReader(indexByteSlice, index.DecodePostingsRaw)
 	require.NoError(t, err)
 	defer func() { _ = indexReader.Close() }()
 

--- a/tools/splitblocks/main_test.go
+++ b/tools/splitblocks/main_test.go
@@ -201,14 +201,14 @@ func buildSeriesSpec(startOfDay time.Time) []*block.SeriesSpec {
 }
 
 func listSeriesAndChunksFromBlock(t *testing.T, blockDir string) []*block.SeriesSpec {
-	blk, err := tsdb.OpenBlock(promslog.NewNopLogger(), blockDir, nil)
+	blk, err := tsdb.OpenBlock(promslog.NewNopLogger(), blockDir, nil, nil)
 	require.NoError(t, err)
 	chunkReader, err := blk.Chunks()
 	require.NoError(t, err)
 	defer require.NoError(t, chunkReader.Close())
 
 	allKey, allValue := index.AllPostingsKey()
-	r, err := index.NewFileReader(filepath.Join(blockDir, block.IndexFilename))
+	r, err := index.NewFileReader(filepath.Join(blockDir, block.IndexFilename), index.DecodePostingsRaw)
 	require.NoError(t, err)
 	defer runutil.CloseWithErrCapture(&err, r, "gather index issue file reader")
 	it, err := r.Postings(context.Background(), allKey, allValue)

--- a/tools/tsdb-compact/main.go
+++ b/tools/tsdb-compact/main.go
@@ -57,7 +57,7 @@ func main() {
 
 		blockDirs = append(blockDirs, d)
 
-		b, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), d, nil)
+		b, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), d, nil, nil)
 		if err != nil {
 			log.Fatalln("failed to open block:", d, err)
 		}

--- a/tools/tsdb-gaps/main.go
+++ b/tools/tsdb-gaps/main.go
@@ -215,7 +215,7 @@ func main() {
 func analyzeBlockForGaps(ctx context.Context, cfg config, blockDir string, matchers []*labels.Matcher) (blockGapStats, error) {
 	var blockStats blockGapStats
 	blockStats.BlockID = blockDir
-	b, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), blockDir, nil)
+	b, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), blockDir, nil, nil)
 	if err != nil {
 		return blockStats, fmt.Errorf("failed to open block: %w", err)
 	}

--- a/tools/tsdb-print-chunk/main.go
+++ b/tools/tsdb-print-chunk/main.go
@@ -32,7 +32,7 @@ func main() {
 }
 
 func printChunks(blockDir string, chunkRefs []string) {
-	b, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), blockDir, nil)
+	b, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), blockDir, nil, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to open TSDB block", blockDir, "due to error:", err)
 		os.Exit(1)

--- a/tools/tsdb-series/main.go
+++ b/tools/tsdb-series/main.go
@@ -106,7 +106,7 @@ type seriesWithStats struct {
 }
 
 func printBlockIndex(ctx context.Context, blockDir string, printChunks bool, seriesStats bool, matchers []*labels.Matcher, minTime time.Time, maxTime time.Time, jsonOutput bool) {
-	block, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), blockDir, nil)
+	block, err := tsdb.OpenBlock(util_log.SlogFromGoKit(logger), blockDir, nil, nil)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to open block", "dir", blockDir, "err", err)
 		return

--- a/tools/tsdb-symbols/main.go
+++ b/tools/tsdb-symbols/main.go
@@ -90,7 +90,7 @@ func main() {
 }
 
 func analyseSymbols(ctx context.Context, blockDir string, uniqueSymbols map[string]struct{}, uniqueSymbolsPerShard []map[string]struct{}) error {
-	block, err := tsdb.OpenBlock(slog.New(slog.NewTextHandler(os.Stderr, nil)), blockDir, nil)
+	block, err := tsdb.OpenBlock(slog.New(slog.NewTextHandler(os.Stderr, nil)), blockDir, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to open block: %v", err)
 	}

--- a/vendor/github.com/prometheus/prometheus/tsdb/compact.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/compact.go
@@ -95,6 +95,7 @@ type LeveledCompactor struct {
 	maxBlockChunkSegmentSize    int64
 	mergeFunc                   storage.VerticalChunkSeriesMergeFunc
 	postingsEncoder             index.PostingsEncoder
+	postingsDecoderFactory      PostingsDecoderFactory
 	enableOverlappingCompaction bool
 	concurrencyOpts             LeveledCompactorConcurrencyOptions
 }
@@ -167,6 +168,9 @@ type LeveledCompactorOptions struct {
 	// PE specifies the postings encoder. It is called when compactor is writing out the postings for a label name/value pair during compaction.
 	// If it is nil then the default encoder is used. At the moment that is the "raw" encoder. See index.EncodePostingsRaw for more.
 	PE index.PostingsEncoder
+	// PD specifies the postings decoder factory to return different postings decoder based on BlockMeta. It is called when opening a block or opening the index file.
+	// If it is nil then a default decoder is used, compatible with Prometheus v2.
+	PD PostingsDecoderFactory
 	// MaxBlockChunkSegmentSize is the max block chunk segment size. If it is 0 then the default chunks.DefaultChunkSegmentSize is used.
 	MaxBlockChunkSegmentSize int64
 	// MergeFunc is used for merging series together in vertical compaction. By default storage.NewCompactingChunkSeriesMerger(storage.ChainedSeriesMerge) is used.
@@ -174,6 +178,12 @@ type LeveledCompactorOptions struct {
 	// EnableOverlappingCompaction enables compaction of overlapping blocks. In Prometheus it is always enabled.
 	// It is useful for downstream projects like Mimir, Cortex, Thanos where they have a separate component that does compaction.
 	EnableOverlappingCompaction bool
+}
+
+type PostingsDecoderFactory func(meta *BlockMeta) index.PostingsDecoder
+
+func DefaultPostingsDecoderFactory(_ *BlockMeta) index.PostingsDecoder {
+	return index.DecodePostingsRaw
 }
 
 func NewLeveledCompactorWithChunkSize(ctx context.Context, r prometheus.Registerer, l *slog.Logger, ranges []int64, pool chunkenc.Pool, maxBlockChunkSegmentSize int64, mergeFunc storage.VerticalChunkSeriesMergeFunc) (*LeveledCompactor, error) {
@@ -222,6 +232,7 @@ func NewLeveledCompactorWithOptions(ctx context.Context, r prometheus.Registerer
 		maxBlockChunkSegmentSize:    maxBlockChunkSegmentSize,
 		mergeFunc:                   mergeFunc,
 		postingsEncoder:             pe,
+		postingsDecoderFactory:      opts.PD,
 		enableOverlappingCompaction: opts.EnableOverlappingCompaction,
 		concurrencyOpts:             DefaultLeveledCompactorConcurrencyOptions(),
 	}, nil
@@ -514,7 +525,7 @@ func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string,
 
 	start := time.Now()
 
-	bs, blocksToClose, err := openBlocksForCompaction(dirs, open, c.logger, c.chunkPool, c.concurrencyOpts.MaxOpeningBlocks)
+	bs, blocksToClose, err := openBlocksForCompaction(dirs, open, c.logger, c.chunkPool, c.postingsDecoderFactory, c.concurrencyOpts.MaxOpeningBlocks)
 	for _, b := range blocksToClose {
 		defer b.Close()
 	}
@@ -1318,7 +1329,7 @@ func populateSymbols(ctx context.Context, mergeFunc storage.VerticalChunkSeriesM
 }
 
 // Returns opened blocks, and blocks that should be closed (also returned in case of error).
-func openBlocksForCompaction(dirs []string, open []*Block, logger *slog.Logger, pool chunkenc.Pool, concurrency int) (blocks, blocksToClose []*Block, _ error) {
+func openBlocksForCompaction(dirs []string, open []*Block, logger *slog.Logger, pool chunkenc.Pool, postingsDecoderFactory PostingsDecoderFactory, concurrency int) (blocks, blocksToClose []*Block, _ error) {
 	blocks = make([]*Block, 0, len(dirs))
 	blocksToClose = make([]*Block, 0, len(dirs))
 
@@ -1372,7 +1383,7 @@ func openBlocksForCompaction(dirs []string, open []*Block, logger *slog.Logger, 
 					return
 				}
 
-				b, err := OpenBlock(logger, d, pool)
+				b, err := OpenBlock(logger, d, pool, postingsDecoderFactory)
 				openResultCh <- openResult{b: b, err: err}
 
 				if err != nil {

--- a/vendor/github.com/prometheus/prometheus/tsdb/index/labelvalues.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/index/labelvalues.go
@@ -88,7 +88,7 @@ func (it *intersectLabelValuesV1) Next() bool {
 		postingsOff := it.postingOffsets[val]
 		// Read from the postings table.
 		d := encoding.NewDecbufAt(it.b, int(postingsOff), castagnoliTable)
-		_, curPostings, err := it.dec.Postings(d.Get())
+		_, curPostings, err := it.dec.DecodePostings(d)
 		if err != nil {
 			it.err = fmt.Errorf("decode postings: %w", err)
 			return false
@@ -164,7 +164,7 @@ func (it *intersectLabelValues) Next() bool {
 		postingsOff := int(it.d.Uvarint64())
 		// Read from the postings table
 		postingsDec := encoding.NewDecbufAt(it.b, postingsOff, castagnoliTable)
-		_, curPostings, err := it.dec.Postings(postingsDec.Get())
+		_, curPostings, err := it.dec.DecodePostings(postingsDec)
 		if err != nil {
 			it.err = fmt.Errorf("decode postings: %w", err)
 			return false

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1017,7 +1017,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20241203165959-320e9aa3985d
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20241204081021-cb322705289f
 ## explicit; go 1.22.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1685,7 +1685,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20241203165959-320e9aa3985d
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20241204081021-cb322705289f
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
…ede04

This is upstream at
https://github.com/prometheus/prometheus/commit/140f4aa9aed6674c582dc603431a4aaa0c702cb7

Which brings in
https://github.com/prometheus/prometheus/pull/13567
which implement allowing for alternative postings decoders in the index reader. However since we don't have alternative decoders, I just hardcoded the default in Mimir.

And also a tiny comment fix in mimir-prometheus
https://github.com/grafana/mimir-prometheus/pull/783
