### PR TITLE
ingest: actually export estimated bytes per record

### DIFF
--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -863,6 +863,10 @@ func (r *concurrentFetchers) start(ctx context.Context, startOffset int64, concu
 			// When there isn't a fetch in flight the HWM will never be updated, we will dispatch the next fetchWant even if that means it's above the HWM.
 			dispatchNextWant = wants
 		}
+
+		// Periodically update our estimation, so it's exported as a metric.
+		r.estimatedBytesPerRecord.Store(int64(nextFetch.estimatedBytesPerRecord))
+
 		select {
 		case <-r.done:
 			return


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This atomic is used to export `cortex_ingest_storage_reader_estimated_bytes_per_record`

https://github.com/grafana/mimir/blob/36da907adaf09db95f18c4427760bc6b9f2457b6/pkg/storage/ingest/reader.go#L1112

But until now it was never mutated. This was a bug.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
