### PR TITLE
Update CHANGELOG.md with PRs not in 2.15-rc.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@
 
 ### Grafana Mimir
 
+* [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
+
+
 ### Mixin
+
+* [BUGFIX] Dashboards: fix how we switch between classic and native histograms. #10018
 
 ### Jsonnet
 
@@ -17,6 +22,8 @@
 ### Query-tee
 
 ### Documentation
+
+* [CHANGE] Add production tips related to cache size, heavy multi-tenancy and latency spikes. #9978
 
 ### Tools
 
@@ -123,7 +130,6 @@
 * [BUGFIX] Querier: Fix stddev+stdvar aggregations to treat Infinity consistently. #9844
 * [BUGFIX] Ingester: Chunks could have one unnecessary zero byte at the end. #9844
 * [BUGFIX] OTLP receiver: Preserve colons and combine multiple consecutive underscores into one when generating metric names in suffix adding mode (`-distributor.otel-metric-suffixes-enabled`). #10075
-* [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 
 ### Mixin
 
@@ -141,7 +147,6 @@
 * [BUGFIX] Alerts: Exclude read-only replicas from `IngesterInstanceHasNoTenants` alert. #9843
 * [BUGFIX] Alerts: Use resident set memory for the `EtcdAllocatingTooMuchMemory` alert so that ephemeral file cache memory doesn't cause the alert to misfire. #9997
 * [BUGFIX] Query-frontend: support `X-Read-Consistency-Offsets` on labels queries too.
-* [BUGFIX] Dashboards: fix how we switch between classic and native histograms. #10018
 
 ### Jsonnet
 
@@ -171,7 +176,6 @@
 
 ### Documentation
 
-* [CHANGE] Add production tips related to cache size, heavy multi-tenancy and latency spikes. #9978
 * [BUGFIX] Send native histograms: update the migration guide with the corrected dashboard query for switching between classic and native histograms queries. #10052
 
 ### Tools


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Some PRs got merged before notifying about the 2.15 release candidate being cut went out; this moves them to `main / unreleased`.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/issues/10151

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
