### PR TITLE
UsageTracker: throttle cleanup

### DIFF
--- a/pkg/usagetracker/tracker.go
+++ b/pkg/usagetracker/tracker.go
@@ -224,7 +224,7 @@ func (t *UsageTracker) run(ctx context.Context) error {
 	for {
 		select {
 		case now := <-ticker.C:
-			t.store.cleanup(now)
+			t.store.cleanup(now, time.Minute/shards/2)
 		case <-ctx.Done():
 			return nil
 		case err := <-t.subservicesWatcher.Chan():

--- a/pkg/usagetracker/tracker_store_bench_test.go
+++ b/pkg/usagetracker/tracker_store_bench_test.go
@@ -70,7 +70,7 @@ func benckmarkTrackerStoreTrackSeries(b *testing.B, seriesRefs []uint64, seriesP
 		go func() {
 			defer wg.Done()
 			for cleanupTime := range cleanup {
-				t.cleanup(cleanupTime)
+				t.cleanup(cleanupTime, 10*time.Microsecond)
 			}
 		}()
 	}


### PR DESCRIPTION
If we cleanup all tenant's shards in a row, we may end up in a situation where a TrackSeries request has to wait on each one of the cleanup calls, which causes a horrible p99.

This switches to cleanup each tenant's Nth shard first, and adds an optional min interval between shards to cover the case when there's only one tenant.