### PR TITLE
ha_tracker_test: Increase test polling duration to 10s

### DIFF
--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -307,8 +307,8 @@ func TestHaTrackerWithMemberList(t *testing.T) {
 	// Update KVStore - this should elect replica 2.
 	tracker.updateKVStoreAll(context.Background(), now)
 
-	// Evaluate up to 2 seconds to verify whether the tracker’s cache replica has been updated to r2.
-	checkReplicaTimestamp(t, 2*time.Second, tracker, "user", cluster, replica2, now, now)
+	// Evaluate up to 10 seconds to verify whether the tracker’s cache replica has been updated to r2.
+	checkReplicaTimestamp(t, 10*time.Second, tracker, "user", cluster, replica2, now, now)
 
 	// Now we should accept from replica 2.
 	err = tracker.checkReplica(context.Background(), "user", cluster, replica2, now)


### PR DESCRIPTION
#### What this PR does

It seems that 2 seconds was not enough to prevent the test from failing again, so I would like to increase it to 10 seconds to address edge cases that require more time. 

#### Which issue(s) this PR fixes or relates to

Relates https://github.com/grafana/mimir/issues/10350

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
