### PR TITLE
Allow to configure usage-tracker zone

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -18266,7 +18266,7 @@
         },
         {
           "kind": "block",
-          "name": "ring",
+          "name": "instance_ring",
           "required": false,
           "desc": "",
           "blockEntries": [
@@ -18283,7 +18283,7 @@
                   "desc": "Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi.",
                   "fieldValue": null,
                   "fieldDefaultValue": "memberlist",
-                  "fieldFlag": "usage-tracker.ring.store",
+                  "fieldFlag": "usage-tracker.instance-ring.store",
                   "fieldType": "string"
                 },
                 {
@@ -18293,7 +18293,7 @@
                   "desc": "The prefix for the keys in the store. Should end with a /.",
                   "fieldValue": null,
                   "fieldDefaultValue": "collectors/",
-                  "fieldFlag": "usage-tracker.ring.prefix",
+                  "fieldFlag": "usage-tracker.instance-ring.prefix",
                   "fieldType": "string",
                   "fieldCategory": "advanced"
                 },
@@ -18310,7 +18310,7 @@
                       "desc": "Hostname and port of Consul.",
                       "fieldValue": null,
                       "fieldDefaultValue": "localhost:8500",
-                      "fieldFlag": "usage-tracker.ring.consul.hostname",
+                      "fieldFlag": "usage-tracker.instance-ring.consul.hostname",
                       "fieldType": "string"
                     },
                     {
@@ -18320,7 +18320,7 @@
                       "desc": "ACL Token used to interact with Consul.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.consul.acl-token",
+                      "fieldFlag": "usage-tracker.instance-ring.consul.acl-token",
                       "fieldType": "string",
                       "fieldCategory": "advanced"
                     },
@@ -18331,7 +18331,7 @@
                       "desc": "HTTP timeout when talking to Consul",
                       "fieldValue": null,
                       "fieldDefaultValue": 20000000000,
-                      "fieldFlag": "usage-tracker.ring.consul.client-timeout",
+                      "fieldFlag": "usage-tracker.instance-ring.consul.client-timeout",
                       "fieldType": "duration",
                       "fieldCategory": "advanced"
                     },
@@ -18342,7 +18342,7 @@
                       "desc": "Enable consistent reads to Consul.",
                       "fieldValue": null,
                       "fieldDefaultValue": false,
-                      "fieldFlag": "usage-tracker.ring.consul.consistent-reads",
+                      "fieldFlag": "usage-tracker.instance-ring.consul.consistent-reads",
                       "fieldType": "boolean",
                       "fieldCategory": "advanced"
                     },
@@ -18353,7 +18353,7 @@
                       "desc": "Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit.",
                       "fieldValue": null,
                       "fieldDefaultValue": 1,
-                      "fieldFlag": "usage-tracker.ring.consul.watch-rate-limit",
+                      "fieldFlag": "usage-tracker.instance-ring.consul.watch-rate-limit",
                       "fieldType": "float",
                       "fieldCategory": "advanced"
                     },
@@ -18364,7 +18364,7 @@
                       "desc": "Burst size used in rate limit. Values less than 1 are treated as 1.",
                       "fieldValue": null,
                       "fieldDefaultValue": 1,
-                      "fieldFlag": "usage-tracker.ring.consul.watch-burst-size",
+                      "fieldFlag": "usage-tracker.instance-ring.consul.watch-burst-size",
                       "fieldType": "int",
                       "fieldCategory": "advanced"
                     },
@@ -18375,7 +18375,7 @@
                       "desc": "Maximum duration to wait before retrying a Compare And Swap (CAS) operation.",
                       "fieldValue": null,
                       "fieldDefaultValue": 1000000000,
-                      "fieldFlag": "usage-tracker.ring.consul.cas-retry-delay",
+                      "fieldFlag": "usage-tracker.instance-ring.consul.cas-retry-delay",
                       "fieldType": "duration",
                       "fieldCategory": "advanced"
                     }
@@ -18396,7 +18396,7 @@
                       "desc": "The etcd endpoints to connect to.",
                       "fieldValue": null,
                       "fieldDefaultValue": [],
