### PR TITLE
Chore: use strconv.ParseInt() with 32bit when parsing 32bit numbers

### DIFF
--- a/pkg/querier/metadata_handler.go
+++ b/pkg/querier/metadata_handler.go
@@ -74,8 +74,8 @@ func NewMetadataHandler(m MetadataSupplier) http.Handler {
 
 		metric := r.FormValue("metric")
 		req := &client.MetricsMetadataRequest{
-			Limit:          int32(limit),
-			LimitPerMetric: int32(limitPerMetric),
+			Limit:          limit,
+			LimitPerMetric: limitPerMetric,
 			Metric:         metric,
 		}
 

--- a/pkg/querier/metadata_handler.go
+++ b/pkg/querier/metadata_handler.go
@@ -50,24 +50,26 @@ func NewMetadataHandler(m MetadataSupplier) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		limit := int32(-1)
 		if s := r.FormValue("limit"); s != "" {
-			if parsed, err := strconv.ParseInt(s, 10, 32); err != nil {
+			parsed, err := strconv.ParseInt(s, 10, 32)
+			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				util.WriteJSONResponse(w, metadataErrorResult{Status: statusError, Error: "limit must be a number"})
 				return
-			} else {
-				limit = int32(parsed)
 			}
+
+			limit = int32(parsed)
 		}
 
 		limitPerMetric := int32(-1)
 		if s := r.FormValue("limit_per_metric"); s != "" {
-			if parsed, err := strconv.ParseInt(s, 10, 32); err != nil {
+			parsed, err := strconv.ParseInt(s, 10, 32)
+			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				util.WriteJSONResponse(w, metadataErrorResult{Status: statusError, Error: "limit_per_metric must be a number"})
 				return
-			} else {
-				limitPerMetric = int32(parsed)
 			}
+
+			limitPerMetric = int32(parsed)
 		}
 
 		metric := r.FormValue("metric")

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -36,7 +36,7 @@ func IngesterPartitionID(ingesterID string) (int32, error) {
 	}
 
 	// Parse the ingester sequence number.
-	ingesterSeq, err := strconv.Atoi(match[1])
+	ingesterSeq, err := strconv.ParseInt(match[1], 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("no ingester sequence number in ingester ID %s", ingesterID)
 	}


### PR DESCRIPTION
#### What this PR does

We have a static security analysis tool which is complaining with "Potential Integer overflow made by strconv.Atoi result conversion to int16/32" in few places. In this PR I'm changing such parsing to use `strconv.ParseInt()` instead.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
