### PR TITLE
integration: Update backward compatibility versions

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -10,10 +10,10 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 	"grafana/mimir:2.12.0": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 	),
-	"grafana/mimir:2.13.0": e2emimir.ChainFlagMappers(
+	"grafana/mimir:2.13.1": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 	),
-	"grafana/mimir:2.14.0": e2emimir.ChainFlagMappers(
+	"grafana/mimir:2.14.2": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 	),
 }


### PR DESCRIPTION
#### What this PR does

Update Mimir versions in integration/backward_compatibility.go, from v2.13.0 -> v2.13.1 and v2.14.0 -> v2.14.2.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
