### PR TITLE
fix(ha-tracker): set electedAtTime to now when the received replicaDesc ha deletedAt higher than zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [BUGFIX] MQE: Fix <aggr_over_time> functions with histograms #10400
 * [BUGFIX] Distributor: return HTTP status 415 Unsupported Media Type instead of 200 Success for Remote Write 2.0 until we support it. #10423
 * [BUGFIX] Query-frontend: Add flag `-query-frontend.prom2-range-compat` and corresponding YAML to rewrite queries with ranges that worked in Prometheus 2 but are invalid in Prometheus 3. #10445 #10461
+* [BUGFIX] Distributor: Fix edge case at the ha-tracker with memberlist as KVStore, where a replica in the KVStore is marked as deleted but not yet removed, it would fail to update the KVStore. #10443
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 * [BUGFIX] MQE: Fix <aggr_over_time> functions with histograms #10400
 * [BUGFIX] Distributor: return HTTP status 415 Unsupported Media Type instead of 200 Success for Remote Write 2.0 until we support it. #10423
 * [BUGFIX] Query-frontend: Add flag `-query-frontend.prom2-range-compat` and corresponding YAML to rewrite queries with ranges that worked in Prometheus 2 but are invalid in Prometheus 3. #10445 #10461
-* [BUGFIX] Distributor: Fix edge case at the ha-tracker with memberlist as KVStore, where a replica in the KVStore is marked as deleted but not yet removed, it would fail to update the KVStore. #10443
+* [BUGFIX] Distributor: Fix edge case at the HA-tracker with memberlist as KVStore, where when a replica in the KVStore is marked as deleted but not yet removed, it fails to update the KVStore. #10443
 
 ### Mixin
 

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -282,7 +282,6 @@ func newHaTracker(cfg HATrackerConfig, limits haTrackerLimits, reg prometheus.Re
 			Help: "Number of elected replicas that failed to be marked for deletion, or deleted.",
 		}),
 	}
