### PR TITLE
querier: check size of whole frontend response before sending it

### DIFF
--- a/pkg/querier/worker/frontend_processor.go
+++ b/pkg/querier/worker/frontend_processor.go
@@ -122,10 +122,20 @@ func (fp *frontendProcessor) process(execCtx context.Context, c frontendv1pb.Fro
 			go fp.runRequest(ctx, request.HttpRequest, request.StatsEnabled, time.Duration(request.QueueTimeNanos), func(response *httpgrpc.HTTPResponse, stats *querier_stats.Stats) error {
 				defer inflightQuery.Store(false)
 
-				return c.Send(&frontendv1pb.ClientToFrontend{
+				// Ensure responses that are too big are not retried.
+				msgToFrontend := &frontendv1pb.ClientToFrontend{
 					HttpResponse: response,
 					Stats:        stats,
-				})
+				}
+
+				if msgSize := msgToFrontend.Size(); msgSize >= fp.maxMessageSize {
+					errMsg := fmt.Sprintf("response larger than the max (%d vs %d)", msgSize, fp.maxMessageSize)
+					msgToFrontend.HttpResponse.Code = http.StatusRequestEntityTooLarge
+					msgToFrontend.HttpResponse.Body = []byte(errMsg)
+					level.Error(fp.log).Log("msg", "query response larger than limit", "err", errMsg)
+				}
+
+				return c.Send(msgToFrontend)
 			})
 
 		case frontendv1pb.GET_ID:
@@ -169,17 +179,7 @@ func (fp *frontendProcessor) runRequest(ctx context.Context, request *httpgrpc.H
 		}
 	}
 
-	// Ensure responses that are too big are not retried.
-	if len(response.Body) >= fp.maxMessageSize {
-		errMsg := fmt.Sprintf("response larger than the max (%d vs %d)", len(response.Body), fp.maxMessageSize)
-		response = &httpgrpc.HTTPResponse{
-			Code: http.StatusRequestEntityTooLarge,
-			Body: []byte(errMsg),
-		}
-		level.Error(fp.log).Log("msg", "error processing query", "err", errMsg)
-	}
-
 	if err := sendHTTPResponse(response, stats); err != nil {
-		level.Error(fp.log).Log("msg", "error processing requests", "err", err)
+		level.Error(fp.log).Log("msg", "error sending query response", "err", err)
 	}
 }

