### PR TITLE
Limiter: avoid stop-the-world pause when reading heap size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Distributor: discard float and histogram samples with duplicated timestamps from each timeseries in a request before the request is forwarded to ingesters. Discarded samples are tracked by the `cortex_discarded_samples_total` metrics with reason `sample_duplicate_timestamp`. #10145
 * [ENHANCEMENT] Ruler: Add `cortex_prometheus_rule_group_last_rule_duration_sum_seconds` metric to track the total evaluation duration of a rule group regardless of concurrency #10189
 * [ENHANCEMENT] Distributor: Add native histogram support for `electedReplicaPropagationTime` metric in ha_tracker. #10264
+* [ENHANCEMENT] Ingester: More efficient CPU/memory utilization-based read request limiting. #10325
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Ruler: fix indeterminate rules being always run concurrently (instead of never) when `-ruler.max-independent-rule-evaluation-concurrency` is set. https://github.com/prometheus/prometheus/pull/15560 #10258


### PR DESCRIPTION
#### What this PR does

Use a Go metric instead of calling `runtime.ReadMemStats`. Empirically this is much faster.

```
                  │ before.txt  │             after.txt              │
                  │   sec/op    │   sec/op     vs base               │
CombinedScanner-4   25.58µ ± 2%   12.41µ ± 3%  -51.48% (p=0.002 n=6)
```

In a trace from a large ingester; the stop-the-world pause was more like 1-5ms; see example in image.
(and this is called every 1 second)

![image](https://github.com/user-attachments/assets/bee81b23-476b-45fd-af19-58600a46a22d)


#### Checklist

- NA Tests updated.
- NA Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- NA [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
