### PR TITLE
query-frontend: Allow for multiple topics in readConsistencyRoundTripper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [CHANGE] Query-frontend: Add `topic` label to `cortex_ingest_storage_strong_consistency_requests_total`, `cortex_ingest_storage_strong_consistency_failures_total`, and `cortex_ingest_storage_strong_consistency_wait_duration_seconds` metrics. #10220
+
 ### Grafana Mimir
 
 * [CHANGE] Distributor: OTLP and push handler replace all non-UTF8 characters with the unicode replacement character `\uFFFD` in error messages before propagating them. #10236

--- a/pkg/frontend/querymiddleware/read_consistency_test.go
+++ b/pkg/frontend/querymiddleware/read_consistency_test.go
@@ -103,7 +103,7 @@ func TestReadConsistencyRoundTripper(t *testing.T) {
 			}
 
 			reg := prometheus.NewPedanticRegistry()
-			rt := newReadConsistencyRoundTripper(downstream, reader, testData.limits, log.NewNopLogger(), newReadConsistencyMetrics(reg))
+			rt := newReadConsistencyRoundTripper(downstream, map[string]*ingest.TopicOffsetsReader{querierapi.ReadConsistencyOffsetsHeader: reader}, testData.limits, log.NewNopLogger(), newReadConsistencyMetrics(reg))
 			_, err = rt.RoundTrip(req)
 			require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -282,7 +282,7 @@ func newQueryTripperware(
 
 		// Enforce read consistency after caching.
 		if len(ingestStorageTopicOffsetsReaders) > 0 {
-			metrics := newReadConsistencyMetrics(registerer)
+			metrics := newReadConsistencyMetrics(registerer, ingestStorageTopicOffsetsReaders)
 
 			queryrange = newReadConsistencyRoundTripper(queryrange, ingestStorageTopicOffsetsReaders, limits, log, metrics)
 			instant = newReadConsistencyRoundTripper(instant, ingestStorageTopicOffsetsReaders, limits, log, metrics)

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -207,10 +207,10 @@ func NewTripperware(
 	cacheExtractor Extractor,
 	engineOpts promql.EngineOpts,
 	engineExperimentalFunctionsEnabled bool,
-	ingestStorageTopicOffsetsReader *ingest.TopicOffsetsReader,
+	ingestStorageTopicOffsetsReaders map[string]*ingest.TopicOffsetsReader,
 	registerer prometheus.Registerer,
 ) (Tripperware, error) {
-	queryRangeTripperware, err := newQueryTripperware(cfg, log, limits, codec, cacheExtractor, engineOpts, engineExperimentalFunctionsEnabled, ingestStorageTopicOffsetsReader, registerer)
+	queryRangeTripperware, err := newQueryTripperware(cfg, log, limits, codec, cacheExtractor, engineOpts, engineExperimentalFunctionsEnabled, ingestStorageTopicOffsetsReaders, registerer)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func newQueryTripperware(
 	cacheExtractor Extractor,
 	engineOpts promql.EngineOpts,
 	engineExperimentalFunctionsEnabled bool,
-	ingestStorageTopicOffsetsReader *ingest.TopicOffsetsReader,
+	ingestStorageTopicOffsetsReaders map[string]*ingest.TopicOffsetsReader,
 	registerer prometheus.Registerer,
 ) (Tripperware, error) {
 	// Disable concurrency limits for sharded queries.
@@ -281,18 +281,18 @@ func newQueryTripperware(
 		}
 
 		// Enforce read consistency after caching.
-		if ingestStorageTopicOffsetsReader != nil {
+		if len(ingestStorageTopicOffsetsReaders) > 0 {
 			metrics := newReadConsistencyMetrics(registerer)
 
-			queryrange = newReadConsistencyRoundTripper(queryrange, ingestStorageTopicOffsetsReader, limits, log, metrics)
-			instant = newReadConsistencyRoundTripper(instant, ingestStorageTopicOffsetsReader, limits, log, metrics)
-			cardinality = newReadConsistencyRoundTripper(cardinality, ingestStorageTopicOffsetsReader, limits, log, metrics)
-			activeSeries = newReadConsistencyRoundTripper(activeSeries, ingestStorageTopicOffsetsReader, limits, log, metrics)
-			activeNativeHistogramMetrics = newReadConsistencyRoundTripper(activeNativeHistogramMetrics, ingestStorageTopicOffsetsReader, limits, log, metrics)
-			labels = newReadConsistencyRoundTripper(labels, ingestStorageTopicOffsetsReader, limits, log, metrics)
-			series = newReadConsistencyRoundTripper(series, ingestStorageTopicOffsetsReader, limits, log, metrics)
-			remoteRead = newReadConsistencyRoundTripper(remoteRead, ingestStorageTopicOffsetsReader, limits, log, metrics)
-			next = newReadConsistencyRoundTripper(next, ingestStorageTopicOffsetsReader, limits, log, metrics)
+			queryrange = newReadConsistencyRoundTripper(queryrange, ingestStorageTopicOffsetsReaders, limits, log, metrics)
+			instant = newReadConsistencyRoundTripper(instant, ingestStorageTopicOffsetsReaders, limits, log, metrics)
+			cardinality = newReadConsistencyRoundTripper(cardinality, ingestStorageTopicOffsetsReaders, limits, log, metrics)
+			activeSeries = newReadConsistencyRoundTripper(activeSeries, ingestStorageTopicOffsetsReaders, limits, log, metrics)
+			activeNativeHistogramMetrics = newReadConsistencyRoundTripper(activeNativeHistogramMetrics, ingestStorageTopicOffsetsReaders, limits, log, metrics)
+			labels = newReadConsistencyRoundTripper(labels, ingestStorageTopicOffsetsReaders, limits, log, metrics)
+			series = newReadConsistencyRoundTripper(series, ingestStorageTopicOffsetsReaders, limits, log, metrics)
+			remoteRead = newReadConsistencyRoundTripper(remoteRead, ingestStorageTopicOffsetsReaders, limits, log, metrics)
+			next = newReadConsistencyRoundTripper(next, ingestStorageTopicOffsetsReaders, limits, log, metrics)
 		}
 
 		// Look up cache as first thing after validation.

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -874,7 +874,7 @@ func TestTripperware_ShouldSupportReadConsistencyOffsetsInjection(t *testing.T) 
 			Timeout:    time.Minute,
 		},
 		true,
-		offsetsReader,
+		map[string]*ingest.TopicOffsetsReader{querierapi.ReadConsistencyOffsetsHeader: offsetsReader},
 		nil,
 	)
 	require.NoError(t, err)

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -705,40 +705,40 @@ type Mimir struct {
 	ServiceMap    map[string]services.Service
 	ModuleManager *modules.Manager
 
-	API                             *api.API
-	Server                          *server.Server
-	IngesterRing                    *ring.Ring
-	IngesterPartitionRingWatcher    *ring.PartitionRingWatcher
-	IngesterPartitionInstanceRing   *ring.PartitionInstanceRing
-	TenantLimits                    validation.TenantLimits
-	Overrides                       *validation.Overrides
-	ActiveGroupsCleanup             *util.ActiveGroupsCleanupService
-	Distributor                     *distributor.Distributor
-	Ingester                        *ingester.Ingester
-	Flusher                         *flusher.Flusher
-	FrontendV1                      *frontendv1.Frontend
-	RuntimeConfig                   *runtimeconfig.Manager
-	QuerierQueryable                prom_storage.SampleAndChunkQueryable
-	ExemplarQueryable               prom_storage.ExemplarQueryable
-	AdditionalStorageQueryables     []querier.TimeRangeQueryable
-	MetadataSupplier                querier.MetadataSupplier
-	QuerierEngine                   promql.QueryEngine
-	QueryFrontendTripperware        querymiddleware.Tripperware
-	QueryFrontendTopicOffsetsReader *ingest.TopicOffsetsReader
-	QueryFrontendCodec              querymiddleware.Codec
-	Ruler                           *ruler.Ruler
-	RulerStorage                    rulestore.RuleStore
-	Alertmanager                    *alertmanager.MultitenantAlertmanager
-	Compactor                       *compactor.MultitenantCompactor
-	StoreGateway                    *storegateway.StoreGateway
-	MemberlistKV                    *memberlist.KVInitService
-	ActivityTracker                 *activitytracker.ActivityTracker
-	Vault                           *vault.Vault
-	UsageStatsReporter              *usagestats.Reporter
-	BlockBuilder                    *blockbuilder.BlockBuilder
-	BlockBuilderScheduler           *blockbuilderscheduler.BlockBuilderScheduler
-	ContinuousTestManager           *continuoustest.Manager
-	BuildInfoHandler                http.Handler
+	API                              *api.API
+	Server                           *server.Server
+	IngesterRing                     *ring.Ring
+	IngesterPartitionRingWatcher     *ring.PartitionRingWatcher
+	IngesterPartitionInstanceRing    *ring.PartitionInstanceRing
+	TenantLimits                     validation.TenantLimits
+	Overrides                        *validation.Overrides
+	ActiveGroupsCleanup              *util.ActiveGroupsCleanupService
+	Distributor                      *distributor.Distributor
+	Ingester                         *ingester.Ingester
+	Flusher                          *flusher.Flusher
+	FrontendV1                       *frontendv1.Frontend
+	RuntimeConfig                    *runtimeconfig.Manager
+	QuerierQueryable                 prom_storage.SampleAndChunkQueryable
+	ExemplarQueryable                prom_storage.ExemplarQueryable
+	AdditionalStorageQueryables      []querier.TimeRangeQueryable
+	MetadataSupplier                 querier.MetadataSupplier
+	QuerierEngine                    promql.QueryEngine
+	QueryFrontendTripperware         querymiddleware.Tripperware
+	QueryFrontendTopicOffsetsReaders map[string]*ingest.TopicOffsetsReader
+	QueryFrontendCodec               querymiddleware.Codec
+	Ruler                            *ruler.Ruler
+	RulerStorage                     rulestore.RuleStore
+	Alertmanager                     *alertmanager.MultitenantAlertmanager
+	Compactor                        *compactor.MultitenantCompactor
+	StoreGateway                     *storegateway.StoreGateway
+	MemberlistKV                     *memberlist.KVInitService
+	ActivityTracker                  *activitytracker.ActivityTracker
+	Vault                            *vault.Vault
+	UsageStatsReporter               *usagestats.Reporter
+	BlockBuilder                     *blockbuilder.BlockBuilder
+	BlockBuilderScheduler            *blockbuilderscheduler.BlockBuilderScheduler
+	ContinuousTestManager            *continuoustest.Manager
+	BuildInfoHandler                 http.Handler
 }
 
 // New makes a new Mimir.

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -729,9 +729,10 @@ func (t *Mimir) initQueryFrontendTopicOffsetsReaders() (services.Service, error)
 
 	ingestTopicOffsetsReader := ingest.NewTopicOffsetsReader(kafkaClient, t.Cfg.IngestStorage.KafkaConfig.Topic, getPartitionIDs, t.Cfg.IngestStorage.KafkaConfig.LastProducedOffsetPollInterval, t.Registerer, util_log.Logger)
 
-	t.QueryFrontendTopicOffsetsReaders = map[string]*ingest.TopicOffsetsReader{
-		querierapi.ReadConsistencyOffsetsHeader: ingestTopicOffsetsReader,
+	if t.QueryFrontendTopicOffsetsReaders == nil {
+		t.QueryFrontendTopicOffsetsReaders = make(map[string]*ingest.TopicOffsetsReader)
 	}
+	t.QueryFrontendTopicOffsetsReaders[querierapi.ReadConsistencyOffsetsHeader] = ingestTopicOffsetsReader
 
 	return ingestTopicOffsetsReader, nil
 }

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -50,6 +50,7 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/transport"
 	"github.com/grafana/mimir/pkg/ingester"
 	"github.com/grafana/mimir/pkg/querier"
+	querierapi "github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/querier/engine"
 	"github.com/grafana/mimir/pkg/querier/tenantfederation"
 	querier_worker "github.com/grafana/mimir/pkg/querier/worker"
@@ -70,42 +71,42 @@ import (
 
 // The various modules that make up Mimir.
 const (
-	ActivityTracker                 string = "activity-tracker"
-	API                             string = "api"
-	SanityCheck                     string = "sanity-check"
-	IngesterRing                    string = "ingester-ring"
-	IngesterPartitionRing           string = "ingester-partitions-ring"
-	RuntimeConfig                   string = "runtime-config"
-	Overrides                       string = "overrides"
-	OverridesExporter               string = "overrides-exporter"
-	Server                          string = "server"
-	ActiveGroupsCleanupService      string = "active-groups-cleanup-service"
-	Distributor                     string = "distributor"
-	DistributorService              string = "distributor-service"
-	Ingester                        string = "ingester"
-	IngesterService                 string = "ingester-service"
-	Flusher                         string = "flusher"
-	Querier                         string = "querier"
-	Queryable                       string = "queryable"
-	StoreQueryable                  string = "store-queryable"
-	QueryFrontend                   string = "query-frontend"
-	QueryFrontendCodec              string = "query-frontend-codec"
-	QueryFrontendTripperware        string = "query-frontend-tripperware"
-	QueryFrontendTopicOffsetsReader string = "query-frontend-topic-offsets-reader"
-	RulerStorage                    string = "ruler-storage"
-	Ruler                           string = "ruler"
-	AlertManager                    string = "alertmanager"
-	Compactor                       string = "compactor"
-	StoreGateway                    string = "store-gateway"
-	MemberlistKV                    string = "memberlist-kv"
-	QueryScheduler                  string = "query-scheduler"
-	Vault                           string = "vault"
-	TenantFederation                string = "tenant-federation"
-	UsageStats                      string = "usage-stats"
-	BlockBuilder                    string = "block-builder"
-	BlockBuilderScheduler           string = "block-builder-scheduler"
-	ContinuousTest                  string = "continuous-test"
-	All                             string = "all"
+	ActivityTracker                  string = "activity-tracker"
+	API                              string = "api"
+	SanityCheck                      string = "sanity-check"
+	IngesterRing                     string = "ingester-ring"
+	IngesterPartitionRing            string = "ingester-partitions-ring"
+	RuntimeConfig                    string = "runtime-config"
+	Overrides                        string = "overrides"
+	OverridesExporter                string = "overrides-exporter"
+	Server                           string = "server"
+	ActiveGroupsCleanupService       string = "active-groups-cleanup-service"
+	Distributor                      string = "distributor"
+	DistributorService               string = "distributor-service"
+	Ingester                         string = "ingester"
+	IngesterService                  string = "ingester-service"
+	Flusher                          string = "flusher"
+	Querier                          string = "querier"
+	Queryable                        string = "queryable"
+	StoreQueryable                   string = "store-queryable"
+	QueryFrontend                    string = "query-frontend"
+	QueryFrontendCodec               string = "query-frontend-codec"
+	QueryFrontendTripperware         string = "query-frontend-tripperware"
+	QueryFrontendTopicOffsetsReaders string = "query-frontend-topic-offsets-reader"
+	RulerStorage                     string = "ruler-storage"
+	Ruler                            string = "ruler"
+	AlertManager                     string = "alertmanager"
+	Compactor                        string = "compactor"
+	StoreGateway                     string = "store-gateway"
+	MemberlistKV                     string = "memberlist-kv"
+	QueryScheduler                   string = "query-scheduler"
+	Vault                            string = "vault"
+	TenantFederation                 string = "tenant-federation"
+	UsageStats                       string = "usage-stats"
+	BlockBuilder                     string = "block-builder"
+	BlockBuilderScheduler            string = "block-builder-scheduler"
+	ContinuousTest                   string = "continuous-test"
+	All                              string = "all"
 
 	// Write Read and Backend are the targets used when using the read-write deployment mode.
 	Write   string = "write"
@@ -702,9 +703,9 @@ func (t *Mimir) initQueryFrontendCodec() (services.Service, error) {
 	return nil, nil
 }
 
-// initQueryFrontendTopicOffsetsReader instantiates the topic offsets reader used by the query-frontend
+// initQueryFrontendTopicOffsetsReaders instantiates the topic offsets reader used by the query-frontend
 // when the ingest storage is enabled.
-func (t *Mimir) initQueryFrontendTopicOffsetsReader() (services.Service, error) {
+func (t *Mimir) initQueryFrontendTopicOffsetsReaders() (services.Service, error) {
 	if !t.Cfg.IngestStorage.Enabled {
 		return nil, nil
 	}
@@ -726,8 +727,13 @@ func (t *Mimir) initQueryFrontendTopicOffsetsReader() (services.Service, error) 
 		return t.IngesterPartitionRingWatcher.PartitionRing().PartitionIDs(), nil
 	}
 
-	t.QueryFrontendTopicOffsetsReader = ingest.NewTopicOffsetsReader(kafkaClient, t.Cfg.IngestStorage.KafkaConfig.Topic, getPartitionIDs, t.Cfg.IngestStorage.KafkaConfig.LastProducedOffsetPollInterval, t.Registerer, util_log.Logger)
-	return t.QueryFrontendTopicOffsetsReader, nil
+	ingestTopicOffsetsReader := ingest.NewTopicOffsetsReader(kafkaClient, t.Cfg.IngestStorage.KafkaConfig.Topic, getPartitionIDs, t.Cfg.IngestStorage.KafkaConfig.LastProducedOffsetPollInterval, t.Registerer, util_log.Logger)
+
+	t.QueryFrontendTopicOffsetsReaders = map[string]*ingest.TopicOffsetsReader{
+		querierapi.ReadConsistencyOffsetsHeader: ingestTopicOffsetsReader,
+	}
+
+	return ingestTopicOffsetsReader, nil
 }
 
 // initQueryFrontendTripperware instantiates the tripperware used by the query frontend
@@ -745,7 +751,7 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 		querymiddleware.PrometheusResponseExtractor{},
 		engineOpts,
 		engineExperimentalFunctionsEnabled,
-		t.QueryFrontendTopicOffsetsReader,
+		t.QueryFrontendTopicOffsetsReaders,
 		t.Registerer,
 	)
 	if err != nil {
@@ -1149,7 +1155,7 @@ func (t *Mimir) setupModuleManager() error {
 	mm.RegisterModule(StoreQueryable, t.initStoreQueryable, modules.UserInvisibleModule)
 	mm.RegisterModule(QueryFrontendCodec, t.initQueryFrontendCodec, modules.UserInvisibleModule)
 	mm.RegisterModule(QueryFrontendTripperware, t.initQueryFrontendTripperware, modules.UserInvisibleModule)
-	mm.RegisterModule(QueryFrontendTopicOffsetsReader, t.initQueryFrontendTopicOffsetsReader, modules.UserInvisibleModule)
+	mm.RegisterModule(QueryFrontendTopicOffsetsReaders, t.initQueryFrontendTopicOffsetsReaders, modules.UserInvisibleModule)
 	mm.RegisterModule(QueryFrontend, t.initQueryFrontend)
 	mm.RegisterModule(RulerStorage, t.initRulerStorage, modules.UserInvisibleModule)
 	mm.RegisterModule(Ruler, t.initRuler)
@@ -1170,39 +1176,39 @@ func (t *Mimir) setupModuleManager() error {
 
 	// Add dependencies
 	deps := map[string][]string{
-		Server:                          {ActivityTracker, SanityCheck, UsageStats},
-		API:                             {Server},
-		MemberlistKV:                    {API, Vault},
-		RuntimeConfig:                   {API},
-		IngesterRing:                    {API, RuntimeConfig, MemberlistKV, Vault},
-		IngesterPartitionRing:           {MemberlistKV, IngesterRing, API},
-		Overrides:                       {RuntimeConfig},
-		OverridesExporter:               {Overrides, MemberlistKV, Vault},
-		Distributor:                     {DistributorService, API, ActiveGroupsCleanupService, Vault},
-		DistributorService:              {IngesterRing, IngesterPartitionRing, Overrides, Vault},
-		Ingester:                        {IngesterService, API, ActiveGroupsCleanupService, Vault},
-		IngesterService:                 {IngesterRing, IngesterPartitionRing, Overrides, RuntimeConfig, MemberlistKV},
-		Flusher:                         {Overrides, API},
-		Queryable:                       {Overrides, DistributorService, IngesterRing, IngesterPartitionRing, API, StoreQueryable, MemberlistKV},
-		Querier:                         {TenantFederation, Vault},
-		StoreQueryable:                  {Overrides, MemberlistKV},
-		QueryFrontendTripperware:        {API, Overrides, QueryFrontendCodec, QueryFrontendTopicOffsetsReader},
-		QueryFrontend:                   {QueryFrontendTripperware, MemberlistKV, Vault},
-		QueryFrontendTopicOffsetsReader: {IngesterPartitionRing},
-		QueryScheduler:                  {API, Overrides, MemberlistKV, Vault},
-		Ruler:                           {DistributorService, StoreQueryable, RulerStorage, Vault},
-		RulerStorage:                    {Overrides},
-		AlertManager:                    {API, MemberlistKV, Overrides, Vault},
-		Compactor:                       {API, MemberlistKV, Overrides, Vault},
-		StoreGateway:                    {API, Overrides, MemberlistKV, Vault},
-		TenantFederation:                {Queryable},
-		BlockBuilder:                    {API, Overrides},
-		BlockBuilderScheduler:           {API},
-		ContinuousTest:                  {API},
-		Write:                           {Distributor, Ingester},
-		Read:                            {QueryFrontend, Querier},
-		Backend:                         {QueryScheduler, Ruler, StoreGateway, Compactor, AlertManager, OverridesExporter},
-		All:                             {QueryFrontend, Querier, Ingester, Distributor, StoreGateway, Ruler, Compactor},
+		Server:                           {ActivityTracker, SanityCheck, UsageStats},
+		API:                              {Server},
+		MemberlistKV:                     {API, Vault},
+		RuntimeConfig:                    {API},
+		IngesterRing:                     {API, RuntimeConfig, MemberlistKV, Vault},
+		IngesterPartitionRing:            {MemberlistKV, IngesterRing, API},
+		Overrides:                        {RuntimeConfig},
+		OverridesExporter:                {Overrides, MemberlistKV, Vault},
+		Distributor:                      {DistributorService, API, ActiveGroupsCleanupService, Vault},
+		DistributorService:               {IngesterRing, IngesterPartitionRing, Overrides, Vault},
+		Ingester:                         {IngesterService, API, ActiveGroupsCleanupService, Vault},
+		IngesterService:                  {IngesterRing, IngesterPartitionRing, Overrides, RuntimeConfig, MemberlistKV},
+		Flusher:                          {Overrides, API},
+		Queryable:                        {Overrides, DistributorService, IngesterRing, IngesterPartitionRing, API, StoreQueryable, MemberlistKV},
+		Querier:                          {TenantFederation, Vault},
+		StoreQueryable:                   {Overrides, MemberlistKV},
+		QueryFrontendTripperware:         {API, Overrides, QueryFrontendCodec, QueryFrontendTopicOffsetsReaders},
+		QueryFrontend:                    {QueryFrontendTripperware, MemberlistKV, Vault},
+		QueryFrontendTopicOffsetsReaders: {IngesterPartitionRing},
+		QueryScheduler:                   {API, Overrides, MemberlistKV, Vault},
+		Ruler:                            {DistributorService, StoreQueryable, RulerStorage, Vault},
+		RulerStorage:                     {Overrides},
+		AlertManager:                     {API, MemberlistKV, Overrides, Vault},
+		Compactor:                        {API, MemberlistKV, Overrides, Vault},
+		StoreGateway:                     {API, Overrides, MemberlistKV, Vault},
+		TenantFederation:                 {Queryable},
+		BlockBuilder:                     {API, Overrides},
+		BlockBuilderScheduler:            {API},
+		ContinuousTest:                   {API},
+		Write:                            {Distributor, Ingester},
+		Read:                             {QueryFrontend, Querier},
+		Backend:                          {QueryScheduler, Ruler, StoreGateway, Compactor, AlertManager, OverridesExporter},
+		All:                              {QueryFrontend, Querier, Ingester, Distributor, StoreGateway, Ruler, Compactor},
 	}
 	for mod, targets := range deps {
 		if err := mm.AddDependency(mod, targets...); err != nil {

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -725,7 +725,7 @@ func TestConcurrentFetchers(t *testing.T) {
 
 		logger := log.NewNopLogger()
 		reg := prometheus.NewPedanticRegistry()
-		metrics := newReaderMetrics(partitionID, reg, noopReaderMetricsSource{})
+		metrics := newReaderMetrics(partitionID, reg, noopReaderMetricsSource{}, topicName)
 
 		client := newKafkaProduceClient(t, clusterAddr)
 
@@ -1151,7 +1151,7 @@ func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Cli
 	logger := testingLogger.WithT(t)
 
 	reg := prometheus.NewPedanticRegistry()
-	metrics := newReaderMetrics(partition, reg, noopReaderMetricsSource{})
+	metrics := newReaderMetrics(partition, reg, noopReaderMetricsSource{}, topic)
 
 	// This instantiates the fields of kprom.
 	// This is usually done by franz-go, but since now we use the metrics ourselves, we need to instantiate the metrics ourselves.

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -199,3 +199,7 @@ func (p *TopicOffsetsReader) FetchLastProducedOffset(ctx context.Context) (map[i
 
 	return p.client.FetchPartitionsLastProducedOffsets(ctx, partitionIDs)
 }
+
+func (p *TopicOffsetsReader) Topic() string {
+	return p.topic
+}

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -124,10 +124,14 @@ func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, instanceID stri
 		reg:                                   reg,
 	}
 
-	r.metrics = newReaderMetrics(partitionID, reg, r)
+	r.metrics = newReaderMetrics(partitionID, reg, r, kafkaCfg.Topic)
 
 	r.Service = services.NewBasicService(r.start, r.run, r.stop)
 	return r, nil
+}
+
+func (r *PartitionReader) Topic() string {
+	return r.kafkaCfg.Topic
 }
 
 // Stop implements fetcher
@@ -761,7 +765,7 @@ func (r *PartitionReader) WaitReadConsistencyUntilOffset(ctx context.Context, of
 }
 
 func (r *PartitionReader) waitReadConsistency(ctx context.Context, withOffset bool, getOffset func(context.Context) (int64, error)) error {
-	_, err := r.metrics.strongConsistencyInstrumentation.Observe(withOffset, func() (struct{}, error) {
+	_, err := r.metrics.strongConsistencyInstrumentation.Observe(r.kafkaCfg.Topic, withOffset, func() (struct{}, error) {
 		spanLog := spanlogger.FromContext(ctx, r.logger)
 		spanLog.DebugLog("msg", "waiting for read consistency")
 
@@ -968,7 +972,7 @@ type readerMetricsSource interface {
 	EstimatedBytesPerRecord() int64
 }
 
-func newReaderMetrics(partitionID int32, reg prometheus.Registerer, metricsSource readerMetricsSource) readerMetrics {
+func newReaderMetrics(partitionID int32, reg prometheus.Registerer, metricsSource readerMetricsSource, topic string) readerMetrics {
 	const component = "partition-reader"
 
 	receiveDelay := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
@@ -1033,7 +1037,7 @@ func newReaderMetrics(partitionID int32, reg prometheus.Registerer, metricsSourc
 			Help:                        "How long a consumer spent processing a batch of records from Kafka. This includes retries on server errors.",
 			NativeHistogramBucketFactor: 1.1,
 		}),
-		strongConsistencyInstrumentation: NewStrongReadConsistencyInstrumentation[struct{}](component, reg),
+		strongConsistencyInstrumentation: NewStrongReadConsistencyInstrumentation[struct{}](component, reg, []string{topic}),
 		lastConsumedOffset:               lastConsumedOffset,
 		kprom:                            NewKafkaReaderClientMetrics(ReaderMetricsPrefix, component, reg),
 		missedRecords: promauto.With(reg).NewCounter(prometheus.CounterOpts{
@@ -1051,23 +1055,23 @@ func newReaderMetrics(partitionID int32, reg prometheus.Registerer, metricsSourc
 
 type StrongReadConsistencyInstrumentation[T any] struct {
 	requests *prometheus.CounterVec
-	failures prometheus.Counter
-	latency  prometheus.Histogram
+	failures *prometheus.CounterVec
+	latency  *prometheus.HistogramVec
 }
 
-func NewStrongReadConsistencyInstrumentation[T any](component string, reg prometheus.Registerer) *StrongReadConsistencyInstrumentation[T] {
+func NewStrongReadConsistencyInstrumentation[T any](component string, reg prometheus.Registerer, topics []string) *StrongReadConsistencyInstrumentation[T] {
 	i := &StrongReadConsistencyInstrumentation[T]{
 		requests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name:        "cortex_ingest_storage_strong_consistency_requests_total",
 			Help:        "Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.",
 			ConstLabels: map[string]string{"component": component},
-		}, []string{"with_offset"}),
-		failures: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		}, []string{"with_offset", "topic"}),
+		failures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name:        "cortex_ingest_storage_strong_consistency_failures_total",
 			Help:        "Total number of failures while waiting for strong consistency to be enforced.",
 			ConstLabels: map[string]string{"component": component},
-		}),
-		latency: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		}, []string{"topic"}),
+		latency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "cortex_ingest_storage_strong_consistency_wait_duration_seconds",
 			Help:                            "How long a request spent waiting for strong consistency to be guaranteed.",
 			NativeHistogramBucketFactor:     1.1,
@@ -1075,20 +1079,24 @@ func NewStrongReadConsistencyInstrumentation[T any](component string, reg promet
 			NativeHistogramMinResetDuration: 1 * time.Hour,
 			Buckets:                         prometheus.DefBuckets,
 			ConstLabels:                     map[string]string{"component": component},
-		}),
+		}, []string{"topic"}),
 	}
 
 	// Init metrics.
-	for _, value := range []bool{true, false} {
-		i.requests.WithLabelValues(strconv.FormatBool(value))
+	for _, topic := range topics {
+		for _, value := range []bool{true, false} {
+			i.requests.WithLabelValues(strconv.FormatBool(value), topic)
+		}
+		i.failures.WithLabelValues(topic)
+		i.latency.WithLabelValues(topic)
 	}
 
 	return i
 }
 
-func (i *StrongReadConsistencyInstrumentation[T]) Observe(withOffset bool, f func() (T, error)) (_ T, returnErr error) {
+func (i *StrongReadConsistencyInstrumentation[T]) Observe(topic string, withOffset bool, f func() (T, error)) (_ T, returnErr error) {
 	startTime := time.Now()
-	i.requests.WithLabelValues(strconv.FormatBool(withOffset)).Inc()
+	i.requests.WithLabelValues(strconv.FormatBool(withOffset), topic).Inc()
 
 	defer func() {
 		// Do not track failure or latency if the request was canceled (because the tracking would be incorrect).
@@ -1098,10 +1106,10 @@ func (i *StrongReadConsistencyInstrumentation[T]) Observe(withOffset bool, f fun
 
 		// Track latency for failures too, so that we have a better measurement of latency if
 		// backend latency is high and requests fail because of timeouts.
-		i.latency.Observe(time.Since(startTime).Seconds())
+		i.latency.WithLabelValues(topic).Observe(time.Since(startTime).Seconds())
 
 		if returnErr != nil {
-			i.failures.Inc()
+			i.failures.WithLabelValues(topic).Inc()
 		}
 	}()
 

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -130,10 +130,6 @@ func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, instanceID stri
 	return r, nil
 }
 
-func (r *PartitionReader) Topic() string {
-	return r.kafkaCfg.Topic
-}
-
 // Stop implements fetcher
 func (r *PartitionReader) Stop() {
 	// Given the partition reader has no concurrency it doesn't support stopping anything.

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -312,13 +312,13 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 1
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 0
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 0
 
 					# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
-					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader"} 0
-				`, withOffset, !withOffset)),
+					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader", topic="%s"} 0
+				`, topicName, withOffset, topicName, !withOffset, topicName)),
 					"cortex_ingest_storage_strong_consistency_requests_total",
 					"cortex_ingest_storage_strong_consistency_failures_total"))
 			})
@@ -362,13 +362,13 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 1
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 0
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 0
 
 					# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
-					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader"} 1
-				`, withOffset, !withOffset)),
+					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader", topic="%s"} 1
+				`, topicName, withOffset, topicName, !withOffset, topicName)),
 					"cortex_ingest_storage_strong_consistency_requests_total",
 					"cortex_ingest_storage_strong_consistency_failures_total"))
 
@@ -415,13 +415,13 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 1
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 0
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 0
 
 					# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
-					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader"} 1
-				`, withOffset, !withOffset)),
+					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader", topic="%s"} 1
+				`, topicName, withOffset, topicName, !withOffset, topicName)),
 					"cortex_ingest_storage_strong_consistency_requests_total",
 					"cortex_ingest_storage_strong_consistency_failures_total"))
 
@@ -452,13 +452,13 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 1
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 0
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 0
 
 					# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
-					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader"} 0
-				`, withOffset, !withOffset)),
+					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader", topic="%s"} 0
+				`, topicName, withOffset, topicName, !withOffset, topicName)),
 					"cortex_ingest_storage_strong_consistency_requests_total",
 					"cortex_ingest_storage_strong_consistency_failures_total"))
 			})
@@ -489,13 +489,13 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 1
-					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="%t"} 0
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 1
+					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 0
 
 					# HELP cortex_ingest_storage_strong_consistency_failures_total Total number of failures while waiting for strong consistency to be enforced.
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
-					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader"} 1
-				`, withOffset, !withOffset)),
+					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader", topic="%s"} 1
+				`, topicName, withOffset, topicName, !withOffset, topicName)),
 					"cortex_ingest_storage_strong_consistency_requests_total",
 					"cortex_ingest_storage_strong_consistency_failures_total"))
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adjust `readConsistencyRoundTripper` to take a map of header keys to offsets readers, allowing it to support the tracking of the produced offsets of multiple topics.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
