### PR TITLE
MQE: don't select more data than strictly necessary

### DIFF
--- a/pkg/streamingpromql/operators/selectors/selector.go
+++ b/pkg/streamingpromql/operators/selectors/selector.go
@@ -57,7 +57,7 @@ func (s *Selector) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, 
 
 	// Apply lookback delta, range and offset after adjusting for timestamp from @ modifier.
 	rangeMilliseconds := s.Range.Milliseconds()
-	startTimestamp = startTimestamp - s.LookbackDelta.Milliseconds() - rangeMilliseconds - s.Offset - 1 // -1 to exclude samples on the lower boundary of the range.
+	startTimestamp = startTimestamp - s.LookbackDelta.Milliseconds() - rangeMilliseconds - s.Offset + 1 // +1 to exclude samples on the lower boundary of the range (queriers work with closed intervals, we use left-open).
 	endTimestamp = endTimestamp - s.Offset
 
 	hints := &storage.SelectHints{


### PR DESCRIPTION
#### What this PR does

This PR fixes the behaviour of MQE to select only the data necessary for the query.

https://github.com/grafana/mimir/pull/9844 introduced an incorrect calculation for the time range required for a selector. The extra millisecond doesn't usually matter, except for range queries that run for exactly `max_partial_query_length`, where this incorrect value would result in us returning a `err-mimir-max-query-length` error incorrectly.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/10067

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a - covered by generic entry for MQE that references #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