-                      "fieldFlag": "usage-tracker.ring.etcd.endpoints",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.endpoints",
                       "fieldType": "list of strings"
                     },
                     {
@@ -18406,7 +18406,7 @@
                       "desc": "The dial timeout for the etcd connection.",
                       "fieldValue": null,
                       "fieldDefaultValue": 10000000000,
-                      "fieldFlag": "usage-tracker.ring.etcd.dial-timeout",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.dial-timeout",
                       "fieldType": "duration",
                       "fieldCategory": "advanced"
                     },
@@ -18417,7 +18417,7 @@
                       "desc": "The maximum number of retries to do for failed ops.",
                       "fieldValue": null,
                       "fieldDefaultValue": 10,
-                      "fieldFlag": "usage-tracker.ring.etcd.max-retries",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.max-retries",
                       "fieldType": "int",
                       "fieldCategory": "advanced"
                     },
@@ -18428,7 +18428,7 @@
                       "desc": "Enable TLS.",
                       "fieldValue": null,
                       "fieldDefaultValue": false,
-                      "fieldFlag": "usage-tracker.ring.etcd.tls-enabled",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.tls-enabled",
                       "fieldType": "boolean",
                       "fieldCategory": "advanced"
                     },
@@ -18439,7 +18439,7 @@
                       "desc": "Path to the client certificate, which will be used for authenticating with the server. Also requires the key path to be configured.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.etcd.tls-cert-path",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.tls-cert-path",
                       "fieldType": "string",
                       "fieldCategory": "advanced"
                     },
@@ -18450,7 +18450,7 @@
                       "desc": "Path to the key for the client certificate. Also requires the client certificate to be configured.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.etcd.tls-key-path",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.tls-key-path",
                       "fieldType": "string",
                       "fieldCategory": "advanced"
                     },
@@ -18461,7 +18461,7 @@
                       "desc": "Path to the CA certificates to validate server certificate against. If not set, the host's root CA certificates are used.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.etcd.tls-ca-path",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.tls-ca-path",
                       "fieldType": "string",
                       "fieldCategory": "advanced"
                     },
@@ -18472,7 +18472,7 @@
                       "desc": "Override the expected name on the server certificate.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.etcd.tls-server-name",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.tls-server-name",
                       "fieldType": "string",
                       "fieldCategory": "advanced"
                     },
@@ -18483,7 +18483,7 @@
                       "desc": "Skip validating server certificate.",
                       "fieldValue": null,
                       "fieldDefaultValue": false,
-                      "fieldFlag": "usage-tracker.ring.etcd.tls-insecure-skip-verify",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.tls-insecure-skip-verify",
                       "fieldType": "boolean",
                       "fieldCategory": "advanced"
                     },
@@ -18494,7 +18494,7 @@
                       "desc": "Override the default cipher suite list (separated by commas). Allowed values:\n\nSecure Ciphers:\n- TLS_AES_128_GCM_SHA256\n- TLS_AES_256_GCM_SHA384\n- TLS_CHACHA20_POLY1305_SHA256\n- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA\n- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA\n- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA\n- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA\n- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\n- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\n- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\n- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\n- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\n- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\n\nInsecure Ciphers:\n- TLS_RSA_WITH_RC4_128_SHA\n- TLS_RSA_WITH_3DES_EDE_CBC_SHA\n- TLS_RSA_WITH_AES_128_CBC_SHA\n- TLS_RSA_WITH_AES_256_CBC_SHA\n- TLS_RSA_WITH_AES_128_CBC_SHA256\n- TLS_RSA_WITH_AES_128_GCM_SHA256\n- TLS_RSA_WITH_AES_256_GCM_SHA384\n- TLS_ECDHE_ECDSA_WITH_RC4_128_SHA\n- TLS_ECDHE_RSA_WITH_RC4_128_SHA\n- TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA\n- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256\n- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256\n",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.etcd.tls-cipher-suites",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.tls-cipher-suites",
                       "fieldType": "string",
                       "fieldCategory": "advanced"
                     },
@@ -18505,7 +18505,7 @@
                       "desc": "Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.etcd.tls-min-version",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.tls-min-version",
                       "fieldType": "string",
                       "fieldCategory": "advanced"
                     },
