### PR TITLE
Runbooks: Add steps for checking Prometheus CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Documentation
 
 * [CHANGE] Add production tips related to cache size, heavy multi-tenancy and latency spikes. #9978
+* [ENHANCEMENT] Update `MimirAutoscalerNotActive` and `MimirAutoscalerKedaFailing` runbooks, with an instruction to check whether Prometheus has enough CPU allocated. #10257
 
 ### Tools
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1203,6 +1203,7 @@ How to **investigate**:
   # Assuming Prometheus is running in namespace "default":
   kubectl --namespace default get pod --selector='name=prometheus'
   ```
+- If Prometheus looks healthy, check that it has enough CPU allocated
 
 For scaled objects with 0 `minReplicas` it is expected for HPA to be inactive when the scaling metric exposed in `keda_scaler_metrics_value` is 0.
 When `keda_scaler_metrics_value` value is 0 or missing, the alert should not be firing.
@@ -1232,6 +1233,7 @@ How to **investigate**:
   # Assuming Prometheus is running in namespace "default":
   kubectl --namespace default get pod --selector='name=prometheus'
   ```
+- If Prometheus looks healthy, check that it has enough CPU allocated
 
 ### MimirContinuousTestNotRunningOnWrites
 


### PR DESCRIPTION
#### What this PR does

Augment the `MimirAutoscalerNotActive` and `MimirAutoscalerKedaFailing` runbooks with an instruction to check whether Prometheus has enough CPU allocated.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
