### PR TITLE
Docs: Adds clarity to step on shutting down ingesters

### DIFF
--- a/docs/sources/mimir/configure/configure-spread-minimizing-tokens/index.md
+++ b/docs/sources/mimir/configure/configure-spread-minimizing-tokens/index.md
@@ -53,10 +53,9 @@ You should see something like this:
 
 ## Step 2: Shut down ingesters from `zone-a`
 
-Next, ensure that all the in-memory series of all ingesters from `zone-a` have been flushed to long-term storage, as well as that the ingesters from `zone-a` have been forgotten from the ring.
-To do this, invoke the [/ingester/shutdown](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/references/http-api/index.md#shutdown) endpoint on all the ingesters from `zone-a`.
+Call the [/ingester/shutdown](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/references/http-api/index.md#shutdown) endpoint on all ingesters from `zone-a` to flush all in-memory series and metrics to long-term storage and to clear all ingesters from the ring.
 
-Before proceeding to the next step, ensure that all the calls completed successfully completed.
+Before proceeding to the next step, ensure that all calls complete successfully.
 
 ## Step 3: Enable spread-minimizing tokens for ingesters in `zone-a`
 


### PR DESCRIPTION

#### What this PR does

This PR adds clarity to step 2 of [shutting down ingesters on zone a](https://grafana.com/docs/mimir/latest/configure/configure-spread-minimizing-tokens/#step-2-shut-down-ingesters-from-zone-a) to also mention the need to flush all in-memory metrics to long-term storage when migrating to spread-minimizing tokens.

#### Which issue(s) this PR fixes or relates to

This PR addresses the support request, https://github.com/grafana/support-escalations/issues/11275.

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
