### PR TITLE
Ruler Concurrency: Remove `independent` from metrics and configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [CHANGE] Querier: pass query matchers to queryable `IsApplicable` hook. #10256
 * [CHANGE] Query-frontend: Add `topic` label to `cortex_ingest_storage_strong_consistency_requests_total`, `cortex_ingest_storage_strong_consistency_failures_total`, and `cortex_ingest_storage_strong_consistency_wait_duration_seconds` metrics. #10220
 * [CHANGE] Ruler: cap the rate of retries for remote query evaluation to 170/sec. This is configurable via `-ruler.query-frontend.max-retries-rate`. #10375 #10403
+* [CHANGE] Ruler: Remove the `independent` keyword from all rule concurrency metrics and configs. Rule concurrency is applied more widely than just independent rules now #10435
 * [ENHANCEMENT] Query Frontend: Return server-side `samples_processed` statistics. #10103
 * [ENHANCEMENT] Distributor: OTLP receiver now converts also metric metadata. See also https://github.com/prometheus/prometheus/pull/15416. #10168
 * [ENHANCEMENT] Distributor: discard float and histogram samples with duplicated timestamps from each timeseries in a request before the request is forwarded to ingesters. Discarded samples are tracked by `cortex_discarded_samples_total` metrics with the reason `sample_duplicate_timestamp`. #10145 #10430

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4487,7 +4487,7 @@
           "kind": "field",
           "name": "ruler_max_rule_evaluation_concurrency_per_tenant",
           "required": false,
-          "desc": "Maximum number of independent rules that can run concurrently for each tenant. Depends on ruler.max-rule-evaluation-concurrency being greater than 0. Ideally this flag should be a lower value. 0 to disable.",
+          "desc": "Maximum number of rules that can run concurrently for each tenant. Depends on ruler.max-rule-evaluation-concurrency being greater than 0. Ideally this flag should be a lower value. 0 to disable.",
           "fieldValue": null,
           "fieldDefaultValue": 4,
           "fieldFlag": "ruler.max-rule-evaluation-concurrency-per-tenant",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4485,12 +4485,12 @@
         },
         {
           "kind": "field",
-          "name": "ruler_max_independent_rule_evaluation_concurrency_per_tenant",
+          "name": "ruler_max_rule_evaluation_concurrency_per_tenant",
           "required": false,
-          "desc": "Maximum number of independent rules that can run concurrently for each tenant. Depends on ruler.max-independent-rule-evaluation-concurrency being greater than 0. Ideally this flag should be a lower value. 0 to disable.",
+          "desc": "Maximum number of independent rules that can run concurrently for each tenant. Depends on ruler.max-rule-evaluation-concurrency being greater than 0. Ideally this flag should be a lower value. 0 to disable.",
           "fieldValue": null,
           "fieldDefaultValue": 4,
-          "fieldFlag": "ruler.max-independent-rule-evaluation-concurrency-per-tenant",
+          "fieldFlag": "ruler.max-rule-evaluation-concurrency-per-tenant",
           "fieldType": "int",
           "fieldCategory": "experimental"
         },
@@ -13297,23 +13297,23 @@
         },
         {
           "kind": "field",
-          "name": "max_independent_rule_evaluation_concurrency",
+          "name": "max_rule_evaluation_concurrency",
           "required": false,
           "desc": "Number of rules rules that don't have dependencies that we allow to be evaluated concurrently across all tenants. 0 to disable.",
           "fieldValue": null,
           "fieldDefaultValue": 0,
-          "fieldFlag": "ruler.max-independent-rule-evaluation-concurrency",
+          "fieldFlag": "ruler.max-rule-evaluation-concurrency",
           "fieldType": "int",
           "fieldCategory": "experimental"
         },
         {
           "kind": "field",
-          "name": "independent_rule_evaluation_concurrency_min_duration_percentage",
+          "name": "rule_evaluation_concurrency_min_duration_percentage",
           "required": false,
           "desc": "Minimum threshold of the interval to last rule group runtime duration to allow a rule to be evaluated concurrency. By default, the rule group runtime duration must exceed 50.0% of the evaluation interval.",
           "fieldValue": null,
           "fieldDefaultValue": 50,
-          "fieldFlag": "ruler.independent-rule-evaluation-concurrency-min-duration-percentage",
+          "fieldFlag": "ruler.rule-evaluation-concurrency-min-duration-percentage",
           "fieldType": "float",
           "fieldCategory": "experimental"
         },

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2919,12 +2919,12 @@ Usage of ./cmd/mimir/mimir:
     	Max time to tolerate outage for restoring "for" state of alert. (default 1h0m0s)
   -ruler.inbound-sync-queue-poll-interval duration
     	[experimental] Interval between applying queued incoming rule sync requests. (default 10s)
