### PR TITLE
jsonnet: fix rollout-operator ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### Jsonnet
 
 * [CHANGE] Update rollout-operator version to 0.22.0. #10229
-* [BUGFIX] Ports used in rollout-operator and its webhooks
+* [BUGFIX] Ports used in rollout-operator and its webhooks. #10273
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Jsonnet
 
 * [CHANGE] Update rollout-operator version to 0.22.0. #10229
+* [BUGFIX] Ports used in rollout-operator and its webhooks
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### Jsonnet
 
 * [CHANGE] Update rollout-operator version to 0.22.0. #10229
-* [BUGFIX] Ports used in rollout-operator and its webhooks. #10273
+* [BUGFIX] Ports in container rollout-operator. #10273
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -623,13 +623,17 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    name: rollout-operator
   name: rollout-operator
   namespace: default
 spec:
   ports:
-  - name: https
-    port: 443
-    protocol: TCP
+  - name: rollout-operator-http-metrics
+    port: 8001
+    targetPort: 8001
+  - name: rollout-operator-https
+    port: 8443
     targetPort: 8443
   selector:
     name: rollout-operator
@@ -1110,6 +1114,8 @@ spec:
         ports:
         - containerPort: 8001
           name: http-metrics
+        - containerPort: 8443
+          name: https
         readinessProbe:
           httpGet:
             path: /ready
@@ -2497,7 +2503,7 @@ webhooks:
       name: rollout-operator
       namespace: default
       path: /admission/prepare-downscale
-      port: 443
+      port: 8443
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: prepare-downscale-default.grafana.com
@@ -2533,7 +2539,7 @@ webhooks:
       name: rollout-operator
       namespace: default
       path: /admission/no-downscale
-      port: 443
+      port: 8443
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: no-downscale-default.grafana.com

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -623,17 +623,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    name: rollout-operator
   name: rollout-operator
   namespace: default
 spec:
   ports:
-  - name: rollout-operator-http-metrics
-    port: 8001
-    targetPort: 8001
-  - name: rollout-operator-https
-    port: 8443
+  - name: https
+    port: 443
+    protocol: TCP
     targetPort: 8443
   selector:
     name: rollout-operator
@@ -2503,7 +2499,7 @@ webhooks:
       name: rollout-operator
       namespace: default
       path: /admission/prepare-downscale
-      port: 8443
+      port: 443
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: prepare-downscale-default.grafana.com
@@ -2539,7 +2535,7 @@ webhooks:
       name: rollout-operator
       namespace: default
       path: /admission/no-downscale
-      port: 8443
+      port: 443
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: no-downscale-default.grafana.com

--- a/operations/mimir/rollout-operator.libsonnet
+++ b/operations/mimir/rollout-operator.libsonnet
@@ -57,7 +57,7 @@
       if $._config.enable_rollout_operator_webhook then
         [
           $.core.v1.containerPort.new('http-metrics', 8001),
-          $.core.v1.containerPort.new('https', 8443)
+          $.core.v1.containerPort.new('https', 8443),
         ]
       else [$.core.v1.containerPort.new('http-metrics', 8001)],
     ) +

--- a/operations/mimir/rollout-operator.libsonnet
+++ b/operations/mimir/rollout-operator.libsonnet
@@ -79,7 +79,12 @@
     $.newMimirNodeAffinityMatchers($.rollout_operator_node_affinity_matchers),
 
   rollout_operator_service: if !rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
-    $.util.serviceFor($.rollout_operator_deployment, $._config.service_ignored_labels),
+    service.new(
+      'rollout-operator',
+      { name: 'rollout-operator' },
+      servicePort.newNamed('https', 443, 8443) +
+      servicePort.withProtocol('TCP'),
+    ),
 
   rollout_operator_role: if !rollout_operator_enabled then null else
     role.new('rollout-operator-role') +
@@ -196,7 +201,7 @@
             name: 'rollout-operator',
             namespace: $._config.namespace,
             path: '/admission/no-downscale',
-            port: 8443,
+            port: 443,
           },
         },
       },
@@ -235,7 +240,7 @@
             name: 'rollout-operator',
             namespace: $._config.namespace,
             path: '/admission/prepare-downscale',
-            port: 8443,
+            port: 443,
           },
         },
       },

--- a/operations/mimir/rollout-operator.libsonnet
+++ b/operations/mimir/rollout-operator.libsonnet
@@ -54,12 +54,10 @@
     container.new('rollout-operator', $._images.rollout_operator) +
     container.withArgsMixin($.util.mapToFlags($.rollout_operator_args)) +
     container.withPorts(
+      [$.core.v1.containerPort.new('http-metrics', 8001)] +
       if $._config.enable_rollout_operator_webhook then
-        [
-          $.core.v1.containerPort.new('http-metrics', 8001),
-          $.core.v1.containerPort.new('https', 8443),
-        ]
-      else [$.core.v1.containerPort.new('http-metrics', 8001)],
+        [$.core.v1.containerPort.new('https', 8443)]
+      else []
     ) +
     $.util.resourcesRequests('100m', '100Mi') +
     $.util.resourcesLimits(null, '200Mi') +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Implements correct port specification for rollout-operator in deployment, service, MutatingWebhookConfiguration and ValidatingWebhookConfiguration

#### Which issue(s) this PR fixes or relates to

Fixes #10272 

#### Checklist

- [x] Tests updated.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
