### PR TITLE
UsageTracker: decouple tests from implementation

### DIFF
--- a/pkg/usagetracker/tracker_store.go
+++ b/pkg/usagetracker/tracker_store.go
@@ -82,6 +82,17 @@ type tenantInfo struct {
 
 func (t *tenantInfo) release() { t.refs.Dec() }
 
+func (t *trackerStore) seriesCounts() map[string]uint64 {
+	t.tenantsMtx.RLock()
+	defer t.tenantsMtx.RUnlock()
+
+	counts := make(map[string]uint64, len(t.tenants))
+	for tenantID, info := range t.tenants {
+		counts[tenantID] = info.series.Load()
+	}
+	return counts
+}
+
 // trackSeries is used in tests so we can provide custom time.Now() value.
 // trackSeries will modify and reuse the input series slice.
 func (t *trackerStore) trackSeries(ctx context.Context, tenantID string, series []uint64, timeNow time.Time) (rejected []uint64, err error) {

--- a/pkg/usagetracker/tracker_store_bench_test.go
+++ b/pkg/usagetracker/tracker_store_bench_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package usagetracker
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func BenchmarkTrackerStoreTrackSeries(b *testing.B) {
+	for _, totalSeries := range []int{10e6, 100e6} {
+		b.Run(fmt.Sprintf("totalSeries=%dM", totalSeries/1e6), func(b *testing.B) {
+			seriesRefs := make([]uint64, totalSeries)
+			for i := range seriesRefs {
+				seriesRefs[i] = rand.Uint64()
+			}
+			for _, seriesPerRequest := range []int{1_000, 10_000} {
+				b.Run(fmt.Sprintf("seriesPerRequest=%dK", seriesPerRequest/1e3), func(b *testing.B) {
+					for _, tenantsCount := range []int{1, 10, 100, 1000} {
+						if totalSeries/tenantsCount <= seriesPerRequest {
+							b.Skip()
+							// Don't benchmark cases where we just send same series again and again.
+							// This skips 10M series for 1K tenants with 10K series per request.
+							continue
+						}
+						b.Run("tenants="+strconv.Itoa(tenantsCount), func(b *testing.B) {
+							for _, cleanupsEnabled := range []bool{true, false} {
+								b.Run("cleanups="+strconv.FormatBool(cleanupsEnabled), func(b *testing.B) {
+									benckmarkTrackerStoreTrackSeries(b, seriesRefs, seriesPerRequest, tenantsCount, cleanupsEnabled)
+								})
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func benckmarkTrackerStoreTrackSeries(b *testing.B, seriesRefs []uint64, seriesPerRequest, tenantsCount int, cleanupsEnabled bool) {
+	nowSeconds := atomic.NewInt64(0)
+	now := func() time.Time { return time.Unix(nowSeconds.Load(), 0) }
+	t := newTrackerStore(20*time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
+
+	seriesPerTenant := len(seriesRefs) / tenantsCount
+	// Warmup each tenant.
+	tenantRefs := make([]uint64, seriesPerTenant)
+	for tenantID := 0; tenantID < tenantsCount; tenantID++ {
+		// Need to copy series refs to tenantRefs because trackSeries modifies the input slice.
+		copy(tenantRefs, seriesRefs[tenantID*seriesPerTenant:(tenantID+1)*seriesPerTenant])
+		_, err := t.trackSeries(context.Background(), strconv.Itoa(tenantID), tenantRefs, now())
+		require.NoError(b, err)
+	}
+	b.ResetTimer()
+
+	cleanup := make(chan time.Time, 1)
+	wg := &sync.WaitGroup{}
+	if cleanupsEnabled {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for cleanupTime := range cleanup {
+				t.cleanup(cleanupTime)
+			}
+		}()
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		refs := make([]uint64, seriesPerRequest)
+		for pb.Next() {
+			tenantID := rand.Intn(tenantsCount)
+			tenant := strconv.Itoa(tenantID)
+			// Each tenant sends their own series.
+			// They start at tenant*seriesPerTenant plus a rand index up to seriesPerTenant-seriesPerRequest (to avoid out of bounds).
+			refsStart := tenantID*seriesPerTenant + rand.Intn(seriesPerTenant-seriesPerRequest)
+			// Copy refs because trackSeries modifies them.
+			copy(refs, seriesRefs[refsStart:refsStart+seriesPerRequest])
+			_, err := t.trackSeries(context.Background(), tenant, refs, now())
+			require.NoError(b, err)
+			if cleanupsEnabled {
+				if seconds := nowSeconds.Inc(); seconds%60 == 0 {
+					select {
+					// Don't block to avoid slowing down the benchmark.
+					// We want to measure how long trackSeries() takes with cleanups, not how long cleanups take.
+					case cleanup <- time.Unix(seconds, 0):
+					default:
+					}
+				}
+			}
+		}
+	})
+	close(cleanup)
+	wg.Wait()
+}

--- a/pkg/usagetracker/tracker_store_snapshot.go
+++ b/pkg/usagetracker/tracker_store_snapshot.go
@@ -128,7 +128,14 @@ func (shard *tenantShard) loadSnapshot(snapshot *encoding.Decbuf, totalTenantSer
 
 	for i := 0; i < seriesLen; i++ {
 		s := snapshot.Be64()
+		if err := snapshot.Err(); err != nil {
+			return fmt.Errorf("failed to read series ref %d: %w", i, err)
+		}
+
 		snapshotTs := minutes(snapshot.Byte())
+		if err := snapshot.Err(); err != nil {
+			return fmt.Errorf("failed to read series timestamp %d: %w", i, err)
+		}
 		if expirationWatermark.greaterThan(snapshotTs) {
 			// We're not interested in this series, it was about to be evicted.
 			continue


### PR DESCRIPTION
This decouples trackerStore tests from the specific implementation by using a new seriesCounts() method and by decoding the snapshots rather than accessing to the data maps.

This will allow us to switch the implementation while keeping the same tests.

Also added `BenchmarkTrackerStoreTrackSeries` to compare future implementations to the current one.