### PR TITLE
refactor(mimirpb): delete TestRemoteWriteV1HistogramEquivalence

### DIFF
--- a/pkg/mimirpb/compat_test.go
+++ b/pkg/mimirpb/compat_test.go
@@ -739,10 +739,6 @@ func TestCompareLabelAdapters(t *testing.T) {
 	}
 }
 
-func TestRemoteWriteV1HistogramEquivalence(t *testing.T) {
-	test.RequireSameShape(t, prompb.Histogram{}, Histogram{}, false, true)
-}
-
 // The main usecase for `LabelsToKeyString` is to generate hashKeys
 // for maps. We are benchmarking that here.
 func BenchmarkSeriesMap(b *testing.B) {


### PR DESCRIPTION
As far as I can tell we don't cast Prometheus Remote Write 1.0 histogram into mimirpb.Histogram anymore. On the flip-side this test fails in #10432 because we're going to store RW 2.0 extra field in mimirpb.Histogram.

Related to #9072
