### PR TITLE
Use v2 of the publish-technical-documentation-release workflow

### DIFF
--- a/.github/workflows/publish-technical-documentation-release-mimir.yml
+++ b/.github/workflows/publish-technical-documentation-release-mimir.yml
@@ -23,12 +23,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Full fetch depth is required to fetch tags. The publishing workflow uses tags to prevent publishing a release branch before it has been formally released, as determined by the presence of a matching tag for the release branch.
+          # Full fetch depth is required to fetch tags.
+          # The publishing workflow uses tags to prevent publishing a release branch before it has been formally released, as determined by the presence of a matching tag for the release branch.
           fetch-depth: 0
-      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v1
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2
         with:
-          release_tag_regexp: "^mimir-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-          release_branch_regexp: "^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-          release_branch_with_patch_regexp: "^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+          release_tag_regexp: "^mimir-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_with_patch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
           source_directory: docs/sources/mimir
           website_directory: content/docs/mimir


### PR DESCRIPTION
#### What this PR does

v2 includes an additional step to check out the HEAD of the release branch before syncing on tag events. This ensures that tags made to older commits on a release branch don't revert documentation.

https://github.com/grafana/writers-toolkit/blob/main/publish-technical-documentation-release/action.yaml#L65-L84

#### Which issue(s) this PR fixes or relates to

Fixes https://raintank-corp.slack.com/archives/C03Q42RLMRQ/p1736193190664809

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