-
 	client, err := kv.NewClient(
 		cfg.KVStore,
 		GetReplicaDescCodec(),
@@ -637,8 +636,8 @@ func (h *defaultHaTracker) updateKVStore(ctx context.Context, userID, cluster, r
 			if desc == nil && electedAtTime == 0 {
 				electedAtTime = timestamp.FromTime(now)
 			} else if desc != nil && desc.DeletedAt > 0 {
-				// if we receive a ReplicaDesc that have been marked as deleted but not deleted from the kvStore yet,
-				// we need to set the value to electedAtTime, otherwise it's going be zero 0
+				//If a ReplicaDesc is marked as deleted but not yet removed from the kvStore, set its value to
+				//electedAtTime to avoid it being zero.
 				electedAtTime = timestamp.FromTime(now)
 			}
 		}

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -634,8 +634,9 @@ func (h *defaultHaTracker) updateKVStore(ctx context.Context, userID, cluster, r
 			}
 		} else {
 			if desc == nil || (desc.DeletedAt > 0) {
-				// If the ReplicaDesc is nil or marked as deleted but not yet removed from the kvStore, set its value to electedAtTime to avoid it being zero.
-				// This ensures the replica is elected to "revive" the cluster entry after the previous one was deleted.
+				// if there is no desc in the kvStore , or if the entry in kvStore is marked as deleted but not yet removed,
+				// set the electedAtTime to avoid being zero
+				// The second part, (desc.DeletedAt > 0), ensures the replica is elected to "revive" the cluster entry after the previous one was deleted.
 				electedAtTime = timestamp.FromTime(now)
 			}
 		}

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -636,6 +636,10 @@ func (h *defaultHaTracker) updateKVStore(ctx context.Context, userID, cluster, r
 		} else {
 			if desc == nil && electedAtTime == 0 {
 				electedAtTime = timestamp.FromTime(now)
+			} else if desc != nil && desc.DeletedAt > 0 {
+				// if we receive a ReplicaDesc that have been marked as deleted but not deleted from the kvStore yet,
+				// we need to set the value to electedAtTime, otherwise it's going be zero 0
+				electedAtTime = timestamp.FromTime(now)
 			}
 		}
 		// Attempt to update KVStore to our timestamp and replica.

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -633,11 +633,9 @@ func (h *defaultHaTracker) updateKVStore(ctx context.Context, userID, cluster, r
 				electedChanges = desc.ElectedChanges + 1
 			}
 		} else {
-			if desc == nil && electedAtTime == 0 {
-				electedAtTime = timestamp.FromTime(now)
-			} else if desc != nil && desc.DeletedAt > 0 {
-				//If a ReplicaDesc is marked as deleted but not yet removed from the kvStore, set its value to electedAtTime to prevent it from being zero.
-				//This ensures the replica is elected to "revive" the cluster entry after the previous one was deleted.
+			if desc == nil || (desc.DeletedAt > 0) {
+				// If the ReplicaDesc is nil or marked as deleted but not yet removed from the kvStore, set its value to electedAtTime to avoid it being zero.
+				// This ensures the replica is elected to "revive" the cluster entry after the previous one was deleted.
 				electedAtTime = timestamp.FromTime(now)
 			}
 		}

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -636,8 +636,8 @@ func (h *defaultHaTracker) updateKVStore(ctx context.Context, userID, cluster, r
 			if desc == nil && electedAtTime == 0 {
 				electedAtTime = timestamp.FromTime(now)
 			} else if desc != nil && desc.DeletedAt > 0 {
-				//If a ReplicaDesc is marked as deleted but not yet removed from the kvStore, set its value to
-				//electedAtTime to avoid it being zero.
+				//If a ReplicaDesc is marked as deleted but not yet removed from the kvStore, set its value to electedAtTime to prevent it from being zero.
+				//This ensures the replica is elected to "revive" the cluster entry after the previous one was deleted.
 				electedAtTime = timestamp.FromTime(now)
 			}
 		}


### PR DESCRIPTION
#### What this PR does

When a key entry at the ha_tracker expires it goes through this [code](https://github.com/grafana/mimir/blob/main/pkg/distributor/ha_tracker.go#L469), which:
- calls the `delete` operation of the `kvStore` client
- sets the `DeletedAt` timestamp of the expired ReplicaDesc

If another entry comes with the same `key` **before the expired ReplicaDesc is removed from the memberlist kvStore** it can fetch a replicaDesc entry with the below format from the kvStore during the CAS operation ([code](https://github.com/grafana/mimir/blob/main/pkg/distributor/ha_tracker.go#L613)):
```
&ReplicaDesc{ 
  Replica:replica_0,
  ReceivedAt:1736949099138
  DeletedAt:1736949236956
  ElectedAt:1736949084145
  ElectedChanges:10,}
```

It will try to replace it with the new `replicaname` and `receivedat`  timestamp:
- `replica_1`
- `now()`

However before this fix, it was not setting the `electedAtTime` to a new value and it had a value equal to zero. So we were generating a replicadesc, similar to the below format

```
&ReplicaDesc{ 
  Replica:replica_1,
  ReceivedAt:now()
  DeletedAt:0
  ElectedAt:0
  ElectedChanges:0}
```
This would cause `errNoChangeDetected = errors.New("no change detected")` ([Ref](https://github.com/grafana/mimir/blob/main/vendor/github.com/grafana/dskit/kv/memberlist/memberlist_client.go#L356)) as the function will return a change but the merge function will return no change, because of how it handles merging now.

The delete operation has not been implemented yet, but I believe we might encounter this edge case in the future, given that the value in the memberlist store is not removed immediately when the Delete function is called.

# Which KVStores are impacted by this?

This edge case likely occurs only with Memberlist, as we do not have a central KVStore and the value is not updated immediately.


#### Which issue(s) this PR fixes or relates to

Relates #https://github.com/grafana/pir-actions/issues/94

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
