### PR TITLE
Init usage-tracker Kafka client

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -19004,6 +19004,636 @@
         },
         {
           "kind": "block",
+          "name": "events_storage",
+          "required": false,
+          "desc": "",
+          "blockEntries": [
+            {
+              "kind": "block",
+              "name": "writer",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "address",
+                  "required": false,
+                  "desc": "The Kafka backend address.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.writer..address",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "topic",
+                  "required": false,
+                  "desc": "The Kafka topic name.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.writer..topic",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "client_id",
+                  "required": false,
+                  "desc": "The Kafka client ID.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.writer..client-id",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "dial_timeout",
+                  "required": false,
+                  "desc": "The maximum time allowed to open a connection to a Kafka broker.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 2000000000,
+                  "fieldFlag": "usage-tracker.events-storage.writer..dial-timeout",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "write_timeout",
+                  "required": false,
+                  "desc": "How long to wait for an incoming write request to be successfully committed to the Kafka backend.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 10000000000,
+                  "fieldFlag": "usage-tracker.events-storage.writer..write-timeout",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "write_clients",
+                  "required": false,
+                  "desc": "The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 1,
+                  "fieldFlag": "usage-tracker.events-storage.writer..write-clients",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "sasl_username",
+                  "required": false,
+                  "desc": "The username used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.writer..sasl-username",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "sasl_password",
+                  "required": false,
+                  "desc": "The password used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.writer..sasl-password",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "consumer_group",
+                  "required": false,
+                  "desc": "The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '\u003cpartition\u003e' placeholder, it is replaced with the actual partition ID owned by the ingester. When empty (recommended), Mimir uses the ingester instance ID to guarantee uniqueness.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.writer..consumer-group",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "consumer_group_offset_commit_interval",
+                  "required": false,
+                  "desc": "How frequently a consumer should commit the consumed offset to Kafka. The last committed offset is used at startup to continue the consumption from where it was left.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 1000000000,
+                  "fieldFlag": "usage-tracker.events-storage.writer..consumer-group-offset-commit-interval",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "last_produced_offset_poll_interval",
+                  "required": false,
+                  "desc": "How frequently to poll the last produced offset, used to enforce strong read consistency.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 1000000000,
+                  "fieldFlag": "usage-tracker.events-storage.writer..last-produced-offset-poll-interval",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "last_produced_offset_retry_timeout",
+                  "required": false,
+                  "desc": "How long to retry a failed request to get the last produced offset.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 10000000000,
+                  "fieldFlag": "usage-tracker.events-storage.writer..last-produced-offset-retry-timeout",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "consume_from_position_at_startup",
+                  "required": false,
+                  "desc": "From which position to start consuming the partition at startup. Supported options: last-offset, start, end, timestamp.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "last-offset",
+                  "fieldFlag": "usage-tracker.events-storage.writer..consume-from-position-at-startup",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "consume_from_timestamp_at_startup",
+                  "required": false,
+                  "desc": "Milliseconds timestamp after which the consumption of the partition starts at startup. Only applies when consume-from-position-at-startup is timestamp",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.events-storage.writer..consume-from-timestamp-at-startup",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "target_consumer_lag_at_startup",
+                  "required": false,
+                  "desc": "The best-effort maximum lag a consumer tries to achieve at startup. Set both -usage-tracker.events-storage.writer..target-consumer-lag-at-startup and -usage-tracker.events-storage.writer..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 2000000000,
+                  "fieldFlag": "usage-tracker.events-storage.writer..target-consumer-lag-at-startup",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "max_consumer_lag_at_startup",
+                  "required": false,
+                  "desc": "The guaranteed maximum lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. Set both -usage-tracker.events-storage.writer..target-consumer-lag-at-startup and -usage-tracker.events-storage.writer..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 15000000000,
+                  "fieldFlag": "usage-tracker.events-storage.writer..max-consumer-lag-at-startup",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "auto_create_topic_enabled",
+                  "required": false,
+                  "desc": "Enable auto-creation of Kafka topic if it doesn't exist.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": true,
+                  "fieldFlag": "usage-tracker.events-storage.writer..auto-create-topic-enabled",
+                  "fieldType": "boolean"
+                },
+                {
+                  "kind": "field",
+                  "name": "auto_create_topic_default_partitions",
+                  "required": false,
+                  "desc": "When auto-creation of Kafka topic is enabled and this value is positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that the Kafka broker uses for auto-created topics. Note that this is a Kafka-cluster wide setting, and applies to any auto-created topic. If the setting of num.partitions fails, Mimir proceeds anyways, but auto-created topics could have an incorrect number of partitions.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.events-storage.writer..auto-create-topic-default-partitions",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "producer_max_record_size_bytes",
+                  "required": false,
+                  "desc": "The maximum size of a Kafka record data that should be generated by the producer. An incoming write request larger than this size is split into multiple Kafka records. We strongly recommend to not change this setting unless for testing purposes.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 15983616,
+                  "fieldFlag": "usage-tracker.events-storage.writer..producer-max-record-size-bytes",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "producer_max_buffered_bytes",
+                  "required": false,
+                  "desc": "The maximum size of (uncompressed) buffered and unacknowledged produced records sent to Kafka. The produce request fails once this limit is reached. This limit is per Kafka client. 0 to disable the limit.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 1073741824,
+                  "fieldFlag": "usage-tracker.events-storage.writer..producer-max-buffered-bytes",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "wait_strong_read_consistency_timeout",
+                  "required": false,
+                  "desc": "The maximum allowed for a read requests processed by an ingester to wait until strong read consistency is enforced. 0 to disable the timeout.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 20000000000,
+                  "fieldFlag": "usage-tracker.events-storage.writer..wait-strong-read-consistency-timeout",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "startup_fetch_concurrency",
+                  "required": false,
+                  "desc": "The number of concurrent fetch requests that the ingester makes when reading data from Kafka during startup. 0 to disable.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.events-storage.writer..startup-fetch-concurrency",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ongoing_fetch_concurrency",
+                  "required": false,
+                  "desc": "The number of concurrent fetch requests that the ingester makes when reading data continuously from Kafka after startup. Is disabled unless usage-tracker.events-storage.writer..startup-fetch-concurrency is greater than 0. 0 to disable.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.events-storage.writer..ongoing-fetch-concurrency",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "use_compressed_bytes_as_fetch_max_bytes",
+                  "required": false,
+                  "desc": "When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": true,
+                  "fieldFlag": "usage-tracker.events-storage.writer..use-compressed-bytes-as-fetch-max-bytes",
+                  "fieldType": "boolean"
+                },
+                {
+                  "kind": "field",
+                  "name": "max_buffered_bytes",
+                  "required": false,
+                  "desc": "The maximum number of buffered records ready to be processed. This limit applies to the sum of all inflight requests. Set to 0 to disable the limit.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 100000000,
+                  "fieldFlag": "usage-tracker.events-storage.writer..max-buffered-bytes",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ingestion_concurrency_max",
+                  "required": false,
+                  "desc": "The maximum number of concurrent ingestion streams to the TSDB head. Every tenant has their own set of streams. 0 to disable.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.events-storage.writer..ingestion-concurrency-max",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ingestion_concurrency_batch_size",
+                  "required": false,
+                  "desc": "The number of timeseries to batch together before ingesting to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 150,
+                  "fieldFlag": "usage-tracker.events-storage.writer..ingestion-concurrency-batch-size",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ingestion_concurrency_queue_capacity",
+                  "required": false,
+                  "desc": "The number of batches to prepare and queue to ingest to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 5,
+                  "fieldFlag": "usage-tracker.events-storage.writer..ingestion-concurrency-queue-capacity",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ingestion_concurrency_target_flushes_per_shard",
+                  "required": false,
+                  "desc": "The expected number of times to ingest timeseries to the TSDB head after batching. With fewer flushes, the overhead of splitting up the work is higher than the benefit of parallelization. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 80,
+                  "fieldFlag": "usage-tracker.events-storage.writer..ingestion-concurrency-target-flushes-per-shard",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ingestion_concurrency_estimated_bytes_per_sample",
+                  "required": false,
+                  "desc": "The estimated number of bytes a sample has at time of ingestion. This value is used to estimate the timeseries without decompressing them. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 500,
+                  "fieldFlag": "usage-tracker.events-storage.writer..ingestion-concurrency-estimated-bytes-per-sample",
+                  "fieldType": "int"
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
+            },
+            {
+              "kind": "block",
+              "name": "reader",
+              "required": false,
+              "desc": "",
+              "blockEntries": [
+                {
+                  "kind": "field",
+                  "name": "address",
+                  "required": false,
+                  "desc": "The Kafka backend address.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.reader..address",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "topic",
+                  "required": false,
+                  "desc": "The Kafka topic name.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.reader..topic",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "client_id",
+                  "required": false,
+                  "desc": "The Kafka client ID.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.reader..client-id",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "dial_timeout",
+                  "required": false,
+                  "desc": "The maximum time allowed to open a connection to a Kafka broker.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 2000000000,
+                  "fieldFlag": "usage-tracker.events-storage.reader..dial-timeout",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "write_timeout",
+                  "required": false,
+                  "desc": "How long to wait for an incoming write request to be successfully committed to the Kafka backend.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 10000000000,
+                  "fieldFlag": "usage-tracker.events-storage.reader..write-timeout",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "write_clients",
+                  "required": false,
+                  "desc": "The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 1,
+                  "fieldFlag": "usage-tracker.events-storage.reader..write-clients",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "sasl_username",
+                  "required": false,
+                  "desc": "The username used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.reader..sasl-username",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "sasl_password",
+                  "required": false,
+                  "desc": "The password used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.reader..sasl-password",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "consumer_group",
+                  "required": false,
+                  "desc": "The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '\u003cpartition\u003e' placeholder, it is replaced with the actual partition ID owned by the ingester. When empty (recommended), Mimir uses the ingester instance ID to guarantee uniqueness.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "usage-tracker.events-storage.reader..consumer-group",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "consumer_group_offset_commit_interval",
+                  "required": false,
+                  "desc": "How frequently a consumer should commit the consumed offset to Kafka. The last committed offset is used at startup to continue the consumption from where it was left.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 1000000000,
+                  "fieldFlag": "usage-tracker.events-storage.reader..consumer-group-offset-commit-interval",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "last_produced_offset_poll_interval",
+                  "required": false,
+                  "desc": "How frequently to poll the last produced offset, used to enforce strong read consistency.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 1000000000,
+                  "fieldFlag": "usage-tracker.events-storage.reader..last-produced-offset-poll-interval",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "last_produced_offset_retry_timeout",
+                  "required": false,
+                  "desc": "How long to retry a failed request to get the last produced offset.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 10000000000,
+                  "fieldFlag": "usage-tracker.events-storage.reader..last-produced-offset-retry-timeout",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "consume_from_position_at_startup",
+                  "required": false,
+                  "desc": "From which position to start consuming the partition at startup. Supported options: last-offset, start, end, timestamp.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "last-offset",
+                  "fieldFlag": "usage-tracker.events-storage.reader..consume-from-position-at-startup",
+                  "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "consume_from_timestamp_at_startup",
+                  "required": false,
+                  "desc": "Milliseconds timestamp after which the consumption of the partition starts at startup. Only applies when consume-from-position-at-startup is timestamp",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.events-storage.reader..consume-from-timestamp-at-startup",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "target_consumer_lag_at_startup",
+                  "required": false,
+                  "desc": "The best-effort maximum lag a consumer tries to achieve at startup. Set both -usage-tracker.events-storage.reader..target-consumer-lag-at-startup and -usage-tracker.events-storage.reader..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 2000000000,
+                  "fieldFlag": "usage-tracker.events-storage.reader..target-consumer-lag-at-startup",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "max_consumer_lag_at_startup",
+                  "required": false,
+                  "desc": "The guaranteed maximum lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. Set both -usage-tracker.events-storage.reader..target-consumer-lag-at-startup and -usage-tracker.events-storage.reader..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 15000000000,
+                  "fieldFlag": "usage-tracker.events-storage.reader..max-consumer-lag-at-startup",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "auto_create_topic_enabled",
+                  "required": false,
+                  "desc": "Enable auto-creation of Kafka topic if it doesn't exist.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": true,
+                  "fieldFlag": "usage-tracker.events-storage.reader..auto-create-topic-enabled",
+                  "fieldType": "boolean"
+                },
+                {
+                  "kind": "field",
+                  "name": "auto_create_topic_default_partitions",
+                  "required": false,
+                  "desc": "When auto-creation of Kafka topic is enabled and this value is positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that the Kafka broker uses for auto-created topics. Note that this is a Kafka-cluster wide setting, and applies to any auto-created topic. If the setting of num.partitions fails, Mimir proceeds anyways, but auto-created topics could have an incorrect number of partitions.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.events-storage.reader..auto-create-topic-default-partitions",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "producer_max_record_size_bytes",
+                  "required": false,
+                  "desc": "The maximum size of a Kafka record data that should be generated by the producer. An incoming write request larger than this size is split into multiple Kafka records. We strongly recommend to not change this setting unless for testing purposes.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 15983616,
+                  "fieldFlag": "usage-tracker.events-storage.reader..producer-max-record-size-bytes",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "producer_max_buffered_bytes",
+                  "required": false,
+                  "desc": "The maximum size of (uncompressed) buffered and unacknowledged produced records sent to Kafka. The produce request fails once this limit is reached. This limit is per Kafka client. 0 to disable the limit.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 1073741824,
+                  "fieldFlag": "usage-tracker.events-storage.reader..producer-max-buffered-bytes",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "wait_strong_read_consistency_timeout",
+                  "required": false,
+                  "desc": "The maximum allowed for a read requests processed by an ingester to wait until strong read consistency is enforced. 0 to disable the timeout.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 20000000000,
+                  "fieldFlag": "usage-tracker.events-storage.reader..wait-strong-read-consistency-timeout",
+                  "fieldType": "duration"
+                },
+                {
+                  "kind": "field",
+                  "name": "startup_fetch_concurrency",
+                  "required": false,
+                  "desc": "The number of concurrent fetch requests that the ingester makes when reading data from Kafka during startup. 0 to disable.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.events-storage.reader..startup-fetch-concurrency",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ongoing_fetch_concurrency",
+                  "required": false,
+                  "desc": "The number of concurrent fetch requests that the ingester makes when reading data continuously from Kafka after startup. Is disabled unless usage-tracker.events-storage.reader..startup-fetch-concurrency is greater than 0. 0 to disable.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.events-storage.reader..ongoing-fetch-concurrency",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "use_compressed_bytes_as_fetch_max_bytes",
+                  "required": false,
+                  "desc": "When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": true,
+                  "fieldFlag": "usage-tracker.events-storage.reader..use-compressed-bytes-as-fetch-max-bytes",
+                  "fieldType": "boolean"
+                },
+                {
+                  "kind": "field",
+                  "name": "max_buffered_bytes",
+                  "required": false,
+                  "desc": "The maximum number of buffered records ready to be processed. This limit applies to the sum of all inflight requests. Set to 0 to disable the limit.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 100000000,
+                  "fieldFlag": "usage-tracker.events-storage.reader..max-buffered-bytes",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ingestion_concurrency_max",
+                  "required": false,
+                  "desc": "The maximum number of concurrent ingestion streams to the TSDB head. Every tenant has their own set of streams. 0 to disable.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 0,
+                  "fieldFlag": "usage-tracker.events-storage.reader..ingestion-concurrency-max",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ingestion_concurrency_batch_size",
+                  "required": false,
+                  "desc": "The number of timeseries to batch together before ingesting to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 150,
+                  "fieldFlag": "usage-tracker.events-storage.reader..ingestion-concurrency-batch-size",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ingestion_concurrency_queue_capacity",
+                  "required": false,
+                  "desc": "The number of batches to prepare and queue to ingest to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 5,
+                  "fieldFlag": "usage-tracker.events-storage.reader..ingestion-concurrency-queue-capacity",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ingestion_concurrency_target_flushes_per_shard",
+                  "required": false,
+                  "desc": "The expected number of times to ingest timeseries to the TSDB head after batching. With fewer flushes, the overhead of splitting up the work is higher than the benefit of parallelization. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 80,
+                  "fieldFlag": "usage-tracker.events-storage.reader..ingestion-concurrency-target-flushes-per-shard",
+                  "fieldType": "int"
+                },
+                {
+                  "kind": "field",
+                  "name": "ingestion_concurrency_estimated_bytes_per_sample",
+                  "required": false,
+                  "desc": "The estimated number of bytes a sample has at time of ingestion. This value is used to estimate the timeseries without decompressing them. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 500,
+                  "fieldFlag": "usage-tracker.events-storage.reader..ingestion-concurrency-estimated-bytes-per-sample",
+                  "fieldType": "int"
+                }
+              ],
+              "fieldValue": null,
+              "fieldDefaultValue": null
+            }
+          ],
+          "fieldValue": null,
+          "fieldDefaultValue": null
+        },
+        {
+          "kind": "block",
           "name": "snapshots_storage",
           "required": false,
           "desc": "",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3341,6 +3341,126 @@ Usage of ./cmd/mimir/mimir:
     	Installation mode. Supported values: custom, helm, jsonnet. (default "custom")
   -usage-tracker.enabled
     	True to enable the usage-tracker.
+  -usage-tracker.events-storage.reader..address string
+    	The Kafka backend address.
+  -usage-tracker.events-storage.reader..auto-create-topic-default-partitions int
+    	When auto-creation of Kafka topic is enabled and this value is positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that the Kafka broker uses for auto-created topics. Note that this is a Kafka-cluster wide setting, and applies to any auto-created topic. If the setting of num.partitions fails, Mimir proceeds anyways, but auto-created topics could have an incorrect number of partitions.
+  -usage-tracker.events-storage.reader..auto-create-topic-enabled
+    	Enable auto-creation of Kafka topic if it doesn't exist. (default true)
+  -usage-tracker.events-storage.reader..client-id string
+    	The Kafka client ID.
+  -usage-tracker.events-storage.reader..consume-from-position-at-startup string
+    	From which position to start consuming the partition at startup. Supported options: last-offset, start, end, timestamp. (default "last-offset")
+  -usage-tracker.events-storage.reader..consume-from-timestamp-at-startup int
+    	Milliseconds timestamp after which the consumption of the partition starts at startup. Only applies when consume-from-position-at-startup is timestamp
+  -usage-tracker.events-storage.reader..consumer-group string
+    	The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '<partition>' placeholder, it is replaced with the actual partition ID owned by the ingester. When empty (recommended), Mimir uses the ingester instance ID to guarantee uniqueness.
+  -usage-tracker.events-storage.reader..consumer-group-offset-commit-interval duration
+    	How frequently a consumer should commit the consumed offset to Kafka. The last committed offset is used at startup to continue the consumption from where it was left. (default 1s)
+  -usage-tracker.events-storage.reader..dial-timeout duration
+    	The maximum time allowed to open a connection to a Kafka broker. (default 2s)
+  -usage-tracker.events-storage.reader..ingestion-concurrency-batch-size int
+    	The number of timeseries to batch together before ingesting to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 150)
+  -usage-tracker.events-storage.reader..ingestion-concurrency-estimated-bytes-per-sample int
+    	The estimated number of bytes a sample has at time of ingestion. This value is used to estimate the timeseries without decompressing them. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 500)
+  -usage-tracker.events-storage.reader..ingestion-concurrency-max int
+    	The maximum number of concurrent ingestion streams to the TSDB head. Every tenant has their own set of streams. 0 to disable.
+  -usage-tracker.events-storage.reader..ingestion-concurrency-queue-capacity int
+    	The number of batches to prepare and queue to ingest to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 5)
+  -usage-tracker.events-storage.reader..ingestion-concurrency-target-flushes-per-shard int
+    	The expected number of times to ingest timeseries to the TSDB head after batching. With fewer flushes, the overhead of splitting up the work is higher than the benefit of parallelization. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 80)
+  -usage-tracker.events-storage.reader..last-produced-offset-poll-interval duration
+    	How frequently to poll the last produced offset, used to enforce strong read consistency. (default 1s)
+  -usage-tracker.events-storage.reader..last-produced-offset-retry-timeout duration
+    	How long to retry a failed request to get the last produced offset. (default 10s)
+  -usage-tracker.events-storage.reader..max-buffered-bytes int
+    	The maximum number of buffered records ready to be processed. This limit applies to the sum of all inflight requests. Set to 0 to disable the limit. (default 100000000)
+  -usage-tracker.events-storage.reader..max-consumer-lag-at-startup duration
+    	The guaranteed maximum lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. Set both -usage-tracker.events-storage.reader..target-consumer-lag-at-startup and -usage-tracker.events-storage.reader..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup. (default 15s)
+  -usage-tracker.events-storage.reader..ongoing-fetch-concurrency int
+    	The number of concurrent fetch requests that the ingester makes when reading data continuously from Kafka after startup. Is disabled unless usage-tracker.events-storage.reader..startup-fetch-concurrency is greater than 0. 0 to disable.
+  -usage-tracker.events-storage.reader..producer-max-buffered-bytes int
+    	The maximum size of (uncompressed) buffered and unacknowledged produced records sent to Kafka. The produce request fails once this limit is reached. This limit is per Kafka client. 0 to disable the limit. (default 1073741824)
+  -usage-tracker.events-storage.reader..producer-max-record-size-bytes int
+    	The maximum size of a Kafka record data that should be generated by the producer. An incoming write request larger than this size is split into multiple Kafka records. We strongly recommend to not change this setting unless for testing purposes. (default 15983616)
+  -usage-tracker.events-storage.reader..sasl-password string
+    	The password used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.
+  -usage-tracker.events-storage.reader..sasl-username string
+    	The username used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.
+  -usage-tracker.events-storage.reader..startup-fetch-concurrency int
+    	The number of concurrent fetch requests that the ingester makes when reading data from Kafka during startup. 0 to disable.
+  -usage-tracker.events-storage.reader..target-consumer-lag-at-startup duration
+    	The best-effort maximum lag a consumer tries to achieve at startup. Set both -usage-tracker.events-storage.reader..target-consumer-lag-at-startup and -usage-tracker.events-storage.reader..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup. (default 2s)
+  -usage-tracker.events-storage.reader..topic string
+    	The Kafka topic name.
+  -usage-tracker.events-storage.reader..use-compressed-bytes-as-fetch-max-bytes
+    	When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently. (default true)
+  -usage-tracker.events-storage.reader..wait-strong-read-consistency-timeout duration
+    	The maximum allowed for a read requests processed by an ingester to wait until strong read consistency is enforced. 0 to disable the timeout. (default 20s)
+  -usage-tracker.events-storage.reader..write-clients int
+    	The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka. (default 1)
+  -usage-tracker.events-storage.reader..write-timeout duration
+    	How long to wait for an incoming write request to be successfully committed to the Kafka backend. (default 10s)
+  -usage-tracker.events-storage.writer..address string
+    	The Kafka backend address.
+  -usage-tracker.events-storage.writer..auto-create-topic-default-partitions int
+    	When auto-creation of Kafka topic is enabled and this value is positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that the Kafka broker uses for auto-created topics. Note that this is a Kafka-cluster wide setting, and applies to any auto-created topic. If the setting of num.partitions fails, Mimir proceeds anyways, but auto-created topics could have an incorrect number of partitions.
+  -usage-tracker.events-storage.writer..auto-create-topic-enabled
+    	Enable auto-creation of Kafka topic if it doesn't exist. (default true)
+  -usage-tracker.events-storage.writer..client-id string
+    	The Kafka client ID.
+  -usage-tracker.events-storage.writer..consume-from-position-at-startup string
+    	From which position to start consuming the partition at startup. Supported options: last-offset, start, end, timestamp. (default "last-offset")
+  -usage-tracker.events-storage.writer..consume-from-timestamp-at-startup int
+    	Milliseconds timestamp after which the consumption of the partition starts at startup. Only applies when consume-from-position-at-startup is timestamp
+  -usage-tracker.events-storage.writer..consumer-group string
+    	The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '<partition>' placeholder, it is replaced with the actual partition ID owned by the ingester. When empty (recommended), Mimir uses the ingester instance ID to guarantee uniqueness.
+  -usage-tracker.events-storage.writer..consumer-group-offset-commit-interval duration
+    	How frequently a consumer should commit the consumed offset to Kafka. The last committed offset is used at startup to continue the consumption from where it was left. (default 1s)
+  -usage-tracker.events-storage.writer..dial-timeout duration
+    	The maximum time allowed to open a connection to a Kafka broker. (default 2s)
+  -usage-tracker.events-storage.writer..ingestion-concurrency-batch-size int
+    	The number of timeseries to batch together before ingesting to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 150)
+  -usage-tracker.events-storage.writer..ingestion-concurrency-estimated-bytes-per-sample int
+    	The estimated number of bytes a sample has at time of ingestion. This value is used to estimate the timeseries without decompressing them. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 500)
+  -usage-tracker.events-storage.writer..ingestion-concurrency-max int
+    	The maximum number of concurrent ingestion streams to the TSDB head. Every tenant has their own set of streams. 0 to disable.
+  -usage-tracker.events-storage.writer..ingestion-concurrency-queue-capacity int
+    	The number of batches to prepare and queue to ingest to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 5)
+  -usage-tracker.events-storage.writer..ingestion-concurrency-target-flushes-per-shard int
+    	The expected number of times to ingest timeseries to the TSDB head after batching. With fewer flushes, the overhead of splitting up the work is higher than the benefit of parallelization. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 80)
+  -usage-tracker.events-storage.writer..last-produced-offset-poll-interval duration
+    	How frequently to poll the last produced offset, used to enforce strong read consistency. (default 1s)
+  -usage-tracker.events-storage.writer..last-produced-offset-retry-timeout duration
+    	How long to retry a failed request to get the last produced offset. (default 10s)
+  -usage-tracker.events-storage.writer..max-buffered-bytes int
+    	The maximum number of buffered records ready to be processed. This limit applies to the sum of all inflight requests. Set to 0 to disable the limit. (default 100000000)
+  -usage-tracker.events-storage.writer..max-consumer-lag-at-startup duration
+    	The guaranteed maximum lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. Set both -usage-tracker.events-storage.writer..target-consumer-lag-at-startup and -usage-tracker.events-storage.writer..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup. (default 15s)
+  -usage-tracker.events-storage.writer..ongoing-fetch-concurrency int
+    	The number of concurrent fetch requests that the ingester makes when reading data continuously from Kafka after startup. Is disabled unless usage-tracker.events-storage.writer..startup-fetch-concurrency is greater than 0. 0 to disable.
+  -usage-tracker.events-storage.writer..producer-max-buffered-bytes int
+    	The maximum size of (uncompressed) buffered and unacknowledged produced records sent to Kafka. The produce request fails once this limit is reached. This limit is per Kafka client. 0 to disable the limit. (default 1073741824)
+  -usage-tracker.events-storage.writer..producer-max-record-size-bytes int
+    	The maximum size of a Kafka record data that should be generated by the producer. An incoming write request larger than this size is split into multiple Kafka records. We strongly recommend to not change this setting unless for testing purposes. (default 15983616)
+  -usage-tracker.events-storage.writer..sasl-password string
+    	The password used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.
+  -usage-tracker.events-storage.writer..sasl-username string
+    	The username used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.
+  -usage-tracker.events-storage.writer..startup-fetch-concurrency int
+    	The number of concurrent fetch requests that the ingester makes when reading data from Kafka during startup. 0 to disable.
+  -usage-tracker.events-storage.writer..target-consumer-lag-at-startup duration
+    	The best-effort maximum lag a consumer tries to achieve at startup. Set both -usage-tracker.events-storage.writer..target-consumer-lag-at-startup and -usage-tracker.events-storage.writer..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup. (default 2s)
+  -usage-tracker.events-storage.writer..topic string
+    	The Kafka topic name.
+  -usage-tracker.events-storage.writer..use-compressed-bytes-as-fetch-max-bytes
+    	When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently. (default true)
+  -usage-tracker.events-storage.writer..wait-strong-read-consistency-timeout duration
+    	The maximum allowed for a read requests processed by an ingester to wait until strong read consistency is enforced. 0 to disable the timeout. (default 20s)
+  -usage-tracker.events-storage.writer..write-clients int
+    	The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka. (default 1)
+  -usage-tracker.events-storage.writer..write-timeout duration
+    	How long to wait for an incoming write request to be successfully committed to the Kafka backend. (default 10s)
   -usage-tracker.idle-timeout duration
     	The time after which series are considered idle and not active anymore. Must be greater than 0 and less than 1 hour. (default 20m0s)
   -usage-tracker.partition-ring.consul.acl-token string

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -865,6 +865,126 @@ Usage of ./cmd/mimir/mimir:
     	Installation mode. Supported values: custom, helm, jsonnet. (default "custom")
   -usage-tracker.enabled
     	True to enable the usage-tracker.
