### PR TITLE
allow setting different annotations for headless service in the distributor

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318
 * [ENHANCEMENT] Minio: update subchart to v5.4.0. #10346
 * [ENHANCEMENT] Individual mimir components can override their container images via the *.image values. The component's image definitions always override the values set in global `image` or `enterprise.image`. #10340
+* [ENHANCEMENT] allow setting different annotations for headless service in the distributor #10485
 * [BUGFIX] Fix calculation of `mimir.siToBytes` and use floating point arithmetics. #10044
 
 ## 5.6.0

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,7 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318
 * [ENHANCEMENT] Minio: update subchart to v5.4.0. #10346
 * [ENHANCEMENT] Individual mimir components can override their container images via the *.image values. The component's image definitions always override the values set in global `image` or `enterprise.image`. #10340
-* [ENHANCEMENT] allow setting different annotations for headless service in the distributor #10485
+* [ENHANCEMENT] Allow setting different annotations for headless service in the distributor #10485
 * [BUGFIX] Fix calculation of `mimir.siToBytes` and use floating point arithmetics. #10044
 
 ## 5.6.0

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    {{- toYaml .Values.distributor.service.annotations | nindent 4 }}
+    {{- toYaml .Values.distributor.service.headlessAnnotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: ClusterIP

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -853,6 +853,7 @@ distributor:
 
   service:
     annotations: {}
+    headlessAnnotations: {}
     labels: {}
     # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
     internalTrafficPolicy: Cluster


### PR DESCRIPTION
#### What this PR does

this PR allows users to specify annotation to the distributor headless service alone (meaning without also setting them on the actual clusterIP service)

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