-  -ruler.independent-rule-evaluation-concurrency-min-duration-percentage float
+  -ruler.rule-evaluation-concurrency-min-duration-percentage float
     	[experimental] Minimum threshold of the interval to last rule group runtime duration to allow a rule to be evaluated concurrency. By default, the rule group runtime duration must exceed 50.0% of the evaluation interval. (default 50)
-  -ruler.max-independent-rule-evaluation-concurrency int
+  -ruler.max-rule-evaluation-concurrency int
     	[experimental] Number of rules rules that don't have dependencies that we allow to be evaluated concurrently across all tenants. 0 to disable.
-  -ruler.max-independent-rule-evaluation-concurrency-per-tenant int
-    	[experimental] Maximum number of independent rules that can run concurrently for each tenant. Depends on ruler.max-independent-rule-evaluation-concurrency being greater than 0. Ideally this flag should be a lower value. 0 to disable. (default 4)
+  -ruler.max-rule-evaluation-concurrency-per-tenant int
+    	[experimental] Maximum number of independent rules that can run concurrently for each tenant. Depends on ruler.max-rule-evaluation-concurrency being greater than 0. Ideally this flag should be a lower value. 0 to disable. (default 4)
   -ruler.max-rule-groups-per-tenant int
     	Maximum number of rule groups per-tenant. 0 to disable. (default 70)
   -ruler.max-rule-groups-per-tenant-by-namespace value

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2919,12 +2919,10 @@ Usage of ./cmd/mimir/mimir:
     	Max time to tolerate outage for restoring "for" state of alert. (default 1h0m0s)
   -ruler.inbound-sync-queue-poll-interval duration
     	[experimental] Interval between applying queued incoming rule sync requests. (default 10s)
-  -ruler.rule-evaluation-concurrency-min-duration-percentage float
-    	[experimental] Minimum threshold of the interval to last rule group runtime duration to allow a rule to be evaluated concurrency. By default, the rule group runtime duration must exceed 50.0% of the evaluation interval. (default 50)
   -ruler.max-rule-evaluation-concurrency int
     	[experimental] Number of rules rules that don't have dependencies that we allow to be evaluated concurrently across all tenants. 0 to disable.
   -ruler.max-rule-evaluation-concurrency-per-tenant int
-    	[experimental] Maximum number of independent rules that can run concurrently for each tenant. Depends on ruler.max-rule-evaluation-concurrency being greater than 0. Ideally this flag should be a lower value. 0 to disable. (default 4)
+    	[experimental] Maximum number of rules that can run concurrently for each tenant. Depends on ruler.max-rule-evaluation-concurrency being greater than 0. Ideally this flag should be a lower value. 0 to disable. (default 4)
   -ruler.max-rule-groups-per-tenant int
     	Maximum number of rule groups per-tenant. 0 to disable. (default 70)
   -ruler.max-rule-groups-per-tenant-by-namespace value
@@ -3067,6 +3065,8 @@ Usage of ./cmd/mimir/mimir:
     	The prefix for the keys in the store. Should end with a /. (default "rulers/")
   -ruler.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+  -ruler.rule-evaluation-concurrency-min-duration-percentage float
