### PR TITLE
Extract delta from rate function

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -2067,6 +2067,12 @@ func TestAnnotations(t *testing.T) {
 			expr: `sum(metric{type="histogram"})`,
 		},
 
+		"delta() native histogram unknown CounterResetHint": {
+			data:                       mixedFloatHistogramData,
+			expr:                       `delta(metric{type="histogram"}[3m])`,
+			expectedWarningAnnotations: []string{`PromQL warning: this native histogram metric is not a gauge: "metric" (1:7)`},
+		},
+
 		"stdvar() with only floats": {
 			data: mixedFloatHistogramData,
 			expr: `stdvar(metric{type="float"})`,

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -296,7 +296,6 @@ func delta(step *types.RangeVectorStepData, rangeSeconds float64, emitAnnotation
 	}
 
 	if fCount >= 2 {
-		// TODO: just pass step here? (and below)
 		val := floatDelta(fCount, fHead, fTail, step.RangeStart, step.RangeEnd, rangeSeconds)
 		return val, true, nil, nil
 	}

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -289,7 +289,7 @@ func delta(step *types.RangeVectorStepData, rangeSeconds float64, emitAnnotation
 		hCount := len(hHead) + len(hTail)
 
 		if fCount > 0 && hCount > 0 {
-			// We need either at least two histograms and no floats, or at least two floats and no histograms to calculate a rate.
+			// We need either at least two histograms and no floats, or at least two floats and no histograms to calculate a delta.
 			// Otherwise, emit a warning and drop this sample.
 			emitAnnotation(annotations.NewMixedFloatsHistogramsWarning)
 			return 0, false, nil, nil

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -281,8 +281,7 @@ func rateSeriesValidator() RangeVectorSeriesValidationFunction {
 	}
 }
 
-func delta() RangeVectorStepFunction {
-	return func(step *types.RangeVectorStepData, rangeSeconds float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+func delta(step *types.RangeVectorStepData, rangeSeconds float64, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
 		fHead, fTail := step.Floats.UnsafePoints()
 		fCount := len(fHead) + len(fTail)
 

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -352,10 +352,6 @@ func histogramDelta(hCount int, hHead []promql.HPoint, hTail []promql.HPoint, ra
 		emitAnnotation(annotations.NewNativeHistogramNotGaugeWarning)
 	}
 
-	if delta.Schema != desiredSchema {
-		delta = delta.CopyToSchema(desiredSchema)
-	}
-
 	val := calculateHistogramRate(false, rangeStart, rangeEnd, rangeSeconds, firstPoint, lastPoint, delta, hCount)
 	return val, nil
 }

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -337,10 +337,6 @@ func histogramDelta(hCount int, hHead []promql.HPoint, hTail []promql.HPoint, ra
 		lastPoint = hHead[len(hHead)-2]
 	}
 
-	if firstPoint.H.CounterResetHint == histogram.GaugeType || lastPoint.H.CounterResetHint == histogram.GaugeType {
-		emitAnnotation(annotations.NewNativeHistogramNotCounterWarning)
-	}
-
 	desiredSchema := min(firstPoint.H.Schema, lastPoint.H.Schema)
 
 	if firstPoint.H.UsesCustomBuckets() != lastPoint.H.UsesCustomBuckets() {

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -344,10 +344,7 @@ func histogramDelta(hCount int, hHead []promql.HPoint, hTail []promql.HPoint, ra
 		emitAnnotation(annotations.NewNativeHistogramNotCounterWarning)
 	}
 
-	desiredSchema := firstPoint.H.Schema
-	if lastPoint.H.Schema < desiredSchema {
-		desiredSchema = lastPoint.H.Schema
-	}
+	desiredSchema := min(firstPoint.H.Schema, lastPoint.H.Schema)
 
 	usingCustomBuckets := firstPoint.H.UsesCustomBuckets()
 	if lastPoint.H.UsesCustomBuckets() != usingCustomBuckets {

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -337,14 +337,11 @@ func histogramDelta(hCount int, hHead []promql.HPoint, hTail []promql.HPoint, ra
 		lastPoint = hHead[len(hHead)-2]
 	}
 
-	desiredSchema := min(firstPoint.H.Schema, lastPoint.H.Schema)
-
 	if firstPoint.H.UsesCustomBuckets() != lastPoint.H.UsesCustomBuckets() {
 		return nil, histogram.ErrHistogramsIncompatibleSchema
 	}
 
-	delta := lastPoint.H.CopyToSchema(desiredSchema)
-	_, err := delta.Sub(firstPoint.H)
+	delta, err := lastPoint.H.Copy().Sub(firstPoint.H)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -346,8 +346,7 @@ func histogramDelta(hCount int, hHead []promql.HPoint, hTail []promql.HPoint, ra
 
 	desiredSchema := min(firstPoint.H.Schema, lastPoint.H.Schema)
 
-	usingCustomBuckets := firstPoint.H.UsesCustomBuckets()
-	if lastPoint.H.UsesCustomBuckets() != usingCustomBuckets {
+	if firstPoint.H.UsesCustomBuckets() != lastPoint.H.UsesCustomBuckets() {
 		return nil, histogram.ErrHistogramsIncompatibleSchema
 	}
 

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -319,7 +319,7 @@ func floatDelta(fCount int, fHead []promql.FPoint, fTail []promql.FPoint, rangeS
 	if len(fTail) > 0 {
 		lastPoint = fTail[len(fTail)-1]
 	} else {
-		lastPoint = fHead[len(fHead)-2]
+		lastPoint = fHead[len(fHead)-1]
 	}
 
 	delta := lastPoint.F - firstPoint.F
@@ -333,7 +333,7 @@ func histogramDelta(hCount int, hHead []promql.HPoint, hTail []promql.HPoint, ra
 	if len(hTail) > 0 {
 		lastPoint = hTail[len(hTail)-1]
 	} else {
-		lastPoint = hHead[len(hHead)-2]
+		lastPoint = hHead[len(hHead)-1]
 	}
 
 	if firstPoint.H.UsesCustomBuckets() != lastPoint.H.UsesCustomBuckets() {

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -315,13 +315,12 @@ func delta(step *types.RangeVectorStepData, rangeSeconds float64, emitAnnotation
 
 func floatDelta(fCount int, fHead []promql.FPoint, fTail []promql.FPoint, rangeStart int64, rangeEnd int64, rangeSeconds float64) float64 {
 	firstPoint := fHead[0]
-	fHead = fHead[1:]
 
 	var lastPoint promql.FPoint
 	if len(fTail) > 0 {
 		lastPoint = fTail[len(fTail)-1]
 	} else {
-		lastPoint = fHead[len(fHead)-1]
+		lastPoint = fHead[len(fHead)-2]
 	}
 
 	delta := lastPoint.F - firstPoint.F
@@ -330,13 +329,12 @@ func floatDelta(fCount int, fHead []promql.FPoint, fTail []promql.FPoint, rangeS
 
 func histogramDelta(hCount int, hHead []promql.HPoint, hTail []promql.HPoint, rangeStart int64, rangeEnd int64, rangeSeconds float64, emitAnnotation types.EmitAnnotationFunc) (*histogram.FloatHistogram, error) {
 	firstPoint := hHead[0]
-	hHead = hHead[1:]
 
 	var lastPoint promql.HPoint
 	if len(hTail) > 0 {
 		lastPoint = hTail[len(hTail)-1]
 	} else {
-		lastPoint = hHead[len(hHead)-1]
+		lastPoint = hHead[len(hHead)-2]
 	}
 
 	if firstPoint.H.CounterResetHint == histogram.GaugeType || lastPoint.H.CounterResetHint == histogram.GaugeType {


### PR DESCRIPTION
This PR is trying to address suggestion in https://github.com/grafana/mimir/pull/9795 to extract delta function from rate. The diff will show how we have many more line additions if we extract the logic from rate.

How this different with #9795 
- We created a new step function called `delta` 
- Delta has no reset handling
- Delta will call `calculateFloatRate` and `calculateHistogramRate` to do extrapolation

My concern with extracting delta from rate is we create many line duplications, such as most of lines in delta(), floatDelta() and histogramDelta(). This is reflected from 118 line additions and 36 line removal in this PR diffs.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