+  -usage-tracker.events-storage.reader..address string
+    	The Kafka backend address.
+  -usage-tracker.events-storage.reader..auto-create-topic-default-partitions int
+    	When auto-creation of Kafka topic is enabled and this value is positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that the Kafka broker uses for auto-created topics. Note that this is a Kafka-cluster wide setting, and applies to any auto-created topic. If the setting of num.partitions fails, Mimir proceeds anyways, but auto-created topics could have an incorrect number of partitions.
+  -usage-tracker.events-storage.reader..auto-create-topic-enabled
+    	Enable auto-creation of Kafka topic if it doesn't exist. (default true)
+  -usage-tracker.events-storage.reader..client-id string
+    	The Kafka client ID.
+  -usage-tracker.events-storage.reader..consume-from-position-at-startup string
+    	From which position to start consuming the partition at startup. Supported options: last-offset, start, end, timestamp. (default "last-offset")
+  -usage-tracker.events-storage.reader..consume-from-timestamp-at-startup int
+    	Milliseconds timestamp after which the consumption of the partition starts at startup. Only applies when consume-from-position-at-startup is timestamp
+  -usage-tracker.events-storage.reader..consumer-group string
+    	The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '<partition>' placeholder, it is replaced with the actual partition ID owned by the ingester. When empty (recommended), Mimir uses the ingester instance ID to guarantee uniqueness.
+  -usage-tracker.events-storage.reader..consumer-group-offset-commit-interval duration
+    	How frequently a consumer should commit the consumed offset to Kafka. The last committed offset is used at startup to continue the consumption from where it was left. (default 1s)
+  -usage-tracker.events-storage.reader..dial-timeout duration
+    	The maximum time allowed to open a connection to a Kafka broker. (default 2s)
+  -usage-tracker.events-storage.reader..ingestion-concurrency-batch-size int
+    	The number of timeseries to batch together before ingesting to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 150)
+  -usage-tracker.events-storage.reader..ingestion-concurrency-estimated-bytes-per-sample int
+    	The estimated number of bytes a sample has at time of ingestion. This value is used to estimate the timeseries without decompressing them. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 500)
+  -usage-tracker.events-storage.reader..ingestion-concurrency-max int
+    	The maximum number of concurrent ingestion streams to the TSDB head. Every tenant has their own set of streams. 0 to disable.
+  -usage-tracker.events-storage.reader..ingestion-concurrency-queue-capacity int
+    	The number of batches to prepare and queue to ingest to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 5)
+  -usage-tracker.events-storage.reader..ingestion-concurrency-target-flushes-per-shard int
+    	The expected number of times to ingest timeseries to the TSDB head after batching. With fewer flushes, the overhead of splitting up the work is higher than the benefit of parallelization. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 80)
+  -usage-tracker.events-storage.reader..last-produced-offset-poll-interval duration
+    	How frequently to poll the last produced offset, used to enforce strong read consistency. (default 1s)
+  -usage-tracker.events-storage.reader..last-produced-offset-retry-timeout duration
+    	How long to retry a failed request to get the last produced offset. (default 10s)
+  -usage-tracker.events-storage.reader..max-buffered-bytes int
+    	The maximum number of buffered records ready to be processed. This limit applies to the sum of all inflight requests. Set to 0 to disable the limit. (default 100000000)
+  -usage-tracker.events-storage.reader..max-consumer-lag-at-startup duration
+    	The guaranteed maximum lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. Set both -usage-tracker.events-storage.reader..target-consumer-lag-at-startup and -usage-tracker.events-storage.reader..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup. (default 15s)
+  -usage-tracker.events-storage.reader..ongoing-fetch-concurrency int
+    	The number of concurrent fetch requests that the ingester makes when reading data continuously from Kafka after startup. Is disabled unless usage-tracker.events-storage.reader..startup-fetch-concurrency is greater than 0. 0 to disable.
+  -usage-tracker.events-storage.reader..producer-max-buffered-bytes int
+    	The maximum size of (uncompressed) buffered and unacknowledged produced records sent to Kafka. The produce request fails once this limit is reached. This limit is per Kafka client. 0 to disable the limit. (default 1073741824)
+  -usage-tracker.events-storage.reader..producer-max-record-size-bytes int
+    	The maximum size of a Kafka record data that should be generated by the producer. An incoming write request larger than this size is split into multiple Kafka records. We strongly recommend to not change this setting unless for testing purposes. (default 15983616)
+  -usage-tracker.events-storage.reader..sasl-password string
+    	The password used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.
+  -usage-tracker.events-storage.reader..sasl-username string
+    	The username used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.
+  -usage-tracker.events-storage.reader..startup-fetch-concurrency int
+    	The number of concurrent fetch requests that the ingester makes when reading data from Kafka during startup. 0 to disable.
+  -usage-tracker.events-storage.reader..target-consumer-lag-at-startup duration
+    	The best-effort maximum lag a consumer tries to achieve at startup. Set both -usage-tracker.events-storage.reader..target-consumer-lag-at-startup and -usage-tracker.events-storage.reader..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup. (default 2s)
+  -usage-tracker.events-storage.reader..topic string
+    	The Kafka topic name.
+  -usage-tracker.events-storage.reader..use-compressed-bytes-as-fetch-max-bytes
+    	When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently. (default true)
+  -usage-tracker.events-storage.reader..wait-strong-read-consistency-timeout duration
+    	The maximum allowed for a read requests processed by an ingester to wait until strong read consistency is enforced. 0 to disable the timeout. (default 20s)
+  -usage-tracker.events-storage.reader..write-clients int
+    	The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka. (default 1)
+  -usage-tracker.events-storage.reader..write-timeout duration
+    	How long to wait for an incoming write request to be successfully committed to the Kafka backend. (default 10s)
+  -usage-tracker.events-storage.writer..address string
+    	The Kafka backend address.
+  -usage-tracker.events-storage.writer..auto-create-topic-default-partitions int
+    	When auto-creation of Kafka topic is enabled and this value is positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that the Kafka broker uses for auto-created topics. Note that this is a Kafka-cluster wide setting, and applies to any auto-created topic. If the setting of num.partitions fails, Mimir proceeds anyways, but auto-created topics could have an incorrect number of partitions.
+  -usage-tracker.events-storage.writer..auto-create-topic-enabled
+    	Enable auto-creation of Kafka topic if it doesn't exist. (default true)
+  -usage-tracker.events-storage.writer..client-id string
+    	The Kafka client ID.
+  -usage-tracker.events-storage.writer..consume-from-position-at-startup string
+    	From which position to start consuming the partition at startup. Supported options: last-offset, start, end, timestamp. (default "last-offset")
+  -usage-tracker.events-storage.writer..consume-from-timestamp-at-startup int
+    	Milliseconds timestamp after which the consumption of the partition starts at startup. Only applies when consume-from-position-at-startup is timestamp
+  -usage-tracker.events-storage.writer..consumer-group string
+    	The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '<partition>' placeholder, it is replaced with the actual partition ID owned by the ingester. When empty (recommended), Mimir uses the ingester instance ID to guarantee uniqueness.
+  -usage-tracker.events-storage.writer..consumer-group-offset-commit-interval duration
+    	How frequently a consumer should commit the consumed offset to Kafka. The last committed offset is used at startup to continue the consumption from where it was left. (default 1s)
+  -usage-tracker.events-storage.writer..dial-timeout duration
+    	The maximum time allowed to open a connection to a Kafka broker. (default 2s)
+  -usage-tracker.events-storage.writer..ingestion-concurrency-batch-size int
+    	The number of timeseries to batch together before ingesting to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 150)
+  -usage-tracker.events-storage.writer..ingestion-concurrency-estimated-bytes-per-sample int
+    	The estimated number of bytes a sample has at time of ingestion. This value is used to estimate the timeseries without decompressing them. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 500)
+  -usage-tracker.events-storage.writer..ingestion-concurrency-max int
+    	The maximum number of concurrent ingestion streams to the TSDB head. Every tenant has their own set of streams. 0 to disable.
+  -usage-tracker.events-storage.writer..ingestion-concurrency-queue-capacity int
+    	The number of batches to prepare and queue to ingest to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 5)
+  -usage-tracker.events-storage.writer..ingestion-concurrency-target-flushes-per-shard int
+    	The expected number of times to ingest timeseries to the TSDB head after batching. With fewer flushes, the overhead of splitting up the work is higher than the benefit of parallelization. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 80)
+  -usage-tracker.events-storage.writer..last-produced-offset-poll-interval duration
+    	How frequently to poll the last produced offset, used to enforce strong read consistency. (default 1s)
+  -usage-tracker.events-storage.writer..last-produced-offset-retry-timeout duration
+    	How long to retry a failed request to get the last produced offset. (default 10s)
+  -usage-tracker.events-storage.writer..max-buffered-bytes int
+    	The maximum number of buffered records ready to be processed. This limit applies to the sum of all inflight requests. Set to 0 to disable the limit. (default 100000000)
+  -usage-tracker.events-storage.writer..max-consumer-lag-at-startup duration
+    	The guaranteed maximum lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. Set both -usage-tracker.events-storage.writer..target-consumer-lag-at-startup and -usage-tracker.events-storage.writer..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup. (default 15s)
+  -usage-tracker.events-storage.writer..ongoing-fetch-concurrency int
+    	The number of concurrent fetch requests that the ingester makes when reading data continuously from Kafka after startup. Is disabled unless usage-tracker.events-storage.writer..startup-fetch-concurrency is greater than 0. 0 to disable.
+  -usage-tracker.events-storage.writer..producer-max-buffered-bytes int
+    	The maximum size of (uncompressed) buffered and unacknowledged produced records sent to Kafka. The produce request fails once this limit is reached. This limit is per Kafka client. 0 to disable the limit. (default 1073741824)
+  -usage-tracker.events-storage.writer..producer-max-record-size-bytes int
+    	The maximum size of a Kafka record data that should be generated by the producer. An incoming write request larger than this size is split into multiple Kafka records. We strongly recommend to not change this setting unless for testing purposes. (default 15983616)
+  -usage-tracker.events-storage.writer..sasl-password string
+    	The password used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.
+  -usage-tracker.events-storage.writer..sasl-username string
+    	The username used to authenticate to Kafka using the SASL plain mechanism. To enable SASL, configure both the username and password.
+  -usage-tracker.events-storage.writer..startup-fetch-concurrency int
+    	The number of concurrent fetch requests that the ingester makes when reading data from Kafka during startup. 0 to disable.
+  -usage-tracker.events-storage.writer..target-consumer-lag-at-startup duration
+    	The best-effort maximum lag a consumer tries to achieve at startup. Set both -usage-tracker.events-storage.writer..target-consumer-lag-at-startup and -usage-tracker.events-storage.writer..max-consumer-lag-at-startup to 0 to disable waiting for maximum consumer lag being honored at startup. (default 2s)
+  -usage-tracker.events-storage.writer..topic string
+    	The Kafka topic name.
+  -usage-tracker.events-storage.writer..use-compressed-bytes-as-fetch-max-bytes
+    	When enabled, the fetch request MaxBytes field is computed using the compressed size of previous records. When disabled, MaxBytes is computed using uncompressed bytes. Different Kafka implementations interpret MaxBytes differently. (default true)
+  -usage-tracker.events-storage.writer..wait-strong-read-consistency-timeout duration
+    	The maximum allowed for a read requests processed by an ingester to wait until strong read consistency is enforced. 0 to disable the timeout. (default 20s)
+  -usage-tracker.events-storage.writer..write-clients int
+    	The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka. (default 1)
+  -usage-tracker.events-storage.writer..write-timeout duration
+    	How long to wait for an incoming write request to be successfully committed to the Kafka backend. (default 10s)
   -usage-tracker.idle-timeout duration
     	The time after which series are considered idle and not active anymore. Must be greater than 0 and less than 1 hour. (default 20m0s)
   -usage-tracker.partition-ring.consul.hostname string