+    	[experimental] Minimum threshold of the interval to last rule group runtime duration to allow a rule to be evaluated concurrency. By default, the rule group runtime duration must exceed 50.0% of the evaluation interval. (default 50)
   -ruler.rule-evaluation-write-enabled
     	[experimental] Writes the results of rule evaluation to ingesters or ingest storage when enabled. Use this option for testing purposes. To disable, set to false. (default true)
   -ruler.rule-path string

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -64,9 +64,9 @@ The following features are currently experimental:
   - Allow protecting rule groups from modification by namespace. Rule groups can always be read, and you can use the `X-Mimir-Ruler-Override-Namespace-Protection` header with namespace names as values to override protection from modification.
   - `-ruler.protected-namespaces`
   - Allow control over independent rules to be evaluated concurrently as long as they exceed a certain threshold on their rule group last duration runtime against their interval. We have both a limit on the number of rules that can be executed per ruler and per tenant:
-  - `-ruler.max-independent-rule-evaluation-concurrency`
-  - `-ruler.max-independent-rule-evaluation-concurrency-per-tenant`
-  - `-ruler.independent-rule-evaluation-concurrency-min-duration-percentage`
+  - `-ruler.max-rule-evaluation-concurrency`
+  - `-ruler.max-rule-evaluation-concurrency-per-tenant`
+  - `-ruler.rule-evaluation-concurrency-min-duration-percentage`
   - `-ruler.rule-evaluation-write-enabled`
   - Allow control over rule sync intervals.
     - `ruler.outbound-sync-queue-poll-interval`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2137,14 +2137,14 @@ tenant_federation:
 
 # (experimental) Number of rules rules that don't have dependencies that we
 # allow to be evaluated concurrently across all tenants. 0 to disable.
-# CLI flag: -ruler.max-independent-rule-evaluation-concurrency
-[max_independent_rule_evaluation_concurrency: <int> | default = 0]
+# CLI flag: -ruler.max-rule-evaluation-concurrency
+[max_rule_evaluation_concurrency: <int> | default = 0]
 
 # (experimental) Minimum threshold of the interval to last rule group runtime
 # duration to allow a rule to be evaluated concurrency. By default, the rule
 # group runtime duration must exceed 50.0% of the evaluation interval.
-# CLI flag: -ruler.independent-rule-evaluation-concurrency-min-duration-percentage
-[independent_rule_evaluation_concurrency_min_duration_percentage: <float> | default = 50]
+# CLI flag: -ruler.rule-evaluation-concurrency-min-duration-percentage
+[rule_evaluation_concurrency_min_duration_percentage: <float> | default = 50]
 
 # (experimental) Writes the results of rule evaluation to ingesters or ingest
 # storage when enabled. Use this option for testing purposes. To disable, set to
@@ -3645,10 +3645,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 [ruler_protected_namespaces: <string> | default = ""]
 
 # (experimental) Maximum number of independent rules that can run concurrently
-# for each tenant. Depends on ruler.max-independent-rule-evaluation-concurrency
+# for each tenant. Depends on ruler.max-rule-evaluation-concurrency
 # being greater than 0. Ideally this flag should be a lower value. 0 to disable.
-# CLI flag: -ruler.max-independent-rule-evaluation-concurrency-per-tenant
-[ruler_max_independent_rule_evaluation_concurrency_per_tenant: <int> | default = 4]
+# CLI flag: -ruler.max-rule-evaluation-concurrency-per-tenant
+[ruler_max_rule_evaluation_concurrency_per_tenant: <int> | default = 4]
 
 # The tenant's shard size, used when store-gateway sharding is enabled. Value of
 # 0 disables shuffle sharding for the tenant, that is all tenant blocks are

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3644,9 +3644,9 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -ruler.protected-namespaces
 [ruler_protected_namespaces: <string> | default = ""]
 
