### PR TITLE
fix(rw2.0): reject remote write 2.0 based on content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [BUGFIX] MQE: Fix deriv with histograms #10383
 * [BUGFIX] PromQL: Fix <aggr_over_time> functions with histograms https://github.com/prometheus/prometheus/pull/15711 #10400
 * [BUGFIX] MQE: Fix <aggr_over_time> functions with histograms #10400
+* [BUGFIX] Distributor: return HTTP status 415 Unsupported medica type instead of success for Remote Write 2.0 until we support it. #10423
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 * [BUGFIX] MQE: Fix deriv with histograms #10383
 * [BUGFIX] PromQL: Fix <aggr_over_time> functions with histograms https://github.com/prometheus/prometheus/pull/15711 #10400
 * [BUGFIX] MQE: Fix <aggr_over_time> functions with histograms #10400
-* [BUGFIX] Distributor: return HTTP status 415 Unsupported medica type instead of success for Remote Write 2.0 until we support it. #10423
+* [BUGFIX] Distributor: return HTTP status 415 Unsupported Media Type instead of 200 Success for Remote Write 2.0 until we support it. #10423
 
 ### Mixin
 

--- a/integration/distributor_test.go
+++ b/integration/distributor_test.go
@@ -376,7 +376,6 @@ overrides:
 func TestDistributorRemoteWrite2(t *testing.T) {
 	queryEnd := time.Now().Round(time.Second)
 	queryStart := queryEnd.Add(-1 * time.Hour)
-	// queryStep := 10 * time.Minute
 
 	testCases := map[string]struct {
 		inRemoteWrite   []*promRW2.Request
@@ -425,7 +424,7 @@ func TestDistributorRemoteWrite2(t *testing.T) {
 		"-distributor.ha-tracker.store":                      "consul",
 		"-distributor.ha-tracker.consul.hostname":            consul.NetworkHTTPEndpoint(),
 		"-distributor.ha-tracker.prefix":                     "prom_ha/",
-		"-timeseries-unmarshal-caching-optimization-enabled": strconv.FormatBool(false), //cachingUnmarshalDataEnabled),
+		"-timeseries-unmarshal-caching-optimization-enabled": strconv.FormatBool(false),
 	}
 
 	flags := mergeFlags(

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -31,6 +31,7 @@ import (
 	promConfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/prompb" // OTLP protos are not compatible with gogo
+	promRW2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
 	"github.com/prometheus/prometheus/storage/remote"
 	yaml "gopkg.in/yaml.v3"
 
@@ -171,6 +172,38 @@ func (c *Client) Push(timeseries []prompb.TimeSeries) (*http.Response, error) {
 	req.Header.Add("Content-Encoding", "snappy")
 	req.Header.Set("Content-Type", "application/x-protobuf")
 	req.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
+	req.Header.Set("X-Scope-OrgID", c.orgID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	// Execute HTTP request
+	res, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	return res, nil
+}
+
+func (c *Client) PushRW2(writeRequest *promRW2.Request) (*http.Response, error) {
+	// Create write request
+	data, err := proto.Marshal(writeRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create HTTP request
+	compressed := snappy.Encode(nil, data)
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://%s/api/v1/push", c.distributorAddress), bytes.NewReader(compressed))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Encoding", "snappy")
+	req.Header.Set("Content-Type", "application/x-protobuf;proto=io.prometheus.write.v2.Request")
+	req.Header.Set("X-Prometheus-Remote-Write-Version", "2.0.0")
 	req.Header.Set("X-Scope-OrgID", c.orgID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)

--- a/pkg/distributor/rw2/utils.go
+++ b/pkg/distributor/rw2/utils.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package rw2
 
 import (

--- a/pkg/distributor/rw2/utils.go
+++ b/pkg/distributor/rw2/utils.go
@@ -1,0 +1,102 @@
+package rw2
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/model/labels"
+	promRW2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
+)
+
+// NewWriteRequest is used in testing Remote Write 2.0 to generate a new write request.
+func NewWriteRequest() *promRW2.Request {
+	return &promRW2.Request{}
+}
+
+// AddFloatSeries is used in testing Remote Write 2.0 to add a float series to a write request.
+// Write 0 into createdTimestamp to not use it.
+func AddFloatSeries(
+	req *promRW2.Request,
+	lbls labels.Labels,
+	floats []promRW2.Sample,
+	metricType promRW2.Metadata_MetricType,
+	help string,
+	unit string,
+	createdTimestamp int64,
+	exemplars []promRW2.Exemplar) *promRW2.Request {
+	if req == nil {
+		req = NewWriteRequest()
+	}
+
+	var labelsRefs []uint32
+	lbls.Range(func(l labels.Label) {
+		labelsRefs = append(labelsRefs, getSymbol(l.Name, &req.Symbols))
+		labelsRefs = append(labelsRefs, getSymbol(l.Value, &req.Symbols))
+	})
+
+	ts := promRW2.TimeSeries{
+		LabelsRefs: labelsRefs,
+		Samples:    floats,
+		Metadata: promRW2.Metadata{
+			Type:    metricType,
+			HelpRef: getSymbol(help, &req.Symbols),
+			UnitRef: getSymbol(unit, &req.Symbols),
+		},
+		Exemplars:        exemplars,
+		CreatedTimestamp: createdTimestamp,
+	}
+	fmt.Printf("KRAJO: AddFloatSeries: %v\n", ts.Metadata)
+	req.Timeseries = append(req.Timeseries, ts)
+
+	return req
+}
+
+// AddHistogramSeries is used in testing Remote Write 2.0 to add a histogram series to a write request.
+// Write 0 into createdTimestamp to not use it.
+func AddHistogramSeries(
+	req *promRW2.Request,
+	lbls labels.Labels,
+	histograms []promRW2.Histogram,
+	help string,
+	unit string,
+	createdTimestamp int64,
+	exemplars []promRW2.Exemplar) *promRW2.Request {
+	if req == nil {
+		req = NewWriteRequest()
+	}
+
+	var labelsRefs []uint32
+	lbls.Range(func(l labels.Label) {
+		labelsRefs = append(labelsRefs, getSymbol(l.Name, &req.Symbols))
+		labelsRefs = append(labelsRefs, getSymbol(l.Value, &req.Symbols))
+	})
+
+	metricType := promRW2.Metadata_METRIC_TYPE_HISTOGRAM
+	if histograms[0].ResetHint == promRW2.Histogram_RESET_HINT_GAUGE {
+		metricType = promRW2.Metadata_METRIC_TYPE_GAUGEHISTOGRAM
+	}
+
+	ts := promRW2.TimeSeries{
+		LabelsRefs: labelsRefs,
+		Histograms: histograms,
+		Metadata: promRW2.Metadata{
+			Type:    metricType,
+			HelpRef: getSymbol(help, &req.Symbols),
+			UnitRef: getSymbol(unit, &req.Symbols),
+		},
+		Exemplars:        exemplars,
+		CreatedTimestamp: createdTimestamp,
+	}
+	req.Timeseries = append(req.Timeseries, ts)
+
+	return req
+}
+
+func getSymbol(sym string, symbols *[]string) uint32 {
+	for i, s := range *symbols {
+		if s == sym {
+			return uint32(i)
+		}
+	}
+	*symbols = append(*symbols, sym)
+	return uint32(len(*symbols) - 1)
+}


### PR DESCRIPTION
#### What this PR does

Reject remote write 2.0 request properly with HTTP status 415, based on [RW2.0 spec](https://prometheus.io/docs/specs/remote_write_spec_2_0/#2-x-vs-1-x-compatibility).

The current solution returns 2xx , but doesn't actually ingest the samples.

Prometheus does detect this
prometheus-1  | time=2025-01-13T13:01:35.028Z level=ERROR source=queue_manager.go:1670 msg="non-recoverable error" component=remote remote_name=150c10
 url=http://mimir-1:8001/api/v1/push failedSampleCount=2000
failedHistogramCount=0 failedExemplarCount=0
err="sent v2 request with 2000 samples, 0 histograms and 0 exemplars;
 got 2xx, but PRW 2.0 response header statistics indicate 0 samples,
 0 histograms and 0 exemplars were accepted; assumining failure e.g.
 the target only supports PRW 1.0 prometheus.WriteRequest, but does not
 check the Content-Type header correctly"

But we can do better and also start working towards RW2.0 support.

#### Which issue(s) this PR fixes or relates to

Related to #9072
Copied and dumbed down integration test from #10432

#### Checklist

- [N/A] Tests updated. Tested manually, we are going to replace this with proper support.
- [N/A] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