@@ -18516,7 +18516,7 @@
                       "desc": "Etcd username.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.etcd.username",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.username",
                       "fieldType": "string"
                     },
                     {
@@ -18526,7 +18526,7 @@
                       "desc": "Etcd password.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.etcd.password",
+                      "fieldFlag": "usage-tracker.instance-ring.etcd.password",
                       "fieldType": "string"
                     }
                   ],
@@ -18546,7 +18546,7 @@
                       "desc": "Primary backend storage used by multi-client.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.multi.primary",
+                      "fieldFlag": "usage-tracker.instance-ring.multi.primary",
                       "fieldType": "string",
                       "fieldCategory": "advanced"
                     },
@@ -18557,7 +18557,7 @@
                       "desc": "Secondary backend storage used by multi-client.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
-                      "fieldFlag": "usage-tracker.ring.multi.secondary",
+                      "fieldFlag": "usage-tracker.instance-ring.multi.secondary",
                       "fieldType": "string",
                       "fieldCategory": "advanced"
                     },
@@ -18568,7 +18568,7 @@
                       "desc": "Mirror writes to secondary store.",
                       "fieldValue": null,
                       "fieldDefaultValue": false,
-                      "fieldFlag": "usage-tracker.ring.multi.mirror-enabled",
+                      "fieldFlag": "usage-tracker.instance-ring.multi.mirror-enabled",
                       "fieldType": "boolean",
                       "fieldCategory": "advanced"
                     },
@@ -18579,7 +18579,7 @@
                       "desc": "Timeout for storing value to secondary store.",
                       "fieldValue": null,
                       "fieldDefaultValue": 2000000000,
-                      "fieldFlag": "usage-tracker.ring.multi.mirror-timeout",
+                      "fieldFlag": "usage-tracker.instance-ring.multi.mirror-timeout",
                       "fieldType": "duration",
                       "fieldCategory": "advanced"
                     }
@@ -18598,7 +18598,7 @@
               "desc": "Period at which to heartbeat to the ring. 0 = disabled.",
               "fieldValue": null,
               "fieldDefaultValue": 15000000000,
-              "fieldFlag": "usage-tracker.ring.heartbeat-period",
+              "fieldFlag": "usage-tracker.instance-ring.heartbeat-period",
               "fieldType": "duration",
               "fieldCategory": "advanced"
             },
@@ -18609,7 +18609,7 @@
               "desc": "The heartbeat timeout after which usage-trackers are considered unhealthy within the ring.",
               "fieldValue": null,
               "fieldDefaultValue": 60000000000,
-              "fieldFlag": "usage-tracker.ring.heartbeat-timeout",
+              "fieldFlag": "usage-tracker.instance-ring.heartbeat-timeout",
               "fieldType": "duration",
               "fieldCategory": "advanced"
             },
@@ -18620,7 +18620,7 @@
               "desc": "Instance ID to register in the ring.",
               "fieldValue": null,
               "fieldDefaultValue": "\u003chostname\u003e",
-              "fieldFlag": "usage-tracker.ring.instance-id",
+              "fieldFlag": "usage-tracker.instance-ring.instance-id",
               "fieldType": "string",
               "fieldCategory": "advanced"
             },
@@ -18631,7 +18631,7 @@
               "desc": "List of network interface names to look up when finding the instance IP address.",
               "fieldValue": null,
               "fieldDefaultValue": [],
-              "fieldFlag": "usage-tracker.ring.instance-interface-names",
+              "fieldFlag": "usage-tracker.instance-ring.instance-interface-names",
               "fieldType": "list of strings"
             },
             {
@@ -18641,7 +18641,7 @@
               "desc": "Port to advertise in the ring (defaults to -server.grpc-listen-port).",
               "fieldValue": null,
               "fieldDefaultValue": 0,
-              "fieldFlag": "usage-tracker.ring.instance-port",
+              "fieldFlag": "usage-tracker.instance-ring.instance-port",
               "fieldType": "int",
               "fieldCategory": "advanced"
             },
@@ -18652,9 +18652,19 @@
               "desc": "IP address to advertise in the ring. Default is auto-detected.",
               "fieldValue": null,
               "fieldDefaultValue": "",
