### PR TITLE
fix(ha_tracker): track when there is a change during merge of ReplicaDesc Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 * [BUGFIX] Querier: Fix stddev+stdvar aggregations to treat Infinity consistently. #9844
 * [BUGFIX] Ingester: Chunks could have one unnecessary zero byte at the end. #9844
 * [BUGFIX] OTLP receiver: Preserve colons and combine multiple consecutive underscores into one when generating metric names in suffix adding mode (`-distributor.otel-metric-suffixes-enabled`). #10075
+* [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 
 ### Mixin
 

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -82,27 +82,32 @@ func (r *ReplicaDesc) mergeWithTime(mergeable memberlist.Mergeable) (memberlist.
 		return nil, nil
 	}
 
+	changed := false
 	if other.Replica == r.Replica {
 		// Keeping the one with the most recent receivedAt timestamp
 		if other.ReceivedAt > r.ReceivedAt {
 			*r = *other
+			changed = true
 		} else if r.ReceivedAt == other.ReceivedAt && r.DeletedAt == 0 && other.DeletedAt != 0 {
 			*r = *other
+			changed = true
 		}
 	} else {
 		// keep the most recent ElectedAt to reach consistency
 		if other.ElectedAt > r.ElectedAt {
 			*r = *other
+			changed = true
 		} else if other.ElectedAt == r.ElectedAt {
 			// if the timestamps are equal we compare ReceivedAt
 			if other.ReceivedAt > r.ReceivedAt {
 				*r = *other
+				changed = true
 			}
 		}
 	}
 
 	// No changes
-	if *r != *other {
+	if !changed {
 		return nil, nil
 	}
 

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -223,6 +223,13 @@ func TestReplicaDescMerge(t *testing.T) {
 			}(),
 			expectedChange: nil,
 		},
+		{
+			name:           "Merge should return no change when replica is the same",
+			rDesc1:         firstReplica(),
+			rDesc2:         firstReplica(),
+			expectedRDesc:  firstReplica(),
+			expectedChange: nil,
+		},
 	}
 
 	for _, tt := range testsMerge {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

## Issue

We observed that the number of `gossipMessages` for the `ha_tracker key` in the memberList KVStore was significantly higher compared to other keys. For example, after 5 minutes of running Mimir locally with 2 distributors and 2 Prom-HA instances, we had:

**Keys**
- ha_tracker: ~24k messages
- alertmanagers/alertmanager: ~987 messages (the next highest)

This is causing several issues:
- A high number of messages being broadcasted between Mimir components, requiring more bandwidth.
- Unnecessary changes in the versions of the keys (ha_tracker).

![Screenshot 2024-12-09 at 14 24 06](https://github.com/user-attachments/assets/7749b7ac-ad0a-45fc-94e2-56f33162c74c)

## Solution

We have observed that this is happening because of how the Merge function of ReplicaDesc was behaving. In order to check if there was a change or not it was comparing the two mergeable objects. However some gossip messages can have the same values and not have any change. So the *r != *other

For that reason we introduced a boolean variable to check if there was change. This reduced by a lot the number of public gossip messages it is shown below

![Screenshot 2024-12-09 at 14 24 45](https://github.com/user-attachments/assets/f7e2c7c6-754d-48ca-86e4-7d1797dfd313)

![Screenshot 2024-12-09 at 14 24 56](https://github.com/user-attachments/assets/ceeae5f7-543f-45f7-98fa-a70a93205576)




#### Which issue(s) this PR fixes or relates to

Related: https://github.com/grafana/mimir-squad/issues/2653

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
