### PR TITLE
Distributor: do not propagate errors with non-utf8 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main / unreleased
 
+* [CHANGE] Distributor: OTLP and push handler replace all non-UTF8 characters with the unicode replacement character `\uFFFD` in error messages before propagating them. #10236
 * [ENHANCEMENT] Distributor: OTLP receiver now converts also metric metadata. See also https://github.com/prometheus/prometheus/pull/15416. #10168
 * [ENHANCEMENT] Distributor: discard float and histogram samples with duplicated timestamps from each timeseries in a request before the request is forwarded to ingesters. Discarded samples are tracked by the `cortex_discarded_samples_total` metrics with reason `sample_duplicate_timestamp`. #10145
 

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -221,7 +221,7 @@ func handler(
 				level.Error(logger).Log(msgs...)
 			}
 			addHeaders(w, err, r, code, retryCfg)
-			http.Error(w, msg, code)
+			http.Error(w, validUTF8Message(msg), code)
 		}
 	})
 }

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -1250,7 +1250,8 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 				Headers: []*httpgrpc.Header{
 					{Key: "Content-Type", Values: []string{"application/json"}},
 				},
-				Url:  "/otlp",
+				Url: "/otlp",
+				// \xf6 and \xd3 are not valid UTF8 characters, and they should be replaced with \UFFFD in the output.
 				Body: []byte("\n\xf6\x16\n\xd3\x02\n\x1d\n\x11container.runtime\x12\x08\n\x06docker\n'\n\x12container.h"),
 			},
 			expectedResponse: &httpgrpc.HTTPResponse{Code: 400,

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -515,11 +515,11 @@ func getMetricAndEllipsis(ls []mimirpb.LabelAdapter) (string, string) {
 
 // validUTF8ErrMessage ensures that the given message contains only valid utf8 characters.
 // The presence of non-utf8 characters in some errors might break some crucial parts of distributor's logic.
-// For example, if httpgrpc.HttpServer.Handle() returns a httpgprc error containing a non-utf8 character,
-// this error will not be propagated to httpgrpc.HttpClient as a htttpgrpc error, but as a generic error,
+// For example, if httpgrpc.HTTPServer.Handle() returns a httpgprc.Error containing a non-utf8 character,
+// this error will not be propagated to httpgrpc.HTTPClient as a htttpgrpc.Error, but as a generic error,
 // which might break some of Mimir internal logic.
 // This is because golang's proto.Marshal(), which is used by gRPC internally, fails when it marshals the
-// httpgrpc error containing non-utf8 character produced by httpgrpc.HttpSeriver.Handle(), making the resulting
+// httpgrpc.Error containing non-utf8 character produced by httpgrpc.HTTPServer.Handle(), making the resulting
 // error lose some important properties.
 func validUTF8Message(msg string) string {
 	return strings.ToValidUTF8(msg, string(utf8.RuneError))

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -713,6 +713,7 @@ func TestValidUTF8Message(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, stBytes)
 
+				//lint:ignore faillint We want to explicitly use on grpcstatus.FromError()
 				grpcSt, ok := grpcstatus.FromError(httpgrpcErr)
 				require.True(t, ok)
 				stBytes, err = golangproto.Marshal(grpcSt.Proto())

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -687,11 +687,12 @@ func TestValidUTF8Message(t *testing.T) {
 			body:                      []byte("valid message"),
 			containsNonUTF8Characters: false,
 		},
-		"message containing only utf8 characters retruns no error": {
+		"message containing only UTF8 characters returns no error": {
 			body:                      []byte("\n\ufffd\u0016\n\ufffd\u0002\n\u001D\n\u0011container.runtime\u0012\b\n\u0006docker\n'\n\u0012container.h"),
 			containsNonUTF8Characters: false,
 		},
-		"message containing non-utf8 character returns an error": {
+		"message containing non-UTF8 character returns an error": {
+			// \xf6 and \xd3 are not valid UTF8 characters.
 			body:                      []byte("\n\xf6\x1a\n\xd3\x02\n\x1d\n\x11container.runtime\x12\x08\n\x06docker\n'\n\x12container.h"),
 			containsNonUTF8Characters: true,
 		},


### PR DESCRIPTION
#### What this PR does

This PR prevents `distributor.OTLPHandler` and `distributor.Handler` from propagating errors containing non-utf8 characters.
The presence of non-utf8 characters in Mimir errors might break some crucial parts of distributor's logic. For example, if `httpgrpc.HTTPServer.Handle()` returns a `httpgprc.Error` containing a non-utf8 character, this error will not be propagated to `httpgrpc.HTTPClient` as a `htttpgrpc.Error`, but as a generic error, which might break some of Mimir internal logic.
This is because golang's `proto.Marshal()`, which is used by gRPC internally, fails when it marshals the `httpgrpc.Error` containing non-utf8 character produced by `httpgrpc.HTTPServer.Handle()`, making the resulting error lose some important properties.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
