### PR TITLE
Security: Enable gosec linter for G109 rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ linters-settings:
   gosec:
     includes:
       - G108
+      - G109
       - G114
 
 run:

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -172,9 +172,10 @@ func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var maxGroups int
+	var maxGroups int32
 	if maxGroupsVal := req.URL.Query().Get("group_limit"); maxGroupsVal != "" {
-		maxGroups, err = strconv.Atoi(maxGroupsVal)
+		maxGroupsRaw, err := strconv.ParseInt(maxGroupsVal, 10, 32)
+		maxGroups = int32(maxGroupsRaw)
 		if err != nil || maxGroups < 0 {
 			respondInvalidRequest(logger, w, "invalid group limit value")
 			return
@@ -188,7 +189,7 @@ func (a *API) PrometheusRules(w http.ResponseWriter, req *http.Request) {
 		File:          req.URL.Query()["file"],
 		ExcludeAlerts: excludeAlerts,
 		NextToken:     req.URL.Query().Get("group_next_token"),
-		MaxGroups:     int32(maxGroups),
+		MaxGroups:     maxGroups,
 	}
 
 	ruleTypeFilter := strings.ToLower(req.URL.Query().Get("type"))


### PR DESCRIPTION
#### What this PR does
Enable gosec linter for G109 rule.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
