### PR TITLE
helm: fix default Graphite config

### DIFF
--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4165,7 +4165,7 @@ graphite:
         [default]
         pattern = .*
         intervals = 0:1s
-        retentions = 10s:8d,10min:1y
+        retentions = 10s:8d,10m:1y
       storageAggregations: |-
         [default]
         aggregationMethod = avg

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-querier/graphite-querier-schemas-configmap.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/graphite-proxy/graphite-querier/graphite-querier-schemas-configmap.yaml
@@ -15,7 +15,7 @@ data:
     [default]
     pattern = .*
     intervals = 0:1s
-    retentions = 10s:8d,10min:1y
+    retentions = 10s:8d,10m:1y
   storage-aggregations.conf: |
     [default]
     aggregationMethod = avg


### PR DESCRIPTION
Fix the default graphite config in the mimir-distributed helm chart so the time specification is valid

Fixes https://github.com/grafana/mimir/issues/10275

There is unfortunately no test covering this config