### PR TITLE
chore(dev): update Prometheus to 3.1.0 and add prometheusRW2 profile

### DIFF
--- a/development/mimir-microservices-mode/config/prom-ha-pair-1.yaml
+++ b/development/mimir-microservices-mode/config/prom-ha-pair-1.yaml
@@ -27,7 +27,7 @@ scrape_configs:
         target_label: 'container'
         regex: '(.+?)(-\d+)?'
         replacement: '${1}'
-    scrape_classic_histograms: true
+    always_scrape_classic_histograms: true
 
 remote_write:
   - url: http://distributor-2:8001/api/v1/push

--- a/development/mimir-microservices-mode/config/prom-ha-pair-2.yaml
+++ b/development/mimir-microservices-mode/config/prom-ha-pair-2.yaml
@@ -27,7 +27,7 @@ scrape_configs:
         target_label: 'container'
         regex: '(.+?)(-\d+)?'
         replacement: '${1}'
-    scrape_classic_histograms: true
+    always_scrape_classic_histograms: true
 
 remote_write:
   - url: http://distributor-2:8001/api/v1/push

--- a/development/mimir-microservices-mode/config/prometheus.yaml
+++ b/development/mimir-microservices-mode/config/prometheus.yaml
@@ -38,7 +38,7 @@ scrape_configs:
         target_label: 'container'
         regex: '(.+?)(-\d+)?'
         replacement: '${1}'
-    scrape_classic_histograms: true
+    always_scrape_classic_histograms: true
 
 remote_write:
   - url: http://distributor-1:8000/api/v1/push

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -341,7 +341,7 @@ std.manifestYamlDoc({
 
   prometheus:: {
     prometheus: {
-      image: 'prom/prometheus:v2.51.1',
+      image: 'prom/prometheus:v3.1.0',
       command: [
         '--config.file=/etc/prometheus/prometheus.yaml',
         '--enable-feature=exemplar-storage',
@@ -358,7 +358,7 @@ std.manifestYamlDoc({
 
   prompair1:: {
     prompair1: {
-      image: 'prom/prometheus:v2.51.1',
+      image: 'prom/prometheus:v3.1.0',
       hostname: 'prom-ha-pair-1',
       command: [
         '--config.file=/etc/prometheus/prom-ha-pair-1.yaml',
@@ -374,7 +374,7 @@ std.manifestYamlDoc({
 
   prompair2:: {
     prompair2: {
-      image: 'prom/prometheus:v2.51.1',
+      image: 'prom/prometheus:v3.1.0',
       hostname: 'prom-ha-pair-2',
       command: [
         '--config.file=/etc/prometheus/prom-ha-pair-2.yaml',

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -329,7 +329,7 @@
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--enable-feature=exemplar-storage"
       - "--enable-feature=native-histograms"
-    "image": "prom/prometheus:v2.51.1"
+    "image": "prom/prometheus:v3.1.0"
     "ports":
       - "9090:9090"
     "volumes":
@@ -342,7 +342,7 @@
       - "--enable-feature=exemplar-storage"
       - "--enable-feature=native-histograms"
     "hostname": "prom-ha-pair-1"
-    "image": "prom/prometheus:v2.51.1"
+    "image": "prom/prometheus:v3.1.0"
     "ports":
       - "9092:9090"
     "volumes":

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -353,7 +353,7 @@
       - "--enable-feature=exemplar-storage"
       - "--enable-feature=native-histograms"
     "hostname": "prom-ha-pair-2"
-    "image": "prom/prometheus:v2.51.1"
+    "image": "prom/prometheus:v3.1.0"
     "ports":
       - "9093:9090"
     "volumes":

--- a/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
+++ b/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 
   prometheus:
 
-    image: prom/prometheus:v2.55.1
+    image: prom/prometheus:v3.1.0
     command: ["--config.file=/etc/prometheus/prometheus.yaml", "--enable-feature=native-histograms"]
     volumes:
       - ./config:/etc/prometheus

--- a/development/mimir-monolithic-mode/config/prometheus.yaml
+++ b/development/mimir-monolithic-mode/config/prometheus.yaml
@@ -9,13 +9,13 @@ scrape_configs:
       - targets: ['mimir-1:8001']
         labels:
           container: 'mimir-1'
-    scrape_classic_histograms: true
+    always_scrape_classic_histograms: true
   - job_name: mimir-2
     static_configs:
       - targets: ['mimir-2:8002']
         labels:
           container: 'mimir-2'
-    scrape_classic_histograms: true
+    always_scrape_classic_histograms: true
 
 remote_write:
   - url: http://mimir-1:8001/api/v1/push

--- a/development/mimir-monolithic-mode/config/prometheusRW2.yaml
+++ b/development/mimir-monolithic-mode/config/prometheusRW2.yaml
@@ -20,3 +20,5 @@ scrape_configs:
 remote_write:
   - url: http://mimir-1:8001/api/v1/push
     send_native_histograms: true
+    protobuf_message: "io.prometheus.write.v2.Request"
+

--- a/development/mimir-monolithic-mode/config/prometheusRW2.yaml
+++ b/development/mimir-monolithic-mode/config/prometheusRW2.yaml
@@ -21,4 +21,3 @@ remote_write:
   - url: http://mimir-1:8001/api/v1/push
     send_native_histograms: true
     protobuf_message: "io.prometheus.write.v2.Request"
-

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -21,8 +21,18 @@ services:
   prometheus:
     profiles:
       - prometheus
-    image: prom/prometheus:v2.55.1
+    image: prom/prometheus:v3.1.0
     command: ["--config.file=/etc/prometheus/prometheus.yaml", "--enable-feature=native-histograms"]
+    volumes:
+      - ./config:/etc/prometheus
+    ports:
+      - 9190:9090
+
+  prometheusRW2:
+    profiles:
+      - prometheusRW2
+    image: prom/prometheus:v3.1.0
+    command: ["--config.file=/etc/prometheus/prometheusRW2.yaml", "--enable-feature=metadata-wal-records,native-histograms"]
     volumes:
       - ./config:/etc/prometheus
     ports:


### PR DESCRIPTION
Update Prometheus and also add a profile for easy RW2.0 testing. To use:
```
development/mimir-monolithic-mode$ ./compose-up.sh --profile prometheusRW2
```

Going from 2.55.1 to 3.1.0
