### PR TITLE
jsonnet: pass downscale-http-port from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [CHANGE] Update rollout-operator version to 0.22.0. #10229
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318
 * [BUGFIX] Ports in container rollout-operator. #10273
+* [BUGFIX] When downscaling is enabled, the components must annotate `prepare-downscale-http-port` with the value set in `$._config.server_http_port`. #10367
 
 ### Mimirtool
 

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1343,7 +1343,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: 12h
@@ -1471,7 +1471,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -1599,7 +1599,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-b
     rollout-max-unavailable: "50"
   labels:

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -1402,7 +1402,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-delayed-downscale: 13h
     grafana.com/rollout-mirror-replicas-from-resource-api-version: rollout-operator.grafana.com/v1
     grafana.com/rollout-mirror-replicas-from-resource-kind: ReplicaTemplate
@@ -1534,7 +1534,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-delayed-downscale: 13h
     grafana.com/rollout-mirror-replicas-from-resource-api-version: rollout-operator.grafana.com/v1
     grafana.com/rollout-mirror-replicas-from-resource-kind: ReplicaTemplate
@@ -1667,7 +1667,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-delayed-downscale: 13h
     grafana.com/rollout-mirror-replicas-from-resource-api-version: rollout-operator.grafana.com/v1
     grafana.com/rollout-mirror-replicas-from-resource-kind: ReplicaTemplate

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -1830,7 +1830,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-delayed-downscale: 13h
     grafana.com/rollout-mirror-replicas-from-resource-api-version: rollout-operator.grafana.com/v1
     grafana.com/rollout-mirror-replicas-from-resource-kind: ReplicaTemplate
@@ -1980,7 +1980,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -2120,7 +2120,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -1830,7 +1830,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-delayed-downscale: 13h
     grafana.com/rollout-mirror-replicas-from-resource-api-version: rollout-operator.grafana.com/v1
     grafana.com/rollout-mirror-replicas-from-resource-kind: ReplicaTemplate
@@ -1980,7 +1980,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -2120,7 +2120,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -1830,7 +1830,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-delayed-downscale: 13h
     grafana.com/rollout-mirror-replicas-from-resource-api-version: rollout-operator.grafana.com/v1
     grafana.com/rollout-mirror-replicas-from-resource-kind: ReplicaTemplate
@@ -1980,7 +1980,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -2120,7 +2120,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -1718,7 +1718,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: 12h
@@ -1855,7 +1855,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -1986,7 +1986,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-b
     rollout-max-unavailable: "50"
   labels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -1791,7 +1791,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: 12h
@@ -1929,7 +1929,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2075,7 +2075,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -2207,7 +2207,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2347,7 +2347,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-b
     rollout-max-unavailable: "50"
   labels:
@@ -2479,7 +2479,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -1807,7 +1807,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: "0"
@@ -1953,7 +1953,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -1807,7 +1807,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-delayed-downscale: 13h
     grafana.com/rollout-mirror-replicas-from-resource-api-version: rollout-operator.grafana.com/v1
     grafana.com/rollout-mirror-replicas-from-resource-kind: ReplicaTemplate
@@ -1957,7 +1957,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -1804,7 +1804,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: 12h
@@ -1942,7 +1942,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2088,7 +2088,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -2220,7 +2220,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2360,7 +2360,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-b
     rollout-max-unavailable: "50"
   labels:
@@ -2492,7 +2492,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -1826,7 +1826,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: 12h
@@ -1964,7 +1964,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2110,7 +2110,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -2242,7 +2242,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2382,7 +2382,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-b
     rollout-max-unavailable: "50"
   labels:
@@ -2514,7 +2514,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -1824,7 +1824,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: 12h
@@ -1962,7 +1962,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2108,7 +2108,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -2240,7 +2240,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2380,7 +2380,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-b
     rollout-max-unavailable: "50"
   labels:
@@ -2512,7 +2512,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -1824,7 +1824,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: "0"
@@ -1962,7 +1962,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2108,7 +2108,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -2240,7 +2240,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2380,7 +2380,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-b
     rollout-max-unavailable: "50"
   labels:
