### PR TITLE
Security: Enable gosec G112 rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,7 @@ linters-settings:
     includes:
       - G108
       - G109
+      - G112
       - G114
 
 run:

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -59,6 +59,8 @@ func TestFrontend_RequestHostHeaderWhenDownstreamURLIsConfigured(t *testing.T) {
 			_, err := w.Write([]byte(responseBody))
 			require.NoError(t, err)
 		}),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
 	}
 
 	defer downstreamServer.Shutdown(context.Background()) //nolint:errcheck
@@ -111,6 +113,8 @@ func TestFrontend_LogsSlowQueriesFormValues(t *testing.T) {
 			_, err := w.Write([]byte(responseBody))
 			require.NoError(t, err)
 		}),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
 	}
 
 	defer downstreamServer.Shutdown(context.Background()) //nolint:errcheck
@@ -173,6 +177,8 @@ func TestFrontend_ReturnsRequestBodyTooLargeError(t *testing.T) {
 			_, err := w.Write([]byte(responseBody))
 			require.NoError(t, err)
 		}),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
 	}
 
 	defer downstreamServer.Shutdown(context.Background()) //nolint:errcheck
@@ -260,7 +266,9 @@ func testFrontend(t *testing.T, config CombinedFrontendConfig, handler http.Hand
 	).Wrap(transport.NewHandler(config.Handler, rt, logger, nil, nil)))
 
 	httpServer := http.Server{
-		Handler: r,
+		Handler:      r,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
 	}
 	defer httpServer.Shutdown(context.Background()) //nolint:errcheck
 

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -345,7 +345,9 @@ func testFrontend(t *testing.T, config Config, handler http.Handler, test func(a
 	).Wrap(transport.NewHandler(handlerCfg, rt, logger, nil, nil)))
 
 	httpServer := http.Server{
-		Handler: r,
+		Handler:      r,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
 	}
 	defer httpServer.Shutdown(context.Background()) //nolint:errcheck
 

--- a/pkg/util/gziphandler/gzip_test.go
+++ b/pkg/util/gziphandler/gzip_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -279,7 +280,9 @@ func TestGzipHandlerContentLength(t *testing.T) {
 	}
 	defer ln.Close()
 	srv := &http.Server{
-		Handler: nil,
+		Handler:      nil,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
 	}
 	go func() { _ = srv.Serve(ln) }()
 

--- a/pkg/util/instrumentation/metrics.go
+++ b/pkg/util/instrumentation/metrics.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -45,7 +46,9 @@ func (s *MetricsServer) Start() error {
 	router.Handle("/metrics", promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{}))
 
 	s.srv = &http.Server{
-		Handler: router,
+		Handler:      router,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
 	}
 
 	go func() {


### PR DESCRIPTION
#### What this PR does

Enable gosec G112 rule, configuring timeouts in `util/instrumentation.MetricsServer`, which is only used by tools.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
