### PR TITLE
MQE: fix issues with vector/vector binary comparsion operations

### DIFF
--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -159,6 +159,9 @@ func TestCases(metricSizes []int) []BenchCase {
 			Expr: "nh_X / a_X",
 		},
 		{
+			Expr: "a_X == b_X",
+		},
+		{
 			Expr: "2 * a_X",
 		},
 		{

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -230,8 +230,8 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 		"single output series": {
 			series: []*oneToOneBinaryOperationOutputSeries{
 				{
-					leftSeriesIndices:  []int{4},
-					rightSeriesIndices: []int{1},
+					leftSeriesIndices: []int{4},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1}},
 				},
 			},
 
@@ -241,12 +241,12 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 		"two output series, both with one input series, read from both sides in same order and already sorted correctly": {
 			series: []*oneToOneBinaryOperationOutputSeries{
 				{
-					leftSeriesIndices:  []int{1},
-					rightSeriesIndices: []int{1},
+					leftSeriesIndices: []int{1},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1}},
 				},
 				{
-					leftSeriesIndices:  []int{2},
-					rightSeriesIndices: []int{2},
+					leftSeriesIndices: []int{2},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{2}},
 				},
 			},
 
@@ -256,12 +256,12 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 		"two output series, both with one input series, read from both sides in same order but sorted incorrectly": {
 			series: []*oneToOneBinaryOperationOutputSeries{
 				{
-					leftSeriesIndices:  []int{2},
-					rightSeriesIndices: []int{2},
+					leftSeriesIndices: []int{2},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{2}},
 				},
 				{
-					leftSeriesIndices:  []int{1},
-					rightSeriesIndices: []int{1},
+					leftSeriesIndices: []int{1},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1}},
 				},
 			},
 
@@ -271,12 +271,12 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 		"two output series, both with one input series, read from both sides in different order": {
 			series: []*oneToOneBinaryOperationOutputSeries{
 				{
-					leftSeriesIndices:  []int{1},
-					rightSeriesIndices: []int{2},
+					leftSeriesIndices: []int{1},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{2}},
 				},
 				{
-					leftSeriesIndices:  []int{2},
-					rightSeriesIndices: []int{1},
+					leftSeriesIndices: []int{2},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1}},
 				},
 			},
 
@@ -286,12 +286,12 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 		"two output series, both with multiple input series": {
 			series: []*oneToOneBinaryOperationOutputSeries{
 				{
-					leftSeriesIndices:  []int{1, 2},
-					rightSeriesIndices: []int{0, 3},
+					leftSeriesIndices: []int{1, 2},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{0, 3}},
 				},
 				{
-					leftSeriesIndices:  []int{0, 3},
-					rightSeriesIndices: []int{1, 2},
+					leftSeriesIndices: []int{0, 3},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1, 2}},
 				},
 			},
 
@@ -301,16 +301,16 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 		"multiple output series, both with one input series, read from both sides in same order and already sorted correctly": {
 			series: []*oneToOneBinaryOperationOutputSeries{
 				{
-					leftSeriesIndices:  []int{1},
-					rightSeriesIndices: []int{1},
+					leftSeriesIndices: []int{1},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1}},
 				},
 				{
-					leftSeriesIndices:  []int{2},
-					rightSeriesIndices: []int{2},
+					leftSeriesIndices: []int{2},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{2}},
 				},
 				{
-					leftSeriesIndices:  []int{3},
-					rightSeriesIndices: []int{3},
+					leftSeriesIndices: []int{3},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{3}},
 				},
 			},
 
@@ -320,16 +320,16 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 		"multiple output series, both with one input series, read from both sides in same order but sorted incorrectly": {
 			series: []*oneToOneBinaryOperationOutputSeries{
 				{
-					leftSeriesIndices:  []int{2},
-					rightSeriesIndices: []int{2},
+					leftSeriesIndices: []int{2},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{2}},
 				},
 				{
-					leftSeriesIndices:  []int{3},
-					rightSeriesIndices: []int{3},
+					leftSeriesIndices: []int{3},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{3}},
 				},
 				{
-					leftSeriesIndices:  []int{1},
-					rightSeriesIndices: []int{1},
+					leftSeriesIndices: []int{1},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1}},
 				},
 			},
 
@@ -339,16 +339,16 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 		"multiple output series, both with one input series, read from both sides in different order": {
 			series: []*oneToOneBinaryOperationOutputSeries{
 				{
-					leftSeriesIndices:  []int{1},
-					rightSeriesIndices: []int{2},
+					leftSeriesIndices: []int{1},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{2}},
 				},
 				{
-					leftSeriesIndices:  []int{3},
-					rightSeriesIndices: []int{3},
+					leftSeriesIndices: []int{3},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{3}},
 				},
 				{
-					leftSeriesIndices:  []int{2},
-					rightSeriesIndices: []int{1},
+					leftSeriesIndices: []int{2},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1}},
 				},
 			},
 
@@ -358,16 +358,16 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 		"multiple output series, with multiple input series each": {
 			series: []*oneToOneBinaryOperationOutputSeries{
 				{
-					leftSeriesIndices:  []int{4, 5, 10},
-					rightSeriesIndices: []int{2, 20},
+					leftSeriesIndices: []int{4, 5, 10},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{2, 20}},
 				},
 				{
-					leftSeriesIndices:  []int{2, 4, 15},
-					rightSeriesIndices: []int{3, 5, 50},
+					leftSeriesIndices: []int{2, 4, 15},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{3, 5, 50}},
 				},
 				{
-					leftSeriesIndices:  []int{3, 1},
-					rightSeriesIndices: []int{1, 40},
+					leftSeriesIndices: []int{3, 1},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1, 40}},
 				},
 			},
 
