### PR TITLE
MQE: add support for `sort` and `sort_desc`

### DIFF
--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -208,6 +208,10 @@ func TestCases(metricSizes []int) []BenchCase {
 		//{
 		//	Expr: "label_join(a_X, 'l2', '-', 'l', 'l')",
 		//},
+		{
+			Expr:             "sort(a_X)",
+			InstantQueryOnly: true,
+		},
 		// Simple aggregations.
 		{
 			Expr: "sum(a_X)",

--- a/pkg/streamingpromql/functions_test.go
+++ b/pkg/streamingpromql/functions_test.go
@@ -133,6 +133,8 @@ func TestFunctionDeduplicateAndMerge(t *testing.T) {
 		"sgn":                `sgn({__name__=~"float.*"})`,
 		"sin":                `sin({__name__=~"float.*"})`,
 		"sinh":               `sinh({__name__=~"float.*"})`,
+		"sort":               `<skip>`, // sort() and sort_desc() don't drop the metric name, so this test doesn't apply.
+		"sort_desc":          `<skip>`, // sort() and sort_desc() don't drop the metric name, so this test doesn't apply.
 		"sqrt":               `sqrt({__name__=~"float.*"})`,
 		"sum_over_time":      `sum_over_time({__name__=~"float.*"}[1m])`,
 		"tan":                `tan({__name__=~"float.*"})`,

--- a/pkg/streamingpromql/operators/functions/sort.go
+++ b/pkg/streamingpromql/operators/functions/sort.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package functions
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"slices"
+
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+type Sort struct {
+	Inner                    types.InstantVectorOperator
+	Descending               bool
+	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
+
+	expressionPosition posrange.PositionRange
+
+	allData           []types.InstantVectorSeriesData // Series data, in the order returned by Inner
+	seriesOutputOrder []int                           // Series indices into allData, in the order they should be returned
+	seriesReturned    int                             // Number of series already returned by NextSeries
+}
+
+var _ types.InstantVectorOperator = &Sort{}
+
+func NewSort(
+	inner types.InstantVectorOperator,
+	descending bool,
+	memoryConsumptionTracker *limiting.MemoryConsumptionTracker,
+	expressionPosition posrange.PositionRange,
+) *Sort {
+	return &Sort{
+		Inner:                    inner,
+		Descending:               descending,
+		MemoryConsumptionTracker: memoryConsumptionTracker,
+		expressionPosition:       expressionPosition,
+	}
+}
+
+func (s *Sort) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
+	innerSeries, err := s.Inner.SeriesMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	defer types.PutSeriesMetadataSlice(innerSeries)
+
+	s.seriesOutputOrder, err = types.IntSlicePool.Get(len(innerSeries), s.MemoryConsumptionTracker)
+	if err != nil {
+		return nil, err
+	}
+
+	s.allData = make([]types.InstantVectorSeriesData, len(innerSeries))
+
+	for idx := range innerSeries {
+		d, err := s.Inner.NextSeries(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		pointCount := len(d.Floats) + len(d.Histograms)
+
+		if pointCount > 1 {
+			return nil, fmt.Errorf("expected series %v to have at most one point, but it had %v", innerSeries[idx], pointCount)
+		}
+
+		if pointCount == 1 {
+			s.allData[idx] = d
+			s.seriesOutputOrder = append(s.seriesOutputOrder, idx)
+		} else {
+			types.PutInstantVectorSeriesData(d, s.MemoryConsumptionTracker)
+		}
+	}
+
+	if s.Descending {
+		slices.SortFunc(s.seriesOutputOrder, s.compareDescending)
+	} else {
+		slices.SortFunc(s.seriesOutputOrder, s.compareAscending)
+	}
+
+	// Why can't we just reorder innerSeries? This would be very difficult to do, as there's no
+	// guarantee that all the input series will be returned.
+	outputSeries := types.GetSeriesMetadataSlice(len(s.seriesOutputOrder))
+
+	for _, seriesIdx := range s.seriesOutputOrder {
+		outputSeries = append(outputSeries, innerSeries[seriesIdx])
+	}
+
+	return outputSeries, nil
+}
+
+func (s *Sort) compareAscending(s1 int, s2 int) int {
+	v1 := s.getValueForSorting(s1)
+	v2 := s.getValueForSorting(s2)
+
+	// NaNs always sort to the end of the list, regardless of the sort order.
+	if math.IsNaN(v1) {
+		return 1
+	} else if math.IsNaN(v2) {
+		return -1
+	}
+
+	if v1 < v2 {
+		return -1
+	} else if v1 > v2 {
+		return 1
+	}
+
+	return 0
+}
+
+func (s *Sort) compareDescending(s1 int, s2 int) int {
+	v1 := s.getValueForSorting(s1)
+	v2 := s.getValueForSorting(s2)
+
+	// NaNs always sort to the end of the list, regardless of the sort order.
+	if math.IsNaN(v1) {
+		return 1
+	} else if math.IsNaN(v2) {
+		return -1
+	}
+
+	if v1 < v2 {
+		return 1
+	} else if v1 > v2 {
+		return -1
+	}
+
+	return 0
+}
+
+func (s *Sort) getValueForSorting(idx int) float64 {
+	series := s.allData[idx]
+
+	if len(series.Floats) == 1 {
+		return series.Floats[0].F
+	}
+
+	return series.Histograms[0].H.Sum
+}
+
+func (s *Sort) NextSeries(_ context.Context) (types.InstantVectorSeriesData, error) {
+	if s.seriesReturned >= len(s.seriesOutputOrder) {
+		return types.InstantVectorSeriesData{}, types.EOS
+	}
+
+	data := s.allData[s.seriesOutputOrder[s.seriesReturned]]
+	s.seriesReturned++
+
+	return data, nil
+}
+
+func (s *Sort) ExpressionPosition() posrange.PositionRange {
+	return s.expressionPosition
+}
+
+func (s *Sort) Close() {
+	s.Inner.Close()
+
+	types.IntSlicePool.Put(s.seriesOutputOrder, s.MemoryConsumptionTracker)
+
+	// We don't need to do anything with s.allData here: we passed ownership of the data to the calling operator when we returned it in NextSeries.
+}

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -683,6 +683,8 @@ eval range from 0 to 7m step 1m last_over_time(some_metric_count[3m])
   some_metric_count{env="prod", cluster="us"} _ _ _ 0 2 4 6 8
   some_metric_count{env="prod", cluster="au"} _ _ _ {{count:5}} {{count:10}} {{count:15}} {{count:20}} {{count:25}}
 
+clear
+
 # Test time-related functions.
 load 5m
     histogram_sample {{schema:0 sum:1 count:1}}
@@ -852,3 +854,89 @@ load 30s
 
 eval range from 0 to 2m step 1m predict_linear(metric[1m1s], scalar(prediction_time))
   {} _ 9.75 100
+
+clear
+
+# Test sort / sort_desc.
+load 1m
+  test_metric{case="float 1"}             0+10x4
+  test_metric{case="float 2"}             0+15x4
+  test_metric{case="float with NaN"}      NaN NaN NaN NaN NaN
+  test_metric{case="float with +Inf"}     +Inf +Inf +Inf +Inf +Inf
+  test_metric{case="float with -Inf"}     -Inf -Inf -Inf -Inf -Inf
+  test_metric{case="histogram 1"}         {{count:0 sum:12}} {{count:0 sum:12}} {{count:0 sum:12}} {{count:0 sum:12}} {{count:0 sum:12}}
+  test_metric{case="histogram 2"}         {{count:20 sum:5}} {{count:20 sum:5}} {{count:20 sum:5}} {{count:20 sum:5}} {{count:20 sum:5}}
+  test_metric{case="histogram with NaN"}  {{count:0 sum:NaN}} {{count:0 sum:NaN}} {{count:0 sum:NaN}} {{count:0 sum:NaN}} {{count:0 sum:NaN}}
+  test_metric{case="histogram with +Inf"} {{count:0 sum:Inf}} {{count:0 sum:Inf}} {{count:0 sum:Inf}} {{count:0 sum:Inf}} {{count:0 sum:Inf}}
+  test_metric{case="histogram with -Inf"} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}}
+
+# Sorting of identical values is not stable, so we exclude those from these test cases and check them below.
+eval_ordered instant at 1m sort(test_metric{case!~".*(NaN|Inf)"})
+  test_metric{case="histogram 2"} {{count:20 sum:5}}
+  test_metric{case="float 1"}     10
+  test_metric{case="histogram 1"} {{count:0 sum:12}}
+  test_metric{case="float 2"}     15
+
+eval_ordered instant at 1m sort_desc(test_metric{case!~".*(NaN|Inf)"})
+  test_metric{case="float 2"}     15
+  test_metric{case="histogram 1"} {{count:0 sum:12}}
+  test_metric{case="float 1"}     10
+  test_metric{case="histogram 2"} {{count:20 sum:5}}
+
+eval_ordered instant at 1m sort(test_metric{case=~"float.*"})
+  test_metric{case="float with -Inf"} -Inf
+  test_metric{case="float 1"}         10
+  test_metric{case="float 2"}         15
+  test_metric{case="float with +Inf"} +Inf
+  test_metric{case="float with NaN"}  NaN
+
+eval_ordered instant at 1m sort_desc(test_metric{case=~"float.*"})
+  test_metric{case="float with +Inf"} +Inf
+  test_metric{case="float 2"}         15
+  test_metric{case="float 1"}         10
+  test_metric{case="float with -Inf"} -Inf
+  test_metric{case="float with NaN"}  NaN
+
+eval_ordered instant at 1m sort(test_metric{case=~"histogram.*"})
+  test_metric{case="histogram with -Inf"} {{count:0 sum:-Inf}}
+  test_metric{case="histogram 2"}         {{count:20 sum:5}}
+  test_metric{case="histogram 1"}         {{count:0 sum:12}}
+  test_metric{case="histogram with +Inf"} {{count:0 sum:Inf}}
+  test_metric{case="histogram with NaN"}  {{count:0 sum:NaN}}
+
+eval_ordered instant at 1m sort_desc(test_metric{case=~"histogram.*"})
+  test_metric{case="histogram with +Inf"} {{count:0 sum:Inf}}
+  test_metric{case="histogram 1"}         {{count:0 sum:12}}
+  test_metric{case="histogram 2"}         {{count:20 sum:5}}
+  test_metric{case="histogram with -Inf"} {{count:0 sum:-Inf}}
+  test_metric{case="histogram with NaN"}  {{count:0 sum:NaN}}
+
+# Test the case where some series have no sample at all.
+eval_ordered instant at 1m sort(test_metric{case=~"float.*"} > 11)
+  test_metric{case="float 2"}         15
+  test_metric{case="float with +Inf"} +Inf
+
+# sort / sort_desc do nothing for range queries.
+eval range from 0 to 4m step 1m sort(test_metric)
+  test_metric{case="float 1"}             0+10x4
+  test_metric{case="float 2"}             0+15x4
+  test_metric{case="float with NaN"}      NaN NaN NaN NaN NaN
+  test_metric{case="float with +Inf"}     +Inf +Inf +Inf +Inf +Inf
+  test_metric{case="float with -Inf"}     -Inf -Inf -Inf -Inf -Inf
+  test_metric{case="histogram 1"}         {{count:0 sum:12}} {{count:0 sum:12}} {{count:0 sum:12}} {{count:0 sum:12}} {{count:0 sum:12}}
+  test_metric{case="histogram 2"}         {{count:20 sum:5}} {{count:20 sum:5}} {{count:20 sum:5}} {{count:20 sum:5}} {{count:20 sum:5}}
+  test_metric{case="histogram with NaN"}  {{count:0 sum:NaN}} {{count:0 sum:NaN}} {{count:0 sum:NaN}} {{count:0 sum:NaN}} {{count:0 sum:NaN}}
+  test_metric{case="histogram with +Inf"} {{count:0 sum:Inf}} {{count:0 sum:Inf}} {{count:0 sum:Inf}} {{count:0 sum:Inf}} {{count:0 sum:Inf}}
+  test_metric{case="histogram with -Inf"} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}}
+
+eval range from 0 to 4m step 1m sort_desc(test_metric)
+  test_metric{case="float 1"}             0+10x4
+  test_metric{case="float 2"}             0+15x4
+  test_metric{case="float with NaN"}      NaN NaN NaN NaN NaN
+  test_metric{case="float with +Inf"}     +Inf +Inf +Inf +Inf +Inf
+  test_metric{case="float with -Inf"}     -Inf -Inf -Inf -Inf -Inf
+  test_metric{case="histogram 1"}         {{count:0 sum:12}} {{count:0 sum:12}} {{count:0 sum:12}} {{count:0 sum:12}} {{count:0 sum:12}}
+  test_metric{case="histogram 2"}         {{count:20 sum:5}} {{count:20 sum:5}} {{count:20 sum:5}} {{count:20 sum:5}} {{count:20 sum:5}}
+  test_metric{case="histogram with NaN"}  {{count:0 sum:NaN}} {{count:0 sum:NaN}} {{count:0 sum:NaN}} {{count:0 sum:NaN}} {{count:0 sum:NaN}}
+  test_metric{case="histogram with +Inf"} {{count:0 sum:Inf}} {{count:0 sum:Inf}} {{count:0 sum:Inf}} {{count:0 sum:Inf}} {{count:0 sum:Inf}}
+  test_metric{case="histogram with -Inf"} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}} {{count:0 sum:-Inf}}

