### PR TITLE
feat: unify mimirtool authentication options and add extra-headers support to all MimirClient commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,8 @@
 
 ### Mimirtool
 
+* [CHANGE] Unify mimirtool authentication options and add extra-headers support for commands that depend on MimirClient. #10178
+
 ### Mimir Continuous Test
 
 ### Query-tee

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -70,12 +70,13 @@ chmod +x mimirtool
 
 For Mimirtools to interact with Grafana Mimir, Grafana Enterprise Metrics, Prometheus, or Grafana, set the following environment variables or CLI flags.
 
-| Environment variable | Flag        | Description                                                                                                                                                                                      |
-| -------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `MIMIR_ADDRESS`      | `--address` | Sets the address of the API of the Grafana Mimir cluster.                                                                                                                                        |
-| `MIMIR_API_USER`     | `--user`    | Sets the basic auth username. If this variable is empty and `MIMIR_API_KEY` is set, the system uses `MIMIR_TENANT_ID` instead. If you're using Grafana Cloud, this variable is your instance ID. |
-| `MIMIR_API_KEY`      | `--key`     | Sets the basic auth password. If you're using Grafana Cloud, this variable is your API key.                                                                                                      |
-| `MIMIR_TENANT_ID`    | `--id`      | Sets the tenant ID of the Grafana Mimir instance that Mimirtools interacts with.                                                                                                                 |
+| Environment variable  | Flag              | Description                                                                                                                                                                                      |
+| --------------------  | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `MIMIR_ADDRESS`       | `--address`       | Sets the address of the API of the Grafana Mimir cluster.                                                                                                                                        |
+| `MIMIR_API_USER`      | `--user`          | Sets the basic auth username. If this variable is empty and `MIMIR_API_KEY` is set, the system uses `MIMIR_TENANT_ID` instead. If you're using Grafana Cloud, this variable is your instance ID. |
+| `MIMIR_API_KEY`       | `--key`           | Sets the basic auth password. If you're using Grafana Cloud, this variable is your API key.                                                                                                      |
+| `MIMIR_TENANT_ID`     | `--id`            | Sets the tenant ID of the Grafana Mimir instance that Mimirtools interacts with.                                                                                                                 |
+| `MIMIR_EXTRA_HEADERS` | `--extra-headers` | Extra headers to add to the requests in header=value format. Flag can be specified multiple times. Env value must be newline separated                                                           |
 
 ## Commands
 
@@ -301,7 +302,6 @@ Configuration options relevant to rules commands:
 | Flag              | Description                                                                               |
 | ----------------- | ----------------------------------------------------------------------------------------- |
 | `--auth-token`    | Authentication token for bearer token or JWT auth.                                        |
-| `--extra-headers` | Extra headers to add to the requests in header=value format. (Can specify multiple times) |
 
 #### List rules
 

