### PR TITLE
mimirtool: document TLS environment variables and CLI flags, and fix stutter in environment variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Mimirtool
 
+* [BUGFIX] Fix issue where `MIMIR_HTTP_PREFIX` environment variable was ignored and the value from `MIMIR_MIMIR_HTTP_PREFIX` was used instead. #10207
+
 ### Mimir Continuous Test
 
 ### Query-tee

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -77,6 +77,15 @@ For Mimirtools to interact with Grafana Mimir, Grafana Enterprise Metrics, Prome
 | `MIMIR_API_KEY`      | `--key`     | Sets the basic auth password. If you're using Grafana Cloud, this variable is your API key.                                                                                                      |
 | `MIMIR_TENANT_ID`    | `--id`      | Sets the tenant ID of the Grafana Mimir instance that Mimirtools interacts with.                                                                                                                 |
 
+It is also possible to set TLS-related options with the following environment variables or CLI flags:
+
+| Environment variable             | Flag                         | Description                                                                                                            |
+|----------------------------------|------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `MIMIR_TLS_CA_PATH`              | `--tls-ca-path`              | Sets the path to the CA certificate to use to verify the connection to the Grafana Mimir cluster.                      |
+| `MIMIR_TLS_CERT_PATH`            | `--tls-cert-path`            | Sets the path to the client certificate to use to authenticate to the Grafana Mimir cluster.                           |
+| `MIMIR_TLS_KEY_PATH`             | `--tls-key-path`             | Sets the path to the private key to use to authenticate to the Grafana Mimir cluster.                                  |
+| `MIMIR_TLS_INSECURE_SKIP_VERIFY` | `--tls-insecure-skip-verify` | If `true`, disables verification of the Grafana Mimir cluster's TLS certificate. This is insecure and not recommended. |
+
 ## Commands
 
 The following sections outline the commands that you can run against Grafana Mimir and Grafana Cloud Metrics.

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -80,7 +80,7 @@ For Mimirtools to interact with Grafana Mimir, Grafana Enterprise Metrics, Prome
 It is also possible to set TLS-related options with the following environment variables or CLI flags:
 
 | Environment variable             | Flag                         | Description                                                                                                            |
-|----------------------------------|------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| -------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `MIMIR_TLS_CA_PATH`              | `--tls-ca-path`              | Sets the path to the CA certificate to use to verify the connection to the Grafana Mimir cluster.                      |
 | `MIMIR_TLS_CERT_PATH`            | `--tls-cert-path`            | Sets the path to the client certificate to use to authenticate to the Grafana Mimir cluster.                           |
 | `MIMIR_TLS_KEY_PATH`             | `--tls-key-path`             | Sets the path to the private key to use to authenticate to the Grafana Mimir cluster.                                  |

--- a/pkg/mimirtool/commands/env_var.go
+++ b/pkg/mimirtool/commands/env_var.go
@@ -30,7 +30,7 @@ func NewEnvVarsWithPrefix(prefix string) EnvVarNames {
 		useLegacyRoutes       = "USE_LEGACY_ROUTES"
 		authToken             = "AUTH_TOKEN"
 		extraHeaders          = "EXTRA_HEADERS"
-		mimirHTTPPrefix       = "MIMIR_HTTP_PREFIX"
+		mimirHTTPPrefix       = "HTTP_PREFIX"
 	)
 
 	if len(prefix) > 0 && prefix[len(prefix)-1] != '_' {


### PR DESCRIPTION
#### What this PR does

This PR documents the TLS-related environment variables and CLI flags for `mimirtool`, and fixes a stutter in the `MIMIR_HTTP_PREFIX` environment variable.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
