### PR TITLE
chore(otel_test): rework test to prep for keep id resource attributes

### DIFF
--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -53,11 +53,11 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 		"service.instance.id": "service ID",
 		"existent-attr":       "resource value",
 		// This one is for testing conflict with metric attribute.
-		"metric-attr": "resource value conflict",
+		"metric-attr": "resource value",
 		// This one is for testing conflict with auto-generated job attribute.
-		"job": "resource value conflict",
+		"job": "resource value",
 		// This one is for testing conflict with auto-generated instance attribute.
-		"instance": "resource value conflict",
+		"instance": "resource value",
 	}
 
 	md := pmetric.NewMetrics()
@@ -113,7 +113,7 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 				},
 				{
 					Name:  "metric_attr",
-					Value: "resource value conflict",
+					Value: "resource value",
 				},
 				{
 					Name:  "job",
@@ -161,7 +161,7 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 				},
 				{
 					Name:  "metric_attr",
-					Value: "resource value conflict",
+					Value: "resource value",
 				},
 				{
 					Name:  "job",
@@ -217,7 +217,7 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 				},
 				{
 					Name:  "metric_attr",
-					Value: "resource value conflict",
+					Value: "resource value",
 				},
 			},
 		},

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
-	prometheustranslator "github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -50,41 +49,16 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 	}, []string{tenantID, "group"})
 	resourceAttrs := map[string]string{
 		"service.name":        "service name",
+		"service.namespace":   "service namespace",
 		"service.instance.id": "service ID",
 		"existent-attr":       "resource value",
 		// This one is for testing conflict with metric attribute.
-		"metric-attr": "resource value",
+		"metric-attr": "resource value conflict",
 		// This one is for testing conflict with auto-generated job attribute.
-		"job": "resource value",
+		"job": "resource value conflict",
 		// This one is for testing conflict with auto-generated instance attribute.
-		"instance": "resource value",
+		"instance": "resource value conflict",
 	}
-	expTargetInfoLabels := []mimirpb.LabelAdapter{
-		{
-			Name:  labels.MetricName,
-			Value: "target_info",
-		},
-	}
-	for k, v := range resourceAttrs {
-		switch k {
-		case "service.name":
-			k = "job"
-		case "service.instance.id":
-			k = "instance"
-		case "job", "instance":
-			// Ignore, as these labels are generated from service.name and service.instance.id
-			continue
-		default:
-			k = prometheustranslator.NormalizeLabel(k, false)
-		}
-		expTargetInfoLabels = append(expTargetInfoLabels, mimirpb.LabelAdapter{
-			Name:  k,
-			Value: v,
-		})
-	}
-	slices.SortStableFunc(expTargetInfoLabels, func(a, b mimirpb.LabelAdapter) int {
-		return strings.Compare(a.Name, b.Name)
-	})
 
 	md := pmetric.NewMetrics()
 	{
@@ -105,6 +79,7 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 		name                      string
 		promoteResourceAttributes []string
 		expectedLabels            []mimirpb.LabelAdapter
+		expectedInfoLabels        []mimirpb.LabelAdapter
 	}{
 		{
 			name:                      "Successful conversion without resource attribute promotion",
@@ -120,11 +95,33 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 				},
 				{
 					Name:  "job",
-					Value: "service name",
+					Value: "service namespace/service name",
 				},
 				{
 					Name:  "metric_attr",
 					Value: "metric value",
+				},
+			},
+			expectedInfoLabels: []mimirpb.LabelAdapter{
+				{
+					Name:  "__name__",
+					Value: "target_info",
+				},
+				{
+					Name:  "existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "metric_attr",
+					Value: "resource value conflict",
+				},
+				{
+					Name:  "job",
+					Value: "service namespace/service name",
+				},
+				{
+					Name:  "instance",
+					Value: "service ID",
 				},
 			},
 		},
@@ -142,7 +139,7 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 				},
 				{
 					Name:  "job",
-					Value: "service name",
+					Value: "service namespace/service name",
 				},
 				{
 					Name:  "metric_attr",
@@ -151,6 +148,28 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 				{
 					Name:  "existent_attr",
 					Value: "resource value",
+				},
+			},
+			expectedInfoLabels: []mimirpb.LabelAdapter{
+				{
+					Name:  "__name__",
+					Value: "target_info",
+				},
+				{
+					Name:  "existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "metric_attr",
+					Value: "resource value conflict",
+				},
+				{
+					Name:  "job",
+					Value: "service namespace/service name",
+				},
+				{
+					Name:  "instance",
+					Value: "service ID",
 				},
 			},
 		},
@@ -168,7 +187,7 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 				},
 				{
 					Name:  "job",
-					Value: "service name",
+					Value: "service namespace/service name",
 				},
 				{
 					Name:  "existent_attr",
@@ -177,6 +196,28 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 				{
 					Name:  "metric_attr",
 					Value: "metric value",
+				},
+			},
+			expectedInfoLabels: []mimirpb.LabelAdapter{
+				{
+					Name:  "__name__",
+					Value: "target_info",
+				},
+				{
+					Name:  "existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "instance",
+					Value: "service ID",
+				},
+				{
+					Name:  "job",
+					Value: "service namespace/service name",
+				},
+				{
+					Name:  "metric_attr",
+					Value: "resource value conflict",
 				},
 			},
 		},
@@ -205,7 +246,7 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 			}
 
 			assert.ElementsMatch(t, ts.Labels, tc.expectedLabels)
-			assert.ElementsMatch(t, targetInfo.Labels, expTargetInfoLabels)
+			assert.ElementsMatch(t, targetInfo.Labels, tc.expectedInfoLabels)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

Rework the test to be more explicit and support testing for https://github.com/prometheus/prometheus/pull/15448 that's coming next.

#### Which issue(s) this PR fixes or relates to

Related to #10188 
Related to https://github.com/prometheus/prometheus/pull/15448

#### Checklist

- [X] Tests updated.
- N/A Documentation added.
- N/A `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
