### PR TITLE
fix(mimirtool): Make remote-read actually return data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [BUGFIX] Ruler: fix indeterminate rules being always run concurrently (instead of never) when `-ruler.max-independent-rule-evaluation-concurrency` is set. https://github.com/prometheus/prometheus/pull/15560 #10258
 * [BUGFIX] PromQL: Fix various UTF-8 bugs related to quoting. https://github.com/prometheus/prometheus/pull/15531 #10258
 * [BUGFIX] Ruler: Fixed an issue when using the experimental `-ruler.max-independent-rule-evaluation-concurrency` feature, where if a rule group was eligible for concurrency, it would flap between running concurrently or not based on the time it took after running concurrently. #9726 #10189
+* [BUGFIX] Mimirtool: `remote-read` commands will now return data. #10286
 
 ### Mixin
 

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -393,6 +393,10 @@ func (c *RemoteReadCommand) stats(_ *kingpin.ParseContext) error {
 		}
 	}
 
+	if err := timeseries.Err(); err != nil {
+		return err
+	}
+
 	output := bytes.NewBuffer(nil)
 	tw := tabwriter.NewWriter(output, 13, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "MIN TIME\tMAX TIME\tDURATION\tNUM SAMPLES\tNUM SERIES\tNUM STALE NAN VALUES\tNUM NAN VALUES")

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -95,7 +95,7 @@ func (c *RemoteReadCommand) Register(app *kingpin.Application, envVars EnvVarNam
 			Default(now.Format(time.RFC3339)).
 			StringVar(&c.to)
 		cmd.Flag("read-size-limit", "Maximum number of bytes to read.").
-			Default(strconv.Itoa(DefaultChunkedReadLimit)). // 1MiB
+			Default(strconv.Itoa(DefaultChunkedReadLimit)).
 			Uint64Var(&c.readSizeLimit)
 	}
 

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -37,6 +37,10 @@ import (
 	"github.com/grafana/mimir/pkg/mimirtool/client"
 )
 
+// DefaultChunkedReadLimit is the default value for the maximum size of the protobuf frame client allows.
+// 50MB is the default. This is equivalent to ~100k full XOR chunks and average labelset.
+const DefaultChunkedReadLimit = 5e+7
+
 type RemoteReadCommand struct {
 	address        string
 	remoteReadPath string
@@ -91,7 +95,7 @@ func (c *RemoteReadCommand) Register(app *kingpin.Application, envVars EnvVarNam
 			Default(now.Format(time.RFC3339)).
 			StringVar(&c.to)
 		cmd.Flag("read-size-limit", "Maximum number of bytes to read.").
-			Default(strconv.Itoa(int(math.Pow(1024, 2)))). // 1MiB
+			Default(strconv.Itoa(DefaultChunkedReadLimit)). // 1MiB
 			Uint64Var(&c.readSizeLimit)
 	}
 


### PR DESCRIPTION
Since https://github.com/grafana/mimir/pull/9156 probably, all the remote read commands return no data

I added a missing error return using `timeseries.Err()` and got this error: `mimirtool: error: chunkedReader: message size exceeded the limit 0 bytes; got: 361 bytes, try --help` which lead me to find that we need to pass in `ChunkedReadLimit` on the client

I set it at a default 1 MiB and configurable through a flag

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
