### PR TITLE
UsageTracker: use only 32 shards

### DIFF
--- a/pkg/usagetracker/tenantshard/map_test.go
+++ b/pkg/usagetracker/tenantshard/map_test.go
@@ -19,7 +19,7 @@ func TestMap(t *testing.T) {
 	limit := uint64(events * seriesPerEvent)
 
 	// Start small, let rehashing happen.
-	m := New(seriesPerEvent, 0, Shards)
+	m := New(seriesPerEvent)
 
 	storedValues := map[uint64]clock.Minutes{}
 	for i := 1; i <= events; i++ {
@@ -100,7 +100,7 @@ func TestMap(t *testing.T) {
 func TestMapValues(t *testing.T) {
 	const count = 10e3
 	stored := map[uint64]clock.Minutes{}
-	m := New(100, 0, Shards)
+	m := New(100)
 	total := atomic.NewUint64(0)
 	for i := 0; i < count; i++ {
 		key := rand.Uint64() &^ valueMask // we can only store values of this shard.

--- a/pkg/usagetracker/tenantshard/map_test.go
+++ b/pkg/usagetracker/tenantshard/map_test.go
@@ -25,7 +25,7 @@ func TestMap(t *testing.T) {
 	for i := 1; i <= events; i++ {
 		refs := make([]uint64, seriesPerEvent)
 		for j := range refs {
-			refs[j] = uint64((i*100 + j) << valueBits)
+			refs[j] = uint64((i*100 + j) << prefixLen)
 			storedValues[refs[j]] = clock.Minutes(i)
 		}
 
@@ -49,7 +49,7 @@ func TestMap(t *testing.T) {
 	{
 		// No more series will fit.
 		resp := make(chan TrackResponse)
-		ref := uint64(65535) << valueBits
+		ref := uint64(65535) << prefixLen
 		m.Events() <- Track(
 			[]uint64{ref},
 			clock.Minutes(0),
@@ -103,8 +103,8 @@ func TestMapValues(t *testing.T) {
 	m := New(100)
 	total := atomic.NewUint64(0)
 	for i := 0; i < count; i++ {
-		key := rand.Uint64() &^ valueMask // we can only store values of this shard.
-		val := clock.Minutes(i) % valueMask
+		key := rand.Uint64()
+		val := clock.Minutes(i) % 128 // make sure we don't try to store 0xff
 		stored[key] = val
 		m.put(key, val, total, 0, false)
 	}

--- a/pkg/usagetracker/tracker_store.go
+++ b/pkg/usagetracker/tracker_store.go
@@ -19,7 +19,7 @@ import (
 	"github.com/grafana/mimir/pkg/usagetracker/tenantshard"
 )
 
-const shards = tenantshard.Shards
+const shards = 32
 const noLimit = math.MaxUint64
 
 // trackerStore holds the core business logic of the usage-tracker abstracted in a testable way.
@@ -188,7 +188,7 @@ func (t *trackerStore) getOrCreateTenant(tenantID string, limit uint64) *tracked
 		capacity = math.MaxUint32
 	}
 	for i := range tenant.shards {
-		tenant.shards[i] = tenantshard.New(uint32(capacity), uint8(i), shards)
+		tenant.shards[i] = tenantshard.New(uint32(capacity))
 	}
 	t.tenants[tenantID] = tenant
 	tenant.RLock()


### PR DESCRIPTION
This reduces the number of shards 4x, thus should reduce the overhead caused by channels synchronization.