-# (experimental) Maximum number of independent rules that can run concurrently
-# for each tenant. Depends on ruler.max-rule-evaluation-concurrency
-# being greater than 0. Ideally this flag should be a lower value. 0 to disable.
+# (experimental) Maximum number of rules that can run concurrently for each
+# tenant. Depends on ruler.max-rule-evaluation-concurrency being greater than 0.
+# Ideally this flag should be a lower value. 0 to disable.
 # CLI flag: -ruler.max-rule-evaluation-concurrency-per-tenant
 [ruler_max_rule_evaluation_concurrency_per_tenant: <int> | default = 4]
 

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1510,11 +1510,11 @@ func TestRulerPerRuleConcurrency(t *testing.T) {
 		// Evaluate rules often.
 		"-ruler.evaluation-interval": "5s",
 		// No delay
-		"-ruler.evaluation-delay-duration":                                       "0",
-		"-ruler.poll-interval":                                                   "2s",
-		"-ruler.max-independent-rule-evaluation-concurrency":                     "4",
-		"-ruler.max-independent-rule-evaluation-concurrency-per-tenant":          "2",
-		"-ruler.independent-rule-evaluation-concurrency-min-duration-percentage": "0", // This makes sure no matter the ratio, we will attempt concurrency.
+		"-ruler.evaluation-delay-duration":                           "0",
+		"-ruler.poll-interval":                                       "2s",
+		"-ruler.max-rule-evaluation-concurrency":                     "4",
+		"-ruler.max-rule-evaluation-concurrency-per-tenant":          "2",
+		"-ruler.rule-evaluation-concurrency-min-duration-percentage": "0", // This makes sure no matter the ratio, we will attempt concurrency.
 	})
 
 	// Start Mimir components.
@@ -1551,12 +1551,12 @@ func TestRulerPerRuleConcurrency(t *testing.T) {
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(20), []string{"cortex_prometheus_rule_group_rules"}, e2e.WaitMissingMetrics))
 
 	// We should have 20 attempts and 20 or less for failed or successful attempts to acquire the lock.
-	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(20), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total"}, e2e.WaitMissingMetrics))
+	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.Equals(20), []string{"cortex_ruler_rule_evaluation_concurrency_attempts_started_total"}, e2e.WaitMissingMetrics))
 	// The magic number here is because we have a maximum per tenant concurrency of 2. So we expect at least 4 (2 slots * 2 tenants) to complete successfully.
