### PR TITLE
mixin: Ignore cache delete errors for cache error alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Mixin
 
 * [BUGFIX] Dashboards: fix how we switch between classic and native histograms. #10018
+* [BUGFIX] Alerts: Ignore cache errors performing `delete` operations since these are expected to fail when keys don't exist. #10287
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -119,11 +119,11 @@ spec:
             expr: |
               (
                 sum by(cluster, namespace, name, operation) (
-                  rate(thanos_cache_operation_failures_total{operation!="add"}[1m])
+                  rate(thanos_cache_operation_failures_total{operation!~"add|delete"}[1m])
                 )
                 /
                 sum by(cluster, namespace, name, operation) (
-                  rate(thanos_cache_operations_total{operation!="add"}[1m])
+                  rate(thanos_cache_operations_total{operation!~"add|delete"}[1m])
                 )
               ) * 100 > 5
             for: 5m

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -107,11 +107,11 @@ groups:
           expr: |
             (
               sum by(cluster, namespace, name, operation) (
-                rate(thanos_cache_operation_failures_total{operation!="add"}[1m])
+                rate(thanos_cache_operation_failures_total{operation!~"add|delete"}[1m])
               )
               /
               sum by(cluster, namespace, name, operation) (
-                rate(thanos_cache_operations_total{operation!="add"}[1m])
+                rate(thanos_cache_operations_total{operation!~"add|delete"}[1m])
               )
             ) * 100 > 5
           for: 5m

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -107,11 +107,11 @@ groups:
           expr: |
             (
               sum by(cluster, namespace, name, operation) (
-                rate(thanos_cache_operation_failures_total{operation!="add"}[1m])
+                rate(thanos_cache_operation_failures_total{operation!~"add|delete"}[1m])
               )
               /
               sum by(cluster, namespace, name, operation) (
-                rate(thanos_cache_operations_total{operation!="add"}[1m])
+                rate(thanos_cache_operations_total{operation!~"add|delete"}[1m])
               )
             ) * 100 > 5
           for: 5m

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -202,16 +202,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
         },
         {
           alert: $.alertName('CacheRequestErrors'),
-          // Specifically exclude "add" operations which are used for cache invalidation and "locking" since
-          // they are expected to sometimes fail in normal operation (such as when a "lock" already exists).
+          // Specifically exclude "add" and "delete" operations which are used for cache invalidation and "locking"
+          // since they are expected to sometimes fail in normal operation (such as when a "lock" already exists or
+          // key being invalidated does not exist).
           expr: |||
             (
               sum by(%(group_by)s, name, operation) (
-                rate(thanos_cache_operation_failures_total{operation!="add"}[%(range_interval)s])
+                rate(thanos_cache_operation_failures_total{operation!~"add|delete"}[%(range_interval)s])
               )
               /
               sum by(%(group_by)s, name, operation) (
-                rate(thanos_cache_operations_total{operation!="add"}[%(range_interval)s])
+                rate(thanos_cache_operations_total{operation!~"add|delete"}[%(range_interval)s])
               )
             ) * 100 > 5
           ||| % {


### PR DESCRIPTION
#### What this PR does

Delete operations are expected to fail when the key doesn't exist when keys are deleted as part of cache invalidation.

#### Which issue(s) this PR fixes or relates to

Related #9386

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