-              "fieldFlag": "usage-tracker.ring.instance-addr",
+              "fieldFlag": "usage-tracker.instance-ring.instance-addr",
               "fieldType": "string",
               "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "instance_availability_zone",
+              "required": false,
+              "desc": "The availability zone where this instance is running.",
+              "fieldValue": null,
+              "fieldDefaultValue": "",
+              "fieldFlag": "usage-tracker.instance-ring.instance-availability-zone",
+              "fieldType": "string"
             },
             {
               "kind": "field",
@@ -18663,7 +18673,7 @@
               "desc": "Enable using a IPv6 instance address. (default false)",
               "fieldValue": null,
               "fieldDefaultValue": false,
-              "fieldFlag": "usage-tracker.ring.instance-enable-ipv6",
+              "fieldFlag": "usage-tracker.instance-ring.instance-enable-ipv6",
               "fieldType": "boolean",
               "fieldCategory": "advanced"
             }

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3463,6 +3463,74 @@ Usage of ./cmd/mimir/mimir:
     	How long to wait for an incoming write request to be successfully committed to the Kafka backend. (default 10s)
   -usage-tracker.idle-timeout duration
     	The time after which series are considered idle and not active anymore. Must be greater than 0 and less than 1 hour. (default 20m0s)
+  -usage-tracker.instance-ring.consul.acl-token string
+    	ACL Token used to interact with Consul.
+  -usage-tracker.instance-ring.consul.cas-retry-delay duration
+    	Maximum duration to wait before retrying a Compare And Swap (CAS) operation. (default 1s)
+  -usage-tracker.instance-ring.consul.client-timeout duration
+    	HTTP timeout when talking to Consul (default 20s)
+  -usage-tracker.instance-ring.consul.consistent-reads
+    	Enable consistent reads to Consul.
+  -usage-tracker.instance-ring.consul.hostname string
+    	Hostname and port of Consul. (default "localhost:8500")
+  -usage-tracker.instance-ring.consul.watch-burst-size int
+    	Burst size used in rate limit. Values less than 1 are treated as 1. (default 1)
+  -usage-tracker.instance-ring.consul.watch-rate-limit float
+    	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
+  -usage-tracker.instance-ring.etcd.dial-timeout duration
+    	The dial timeout for the etcd connection. (default 10s)
+  -usage-tracker.instance-ring.etcd.endpoints string
+    	The etcd endpoints to connect to.
+  -usage-tracker.instance-ring.etcd.max-retries int
+    	The maximum number of retries to do for failed ops. (default 10)
+  -usage-tracker.instance-ring.etcd.password string
+    	Etcd password.
+  -usage-tracker.instance-ring.etcd.tls-ca-path string
+    	Path to the CA certificates to validate server certificate against. If not set, the host's root CA certificates are used.
+  -usage-tracker.instance-ring.etcd.tls-cert-path string
+    	Path to the client certificate, which will be used for authenticating with the server. Also requires the key path to be configured.
+  -usage-tracker.instance-ring.etcd.tls-cipher-suites string
+    	Override the default cipher suite list (separated by commas).
+  -usage-tracker.instance-ring.etcd.tls-enabled
+    	Enable TLS.
+  -usage-tracker.instance-ring.etcd.tls-insecure-skip-verify
+    	Skip validating server certificate.
+  -usage-tracker.instance-ring.etcd.tls-key-path string
+    	Path to the key for the client certificate. Also requires the client certificate to be configured.
+  -usage-tracker.instance-ring.etcd.tls-min-version string
+    	Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
+  -usage-tracker.instance-ring.etcd.tls-server-name string
+    	Override the expected name on the server certificate.
+  -usage-tracker.instance-ring.etcd.username string
+    	Etcd username.
+  -usage-tracker.instance-ring.heartbeat-period duration
+    	Period at which to heartbeat to the ring. 0 = disabled. (default 15s)
+  -usage-tracker.instance-ring.heartbeat-timeout duration
+    	The heartbeat timeout after which usage-trackers are considered unhealthy within the ring. (default 1m0s)
+  -usage-tracker.instance-ring.instance-addr string
+    	IP address to advertise in the ring. Default is auto-detected.
+  -usage-tracker.instance-ring.instance-availability-zone string
+    	The availability zone where this instance is running.
+  -usage-tracker.instance-ring.instance-enable-ipv6
+    	Enable using a IPv6 instance address. (default false)
+  -usage-tracker.instance-ring.instance-id string
+    	Instance ID to register in the ring. (default "<hostname>")
+  -usage-tracker.instance-ring.instance-interface-names string
+    	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
+  -usage-tracker.instance-ring.instance-port int
+    	Port to advertise in the ring (defaults to -server.grpc-listen-port).
+  -usage-tracker.instance-ring.multi.mirror-enabled
+    	Mirror writes to secondary store.
+  -usage-tracker.instance-ring.multi.mirror-timeout duration
+    	Timeout for storing value to secondary store. (default 2s)
+  -usage-tracker.instance-ring.multi.primary string
+    	Primary backend storage used by multi-client.
+  -usage-tracker.instance-ring.multi.secondary string
+    	Secondary backend storage used by multi-client.
+  -usage-tracker.instance-ring.prefix string
+    	The prefix for the keys in the store. Should end with a /. (default "collectors/")
+  -usage-tracker.instance-ring.store string
+    	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -usage-tracker.partition-ring.consul.acl-token string
     	ACL Token used to interact with Consul.
   -usage-tracker.partition-ring.consul.cas-retry-delay duration
