### PR TITLE
UsageTracker: load generator for multiple tenants

### DIFF
--- a/tools/usage-tracker-load-generator/.gitignore
+++ b/tools/usage-tracker-load-generator/.gitignore
@@ -1,0 +1,1 @@
+usage-tracker-load-generator

--- a/tools/usage-tracker-load-generator/main.go
+++ b/tools/usage-tracker-load-generator/main.go
@@ -122,7 +122,7 @@ func main() {
 
 func runWorker(ctx context.Context, userID string, workerID, numWorkers int, cfg Config, client *usagetrackerclient.UsageTrackerClient) {
 	numSeriesPerRequest := cfg.SimulatedSeriesPerWriteRequest
-	numSeriesPerWorker := cfg.SimulatedTotalSeries / numWorkers
+	numSeriesPerWorker := cfg.SimulatedTotalSeries / numWorkers / cfg.SimulatedTotalTenants
 	numRequestsPerWorker := (numSeriesPerWorker / numSeriesPerRequest) + 1
 	targetTimePerRequest := cfg.SimulatedScrapeInterval / time.Duration(numRequestsPerWorker)
 


### PR DESCRIPTION
This allows sending series for more than 1 tenant, testing the overhead of having multiple small tenants.
