### PR TITLE
Fix UsageTrackerClient.TrackSeries() when there are no series to track

### DIFF
--- a/pkg/usagetracker/usagetrackerclient/client.go
+++ b/pkg/usagetracker/usagetrackerclient/client.go
@@ -100,6 +100,11 @@ func (c *UsageTrackerClient) stop(_ error) error {
 }
 
 func (c *UsageTrackerClient) TrackSeries(ctx context.Context, userID string, series []uint64) (_ []uint64, returnErr error) {
+	// Nothing to do if there are no series to track.
+	if len(series) == 0 {
+		return nil, nil
+	}
+
 	var (
 		batchOptions = ring.DoBatchOptions{
 			Cleanup:       nil,


### PR DESCRIPTION
#### What this PR does

I just found out that `ring.DoBatchWithOptions()` hungs if the slice of keys is empty. Ideally we should fix it in dskit, but for now it's faster to add a protection in `UsageTrackerClient.TrackSeries()`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