@@ -377,20 +377,20 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 		"multiple output series which depend on the same input series": {
 			series: []*oneToOneBinaryOperationOutputSeries{
 				{
-					leftSeriesIndices:  []int{1},
-					rightSeriesIndices: []int{2},
+					leftSeriesIndices: []int{1},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{2}},
 				},
 				{
-					leftSeriesIndices:  []int{1},
-					rightSeriesIndices: []int{1},
+					leftSeriesIndices: []int{1},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1}},
 				},
 				{
-					leftSeriesIndices:  []int{2},
-					rightSeriesIndices: []int{2},
+					leftSeriesIndices: []int{2},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{2}},
 				},
 				{
-					leftSeriesIndices:  []int{2},
-					rightSeriesIndices: []int{1},
+					leftSeriesIndices: []int{2},
+					rightSide:         &oneToOneBinaryOperationRightSide{rightSeriesIndices: []int{1}},
 				},
 			},
 

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -273,7 +273,7 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr, timeRange types
 			case parser.CardOneToMany, parser.CardManyToOne:
 				return binops.NewGroupedVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange(), timeRange)
 			case parser.CardOneToOne:
-				return binops.NewOneToOneVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange())
+				return binops.NewOneToOneVectorVectorBinaryOperation(lhs, rhs, *e.VectorMatching, e.Op, e.ReturnBool, q.memoryConsumptionTracker, q.annotations, e.PositionRange(), timeRange)
 			default:
 				return nil, compat.NewNotSupportedError(fmt.Sprintf("binary expression with %v matching for '%v'", e.VectorMatching.Card, e.Op))
 			}

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1397,10 +1397,9 @@ load 6m
   left_side_b{env="test", pod="a"} 5 6 7 8
   right_side{env="test", pod="a"}  2 2 7 7
 
-# FIXME: MQE currently does not correctly handle this case because it performs filtering after merging input series, whereas we should do it in the other order.
-#eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
-#  left_side_a{pod="a"} _ 2 _ _
-#  left_side_b{pod="a"} _ _ 7 _
+eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
+  left_side_a{pod="a"} _ 2 _ _
+  left_side_b{pod="a"} _ _ 7 _
 
 eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool ignoring(env) right_side
   expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the left side of the operation)
@@ -1416,9 +1415,8 @@ eval_fail range from 0 to 18m step 6m right_side == bool ignoring(env) {__name__
 #  left_side_b{pod="a"} _ _ 7 _
 # but instead both engines drop the metric names in the output.
 # This is accepted behaviour: https://github.com/prometheus/prometheus/issues/5326
-# FIXME: MQE currently does not correctly handle this case because it performs filtering after merging input series, whereas we should do it in the other order.
-#eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == on(pod) right_side
-#  {pod="a"} _ 2 7 _
+eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == on(pod) right_side
+  {pod="a"} _ 2 7 _
 
 eval_fail range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool on(pod) right_side
   expected_fail_regexp (multiple matches for labels: many-to-one matching must be explicit|found duplicate series for the match group .* on the left side of the operation)
@@ -1458,9 +1456,8 @@ load 6m
   left{pod="b"} 5 6 7 8
   right         2 2 7 7
 
-# FIXME: MQE currently does not correctly handle this case because it performs filtering after merging input series, whereas we should do it in the other order.
-# eval range from 0 to 18m step 6m left == ignoring(pod) right
-#   left _ 2 7 _
+eval range from 0 to 18m step 6m left == ignoring(pod) right
+  left _ 2 7 _
 
 eval_fail range from 0 to 18m step 6m left == ignoring(pod) group_right right
   expected_fail_regexp found duplicate series for the match group .* on the left (hand-)?side of the operation

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1473,10 +1473,9 @@ load 6m
   left_side_b{env="test", pod="a"} _ _ 7 8
   right_side{env="test", pod="a"}  2 2 7 7
 
-# FIXME: MQE currently does not correctly handle this case.
-#eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
-#  left_side_a{pod="a"} _ 2 _ _
-#  left_side_b{pod="a"} _ _ 7 _
+eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == ignoring(env) right_side
+  left_side_a{pod="a"} _ 2 _ _
+  left_side_b{pod="a"} _ _ 7 _
 
 eval range from 0 to 18m step 6m {__name__=~"left_side.*"} == bool ignoring(env) right_side
   {pod="a"} 0 1 1 0

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1462,6 +1462,9 @@ load 6m
 # eval range from 0 to 18m step 6m left == ignoring(pod) right
 #   left _ 2 7 _
 
+eval_fail range from 0 to 18m step 6m left == ignoring(pod) group_right right
+  expected_fail_regexp found duplicate series for the match group .* on the left (hand-)?side of the operation
+
 clear
 
 # Same thing as above, but with no overlapping samples on left side.


### PR DESCRIPTION
#### What this PR does

This PR fixes two issues with the implementation of comparison operations between two vectors without the `bool` modifier in MQE:

* Queries would return incorrect results if the left side contained series with different metric names, and all results would be merged into a single series rather than returned in separate series for each metric name
* Queries would incorrectly fail with a conflict error if multiple series on the left side matched the same series on the right side, those left side series had points at the same timestamp, and one or none of those points remained after applying the comparison operation

Changes in latency and peak memory consumption of affected benchmarks are within the margin of error of our benchmarks.

I'd recommend reviewing each commit separately.

#### Which issue(s) this PR fixes or relates to

#10067

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