--- a/pkg/streamingpromql/testdata/upstream/functions.test
+++ b/pkg/streamingpromql/testdata/upstream/functions.test
@@ -588,29 +588,27 @@ load 5m
 	http_requests{job="app-server", instance="0", group="canary"}		0+70x10
 	http_requests{job="app-server", instance="1", group="canary"}		0+80x10
 
-# Unsupported by streaming engine.
-# eval_ordered instant at 50m sort(http_requests)
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="production", instance="1", job="app-server"} 600
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="canary", instance="2", job="api-server"} NaN
+eval_ordered instant at 50m sort(http_requests)
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="production", instance="1", job="app-server"} 600
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="canary", instance="2", job="api-server"} NaN
 
-# Unsupported by streaming engine.
-# eval_ordered instant at 50m sort_desc(http_requests)
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="production", instance="1", job="app-server"} 600
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="canary", instance="2", job="api-server"} NaN
+eval_ordered instant at 50m sort_desc(http_requests)
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="production", instance="1", job="app-server"} 600
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="canary", instance="2", job="api-server"} NaN
 
 # Tests for sort_by_label/sort_by_label_desc.
 clear


### PR DESCRIPTION
#### What this PR does

This PR adds support in MQE for `sort` and `sort_desc`.

Performance compared to Prometheus' engine is slightly better, and peak memory consumption is the same:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/streamingpromql/benchmarks
cpu: Apple M1 Pro
                                     │ Prometheus  │               Mimir               │
                                     │   sec/op    │   sec/op     vs base              │
