### PR TITLE
tools/copyblocks: Disable pprof endpoint, to satisfy gosec's G108 rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - errorlint
     - forbidigo
     - loggercheck
-    - staticcheck
     - gosec
 
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,6 +63,10 @@ linters-settings:
       - p: ^.*\.CloseSend.*$
         msg: Do not use CloseSend on a server-streaming gRPC stream. Use util.CloseAndExhaust instead. See the documentation on CloseAndExhaust for further explanation.
 
+  gosec:
+    includes:
+      - G108
+
 run:
   timeout: 10m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,8 @@ linters:
     - errorlint
     - forbidigo
     - loggercheck
+    - staticcheck
+    - gosec
 
 linters-settings:
   errcheck:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 
 ### Tools
 
+* [CHANGE] `copyblocks`: Remove /pprof endpoint. #10329
+
 ## 2.15.0-rc.0
 
 ### Grafana Mimir

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -12,7 +12,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof" // anonymous import to get the pprof handler registered
 	"os"
 	"os/signal"
 	"path/filepath"


### PR DESCRIPTION
#### What this PR does

Disable pprof endpoint in tools/copyblocks, to satisfy gosec's [G108 rule](https://github.com/securego/gosec?tab=readme-ov-file#available-rules). Also enable gosec for said rule.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