@@ -3514,72 +3582,6 @@ Usage of ./cmd/mimir/mimir:
   -usage-tracker.partition-ring.prefix string
     	The prefix for the keys in the store. Should end with a /. (default "collectors/")
   -usage-tracker.partition-ring.store string
-    	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
-  -usage-tracker.ring.consul.acl-token string
-    	ACL Token used to interact with Consul.
-  -usage-tracker.ring.consul.cas-retry-delay duration
-    	Maximum duration to wait before retrying a Compare And Swap (CAS) operation. (default 1s)
-  -usage-tracker.ring.consul.client-timeout duration
-    	HTTP timeout when talking to Consul (default 20s)
-  -usage-tracker.ring.consul.consistent-reads
-    	Enable consistent reads to Consul.
-  -usage-tracker.ring.consul.hostname string
-    	Hostname and port of Consul. (default "localhost:8500")
-  -usage-tracker.ring.consul.watch-burst-size int
-    	Burst size used in rate limit. Values less than 1 are treated as 1. (default 1)
-  -usage-tracker.ring.consul.watch-rate-limit float
-    	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
-  -usage-tracker.ring.etcd.dial-timeout duration
-    	The dial timeout for the etcd connection. (default 10s)
-  -usage-tracker.ring.etcd.endpoints string
-    	The etcd endpoints to connect to.
-  -usage-tracker.ring.etcd.max-retries int
-    	The maximum number of retries to do for failed ops. (default 10)
-  -usage-tracker.ring.etcd.password string
-    	Etcd password.
-  -usage-tracker.ring.etcd.tls-ca-path string
-    	Path to the CA certificates to validate server certificate against. If not set, the host's root CA certificates are used.
-  -usage-tracker.ring.etcd.tls-cert-path string
-    	Path to the client certificate, which will be used for authenticating with the server. Also requires the key path to be configured.
-  -usage-tracker.ring.etcd.tls-cipher-suites string
-    	Override the default cipher suite list (separated by commas).
-  -usage-tracker.ring.etcd.tls-enabled
-    	Enable TLS.
-  -usage-tracker.ring.etcd.tls-insecure-skip-verify
-    	Skip validating server certificate.
-  -usage-tracker.ring.etcd.tls-key-path string
-    	Path to the key for the client certificate. Also requires the client certificate to be configured.
-  -usage-tracker.ring.etcd.tls-min-version string
-    	Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
-  -usage-tracker.ring.etcd.tls-server-name string
-    	Override the expected name on the server certificate.
-  -usage-tracker.ring.etcd.username string
-    	Etcd username.
-  -usage-tracker.ring.heartbeat-period duration
-    	Period at which to heartbeat to the ring. 0 = disabled. (default 15s)
-  -usage-tracker.ring.heartbeat-timeout duration
-    	The heartbeat timeout after which usage-trackers are considered unhealthy within the ring. (default 1m0s)
-  -usage-tracker.ring.instance-addr string
-    	IP address to advertise in the ring. Default is auto-detected.
-  -usage-tracker.ring.instance-enable-ipv6
-    	Enable using a IPv6 instance address. (default false)
-  -usage-tracker.ring.instance-id string
-    	Instance ID to register in the ring. (default "<hostname>")
-  -usage-tracker.ring.instance-interface-names string
-    	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
-  -usage-tracker.ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.grpc-listen-port).
-  -usage-tracker.ring.multi.mirror-enabled
-    	Mirror writes to secondary store.
-  -usage-tracker.ring.multi.mirror-timeout duration
-    	Timeout for storing value to secondary store. (default 2s)
-  -usage-tracker.ring.multi.primary string
-    	Primary backend storage used by multi-client.
-  -usage-tracker.ring.multi.secondary string
-    	Secondary backend storage used by multi-client.
-  -usage-tracker.ring.prefix string
-    	The prefix for the keys in the store. Should end with a /. (default "collectors/")
-  -usage-tracker.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -usage-tracker.snapshot-storage.azure.account-key string
     	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -987,6 +987,20 @@ Usage of ./cmd/mimir/mimir:
     	How long to wait for an incoming write request to be successfully committed to the Kafka backend. (default 10s)
   -usage-tracker.idle-timeout duration
     	The time after which series are considered idle and not active anymore. Must be greater than 0 and less than 1 hour. (default 20m0s)
