### PR TITLE
UsageTracker: more sparse map

### DIFF
--- a/pkg/usagetracker/tenantshard/map_nonsimd.go
+++ b/pkg/usagetracker/tenantshard/map_nonsimd.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	groupSize       = 8
-	maxAvgGroupLoad = 7
+	groupSize = 8
+	// maxAvgGroupLoad was 7 in dolthub/swiss, but we trade in some memory for less CPU by having to check less entries.
+	maxAvgGroupLoad = 4
 
 	loBits uint64 = 0x0101010101010101
 	hiBits uint64 = 0x8080808080808080


### PR DESCRIPTION
This will use more memory, but also probably less CPU as the buckets will be less full.