### PR TITLE
Label and close stale PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,7 +14,7 @@ jobs:
           # Pull Request Settings
           days-before-pr-stale: 150
           days-before-pr-close: 30
-          stale-pr-message: 'Thank you for your contribution. This pull request has been marked as stale because it has had no activity in the last 150 days. It will be closed in 30 days if there is no further activity. If you need more time, you can remove the "stale" label.'
+          stale-pr-message: 'Thank you for your contribution. This pull request has been marked as stale because it has had no activity in the last 150 days. It will be closed in 30 days if there is no further activity. If you need more time, you can add a comment to the PR.'
           close-pr-message: 'This pull request has been closed because it has been stale for 30 days with no activity. Feel free to reopen if you want to continue working on this.'
           stale-pr-label: 'stale'
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,32 @@
+name: 'Label and close stale PRs'
+on:
+  schedule:
+    # Run at 1:30 AM UTC every day
+    - cron: '30 1 * * *'
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Pull Request Settings
+          days-before-pr-stale: 150
+          days-before-pr-close: 30
+          stale-pr-message: 'Thank you for your contribution. This pull request has been marked as stale because it has had no activity in the last 150 days. It will be closed in 30 days if there is no further activity. If you need more time, you can remove the "stale" label.'
+          close-pr-message: 'This pull request has been closed because it has been stale for 30 days with no activity. Feel free to reopen if you want to continue working on this.'
+          stale-pr-label: 'stale'
+
+          # Disable issue handling completely
+          days-before-stale: -1
+          days-before-close: -1
+
+          # Optional: Remove stale label when PR is updated
+          remove-stale-when-updated: true
+
+          # Optional settings to reduce API usage
+          operations-per-run: 100
+
+          # Enable statistics in the logs
+          enable-statistics: true

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -10,6 +10,8 @@ Doing so can be a helpful way of asking for assistance or to develop an idea.
 
 When you open a PR as a draft, add a short description of what you’re still working on, what you are seeking assistance with, or both.
 
+There is an automated GitHub action which closes PRs after 180 days of inactivity to keep the PR list clean. 30 days before closing, the GitHub action will add `stale` label to the PR. If you need more time, please remove the `stale` label.
+
 Before a piece of work is finished:
 
 - Organize it into one or more commits, and include a commit message for each that describes all of the changes that you made in that commit. It is more helpful to explain _why_ more than _what_, which are available via `git diff`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does


We just had a session going over PRs. For some of them we just followed up and asked if the author would like to continue working on it. We can automate that.

We chose a very conservative thresholds: 150 days (5 months) before `stale` label; 180 days (6 months) before closing. But these are very much open for discussion and suggestions.