+  -usage-tracker.instance-ring.consul.hostname string
+    	Hostname and port of Consul. (default "localhost:8500")
+  -usage-tracker.instance-ring.etcd.endpoints string
+    	The etcd endpoints to connect to.
+  -usage-tracker.instance-ring.etcd.password string
+    	Etcd password.
+  -usage-tracker.instance-ring.etcd.username string
+    	Etcd username.
+  -usage-tracker.instance-ring.instance-availability-zone string
+    	The availability zone where this instance is running.
+  -usage-tracker.instance-ring.instance-interface-names string
+    	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
+  -usage-tracker.instance-ring.store string
+    	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -usage-tracker.partition-ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -usage-tracker.partition-ring.etcd.endpoints string
@@ -996,18 +1010,6 @@ Usage of ./cmd/mimir/mimir:
   -usage-tracker.partition-ring.etcd.username string
     	Etcd username.
   -usage-tracker.partition-ring.store string
-    	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
-  -usage-tracker.ring.consul.hostname string
-    	Hostname and port of Consul. (default "localhost:8500")
-  -usage-tracker.ring.etcd.endpoints string
-    	The etcd endpoints to connect to.
-  -usage-tracker.ring.etcd.password string
-    	Etcd password.
-  -usage-tracker.ring.etcd.username string
-    	Etcd username.
-  -usage-tracker.ring.instance-interface-names string
-    	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
-  -usage-tracker.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -usage-tracker.snapshot-storage.azure.account-key string
     	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.

