### PR TITLE
Fix only run on fork guard

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-pr-preview:
-    if: github.repository == 'grafana/mimir'
+    if: ! github.event.pull_request.head.repo.fork
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:
       sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
#### What this PR does

The previous guard fails because `github.repository` resolves to the base repository on `pull_request` events.


#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
