### PR TITLE
Remove hardcoding for middleware checking for access to PromQL experimental functions

### DIFF
--- a/pkg/frontend/querymiddleware/experimental_functions.go
+++ b/pkg/frontend/querymiddleware/experimental_functions.go
@@ -100,10 +100,7 @@ func containedExperimentalFunctions(expr parser.Expr) map[string]struct{} {
 		}
 		agg, ok := node.(*parser.AggregateExpr)
 		if ok {
-			// Note that unlike most PromQL functions, the experimental nature of the aggregation functions are manually
-			// defined and enforced, so they have to be hardcoded here and updated along with changes in Prometheus.
-			switch agg.Op {
-			case parser.LIMITK, parser.LIMIT_RATIO:
+			if agg.Op.IsExperimentalAggregator() {
 				expFuncNames[agg.Op.String()] = struct{}{}
 			}
 		}


### PR DESCRIPTION
#### What this PR does

Very minor change to not hardcode the PromQL experimental aggregation functions, and use a function defined in Prometheus instead (made possible with a recent sync).

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/grafana/mimir/pull/9798 , part of https://github.com/grafana/mimir-squad/issues/2586

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
