### PR TITLE
`make generate-otlp`: check that tools are installed

### DIFF
--- a/pkg/distributor/otlp/generate.sh
+++ b/pkg/distributor/otlp/generate.sh
@@ -3,8 +3,11 @@
 
 set -euo pipefail
 
+command -v gopatch >/dev/null 2>&1 || { echo "Please install gopatch. Run 'go install github.com/uber-go/gopatch@latest' or visit https://github.com/uber-go/gopatch for more info."; exit 1; }
+command -v goimports >/dev/null 2>&1 || { echo "Please install goimports. Run 'go install golang.org/x/tools/cmd/goimports@latest' or visit https://pkg.go.dev/golang.org/x/tools/cmd/goimports for more info."; exit 1; }
+
 # Use GNU sed on MacOS falling back to `sed` everywhere else
-SED=sed
+SED="sed"
 type gsed >/dev/null 2>&1 && SED=gsed
 
 FILES=$(find ../../../vendor/github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite -name '*.go' ! -name timeseries.go ! -name "*_test.go")


### PR DESCRIPTION
#### What this PR does

Saves some time to the next developer who has to run `make generate-otlp` and isn't familiar with the tools required.