### PR TITLE
mimir-distributed: allow StatefulSets to configure their PVC template names

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318
 * [ENHANCEMENT] Minio: update subchart to v5.4.0. #10346
 * [ENHANCEMENT] Individual mimir components can override their container images via the *.image values. The component's image definitions always override the values set in global `image` or `enterprise.image`. #10340
+* [ENHANCEMENT] Alertmanager, compactor, ingester and store-gateway StatefulSets can configure their PVC template name via the corresponding *.persistentVolume.name values. #10376
 * [BUGFIX] Fix calculation of `mimir.siToBytes` and use floating point arithmetics. #10044
 
 ## 5.6.0-rc.0

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,7 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318
 * [ENHANCEMENT] Minio: update subchart to v5.4.0. #10346
 * [ENHANCEMENT] Individual mimir components can override their container images via the *.image values. The component's image definitions always override the values set in global `image` or `enterprise.image`. #10340
-* [ENHANCEMENT] Alertmanager, compactor, ingester and store-gateway StatefulSets can configure their PVC template name via the corresponding *.persistentVolume.name values. #10376
+* [ENHANCEMENT] Alertmanager, compactor, ingester, and store-gateway StatefulSets can configure their PVC template name via the corresponding *.persistentVolume.name values. #10376
 * [BUGFIX] Fix calculation of `mimir.siToBytes` and use floating point arithmetics. #10044
 
 ## 5.6.0-rc.0

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -32,17 +32,18 @@ spec:
     {{- end }}
   serviceName: {{ template "mimir.fullname" . }}-alertmanager
   {{- if .Values.alertmanager.persistentVolume.enabled }}
