### PR TITLE
Alertmanager: Skip starting the Alertmanager for Grafana tenants unless they have a promoted, non-default configuration

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -15578,12 +15578,12 @@
         },
         {
           "kind": "field",
-          "name": "grafana_alertmanager_tenant_suffix",
+          "name": "grafana_alertmanager_conditionally_skip_tenant_suffix",
           "required": false,
-          "desc": "Skip starting the Alertmanager for Grafana Alertmanager tenants unless they have a promoted, non-default configuration.",
+          "desc": "Skip starting the Alertmanager for tenants matching this suffix unless they have a promoted, non-default Grafana Alertmanager configuration.",
           "fieldValue": null,
           "fieldDefaultValue": "",
-          "fieldFlag": "alertmanager.grafana-tenant-suffix",
+          "fieldFlag": "alertmanager.grafana-alertmanager-conditionally-skip-tenant-suffix",
           "fieldType": "string",
           "fieldCategory": "experimental"
         },

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -15578,6 +15578,17 @@
         },
         {
           "kind": "field",
+          "name": "grafana_alertmanager_tenant_suffix",
+          "required": false,
+          "desc": "Skip starting the Alertmanager for Grafana Alertmanager tenants unless they have a promoted, non-default configuration.",
+          "fieldValue": null,
+          "fieldDefaultValue": "",
+          "fieldFlag": "alertmanager.grafana-tenant-suffix",
+          "fieldType": "string",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "max_concurrent_get_requests_per_tenant",
           "required": false,
           "desc": "Maximum number of concurrent GET requests allowed per tenant. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -239,6 +239,8 @@ Usage of ./cmd/mimir/mimir:
     	Enables periodic cleanup of alertmanager stateful data (notification logs and silences) from object storage. When enabled, data is removed for any tenant that does not have a configuration. (default true)
   -alertmanager.grafana-alertmanager-compatibility-enabled
     	[experimental] Enable routes to support the migration and operation of the Grafana Alertmanager.
+  -alertmanager.grafana-tenant-suffix string
+    	[experimental] Skip starting the Alertmanager for Grafana Alertmanager tenants unless they have a promoted, non-default configuration.
   -alertmanager.log-parsing-label-matchers
     	[experimental] Enable logging when parsing label matchers. This flag is intended to be used with -alertmanager.utf8-strict-mode-enabled to validate UTF-8 strict mode is working as intended.
   -alertmanager.max-alerts-count int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -239,8 +239,8 @@ Usage of ./cmd/mimir/mimir:
     	Enables periodic cleanup of alertmanager stateful data (notification logs and silences) from object storage. When enabled, data is removed for any tenant that does not have a configuration. (default true)
   -alertmanager.grafana-alertmanager-compatibility-enabled
     	[experimental] Enable routes to support the migration and operation of the Grafana Alertmanager.
-  -alertmanager.grafana-tenant-suffix string
-    	[experimental] Skip starting the Alertmanager for Grafana Alertmanager tenants unless they have a promoted, non-default configuration.
+  -alertmanager.grafana-alertmanager-conditionally-skip-tenant-suffix string
+    	[experimental] Skip starting the Alertmanager for tenants matching this suffix unless they have a promoted, non-default Grafana Alertmanager configuration.
   -alertmanager.log-parsing-label-matchers
     	[experimental] Enable logging when parsing label matchers. This flag is intended to be used with -alertmanager.utf8-strict-mode-enabled to validate UTF-8 strict mode is working as intended.
   -alertmanager.max-alerts-count int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2372,6 +2372,11 @@ sharding_ring:
 # CLI flag: -alertmanager.grafana-alertmanager-compatibility-enabled
 [grafana_alertmanager_compatibility_enabled: <boolean> | default = false]
 
+# (experimental) Skip starting the Alertmanager for Grafana Alertmanager tenants
+# unless they have a promoted, non-default configuration.
+# CLI flag: -alertmanager.grafana-tenant-suffix
+[grafana_alertmanager_tenant_suffix: <string> | default = ""]
+
 # (advanced) Maximum number of concurrent GET requests allowed per tenant. The
 # zero value (and negative values) result in a limit of GOMAXPROCS or 8,
 # whichever is larger. Status code 503 is served for GET requests that would

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2372,10 +2372,10 @@ sharding_ring:
 # CLI flag: -alertmanager.grafana-alertmanager-compatibility-enabled
 [grafana_alertmanager_compatibility_enabled: <boolean> | default = false]
 
-# (experimental) Skip starting the Alertmanager for Grafana Alertmanager tenants
-# unless they have a promoted, non-default configuration.
-# CLI flag: -alertmanager.grafana-tenant-suffix
-[grafana_alertmanager_tenant_suffix: <string> | default = ""]
+# (experimental) Skip starting the Alertmanager for tenants matching this suffix
+# unless they have a promoted, non-default Grafana Alertmanager configuration.
+# CLI flag: -alertmanager.grafana-alertmanager-conditionally-skip-tenant-suffix
+[grafana_alertmanager_conditionally_skip_tenant_suffix: <string> | default = ""]
 
 # (advanced) Maximum number of concurrent GET requests allowed per tenant. The
 # zero value (and negative values) result in a limit of GOMAXPROCS or 8,

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -104,6 +104,7 @@ type Config struct {
 	PersisterConfig   PersisterConfig
 
 	GrafanaAlertmanagerCompatibility bool
+	GrafanaAlertmanagerTenantSuffix  string
 }
 
 // An Alertmanager manages the alerts for one user.

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -128,7 +128,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet, logger 
 
 	f.BoolVar(&cfg.EnableAPI, "alertmanager.enable-api", true, "Enable the alertmanager config API.")
 	f.BoolVar(&cfg.GrafanaAlertmanagerCompatibilityEnabled, "alertmanager.grafana-alertmanager-compatibility-enabled", false, "Enable routes to support the migration and operation of the Grafana Alertmanager.")
-	f.StringVar(&cfg.GrafanaAlertmanagerTenantSuffix, "alertmanager.grafana-tenant-suffix", "", "Avoid starting the Alertmanager for Grafana Alertmanager tenants unless they have a promoted, non-default configuration.")
+	f.StringVar(&cfg.GrafanaAlertmanagerTenantSuffix, "alertmanager.grafana-tenant-suffix", "", "Skip starting the Alertmanager for Grafana Alertmanager tenants unless they have a promoted, non-default configuration.")
 	f.IntVar(&cfg.MaxConcurrentGetRequestsPerTenant, "alertmanager.max-concurrent-get-requests-per-tenant", 0, "Maximum number of concurrent GET requests allowed per tenant. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.")
 
 	f.BoolVar(&cfg.EnableStateCleanup, "alertmanager.enable-state-cleanup", true, "Enables periodic cleanup of alertmanager stateful data (notification logs and silences) from object storage. When enabled, data is removed for any tenant that does not have a configuration.")

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -84,7 +84,7 @@ type MultitenantAlertmanagerConfig struct {
 	EnableAPI bool `yaml:"enable_api" category:"advanced"`
 
 	GrafanaAlertmanagerCompatibilityEnabled bool   `yaml:"grafana_alertmanager_compatibility_enabled" category:"experimental"`
-	GrafanaAlertmanagerTenantSuffix         string `yaml:"grafana_alertmanager_tenant_suffix" category:"experimental"`
+	GrafanaAlertmanagerTenantSuffix         string `yaml:"grafana_alertmanager_conditionally_skip_tenant_suffix" category:"experimental"`
 
 	MaxConcurrentGetRequestsPerTenant int `yaml:"max_concurrent_get_requests_per_tenant" category:"advanced"`
 
@@ -128,7 +128,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet, logger 
 
 	f.BoolVar(&cfg.EnableAPI, "alertmanager.enable-api", true, "Enable the alertmanager config API.")
 	f.BoolVar(&cfg.GrafanaAlertmanagerCompatibilityEnabled, "alertmanager.grafana-alertmanager-compatibility-enabled", false, "Enable routes to support the migration and operation of the Grafana Alertmanager.")
-	f.StringVar(&cfg.GrafanaAlertmanagerTenantSuffix, "alertmanager.grafana-tenant-suffix", "", "Skip starting the Alertmanager for Grafana Alertmanager tenants unless they have a promoted, non-default configuration.")
+	f.StringVar(&cfg.GrafanaAlertmanagerTenantSuffix, "alertmanager.grafana-alertmanager-conditionally-skip-tenant-suffix", "", "Skip starting the Alertmanager for tenants matching this suffix unless they have a promoted, non-default Grafana Alertmanager configuration.")
 	f.IntVar(&cfg.MaxConcurrentGetRequestsPerTenant, "alertmanager.max-concurrent-get-requests-per-tenant", 0, "Maximum number of concurrent GET requests allowed per tenant. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.")
 
 	f.BoolVar(&cfg.EnableStateCleanup, "alertmanager.enable-state-cleanup", true, "Enables periodic cleanup of alertmanager stateful data (notification logs and silences) from object storage. When enabled, data is removed for any tenant that does not have a configuration.")

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2521,63 +2521,21 @@ func TestComputeConfig(t *testing.T) {
 	mimirExternalURL := am.cfg.ExternalURL.String()
 
 	tests := []struct {
-		name          string
-		cfg           alertspb.AlertConfigDescs
-		expErr        string
-		expCfg        alertspb.AlertConfigDesc
-		shouldStartAm bool
-		expURL        string
-		expHeaders    map[string]string
+		name       string
+		cfg        alertspb.AlertConfigDescs
+		expErr     string
+		expCfg     alertspb.AlertConfigDesc
+		expURL     string
+		expHeaders map[string]string
 	}{
 		{
-			name: "no Grafana configuration",
+			name: "no grafana configuration",
 			cfg: alertspb.AlertConfigDescs{
 				Mimir: alertspb.AlertConfigDesc{
 					User:      "user",
 					RawConfig: simpleConfigOne,
 				},
 			},
-			expCfg: alertspb.AlertConfigDesc{
-				User:      "user",
-				RawConfig: simpleConfigOne,
-			},
-			shouldStartAm: true,
-			expURL:        mimirExternalURL,
-		},
-		{
-			name: "no Grafana config, default Mimir config",
-			cfg: alertspb.AlertConfigDescs{
-				Mimir: alertspb.AlertConfigDesc{
-					User:      "user",
-					RawConfig: am.fallbackConfig,
-				},
-			},
-			shouldStartAm: false,
-			expURL:        mimirExternalURL,
-		},
-		{
-			name:          "no Grafana config, no Mimir config",
-			cfg:           alertspb.AlertConfigDescs{},
-			shouldStartAm: true,
-			expURL:        mimirExternalURL,
-		},
-		{
-			name: "empty Grafana configuration",
-			cfg: alertspb.AlertConfigDescs{
-				Mimir: alertspb.AlertConfigDesc{
-					User:      "user",
-					RawConfig: simpleConfigOne,
-				},
-				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:          "user",
-					RawConfig:     "",
-					Default:       false,
-					Promoted:      true,
-					ExternalUrl:   grafanaExternalURL,
-					StaticHeaders: map[string]string{"Test-Header": "test-value"},
-				},
-			},
-			shouldStartAm: true,
 			expCfg: alertspb.AlertConfigDesc{
 				User:      "user",
 				RawConfig: simpleConfigOne,
@@ -2585,11 +2543,11 @@ func TestComputeConfig(t *testing.T) {
 			expURL: mimirExternalURL,
 		},
 		{
-			name: "empty Grafana config, default Mimir config",
+			name: "empty grafana configuration",
 			cfg: alertspb.AlertConfigDescs{
 				Mimir: alertspb.AlertConfigDesc{
 					User:      "user",
-					RawConfig: am.fallbackConfig,
+					RawConfig: simpleConfigOne,
 				},
 				Grafana: alertspb.GrafanaAlertConfigDesc{
 					User:          "user",
@@ -2600,26 +2558,14 @@ func TestComputeConfig(t *testing.T) {
 					StaticHeaders: map[string]string{"Test-Header": "test-value"},
 				},
 			},
-			shouldStartAm: false,
-			expURL:        mimirExternalURL,
-		},
-		{
-			name: "empty Grafana config, no Mimir config",
-			cfg: alertspb.AlertConfigDescs{
-				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:          "user",
-					RawConfig:     "",
-					Default:       false,
-					Promoted:      true,
-					ExternalUrl:   grafanaExternalURL,
-					StaticHeaders: map[string]string{"Test-Header": "test-value"},
-				},
+			expCfg: alertspb.AlertConfigDesc{
+				User:      "user",
+				RawConfig: simpleConfigOne,
 			},
-			shouldStartAm: true,
-			expURL:        mimirExternalURL,
+			expURL: mimirExternalURL,
 		},
 		{
-			name: "unpromoted Grafana configuration",
+			name: "grafana configuration is not promoted",
 			cfg: alertspb.AlertConfigDescs{
 				Mimir: alertspb.AlertConfigDesc{
 					User:      "user",
@@ -2637,43 +2583,10 @@ func TestComputeConfig(t *testing.T) {
 				User:      "user",
 				RawConfig: simpleConfigOne,
 			},
-			shouldStartAm: true,
-			expURL:        mimirExternalURL,
+			expURL: mimirExternalURL,
 		},
 		{
-			name: "unpromoted Grafana config, default Mimir config",
-			cfg: alertspb.AlertConfigDescs{
-				Mimir: alertspb.AlertConfigDesc{
-					User:      "user",
-					RawConfig: am.fallbackConfig,
-				},
-				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:          "user",
-					RawConfig:     grafanaConfig,
-					Promoted:      false,
-					ExternalUrl:   grafanaExternalURL,
-					StaticHeaders: map[string]string{"Test-Header": "test-value"},
-				},
-			},
-			shouldStartAm: false,
-			expURL:        mimirExternalURL,
-		},
-		{
-			name: "unpromoted Grafana config, no Mimir config",
-			cfg: alertspb.AlertConfigDescs{
-				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:          "user",
-					RawConfig:     grafanaConfig,
-					Promoted:      false,
-					ExternalUrl:   grafanaExternalURL,
-					StaticHeaders: map[string]string{"Test-Header": "test-value"},
-				},
-			},
-			shouldStartAm: false,
-			expURL:        mimirExternalURL,
-		},
-		{
-			name: "default Grafana configuration",
+			name: "grafana configuration is default",
 			cfg: alertspb.AlertConfigDescs{
 				Mimir: alertspb.AlertConfigDesc{
 					User:      "user",
@@ -2692,45 +2605,10 @@ func TestComputeConfig(t *testing.T) {
 				User:      "user",
 				RawConfig: simpleConfigOne,
 			},
-			shouldStartAm: true,
-			expURL:        mimirExternalURL,
+			expURL: mimirExternalURL,
 		},
 		{
-			name: "default Grafana config, default Mimir config",
-			cfg: alertspb.AlertConfigDescs{
-				Mimir: alertspb.AlertConfigDesc{
-					User:      "user",
-					RawConfig: am.fallbackConfig,
-				},
-				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:          "user",
-					RawConfig:     grafanaConfig,
-					Default:       true,
-					Promoted:      true,
-					ExternalUrl:   grafanaExternalURL,
-					StaticHeaders: map[string]string{"Test-Header": "test-value"},
-				},
-			},
-			shouldStartAm: false,
-			expURL:        mimirExternalURL,
-		},
-		{
-			name: "default Grafana config, no Mimir config",
-			cfg: alertspb.AlertConfigDescs{
-				Grafana: alertspb.GrafanaAlertConfigDesc{
-					User:          "user",
-					RawConfig:     grafanaConfig,
-					Default:       true,
-					Promoted:      true,
-					ExternalUrl:   grafanaExternalURL,
-					StaticHeaders: map[string]string{"Test-Header": "test-value"},
-				},
-			},
-			shouldStartAm: false,
-			expURL:        mimirExternalURL,
-		},
-		{
-			name: "no Mimir configuration",
+			name: "no mimir configuration",
 			cfg: alertspb.AlertConfigDescs{
 				Grafana: alertspb.GrafanaAlertConfigDesc{
 					User:          "user",
@@ -2746,12 +2624,11 @@ func TestComputeConfig(t *testing.T) {
 				RawConfig: string(combinedCfg),
 				Templates: []*alertspb.TemplateDesc{},
 			},
-			shouldStartAm: true,
-			expURL:        grafanaExternalURL,
-			expHeaders:    map[string]string{"Test-Header": "test-value"},
+			expURL:     grafanaExternalURL,
+			expHeaders: map[string]string{"Test-Header": "test-value"},
 		},
 		{
-			name: "empty Mimir configuration",
+			name: "empty mimir configuration",
 			cfg: alertspb.AlertConfigDescs{
 				Mimir: alertspb.AlertConfigDesc{
 					User:      "user",
@@ -2771,12 +2648,11 @@ func TestComputeConfig(t *testing.T) {
 				RawConfig: string(combinedCfg),
 				Templates: []*alertspb.TemplateDesc{},
 			},
-			shouldStartAm: true,
-			expURL:        grafanaExternalURL,
-			expHeaders:    map[string]string{"Test-Header-1": "test-value-1", "Test-Header-2": "test-value-2"},
+			expURL:     grafanaExternalURL,
+			expHeaders: map[string]string{"Test-Header-1": "test-value-1", "Test-Header-2": "test-value-2"},
 		},
 		{
-			name: "default Mimir configuration",
+			name: "default mimir configuration",
 			cfg: alertspb.AlertConfigDescs{
 				Mimir: alertspb.AlertConfigDesc{
 					User:      "user",
@@ -2796,13 +2672,12 @@ func TestComputeConfig(t *testing.T) {
 				RawConfig: string(combinedCfg),
 				Templates: []*alertspb.TemplateDesc{},
 			},
-			shouldStartAm: true,
-			expURL:        grafanaExternalURL,
-			expHeaders:    map[string]string{"Test-Header-1": "test-value-1", "Test-Header-2": "test-value-2"},
+			expURL:     grafanaExternalURL,
+			expHeaders: map[string]string{"Test-Header-1": "test-value-1", "Test-Header-2": "test-value-2"},
 		},
 		{
 			// TODO: change once merging configs is implemented.
-			name: "both Mimir and Grafana configurations (merging not implemented)",
+			name: "both mimir and grafana configurations (merging not implemented)",
 			cfg: alertspb.AlertConfigDescs{
 				Mimir: alertspb.AlertConfigDesc{
 					User:      "user",
@@ -2821,22 +2696,15 @@ func TestComputeConfig(t *testing.T) {
 				User:      "user",
 				RawConfig: simpleConfigOne,
 			},
-			shouldStartAm: true,
-			expURL:        am.cfg.ExternalURL.String(),
+			expURL: am.cfg.ExternalURL.String(),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// TODO: fix
-			cfg, shouldStartAm, err := am.computeConfig(test.cfg)
+			cfg, err := am.computeConfig(test.cfg)
 			if test.expErr != "" {
 				require.EqualError(t, err, test.expErr)
-				return
-			}
-
-			if !test.shouldStartAm {
-				require.False(t, shouldStartAm)
 				return
 			}
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2702,7 +2702,8 @@ func TestComputeConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg, err := am.computeConfig(test.cfg)
+			// TODO: fix
+			cfg, _, err := am.computeConfig(test.cfg)
 			if test.expErr != "" {
 				require.EqualError(t, err, test.expErr)
 				return


### PR DESCRIPTION
### Description

We currently run an Alertmanager for each tenant in the database, no matter whether their configurations are usable or not. This results in many unused Alertmanagers consuming resources.

This PR adds the option to skip initializing Alertmanagers for Grafana Alertmanager tenants without a usable Grafana Alertmanager configuration.

The new `-alertmanager.grafana-alertmanager-conditionally-skip-tenant-suffix` argument takes a string that will be compared against tenants' IDs. If it matches, the Alertmanager will only be initialized if there's a promoted, non-default, non-empty Grafana Alertmanager configuration for that tenant.

### Testing locally

I tested this by spinning up two Alertmanagers:
- `mimir-1` built from `main`
- `mimir-1-new` build from this branch

I added 600 tenants to each one:
- 200 with promoted, non-default configuration
- 200 with non-promoted, non-default configuration
- 200 with promoted, default configuration

<details><summary>Both Alertmanagers owned 600 tenants, but only 200 of them were active in the Alertmanager build from this branch.</summary>

Tenants owned per AM.

<img width="947" alt="Screenshot 2025-01-23 at 2 48 41 PM" src="https://github.com/user-attachments/assets/b301a967-cec2-4ad6-b3f5-ce540adbb22a" />

Tenant config reloads per Alertmanager.

<img width="947" alt="Screenshot 2025-01-23 at 2 44 16 PM" src="https://github.com/user-attachments/assets/40a3d5d2-ead7-42b4-959a-46a1f3188ac8" />
</details>

<details><summary>The memory footprint was reduced by roughly half in the Alertmanager filtering out the Grafana Alertmanager tenants without a usable configuration.</summary>

`avg_over_time(go_memstats_heap_inuse_bytes{job=~"mimir-1.*"}[1m])`

<img width="910" alt="Screenshot 2025-01-23 at 4 17 08 PM" src="https://github.com/user-attachments/assets/4b887d04-bfbb-47dc-a4cb-80c0cde2f0ec" />

</details>

<details><summary>CPU time in the new Alertmanager was decreased by roughly ~45%, goroutines by ~55%.</summary>

`sum by (job) (rate(process_cpu_seconds_total{job=~"mimir-1.*"}[5m]))`

<img width="902" alt="Screenshot 2025-01-23 at 4 20 19 PM" src="https://github.com/user-attachments/assets/ec60c66e-4b1a-4ea3-896d-0f7d4e1a5523" />

`go_goroutines{job=~"mimir-1.*"}`

<img width="924" alt="Screenshot 2025-01-23 at 4 22 01 PM" src="https://github.com/user-attachments/assets/c36484ab-9e93-4be6-8f0f-6d598545b272" />
</details>
