### PR TITLE
UsageTracker: use custom swiss map & channels

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -19019,6 +19019,16 @@
           "desc": "",
           "blockEntries": [
             {
+              "kind": "field",
+              "name": "topic_name",
+              "required": false,
+              "desc": "Kafka topic name for usage tracker events",
+              "fieldValue": null,
+              "fieldDefaultValue": "usage-tracker-events-storage",
+              "fieldFlag": "usage-tracker.events-storage.topic-name",
+              "fieldType": "string"
+            },
+            {
               "kind": "block",
               "name": "writer",
               "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3409,6 +3409,8 @@ Usage of ./cmd/mimir/mimir:
     	The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka. (default 1)
   -usage-tracker.events-storage.reader.write-timeout duration
     	How long to wait for an incoming write request to be successfully committed to the Kafka backend. (default 10s)
+  -usage-tracker.events-storage.topic-name string
+    	Kafka topic name for usage tracker events (default "usage-tracker-events-storage")
   -usage-tracker.events-storage.writer.address string
     	The Kafka backend address.
   -usage-tracker.events-storage.writer.auto-create-topic-default-partitions int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -933,6 +933,8 @@ Usage of ./cmd/mimir/mimir:
     	The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka. (default 1)
   -usage-tracker.events-storage.reader.write-timeout duration
     	How long to wait for an incoming write request to be successfully committed to the Kafka backend. (default 10s)
+  -usage-tracker.events-storage.topic-name string
+    	Kafka topic name for usage tracker events (default "usage-tracker-events-storage")
   -usage-tracker.events-storage.writer.address string
     	The Kafka backend address.
   -usage-tracker.events-storage.writer.auto-create-topic-default-partitions int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -475,6 +475,10 @@ usage_tracker:
         [mirror_timeout: <duration> | default = 2s]
 
   events_storage:
+    # Kafka topic name for usage tracker events
+    # CLI flag: -usage-tracker.events-storage.topic-name
+    [topic_name: <string> | default = "usage-tracker-events-storage"]
+
     writer:
       # The Kafka backend address.
       # CLI flag: -usage-tracker.events-storage.writer.address

--- a/pkg/usagetracker/tenantshard/event.go
+++ b/pkg/usagetracker/tenantshard/event.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package tenantshard
+
+import (
+	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/usagetracker/clock"
+)
+
+type EventType uint8
+
+const (
+	TrackSeries EventType = iota
+	Load
+	Clone
+	Cleanup
+	Shutdown
+)
+
+type Event struct {
+	Type EventType
+
+	// Series is sent in all events.
+	Series *atomic.Uint64
+
+	// Limit is sent in TrackSeries event, it could be math.MaxUint64.
+	Limit uint64
+
+	// Refs is sent in TrackSeries event.
+	Refs []uint64
+
+	// Value is sent in TrackSeries event.
+	Value clock.Minutes
+
+	// LoadRefs is sent in Load event.
+	// TODO: we could optimize allocations making this a slice of ref/ts pairs.
+	LoadRefs map[uint64]clock.Minutes
+
+	// Watermark is sent in Cleanup event.
+	Watermark clock.Minutes
+
+	// Created is sent in TrackSeries event.
+	Created chan []uint64
+	// Rejected is sent in TrackSeries event.
+	Rejected chan []uint64
+
+	// Cloner is sent in Clone event.
+	// The received function will call LengthCallback first, and then IteratorCallback for each one of the series.
+	Cloner chan<- func(LengthCallback, IteratorCallback)
+
+	// Done is sent in Cleanup event.
+	Done chan struct{}
+}
+
+// Events returns the event channel for the map where the events can be sent.
+func (m *Map) Events() chan<- Event { return m.events }
+
+func (m *Map) worker() {
+	for ev := range m.events {
+		switch ev.Type {
+		case TrackSeries:
+			var createdRefs []uint64
+			var rejectedRefs []uint64
+			for _, ref := range ev.Refs {
+				if created, rejected := m.put(ref, ev.Value, ev.Series, ev.Limit, true); created {
+					createdRefs = append(createdRefs, ref)
+				} else if rejected {
+					rejectedRefs = append(rejectedRefs, ref)
+				}
+			}
+			ev.Created <- createdRefs
+			ev.Rejected <- rejectedRefs
+			// TODO: we could use this idle time to resize even larger.
+
+		case Load:
+			for ref, v := range ev.LoadRefs {
+				m.put(ref, v, ev.Series, 0, false)
+			}
+			ev.Done <- struct{}{}
+
+		case Clone:
+			ev.Cloner <- m.cloner()
+
+		case Cleanup:
+			m.cleanup(ev.Watermark, ev.Series)
+			if m.dead > m.limit/2 {
+				m.rehash(m.nextSize())
+			}
+			ev.Done <- struct{}{}
+
+		case Shutdown:
+			return
+		}
+	}
+}

--- a/pkg/usagetracker/tenantshard/event.go
+++ b/pkg/usagetracker/tenantshard/event.go
@@ -8,50 +8,107 @@ import (
 	"github.com/grafana/mimir/pkg/usagetracker/clock"
 )
 
-type EventType uint8
+func Track(refs []uint64, value clock.Minutes, series *atomic.Uint64, limit uint64, resp chan TrackResponse) Event {
+	return Event{
+		typ:           track,
+		series:        series,
+		limit:         limit,
+		refs:          refs,
+		timestamp:     value,
+		trackResponse: resp,
+	}
+}
+
+func Create(refs []uint64, ts clock.Minutes, series *atomic.Uint64, done chan struct{}) Event {
+	return Event{
+		typ:       create,
+		series:    series,
+		refs:      refs,
+		timestamp: ts,
+		done:      done,
+	}
+}
+
+func Load(refs []RefTimestamp, series *atomic.Uint64, done chan struct{}) Event {
+	return Event{
+		typ:      load,
+		series:   series,
+		loadRefs: refs,
+		done:     done,
+	}
+}
+
+func Clone(cloner chan<- func(LengthCallback, IteratorCallback)) Event {
+	return Event{
+		typ:    clone,
+		cloner: cloner,
+	}
+}
+
+func Cleanup(watermark clock.Minutes, series *atomic.Uint64, done chan struct{}) Event {
+	return Event{
+		typ:       cleanup,
+		series:    series,
+		watermark: watermark,
+		done:      done,
+	}
+}
+
+func Shutdown() Event {
+	return Event{
+		typ: shutdown,
+	}
+}
+
+type RefTimestamp struct {
+	Ref       uint64
+	Timestamp clock.Minutes
+}
+
+type eventType uint8
 
 const (
-	TrackSeries EventType = iota
-	Load
-	Clone
-	Cleanup
-	Shutdown
+	track eventType = iota
+	create
+	load
+	clone
+	cleanup
+	shutdown
 )
 
 type Event struct {
-	Type EventType
+	typ eventType
 
-	// Series is sent in all events.
-	Series *atomic.Uint64
+	// Series is sent Track, Load and Cleanup.
+	series *atomic.Uint64
 
-	// Limit is sent in TrackSeries event, it could be math.MaxUint64.
-	Limit uint64
+	// Limit is sent in Track event, it could be math.MaxUint64.
+	limit uint64
 
-	// Refs is sent in TrackSeries event.
-	Refs []uint64
+	// Refs is sent in Track and Create events.
+	refs []uint64
 
-	// Value is sent in TrackSeries event.
-	Value clock.Minutes
+	// Timestamp is sent in Track and Create events.
+	timestamp clock.Minutes
 
 	// LoadRefs is sent in Load event.
-	// TODO: we could optimize allocations making this a slice of ref/ts pairs.
-	LoadRefs map[uint64]clock.Minutes
+	loadRefs []RefTimestamp
 
 	// Watermark is sent in Cleanup event.
-	Watermark clock.Minutes
+	watermark clock.Minutes
 
-	// TrackSeriesResponse is sent in TrackSeries event.
-	TrackSeriesResponse chan TrackSeriesResponse
+	// TrackResponse is sent in Track event.
+	trackResponse chan TrackResponse
 
 	// Cloner is sent in Clone event.
 	// The received function will call LengthCallback first, and then IteratorCallback for each one of the series.
-	Cloner chan<- func(LengthCallback, IteratorCallback)
+	cloner chan<- func(LengthCallback, IteratorCallback)
 
 	// Done is sent in Cleanup event.
-	Done chan struct{}
+	done chan struct{}
 }
 
-type TrackSeriesResponse struct {
+type TrackResponse struct {
 	Created  []uint64
 	Rejected []uint64
 }
@@ -61,36 +118,42 @@ func (m *Map) Events() chan<- Event { return m.events }
 
 func (m *Map) worker() {
 	for ev := range m.events {
-		switch ev.Type {
-		case TrackSeries:
-			var resp TrackSeriesResponse
-			for _, ref := range ev.Refs {
-				if created, rejected := m.put(ref, ev.Value, ev.Series, ev.Limit, true); created {
+		switch ev.typ {
+		case track:
+			var resp TrackResponse
+			for _, ref := range ev.refs {
+				if created, rejected := m.put(ref, ev.timestamp, ev.series, ev.limit, true); created {
 					resp.Created = append(resp.Created, ref)
 				} else if rejected {
 					resp.Rejected = append(resp.Rejected, ref)
 				}
 			}
-			ev.TrackSeriesResponse <- resp
+			ev.trackResponse <- resp
 			// TODO: we could use this idle time to resize even larger.
 
-		case Load:
-			for ref, v := range ev.LoadRefs {
-				m.put(ref, v, ev.Series, 0, false)
+		case create:
+			for _, ref := range ev.refs {
+				m.put(ref, ev.timestamp, ev.series, 0, false)
 			}
-			ev.Done <- struct{}{}
+			ev.done <- struct{}{}
 
-		case Clone:
-			ev.Cloner <- m.cloner()
+		case load:
+			for _, entry := range ev.loadRefs {
+				m.put(entry.Ref, entry.Timestamp, ev.series, 0, false)
+			}
+			ev.done <- struct{}{}
 
-		case Cleanup:
-			m.cleanup(ev.Watermark, ev.Series)
+		case clone:
+			ev.cloner <- m.cloner()
+
+		case cleanup:
+			m.cleanup(ev.watermark, ev.series)
 			if m.dead > m.limit/2 {
 				m.rehash(m.nextSize())
 			}
-			ev.Done <- struct{}{}
+			ev.done <- struct{}{}
 
-		case Shutdown:
+		case shutdown:
 			return
 		}
 	}

--- a/pkg/usagetracker/tenantshard/map.go
+++ b/pkg/usagetracker/tenantshard/map.go
@@ -6,6 +6,7 @@
 package tenantshard
 
 import (
+	"math"
 	"slices"
 
 	"go.uber.org/atomic"
@@ -14,13 +15,11 @@ import (
 )
 
 const (
-	valueBits = 7
-	valueMask = Shards - 1
+	valueBits        = 7
+	valueMask        = Shards - 1
+	keyMask   uint64 = uint64(math.MaxUint64) &^ valueMask
 
 	Shards = 1 << valueBits
-
-	// TODO: ? keyMask          = math.MaxUint64 & ^ valueMask
-	keyMask uint64 = 0xffff_ffff_ffff_ff80
 )
 
 // Map is an open-addressing hash map based on Abseil's flat_hash_map.

--- a/pkg/usagetracker/tenantshard/map.go
+++ b/pkg/usagetracker/tenantshard/map.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/dolthub/swiss/blob/master/map.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: Dolthub, Inc.
+
+package tenantshard
+
+import (
+	"slices"
+
+	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/usagetracker/clock"
+)
+
+const (
+	valueBits = 7
+	valueMask = Shards - 1
+
+	Shards = 1 << valueBits
+
+	// TODO: ? keyMask          = math.MaxUint64 & ^ valueMask
+	keyMask uint64 = 0xffff_ffff_ffff_ff80
+)
+
+// Map is an open-addressing hash map based on Abseil's flat_hash_map.
+type Map struct {
+	shard uint8
+
+	index []index
+	data  []data
+
+	events chan Event
+	empty  chan struct{}
+
+	resident uint32
+	dead     uint32
+	limit    uint32
+}
+
+// index is the prefix index array for data.
+// find operations first probe the index bytes
+// to filter candidates before matching data entries.
+type index [groupSize]prefix
+
+// data is a group of groupSize data/value entries.
+// Each entry is the keyMasked key and valueMasked value.
+type data [groupSize]uint64
+
+const (
+	prefixOffset        = 2
+	empty        prefix = 0b0000_0000
+	tombstone    prefix = 0b0000_0001
+)
+
+type prefix uint8
+type suffix uint64
+
+// New constructs a Map.
+func New(sz uint32, shard uint8) (m *Map) {
+	if shard >= Shards {
+		panic("shard out of bounds")
+	}
+
+	groups := numGroups(sz)
+	m = &Map{
+		shard: shard,
+
+		index: make([]index, groups),
+		data:  make([]data, groups),
+
+		events: make(chan Event),
+
+		limit: groups * maxAvgGroupLoad,
+	}
+	go m.worker()
+	return
+}
+
+func (m *Map) wrongShard(key uint64) bool {
+	return uint8(key&valueMask) != m.shard
+}
+
+// Put inserts |key| and |value| into the map.
+// Series is incremented if it's not nil and it's below limit, unless track is false.
+// If track is false, then the value is only updated if it's greater than the current value.
+func (m *Map) put(key uint64, value clock.Minutes, series *atomic.Uint64, limit uint64, track bool) (created, rejected bool) {
+	if m.resident >= m.limit {
+		m.rehash(m.nextSize())
+	}
+
+	masked := key & keyMask
+	pfx, sfx := splitHash(key)
+	i := probeStart(sfx, len(m.index))
+	for { // inlined find loop
+		matches := metaMatchH2(&m.index[i], pfx)
+		for matches != 0 {
+			j := nextMatch(&matches)
+			if masked == m.data[i][j]&keyMask { // found
+				// Always update the value if we're tracking series, but only increment it when processing Load events.
+				if track || value.GreaterThan(clock.Minutes(m.data[i][j]&valueMask^valueMask)) {
+					m.data[i][j] = masked | uint64(value&valueMask^valueMask)
+				}
+				return false, false
+			}
+		}
+		// |key| is not in group |i|,
+		// stop probing if we see an empty slot
+		matches = metaMatchEmpty(&m.index[i])
+		if matches != 0 { // insert
+			// Only check limit if we're tracking series.
+			// We don't check limit for Load events.
+			if series != nil {
+				if track && series.Load() >= limit {
+					return false, true // reject
+				}
+				series.Inc()
+			}
+			s := nextMatch(&matches)
+			m.index[i][s] = pfx
+			m.data[i][s] = masked | uint64(value&valueMask^valueMask)
+			m.resident++
+			return true, false
+		}
+		i += 1 // linear probing
+		if i >= uint32(len(m.index)) {
+			i = 0
+		}
+	}
+}
+
+// Count returns the number of elements in the Map.
+// LockKeys or Lock must be held when performing this operation.
+func (m *Map) count() int {
+	return int(m.resident - m.dead)
+}
+
+func (m *Map) cleanup(watermark clock.Minutes, series *atomic.Uint64) {
+	for i := range m.data {
+		for j, v := range m.data[i] {
+			raw := v & valueMask
+			if raw == 0 {
+				// There's nothing here.
+				continue
+			}
+			val := clock.Minutes(raw ^ valueMask)
+			if watermark.GreaterOrEqualThan(val) {
+				m.index[i][j] = tombstone
+				m.data[i][j] = 0
+				m.dead++
+				series.Dec()
+			}
+		}
+	}
+}
+
+func (m *Map) nextSize() (n uint32) {
+	n = uint32(len(m.index)) * 2
+	if m.dead >= (m.resident / 2) {
+		n = uint32(len(m.index))
+	}
+	return
+}
+
+func (m *Map) rehash(n uint32) {
+	datas, indices := m.data, m.index
+	m.data = make([]data, n)
+	m.index = make([]index, n)
+	m.limit = n * maxAvgGroupLoad
+	m.resident, m.dead = 0, 0
+	for g := range indices {
+		for s := range indices[g] {
+			c := indices[g][s]
+			if c == empty || c == tombstone {
+				continue
+			}
+			// We don't need to mask the key here, data suffix of the key is always masked out.
+			m.put(datas[g][s], clock.Minutes(datas[g][s]&valueMask^valueMask), nil, 0, false)
+		}
+	}
+}
+
+func (m *Map) loadFactor() float32 {
+	slots := float32(len(m.index) * groupSize)
+	return float32(m.resident-m.dead) / slots
+}
+
+// numGroups returns the minimum number of groups needed to store |n| elems.
+func numGroups(n uint32) (groups uint32) {
+	groups = (n + maxAvgGroupLoad - 1) / maxAvgGroupLoad
+	if groups == 0 {
+		groups = 1
+	}
+	return
+}
+
+// splitHash extracts the prefix and suffix components from a 64 bit hash.
+// prefix is the upper 7 bits plus two, suffix is the lower 57 bits.
+// By adding 2 to the prefix, it ensures that prefix is never uint8(0) or uint8(1).
+func splitHash(h uint64) (prefix, suffix) {
+	return prefix(h>>(64-valueBits)) + prefixOffset, suffix(h << valueBits >> valueBits)
+}
+
+func probeStart(s suffix, groups int) uint32 {
+	// ignore the first |valueBits| bits for probing.
+	// We're going to convert it to uint32 anyway, so we don't really care.
+	return fastModN(uint32(s>>valueBits), uint32(groups))
+}
+
+// lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+func fastModN(x, n uint32) uint32 {
+	return uint32((uint64(x) * uint64(n)) >> 32)
+}
+
+type LengthCallback func(int)
+
+type IteratorCallback func(k uint64, v clock.Minutes)
+
+func (m *Map) cloner() func(LengthCallback, IteratorCallback) {
+	shard := m.shard
+	clone := slices.Clone(m.data)
+	count := m.count()
+
+	return func(length LengthCallback, iterSeries IteratorCallback) {
+		length(count)
+
+		for _, g := range clone {
+			for _, v := range g {
+				raw := v & valueMask
+				if raw == 0 {
+					// TODO: document somewhwere that we can't store 127 as a value.
+					// There's nothing here.
+					continue
+				}
+				key := (v &^ valueMask) | uint64(shard)
+				val := clock.Minutes(raw ^ valueMask)
+				iterSeries(key, val)
+			}
+		}
+	}
+}

--- a/pkg/usagetracker/tenantshard/map_nonsimd.go
+++ b/pkg/usagetracker/tenantshard/map_nonsimd.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/dolthub/swiss/blob/master/bits.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: Dolthub, Inc.
+
+package tenantshard
+
+import (
+	"math/bits"
+	"unsafe"
+)
+
+const (
+	groupSize       = 8
+	maxAvgGroupLoad = 7
+
+	loBits uint64 = 0x0101010101010101
+	hiBits uint64 = 0x8080808080808080
+)
+
+type bitset uint64
+
+func metaMatchH2(m *index, p prefix) bitset {
+	// https://graphics.stanford.edu/~seander/bithacks.html##ValueInWord
+	return hasZeroByte(castUint64(m) ^ (loBits * uint64(p)))
+}
+
+func metaMatchEmpty(m *index) bitset {
+	return hasZeroByte(castUint64(m))
+}
+
+func nextMatch(b *bitset) uint32 {
+	s := uint32(bits.TrailingZeros64(uint64(*b)))
+	*b &= ^(1 << s) // clear bit |s|
+	return s >> 3   // div by 8
+}
+
+func hasZeroByte(x uint64) bitset {
+	return bitset(((x - loBits) & ^(x)) & hiBits)
+}
+
+func castUint64(m *index) uint64 {
+	return *(*uint64)((unsafe.Pointer)(m))
+}

--- a/pkg/usagetracker/tenantshard/map_test.go
+++ b/pkg/usagetracker/tenantshard/map_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package tenantshard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/usagetracker/clock"
+)
+
+func TestMap(t *testing.T) {
+	series := atomic.NewUint64(0)
+	const events = 5
+	const seriesPerEvent = 5
+	limit := uint64(events * seriesPerEvent)
+
+	// Start small, let rehashing happen.
+	m := New(seriesPerEvent, 0)
+
+	storedValues := map[uint64]clock.Minutes{}
+	for i := 1; i <= events; i++ {
+		refs := make([]uint64, seriesPerEvent)
+		for j := range refs {
+			refs[j] = uint64((i*100 + j) << valueBits)
+			storedValues[refs[j]] = clock.Minutes(i)
+		}
+
+		createdResp := make(chan []uint64)
+		rejectedResp := make(chan []uint64)
+		m.Events() <- Event{
+			Type:     TrackSeries,
+			Refs:     refs,
+			Value:    clock.Minutes(i),
+			Limit:    limit,
+			Series:   series,
+			Rejected: rejectedResp,
+		}
+		created := <-createdResp
+		rejected := <-rejectedResp
+
+		require.Len(t, created, seriesPerEvent, "iteration %d", i)
+		require.Empty(t, rejected, "iteration %d", i)
+	}
+
+	require.Equal(t, events*seriesPerEvent, m.count())
+	require.Equal(t, uint64(events*seriesPerEvent), series.Load())
+
+	{
+		// No more series will fit.
+		createdResp := make(chan []uint64)
+		rejectedResp := make(chan []uint64)
+		ref := uint64(65535) << valueBits
+		m.Events() <- Event{
+			Type:     TrackSeries,
+			Refs:     []uint64{ref},
+			Value:    clock.Minutes(0),
+			Limit:    limit,
+			Series:   series,
+			Rejected: rejectedResp,
+		}
+		created := <-createdResp
+		require.Empty(t, created)
+		rejected := <-rejectedResp
+		require.Equal(t, []uint64{ref}, rejected)
+	}
+
+	{
+		gotValues := map[uint64]clock.Minutes{}
+		resp := make(chan func(LengthCallback, IteratorCallback))
+		m.Events() <- Event{
+			Type:   Clone,
+			Cloner: resp,
+		}
+		iterator := <-resp
+		count := 0
+		iterator(
+			func(c int) {
+				count = c
+			},
+			func(key uint64, value clock.Minutes) {
+				gotValues[key] = value
+			},
+		)
+		require.Equal(t, len(storedValues), count)
+		require.Equal(t, storedValues, gotValues)
+	}
+
+	{
+		// Cleanup first wave of series
+		resp := make(chan struct{})
+		m.Events() <- Event{
+			Type:      Cleanup,
+			Watermark: clock.Minutes(2),
+			Series:    series,
+			Done:      resp,
+		}
+		<-resp
+
+		expectedSeries := (events - 1) * seriesPerEvent
+
+		// It's unsafe to check m.count() after Cleanup event.
+		require.Equal(t, expectedSeries, int(series.Load()))
+	}
+
+}

--- a/pkg/usagetracker/tenantshard/map_test.go
+++ b/pkg/usagetracker/tenantshard/map_test.go
@@ -36,7 +36,7 @@ func TestMap(t *testing.T) {
 			Value:    clock.Minutes(i),
 			Limit:    limit,
 			Series:   series,
-			Created: createdResp,
+			Created:  createdResp,
 			Rejected: rejectedResp,
 		}
 		created := <-createdResp
@@ -60,7 +60,7 @@ func TestMap(t *testing.T) {
 			Value:    clock.Minutes(0),
 			Limit:    limit,
 			Series:   series,
-			Created: createdResp,
+			Created:  createdResp,
 			Rejected: rejectedResp,
 		}
 		created := <-createdResp

--- a/pkg/usagetracker/tenantshard/map_test.go
+++ b/pkg/usagetracker/tenantshard/map_test.go
@@ -36,6 +36,7 @@ func TestMap(t *testing.T) {
 			Value:    clock.Minutes(i),
 			Limit:    limit,
 			Series:   series,
+			Created: createdResp,
 			Rejected: rejectedResp,
 		}
 		created := <-createdResp
@@ -59,6 +60,7 @@ func TestMap(t *testing.T) {
 			Value:    clock.Minutes(0),
 			Limit:    limit,
 			Series:   series,
+			Created: createdResp,
 			Rejected: rejectedResp,
 		}
 		created := <-createdResp
@@ -93,7 +95,7 @@ func TestMap(t *testing.T) {
 		resp := make(chan struct{})
 		m.Events() <- Event{
 			Type:      Cleanup,
-			Watermark: clock.Minutes(2),
+			Watermark: clock.Minutes(1),
 			Series:    series,
 			Done:      resp,
 		}

--- a/pkg/usagetracker/tracker_events.go
+++ b/pkg/usagetracker/tracker_events.go
@@ -11,11 +11,13 @@ import (
 )
 
 type EventsStorageConfig struct {
-	Writer ingest.KafkaConfig `yaml:"writer"`
-	Reader ingest.KafkaConfig `yaml:"reader"`
+	TopicName string             `yaml:"topic_name"`
+	Writer    ingest.KafkaConfig `yaml:"writer"`
+	Reader    ingest.KafkaConfig `yaml:"reader"`
 }
 
 func (c *EventsStorageConfig) RegisterFlags(f *flag.FlagSet) {
+	f.StringVar(&c.TopicName, "usage-tracker.events-storage.topic-name", "usage-tracker-events-storage", "Kafka topic name for usage tracker events")
 	c.Writer.RegisterFlagsWithPrefix("usage-tracker.events-storage.writer", f)
 	c.Reader.RegisterFlagsWithPrefix("usage-tracker.events-storage.reader", f)
 }

--- a/pkg/usagetracker/tracker_store.go
+++ b/pkg/usagetracker/tracker_store.go
@@ -16,22 +16,18 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/usagetracker/clock"
+	"github.com/grafana/mimir/pkg/usagetracker/tenantshard"
 )
 
-const shards = 128
+const shards = tenantshard.Shards
 const noLimit = math.MaxUint64
 
 // trackerStore holds the core business logic of the usage-tracker abstracted in a testable way.
 // trackerStore should not depend on wall clock: time.Now() should be always injected as a parameter,
 // and timer calls should be made from the outside.
 type trackerStore struct {
-	// lock[i] locks data[i] map.
-	lock [shards]shardLock
-	// data[i] map is protected by lock[i].
-	data [shards]map[string]*tenantShard
-
-	tenantsMtx sync.RWMutex
-	tenants    map[string]*tenantInfo
+	mtx     sync.RWMutex
+	tenants map[string]*trackedTenant
 
 	// dependencies
 	limiter limiter
@@ -56,40 +52,22 @@ type events interface {
 
 func newTrackerStore(idleTimeout time.Duration, logger log.Logger, l limiter, ev events) *trackerStore {
 	t := &trackerStore{
-		tenants:     make(map[string]*tenantInfo),
+		tenants:     make(map[string]*trackedTenant),
 		limiter:     l,
 		events:      ev,
 		logger:      logger,
 		idleTimeout: idleTimeout,
 	}
-	for i := range t.data {
-		t.data[i] = make(map[string]*tenantShard)
-	}
 	return t
 }
 
-// shardLock is borrowed from https://github.com/prometheus/prometheus/blob/cd1f8ac129a289be8e7d98b6de57a9ba5814c406/tsdb/agent/series.go#L132-L136
-type shardLock struct {
-	sync.RWMutex
-	// Padding to avoid multiple locks being on the same cache line.
-	_ [40]byte
-}
-
-// tenantInfo holds the global information about the tenant (specifically its total series amount).
-type tenantInfo struct {
-	series atomic.Uint64
-	refs   atomic.Uint64
-}
-
-func (t *tenantInfo) release() { t.refs.Dec() }
-
 func (t *trackerStore) seriesCounts() map[string]uint64 {
-	t.tenantsMtx.RLock()
-	defer t.tenantsMtx.RUnlock()
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
 
 	counts := make(map[string]uint64, len(t.tenants))
-	for tenantID, info := range t.tenants {
-		counts[tenantID] = info.series.Load()
+	for tenantID, tenant := range t.tenants {
+		counts[tenantID] = tenant.series.Load()
 	}
 	return counts
 }
@@ -97,13 +75,9 @@ func (t *trackerStore) seriesCounts() map[string]uint64 {
 // trackSeries is used in tests so we can provide custom time.Now() value.
 // trackSeries will modify and reuse the input series slice.
 func (t *trackerStore) trackSeries(ctx context.Context, tenantID string, series []uint64, timeNow time.Time) (rejected []uint64, err error) {
-	info := t.getOrCreateTenantInfo(tenantID)
-	defer info.release()
-
-	limit := t.limiter.localSeriesLimit(tenantID)
-	if limit == 0 {
-		limit = math.MaxUint64
-	}
+	limit := zeroAsNoLimit(t.limiter.localSeriesLimit(tenantID))
+	tenant := t.getOrCreateTenant(tenantID, limit)
+	defer tenant.RUnlock()
 
 	// Sort series by shard.
 	// Start each tenant on its own shard to avoid hotspots.
@@ -113,16 +87,32 @@ func (t *trackerStore) trackSeries(ctx context.Context, tenantID string, series 
 	})
 
 	now := clock.ToMinutes(timeNow)
-	created := make([]uint64, 0, len(series)) // TODO: This should probably be pooled.
-	rejected = series[:0]                     // Rejected will never have more series than created, so we can reuse the same slice.
 	i0 := 0
+	createdResp := make(chan []uint64, shards)
+	rejectedResp := make(chan []uint64, shards)
+	sent := 0
 	for i := 1; i <= len(series); i++ {
 		// Track series if shard changes on the next element or if we're at the end of series.
-		if currentShard := uint8(series[i0] % shards); i == len(series) || currentShard != uint8(series[i]%shards) {
-			shard := t.getOrCreateTenantShard(tenantID, currentShard, limit)
-			created, rejected = shard.trackSeries(series[i0:i], now, &info.series, limit, created, rejected)
+		if shard := uint8(series[i0] % shards); i == len(series) || shard != uint8(series[i]%shards) {
+			tenant.shards[shard].Events() <- tenantshard.Event{
+				Type:     tenantshard.TrackSeries,
+				Refs:     series[i0:i],
+				Value:    now,
+				Limit:    limit,
+				Series:   tenant.series,
+				Created:  createdResp,
+				Rejected: rejectedResp,
+			}
 			i0 = i
+			sent++
 		}
+	}
+	// TODO: optimize this.
+	created := make([]uint64, 0, len(series)/4) // TODO: This should probably be pooled.
+	rejected = series[:0]                       // Rejected will never have more series than created, so we can reuse the same slice.
+	for i := 0; i < sent; i++ {
+		created = append(created, <-createdResp...)
+		rejected = append(rejected, <-rejectedResp...)
 	}
 
 	level.Debug(t.logger).Log("msg", "tracked series", "tenant", tenantID, "received_len", len(series), "created_len", len(created), "rejected_len", len(rejected), "now", timeNow.Unix(), "now_minutes", now)
@@ -147,318 +137,153 @@ func (t *trackerStore) processCreatedSeriesEvent(tenantID string, series []uint6
 		return
 	}
 
-	info := t.getOrCreateTenantInfo(tenantID)
-	defer info.release()
-
-	// We need the limit to create the tenant shard of an appropriate size.
-	// We are not going to limit series creation based on the shard.
-	limit := t.limiter.localSeriesLimit(tenantID)
-	if limit == 0 {
-		limit = noLimit
-	}
+	limit := zeroAsNoLimit(t.limiter.localSeriesLimit(tenantID))
+	tenant := t.getOrCreateTenant(tenantID, limit)
+	defer tenant.RUnlock()
 
 	// Sort series by shard. We're going to accept all of them, so we can start on shard 0 here.
 	slices.SortFunc(series, func(a, b uint64) int { return int(a%shards) - int(b%shards) })
 
 	timestamp := clock.ToMinutes(eventTimestamp)
 	i0 := 0
+	done := make(chan struct{}, shards)
+	sent := 0
 	for i := 1; i <= len(series); i++ {
 		// Track series if shard changes on the next element or if we're at the end of series.
-		if currentShard := uint8(series[i0] % shards); i == len(series) || currentShard != uint8(series[i]%shards) {
-			shard := t.getOrCreateTenantShard(tenantID, currentShard, limit)
-			shard.processCreatedSeriesEvent(series[i0:i], timestamp, &info.series)
+		if shard := uint8(series[i0] % shards); i == len(series) || shard != uint8(series[i]%shards) {
+			loadRefs := make(map[uint64]clock.Minutes, i-i0)
+			for _, seriesID := range series[i0:i] {
+				loadRefs[seriesID] = timestamp
+			}
+			tenant.shards[shard].Events() <- tenantshard.Event{
+				Type:     tenantshard.Load,
+				LoadRefs: loadRefs,
+				Series:   tenant.series,
+				Done:     done,
+			}
+			sent++
 			i0 = i
 		}
 	}
+	// TODO: this is just for the tests, we dont really need to wait here.
+	for i := 0; i < sent; i++ {
+		<-done
+	}
 }
 
-func (t *trackerStore) getOrCreateTenantShard(userID string, shard uint8, limit uint64) *tenantShard {
-	t.lock[shard].RLock()
-	m := t.data[shard][userID]
-	if m != nil {
-		t.lock[shard].RUnlock()
-		return m
+// getOrCreateTenant returns the trackedTenant for the given tenantID, with shards for the limit provided.
+// The tenant returned is RLock'ed() and needs to be RUnlocked() after use.
+func (t *trackerStore) getOrCreateTenant(tenantID string, limit uint64) *trackedTenant {
+	t.mtx.RLock()
+	if tenant, ok := t.tenants[tenantID]; ok {
+		tenant.RLock()
+		t.mtx.RUnlock()
+		return tenant
 	}
-	t.lock[shard].RUnlock()
+	t.mtx.RUnlock()
 
-	t.lock[shard].Lock()
-	defer t.lock[shard].Unlock()
-	if m = t.data[shard][userID]; m != nil {
-		return m
-	}
-
-	var series map[uint64]*atomic.Int32
-	if limit == noLimit {
-		series = make(map[uint64]*atomic.Int32)
-	} else {
-		series = make(map[uint64]*atomic.Int32, int(limit/shards))
-	}
-	m = &tenantShard{series: series}
-	t.data[shard][userID] = m
-	return m
-}
-
-// getOrCreateTenantInfo returns the tenantInfo for the tenantID.
-// Caller should call tenantInfo.release() after using it.
-func (t *trackerStore) getOrCreateTenantInfo(tenantID string) *tenantInfo {
-	t.tenantsMtx.RLock()
-	if info, ok := t.tenants[tenantID]; ok {
-		// It is important to increase references count before we release the lock.
-		info.refs.Inc()
-		t.tenantsMtx.RUnlock()
-		return info
-	}
-	t.tenantsMtx.RUnlock()
-
-	t.tenantsMtx.Lock()
-	defer t.tenantsMtx.Unlock()
-	if info, ok := t.tenants[tenantID]; ok {
-		info.refs.Inc()
-		return info
+	// Let's prepare a tenant with all shards instead of doing it while locked.
+	preparedTenant := &trackedTenant{
+		series: atomic.NewUint64(0),
 	}
 
-	info := &tenantInfo{}
-	info.refs.Inc()
-	t.tenants[tenantID] = info
-	return info
-}
-
-// casIfGreater will CAS ts to now if now is greater than the value stored in ts.
-// It will retry until it's possible to CAS or the condition is not et.
-// It returns the last seen value that was stored in ts before CAS-ing.
-func casIfGreater(now clock.Minutes, ts *atomic.Int32) (lastSeen clock.Minutes) {
-	lastSeen = clock.Minutes(ts.Load())
-	for now.GreaterThan(lastSeen) && !ts.CompareAndSwap(int32(lastSeen), int32(now)) {
-		lastSeen = clock.Minutes(ts.Load())
+	capacity := int(limit / shards)
+	if limit == noLimit || limit == 0 {
+		capacity = 512 // let's be modest.
+	} else if capacity > math.MaxUint32 {
+		capacity = math.MaxUint32
 	}
-	return lastSeen
+	for i := range preparedTenant.shards {
+		preparedTenant.shards[i] = tenantshard.New(uint32(capacity), uint8(i))
+	}
+
+	t.mtx.Lock()
+	if gotTenant, ok := t.tenants[tenantID]; ok {
+		gotTenant.RLock()
+		t.mtx.Unlock()
+		preparedTenant.shutdown()
+		return gotTenant
+	}
+
+	t.tenants[tenantID] = preparedTenant
+	preparedTenant.RLock()
+	t.mtx.Unlock()
+	return preparedTenant
 }
 
 func (t *trackerStore) cleanup(now time.Time) {
 	watermark := clock.ToMinutes(now.Add(-t.idleTimeout))
 
 	// We will work on a copy of tenants.
-	t.tenantsMtx.RLock()
+	t.mtx.RLock()
 	tenantsClone := maps.Clone(t.tenants)
-	t.tenantsMtx.RUnlock()
+	t.mtx.RUnlock()
 
-	for i := range t.data {
-		t.lock[i].Lock()
-		// Take a clone of data and work with that.
-		// This is orders of tens of thousands elements map, so it's not a big deal.
-		// It's better than holding the mutex while we're inspecting each tenant.
-		// We don't care about the tenants added *after* we took the snapshot, they're too new to cleanup.
-		shardClone := maps.Clone(t.data[i])
-		t.lock[i].Unlock()
-
-		for tenantID, shard := range shardClone {
-			if empty := t.cleanupTenantShard(tenantID, shard, watermark, tenantsClone); empty {
-				t.maybeRemoveTenantShard(tenantID, uint8(i))
+	var deletionCandidates []string
+	done := make(chan struct{}, shards)
+	for tenantID, tenant := range tenantsClone {
+		for _, shard := range tenant.shards {
+			shard.Events() <- tenantshard.Event{
+				Type:      tenantshard.Cleanup,
+				Value:     watermark,
+				Series:    tenant.series,
+				Watermark: watermark,
+				Done:      done,
 			}
 		}
-	}
 
-	tenantsToDelete := make([]string, 0, len(tenantsClone))
-	// Check tenants to delete on our copy of t.tenants.
-	// The ones added after we took the copy are likely to have some series.
-	for tenantID, info := range tenantsClone {
-		if info.series.Load() == 0 {
-			tenantsToDelete = append(tenantsToDelete, tenantID)
-			continue
+		// TODO: do we need this done? so far it's only added for testing purposes.
+		for i := 0; i < shards; i++ {
+			<-done
+		}
+
+		if tenant.series.Load() == 0 {
+			deletionCandidates = append(deletionCandidates, tenantID)
 		}
 	}
-	if len(tenantsToDelete) == 0 {
+
+	if len(deletionCandidates) == 0 {
 		return
 	}
 
-	t.tenantsMtx.Lock()
-	defer t.tenantsMtx.Unlock()
-	for _, tenantID := range tenantsToDelete {
-		info, ok := t.tenants[tenantID]
+	var toShutdown []*trackedTenant
+	t.mtx.Lock()
+	for _, tenantID := range deletionCandidates {
+		tenant, ok := t.tenants[tenantID]
 		if !ok {
-			// This shouldn't happen unless we have two concurrent cleanup() calls.
-			continue
+			continue // weird, two concurrent cleanups maybe?
 		}
-		if info.series.Load() > 0 {
-			// Someone added series in the meantime.
-			continue
-		}
-		if info.refs.Load() == 0 {
-			// No series and nobody is adding them, so we can delete it.
+		// Make sure nobody is appending.
+		// Since we have the t.mtx, we know that nobody can also get this tenant.
+		tenant.Lock()
+		if tenant.series.Load() == 0 {
+			toShutdown = append(toShutdown, tenant)
 			delete(t.tenants, tenantID)
 		}
+		tenant.Unlock()
+	}
+	t.mtx.Unlock()
+
+	for _, tenant := range toShutdown {
+		tenant.shutdown()
 	}
 }
 
-func (t *trackerStore) cleanupTenantShard(tenantID string, shard *tenantShard, watermark clock.Minutes, tenantsClone map[string]*tenantInfo) (empty bool) {
-	info, ok := tenantsClone[tenantID]
-	if !ok {
-		// This shard might have been added after we made our clone.
-		info = t.getOrCreateTenantInfo(tenantID)
-		// We need to release this one correctly.
-		defer info.release()
-	}
-	return shard.cleanup(&info.series, watermark)
+type trackedTenant struct {
+	sync.RWMutex
+	series *atomic.Uint64
+	shards [shards]*tenantshard.Map
 }
 
-func (t *trackerStore) maybeRemoveTenantShard(tenantID string, s uint8) {
-	info := t.getOrCreateTenantInfo(tenantID)
-	defer info.release()
-
-	t.lock[s].Lock()
-	defer t.lock[s].Unlock()
-	if info.refs.Load() > 1 { // 1 for us.
-		// Someone else is interacting with this tenant.
-		return
+func (tenant *trackedTenant) shutdown() {
+	for i := range tenant.shards {
+		tenant.shards[i].Events() <- tenantshard.Event{Type: tenantshard.Shutdown}
 	}
-
-	shard, ok := t.data[s][tenantID]
-	if !ok {
-		return // how did this happen?
-	}
-	if !shard.empty() {
-		return // someone added series while we were thinking.
-	}
-
-	// Okay, nobody is interacting with the tenant, and shard is empty, now it's safe to delete it.
-	delete(t.data[s], tenantID)
 }
 
-type tenantShard struct {
-	shardLock
-	series map[uint64]*atomic.Int32
-}
-
-func (shard *tenantShard) empty() bool {
-	shard.RLock()
-	defer shard.RUnlock()
-	return len(shard.series) == 0
-}
-
-// trackSeries will track the provided series trying to keep totalTenantSeries below the limit.
-// Each time a series is created, it will be appended to the created slice and totalTenantSeries will be increased.
-//
-// The input slices created and rejected should be returned with the series that were created and rejected appended to them.
-func (shard *tenantShard) trackSeries(series []uint64, now clock.Minutes, totalTenantSeries *atomic.Uint64, limit uint64, created, rejected []uint64) (_created, _rejected []uint64) {
-	// missing contains the series that have to be created.
-	// As we advance through series, we reuse the same slice to avoid allocations.
-	missing := series[:0]
-
-	// First try to update the series that already exist, the ones that don't exist are moved to missing.
-	shard.RLock()
-	for len(series) > 0 {
-		s := series[0]
-		series = series[1:]
-
-		ts, ok := shard.series[s]
-		if !ok {
-			missing = append(missing, s)
-			continue
-		}
-
-		ts.Store(int32(now))
+func zeroAsNoLimit(v uint64) uint64 {
+	if v == 0 {
+		return noLimit
 	}
-	shard.RUnlock()
-
-	// If no series missing, return.
-	if len(missing) == 0 {
-		return created, rejected
-	}
-
-	// Only take the Lock() if we're below the limit.
-	if totalTenantSeries.Load() < limit {
-		shard.Lock()
-		for len(missing) > 0 {
-			s := missing[0]
-			ts, ok := shard.series[s]
-			if ok {
-				ts.Store(int32(now))
-			} else if totalTenantSeries.Load() >= limit {
-				// We've reached the limit.
-				// Note that while we're holding the mutex on this shard,
-				// other request may have increased the series count in a different shard.
-				break
-			} else {
-				shard.series[s] = atomic.NewInt32(int32(now))
-				created = append(created, s)
-				totalTenantSeries.Inc()
-			}
-			missing = missing[1:]
-		}
-		shard.Unlock()
-	}
-
-	// Whatever is still missing is rejected (if any)
-	rejected = append(rejected, missing...)
-	return created, rejected
-}
-
-// processCreatedSeriesEvent creates the series coming from an event from Kafka,
-// i.e. series that were created by a different instance.
-// This does not check the limits, as we prioritize staying consistent across replicas over enforcing limits.
-// Timestamp is not updated if series exists already.
-func (shard *tenantShard) processCreatedSeriesEvent(series []uint64, timestamp clock.Minutes, totalTenantSeries *atomic.Uint64) {
-	// missing contains the series that have to be created.
-	// As we advance through series, we reuse the same slice to avoid allocations.
-	missing := series[:0]
-
-	// Find the missing ones.
-	shard.RLock()
-	for len(series) > 0 {
-		s := series[0]
-		series = series[1:]
-
-		_, ok := shard.series[s]
-		if !ok {
-			missing = append(missing, s)
-		}
-	}
-	shard.RUnlock()
-
-	if len(missing) == 0 {
-		return
-	}
-
-	shard.Lock()
-	for _, s := range missing {
-		_, ok := shard.series[s]
-		if !ok {
-			// Still doesn't exist, so create with the timestamp from the event.
-			shard.series[s] = atomic.NewInt32(int32(timestamp))
-			totalTenantSeries.Inc()
-		}
-	}
-	shard.Unlock()
-}
-
-func (shard *tenantShard) cleanup(totalTenantSeries *atomic.Uint64, watermark clock.Minutes) (empty bool) {
-	// Work on the stack.
-	// If we have 1e9 series, 33% of that churning every 2 hours, that's ~21K per shard (1e9/3/120/128).
-	// This is ~168K on the stack, which is fine, but it saves lots of allocations.
-	// This should only make the stack grow once.
-	var stackSeries [1 << 16]uint64
-	candidates := stackSeries[:0]
-
-	shard.RLock()
-	empty = len(shard.series) == 0
-	for s, ts := range shard.series {
-		if lastSeen := clock.Minutes(ts.Load()); watermark.GreaterOrEqualThan(lastSeen) {
-			candidates = append(candidates, s)
-		}
-	}
-	shard.RUnlock()
-
-	if len(candidates) == 0 {
-		return empty
-	}
-
-	shard.Lock()
-	defer shard.Unlock()
-	for s, ts := range shard.series {
-		if lastSeen := clock.Minutes(ts.Load()); watermark.GreaterOrEqualThan(lastSeen) {
-			delete(shard.series, s)
-			totalTenantSeries.Dec()
-		}
-	}
-	return len(shard.series) == 0
+	return v
 }

--- a/pkg/usagetracker/tracker_store_bench_test.go
+++ b/pkg/usagetracker/tracker_store_bench_test.go
@@ -50,13 +50,7 @@ func benckmarkTrackerStoreTrackSeries(b *testing.B, seriesRefs []uint64, seriesP
 	nowSeconds := atomic.NewInt64(0)
 	now := func() time.Time { return time.Unix(nowSeconds.Load(), 0) }
 	t := newTrackerStore(20*time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
-	b.Cleanup(func() {
-		t.mtx.RLock()
-		defer t.mtx.RUnlock()
-		for _, tenant := range t.tenants {
-			tenant.shutdown()
-		}
-	})
+	b.Cleanup(t.shutdownAllTenants)
 
 	seriesPerTenant := len(seriesRefs) / tenantsCount
 	// Warmup each tenant.

--- a/pkg/usagetracker/tracker_store_bench_test.go
+++ b/pkg/usagetracker/tracker_store_bench_test.go
@@ -50,6 +50,13 @@ func benckmarkTrackerStoreTrackSeries(b *testing.B, seriesRefs []uint64, seriesP
 	nowSeconds := atomic.NewInt64(0)
 	now := func() time.Time { return time.Unix(nowSeconds.Load(), 0) }
 	t := newTrackerStore(20*time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	b.Cleanup(func() {
+		t.mtx.RLock()
+		defer t.mtx.RUnlock()
+		for _, tenant := range t.tenants {
+			tenant.shutdown()
+		}
+	})
 
 	seriesPerTenant := len(seriesRefs) / tenantsCount
 	// Warmup each tenant.

--- a/pkg/usagetracker/tracker_store_collector.go
+++ b/pkg/usagetracker/tracker_store_collector.go
@@ -17,9 +17,9 @@ func (t *trackerStore) Describe(descs chan<- *prometheus.Desc) {
 }
 
 func (t *trackerStore) Collect(metrics chan<- prometheus.Metric) {
-	t.tenantsMtx.RLock()
-	defer t.tenantsMtx.RUnlock()
-	for tenantID, info := range t.tenants {
-		metrics <- prometheus.MustNewConstMetric(trackerStoreMetricDesc, prometheus.GaugeValue, float64(info.series.Load()), tenantID)
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	for tenantID, tenant := range t.tenants {
+		metrics <- prometheus.MustNewConstMetric(trackerStoreMetricDesc, prometheus.GaugeValue, float64(tenant.series.Load()), tenantID)
 	}
 }

--- a/pkg/usagetracker/tracker_store_test.go
+++ b/pkg/usagetracker/tracker_store_test.go
@@ -185,7 +185,7 @@ func TestTrackerStore_Snapshot(t *testing.T) {
 
 	tracker2 := newTrackerStore(idleTimeoutMinutes*time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
 	t.Cleanup(tracker2.shutdownAllTenants)
-	
+
 	var data []byte
 	for shard := uint8(0); shard < shards; shard++ {
 		data = tracker1.snapshot(shard, now, data[:0])

--- a/pkg/usagetracker/tracker_store_test.go
+++ b/pkg/usagetracker/tracker_store_test.go
@@ -29,6 +29,8 @@ func TestTrackerStore_HappyCase(t *testing.T) {
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
 
 	tracker := newTrackerStore(idleTimeout, log.NewNopLogger(), limits, noopEvents{})
+	t.Cleanup(tracker.shutdownAllTenants)
+
 	{
 		// Push 2 series, both are accepted.
 		rejected, err := tracker.trackSeries(context.Background(), testUser1, []uint64{1, 2}, now)
@@ -80,8 +82,10 @@ func TestTrackerStore_CreatedSeriesCommunication(t *testing.T) {
 
 	tracker1Events := eventsPipe{}
 	tracker1 := newTrackerStore(idleTimeout, log.NewNopLogger(), limits, &tracker1Events)
+	t.Cleanup(tracker1.shutdownAllTenants)
 	tracker2Events := eventsPipe{}
 	tracker2 := newTrackerStore(idleTimeout, log.NewNopLogger(), limits, &tracker2Events)
+	t.Cleanup(tracker2.shutdownAllTenants)
 	tracker1Events.listeners = []*trackerStore{tracker2}
 	tracker2Events.listeners = []*trackerStore{tracker1}
 
@@ -157,6 +161,8 @@ func TestTrackerStore_Snapshot(t *testing.T) {
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
 
 	tracker1 := newTrackerStore(idleTimeoutMinutes*time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	t.Cleanup(tracker1.shutdownAllTenants)
+
 	for i := 0; i < 60; i++ {
 		rejected, err := tracker1.trackSeries(context.Background(), testUser1, []uint64{uint64(i)}, now)
 		require.Empty(t, rejected)
@@ -178,6 +184,8 @@ func TestTrackerStore_Snapshot(t *testing.T) {
 	}, tracker1.seriesCounts())
 
 	tracker2 := newTrackerStore(idleTimeoutMinutes*time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	t.Cleanup(tracker2.shutdownAllTenants)
+	
 	var data []byte
 	for shard := uint8(0); shard < shards; shard++ {
 		data = tracker1.snapshot(shard, now, data[:0])
@@ -214,6 +222,7 @@ func TestTrackerStore_Cleanup_OffByOneError(t *testing.T) {
 
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
 	tracker := newTrackerStore(time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	t.Cleanup(tracker.shutdownAllTenants)
 
 	rejected, err := tracker.trackSeries(context.Background(), testUser1, []uint64{1}, now)
 	require.Empty(t, rejected)
@@ -240,6 +249,8 @@ func TestTrackerStore_Cleanup_Tenants(t *testing.T) {
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
 
 	tracker := newTrackerStore(defaultIdleTimeout, log.NewNopLogger(), limits, noopEvents{})
+	t.Cleanup(tracker.shutdownAllTenants)
+
 	// Push 2 series to testUser1, both are accepted.
 	rejected, err := tracker.trackSeries(context.Background(), testUser1, []uint64{1, 2}, now)
 	require.NoError(t, err)
@@ -293,6 +304,7 @@ func TestTrackerStore_Cleanup_Concurrency(t *testing.T) {
 
 	createdSeries := createdSeriesCounter{count: atomic.NewUint64(0)}
 	tracker := newTrackerStore(idleTimeoutMinutes*time.Minute, log.NewNopLogger(), limiterMock{}, createdSeries)
+	t.Cleanup(tracker.shutdownAllTenants)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -351,6 +363,8 @@ func TestTrackerStore_PrometheusCollector(t *testing.T) {
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
 
 	tracker := newTrackerStore(defaultIdleTimeout, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	t.Cleanup(tracker.shutdownAllTenants)
+
 	reg := prometheus.NewRegistry()
 	require.NoError(t, reg.Register(tracker))
 
@@ -475,4 +489,12 @@ func decodeSnapshot(t *testing.T, data []byte) map[string]map[uint64]clock.Minut
 		res[tenantID] = shard
 	}
 	return res
+}
+
+func (t *trackerStore) shutdownAllTenants() {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	for _, tenant := range t.tenants {
+		tenant.shutdown()
+	}
 }


### PR DESCRIPTION
This refactors the entire tracker.

There are two big changes here: how the map is implemented and how we interact with it.

How the map is implemented:

We're getting rid of usual maps storing atomic.Int32: it's an overkill to have 32bit int to store a byte, it's even more an overkill to store a 64bit pointer to that, let's not talk about map overhead.

Instead of that, we're building kind of swiss map, I based the implementation on the code from dolthub/swiss, you can read a blog post how that works here:
https://www.dolthub.com/blog/2023-03-28-swiss-map/

However, most of the code was replaced.

What did I do? Swiss map has a slice groups of hash suffixes, which are one byte, to quickly find the bucket where our element is, and it also has a slice of groups of keys. That's still a lot of overhead for our use.

What are our restrictions:
- Our keys are uint64, so great, we don't need to hash, our keys are hashes already!.
- All our keys in a single shard have the same suffix of 7 bytes (because we have 128 shards).

So, I changed the implementation to "index" based on the prefix, not the suffix of the key (series hash), and since the suffix is always the same, we could use that space for something else... Guess what? Our values are also 7 bits, so we're storing the key AND the value in a single uint64 field. Now each series is just uint64+uint8 in the map implementation (plus the overallocation of the slice, of course).

I didn't just store the value in the suffix of the uint64 data, but I also negated it, so we can figure out whether a value is a real value or an empty value without having to check if there's a tombstone in the index! Cleanup is now just iterating one single slice, isn't that awesome?

Well, but how do we coordinate all of that? We can't do atomic byte operations (can we? IDK), but also we probably don't want to. I guessed (to be investigated whether that was true) that lots of CPU usage comes from having to do atomic-everything.

I head that golang is good at handling hundreds of goroutines (and I managed tens of thousands of them in the past, although not in a high-performance env), so I decided to just run one goroutine per each map shard.

Each map shard has its own worker which takes care of updating the internal state: now the synchronization overhad is in pushing the data to the workers through a channel. But once data is in the worker, a single shard is always updated by the same goroutine.

Say we have 10k tenants in an env, that's 10K goroutines, not that bad... I hope. We'll see.

I also considered lowering the number of shards to 64, ~but in order to achieve that we need to restrict the idleTimeout to 30 minutes, so we can fit the minutes timestamp in a 64 byte value. I think we can do that.~ We can fit any number of shards if we shift the ref stored in data by 7 bits to the left, as we already have those bits in the index anyway.

Benchmarks look great, the improvements get better as the load grows, especially when cleanup p goroutine is running:
```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/usagetracker
cpu: Apple M3 Pro
                                                                                             │ map_atomic_ptrs │              swiss_chans              │
                                                                                             │     sec/op      │    sec/op      vs base                │
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=1K/tenants=1/cleanups=true-12            71.68µ ± 12%   138.49µ ±  6%   +93.21% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=1K/tenants=1/cleanups=false-12           16.35µ ±  1%    28.77µ ±  1%   +75.91% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=1K/tenants=10/cleanups=true-12           31.69µ ±  5%    69.19µ ±  2%  +118.37% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=1K/tenants=10/cleanups=false-12          16.15µ ±  3%    23.59µ ±  1%   +46.07% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=1K/tenants=100/cleanups=true-12          46.96µ ± 30%    34.10µ ±  4%         ~ (p=0.240 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=1K/tenants=100/cleanups=false-12         16.39µ ±  2%    24.74µ ±  1%   +50.94% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=1K/tenants=1000/cleanups=true-12      12480.17µ ±  6%    38.47µ ± 18%   -99.69% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=1K/tenants=1000/cleanups=false-12        11.98µ ±  1%    25.52µ ±  1%  +112.99% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=10K/tenants=1/cleanups=true-12           211.0µ ± 10%    354.9µ ±  2%   +68.24% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=10K/tenants=1/cleanups=false-12          137.3µ ±  1%    110.6µ ±  2%   -19.42% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=10K/tenants=10/cleanups=true-12          208.6µ ± 20%    175.5µ ±  3%   -15.89% (p=0.009 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=10K/tenants=10/cleanups=false-12         132.8µ ±  2%    101.6µ ±  1%   -23.53% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=10K/tenants=100/cleanups=true-12        161.90µ ± 16%    94.78µ ±  3%   -41.46% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=10M/seriesPerRequest=10K/tenants=100/cleanups=false-12        90.56µ ±  2%    77.28µ ±  1%   -14.67% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=1K/tenants=1/cleanups=true-12          11.997m ±  7%    1.382m ±  9%   -88.48% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=1K/tenants=1/cleanups=false-12          18.77µ ±  5%    30.23µ ± 14%   +61.07% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=1K/tenants=10/cleanups=true-12         11.142m ± 11%    1.489m ± 10%   -86.64% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=1K/tenants=10/cleanups=false-12         17.96µ ±  3%    25.53µ ±  2%   +42.11% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=1K/tenants=100/cleanups=true-12       11520.7µ ± 48%    167.9µ ±  4%   -98.54% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=1K/tenants=100/cleanups=false-12        18.27µ ± 66%    27.77µ ±  1%         ~ (p=0.065 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=1K/tenants=1000/cleanups=true-12      20411.1µ ±  3%    191.5µ ± 72%   -99.06% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=1K/tenants=1000/cleanups=false-12       18.78µ ± 24%    26.78µ ±  6%   +42.64% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=10K/tenants=1/cleanups=true-12         13.098m ± 44%    2.635m ± 21%   -79.88% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=10K/tenants=1/cleanups=false-12         153.3µ ±  9%    130.0µ ±  7%   -15.15% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=10K/tenants=10/cleanups=true-12        11.623m ± 12%    1.750m ± 10%   -84.94% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=10K/tenants=10/cleanups=false-12        156.3µ ± 25%    119.4µ ±  1%   -23.59% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=10K/tenants=100/cleanups=true-12       10.716m ± 18%    1.234m ±  4%   -88.49% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=10K/tenants=100/cleanups=false-12       140.9µ ±  7%    110.1µ ± 19%   -21.84% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=10K/tenants=1000/cleanups=true-12     20809.0µ ±  4%    275.3µ ±  2%   -98.68% (p=0.002 n=6)
TrackerStoreTrackSeries/totalSeries=100M/seriesPerRequest=10K/tenants=1000/cleanups=false-12     107.66µ ±  7%    75.79µ ±  2%   -29.60% (p=0.002 n=6)
geomean                                                                                           283.2µ          119.6µ         -57.78%
```