-	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(4), []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total"}, e2e.WaitMissingMetrics))
+	require.NoError(t, ruler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(4), []string{"cortex_ruler_rule_evaluation_concurrency_attempts_completed_total"}, e2e.WaitMissingMetrics))
 	require.NoError(t, ruler.WaitSumMetricsWithOptions(func(sums ...float64) bool {
 		return e2e.SumValues(sums) == 20
-	}, []string{"cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total", "cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total"}, e2e.WaitMissingMetrics))
+	}, []string{"cortex_ruler_rule_evaluation_concurrency_attempts_completed_total", "cortex_ruler_rule_evaluation_concurrency_attempts_incomplete_total"}, e2e.WaitMissingMetrics))
 }
 
 func TestRulerEnableAPIs(t *testing.T) {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -907,11 +907,11 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 
 	var concurrencyController ruler.MultiTenantRuleConcurrencyController
 	concurrencyController = &ruler.NoopMultiTenantConcurrencyController{}
-	if t.Cfg.Ruler.MaxIndependentRuleEvaluationConcurrency > 0 {
+	if t.Cfg.Ruler.MaxRuleEvaluationConcurrency > 0 {
 		concurrencyController = ruler.NewMultiTenantConcurrencyController(
 			util_log.Logger,
-			t.Cfg.Ruler.MaxIndependentRuleEvaluationConcurrency,
-			t.Cfg.Ruler.IndependentRuleEvaluationConcurrencyMinDurationPercentage,
+			t.Cfg.Ruler.MaxRuleEvaluationConcurrency,
+			t.Cfg.Ruler.RuleEvaluationConcurrencyMinDurationPercentage,
 			t.Registerer,
 			t.Overrides,
 		)

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -206,7 +206,7 @@ type RulesLimits interface {
 	RulerAlertingRulesEvaluationEnabled(userID string) bool
 	RulerSyncRulesOnChangesEnabled(userID string) bool
 	RulerProtectedNamespaces(userID string) []string
-	RulerMaxIndependentRuleEvaluationConcurrencyPerTenant(userID string) int64
+	RulerMaxRuleEvaluationConcurrencyPerTenant(userID string) int64
 }
 
 func MetricsQueryFunc(qf rules.QueryFunc, queries, failedQueries prometheus.Counter, remoteQuerier bool) rules.QueryFunc {

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -632,7 +632,7 @@ func TestDefaultManagerFactory_ShouldInjectReadConsistencyToContextBasedOnRuleDe
 		},
 		"should not inject read consistency level if the rule is independent, to let run with the per-tenant default": {
 			ruleGroup: rulespb.RuleGroupDesc{
-				Name: "independent-rules",
+				Name: "rules",
 				Rules: []*rulespb.RuleDesc{
 					createRecordingRule("sum:up:1", "sum(up_1)"),
 					createRecordingRule("sum:up:2", "sum(up_2)"),

--- a/pkg/ruler/rule_concurrency.go
+++ b/pkg/ruler/rule_concurrency.go
@@ -73,19 +73,19 @@ type MultiTenantConcurrencyControllerMetrics struct {
 func newMultiTenantConcurrencyControllerMetrics(reg prometheus.Registerer) *MultiTenantConcurrencyControllerMetrics {
 	m := &MultiTenantConcurrencyControllerMetrics{
 		SlotsInUse: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use",
+			Name: "cortex_ruler_rule_evaluation_concurrency_slots_in_use",
 			Help: "Current number of concurrency slots currently in use across all tenants",
 		}, []string{"user"}),
 		AttemptsStartedTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total",
+			Name: "cortex_ruler_rule_evaluation_concurrency_attempts_started_total",
 			Help: "Total number of started attempts to acquire concurrency slots across all tenants",
 		}, []string{"user"}),
 		AttemptsIncompleteTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total",
+			Name: "cortex_ruler_rule_evaluation_concurrency_attempts_incomplete_total",
 			Help: "Total number of incomplete attempts to acquire concurrency slots across all tenants",
 		}, []string{"user"}),
 		AttemptsCompletedTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total",
+			Name: "cortex_ruler_rule_evaluation_concurrency_attempts_completed_total",
 			Help: "Total number of concurrency slots we're done using across all tenants",
 		}, []string{"user"}),
 	}
@@ -127,7 +127,7 @@ func (c *MultiTenantConcurrencyController) NewTenantConcurrencyControllerFor(ten
 		thresholdRuleConcurrency: c.thresholdRuleConcurrency,
 		globalConcurrency:        c.globalConcurrency,
 		tenantConcurrency: NewDynamicSemaphore(func() int64 {
-			return c.limits.RulerMaxIndependentRuleEvaluationConcurrencyPerTenant(tenantID)
+			return c.limits.RulerMaxRuleEvaluationConcurrencyPerTenant(tenantID)
 		}),
 	}
 }

