### PR TITLE
Security: Enable gosec's G114 rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ linters-settings:
   gosec:
     includes:
       - G108
+      - G114
 
 run:
   timeout: 10m

--- a/pkg/mimirtool/commands/alerts.go
+++ b/pkg/mimirtool/commands/alerts.go
@@ -351,7 +351,12 @@ func (a *AlertCommand) verifyConfig(_ *kingpin.ParseContext) error {
 	))
 
 	go func() {
-		log.Fatal(http.ListenAndServe(":9090", nil))
+		server := http.Server{
+			Addr:         ":9090",
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		}
+		log.Fatal(server.ListenAndServe())
 	}()
 
 	ctx := context.Background()

--- a/pkg/mimirtool/commands/loadgen.go
+++ b/pkg/mimirtool/commands/loadgen.go
@@ -121,8 +121,12 @@ func (c *LoadgenCommand) run(_ *kingpin.ParseContext) error {
 
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
-		err := http.ListenAndServe(c.metricsListenAddress, nil)
-		if err != nil {
+		server := http.Server{
+			Addr:         c.metricsListenAddress,
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		}
+		if err := server.ListenAndServe(); err != nil {
 			logrus.WithError(err).Errorln("metrics listener failed")
 		}
 	}()

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -167,8 +167,12 @@ func main() {
 	go func() {
 		level.Info(logger).Log("msg", "HTTP server listening on "+cfg.httpListen)
 		http.Handle("/metrics", promhttp.Handler())
-		err := http.ListenAndServe(cfg.httpListen, nil)
-		if err != nil {
+		server := &http.Server{
+			Addr:         cfg.httpListen,
+			ReadTimeout:  10 * time.Second,
+			WriteTimeout: 10 * time.Second,
+		}
+		if err := server.ListenAndServe(); err != nil {
 			level.Error(logger).Log("msg", "failed to start HTTP server")
 			os.Exit(1)
 		}

--- a/tools/trafficdump/main.go
+++ b/tools/trafficdump/main.go
@@ -51,7 +51,12 @@ func main() {
 	if *httpServer != "" {
 		go func() {
 			log.Println("HTTP server running on", *httpServer)
-			log.Println(http.ListenAndServe(*httpServer, nil))
+			server := &http.Server{
+				Addr:         *httpServer,
+				ReadTimeout:  10 * time.Second,
+				WriteTimeout: 10 * time.Second,
+			}
+			log.Println(server.ListenAndServe())
 		}()
 	}
 


### PR DESCRIPTION
#### What this PR does

Enable gosec's [G114 rule](https://github.com/securego/gosec?tab=readme-ov-file#available-rules), and satisfy it by configuring HTTP servers w/ timeouts in:

* tools/copyblocks
* tools/trafficdump
* mimirtool

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