--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -102,7 +102,7 @@ std.manifestYamlDoc({
     'usage-tracker-zone-b-1': mimirService({
       name: 'usage-tracker-zone-b-1',
       target: 'usage-tracker',
-      publishedHttpPort: 8008,
+      publishedHttpPort: 8009,
       extraArguments: [
         '-usage-tracker.instance-ring.instance-availability-zone=zone-b',
       ],

--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -91,10 +91,21 @@ std.manifestYamlDoc({
   },
 
   usage_tracker:: {
-    'usage-tracker-1': mimirService({
-      name: 'usage-tracker-1',
+    'usage-tracker-zone-a-1': mimirService({
+      name: 'usage-tracker-zone-a-1',
       target: 'usage-tracker',
       publishedHttpPort: 8008,
+      extraArguments: [
+        '-usage-tracker.instance-ring.instance-availability-zone=zone-a',
+      ],
+    }),
+    'usage-tracker-zone-b-1': mimirService({
+      name: 'usage-tracker-zone-b-1',
+      target: 'usage-tracker',
+      publishedHttpPort: 8008,
+      extraArguments: [
+        '-usage-tracker.instance-ring.instance-availability-zone=zone-b',
+      ],
     }),
   },
 

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -430,8 +430,8 @@
     "hostname": "usage-tracker-zone-b-1"
     "image": "mimir"
     "ports":
-      - "8008:8080"
-      - "11008:11008"
+      - "8009:8080"
+      - "11009:11009"
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -375,14 +375,14 @@
       - "8080:8080"
     "volumes":
       - "../common/config:/etc/nginx/templates"
-  "usage-tracker-1":
+  "usage-tracker-zone-a-1":
     "build":
       "context": "."
       "dockerfile": "dev.dockerfile"
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=usage-tracker -activity-tracker.filepath=/activity/usage-tracker-1"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=usage-tracker -activity-tracker.filepath=/activity/usage-tracker-zone-a-1 -usage-tracker.instance-ring.instance-availability-zone=zone-a"
     "depends_on":
       "kafka_1":
         "condition": "service_healthy"
@@ -397,7 +397,37 @@
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=usage-tracker"
-    "hostname": "usage-tracker-1"
+    "hostname": "usage-tracker-zone-a-1"
+    "image": "mimir"
+    "ports":
+      - "8008:8080"
+      - "11008:11008"
+    "volumes":
+      - "./config:/mimir/config"
+      - "./activity:/activity"
+  "usage-tracker-zone-b-1":
+    "build":
+      "context": "."
+      "dockerfile": "dev.dockerfile"
+    "command":
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=usage-tracker -activity-tracker.filepath=/activity/usage-tracker-zone-b-1 -usage-tracker.instance-ring.instance-availability-zone=zone-b"
+    "depends_on":
+      "kafka_1":
+        "condition": "service_healthy"
+      "kafka_2":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
+    "environment":
+      - "JAEGER_AGENT_HOST=jaeger"
+      - "JAEGER_AGENT_PORT=6831"
+      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
+      - "JAEGER_SAMPLER_PARAM=1"
+      - "JAEGER_SAMPLER_TYPE=const"
+      - "JAEGER_TAGS=app=usage-tracker"
+    "hostname": "usage-tracker-zone-b-1"
     "image": "mimir"
     "ports":
       - "8008:8080"

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -359,74 +359,80 @@ usage_tracker:
   # CLI flag: -usage-tracker.enabled
   [enabled: <boolean> | default = false]
 
-  ring:
+  instance_ring:
     # The key-value store used to share the hash ring across multiple instances.
     # When usage-tracker is enabled, this option needs be set on usage-trackers
     # and distributors.
     kvstore:
       # Backend storage to use for the ring. Supported values are: consul, etcd,
       # inmemory, memberlist, multi.
-      # CLI flag: -usage-tracker.ring.store
+      # CLI flag: -usage-tracker.instance-ring.store
       [store: <string> | default = "memberlist"]
 
       # (advanced) The prefix for the keys in the store. Should end with a /.
-      # CLI flag: -usage-tracker.ring.prefix
+      # CLI flag: -usage-tracker.instance-ring.prefix
       [prefix: <string> | default = "collectors/"]
 
       # The consul block configures the consul client.
-      # The CLI flags prefix for this block configuration is: usage-tracker.ring
+      # The CLI flags prefix for this block configuration is:
+      # usage-tracker.instance-ring
       [consul: <consul>]
 
       # The etcd block configures the etcd client.
-      # The CLI flags prefix for this block configuration is: usage-tracker.ring
+      # The CLI flags prefix for this block configuration is:
+      # usage-tracker.instance-ring
       [etcd: <etcd>]
 
       multi:
         # (advanced) Primary backend storage used by multi-client.
-        # CLI flag: -usage-tracker.ring.multi.primary
+        # CLI flag: -usage-tracker.instance-ring.multi.primary
         [primary: <string> | default = ""]
 
         # (advanced) Secondary backend storage used by multi-client.
-        # CLI flag: -usage-tracker.ring.multi.secondary
+        # CLI flag: -usage-tracker.instance-ring.multi.secondary
         [secondary: <string> | default = ""]
 
         # (advanced) Mirror writes to secondary store.
-        # CLI flag: -usage-tracker.ring.multi.mirror-enabled
+        # CLI flag: -usage-tracker.instance-ring.multi.mirror-enabled
         [mirror_enabled: <boolean> | default = false]
 
         # (advanced) Timeout for storing value to secondary store.
-        # CLI flag: -usage-tracker.ring.multi.mirror-timeout
+        # CLI flag: -usage-tracker.instance-ring.multi.mirror-timeout
         [mirror_timeout: <duration> | default = 2s]
 
     # (advanced) Period at which to heartbeat to the ring. 0 = disabled.
-    # CLI flag: -usage-tracker.ring.heartbeat-period
+    # CLI flag: -usage-tracker.instance-ring.heartbeat-period
     [heartbeat_period: <duration> | default = 15s]
 
     # (advanced) The heartbeat timeout after which usage-trackers are considered
     # unhealthy within the ring.
-    # CLI flag: -usage-tracker.ring.heartbeat-timeout
+    # CLI flag: -usage-tracker.instance-ring.heartbeat-timeout
     [heartbeat_timeout: <duration> | default = 1m]
 
     # (advanced) Instance ID to register in the ring.
-    # CLI flag: -usage-tracker.ring.instance-id
+    # CLI flag: -usage-tracker.instance-ring.instance-id
     [instance_id: <string> | default = "<hostname>"]
 
     # List of network interface names to look up when finding the instance IP
     # address.
-    # CLI flag: -usage-tracker.ring.instance-interface-names
+    # CLI flag: -usage-tracker.instance-ring.instance-interface-names
     [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
     # (advanced) Port to advertise in the ring (defaults to
     # -server.grpc-listen-port).
-    # CLI flag: -usage-tracker.ring.instance-port
+    # CLI flag: -usage-tracker.instance-ring.instance-port
     [instance_port: <int> | default = 0]
 
     # (advanced) IP address to advertise in the ring. Default is auto-detected.
-    # CLI flag: -usage-tracker.ring.instance-addr
+    # CLI flag: -usage-tracker.instance-ring.instance-addr
     [instance_addr: <string> | default = ""]
 
+    # The availability zone where this instance is running.
+    # CLI flag: -usage-tracker.instance-ring.instance-availability-zone
+    [instance_availability_zone: <string> | default = ""]
+
     # (advanced) Enable using a IPv6 instance address. (default false)
-    # CLI flag: -usage-tracker.ring.instance-enable-ipv6
+    # CLI flag: -usage-tracker.instance-ring.instance-enable-ipv6
     [instance_enable_ipv6: <boolean> | default = false]
 
   partition_ring:
@@ -3410,8 +3416,8 @@ The `etcd` block configures the etcd client. The supported CLI flags `<prefix>` 
 - `query-scheduler.ring`
 - `ruler.ring`
 - `store-gateway.sharding-ring`
+- `usage-tracker.instance-ring`
 - `usage-tracker.partition-ring`
-- `usage-tracker.ring`
 
 &nbsp;
 
@@ -3517,8 +3523,8 @@ The `consul` block configures the consul client. The supported CLI flags `<prefi
 - `query-scheduler.ring`
 - `ruler.ring`
 - `store-gateway.sharding-ring`
+- `usage-tracker.instance-ring`
 - `usage-tracker.partition-ring`
-- `usage-tracker.ring`
 
 &nbsp;
 

--- a/pkg/usagetracker/tracker.go
+++ b/pkg/usagetracker/tracker.go
@@ -32,7 +32,7 @@ const (
 
 type Config struct {
 	Enabled       bool                `yaml:"enabled"`
-	InstanceRing  InstanceRingConfig  `yaml:"ring"`
+	InstanceRing  InstanceRingConfig  `yaml:"instance_ring"`
 	PartitionRing PartitionRingConfig `yaml:"partition_ring"`
 
 	EventsStorage    EventsStorageConfig `yaml:"events_storage"`


### PR DESCRIPTION
#### What this PR does

In this PR:
- Allow to configure usage-tracker zone
- Rename "ring" to "instance-ring" in the config

Now usage-tracker correctly register the zone in the ring:

![Screenshot 2024-12-05 at 11 42 28](https://github.com/user-attachments/assets/8037ab74-e037-4dd3-a66c-b340a93494ef)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