--- a/pkg/ruler/rule_concurrency_test.go
+++ b/pkg/ruler/rule_concurrency_test.go
@@ -93,9 +93,9 @@ func TestMultiTenantConcurrencyController(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	limits := validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
 		tenantLimits["user1"] = validation.MockDefaultLimits()
-		tenantLimits["user1"].RulerMaxIndependentRuleEvaluationConcurrencyPerTenant = 2
+		tenantLimits["user1"].RulerMaxRuleEvaluationConcurrencyPerTenant = 2
 		tenantLimits["user2"] = validation.MockDefaultLimits()
-		tenantLimits["user2"].RulerMaxIndependentRuleEvaluationConcurrencyPerTenant = 2
+		tenantLimits["user2"].RulerMaxRuleEvaluationConcurrencyPerTenant = 2
 	})
 
 	rg := rules.NewGroup(rules.GroupOptions{
@@ -125,22 +125,22 @@ func TestMultiTenantConcurrencyController(t *testing.T) {
 
 	// Let's check the metrics up until this point.
 	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-# HELP cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total Total number of concurrency slots we're done using across all tenants
-# TYPE cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total counter
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total{user="user1"} 0
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total{user="user2"} 0
-# HELP cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total Total number of incomplete attempts to acquire concurrency slots across all tenants
-# TYPE cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total counter
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total{user="user1"} 1
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total{user="user2"} 1
-# HELP cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total Total number of started attempts to acquire concurrency slots across all tenants
-# TYPE cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total counter
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total{user="user1"} 3
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total{user="user2"} 2
-# HELP cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use Current number of concurrency slots currently in use across all tenants
-# TYPE cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use gauge
-cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use{user="user1"} 2
-cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use{user="user2"} 1
+# HELP cortex_ruler_rule_evaluation_concurrency_attempts_completed_total Total number of concurrency slots we're done using across all tenants
+# TYPE cortex_ruler_rule_evaluation_concurrency_attempts_completed_total counter
+cortex_ruler_rule_evaluation_concurrency_attempts_completed_total{user="user1"} 0
+cortex_ruler_rule_evaluation_concurrency_attempts_completed_total{user="user2"} 0
+# HELP cortex_ruler_rule_evaluation_concurrency_attempts_incomplete_total Total number of incomplete attempts to acquire concurrency slots across all tenants
+# TYPE cortex_ruler_rule_evaluation_concurrency_attempts_incomplete_total counter
+cortex_ruler_rule_evaluation_concurrency_attempts_incomplete_total{user="user1"} 1
+cortex_ruler_rule_evaluation_concurrency_attempts_incomplete_total{user="user2"} 1
+# HELP cortex_ruler_rule_evaluation_concurrency_attempts_started_total Total number of started attempts to acquire concurrency slots across all tenants
+# TYPE cortex_ruler_rule_evaluation_concurrency_attempts_started_total counter
+cortex_ruler_rule_evaluation_concurrency_attempts_started_total{user="user1"} 3
+cortex_ruler_rule_evaluation_concurrency_attempts_started_total{user="user2"} 2
+# HELP cortex_ruler_rule_evaluation_concurrency_slots_in_use Current number of concurrency slots currently in use across all tenants
+# TYPE cortex_ruler_rule_evaluation_concurrency_slots_in_use gauge
+cortex_ruler_rule_evaluation_concurrency_slots_in_use{user="user1"} 2
+cortex_ruler_rule_evaluation_concurrency_slots_in_use{user="user2"} 1
 `)))
 
 	// Now let's release some slots and acquire one for tenant 2 which previously failed.
@@ -150,22 +150,22 @@ cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use{user="user2"} 
 
 	// Let's look at the metrics again.
 	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
-# HELP cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total Total number of incomplete attempts to acquire concurrency slots across all tenants
-# TYPE cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total counter
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total{user="user1"} 2
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_incomplete_total{user="user2"} 1
-# HELP cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total Total number of started attempts to acquire concurrency slots across all tenants
-# TYPE cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total counter
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total{user="user1"} 4
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_started_total{user="user2"} 3
-# HELP cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use Current number of concurrency slots currently in use across all tenants
-# TYPE cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use gauge
-cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use{user="user1"} 1
-cortex_ruler_independent_rule_evaluation_concurrency_slots_in_use{user="user2"} 2
-# HELP cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total Total number of concurrency slots we're done using across all tenants
-# TYPE cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total counter
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total{user="user1"} 1
-cortex_ruler_independent_rule_evaluation_concurrency_attempts_completed_total{user="user2"} 0
+# HELP cortex_ruler_rule_evaluation_concurrency_attempts_incomplete_total Total number of incomplete attempts to acquire concurrency slots across all tenants
+# TYPE cortex_ruler_rule_evaluation_concurrency_attempts_incomplete_total counter
+cortex_ruler_rule_evaluation_concurrency_attempts_incomplete_total{user="user1"} 2
+cortex_ruler_rule_evaluation_concurrency_attempts_incomplete_total{user="user2"} 1
+# HELP cortex_ruler_rule_evaluation_concurrency_attempts_started_total Total number of started attempts to acquire concurrency slots across all tenants
+# TYPE cortex_ruler_rule_evaluation_concurrency_attempts_started_total counter
+cortex_ruler_rule_evaluation_concurrency_attempts_started_total{user="user1"} 4
+cortex_ruler_rule_evaluation_concurrency_attempts_started_total{user="user2"} 3
+# HELP cortex_ruler_rule_evaluation_concurrency_slots_in_use Current number of concurrency slots currently in use across all tenants
+# TYPE cortex_ruler_rule_evaluation_concurrency_slots_in_use gauge
+cortex_ruler_rule_evaluation_concurrency_slots_in_use{user="user1"} 1
+cortex_ruler_rule_evaluation_concurrency_slots_in_use{user="user2"} 2
+# HELP cortex_ruler_rule_evaluation_concurrency_attempts_completed_total Total number of concurrency slots we're done using across all tenants
+# TYPE cortex_ruler_rule_evaluation_concurrency_attempts_completed_total counter
+cortex_ruler_rule_evaluation_concurrency_attempts_completed_total{user="user1"} 1
+cortex_ruler_rule_evaluation_concurrency_attempts_completed_total{user="user2"} 0
 `)))
 
 	// Release all slots, to make sure there is room for the next set of edge cases.