+  {{- with .Values.alertmanager.persistentVolume }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
-        name: storage
-        {{- if .Values.alertmanager.persistentVolume.annotations }}
+        name: {{ .name }}
+        {{- if .annotations }}
         annotations:
-          {{ toYaml .Values.alertmanager.persistentVolume.annotations | nindent 10 }}
+          {{ toYaml .annotations | nindent 10 }}
         {{- end }}
       spec:
-        {{- $storageClass := default .Values.alertmanager.persistentVolume.storageClass $rolloutZone.storageClass }}
+        {{- $storageClass := default .storageClass $rolloutZone.storageClass }}
         {{- if $storageClass }}
         {{- if (eq "-" $storageClass) }}
         storageClassName: ""
@@ -51,10 +52,11 @@ spec:
         {{- end }}
         {{- end }}
         accessModes:
-          {{- toYaml .Values.alertmanager.persistentVolume.accessModes | nindent 10 }}
+          {{- toYaml .accessModes | nindent 10 }}
         resources:
           requests:
-            storage: "{{ .Values.alertmanager.persistentVolume.size }}"
+            storage: "{{ .size }}"
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -23,28 +23,30 @@ spec:
     {{- toYaml .Values.compactor.strategy | nindent 4 }}
   serviceName: {{ template "mimir.fullname" . }}-compactor
   {{- if .Values.compactor.persistentVolume.enabled }}
+  {{- with .Values.compactor.persistentVolume }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
-        name: storage
-        {{- if .Values.compactor.persistentVolume.annotations }}
+        name: {{ .name }}
+        {{- if .annotations }}
         annotations:
-          {{ toYaml .Values.compactor.persistentVolume.annotations | nindent 10 }}
+          {{ toYaml .annotations | nindent 10 }}
         {{- end }}
       spec:
-        {{- if .Values.compactor.persistentVolume.storageClass }}
-        {{- if (eq "-" .Values.compactor.persistentVolume.storageClass) }}
+        {{- if .storageClass }}
+        {{- if (eq "-" .storageClass) }}
         storageClassName: ""
         {{- else }}
-        storageClassName: "{{ .Values.compactor.persistentVolume.storageClass }}"
+        storageClassName: "{{ .storageClass }}"
         {{- end }}
         {{- end }}
         accessModes:
-          {{- toYaml .Values.compactor.persistentVolume.accessModes | nindent 10 }}
+          {{- toYaml .accessModes | nindent 10 }}
         resources:
           requests:
-            storage: "{{ .Values.compactor.persistentVolume.size }}"
+            storage: "{{ .size }}"
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -32,17 +32,18 @@ spec:
     {{- end }}
   serviceName: {{ template "mimir.fullname" . }}-ingester{{- if not .Values.enterprise.legacyLabels -}}-headless{{- end -}}
   {{- if .Values.ingester.persistentVolume.enabled }}
+  {{- with .Values.ingester.persistentVolume }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
-        name: storage
-        {{- if .Values.ingester.persistentVolume.annotations }}
+        name: {{ .name }}
+        {{- if .annotations }}
         annotations:
-          {{- toYaml .Values.ingester.persistentVolume.annotations | nindent 10 }}
+          {{- toYaml .annotations | nindent 10 }}
         {{- end }}
       spec:
-        {{- $storageClass := default .Values.ingester.persistentVolume.storageClass $rolloutZone.storageClass }}
+        {{- $storageClass := default .storageClass $rolloutZone.storageClass }}
         {{- if $storageClass }}
         {{- if (eq "-" $storageClass) }}
         storageClassName: ""
@@ -51,10 +52,11 @@ spec:
         {{- end }}
         {{- end }}
         accessModes:
-          {{- toYaml .Values.ingester.persistentVolume.accessModes | nindent 10 }}
+          {{- toYaml .accessModes | nindent 10 }}
         resources:
           requests:
-            storage: "{{ .Values.ingester.persistentVolume.size }}"
+            storage: "{{ .size }}"
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -32,17 +32,18 @@ spec:
     {{- end }}
   serviceName: {{ template "mimir.fullname" . }}-store-gateway{{- if not .Values.enterprise.legacyLabels -}}-headless{{- end -}}
   {{- if .Values.store_gateway.persistentVolume.enabled }}
+  {{- with .Values.store_gateway.persistentVolume }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
-        name: storage
-        {{- if .Values.store_gateway.persistentVolume.annotations }}
+        name: {{ .name }}
+        {{- if .annotations }}
         annotations:
-          {{- toYaml .Values.store_gateway.persistentVolume.annotations | nindent 10 }}
+          {{- toYaml .annotations | nindent 10 }}
         {{- end }}
       spec:
-        {{- $storageClass := default .Values.store_gateway.persistentVolume.storageClass $rolloutZone.storageClass }}
+        {{- $storageClass := default .storageClass $rolloutZone.storageClass }}
         {{- if $storageClass }}
         {{- if (eq "-" $storageClass) }}
         storageClassName: ""
@@ -51,10 +52,11 @@ spec:
         {{- end }}
         {{- end }}
         accessModes:
-          {{- toYaml .Values.store_gateway.persistentVolume.accessModes | nindent 10 }}
+          {{- toYaml .accessModes | nindent 10 }}
         resources:
           requests:
-            storage: "{{ .Values.store_gateway.persistentVolume.size }}"
+            storage: "{{ .size }}"
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -636,6 +636,10 @@ alertmanager:
     # If false, use emptyDir
     enabled: true
 
+    # Alertmanager data Persistent Volume Claim template name
+    #
+    name: storage
+
     # Alertmanager data Persistent Volume Claim annotations
     #
     annotations: {}
@@ -1014,6 +1018,10 @@ ingester:
     # It is advisable to enable volume persistence in ingester to avoid losing metrics.
     #
     enabled: true
+
+    # Ingester data Persistent Volume Claim template name
+    #
+    name: storage
 
     # Ingester data Persistent Volume Claim annotations
     #
@@ -2154,6 +2162,10 @@ store_gateway:
     #
     enabled: true
 
+    # Store-gateway data Persistent Volume Claim template name
+    #
+    name: storage
+
     # Store-gateway data Persistent Volume Claim annotations
     #
     annotations: {}
@@ -2365,6 +2377,10 @@ compactor:
     # If false, use emptyDir
     #
     enabled: true
+
+    # compactor data Persistent Volume Claim template name
+    #
+    name: storage
 
     # compactor data Persistent Volume Claim annotations
     #


### PR DESCRIPTION
#### What this PR does

This PR updates the chart StatefulSets templates, to allow configuring their PVC template names. E.g.

```yaml
store_gateway:
  persistentVolume:
    enabled: true
    name: store-gateway-data
```

This is a noop change for the existing systems. But this'll allow us to minimise the discrepancies between the Jsonnet bundle and the Helm chart, when migrating our internal systems to use the chart.

Also, the PR simplifies the templates of the `volumeClaimTemplates` yaml sections.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