--- a/pkg/querier/worker/frontend_processor_test.go
+++ b/pkg/querier/worker/frontend_processor_test.go
@@ -7,11 +7,15 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/test"
@@ -340,63 +344,131 @@ func (m mockHandlerFunc) Handle(ctx context.Context, req *httpgrpc.HTTPRequest) 
 }
 
 func TestFrontendProcessor(t *testing.T) {
-	lis, err := net.Listen("tcp", "localhost:0")
-	require.NoError(t, err)
+	//logger := log.NewNopLogger()
+	logger := log.NewLogfmtLogger(os.Stdout)
 
-	srv := grpc.NewServer()
-
-	receivedResponse := make(chan *httpgrpc.HTTPResponse, 1)
-
-	// Setup mock frontend server
-	mockFrontend := &mockFrontendServer{
-		receiveFunc: func(resp *frontendv1pb.ClientToFrontend) error {
-			receivedResponse <- resp.HttpResponse
-			return nil
+	tests := []struct {
+		name             string
+		customizeConfig  func(*Config)
+		handlerResponse  *httpgrpc.HTTPResponse
+		handlerError     error
+		expectedResponse *httpgrpc.HTTPResponse
+	}{
+		{
+			name: "success case",
+			handlerResponse: &httpgrpc.HTTPResponse{
+				Code: 200,
+				Body: []byte("success"),
+			},
+			expectedResponse: &httpgrpc.HTTPResponse{
+				Code: 200,
+				Body: []byte("success"),
+			},
+		},
+		{
+			name: "response too large",
+			customizeConfig: func(cfg *Config) {
+				cfg.QueryFrontendGRPCClientConfig.MaxSendMsgSize = 100
+			},
+			handlerResponse: &httpgrpc.HTTPResponse{
+				Code: 200,
+				Body: []byte(strings.Repeat("some very large response", 100)),
+			},
+			expectedResponse: &httpgrpc.HTTPResponse{
+				Code: 413,
+				Body: []byte("response larger than the max (2417 vs 100)"),
+			},
+		},
+		{
+			name: "small body but large headers",
+			customizeConfig: func(cfg *Config) {
+				cfg.QueryFrontendGRPCClientConfig.MaxSendMsgSize = 1000
+			},
+			handlerResponse: &httpgrpc.HTTPResponse{
+				Code: 200,
+				Headers: []*httpgrpc.Header{
+					{Key: "Header1", Values: []string{strings.Repeat("x", 500)}},
+				},
+				Body: []byte(strings.Repeat("x", 500)),
+			},
+			expectedResponse: &httpgrpc.HTTPResponse{
+				Code: 413,
+				Headers: []*httpgrpc.Header{
+					{Key: "Header1", Values: []string{strings.Repeat("x", 500)}},
+				},
+				Body: []byte("response larger than the max (1032 vs 1000)"),
+			},
+		},
+		{
+			name:         "handler error",
+			handlerError: fmt.Errorf("handler error"),
+			expectedResponse: &httpgrpc.HTTPResponse{
+				Code: 500,
+				Body: []byte("handler error"),
+			},
 		},
 	}
-	frontendv1pb.RegisterFrontendServer(srv, mockFrontend)
 
-	// Start server
-	go func() {
-		_ = srv.Serve(lis)
-	}()
-	t.Cleanup(srv.Stop)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lis, err := net.Listen("tcp", "localhost:0")
+			require.NoError(t, err)
 
-	// Create client connection
-	ctx := context.Background()
-	conn, err := grpc.NewClient(
-		lis.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, conn.Close())
-	})
+			srv := grpc.NewServer()
 
-	// Create frontend processor
-	mockHandler := mockHandlerFunc(func(ctx context.Context, req *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
-		return &httpgrpc.HTTPResponse{
-			Code: 200,
-			Body: []byte("success"),
-		}, nil
-	})
+			receivedResponse := make(chan *httpgrpc.HTTPResponse, 1)
 
-	cfg := Config{
-		QuerierID:                     "test-querier",
-		QueryFrontendGRPCClientConfig: grpcclient.Config{MaxSendMsgSize: 1024 * 1024},
-	}
+			// Setup mock frontend server
+			mockFrontend := &mockFrontendServer{
+				receiveFunc: func(resp *frontendv1pb.ClientToFrontend) error {
+					receivedResponse <- resp.HttpResponse
+					return nil
+				},
+			}
+			frontendv1pb.RegisterFrontendServer(srv, mockFrontend)
 
-	processor := newFrontendProcessor(cfg, mockHandler, log.NewNopLogger())
+			// Start server
+			go func() {
+				_ = srv.Serve(lis)
+			}()
+			t.Cleanup(srv.Stop)
 
-	// Process queries
-	go processor.processQueriesOnSingleStream(ctx, conn, lis.Addr().String())
+			// Create client connection
+			ctx := context.Background()
+			cfg := Config{}
+			flagext.DefaultValues(&cfg)
+			if tc.customizeConfig != nil {
+				tc.customizeConfig(&cfg)
+			}
 
-	// Wait for response and verify
-	select {
-	case resp := <-receivedResponse:
-		require.Equal(t, 200, int(resp.Code))
-		require.Equal(t, []byte("success"), resp.Body)
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for response")
+			dialOpts, err := cfg.QueryFrontendGRPCClientConfig.DialOption(nil, nil)
+			require.NoError(t, err)
+			dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+			conn, err := grpc.NewClient(lis.Addr().String(), dialOpts...)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, conn.Close())
+			})
+
+			mockHandler := mockHandlerFunc(func(ctx context.Context, req *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
+				if tc.handlerError != nil {
+					return nil, tc.handlerError
+				}
+				return tc.handlerResponse, nil
+			})
+
+			// Create frontend processor
+			processor := newFrontendProcessor(cfg, mockHandler, logger)
+			go processor.processQueriesOnSingleStream(ctx, conn, lis.Addr().String())
+
+			// Wait for response and verify
+			select {
+			case resp := <-receivedResponse:
+				require.Equal(t, *tc.expectedResponse, *resp)
+			case <-time.After(2 * time.Second):
+				t.Fatal("timeout waiting for response")
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Background

Previously we'd check the size only of the body before sending a response to the query-frontend. The reason for this check is so that we don't leave it to the gRPC library. The library returns an error and doesn't tell the server anything. This results in timeouts at the query-frontend.

### Problem

Because we only check the length of the body there are edge cases where the size of the whole response (including stats & headers) exceeds the limit. The gRPC library would still refuse to send the response and the frontend would time out waiting for it.

### Is it really happening?

I discovered this in tests with very small limits. But there are probably realistic cases where this is happening: the body is just below the limit, add stats and headers, and it's over the limit.


### Solution

Check the size of the whole response to the frontend, not just the httpgrpc body.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