Query/sort(a_1),_instant_query-10      146.4µ ± 2%   142.4µ ± 2%  -2.71% (p=0.009 n=6)
Query/sort(a_100),_instant_query-10    839.6µ ± 1%   798.6µ ± 2%  -4.88% (p=0.002 n=6)
Query/sort(a_2000),_instant_query-10   11.14m ± 1%   10.78m ± 1%  -3.18% (p=0.002 n=6)
geomean                                1.110m        1.070m       -3.59%

                                     │  Prometheus  │               Mimir                │
                                     │      B       │      B        vs base              │
Query/sort(a_1),_instant_query-10      66.26Mi ± 1%   65.87Mi ± 1%       ~ (p=0.310 n=6)
Query/sort(a_100),_instant_query-10    61.38Mi ± 1%   60.78Mi ± 1%       ~ (p=0.128 n=6)
Query/sort(a_2000),_instant_query-10   62.58Mi ± 1%   62.93Mi ± 1%       ~ (p=0.143 n=6)
geomean                                63.37Mi        63.16Mi       -0.33%

```

Given `sort` and `sort_desc` only apply to instant queries and we have to load the entire set of data into memory to sort it, there's not much room for improvement over Prometheus' engine.

#### Which issue(s) this PR fixes or relates to

#10067

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