--- a/pkg/mimirtool/commands/alerts.go
+++ b/pkg/mimirtool/commands/alerts.go
@@ -95,6 +95,8 @@ func (a *AlertmanagerCommand) Register(app *kingpin.Application, envVars EnvVarN
 	for _, cmd := range []*kingpin.CmdClause{getAlertsCmd, deleteCmd, loadalertCmd} {
 		cmd.Flag("address", "Address of the Grafana Mimir cluster; alternatively, set "+envVars.Address+".").Envar(envVars.Address).Required().StringVar(&a.ClientConfig.Address)
 		cmd.Flag("id", "Grafana Mimir tenant ID; alternatively, set "+envVars.TenantID+". Used for X-Scope-OrgID HTTP header. Also used for basic auth if --user is not provided.").Envar(envVars.TenantID).Required().StringVar(&a.ClientConfig.ID)
+		a.ClientConfig.ExtraHeaders = map[string]string{}
+		cmd.Flag("extra-headers", "Extra headers to add to the requests in header=value format, alternatively set newline separated "+envVars.ExtraHeaders+".").Envar(envVars.ExtraHeaders).StringMapVar(&a.ClientConfig.ExtraHeaders)
 	}
 
 	migrateCmd := alertCmd.Command("migrate-utf8", "Migrate the Alertmanager tenant configuration for UTF-8.").Action(a.migrateConfig)
@@ -270,6 +272,8 @@ func (a *AlertCommand) Register(app *kingpin.Application, envVars EnvVarNames, r
 	alertCmd.Flag("user", fmt.Sprintf("Basic auth username to use when contacting Grafana Mimir, alternatively set %s. If empty, %s will be used instead. ", envVars.APIUser, envVars.TenantID)).Default("").Envar(envVars.APIUser).StringVar(&a.ClientConfig.User)
 	alertCmd.Flag("key", "Basic auth password to use when contacting Grafana Mimir; alternatively, set "+envVars.APIKey+".").Default("").Envar(envVars.APIKey).StringVar(&a.ClientConfig.Key)
 	alertCmd.Flag("auth-token", "Authentication token for bearer token or JWT auth, alternatively set "+envVars.AuthToken+".").Default("").Envar(envVars.AuthToken).StringVar(&a.ClientConfig.AuthToken)
+	a.ClientConfig.ExtraHeaders = map[string]string{}
+	alertCmd.Flag("extra-headers", "Extra headers to add to the requests in header=value format, alternatively set newline separated "+envVars.ExtraHeaders+".").Envar(envVars.ExtraHeaders).StringMapVar(&a.ClientConfig.ExtraHeaders)
 
 	verifyAlertsCmd := alertCmd.Command("verify", "Verifies whether or not alerts in an Alertmanager cluster are deduplicated; useful for verifying correct configuration when transferring from Prometheus to Grafana Mimir alert evaluation.").Action(a.verifyConfig)
 	verifyAlertsCmd.Flag("ignore-alerts", "A comma separated list of Alert names to ignore in deduplication checks.").StringVar(&a.IgnoreString)

--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -34,6 +34,7 @@ type PrometheusAnalyzeCommand struct {
 	address              string
 	prometheusHTTPPrefix string
 	username             string
+	tenantID             string
 	password             string
 	authToken            string
 	readTimeout          time.Duration
@@ -90,14 +91,21 @@ func (cmd *PrometheusAnalyzeCommand) parseUsedMetrics() (model.LabelValues, erro
 func (cmd *PrometheusAnalyzeCommand) newAPI() (v1.API, error) {
 	rt := api.DefaultRoundTripper
 	rt = config.NewUserAgentRoundTripper(client.UserAgent(), rt)
-	if cmd.authToken != "" {
-		rt = config.NewAuthorizationCredentialsRoundTripper("Bearer", config.NewInlineSecret(cmd.authToken), rt)
-	} else if cmd.username != "" {
-		rt = &setTenantIDTransport{
-			RoundTripper: rt,
-			tenantID:     cmd.username,
-		}
+
+	switch {
+	case cmd.username != "":
 		rt = config.NewBasicAuthRoundTripper(config.NewInlineSecret(cmd.username), config.NewInlineSecret(cmd.password), rt)
+
+	case cmd.password != "":
+		rt = config.NewBasicAuthRoundTripper(config.NewInlineSecret(cmd.tenantID), config.NewInlineSecret(cmd.password), rt)
+
+	case cmd.authToken != "":
+		rt = config.NewAuthorizationCredentialsRoundTripper("Bearer", config.NewInlineSecret(cmd.authToken), rt)
+	}
+
+	rt = &setTenantIDTransport{
+		RoundTripper: rt,
+		tenantID:     cmd.tenantID,
 	}
 
 	address, err := url.JoinPath(cmd.address, cmd.prometheusHTTPPrefix)

--- a/pkg/mimirtool/commands/backfill.go
+++ b/pkg/mimirtool/commands/backfill.go
@@ -69,6 +69,11 @@ func (c *BackfillCommand) Register(app *kingpin.Application, envVars EnvVarNames
 		Envar(envVars.APIKey).
 		StringVar(&c.clientConfig.Key)
 
+	c.clientConfig.ExtraHeaders = map[string]string{}
+	cmd.Flag("extra-headers", "Extra headers to add to the requests in header=value format, alternatively set newline separated "+envVars.ExtraHeaders+".").
+		Envar(envVars.ExtraHeaders).
+		StringMapVar(&c.clientConfig.ExtraHeaders)
+
 	cmd.Flag("tls-ca-path", "TLS CA certificate to verify Grafana Mimir API as part of mTLS; alternatively, set "+envVars.TLSCAPath+".").
 		Default("").
 		Envar(envVars.TLSCAPath).


### PR DESCRIPTION
#### What this PR does

1. Unifies all authentication options for mimirtool commands so that the [Configuration options](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/#configuration-options) work the same for subcommands which use [MimirClient](https://github.com/grafana/mimir/blob/66b315c1ca41df9d1adff4a23fe4c4f28a0ebedd/pkg/mimirtool/client/client.go#L55). 
2. Adds extra headers support to all commands from mimirtool which depend on [MimirClient](https://github.com/grafana/mimir/blob/66b315c1ca41df9d1adff4a23fe4c4f28a0ebedd/pkg/mimirtool/client/client.go#L55) so that any supported command can be used like in the use case that was described in https://github.com/grafana/mimir/pull/7141.
3. Adjusted the Prometheus api client for analyse prometheus command so that its auth behaves similarly to other mimirtools commands.

#### Which issue(s) this PR fixes or relates to

There is a discussion opened by my team member: https://github.com/grafana/mimir/discussions/10152#discussion-7622048 and I have created an issue from it: https://github.com/grafana/mimir/issues/10178. This PR addresses the issues he is facing.

Related PRs to the changes I am proposing:
- https://github.com/grafana/mimir/pull/7141
- https://github.com/grafana/mimir/pull/6798

Thanks for making such a great product and all the tooling around it! Working with mimir and mimirtool is a breeze and helps a lot with our monitoring setup. We have discovered the above limitations during optimising our stored metrics in mimir. For us the basic auth username configured on the nginx proxy that is in front of mimir **does not** match the tenant name to which we push metrics and that prevents us from using some of the subcommands but others work and with that PR all of them should be unified. The proposed changes should be backwards compatible so anyone using mimirtool shouldn't be forced to change the passed ENVS / flags.

#### Checklist

- [X] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [X] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.