### PR TITLE
Add `gocritic/dupImport` check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,14 +4,15 @@ output:
 
 linters:
   enable:
-    - gci
-    - revive
-    - gofmt
-    - misspell
     - errorlint
     - forbidigo
-    - loggercheck
+    - gci
+    - gocritic
+    - gofmt
     - gosec
+    - loggercheck
+    - misspell
+    - revive
 
 linters-settings:
   errcheck:
@@ -70,6 +71,12 @@ linters-settings:
       - G112
       - G114
       - G302
+  
+  gocritic:
+    disable-all: true
+    enabled-checks:
+      # See https://golangci-lint.run/usage/linters/#gocritic for possible checks.
+      - dupImport
 
 run:
   timeout: 10m

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
-	"github.com/grafana/mimir/pkg/querier/stats"
 	querier_stats "github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
 	"github.com/grafana/mimir/pkg/util/test"
@@ -293,7 +292,7 @@ func TestSchedulerProcessor_QueryTime(t *testing.T) {
 		requestHandler.On("Handle", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			workerCancel()
 
-			stat := stats.FromContext(args.Get(0).(context.Context))
+			stat := querier_stats.FromContext(args.Get(0).(context.Context))
 
 			if statsEnabled {
 				require.Equal(t, queueTime, stat.LoadQueueTime())

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/rules"
 	promRules "github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/assert"
@@ -136,7 +135,7 @@ type prepareOptions struct {
 	rulerAddrMap     map[string]*Ruler
 	rulerAddrAutoMap bool
 	start            bool
-	managerQueryFunc rules.QueryFunc
+	managerQueryFunc promRules.QueryFunc
 }
 
 func applyPrepareOptions(t *testing.T, instanceID string, opts ...prepareOption) prepareOptions {
@@ -199,7 +198,7 @@ func withPrometheusRegisterer(reg prometheus.Registerer) prepareOption {
 }
 
 // withManagerQueryFunc is a prepareOption that configures the query function to pass to the ruler manager.
-func withManagerQueryFunc(queryFunc rules.QueryFunc) prepareOption {
+func withManagerQueryFunc(queryFunc promRules.QueryFunc) prepareOption {
 	return func(opts *prepareOptions) {
 		opts.managerQueryFunc = queryFunc
 	}
@@ -236,7 +235,7 @@ func prepareRulerManager(t *testing.T, cfg Config, opts ...prepareOption) *Defau
 		return storage.NoopQuerier(), nil
 	})
 
-	var queryFunc rules.QueryFunc
+	var queryFunc promRules.QueryFunc
 	if options.managerQueryFunc != nil {
 		queryFunc = options.managerQueryFunc
 	} else {

--- a/pkg/storage/tsdb/block/block_test.go
+++ b/pkg/storage/tsdb/block/block_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 
-	"github.com/grafana/mimir/pkg/util/test"
 	testutil "github.com/grafana/mimir/pkg/util/test"
 )
 
@@ -158,7 +157,7 @@ func TestUpload(t *testing.T) {
 	})
 
 	t.Run("missing chunks", func(t *testing.T) {
-		test.Copy(t, path.Join(tmpDir, b1.String(), MetaFilename), path.Join(tmpDir, "test", b1.String(), MetaFilename))
+		testutil.Copy(t, path.Join(tmpDir, b1.String(), MetaFilename), path.Join(tmpDir, "test", b1.String(), MetaFilename))
 
 		err := Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), nil)
 		require.Error(t, err)
@@ -167,7 +166,7 @@ func TestUpload(t *testing.T) {
 
 	t.Run("missing index file", func(t *testing.T) {
 		require.NoError(t, os.MkdirAll(path.Join(tmpDir, "test", b1.String(), ChunksDirname), 0777))
-		test.Copy(t, path.Join(tmpDir, b1.String(), ChunksDirname, "000001"), path.Join(tmpDir, "test", b1.String(), ChunksDirname, "000001"))
+		testutil.Copy(t, path.Join(tmpDir, b1.String(), ChunksDirname, "000001"), path.Join(tmpDir, "test", b1.String(), ChunksDirname, "000001"))
 
 		err := Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, "test", b1.String()), nil)
 		require.Error(t, err)
@@ -175,7 +174,7 @@ func TestUpload(t *testing.T) {
 	})
 
 	t.Run("missing meta.json file", func(t *testing.T) {
-		test.Copy(t, path.Join(tmpDir, b1.String(), IndexFilename), path.Join(tmpDir, "test", b1.String(), IndexFilename))
+		testutil.Copy(t, path.Join(tmpDir, b1.String(), IndexFilename), path.Join(tmpDir, "test", b1.String(), IndexFilename))
 		require.NoError(t, os.Remove(path.Join(tmpDir, "test", b1.String(), MetaFilename)))
 
 		// Missing meta.json file.
@@ -198,7 +197,7 @@ func TestUpload(t *testing.T) {
 		require.Contains(t, err.Error(), "/meta.json: no such file or directory")
 	})
 
-	test.Copy(t, path.Join(tmpDir, b1.String(), MetaFilename), path.Join(tmpDir, "test", b1.String(), MetaFilename))
+	testutil.Copy(t, path.Join(tmpDir, b1.String(), MetaFilename), path.Join(tmpDir, "test", b1.String(), MetaFilename))
 
 	t.Run("full block", func(t *testing.T) {
 		// Full


### PR DESCRIPTION
`gocritic` is too noisy to add as a whole, but we can add checks when we find non-controversial things that could've easily been fixed