@@ -2512,7 +2512,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -1824,7 +1824,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: "0"
@@ -1962,7 +1962,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2108,7 +2108,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -2240,7 +2240,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2380,7 +2380,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-b
     rollout-max-unavailable: "50"
   labels:
@@ -2512,7 +2512,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -1755,7 +1755,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -1901,7 +1901,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2041,7 +2041,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -1771,7 +1771,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -1917,7 +1917,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2057,7 +2057,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -1771,7 +1771,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -1917,7 +1917,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"
@@ -2057,7 +2057,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/prepare-downscale: "true"

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -1748,7 +1748,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: "0"
@@ -1894,7 +1894,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -1830,7 +1830,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-delayed-downscale: 13h
     grafana.com/rollout-mirror-replicas-from-resource-api-version: rollout-operator.grafana.com/v1
     grafana.com/rollout-mirror-replicas-from-resource-kind: ReplicaTemplate
@@ -1980,7 +1980,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:
@@ -2120,7 +2120,7 @@ kind: StatefulSet
 metadata:
   annotations:
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: ingester-zone-a
     rollout-max-unavailable: "50"
   labels:

--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -98,7 +98,7 @@
       statefulSet.mixin.metadata.withAnnotationsMixin(
         {
           'grafana.com/prepare-downscale-http-path': 'ingester/prepare-shutdown',  // We want to tell ingesters that they are shutting down.
-          'grafana.com/prepare-downscale-http-port': '80',
+          'grafana.com/prepare-downscale-http-port': '%(server_http_port)s' % $._config,
         } + (
           if zone == $._config.ingest_storage_ingester_autoscaling_primary_zone then {
             'grafana.com/rollout-mirror-replicas-from-resource-name': $._config.ingest_storage_ingester_autoscaling_primary_zone,

--- a/operations/mimir/ingest-storage-migration.libsonnet
+++ b/operations/mimir/ingest-storage-migration.libsonnet
@@ -67,7 +67,7 @@
     }) +
     statefulSet.mixin.metadata.withAnnotationsMixin({
       'grafana.com/prepare-downscale-http-path': 'ingester/prepare-shutdown',
-      'grafana.com/prepare-downscale-http-port': '80',
+      'grafana.com/prepare-downscale-http-port': '%(server_http_port)s' % $._config,
     }),
 
   local gossipLabel = if !$._config.memberlist_ring_enabled then {} else

--- a/operations/mimir/ingester-automated-downscale-v2.libsonnet
+++ b/operations/mimir/ingester-automated-downscale-v2.libsonnet
@@ -57,7 +57,7 @@
         // Endpoint for telling ingester that it's going to be scaled down. Ingester will flush the
         // data and unregister from the ring on shutdown.
         'grafana.com/prepare-downscale-http-path': 'ingester/prepare-shutdown',
-        'grafana.com/prepare-downscale-http-port': '80',
+        'grafana.com/prepare-downscale-http-port': '%(server_http_port)s' % $._config,
         // Ingester statefulset will follow number of replicas from ReplicaTemplate/ingester-zone-a.
         'grafana.com/rollout-mirror-replicas-from-resource-api-version': 'rollout-operator.grafana.com/v1',
         'grafana.com/rollout-mirror-replicas-from-resource-kind': 'ReplicaTemplate',

--- a/operations/mimir/ingester-automated-downscale.libsonnet
+++ b/operations/mimir/ingester-automated-downscale.libsonnet
@@ -33,7 +33,7 @@
     }) +
     statefulSet.mixin.metadata.withAnnotationsMixin({
       'grafana.com/prepare-downscale-http-path': 'ingester/prepare-shutdown',
-      'grafana.com/prepare-downscale-http-port': '80',
+      'grafana.com/prepare-downscale-http-port': '%(server_http_port)s' % $._config,
     }),
 
   // Ingester prepare-downscale configuration


### PR DESCRIPTION
#### What this PR does

The jsonnet bundle hardcodes the `prepare-downscale-http-port: 80` in all components, that use autoscaling and downscaling via the rollout-operator. This doesn't match the default HTTP port the bundle sets for the `*-http-metrics` container port, which is `:8080`.

Note we haven't noticed this previously, because internally all mimir components are run with `$._config.server_http_port=80`.

#### Which issue(s) this PR fixes or relates to

Fixes n/a

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