@@ -233,7 +233,7 @@ var splitToBatchesTestCases = map[string]struct {
 func TestSplitGroupIntoBatches(t *testing.T) {
 	limits := validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
 		tenantLimits["user1"] = validation.MockDefaultLimits()
-		tenantLimits["user1"].RulerMaxIndependentRuleEvaluationConcurrencyPerTenant = 2
+		tenantLimits["user1"].RulerMaxRuleEvaluationConcurrencyPerTenant = 2
 	})
 
 	mtController := NewMultiTenantConcurrencyController(log.NewNopLogger(), 3, 50.0, prometheus.NewPedanticRegistry(), limits)
@@ -268,7 +268,7 @@ func TestSplitGroupIntoBatches(t *testing.T) {
 func BenchmarkSplitGroupIntoBatches(b *testing.B) {
 	limits := validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
 		tenantLimits["user1"] = validation.MockDefaultLimits()
-		tenantLimits["user1"].RulerMaxIndependentRuleEvaluationConcurrencyPerTenant = 2
+		tenantLimits["user1"].RulerMaxRuleEvaluationConcurrencyPerTenant = 2
 	})
 
 	mtController := NewMultiTenantConcurrencyController(log.NewNopLogger(), 3, 50.0, prometheus.NewPedanticRegistry(), limits)

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -140,8 +140,8 @@ type Config struct {
 	// Allow to override timers for testing purposes.
 	RingCheckPeriod time.Duration `yaml:"-"`
 
-	MaxIndependentRuleEvaluationConcurrency                   int64   `yaml:"max_independent_rule_evaluation_concurrency" category:"experimental"`
-	IndependentRuleEvaluationConcurrencyMinDurationPercentage float64 `yaml:"independent_rule_evaluation_concurrency_min_duration_percentage" category:"experimental"`
+	MaxRuleEvaluationConcurrency                   int64   `yaml:"max_rule_evaluation_concurrency" category:"experimental"`
+	RuleEvaluationConcurrencyMinDurationPercentage float64 `yaml:"rule_evaluation_concurrency_min_duration_percentage" category:"experimental"`
 
 	RuleEvaluationWriteEnabled bool `yaml:"rule_evaluation_write_enabled" category:"experimental"`
 }
@@ -160,7 +160,7 @@ func (cfg *Config) Validate(limits validation.Limits) error {
 		return errors.Wrap(err, "invalid ruler query-frontend config")
 	}
 
