### PR TITLE
MQE: eliminate loops in `BucketedPool`

### DIFF
--- a/pkg/streamingpromql/operators/functions/histogram_quantile.go
+++ b/pkg/streamingpromql/operators/functions/histogram_quantile.go
@@ -77,7 +77,7 @@ var bucketGroupPool = zeropool.New(func() *bucketGroup {
 })
 
 var pointBucketPool = types.NewLimitingBucketedPool(
-	pool.NewBucketedPool(1, types.MaxExpectedPointsPerSeries, types.PointsPerSeriesBucketFactor, func(size int) []buckets {
+	pool.NewBucketedPool(types.MaxExpectedPointsPerSeries, func(size int) []buckets {
 		return make([]buckets, 0, size)
 	}),
 	uint64(unsafe.Sizeof(buckets{})),
@@ -98,7 +98,7 @@ func mangleBuckets(b buckets) buckets {
 const maxExpectedBucketsPerHistogram = 64 // There isn't much science to this
 
 var bucketSliceBucketedPool = types.NewLimitingBucketedPool(
-	pool.NewBucketedPool(1, maxExpectedBucketsPerHistogram, 2, func(size int) []bucket {
+	pool.NewBucketedPool(maxExpectedBucketsPerHistogram, func(size int) []bucket {
 		return make([]bucket, 0, size)
 	}),
 	uint64(unsafe.Sizeof(bucket{})),

--- a/pkg/streamingpromql/operators/subquery.go
+++ b/pkg/streamingpromql/operators/subquery.go
@@ -69,8 +69,15 @@ func (s *Subquery) NextSeries(ctx context.Context) error {
 	}
 
 	s.nextStepT = s.ParentQueryTimeRange.StartT
-	s.floats.Use(data.Floats)
-	s.histograms.Use(data.Histograms)
+
+	if err := s.floats.Use(data.Floats); err != nil {
+		return err
+	}
+
+	if err := s.histograms.Use(data.Histograms); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -124,7 +124,7 @@ func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, error) {
 		if !isPowerOfTwo(cap(newSlice)) {
 			// We rely on the capacity being a power of two for the pointsIndexMask optimisation below.
 			// If we can guarantee that newSlice has a capacity that is a power of two in the future, then we can drop this check.
-			panic(fmt.Sprintf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize))
+			return nil, fmt.Errorf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize)
 		}
 
 		newSlice = newSlice[:cap(newSlice)]
@@ -184,10 +184,10 @@ func (b *HPointRingBuffer) Release() {
 // s will be returned to the pool when Close is called, Use is called again, or the buffer needs to expand, so callers
 // should not return s to the pool themselves.
 // s must have a capacity that is a power of two.
-func (b *HPointRingBuffer) Use(s []promql.HPoint) {
+func (b *HPointRingBuffer) Use(s []promql.HPoint) error {
 	if !isPowerOfTwo(cap(s)) {
 		// We rely on the capacity being a power of two for the pointsIndexMask optimisation below.
-		panic(fmt.Sprintf("slice capacity must be a power of two, but is %v", cap(s)))
+		return fmt.Errorf("slice capacity must be a power of two, but is %v", cap(s))
 	}
 
 	putHPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
@@ -196,6 +196,7 @@ func (b *HPointRingBuffer) Use(s []promql.HPoint) {
 	b.firstIndex = 0
 	b.size = len(s)
 	b.pointsIndexMask = cap(s) - 1
+	return nil
 }
 
 // Close releases any resources associated with this buffer.

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	MaxExpectedPointsPerSeries  = 100_000 // There's not too much science behind this number: 100000 points allows for a point per minute for just under 70 days.
-	PointsPerSeriesBucketFactor = 2
+	MaxExpectedPointsPerSeries = 100_000 // There's not too much science behind this number: 100000 points allows for a point per minute for just under 70 days.
 
 	// Treat a native histogram sample as equivalent to this many float samples when considering max in-memory bytes limit.
 	// Keep in mind that float sample = timestamp + float value, so 5x this is equivalent to five timestamps and five floats.
@@ -36,7 +35,7 @@ var (
 	EnableManglingReturnedSlices = false
 
 	FPointSlicePool = NewLimitingBucketedPool(
-		pool.NewBucketedPool(1, MaxExpectedPointsPerSeries, PointsPerSeriesBucketFactor, func(size int) []promql.FPoint {
+		pool.NewBucketedPool(MaxExpectedPointsPerSeries, func(size int) []promql.FPoint {
 			return make([]promql.FPoint, 0, size)
 		}),
 		FPointSize,
@@ -45,7 +44,7 @@ var (
 	)
 
 	HPointSlicePool = NewLimitingBucketedPool(
-		pool.NewBucketedPool(1, MaxExpectedPointsPerSeries, PointsPerSeriesBucketFactor, func(size int) []promql.HPoint {
+		pool.NewBucketedPool(MaxExpectedPointsPerSeries, func(size int) []promql.HPoint {
 			return make([]promql.HPoint, 0, size)
 		}),
 		HPointSize,
@@ -57,7 +56,7 @@ var (
 	)
 
 	VectorPool = NewLimitingBucketedPool(
-		pool.NewBucketedPool(1, MaxExpectedPointsPerSeries, PointsPerSeriesBucketFactor, func(size int) promql.Vector {
+		pool.NewBucketedPool(MaxExpectedPointsPerSeries, func(size int) promql.Vector {
 			return make(promql.Vector, 0, size)
 		}),
 		VectorSampleSize,
@@ -66,7 +65,7 @@ var (
 	)
 
 	Float64SlicePool = NewLimitingBucketedPool(
-		pool.NewBucketedPool(1, MaxExpectedPointsPerSeries, PointsPerSeriesBucketFactor, func(size int) []float64 {
+		pool.NewBucketedPool(MaxExpectedPointsPerSeries, func(size int) []float64 {
 			return make([]float64, 0, size)
 		}),
 		Float64Size,
@@ -75,7 +74,7 @@ var (
 	)
 
 	BoolSlicePool = NewLimitingBucketedPool(
-		pool.NewBucketedPool(1, MaxExpectedPointsPerSeries, PointsPerSeriesBucketFactor, func(size int) []bool {
+		pool.NewBucketedPool(MaxExpectedPointsPerSeries, func(size int) []bool {
 			return make([]bool, 0, size)
 		}),
 		BoolSize,
@@ -84,7 +83,7 @@ var (
 	)
 
 	HistogramSlicePool = NewLimitingBucketedPool(
-		pool.NewBucketedPool(1, MaxExpectedPointsPerSeries, PointsPerSeriesBucketFactor, func(size int) []*histogram.FloatHistogram {
+		pool.NewBucketedPool(MaxExpectedPointsPerSeries, func(size int) []*histogram.FloatHistogram {
 			return make([]*histogram.FloatHistogram, 0, size)
 		}),
 		HistogramPointerSize,

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -25,7 +25,7 @@ func TestLimitingBucketedPool_Unlimited(t *testing.T) {
 	tracker := limiting.NewMemoryConsumptionTracker(0, metric)
 
 	p := NewLimitingBucketedPool(
-		pool.NewBucketedPool(1, 1000, 2, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
+		pool.NewBucketedPool(1000, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
 		FPointSize,
 		false,
 		nil,
@@ -78,7 +78,7 @@ func TestLimitingPool_Limited(t *testing.T) {
 	tracker := limiting.NewMemoryConsumptionTracker(limit, metric)
 
 	p := NewLimitingBucketedPool(
-		pool.NewBucketedPool(1, 1000, 2, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
+		pool.NewBucketedPool(1000, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
 		FPointSize,
 		false,
 		nil,
@@ -203,7 +203,7 @@ func TestLimitingPool_Mangling(t *testing.T) {
 	tracker := limiting.NewMemoryConsumptionTracker(0, metric)
 
 	p := NewLimitingBucketedPool(
-		pool.NewBucketedPool(1, 1000, 2, func(size int) []int { return make([]int, 0, size) }),
+		pool.NewBucketedPool(1000, func(size int) []int { return make([]int, 0, size) }),
 		1,
 		false,
 		func(_ int) int { return 123 },

--- a/pkg/streamingpromql/types/pool.go
+++ b/pkg/streamingpromql/types/pool.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	maxExpectedSeriesPerResult = 10_000_000 // Likewise, there's not too much science behind this number: this is the based on examining the largest queries seen at Grafana Labs.
+	maxExpectedSeriesPerResult = 10_000_000 // There's not too much science behind this number: this is the based on examining the largest queries seen at Grafana Labs.
 )
 
 var (

--- a/pkg/streamingpromql/types/pool.go
+++ b/pkg/streamingpromql/types/pool.go
@@ -9,16 +9,15 @@ import (
 )
 
 const (
-	maxExpectedSeriesPerResult  = 10_000_000 // Likewise, there's not too much science behind this number: this is the based on examining the largest queries seen at Grafana Labs.
-	seriesPerResultBucketFactor = 2
+	maxExpectedSeriesPerResult = 10_000_000 // Likewise, there's not too much science behind this number: this is the based on examining the largest queries seen at Grafana Labs.
 )
 
 var (
-	matrixPool = pool.NewBucketedPool(1, maxExpectedSeriesPerResult, seriesPerResultBucketFactor, func(size int) promql.Matrix {
+	matrixPool = pool.NewBucketedPool(maxExpectedSeriesPerResult, func(size int) promql.Matrix {
 		return make(promql.Matrix, 0, size)
 	})
 
-	seriesMetadataSlicePool = pool.NewBucketedPool(1, maxExpectedSeriesPerResult, seriesPerResultBucketFactor, func(size int) []SeriesMetadata {
+	seriesMetadataSlicePool = pool.NewBucketedPool(maxExpectedSeriesPerResult, func(size int) []SeriesMetadata {
 		return make([]SeriesMetadata, 0, size)
 	})
 )

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -19,7 +19,7 @@ type ringBuffer[T any] interface {
 	DiscardPointsAtOrBefore(t int64)
 	Append(p T) error
 	Reset()
-	Use(s []T)
+	Use(s []T) error
 	Release()
 	ViewUntilSearchingForwardsForTesting(maxT int64) ringBufferView[T]
 	ViewUntilSearchingBackwardsForTesting(maxT int64) ringBufferView[T]
@@ -120,7 +120,8 @@ func testRingBuffer[T any](t *testing.T, buf ringBuffer[T], points []T) {
 
 	pointsWithPowerOfTwoCapacity := make([]T, 0, 16) // Use must be passed a slice with a capacity that is equal to a power of 2.
 	pointsWithPowerOfTwoCapacity = append(pointsWithPowerOfTwoCapacity, points...)
-	buf.Use(pointsWithPowerOfTwoCapacity)
+	err := buf.Use(pointsWithPowerOfTwoCapacity)
+	require.NoError(t, err)
 	shouldHavePoints(t, buf, points...)
 
 	buf.DiscardPointsAtOrBefore(4)
@@ -131,7 +132,8 @@ func testRingBuffer[T any](t *testing.T, buf ringBuffer[T], points []T) {
 
 	subsliceWithPowerOfTwoCapacity := make([]T, 0, 8) // Use must be passed a slice with a capacity that is equal to a power of 2.
 	subsliceWithPowerOfTwoCapacity = append(subsliceWithPowerOfTwoCapacity, points[4:]...)
-	buf.Use(subsliceWithPowerOfTwoCapacity)
+	err = buf.Use(subsliceWithPowerOfTwoCapacity)
+	require.NoError(t, err)
 	shouldHavePoints(t, buf, points[4:]...)
 }
 

--- a/pkg/util/pool/bucketed_pool.go
+++ b/pkg/util/pool/bucketed_pool.go
@@ -6,41 +6,35 @@
 package pool
 
 import (
+	"fmt"
+	"math/bits"
+
 	"github.com/prometheus/prometheus/util/zeropool"
 )
 
 // BucketedPool is a bucketed pool for variably sized slices.
-// It is similar to prometheus/prometheus' pool.Pool, but uses zeropool.Pool internally, and
-// generics to avoid reflection.
+// It is similar to prometheus/prometheus' pool.Pool, but:
+// - uses zeropool.Pool internally
+// - uses generics to avoid reflection
+// - only supports using a factor of 2
 type BucketedPool[T ~[]E, E any] struct {
 	buckets []zeropool.Pool[T]
-	sizes   []int
+	maxSize uint
 	// make is the function used to create an empty slice when none exist yet.
 	make func(int) T
 }
 
-// NewBucketedPool returns a new BucketedPool with size buckets for minSize to maxSize
-// increasing by the given factor.
-func NewBucketedPool[T ~[]E, E any](minSize, maxSize int, factor int, makeFunc func(int) T) *BucketedPool[T, E] {
-	if minSize < 1 {
-		panic("invalid minimum pool size")
-	}
-	if maxSize < 1 {
+// NewBucketedPool returns a new BucketedPool with buckets separated by a factor of 2 up to maxSize.
+func NewBucketedPool[T ~[]E, E any](maxSize uint, makeFunc func(int) T) *BucketedPool[T, E] {
+	if maxSize <= 1 {
 		panic("invalid maximum pool size")
 	}
-	if factor < 1 {
-		panic("invalid factor")
-	}
 
-	var sizes []int
-
-	for s := minSize; s <= maxSize; s = s * factor {
-		sizes = append(sizes, s)
-	}
+	bucketCount := bits.Len(maxSize)
 
 	p := &BucketedPool[T, E]{
-		buckets: make([]zeropool.Pool[T], len(sizes)),
-		sizes:   sizes,
+		buckets: make([]zeropool.Pool[T], bucketCount),
+		maxSize: maxSize,
 		make:    makeFunc,
 	}
 
@@ -49,39 +43,42 @@ func NewBucketedPool[T ~[]E, E any](minSize, maxSize int, factor int, makeFunc f
 
 // Get returns a new slice with capacity greater than or equal to size.
 func (p *BucketedPool[T, E]) Get(size int) T {
-	for i, bktSize := range p.sizes {
-		if size > bktSize {
-			continue
-		}
-		b := p.buckets[i].Get()
-		if b == nil {
-			b = p.make(bktSize)
-		}
-		return b
+	if size < 0 {
+		panic(fmt.Sprintf("BucketedPool.Get with negative size %v", size))
 	}
-	return p.make(size)
+
+	if size == 0 {
+		return nil
+	}
+
+	if uint(size) > p.maxSize {
+		return p.make(size)
+	}
+
+	bucketIndex := bits.Len(uint(size - 1))
+	s := p.buckets[bucketIndex].Get()
+
+	if s == nil {
+		nextPowerOfTwo := 1 << bucketIndex
+		s = p.make(nextPowerOfTwo)
+	}
+
+	return s
 }
 
 // Put adds a slice to the right bucket in the pool.
 // If the slice does not belong to any bucket in the pool, it is ignored.
 func (p *BucketedPool[T, E]) Put(s T) {
-	if cap(s) < p.sizes[0] {
+	size := uint(cap(s))
+
+	if size == 0 || size > p.maxSize {
 		return
 	}
 
-	for i, size := range p.sizes {
-		if cap(s) > size {
-			continue
-		}
-
-		if cap(s) == size {
-			// Slice is exactly the minimum size for this bucket. Add it to this bucket.
-			p.buckets[i].Put(s[0:0])
-		} else {
-			// Slice belongs in previous bucket.
-			p.buckets[i-1].Put(s[0:0])
-		}
-
-		return
+	bucketIndex := bits.Len(size - 1)
+	if size != (1 << bucketIndex) {
+		bucketIndex--
 	}
+
+	p.buckets[bucketIndex].Put(s[0:0])
 }

--- a/pkg/util/pool/bucketed_pool_test.go
+++ b/pkg/util/pool/bucketed_pool_test.go
@@ -59,7 +59,7 @@ func TestBucketedPool_HappyPath(t *testing.T) {
 		},
 		{
 			size:        20,
-			expectedCap: 20,
+			expectedCap: 20, // Max size is 19, so we expect to get a slice with the size requested (20), not 32 (the next power of two).
 		},
 	}
 

--- a/pkg/util/pool/bucketed_pool_test.go
+++ b/pkg/util/pool/bucketed_pool_test.go
@@ -16,48 +16,109 @@ func makeFunc(size int) []int {
 }
 
 func TestBucketedPool_HappyPath(t *testing.T) {
-	testPool := NewBucketedPool(1, 8, 2, makeFunc)
+
 	cases := []struct {
 		size        int
 		expectedCap int
 	}{
 		{
-			size:        -1,
+			size:        0,
+			expectedCap: 0,
+		},
+		{
+			size:        1,
 			expectedCap: 1,
 		},
 		{
+			// One less than bucket boundary
 			size:        3,
 			expectedCap: 4,
 		},
 		{
-			size:        10,
-			expectedCap: 10,
+			// Same as bucket boundary
+			size:        4,
+			expectedCap: 4,
+		},
+		{
+			// One more than bucket boundary
+			size:        5,
+			expectedCap: 8,
+		},
+		{
+			// Two more than bucket boundary
+			size:        6,
+			expectedCap: 8,
+		},
+		{
+			size:        8,
+			expectedCap: 8,
+		},
+		{
+			size:        16,
+			expectedCap: 16,
+		},
+		{
+			size:        20,
+			expectedCap: 20,
 		},
 	}
-	for _, c := range cases {
-		ret := testPool.Get(c.size)
-		require.Equal(t, c.expectedCap, cap(ret))
-		testPool.Put(ret)
+
+	runTests := func(t *testing.T, returnToPool bool) {
+		testPool := NewBucketedPool(19, makeFunc)
+		for _, c := range cases {
+			ret := testPool.Get(c.size)
+			require.Equal(t, c.expectedCap, cap(ret))
+			require.Len(t, ret, 0)
+
+			if returnToPool {
+				// Add something to the slice, so we can test that the next consumer of the slice receives a slice of length 0.
+				if cap(ret) > 0 {
+					ret = append(ret, 123)
+				}
+
+				testPool.Put(ret)
+			}
+		}
 	}
+
+	t.Run("populated pool", func(t *testing.T) {
+		runTests(t, true)
+	})
+
+	t.Run("empty pool", func(t *testing.T) {
+		runTests(t, false)
+	})
 }
 
 func TestBucketedPool_SliceNotAlignedToBuckets(t *testing.T) {
-	pool := NewBucketedPool(1, 1000, 10, makeFunc)
-	pool.Put(make([]int, 0, 2))
-	s := pool.Get(3)
-	require.GreaterOrEqual(t, cap(s), 3)
+	pool := NewBucketedPool(1000, makeFunc)
+	pool.Put(make([]int, 0, 5))
+	s := pool.Get(6)
+	require.Equal(t, 8, cap(s))
+	require.Len(t, s, 0)
 }
 
 func TestBucketedPool_PutEmptySlice(t *testing.T) {
-	pool := NewBucketedPool(1, 1000, 10, makeFunc)
+	pool := NewBucketedPool(1000, makeFunc)
 	pool.Put([]int{})
 	s := pool.Get(1)
-	require.GreaterOrEqual(t, cap(s), 1)
+	require.Equal(t, 1, cap(s))
+	require.Len(t, s, 0)
 }
 
-func TestBucketedPool_PutSliceSmallerThanMinimum(t *testing.T) {
-	pool := NewBucketedPool(3, 1000, 10, makeFunc)
-	pool.Put([]int{1, 2})
-	s := pool.Get(3)
-	require.GreaterOrEqual(t, cap(s), 3)
+func TestBucketedPool_PutNilSlice(t *testing.T) {
+	pool := NewBucketedPool(1000, makeFunc)
+	pool.Put(nil)
+	s := pool.Get(1)
+	require.Equal(t, 1, cap(s))
+	require.Len(t, s, 0)
+}
+
+func TestBucketedPool_PutSliceLargerThanMaximum(t *testing.T) {
+	pool := NewBucketedPool(100, makeFunc)
+	s1 := make([]int, 101)
+	pool.Put(s1)
+	s2 := pool.Get(101)[:101]
+	require.NotSame(t, &s1[0], &s2[0])
+	require.Equal(t, 101, cap(s2))
 }


### PR DESCRIPTION
#### What this PR does

This PR eliminates the use of loops in `BucketedPool`. This gives a very mild speedup (<1%) to queries with many steps and many series.

It also removes the panics in both ring buffer's `Append` and `Use` methods. It's possible that the conditions that previously would have caused a panic could happen in the real world if a subquery selected enough points that it exceeded the maximum size of a slice returned from the `FPoint` or `HPoint` pool, so it seems safer to return an error here rather than crashing the process.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
