### PR TITLE
UsageTracker: add bucket config/client for snapshots storage

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -19003,6 +19003,1057 @@
           "fieldDefaultValue": null
         },
         {
+          "kind": "block",
+          "name": "snapshots_storage",
+          "required": false,
+          "desc": "",
+          "blockEntries": [
+            {
+              "kind": "field",
+              "name": "backend",
+              "required": false,
+              "desc": "Backend storage to use. Supported backends are: s3, gcs, azure, swift, filesystem.",
+              "fieldValue": null,
+              "fieldDefaultValue": "filesystem",
+              "fieldFlag": "usage-tracker.snapshot-storage.backend",
+              "fieldType": "string"
+            },
+            {
+              "kind": "block",
+              "name": "s3",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "endpoint",
+                  "required": false,
+                  "desc": "The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.endpoint",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "region",
+                  "required": false,
+                  "desc": "S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.region",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "bucket_name",
+                  "required": false,
+                  "desc": "S3 bucket name",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.bucket-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "secret_access_key",
+                  "required": false,
+                  "desc": "S3 secret access key",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.secret-access-key",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "access_key_id",
+                  "required": false,
+                  "desc": "S3 access key ID",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.access-key-id",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "session_token",
+                  "required": false,
+                  "desc": "S3 session token",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.session-token",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "insecure",
+                  "required": false,
+                  "desc": "If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.insecure",
+                  "fieldType": "boolean",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "signature_version",
+                  "required": false,
+                  "desc": "The signature version to use for authenticating against S3. Supported values are: v4, v2.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "v4",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.signature-version",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "list_objects_version",
+                  "required": false,
+                  "desc": "Use a specific version of the S3 list object API. Supported values are v1 or v2. Default is unset.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.list-objects-version",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "bucket_lookup_type",
+                  "required": false,
+                  "desc": "Bucket lookup style type, used to access bucket in S3-compatible service. Default is auto. Supported values are: auto, path, virtual-hosted.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "auto",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.bucket-lookup-type",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "dualstack_enabled",
+                  "required": false,
+                  "desc": "When enabled, direct all AWS S3 requests to the dual-stack IPv4/IPv6 endpoint for the configured region.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": true,
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.dualstack-enabled",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
+                  "name": "storage_class",
+                  "required": false,
+                  "desc": "The S3 storage class to use, not set by default. Details can be found at https://aws.amazon.com/s3/storage-classes/. Supported values are: STANDARD, REDUCED_REDUNDANCY, GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE, OUTPOSTS, GLACIER_IR, SNOW, EXPRESS_ONEZONE",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.storage-class",
+                  "fieldType": "string",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
+                  "name": "native_aws_auth_enabled",
+                  "required": false,
+                  "desc": "If enabled, it will use the default authentication methods of the AWS SDK for go based on known environment variables and known AWS config files.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.native-aws-auth-enabled",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
+                  "name": "part_size",
+                  "required": false,
+                  "desc": "The minimum file size in bytes used for multipart uploads. If 0, the value is optimally computed for each object.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.part-size",
+                  "fieldType": "int",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
+                  "name": "send_content_md5",
+                  "required": false,
+                  "desc": "If enabled, a Content-MD5 header is sent with S3 Put Object requests. Consumes more resources to compute the MD5, but may improve compatibility with object storage services that do not support checksums.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": false,
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.send-content-md5",
+                  "fieldType": "boolean",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
+                  "name": "sts_endpoint",
+                  "required": false,
+                  "desc": "Accessing S3 resources using temporary, secure credentials provided by AWS Security Token Service.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.s3.sts-endpoint",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "block",
+                  "name": "sse",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "type",
+                      "required": false,
+                      "desc": "Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.sse.type",
+                      "fieldType": "string"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "kms_key_id",
+                      "required": false,
+                      "desc": "KMS Key ID used to encrypt objects in S3",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.sse.kms-key-id",
+                      "fieldType": "string"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "kms_encryption_context",
+                      "required": false,
+                      "desc": "KMS Encryption Context used for object encryption. It expects JSON formatted string.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.sse.kms-encryption-context",
+                      "fieldType": "string"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                },
+                {
+                  "kind": "block",
+                  "name": "http",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "idle_conn_timeout",
+                      "required": false,
+                      "desc": "The time an idle connection remains idle before closing.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 90000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.http.idle-conn-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "response_header_timeout",
+                      "required": false,
+                      "desc": "The amount of time the client waits for a server's response headers.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 120000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.http.response-header-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "insecure_skip_verify",
+                      "required": false,
+                      "desc": "If the client connects to object storage via HTTPS and this option is enabled, the client accepts any certificate and hostname.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.http.insecure-skip-verify",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_handshake_timeout",
+                      "required": false,
+                      "desc": "Maximum time to wait for a TLS handshake. Set to 0 for no limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 10000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.tls-handshake-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "expect_continue_timeout",
+                      "required": false,
+                      "desc": "The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 1000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.expect-continue-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_idle_connections",
+                      "required": false,
+                      "desc": "Maximum number of idle (keep-alive) connections across all hosts. Set to 0 for no limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 100,
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.max-idle-connections",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_idle_connections_per_host",
+                      "required": false,
+                      "desc": "Maximum number of idle (keep-alive) connections to keep per-host. Set to 0 to use a built-in default value of 2.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 100,
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.max-idle-connections-per-host",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_connections_per_host",
+                      "required": false,
+                      "desc": "Maximum number of connections per host. Set to 0 for no limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 0,
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.max-connections-per-host",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_ca_path",
+                      "required": false,
+                      "desc": "Path to the Certificate Authority (CA) certificates to validate the server certificate. If not set, the host's root CA certificates are used.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.http.tls-ca-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_cert_path",
+                      "required": false,
+                      "desc": "Path to the client certificate, which is used for authenticating with the server. This setting also requires you to configure the key path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.http.tls-cert-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_key_path",
+                      "required": false,
+                      "desc": "Path to the key for the client certificate. This setting also requires you to configure the client certificate.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.http.tls-key-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_server_name",
+                      "required": false,
+                      "desc": "Override the expected name on the server certificate.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.http.tls-server-name",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                },
+                {
+                  "kind": "block",
+                  "name": "trace",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "enabled",
+                      "required": false,
+                      "desc": "When enabled, low-level S3 HTTP operation information is logged at the debug level.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.snapshot-storage.s3.trace.enabled",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
+            },
+            {
+              "kind": "block",
+              "name": "gcs",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "bucket_name",
+                  "required": false,
+                  "desc": "GCS bucket name",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.gcs.bucket-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "service_account",
+                  "required": false,
+                  "desc": "JSON either from a Google Developers Console client_credentials.json file, or a Google Developers service account key. Needs to be valid JSON, not a filesystem path. If empty, fallback to Google default logic:\n1. A JSON file whose path is specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable. For workload identity federation, refer to https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation on how to generate the JSON configuration file for on-prem/non-Google cloud platforms.\n2. A JSON file in a location known to the gcloud command-line tool: $HOME/.config/gcloud/application_default_credentials.json.\n3. On Google Compute Engine it fetches credentials from the metadata server.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.gcs.service-account",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "block",
+                  "name": "http",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "idle_conn_timeout",
+                      "required": false,
+                      "desc": "The time an idle connection remains idle before closing.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 90000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.http.idle-conn-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "response_header_timeout",
+                      "required": false,
+                      "desc": "The amount of time the client waits for a server's response headers.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 120000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.http.response-header-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "insecure_skip_verify",
+                      "required": false,
+                      "desc": "If the client connects to object storage via HTTPS and this option is enabled, the client accepts any certificate and hostname.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.http.insecure-skip-verify",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_handshake_timeout",
+                      "required": false,
+                      "desc": "Maximum time to wait for a TLS handshake. Set to 0 for no limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 10000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.tls-handshake-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "expect_continue_timeout",
+                      "required": false,
+                      "desc": "The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 1000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.expect-continue-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_idle_connections",
+                      "required": false,
+                      "desc": "Maximum number of idle (keep-alive) connections across all hosts. Set to 0 for no limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 100,
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.max-idle-connections",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_idle_connections_per_host",
+                      "required": false,
+                      "desc": "Maximum number of idle (keep-alive) connections to keep per-host. Set to 0 to use a built-in default value of 2.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 100,
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.max-idle-connections-per-host",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_connections_per_host",
+                      "required": false,
+                      "desc": "Maximum number of connections per host. Set to 0 for no limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 0,
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.max-connections-per-host",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_ca_path",
+                      "required": false,
+                      "desc": "Path to the Certificate Authority (CA) certificates to validate the server certificate. If not set, the host's root CA certificates are used.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.http.tls-ca-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_cert_path",
+                      "required": false,
+                      "desc": "Path to the client certificate, which is used for authenticating with the server. This setting also requires you to configure the key path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.http.tls-cert-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_key_path",
+                      "required": false,
+                      "desc": "Path to the key for the client certificate. This setting also requires you to configure the client certificate.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.http.tls-key-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_server_name",
+                      "required": false,
+                      "desc": "Override the expected name on the server certificate.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.gcs.http.tls-server-name",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
+            },
+            {
+              "kind": "block",
+              "name": "azure",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "account_name",
+                  "required": false,
+                  "desc": "Azure storage account name",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.azure.account-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "account_key",
+                  "required": false,
+                  "desc": "Azure storage account key. If unset, Azure managed identities will be used for authentication instead.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.azure.account-key",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "connection_string",
+                  "required": false,
+                  "desc": "If `connection-string` is set, the value of `endpoint-suffix` will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.azure.connection-string",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "container_name",
+                  "required": false,
+                  "desc": "Azure storage container name",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.azure.container-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "endpoint_suffix",
+                  "required": false,
+                  "desc": "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.azure.endpoint-suffix",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "max_retries",
+                  "required": false,
+                  "desc": "Number of retries for recoverable errors",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 20,
+                  "fieldFlag": "usage-tracker.snapshot-storage.azure.max-retries",
+                  "fieldType": "int",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "user_assigned_id",
+                  "required": false,
+                  "desc": "User assigned managed identity. If empty, then System assigned identity is used.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.azure.user-assigned-id",
+                  "fieldType": "string",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "block",
+                  "name": "http",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "idle_conn_timeout",
+                      "required": false,
+                      "desc": "The time an idle connection remains idle before closing.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 90000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.http.idle-conn-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "response_header_timeout",
+                      "required": false,
+                      "desc": "The amount of time the client waits for a server's response headers.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 120000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.http.response-header-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "insecure_skip_verify",
+                      "required": false,
+                      "desc": "If the client connects to object storage via HTTPS and this option is enabled, the client accepts any certificate and hostname.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.http.insecure-skip-verify",
+                      "fieldType": "boolean",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_handshake_timeout",
+                      "required": false,
+                      "desc": "Maximum time to wait for a TLS handshake. Set to 0 for no limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 10000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.tls-handshake-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "expect_continue_timeout",
+                      "required": false,
+                      "desc": "The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 1000000000,
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.expect-continue-timeout",
+                      "fieldType": "duration",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_idle_connections",
+                      "required": false,
+                      "desc": "Maximum number of idle (keep-alive) connections across all hosts. Set to 0 for no limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 100,
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.max-idle-connections",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_idle_connections_per_host",
+                      "required": false,
+                      "desc": "Maximum number of idle (keep-alive) connections to keep per-host. Set to 0 to use a built-in default value of 2.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 100,
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.max-idle-connections-per-host",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "max_connections_per_host",
+                      "required": false,
+                      "desc": "Maximum number of connections per host. Set to 0 for no limit.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": 0,
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.max-connections-per-host",
+                      "fieldType": "int",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_ca_path",
+                      "required": false,
+                      "desc": "Path to the Certificate Authority (CA) certificates to validate the server certificate. If not set, the host's root CA certificates are used.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.http.tls-ca-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_cert_path",
+                      "required": false,
+                      "desc": "Path to the client certificate, which is used for authenticating with the server. This setting also requires you to configure the key path.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.http.tls-cert-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_key_path",
+                      "required": false,
+                      "desc": "Path to the key for the client certificate. This setting also requires you to configure the client certificate.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.http.tls-key-path",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "tls_server_name",
+                      "required": false,
+                      "desc": "Override the expected name on the server certificate.",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldFlag": "usage-tracker.snapshot-storage.azure.http.tls-server-name",
+                      "fieldType": "string",
+                      "fieldCategory": "advanced"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
+            },
+            {
+              "kind": "block",
+              "name": "swift",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "application_credential_id",
+                  "required": false,
+                  "desc": "OpenStack Swift application credential id",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.application-credential-id",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "application_credential_name",
+                  "required": false,
+                  "desc": "OpenStack Swift application credential name",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.application-credential-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "application_credential_secret",
+                  "required": false,
+                  "desc": "OpenStack Swift application credential secret",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.application-credential-secret",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "auth_version",
+                  "required": false,
+                  "desc": "OpenStack Swift authentication API version. 0 to autodetect.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.auth-version",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "auth_url",
+                  "required": false,
+                  "desc": "OpenStack Swift authentication URL",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.auth-url",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "username",
+                  "required": false,
+                  "desc": "OpenStack Swift username.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.username",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "user_domain_name",
+                  "required": false,
+                  "desc": "OpenStack Swift user's domain name.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.user-domain-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "user_domain_id",
+                  "required": false,
+                  "desc": "OpenStack Swift user's domain ID.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.user-domain-id",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "user_id",
+                  "required": false,
+                  "desc": "OpenStack Swift user ID.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.user-id",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "password",
+                  "required": false,
+                  "desc": "OpenStack Swift API key.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.password",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "domain_id",
+                  "required": false,
+                  "desc": "OpenStack Swift user's domain ID.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.domain-id",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "domain_name",
+                  "required": false,
+                  "desc": "OpenStack Swift user's domain name.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.domain-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "project_id",
+                  "required": false,
+                  "desc": "OpenStack Swift project ID (v2,v3 auth only).",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.project-id",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "project_name",
+                  "required": false,
+                  "desc": "OpenStack Swift project name (v2,v3 auth only).",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.project-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "project_domain_id",
+                  "required": false,
+                  "desc": "ID of the OpenStack Swift project's domain (v3 auth only), only needed if it differs the from user domain.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.project-domain-id",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "project_domain_name",
+                  "required": false,
+                  "desc": "Name of the OpenStack Swift project's domain (v3 auth only), only needed if it differs from the user domain.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.project-domain-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "region_name",
+                  "required": false,
+                  "desc": "OpenStack Swift Region to use (v2,v3 auth only).",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.region-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "container_name",
+                  "required": false,
+                  "desc": "Name of the OpenStack Swift container to put chunks in.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.container-name",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "max_retries",
+                  "required": false,
+                  "desc": "Max retries on requests error.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 3,
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.max-retries",
+                  "fieldType": "int",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "connect_timeout",
+                  "required": false,
+                  "desc": "Time after which a connection attempt is aborted.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 10000000000,
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.connect-timeout",
+                  "fieldType": "duration",
+                  "fieldCategory": "advanced"
+                },
+                {
+                  "kind": "field",
+                  "name": "request_timeout",
+                  "required": false,
+                  "desc": "Time after which an idle request is aborted. The timeout watchdog is reset each time some data is received, so the timeout triggers after X time no data is received on a request.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 5000000000,
+                  "fieldFlag": "usage-tracker.snapshot-storage.swift.request-timeout",
+                  "fieldType": "duration",
+                  "fieldCategory": "advanced"
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
+            },
+            {
+              "kind": "block",
+              "name": "filesystem",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "dir",
+                  "required": false,
+                  "desc": "Local filesystem storage directory.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "usagetrackersnapshots",
+                  "fieldFlag": "usage-tracker.snapshot-storage.filesystem.dir",
+                  "fieldType": "string"
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
+            },
+            {
+              "kind": "field",
+              "name": "storage_prefix",
+              "required": false,
+              "desc": "Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet letters.",
+              "fieldValue": null,
+              "fieldDefaultValue": "",
+              "fieldFlag": "usage-tracker.snapshot-storage.storage-prefix",
+              "fieldType": "string"
+            }
+          ],
+          "fieldValue": null,
+          "fieldDefaultValue": null
+        },
+        {
           "kind": "field",
           "name": "idle_timeout",
           "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3461,6 +3461,184 @@ Usage of ./cmd/mimir/mimir:
     	The prefix for the keys in the store. Should end with a /. (default "collectors/")
   -usage-tracker.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+  -usage-tracker.snapshot-storage.azure.account-key string
+    	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.
+  -usage-tracker.snapshot-storage.azure.account-name string
+    	Azure storage account name
+  -usage-tracker.snapshot-storage.azure.connection-string string
+    	If `connection-string` is set, the value of `endpoint-suffix` will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.
+  -usage-tracker.snapshot-storage.azure.container-name string
+    	Azure storage container name
+  -usage-tracker.snapshot-storage.azure.endpoint-suffix string
+    	Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.
+  -usage-tracker.snapshot-storage.azure.expect-continue-timeout duration
+    	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -usage-tracker.snapshot-storage.azure.http.idle-conn-timeout duration
+    	The time an idle connection remains idle before closing. (default 1m30s)
+  -usage-tracker.snapshot-storage.azure.http.insecure-skip-verify
+    	If the client connects to object storage via HTTPS and this option is enabled, the client accepts any certificate and hostname.
+  -usage-tracker.snapshot-storage.azure.http.response-header-timeout duration
+    	The amount of time the client waits for a server's response headers. (default 2m0s)
+  -usage-tracker.snapshot-storage.azure.http.tls-ca-path string
+    	Path to the Certificate Authority (CA) certificates to validate the server certificate. If not set, the host's root CA certificates are used.
+  -usage-tracker.snapshot-storage.azure.http.tls-cert-path string
+    	Path to the client certificate, which is used for authenticating with the server. This setting also requires you to configure the key path.
+  -usage-tracker.snapshot-storage.azure.http.tls-key-path string
+    	Path to the key for the client certificate. This setting also requires you to configure the client certificate.
+  -usage-tracker.snapshot-storage.azure.http.tls-server-name string
+    	Override the expected name on the server certificate.
+  -usage-tracker.snapshot-storage.azure.max-connections-per-host int
+    	Maximum number of connections per host. Set to 0 for no limit.
+  -usage-tracker.snapshot-storage.azure.max-idle-connections int
+    	Maximum number of idle (keep-alive) connections across all hosts. Set to 0 for no limit. (default 100)
+  -usage-tracker.snapshot-storage.azure.max-idle-connections-per-host int
+    	Maximum number of idle (keep-alive) connections to keep per-host. Set to 0 to use a built-in default value of 2. (default 100)
+  -usage-tracker.snapshot-storage.azure.max-retries int
+    	Number of retries for recoverable errors (default 20)
+  -usage-tracker.snapshot-storage.azure.tls-handshake-timeout duration
+    	Maximum time to wait for a TLS handshake. Set to 0 for no limit. (default 10s)
+  -usage-tracker.snapshot-storage.azure.user-assigned-id string
+    	User assigned managed identity. If empty, then System assigned identity is used.
+  -usage-tracker.snapshot-storage.backend string
+    	Backend storage to use. Supported backends are: s3, gcs, azure, swift, filesystem. (default "filesystem")
+  -usage-tracker.snapshot-storage.filesystem.dir string
+    	Local filesystem storage directory. (default "usagetrackersnapshots")
+  -usage-tracker.snapshot-storage.gcs.bucket-name string
+    	GCS bucket name
+  -usage-tracker.snapshot-storage.gcs.expect-continue-timeout duration
+    	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -usage-tracker.snapshot-storage.gcs.http.idle-conn-timeout duration
+    	The time an idle connection remains idle before closing. (default 1m30s)
+  -usage-tracker.snapshot-storage.gcs.http.insecure-skip-verify
+    	If the client connects to object storage via HTTPS and this option is enabled, the client accepts any certificate and hostname.
+  -usage-tracker.snapshot-storage.gcs.http.response-header-timeout duration
+    	The amount of time the client waits for a server's response headers. (default 2m0s)
+  -usage-tracker.snapshot-storage.gcs.http.tls-ca-path string
+    	Path to the Certificate Authority (CA) certificates to validate the server certificate. If not set, the host's root CA certificates are used.
+  -usage-tracker.snapshot-storage.gcs.http.tls-cert-path string
+    	Path to the client certificate, which is used for authenticating with the server. This setting also requires you to configure the key path.
+  -usage-tracker.snapshot-storage.gcs.http.tls-key-path string
+    	Path to the key for the client certificate. This setting also requires you to configure the client certificate.
+  -usage-tracker.snapshot-storage.gcs.http.tls-server-name string
+    	Override the expected name on the server certificate.
+  -usage-tracker.snapshot-storage.gcs.max-connections-per-host int
+    	Maximum number of connections per host. Set to 0 for no limit.
+  -usage-tracker.snapshot-storage.gcs.max-idle-connections int
+    	Maximum number of idle (keep-alive) connections across all hosts. Set to 0 for no limit. (default 100)
+  -usage-tracker.snapshot-storage.gcs.max-idle-connections-per-host int
+    	Maximum number of idle (keep-alive) connections to keep per-host. Set to 0 to use a built-in default value of 2. (default 100)
+  -usage-tracker.snapshot-storage.gcs.service-account string
+    	JSON either from a Google Developers Console client_credentials.json file, or a Google Developers service account key. Needs to be valid JSON, not a filesystem path.
+  -usage-tracker.snapshot-storage.gcs.tls-handshake-timeout duration
+    	Maximum time to wait for a TLS handshake. Set to 0 for no limit. (default 10s)
+  -usage-tracker.snapshot-storage.s3.access-key-id string
+    	S3 access key ID
+  -usage-tracker.snapshot-storage.s3.bucket-lookup-type value
+    	Bucket lookup style type, used to access bucket in S3-compatible service. Default is auto. Supported values are: auto, path, virtual-hosted.
+  -usage-tracker.snapshot-storage.s3.bucket-name string
+    	S3 bucket name
+  -usage-tracker.snapshot-storage.s3.dualstack-enabled
+    	[experimental] When enabled, direct all AWS S3 requests to the dual-stack IPv4/IPv6 endpoint for the configured region. (default true)
+  -usage-tracker.snapshot-storage.s3.endpoint string
+    	The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.
+  -usage-tracker.snapshot-storage.s3.expect-continue-timeout duration
+    	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. Set to 0 to send the request body immediately. (default 1s)
+  -usage-tracker.snapshot-storage.s3.http.idle-conn-timeout duration
+    	The time an idle connection remains idle before closing. (default 1m30s)
+  -usage-tracker.snapshot-storage.s3.http.insecure-skip-verify
+    	If the client connects to object storage via HTTPS and this option is enabled, the client accepts any certificate and hostname.
+  -usage-tracker.snapshot-storage.s3.http.response-header-timeout duration
+    	The amount of time the client waits for a server's response headers. (default 2m0s)
+  -usage-tracker.snapshot-storage.s3.http.tls-ca-path string
+    	Path to the Certificate Authority (CA) certificates to validate the server certificate. If not set, the host's root CA certificates are used.
+  -usage-tracker.snapshot-storage.s3.http.tls-cert-path string
+    	Path to the client certificate, which is used for authenticating with the server. This setting also requires you to configure the key path.
+  -usage-tracker.snapshot-storage.s3.http.tls-key-path string
+    	Path to the key for the client certificate. This setting also requires you to configure the client certificate.
+  -usage-tracker.snapshot-storage.s3.http.tls-server-name string
+    	Override the expected name on the server certificate.
+  -usage-tracker.snapshot-storage.s3.insecure
+    	If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.
+  -usage-tracker.snapshot-storage.s3.list-objects-version string
+    	Use a specific version of the S3 list object API. Supported values are v1 or v2. Default is unset.
+  -usage-tracker.snapshot-storage.s3.max-connections-per-host int
+    	Maximum number of connections per host. Set to 0 for no limit.
+  -usage-tracker.snapshot-storage.s3.max-idle-connections int
+    	Maximum number of idle (keep-alive) connections across all hosts. Set to 0 for no limit. (default 100)
+  -usage-tracker.snapshot-storage.s3.max-idle-connections-per-host int
+    	Maximum number of idle (keep-alive) connections to keep per-host. Set to 0 to use a built-in default value of 2. (default 100)
+  -usage-tracker.snapshot-storage.s3.native-aws-auth-enabled
+    	[experimental] If enabled, it will use the default authentication methods of the AWS SDK for go based on known environment variables and known AWS config files.
+  -usage-tracker.snapshot-storage.s3.part-size uint
+    	[experimental] The minimum file size in bytes used for multipart uploads. If 0, the value is optimally computed for each object.
+  -usage-tracker.snapshot-storage.s3.region string
+    	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
+  -usage-tracker.snapshot-storage.s3.secret-access-key string
+    	S3 secret access key
+  -usage-tracker.snapshot-storage.s3.send-content-md5
+    	[experimental] If enabled, a Content-MD5 header is sent with S3 Put Object requests. Consumes more resources to compute the MD5, but may improve compatibility with object storage services that do not support checksums.
+  -usage-tracker.snapshot-storage.s3.session-token string
+    	S3 session token
+  -usage-tracker.snapshot-storage.s3.signature-version string
+    	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
+  -usage-tracker.snapshot-storage.s3.sse.kms-encryption-context string
+    	KMS Encryption Context used for object encryption. It expects JSON formatted string.
+  -usage-tracker.snapshot-storage.s3.sse.kms-key-id string
+    	KMS Key ID used to encrypt objects in S3
+  -usage-tracker.snapshot-storage.s3.sse.type string
+    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+  -usage-tracker.snapshot-storage.s3.storage-class string
+    	[experimental] The S3 storage class to use, not set by default. Details can be found at https://aws.amazon.com/s3/storage-classes/. Supported values are: STANDARD, REDUCED_REDUNDANCY, GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE, OUTPOSTS, GLACIER_IR, SNOW, EXPRESS_ONEZONE
+  -usage-tracker.snapshot-storage.s3.sts-endpoint string
+    	Accessing S3 resources using temporary, secure credentials provided by AWS Security Token Service.
+  -usage-tracker.snapshot-storage.s3.tls-handshake-timeout duration
+    	Maximum time to wait for a TLS handshake. Set to 0 for no limit. (default 10s)
+  -usage-tracker.snapshot-storage.s3.trace.enabled
+    	When enabled, low-level S3 HTTP operation information is logged at the debug level.
+  -usage-tracker.snapshot-storage.storage-prefix string
+    	Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet letters.
+  -usage-tracker.snapshot-storage.swift.application-credential-id string
+    	OpenStack Swift application credential id
+  -usage-tracker.snapshot-storage.swift.application-credential-name string
+    	OpenStack Swift application credential name
+  -usage-tracker.snapshot-storage.swift.application-credential-secret string
+    	OpenStack Swift application credential secret
+  -usage-tracker.snapshot-storage.swift.auth-url string
+    	OpenStack Swift authentication URL
+  -usage-tracker.snapshot-storage.swift.auth-version int
+    	OpenStack Swift authentication API version. 0 to autodetect.
+  -usage-tracker.snapshot-storage.swift.connect-timeout duration
+    	Time after which a connection attempt is aborted. (default 10s)
+  -usage-tracker.snapshot-storage.swift.container-name string
+    	Name of the OpenStack Swift container to put chunks in.
+  -usage-tracker.snapshot-storage.swift.domain-id string
+    	OpenStack Swift user's domain ID.
+  -usage-tracker.snapshot-storage.swift.domain-name string
+    	OpenStack Swift user's domain name.
+  -usage-tracker.snapshot-storage.swift.max-retries int
+    	Max retries on requests error. (default 3)
+  -usage-tracker.snapshot-storage.swift.password string
+    	OpenStack Swift API key.
+  -usage-tracker.snapshot-storage.swift.project-domain-id string
+    	ID of the OpenStack Swift project's domain (v3 auth only), only needed if it differs the from user domain.
+  -usage-tracker.snapshot-storage.swift.project-domain-name string
+    	Name of the OpenStack Swift project's domain (v3 auth only), only needed if it differs from the user domain.
+  -usage-tracker.snapshot-storage.swift.project-id string
+    	OpenStack Swift project ID (v2,v3 auth only).
+  -usage-tracker.snapshot-storage.swift.project-name string
+    	OpenStack Swift project name (v2,v3 auth only).
+  -usage-tracker.snapshot-storage.swift.region-name string
+    	OpenStack Swift Region to use (v2,v3 auth only).
+  -usage-tracker.snapshot-storage.swift.request-timeout duration
+    	Time after which an idle request is aborted. The timeout watchdog is reset each time some data is received, so the timeout triggers after X time no data is received on a request. (default 5s)
+  -usage-tracker.snapshot-storage.swift.user-domain-id string
+    	OpenStack Swift user's domain ID.
+  -usage-tracker.snapshot-storage.swift.user-domain-name string
+    	OpenStack Swift user's domain name.
+  -usage-tracker.snapshot-storage.swift.user-id string
+    	OpenStack Swift user ID.
+  -usage-tracker.snapshot-storage.swift.username string
+    	OpenStack Swift username.
   -validation.create-grace-period duration
     	Controls how far into the future incoming samples and exemplars are accepted compared to the wall clock. Any sample or exemplar will be rejected if its timestamp is greater than '(now + creation_grace_period)'. This configuration is enforced in the distributor and ingester. (default 10m)
   -validation.enforce-metadata-metric-name

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -889,6 +889,82 @@ Usage of ./cmd/mimir/mimir:
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -usage-tracker.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+  -usage-tracker.snapshot-storage.azure.account-key string
+    	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.
+  -usage-tracker.snapshot-storage.azure.account-name string
+    	Azure storage account name
+  -usage-tracker.snapshot-storage.azure.connection-string string
+    	If `connection-string` is set, the value of `endpoint-suffix` will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.
+  -usage-tracker.snapshot-storage.azure.container-name string
+    	Azure storage container name
+  -usage-tracker.snapshot-storage.azure.endpoint-suffix string
+    	Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.
+  -usage-tracker.snapshot-storage.backend string
+    	Backend storage to use. Supported backends are: s3, gcs, azure, swift, filesystem. (default "filesystem")
+  -usage-tracker.snapshot-storage.filesystem.dir string
+    	Local filesystem storage directory. (default "usagetrackersnapshots")
+  -usage-tracker.snapshot-storage.gcs.bucket-name string
+    	GCS bucket name
+  -usage-tracker.snapshot-storage.gcs.service-account string
+    	JSON either from a Google Developers Console client_credentials.json file, or a Google Developers service account key. Needs to be valid JSON, not a filesystem path.
+  -usage-tracker.snapshot-storage.s3.access-key-id string
+    	S3 access key ID
+  -usage-tracker.snapshot-storage.s3.bucket-name string
+    	S3 bucket name
+  -usage-tracker.snapshot-storage.s3.endpoint string
+    	The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.
+  -usage-tracker.snapshot-storage.s3.region string
+    	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
+  -usage-tracker.snapshot-storage.s3.secret-access-key string
+    	S3 secret access key
+  -usage-tracker.snapshot-storage.s3.session-token string
+    	S3 session token
+  -usage-tracker.snapshot-storage.s3.sse.kms-encryption-context string
+    	KMS Encryption Context used for object encryption. It expects JSON formatted string.
+  -usage-tracker.snapshot-storage.s3.sse.kms-key-id string
+    	KMS Key ID used to encrypt objects in S3
+  -usage-tracker.snapshot-storage.s3.sse.type string
+    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+  -usage-tracker.snapshot-storage.s3.sts-endpoint string
+    	Accessing S3 resources using temporary, secure credentials provided by AWS Security Token Service.
+  -usage-tracker.snapshot-storage.storage-prefix string
+    	Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet letters.
+  -usage-tracker.snapshot-storage.swift.application-credential-id string
+    	OpenStack Swift application credential id
+  -usage-tracker.snapshot-storage.swift.application-credential-name string
+    	OpenStack Swift application credential name
+  -usage-tracker.snapshot-storage.swift.application-credential-secret string
+    	OpenStack Swift application credential secret
+  -usage-tracker.snapshot-storage.swift.auth-url string
+    	OpenStack Swift authentication URL
+  -usage-tracker.snapshot-storage.swift.auth-version int
+    	OpenStack Swift authentication API version. 0 to autodetect.
+  -usage-tracker.snapshot-storage.swift.container-name string
+    	Name of the OpenStack Swift container to put chunks in.
+  -usage-tracker.snapshot-storage.swift.domain-id string
+    	OpenStack Swift user's domain ID.
+  -usage-tracker.snapshot-storage.swift.domain-name string
+    	OpenStack Swift user's domain name.
+  -usage-tracker.snapshot-storage.swift.password string
+    	OpenStack Swift API key.
+  -usage-tracker.snapshot-storage.swift.project-domain-id string
+    	ID of the OpenStack Swift project's domain (v3 auth only), only needed if it differs the from user domain.
+  -usage-tracker.snapshot-storage.swift.project-domain-name string
+    	Name of the OpenStack Swift project's domain (v3 auth only), only needed if it differs from the user domain.
+  -usage-tracker.snapshot-storage.swift.project-id string
+    	OpenStack Swift project ID (v2,v3 auth only).
+  -usage-tracker.snapshot-storage.swift.project-name string
+    	OpenStack Swift project name (v2,v3 auth only).
+  -usage-tracker.snapshot-storage.swift.region-name string
+    	OpenStack Swift Region to use (v2,v3 auth only).
+  -usage-tracker.snapshot-storage.swift.user-domain-id string
+    	OpenStack Swift user's domain ID.
+  -usage-tracker.snapshot-storage.swift.user-domain-name string
+    	OpenStack Swift user's domain name.
+  -usage-tracker.snapshot-storage.swift.user-id string
+    	OpenStack Swift user ID.
+  -usage-tracker.snapshot-storage.swift.username string
+    	OpenStack Swift username.
   -validation.max-label-names-per-info-series int
     	Maximum number of label names per info series. Has no effect if less than the value of the maximum number of label names per series option (-validation.max-label-names-per-series) (default 80)
   -validation.max-label-names-per-series int

--- a/development/mimir-ingest-storage/config/mimir.yaml
+++ b/development/mimir-ingest-storage/config/mimir.yaml
@@ -96,6 +96,9 @@ overrides_exporter:
 
 usage_tracker:
   enabled: true
+  snapshots_storage:
+    s3:
+      bucket_name: usage-tracker-snapshots
 
 limits:
   native_histograms_ingestion_enabled: true

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -468,6 +468,47 @@ usage_tracker:
         # CLI flag: -usage-tracker.partition-ring.multi.mirror-timeout
         [mirror_timeout: <duration> | default = 2s]
 
+  snapshots_storage:
+    # Backend storage to use. Supported backends are: s3, gcs, azure, swift,
+    # filesystem.
+    # CLI flag: -usage-tracker.snapshot-storage.backend
+    [backend: <string> | default = "filesystem"]
+
+    # The s3_backend block configures the connection to Amazon S3 object storage
+    # backend.
+    # The CLI flags prefix for this block configuration is:
+    # usage-tracker.snapshot-storage
+    [s3: <s3_storage_backend>]
+
+    # The gcs_backend block configures the connection to Google Cloud Storage
+    # object storage backend.
+    # The CLI flags prefix for this block configuration is:
+    # usage-tracker.snapshot-storage
+    [gcs: <gcs_storage_backend>]
+
+    # The azure_storage_backend block configures the connection to Azure object
+    # storage backend.
+    # The CLI flags prefix for this block configuration is:
+    # usage-tracker.snapshot-storage
+    [azure: <azure_storage_backend>]
+
+    # The swift_storage_backend block configures the connection to OpenStack
+    # Object Storage (Swift) object storage backend.
+    # The CLI flags prefix for this block configuration is:
+    # usage-tracker.snapshot-storage
+    [swift: <swift_storage_backend>]
+
+    # The filesystem_storage_backend block configures the usage of local file
+    # system as object storage backend.
+    # The CLI flags prefix for this block configuration is:
+    # usage-tracker.snapshot-storage
+    [filesystem: <filesystem_storage_backend>]
+
+    # Prefix for all objects stored in the backend storage. For simplicity, it
+    # may only contain digits and English alphabet letters.
+    # CLI flag: -usage-tracker.snapshot-storage.storage-prefix
+    [storage_prefix: <string> | default = ""]
+
   # The time after which series are considered idle and not active anymore. Must
   # be greater than 0 and less than 1 hour.
   # CLI flag: -usage-tracker.idle-timeout
@@ -5369,6 +5410,7 @@ The s3_backend block configures the connection to Amazon S3 object storage backe
 - `blocks-storage`
 - `common.storage`
 - `ruler-storage`
+- `usage-tracker.snapshot-storage`
 
 &nbsp;
 
@@ -5543,6 +5585,7 @@ The gcs_backend block configures the connection to Google Cloud Storage object s
 - `blocks-storage`
 - `common.storage`
 - `ruler-storage`
+- `usage-tracker.snapshot-storage`
 
 &nbsp;
 
@@ -5633,6 +5676,7 @@ The `azure_storage_backend` block configures the connection to Azure object stor
 - `blocks-storage`
 - `common.storage`
 - `ruler-storage`
+- `usage-tracker.snapshot-storage`
 
 &nbsp;
 
@@ -5739,6 +5783,7 @@ The `swift_storage_backend` block configures the connection to OpenStack Object 
 - `blocks-storage`
 - `common.storage`
 - `ruler-storage`
+- `usage-tracker.snapshot-storage`
 
 &nbsp;
 
@@ -5840,6 +5885,7 @@ The `filesystem_storage_backend` block configures the usage of local file system
 - `blocks-storage`
 - `common.storage`
 - `ruler-storage`
+- `usage-tracker.snapshot-storage`
 
 &nbsp;
 


### PR DESCRIPTION
Adds bucket client config & client, still not used.