-	if cfg.IndependentRuleEvaluationConcurrencyMinDurationPercentage < 0 {
+	if cfg.RuleEvaluationConcurrencyMinDurationPercentage < 0 {
 		return errInnvalidRuleEvaluationConcurrencyMinDurationPercentage
 	}
 
@@ -201,8 +201,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 
 	f.BoolVar(&cfg.EnableQueryStats, "ruler.query-stats-enabled", false, "Report the wall time for ruler queries to complete as a per-tenant metric and as an info level log message.")
 
-	f.Int64Var(&cfg.MaxIndependentRuleEvaluationConcurrency, "ruler.max-independent-rule-evaluation-concurrency", 0, "Number of rules rules that don't have dependencies that we allow to be evaluated concurrently across all tenants. 0 to disable.")
-	f.Float64Var(&cfg.IndependentRuleEvaluationConcurrencyMinDurationPercentage, "ruler.independent-rule-evaluation-concurrency-min-duration-percentage", 50.0, "Minimum threshold of the interval to last rule group runtime duration to allow a rule to be evaluated concurrency. By default, the rule group runtime duration must exceed 50.0% of the evaluation interval.")
+	f.Int64Var(&cfg.MaxRuleEvaluationConcurrency, "ruler.max-rule-evaluation-concurrency", 0, "Number of rules rules that don't have dependencies that we allow to be evaluated concurrently across all tenants. 0 to disable.")
+	f.Float64Var(&cfg.RuleEvaluationConcurrencyMinDurationPercentage, "ruler.rule-evaluation-concurrency-min-duration-percentage", 50.0, "Minimum threshold of the interval to last rule group runtime duration to allow a rule to be evaluated concurrency. By default, the rule group runtime duration must exceed 50.0% of the evaluation interval.")
 
 	f.BoolVar(&cfg.RuleEvaluationWriteEnabled, "ruler.rule-evaluation-write-enabled", true, "Writes the results of rule evaluation to ingesters or ingest storage when enabled. Use this option for testing purposes. To disable, set to false.")
 

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -2081,7 +2081,7 @@ func TestConfig_Validate(t *testing.T) {
 
 	t.Run("invalid concurrency evaluation percentage", func(t *testing.T) {
 		cfg := defaultRulerConfig(t)
-		cfg.IndependentRuleEvaluationConcurrencyMinDurationPercentage = -1.0
+		cfg.RuleEvaluationConcurrencyMinDurationPercentage = -1.0
 		limits := validation.MockDefaultLimits()
 
 		err := cfg.Validate(*limits)

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -977,27 +977,27 @@ func TestRulerMaxConcurrentRuleEvaluationsPerTenantOverrides(t *testing.T) {
 	}{
 		"no user specific concurrency": {
 			inputYAML: `
-ruler_max_independent_rule_evaluation_concurrency_per_tenant: 5
+ruler_max_rule_evaluation_concurrency_per_tenant: 5
 `,
 			expectedPerTenantConcurrency: 5,
 		},
 		"default limit for not specific user": {
 			inputYAML: `
-ruler_max_independent_rule_evaluation_concurrency_per_tenant: 5
+ruler_max_rule_evaluation_concurrency_per_tenant: 5
 `,
 			overrides: `
 randomuser:
-  ruler_max_independent_rule_evaluation_concurrency_per_tenant: 10
+  ruler_max_rule_evaluation_concurrency_per_tenant: 10
 `,
 			expectedPerTenantConcurrency: 5,
 		},
 		"overridden limit for specific user": {
 			inputYAML: `
-ruler_max_independent_rule_evaluation_concurrency_per_tenant: 5
+ruler_max_rule_evaluation_concurrency_per_tenant: 5
 `,
 			overrides: `
 user1:
-  ruler_max_independent_rule_evaluation_concurrency_per_tenant: 15
+  ruler_max_rule_evaluation_concurrency_per_tenant: 15
 `,
 			expectedPerTenantConcurrency: 15,
 		},
@@ -1019,7 +1019,7 @@ user1:
 			ov, err := NewOverrides(LimitsYAML, tl)
 			require.NoError(t, err)
 
-			require.Equal(t, tt.expectedPerTenantConcurrency, ov.RulerMaxIndependentRuleEvaluationConcurrencyPerTenant("user1"))
+			require.Equal(t, tt.expectedPerTenantConcurrency, ov.RulerMaxRuleEvaluationConcurrencyPerTenant("user1"))
 		})
 	}
 }


### PR DESCRIPTION
Concurrency applies to more than just independent rules now. I am updating these metrics ahead of building new dashboards (or dashboard section to observe ruler concurrency in a cell)


#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
