### PR TITLE
add deploy preview workflow

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,24 @@
+name: Deploy pr preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - closed
+    paths:
+      - "docs/sources/**"
+
+jobs:
+  deploy-pr-preview:
+    if: github.repository == 'grafana/mimir'
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    with:
+      sha: ${{ github.event.pull_request.head.sha }}
+      branch: ${{ github.head_ref }}
+      event_number: ${{ github.event.number }}
+      title: ${{ github.event.pull_request.title }}
+      repo: mimir
+      website_directory: content/docs/mimir/latest
+      relative_prefix: /docs/mimir/latest/
+      index_file: true

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -19,6 +19,7 @@ jobs:
       event_number: ${{ github.event.number }}
       title: ${{ github.event.pull_request.title }}
       repo: mimir
+      source_directory: docs/sources/mimir
       website_directory: content/docs/mimir/latest
       relative_prefix: /docs/mimir/latest/
       index_file: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 * @grafana/mimir-maintainers
 
 # Documentation.
+/.github/workflows/deploy-pr-preview.yml                                    @grafana/docs-tooling @grafana/mimir-maintainers
 /.github/workflows/publish-technical-documentation-next.yml                 @grafana/docs-tooling @grafana/mimir-maintainers
 /.github/workflows/publish-technical-documentation-release-helm-charts.yml  @grafana/docs-tooling @grafana/mimir-maintainers
 /.github/workflows/publish-technical-documentation-release-mimir.yml        @grafana/docs-tooling @grafana/mimir-maintainers


### PR DESCRIPTION
for https://github.com/grafana/website/issues/10101

**What is this feature?**

This PR adds a workflow to deploy the output of the `make docs` command to a public deploy preview. The workflow posts a comment with a link to the preview after it has been deployed.

**Why do we need this feature?**

Docs contributors will no longer need to run `make docs` on their machine, as they will be able to view the deploy preview instead.

**Who is this feature for?**

Everyone.



