### PR TITLE
alertmanager: Sync metric documentation from upstream

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -764,7 +764,7 @@ func buildReceiverIntegrations(nc config.Receiver, tmpl *template.Template, fire
 }
 
 func md5HashAsMetricValue(data []byte) float64 {
-	sum := md5.Sum(data)
+	sum := md5.Sum(data) //nolint:gosec
 	// We only want 48 bits as a float64 only has a 53 bit mantissa.
 	smallSum := sum[0:6]
 	var bytes = make([]byte, 8)

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -202,7 +202,7 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 		maintenanceStop: make(chan struct{}),
 		configHashMetric: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "alertmanager_config_hash",
-			Help: "Hash of the currently loaded alertmanager configuration.",
+			Help: "Hash of the currently loaded alertmanager configuration. Note that this is not a cryptographically strong hash.",
 		}),
 
 		rateLimitedNotifications: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -197,7 +197,7 @@ func newAlertmanagerMetrics(logger log.Logger) *alertmanagerMetrics {
 			[]string{"user", "state"}, nil),
 		configHashValue: prometheus.NewDesc(
 			"cortex_alertmanager_config_hash",
-			"Hash of the currently loaded alertmanager configuration.",
+			"Hash of the currently loaded alertmanager configuration. Note that this is not a cryptographically strong hash.",
 			[]string{"user"}, nil),
 		partialMerges: prometheus.NewDesc(
 			"cortex_alertmanager_partial_state_merges_total",

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -61,7 +61,7 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		cortex_alertmanager_alerts_received_total{user="user1"} 10
 		cortex_alertmanager_alerts_received_total{user="user2"} 100
 		cortex_alertmanager_alerts_received_total{user="user3"} 1000
-		# HELP cortex_alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+		# HELP cortex_alertmanager_config_hash Hash of the currently loaded alertmanager configuration. Note that this is not a cryptographically strong hash.
 		# TYPE cortex_alertmanager_config_hash gauge
 		cortex_alertmanager_config_hash{user="user1"} 0
 		cortex_alertmanager_config_hash{user="user2"} 0
@@ -389,7 +389,7 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
         	            cortex_alertmanager_alerts_received_total{user="user2"} 100
         	            cortex_alertmanager_alerts_received_total{user="user3"} 1000
 
-        	            # HELP cortex_alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+        	            # HELP cortex_alertmanager_config_hash Hash of the currently loaded alertmanager configuration. Note that this is not a cryptographically strong hash.
         	            # TYPE cortex_alertmanager_config_hash gauge
         	            cortex_alertmanager_config_hash{user="user1"} 0
         	            cortex_alertmanager_config_hash{user="user2"} 0
@@ -720,7 +720,7 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
     		cortex_alertmanager_alerts_received_total{user="user1"} 10
     		cortex_alertmanager_alerts_received_total{user="user2"} 100
 
-    		# HELP cortex_alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+    		# HELP cortex_alertmanager_config_hash Hash of the currently loaded alertmanager configuration. Note that this is not a cryptographically strong hash.
     		# TYPE cortex_alertmanager_config_hash gauge
     		cortex_alertmanager_config_hash{user="user1"} 0
     		cortex_alertmanager_config_hash{user="user2"} 0
@@ -987,7 +987,7 @@ func populateAlertmanager(base float64) *prometheus.Registry {
 	reg := prometheus.NewRegistry()
 	promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 		Name: "alertmanager_config_hash",
-		Help: "Hash of the currently loaded alertmanager configuration.",
+		Help: "Hash of the currently loaded alertmanager configuration. Note that this is not a cryptographically strong hash.",
 	})
 
 	s := newSilenceMetrics(reg)


### PR DESCRIPTION
#### What this PR does

Incorporates https://github.com/prometheus/alertmanager/pull/4210, which changes the helptext of `alertmanager_config_hash` to state that the hash is expected to collide.

Since that's documented in the hash we deliver to users, we can safely suppress g401 on the code generating the hash.

Since Mimir metrics layer their own helptext on top of the base alertmanager metrics, this can be done without updating the vendored code, which can be left to Alerting team.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
