### PR TITLE
Fix inconsistent map iteration order flake in blockbuilder/schedulerpb TestSendUpdates

### DIFF
--- a/pkg/blockbuilder/schedulerpb/client_test.go
+++ b/pkg/blockbuilder/schedulerpb/client_test.go
@@ -48,12 +48,12 @@ func TestSendUpdates(t *testing.T) {
 	require.Empty(t, sched.updates)
 
 	cli.sendUpdates(ctx)
-	require.EqualValues(t, []*UpdateJobRequest{
+	require.ElementsMatch(t, []*UpdateJobRequest{
 		{Key: &sched.jobs[0].key, WorkerId: "worker1", Spec: &sched.jobs[0].spec, Complete: false},
 	}, sched.updates)
 
 	cli.sendUpdates(ctx)
-	require.EqualValues(t, []*UpdateJobRequest{
+	require.ElementsMatch(t, []*UpdateJobRequest{
 		{Key: &sched.jobs[0].key, WorkerId: "worker1", Spec: &sched.jobs[0].spec, Complete: false},
 		{Key: &sched.jobs[0].key, WorkerId: "worker1", Spec: &sched.jobs[0].spec, Complete: false},
 	}, sched.updates)
@@ -64,7 +64,7 @@ func TestSendUpdates(t *testing.T) {
 
 	// Now we have one complete job and one incomplete. We should be sending updates for both.
 	cli.sendUpdates(ctx)
-	require.EqualValues(t, []*UpdateJobRequest{
+	require.ElementsMatch(t, []*UpdateJobRequest{
 		{Key: &sched.jobs[0].key, WorkerId: "worker1", Spec: &sched.jobs[0].spec, Complete: false},
 		{Key: &sched.jobs[0].key, WorkerId: "worker1", Spec: &sched.jobs[0].spec, Complete: false},
 		{Key: &sched.jobs[0].key, WorkerId: "worker1", Spec: &sched.jobs[0].spec, Complete: true},
@@ -72,7 +72,7 @@ func TestSendUpdates(t *testing.T) {
 	}, sched.updates)
 
 	cli.sendUpdates(ctx)
-	require.EqualValues(t, []*UpdateJobRequest{
+	require.ElementsMatch(t, []*UpdateJobRequest{
 		{Key: &sched.jobs[0].key, WorkerId: "worker1", Spec: &sched.jobs[0].spec, Complete: false},
 		{Key: &sched.jobs[0].key, WorkerId: "worker1", Spec: &sched.jobs[0].spec, Complete: false},
 		{Key: &sched.jobs[0].key, WorkerId: "worker1", Spec: &sched.jobs[0].spec, Complete: true},


### PR DESCRIPTION
#### What this PR does

Fixes a flaky test where map iteration order is sometimes different than the order expected by the test assertion.
One such failure can be seen here: https://github.com/grafana/mimir/actions/runs/12434636520/job/34718770602

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
