### PR TITLE
UsageTracker: store.cleanup() test & refactor

### DIFF
--- a/pkg/usagetracker/tracker_store_test.go
+++ b/pkg/usagetracker/tracker_store_test.go
@@ -333,7 +333,7 @@ func TestTrackerStore_Cleanup_Concurrency(t *testing.T) {
 	}()
 
 	// Wait until we perform 1e3 cleanups and create 1e3 series.
-	for cleanups.Load() < 1e4 || createdSeries.count.Load() < 1e4 {
+	for cleanups.Load() < 1e3 || createdSeries.count.Load() < 1e3 {
 		info := tracker.getOrCreateTenantInfo(tenant)
 		require.LessOrEqual(t, info.series.Load(), uint64(limit))
 		info.release()

--- a/pkg/usagetracker/tracker_store_test.go
+++ b/pkg/usagetracker/tracker_store_test.go
@@ -344,13 +344,11 @@ func TestTrackerStore_Cleanup_Concurrency(t *testing.T) {
 	t.Logf("Total series created: %d, cleanups: %d", createdSeries.count.Load(), cleanups.Load())
 	wg.Wait()
 
-	// Wait two more idle periods, then cleanup.
+	// Wait an idle period then cleanup.
 	now.Add(idleTimeoutSeconds)
-	// First cleanup will mark things to be deleted.
-	tracker.cleanup(time.Unix(now.Load(), 0))
-	// Second cleanup should actually delete them.
 	tracker.cleanup(time.Unix(now.Load(), 0))
 	// Tracker should be empty now.
+	// If it's not, then we did something wrong.
 	require.Empty(t, tracker.tenants)
 	for i := uint8(0); i < shards; i++ {
 		require.Empty(t, tracker.data[i], "shard %d is not empty", i)

--- a/pkg/usagetracker/tracker_store_test.go
+++ b/pkg/usagetracker/tracker_store_test.go
@@ -245,37 +245,6 @@ func TestTrackerStore_Cleanup_OffByOneError(t *testing.T) {
 	require.Equal(t, 1, int(tracker.tenants[testUser1].series.Load()))
 }
 
-//	func TestTrackerStore_Cleanup_Shards(t *testing.T) {
-//		const defaultIdleTimeout = 20 * time.Minute
-//		const testUser1 = "user1"
-//		const testUser2 = "user2"
-//		limits := limiterMock{testUser1: 3}
-//
-//		now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
-//
-//		tracker := newTrackerStore(defaultIdleTimeout, log.NewNopLogger(), limits, noopEvents{})
-//		// Push 2 series, both are accepted.
-//		rejected, err := tracker.trackSeries(context.Background(), testUser1, []uint64{1, 2}, now)
-//		require.NoError(t, err)
-//		require.Empty(t, rejected)
-//
-//		now = now.Add(defaultIdleTimeout * 2)
-//		// First cleanup marks shards for deletion.
-//		tracker.cleanup(now)
-//
-//		now = now.Add(time.Minute)
-//		// Series 2 is pushed again, this makes shard 2 alive.
-//		rejected, err = tracker.trackSeries(context.Background(), testUser1, []uint64{2}, now)
-//		require.NoError(t, err)
-//		require.Empty(t, rejected)
-//
-//		now = now.Add(time.Minute)
-//		// Second cleanup deletes the shard 1 as it didn't get sample in the meantime.
-//		// Shard 2 is not marked for deletion anymore.
-//		tracker.cleanup(now)
-//		require.Empty(t, tracker.data[1])
-//		require.False(t, tracker.data[2][testUser1].markedForDeletion.Load())
-//	}
 func TestTrackerStore_Cleanup_Tenants(t *testing.T) {
 	const defaultIdleTimeout = 20 * time.Minute
 	const testUser1 = "user1"


### PR DESCRIPTION
The whole markForDeletion didn't work well, so I refactored it to track the number of ongoing requests and rely on that being 0 to perform deletions.