### PR TITLE
Refactoring: expose filterRuleGroupsByNotMissing()

### DIFF
--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -519,7 +519,7 @@ func (a *API) ListRules(w http.ResponseWriter, req *http.Request) {
 		// so their content is empty).
 		numRuleGroupsBeforeFiltering := len(rgs)
 		tenantRuleGroups := map[string]rulespb.RuleGroupList{userID: rgs}
-		tenantRuleGroups = filterRuleGroupsByNotMissing(tenantRuleGroups, missing, a.logger)
+		tenantRuleGroups = FilterRuleGroupsByNotMissing(tenantRuleGroups, missing, a.logger)
 
 		var tenantFound bool
 		rgs, tenantFound = tenantRuleGroups[userID]

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -638,7 +638,7 @@ func (r *Ruler) loadRuleGroupsToSync(ctx context.Context, configs map[string]rul
 	// cached for a short period of time. This means that some rule groups discovered by listing
 	// the bucket (cached) may no longer exist because deleted in the meanwhile. For this reason,
 	// we filter out any missing rule group, not considering it as an hard error.
-	configs = filterRuleGroupsByNotMissing(configs, missing, r.logger)
+	configs = FilterRuleGroupsByNotMissing(configs, missing, r.logger)
 
 	return configs, nil
 }
@@ -888,11 +888,11 @@ func filterRuleGroupByEnabled(group *rulespb.RuleGroupDesc, recordingEnabled, al
 	return filtered, removedRules
 }
 
-// filterRuleGroupsByNotMissing filters out from the input configs all the rules groups which are in the missing list.
+// FilterRuleGroupsByNotMissing filters out from the input configs all the rules groups which are in the missing list.
 //
 // This function doesn't modify the input configs in place (even if it could) in order to reduce the likelihood of introducing
 // future bugs, in case the rule groups will be cached in memory.
-func filterRuleGroupsByNotMissing(configs map[string]rulespb.RuleGroupList, missing rulespb.RuleGroupList, logger log.Logger) (filtered map[string]rulespb.RuleGroupList) {
+func FilterRuleGroupsByNotMissing(configs map[string]rulespb.RuleGroupList, missing rulespb.RuleGroupList, logger log.Logger) (filtered map[string]rulespb.RuleGroupList) {
 	// Nothing to do if there are no missing rule groups.
 	if len(missing) == 0 {
 		return configs

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -1939,7 +1939,7 @@ func TestFilterRuleGroupsByNotMissing(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			logger := log.NewNopLogger()
 
-			actual := filterRuleGroupsByNotMissing(testData.configs, testData.missing, logger)
+			actual := FilterRuleGroupsByNotMissing(testData.configs, testData.missing, logger)
 			assert.Equal(t, testData.expected, actual)
 		})
 	}


### PR DESCRIPTION
#### What this PR does

Exposing `filterRuleGroupsByNotMissing()` to reuse it in GEM.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