--- a/development/mimir-ingest-storage/config/mimir.yaml
+++ b/development/mimir-ingest-storage/config/mimir.yaml
@@ -99,6 +99,13 @@ usage_tracker:
   snapshots_storage:
     s3:
       bucket_name: usage-tracker-snapshots
+  events_storage:
+    writer:
+      address: kafka_1:9092
+      topic: usage-tracker-events
+    reader:
+      address: kafka_1:9092
+      topic: usage-tracker-events
 
 limits:
   native_histograms_ingestion_enabled: true

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -468,6 +468,367 @@ usage_tracker:
         # CLI flag: -usage-tracker.partition-ring.multi.mirror-timeout
         [mirror_timeout: <duration> | default = 2s]
 
+  events_storage:
+    writer:
+      # The Kafka backend address.
+      # CLI flag: -usage-tracker.events-storage.writer..address
+      [address: <string> | default = ""]
+
+      # The Kafka topic name.
+      # CLI flag: -usage-tracker.events-storage.writer..topic
+      [topic: <string> | default = ""]
+
+      # The Kafka client ID.
+      # CLI flag: -usage-tracker.events-storage.writer..client-id
+      [client_id: <string> | default = ""]
+
+      # The maximum time allowed to open a connection to a Kafka broker.
+      # CLI flag: -usage-tracker.events-storage.writer..dial-timeout
+      [dial_timeout: <duration> | default = 2s]
+
+      # How long to wait for an incoming write request to be successfully
+      # committed to the Kafka backend.
+      # CLI flag: -usage-tracker.events-storage.writer..write-timeout
+      [write_timeout: <duration> | default = 10s]
+
+      # The number of Kafka clients used by producers. When the configured
+      # number of clients is greater than 1, partitions are sharded among Kafka
+      # clients. A higher number of clients may provide higher write throughput
+      # at the cost of additional Metadata requests pressure to Kafka.
+      # CLI flag: -usage-tracker.events-storage.writer..write-clients
+      [write_clients: <int> | default = 1]
+
+      # The username used to authenticate to Kafka using the SASL plain
+      # mechanism. To enable SASL, configure both the username and password.
+      # CLI flag: -usage-tracker.events-storage.writer..sasl-username
+      [sasl_username: <string> | default = ""]
+
+      # The password used to authenticate to Kafka using the SASL plain
+      # mechanism. To enable SASL, configure both the username and password.
+      # CLI flag: -usage-tracker.events-storage.writer..sasl-password
+      [sasl_password: <string> | default = ""]
+
+      # The consumer group used by the consumer to track the last consumed
+      # offset. The consumer group must be different for each ingester. If the
+      # configured consumer group contains the '<partition>' placeholder, it is
+      # replaced with the actual partition ID owned by the ingester. When empty
+      # (recommended), Mimir uses the ingester instance ID to guarantee
+      # uniqueness.
+      # CLI flag: -usage-tracker.events-storage.writer..consumer-group
+      [consumer_group: <string> | default = ""]
+
+      # How frequently a consumer should commit the consumed offset to Kafka.
+      # The last committed offset is used at startup to continue the consumption
+      # from where it was left.
+      # CLI flag: -usage-tracker.events-storage.writer..consumer-group-offset-commit-interval
+      [consumer_group_offset_commit_interval: <duration> | default = 1s]
+
+      # How frequently to poll the last produced offset, used to enforce strong
+      # read consistency.
+      # CLI flag: -usage-tracker.events-storage.writer..last-produced-offset-poll-interval
+      [last_produced_offset_poll_interval: <duration> | default = 1s]
+
+      # How long to retry a failed request to get the last produced offset.
+      # CLI flag: -usage-tracker.events-storage.writer..last-produced-offset-retry-timeout
+      [last_produced_offset_retry_timeout: <duration> | default = 10s]
+
+      # From which position to start consuming the partition at startup.
+      # Supported options: last-offset, start, end, timestamp.
+      # CLI flag: -usage-tracker.events-storage.writer..consume-from-position-at-startup
+      [consume_from_position_at_startup: <string> | default = "last-offset"]
+
+      # Milliseconds timestamp after which the consumption of the partition
+      # starts at startup. Only applies when consume-from-position-at-startup is
+      # timestamp
+      # CLI flag: -usage-tracker.events-storage.writer..consume-from-timestamp-at-startup
+      [consume_from_timestamp_at_startup: <int> | default = 0]
+
+      # The best-effort maximum lag a consumer tries to achieve at startup. Set
+      # both
+      # -usage-tracker.events-storage.writer..target-consumer-lag-at-startup and
+      # -usage-tracker.events-storage.writer..max-consumer-lag-at-startup to 0
+      # to disable waiting for maximum consumer lag being honored at startup.
+      # CLI flag: -usage-tracker.events-storage.writer..target-consumer-lag-at-startup
+      [target_consumer_lag_at_startup: <duration> | default = 2s]
+
+      # The guaranteed maximum lag before a consumer is considered to have
+      # caught up reading from a partition at startup, becomes ACTIVE in the
+      # hash ring and passes the readiness check. Set both
+      # -usage-tracker.events-storage.writer..target-consumer-lag-at-startup and
+      # -usage-tracker.events-storage.writer..max-consumer-lag-at-startup to 0
+      # to disable waiting for maximum consumer lag being honored at startup.
+      # CLI flag: -usage-tracker.events-storage.writer..max-consumer-lag-at-startup
+      [max_consumer_lag_at_startup: <duration> | default = 15s]
+
+      # Enable auto-creation of Kafka topic if it doesn't exist.
+      # CLI flag: -usage-tracker.events-storage.writer..auto-create-topic-enabled
+      [auto_create_topic_enabled: <boolean> | default = true]
+
+      # When auto-creation of Kafka topic is enabled and this value is positive,
+      # Kafka's num.partitions configuration option is set on Kafka brokers with
+      # this value when Mimir component that uses Kafka starts. This
+      # configuration option specifies the default number of partitions that the
+      # Kafka broker uses for auto-created topics. Note that this is a
+      # Kafka-cluster wide setting, and applies to any auto-created topic. If
+      # the setting of num.partitions fails, Mimir proceeds anyways, but
+      # auto-created topics could have an incorrect number of partitions.
+      # CLI flag: -usage-tracker.events-storage.writer..auto-create-topic-default-partitions
+      [auto_create_topic_default_partitions: <int> | default = 0]
+
+      # The maximum size of a Kafka record data that should be generated by the
+      # producer. An incoming write request larger than this size is split into
+      # multiple Kafka records. We strongly recommend to not change this setting
+      # unless for testing purposes.
+      # CLI flag: -usage-tracker.events-storage.writer..producer-max-record-size-bytes
+      [producer_max_record_size_bytes: <int> | default = 15983616]
+
+      # The maximum size of (uncompressed) buffered and unacknowledged produced
+      # records sent to Kafka. The produce request fails once this limit is
+      # reached. This limit is per Kafka client. 0 to disable the limit.
+      # CLI flag: -usage-tracker.events-storage.writer..producer-max-buffered-bytes
+      [producer_max_buffered_bytes: <int> | default = 1073741824]
+
+      # The maximum allowed for a read requests processed by an ingester to wait
+      # until strong read consistency is enforced. 0 to disable the timeout.
+      # CLI flag: -usage-tracker.events-storage.writer..wait-strong-read-consistency-timeout
+      [wait_strong_read_consistency_timeout: <duration> | default = 20s]
+
+      # The number of concurrent fetch requests that the ingester makes when
+      # reading data from Kafka during startup. 0 to disable.
+      # CLI flag: -usage-tracker.events-storage.writer..startup-fetch-concurrency
+      [startup_fetch_concurrency: <int> | default = 0]
+
+      # The number of concurrent fetch requests that the ingester makes when
+      # reading data continuously from Kafka after startup. Is disabled unless
+      # usage-tracker.events-storage.writer..startup-fetch-concurrency is
+      # greater than 0. 0 to disable.
+      # CLI flag: -usage-tracker.events-storage.writer..ongoing-fetch-concurrency
+      [ongoing_fetch_concurrency: <int> | default = 0]
+
+      # When enabled, the fetch request MaxBytes field is computed using the
+      # compressed size of previous records. When disabled, MaxBytes is computed
+      # using uncompressed bytes. Different Kafka implementations interpret
+      # MaxBytes differently.
+      # CLI flag: -usage-tracker.events-storage.writer..use-compressed-bytes-as-fetch-max-bytes
+      [use_compressed_bytes_as_fetch_max_bytes: <boolean> | default = true]
+
+      # The maximum number of buffered records ready to be processed. This limit
+      # applies to the sum of all inflight requests. Set to 0 to disable the
+      # limit.
+      # CLI flag: -usage-tracker.events-storage.writer..max-buffered-bytes
+      [max_buffered_bytes: <int> | default = 100000000]
+
+      # The maximum number of concurrent ingestion streams to the TSDB head.
+      # Every tenant has their own set of streams. 0 to disable.
+      # CLI flag: -usage-tracker.events-storage.writer..ingestion-concurrency-max
+      [ingestion_concurrency_max: <int> | default = 0]
+
+      # The number of timeseries to batch together before ingesting to the TSDB
+      # head. Only use this setting when
+      # -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.
+      # CLI flag: -usage-tracker.events-storage.writer..ingestion-concurrency-batch-size
+      [ingestion_concurrency_batch_size: <int> | default = 150]
+
+      # The number of batches to prepare and queue to ingest to the TSDB head.
+      # Only use this setting when
+      # -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.
+      # CLI flag: -usage-tracker.events-storage.writer..ingestion-concurrency-queue-capacity
+      [ingestion_concurrency_queue_capacity: <int> | default = 5]
+
+      # The expected number of times to ingest timeseries to the TSDB head after
+      # batching. With fewer flushes, the overhead of splitting up the work is
+      # higher than the benefit of parallelization. Only use this setting when
+      # -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.
+      # CLI flag: -usage-tracker.events-storage.writer..ingestion-concurrency-target-flushes-per-shard
+      [ingestion_concurrency_target_flushes_per_shard: <int> | default = 80]
+
+      # The estimated number of bytes a sample has at time of ingestion. This
+      # value is used to estimate the timeseries without decompressing them.
+      # Only use this setting when
+      # -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.
+      # CLI flag: -usage-tracker.events-storage.writer..ingestion-concurrency-estimated-bytes-per-sample
+      [ingestion_concurrency_estimated_bytes_per_sample: <int> | default = 500]
+
+    reader:
+      # The Kafka backend address.
+      # CLI flag: -usage-tracker.events-storage.reader..address
+      [address: <string> | default = ""]
+
+      # The Kafka topic name.
+      # CLI flag: -usage-tracker.events-storage.reader..topic
+      [topic: <string> | default = ""]
+
+      # The Kafka client ID.
+      # CLI flag: -usage-tracker.events-storage.reader..client-id
+      [client_id: <string> | default = ""]
+
+      # The maximum time allowed to open a connection to a Kafka broker.
+      # CLI flag: -usage-tracker.events-storage.reader..dial-timeout
+      [dial_timeout: <duration> | default = 2s]
+
+      # How long to wait for an incoming write request to be successfully
+      # committed to the Kafka backend.
+      # CLI flag: -usage-tracker.events-storage.reader..write-timeout
+      [write_timeout: <duration> | default = 10s]
+
+      # The number of Kafka clients used by producers. When the configured
+      # number of clients is greater than 1, partitions are sharded among Kafka
+      # clients. A higher number of clients may provide higher write throughput
+      # at the cost of additional Metadata requests pressure to Kafka.
+      # CLI flag: -usage-tracker.events-storage.reader..write-clients
+      [write_clients: <int> | default = 1]
+
+      # The username used to authenticate to Kafka using the SASL plain
+      # mechanism. To enable SASL, configure both the username and password.
+      # CLI flag: -usage-tracker.events-storage.reader..sasl-username
+      [sasl_username: <string> | default = ""]
+
+      # The password used to authenticate to Kafka using the SASL plain
+      # mechanism. To enable SASL, configure both the username and password.
+      # CLI flag: -usage-tracker.events-storage.reader..sasl-password
+      [sasl_password: <string> | default = ""]
+
+      # The consumer group used by the consumer to track the last consumed
+      # offset. The consumer group must be different for each ingester. If the
+      # configured consumer group contains the '<partition>' placeholder, it is
+      # replaced with the actual partition ID owned by the ingester. When empty
+      # (recommended), Mimir uses the ingester instance ID to guarantee
+      # uniqueness.
+      # CLI flag: -usage-tracker.events-storage.reader..consumer-group
+      [consumer_group: <string> | default = ""]
+
+      # How frequently a consumer should commit the consumed offset to Kafka.
+      # The last committed offset is used at startup to continue the consumption
+      # from where it was left.
+      # CLI flag: -usage-tracker.events-storage.reader..consumer-group-offset-commit-interval
+      [consumer_group_offset_commit_interval: <duration> | default = 1s]
+
+      # How frequently to poll the last produced offset, used to enforce strong
+      # read consistency.
+      # CLI flag: -usage-tracker.events-storage.reader..last-produced-offset-poll-interval
+      [last_produced_offset_poll_interval: <duration> | default = 1s]
+
+      # How long to retry a failed request to get the last produced offset.
+      # CLI flag: -usage-tracker.events-storage.reader..last-produced-offset-retry-timeout
+      [last_produced_offset_retry_timeout: <duration> | default = 10s]
+
+      # From which position to start consuming the partition at startup.
+      # Supported options: last-offset, start, end, timestamp.
+      # CLI flag: -usage-tracker.events-storage.reader..consume-from-position-at-startup
+      [consume_from_position_at_startup: <string> | default = "last-offset"]
+
+      # Milliseconds timestamp after which the consumption of the partition
+      # starts at startup. Only applies when consume-from-position-at-startup is
+      # timestamp
+      # CLI flag: -usage-tracker.events-storage.reader..consume-from-timestamp-at-startup
+      [consume_from_timestamp_at_startup: <int> | default = 0]
+
+      # The best-effort maximum lag a consumer tries to achieve at startup. Set
+      # both
+      # -usage-tracker.events-storage.reader..target-consumer-lag-at-startup and
+      # -usage-tracker.events-storage.reader..max-consumer-lag-at-startup to 0
+      # to disable waiting for maximum consumer lag being honored at startup.
+      # CLI flag: -usage-tracker.events-storage.reader..target-consumer-lag-at-startup
+      [target_consumer_lag_at_startup: <duration> | default = 2s]
+
+      # The guaranteed maximum lag before a consumer is considered to have
+      # caught up reading from a partition at startup, becomes ACTIVE in the
+      # hash ring and passes the readiness check. Set both
+      # -usage-tracker.events-storage.reader..target-consumer-lag-at-startup and
+      # -usage-tracker.events-storage.reader..max-consumer-lag-at-startup to 0
+      # to disable waiting for maximum consumer lag being honored at startup.
+      # CLI flag: -usage-tracker.events-storage.reader..max-consumer-lag-at-startup
+      [max_consumer_lag_at_startup: <duration> | default = 15s]
+
+      # Enable auto-creation of Kafka topic if it doesn't exist.
+      # CLI flag: -usage-tracker.events-storage.reader..auto-create-topic-enabled
+      [auto_create_topic_enabled: <boolean> | default = true]
+
+      # When auto-creation of Kafka topic is enabled and this value is positive,
+      # Kafka's num.partitions configuration option is set on Kafka brokers with
+      # this value when Mimir component that uses Kafka starts. This
+      # configuration option specifies the default number of partitions that the
+      # Kafka broker uses for auto-created topics. Note that this is a
+      # Kafka-cluster wide setting, and applies to any auto-created topic. If
+      # the setting of num.partitions fails, Mimir proceeds anyways, but
+      # auto-created topics could have an incorrect number of partitions.
+      # CLI flag: -usage-tracker.events-storage.reader..auto-create-topic-default-partitions
+      [auto_create_topic_default_partitions: <int> | default = 0]
+
+      # The maximum size of a Kafka record data that should be generated by the
+      # producer. An incoming write request larger than this size is split into
+      # multiple Kafka records. We strongly recommend to not change this setting
+      # unless for testing purposes.
+      # CLI flag: -usage-tracker.events-storage.reader..producer-max-record-size-bytes
+      [producer_max_record_size_bytes: <int> | default = 15983616]
+
+      # The maximum size of (uncompressed) buffered and unacknowledged produced
+      # records sent to Kafka. The produce request fails once this limit is
+      # reached. This limit is per Kafka client. 0 to disable the limit.
+      # CLI flag: -usage-tracker.events-storage.reader..producer-max-buffered-bytes
+      [producer_max_buffered_bytes: <int> | default = 1073741824]
+
+      # The maximum allowed for a read requests processed by an ingester to wait
+      # until strong read consistency is enforced. 0 to disable the timeout.
+      # CLI flag: -usage-tracker.events-storage.reader..wait-strong-read-consistency-timeout
+      [wait_strong_read_consistency_timeout: <duration> | default = 20s]
+
+      # The number of concurrent fetch requests that the ingester makes when
+      # reading data from Kafka during startup. 0 to disable.
+      # CLI flag: -usage-tracker.events-storage.reader..startup-fetch-concurrency
+      [startup_fetch_concurrency: <int> | default = 0]
+
+      # The number of concurrent fetch requests that the ingester makes when
+      # reading data continuously from Kafka after startup. Is disabled unless
+      # usage-tracker.events-storage.reader..startup-fetch-concurrency is
+      # greater than 0. 0 to disable.
+      # CLI flag: -usage-tracker.events-storage.reader..ongoing-fetch-concurrency
+      [ongoing_fetch_concurrency: <int> | default = 0]
+
+      # When enabled, the fetch request MaxBytes field is computed using the
+      # compressed size of previous records. When disabled, MaxBytes is computed
+      # using uncompressed bytes. Different Kafka implementations interpret
+      # MaxBytes differently.
+      # CLI flag: -usage-tracker.events-storage.reader..use-compressed-bytes-as-fetch-max-bytes
+      [use_compressed_bytes_as_fetch_max_bytes: <boolean> | default = true]
+
+      # The maximum number of buffered records ready to be processed. This limit
+      # applies to the sum of all inflight requests. Set to 0 to disable the
+      # limit.
+      # CLI flag: -usage-tracker.events-storage.reader..max-buffered-bytes
+      [max_buffered_bytes: <int> | default = 100000000]
+
+      # The maximum number of concurrent ingestion streams to the TSDB head.
+      # Every tenant has their own set of streams. 0 to disable.
+      # CLI flag: -usage-tracker.events-storage.reader..ingestion-concurrency-max
+      [ingestion_concurrency_max: <int> | default = 0]
+
+      # The number of timeseries to batch together before ingesting to the TSDB
+      # head. Only use this setting when
+      # -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.
+      # CLI flag: -usage-tracker.events-storage.reader..ingestion-concurrency-batch-size
+      [ingestion_concurrency_batch_size: <int> | default = 150]
+
+      # The number of batches to prepare and queue to ingest to the TSDB head.
+      # Only use this setting when
+      # -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.
+      # CLI flag: -usage-tracker.events-storage.reader..ingestion-concurrency-queue-capacity
+      [ingestion_concurrency_queue_capacity: <int> | default = 5]
+
+      # The expected number of times to ingest timeseries to the TSDB head after
+      # batching. With fewer flushes, the overhead of splitting up the work is
+      # higher than the benefit of parallelization. Only use this setting when
+      # -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.
+      # CLI flag: -usage-tracker.events-storage.reader..ingestion-concurrency-target-flushes-per-shard
+      [ingestion_concurrency_target_flushes_per_shard: <int> | default = 80]
+
+      # The estimated number of bytes a sample has at time of ingestion. This
+      # value is used to estimate the timeseries without decompressing them.
+      # Only use this setting when
+      # -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.
+      # CLI flag: -usage-tracker.events-storage.reader..ingestion-concurrency-estimated-bytes-per-sample
+      [ingestion_concurrency_estimated_bytes_per_sample: <int> | default = 500]
+
   snapshots_storage:
     # Backend storage to use. Supported backends are: s3, gcs, azure, swift,
     # filesystem.

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -92,7 +92,7 @@ func (b *BlockBuilder) starting(context.Context) (err error) {
 
 	b.kafkaClient, err = ingest.NewKafkaReaderClient(
 		b.cfg.Kafka,
-		ingest.NewKafkaReaderClientMetrics("block-builder", b.register),
+		ingest.NewKafkaReaderClientMetrics(ingest.KafkaReaderMetricsPrefix, "block-builder", b.register),
 		b.logger,
 	)
 	if err != nil {

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -60,7 +60,7 @@ func New(
 func (s *BlockBuilderScheduler) starting(ctx context.Context) error {
 	kc, err := ingest.NewKafkaReaderClient(
 		s.cfg.Kafka,
-		ingest.NewKafkaReaderClientMetrics("block-builder-scheduler", s.register),
+		ingest.NewKafkaReaderClientMetrics(ingest.KafkaReaderMetricsPrefix, "block-builder-scheduler", s.register),
 		s.logger,
 	)
 	if err != nil {

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -307,6 +307,9 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.UsageStats.Validate(); err != nil {
 		return errors.Wrap(err, "invalid usage stats config")
 	}
+	if err := c.UsageTracker.Validate(); err != nil {
+		return errors.Wrap(err, "invalid usage-tracker config")
+	}
 	if err := c.Vault.Validate(); err != nil {
 		return errors.Wrap(err, "invalid vault config")
 	}

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -719,7 +719,7 @@ func (t *Mimir) initQueryFrontendTopicOffsetsReader() (services.Service, error) 
 
 	var err error
 
-	kafkaMetrics := ingest.NewKafkaReaderClientMetrics("query-frontend", t.Registerer)
+	kafkaMetrics := ingest.NewKafkaReaderClientMetrics(ingest.KafkaReaderMetricsPrefix, "query-frontend", t.Registerer)
 	kafkaClient, err := ingest.NewKafkaReaderClient(t.Cfg.IngestStorage.KafkaConfig, kafkaMetrics, util_log.Logger)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -22,9 +22,9 @@ const (
 	consumeFromEnd        = "end"
 	consumeFromTimestamp  = "timestamp"
 
-	kafkaConfigFlagPrefix          = "ingest-storage.kafka"
-	targetConsumerLagAtStartupFlag = kafkaConfigFlagPrefix + ".target-consumer-lag-at-startup"
-	maxConsumerLagAtStartupFlag    = kafkaConfigFlagPrefix + ".max-consumer-lag-at-startup"
+	kafkaConfigFlagPrefix                = "ingest-storage.kafka"
+	targetConsumerLagAtStartupFlagSuffix = ".target-consumer-lag-at-startup"
+	maxConsumerLagAtStartupFlagSuffix    = ".max-consumer-lag-at-startup"
 )
 
 var (
@@ -164,9 +164,9 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.StringVar(&cfg.ConsumeFromPositionAtStartup, prefix+".consume-from-position-at-startup", consumeFromLastOffset, fmt.Sprintf("From which position to start consuming the partition at startup. Supported options: %s.", strings.Join(consumeFromPositionOptions, ", ")))
 	f.Int64Var(&cfg.ConsumeFromTimestampAtStartup, prefix+".consume-from-timestamp-at-startup", 0, fmt.Sprintf("Milliseconds timestamp after which the consumption of the partition starts at startup. Only applies when consume-from-position-at-startup is %s", consumeFromTimestamp))
 
-	howToDisableConsumerLagAtStartup := fmt.Sprintf("Set both -%s and -%s to 0 to disable waiting for maximum consumer lag being honored at startup.", targetConsumerLagAtStartupFlag, maxConsumerLagAtStartupFlag)
-	f.DurationVar(&cfg.TargetConsumerLagAtStartup, targetConsumerLagAtStartupFlag, 2*time.Second, "The best-effort maximum lag a consumer tries to achieve at startup. "+howToDisableConsumerLagAtStartup)
-	f.DurationVar(&cfg.MaxConsumerLagAtStartup, maxConsumerLagAtStartupFlag, 15*time.Second, "The guaranteed maximum lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. "+howToDisableConsumerLagAtStartup)
+	howToDisableConsumerLagAtStartup := fmt.Sprintf("Set both -%s and -%s to 0 to disable waiting for maximum consumer lag being honored at startup.", prefix+targetConsumerLagAtStartupFlagSuffix, prefix+maxConsumerLagAtStartupFlagSuffix)
+	f.DurationVar(&cfg.TargetConsumerLagAtStartup, prefix+targetConsumerLagAtStartupFlagSuffix, 2*time.Second, "The best-effort maximum lag a consumer tries to achieve at startup. "+howToDisableConsumerLagAtStartup)
+	f.DurationVar(&cfg.MaxConsumerLagAtStartup, prefix+maxConsumerLagAtStartupFlagSuffix, 15*time.Second, "The guaranteed maximum lag before a consumer is considered to have caught up reading from a partition at startup, becomes ACTIVE in the hash ring and passes the readiness check. "+howToDisableConsumerLagAtStartup)
 
 	f.BoolVar(&cfg.AutoCreateTopicEnabled, prefix+".auto-create-topic-enabled", true, "Enable auto-creation of Kafka topic if it doesn't exist.")
 	f.IntVar(&cfg.AutoCreateTopicDefaultPartitions, prefix+".auto-create-topic-default-partitions", 0, "When auto-creation of Kafka topic is enabled and this value is positive, Kafka's num.partitions configuration option is set on Kafka brokers with this value when Mimir component that uses Kafka starts. This configuration option specifies the default number of partitions that the Kafka broker uses for auto-created topics. Note that this is a Kafka-cluster wide setting, and applies to any auto-created topic. If the setting of num.partitions fails, Mimir proceeds anyways, but auto-created topics could have an incorrect number of partitions.")

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -1099,7 +1099,7 @@ func newReaderMetrics(partitionID int32, reg prometheus.Registerer, metricsSourc
 		}),
 		strongConsistencyInstrumentation: NewStrongReadConsistencyInstrumentation[struct{}](component, reg),
 		lastConsumedOffset:               lastConsumedOffset,
-		kprom:                            NewKafkaReaderClientMetrics(component, reg),
+		kprom:                            NewKafkaReaderClientMetrics(KafkaReaderMetricsPrefix, component, reg),
 		missedRecords: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_ingest_storage_reader_missed_records_total",
 			Help: "The number of offsets that were never consumed by the reader because they weren't fetched.",

--- a/pkg/storage/ingest/reader_client.go
+++ b/pkg/storage/ingest/reader_client.go
@@ -10,6 +10,8 @@ import (
 	"github.com/twmb/franz-go/plugin/kprom"
 )
 
+const KafkaReaderMetricsPrefix = "cortex_ingest_storage_reader"
+
 // NewKafkaReaderClient returns the kgo.Client that should be used by the Reader.
 func NewKafkaReaderClient(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Logger, opts ...kgo.Opt) (*kgo.Client, error) {
 	const fetchMaxBytes = 100_000_000
@@ -36,8 +38,8 @@ func NewKafkaReaderClient(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Lo
 	return client, nil
 }
 
-func NewKafkaReaderClientMetrics(component string, reg prometheus.Registerer) *kprom.Metrics {
-	return kprom.NewMetrics("cortex_ingest_storage_reader",
+func NewKafkaReaderClientMetrics(prefix, component string, reg prometheus.Registerer) *kprom.Metrics {
+	return kprom.NewMetrics(prefix,
 		kprom.Registerer(prometheus.WrapRegistererWith(prometheus.Labels{"component": component}, reg)),
 		// Do not export the client ID, because we use it to specify options to the backend.
 		kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes))

--- a/pkg/usagetracker/tracker.go
+++ b/pkg/usagetracker/tracker.go
@@ -64,6 +64,9 @@ func (c *Config) Validate() error {
 	if err := c.SnapshotsStorage.Validate(); err != nil {
 		return err
 	}
+	if c.IdleTimeout <= 0 || c.IdleTimeout > time.Hour {
+		return fmt.Errorf("invalid usage-tracker idle timeout %q, should be greater than 0 and less than 1 hour", c.IdleTimeout)
+	}
 
 	return nil
 }
@@ -96,10 +99,6 @@ type UsageTracker struct {
 }
 
 func NewUsageTracker(cfg Config, partitionRing *ring.PartitionInstanceRing, overrides *validation.Overrides, logger log.Logger, registerer prometheus.Registerer) (*UsageTracker, error) {
-	if cfg.IdleTimeout <= 0 || cfg.IdleTimeout > time.Hour {
-		return nil, fmt.Errorf("invalid idle timeout %q, should be greater than 0 and less than 1 hour", cfg.IdleTimeout)
-	}
-
 	t := &UsageTracker{
 		cfg:           cfg,
 		partitionRing: partitionRing,

--- a/pkg/usagetracker/tracker.go
+++ b/pkg/usagetracker/tracker.go
@@ -15,20 +15,28 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
+	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
+	"github.com/grafana/mimir/pkg/storage/ingest"
 	"github.com/grafana/mimir/pkg/usagetracker/usagetrackerpb"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
-const SnapshotsStoragePrefix = "usage-tracker-snapshots"
+const (
+	SnapshotsStoragePrefix = "usage-tracker-snapshots"
+
+	eventsKafkaWriterMetricsPrefix = "cortex_usage_tracker_events_writer"
+	eventsKafkaReaderMetricsPrefix = "cortex_usage_tracker_events_reader"
+)
 
 type Config struct {
 	Enabled       bool                `yaml:"enabled"`
 	InstanceRing  InstanceRingConfig  `yaml:"ring"`
 	PartitionRing PartitionRingConfig `yaml:"partition_ring"`
 
-	SnapshotsStorage bucket.Config `yaml:"snapshots_storage"`
+	EventsStorage    EventsStorageConfig `yaml:"events_storage"`
+	SnapshotsStorage bucket.Config       `yaml:"snapshots_storage"`
 
 	IdleTimeout time.Duration `yaml:"idle_timeout"`
 }
@@ -38,9 +46,26 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 
 	c.InstanceRing.RegisterFlags(f, logger)
 	c.PartitionRing.RegisterFlags(f)
+	c.EventsStorage.RegisterFlags(f)
 	c.SnapshotsStorage.RegisterFlagsWithPrefixAndDefaultDirectory("usage-tracker.snapshot-storage.", "usagetrackersnapshots", f)
 
 	f.DurationVar(&c.IdleTimeout, "usage-tracker.idle-timeout", 20*time.Minute, "The time after which series are considered idle and not active anymore. Must be greater than 0 and less than 1 hour.")
+}
+
+func (c *Config) Validate() error {
+	// Skip validation if not enabled.
+	if !c.Enabled {
+		return nil
+	}
+
+	if err := c.EventsStorage.Validate(); err != nil {
+		return err
+	}
+	if err := c.SnapshotsStorage.Validate(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type UsageTracker struct {
@@ -48,15 +73,22 @@ type UsageTracker struct {
 
 	store *trackerStore
 
-	bucket    objstore.InstrumentedBucket
-	overrides *validation.Overrides
-	logger    log.Logger
+	cfg        Config
+	bucket     objstore.InstrumentedBucket
+	overrides  *validation.Overrides
+	logger     log.Logger
+	registerer prometheus.Registerer
 
-	partitionID         int32
+	partitionID int32
+
+	// Partition and instance ring.
 	partitionLifecycler *ring.PartitionInstanceLifecycler
 	partitionRing       *ring.PartitionInstanceRing
+	instanceLifecycler  *ring.BasicLifecycler
 
-	instanceLifecycler *ring.BasicLifecycler
+	// Events storage (Kafka).
+	eventsKafkaWriter *kgo.Client
+	eventsKafkaReader *kgo.Client
 
 	// Dependencies.
 	subservices        *services.Manager
@@ -69,9 +101,11 @@ func NewUsageTracker(cfg Config, partitionRing *ring.PartitionInstanceRing, over
 	}
 
 	t := &UsageTracker{
+		cfg:           cfg,
 		partitionRing: partitionRing,
 		overrides:     overrides,
 		logger:        logger,
+		registerer:    registerer,
 	}
 
 	// Get the partition ID.
@@ -126,6 +160,18 @@ func (t *UsageTracker) start(ctx context.Context) error {
 		return errors.Wrap(err, "unable to start usage-tracker subservices")
 	}
 
+	// Create Kafka writer for events storage.
+	t.eventsKafkaWriter, err = ingest.NewKafkaWriterClient(t.cfg.EventsStorage.Writer, 20, t.logger, prometheus.WrapRegistererWithPrefix(eventsKafkaWriterMetricsPrefix, t.registerer))
+	if err != nil {
+		return errors.Wrap(err, "failed to create Kafka writer client for usage-tracker")
+	}
+
+	// Create Kafka reader for events storage.
+	t.eventsKafkaReader, err = ingest.NewKafkaReaderClient(t.cfg.EventsStorage.Reader, ingest.NewKafkaReaderClientMetrics(eventsKafkaReaderMetricsPrefix, "usage-tracker", t.registerer), t.logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to create Kafka reader client for usage-tracker")
+	}
+
 	return nil
 }
 
@@ -135,6 +181,10 @@ func (t *UsageTracker) stop(_ error) error {
 	if t.subservices != nil {
 		_ = services.StopManagerAndAwaitStopped(context.Background(), t.subservices)
 	}
+
+	// Close Kafka clients.
+	t.eventsKafkaWriter.Close()
+	t.eventsKafkaReader.Close()
 
 	return nil
 }

--- a/pkg/usagetracker/tracker_events.go
+++ b/pkg/usagetracker/tracker_events.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagetracker
+
+import (
+	"flag"
+
+	"github.com/pkg/errors"
+
+	"github.com/grafana/mimir/pkg/storage/ingest"
+)
+
+type EventsStorageConfig struct {
+	Writer ingest.KafkaConfig `yaml:"writer"`
+	Reader ingest.KafkaConfig `yaml:"reader"`
+}
+
+func (c *EventsStorageConfig) RegisterFlags(f *flag.FlagSet) {
+	c.Writer.RegisterFlagsWithPrefix("usage-tracker.events-storage.writer.", f)
+	c.Reader.RegisterFlagsWithPrefix("usage-tracker.events-storage.reader.", f)
+}
+
+func (c *EventsStorageConfig) Validate() error {
+	if err := c.Writer.Validate(); err != nil {
+		return errors.Wrap(err, "Kafka writer")
+	}
+	if err := c.Reader.Validate(); err != nil {
+		return errors.Wrap(err, "Kafka reader")
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### What this PR does

Init usage-tracker Kafka client. There are 2 different configs for writer and reader, because we'll need to address different brokers. The config is inherited by `ingest.KafkaConfig` that contains a bunch of extra stuff we don't need. To productionise the usage-tracker we'll have to decouple the basic Kafka client config from the rest used to configure the ingest storage, but this shouldn't be a blocker for the prototype.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
