### PR TITLE
Add visibility when subqueries are rewritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 * [BUGFIX] PromQL: Fix <aggr_over_time> functions with histograms https://github.com/prometheus/prometheus/pull/15711 #10400
 * [BUGFIX] MQE: Fix <aggr_over_time> functions with histograms #10400
 * [BUGFIX] Distributor: return HTTP status 415 Unsupported Media Type instead of 200 Success for Remote Write 2.0 until we support it. #10423
-* [BUGFIX] Query-frontend: Add flag `-query-frontend.prom2-range-compat` and corresponding YAML to rewrite queries with ranges that worked in Prometheus 2 but are invalid in Prometheus 3. #10445 #10461
+* [BUGFIX] Query-frontend: Add flag `-query-frontend.prom2-range-compat` and corresponding YAML to rewrite queries with ranges that worked in Prometheus 2 but are invalid in Prometheus 3. #10445 #10461 #10502
 * [BUGFIX] Distributor: Fix edge case at the HA-tracker with memberlist as KVStore, where when a replica in the KVStore is marked as deleted but not yet removed, it fails to update the KVStore. #10443
 
 ### Mixin

--- a/pkg/costattribution/sample_tracker_test.go
+++ b/pkg/costattribution/sample_tracker_test.go
@@ -122,6 +122,9 @@ func TestSampleTracker_inactiveObservations(t *testing.T) {
 }
 
 func TestSampleTracker_Concurrency(t *testing.T) {
+	// Disabled due to spurious failures. See https://github.com/grafana/mimir/issues/10482
+	t.Skip()
+
 	m := newTestManager()
 	st := m.SampleTracker("user1")
 

--- a/pkg/frontend/querymiddleware/prom2_range_compat_test.go
+++ b/pkg/frontend/querymiddleware/prom2_range_compat_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +24,7 @@ func TestProm2RangeCompat_Do(t *testing.T) {
 	}
 
 	runHandler := func(ctx context.Context, inner MetricsQueryHandler, limits Limits, req MetricsQueryRequest) (Response, error) {
-		middleware := newProm2RangeCompatMiddleware(limits, log.NewNopLogger())
+		middleware := newProm2RangeCompatMiddleware(limits, log.NewNopLogger(), prometheus.NewPedanticRegistry())
 		handler := middleware.Wrap(inner)
 		return handler.Do(ctx, req)
 	}

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -357,7 +357,7 @@ func newQueryMiddlewares(
 	metrics := newInstrumentMiddlewareMetrics(registerer)
 	queryBlockerMiddleware := newQueryBlockerMiddleware(limits, log, registerer)
 	queryStatsMiddleware := newQueryStatsMiddleware(registerer, engine)
-	prom2CompatMiddleware := newProm2RangeCompatMiddleware(limits, log)
+	prom2CompatMiddleware := newProm2RangeCompatMiddleware(limits, log, registerer)
 
 	remoteReadMiddleware = append(remoteReadMiddleware,
 		// Track query range statistics. Added first before any subsequent middleware modifies the request.


### PR DESCRIPTION
#### What this PR does

Follow up to #10445, add a metric when queries are rewritten for compatibility with Prometheus 3 range selector semantics.

#### Which issue(s) this PR fixes or relates to

Fixes #10464

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
