### PR TITLE
influx: fix endpoint path to match existing proxy

### DIFF
--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -88,7 +88,7 @@ The following features are currently experimental:
     - `-ruler-storage.cache.rule-group-enabled`
 - Distributor
   - Influx ingestion
-    - `/api/v1/influx/push` endpoint
+    - `/api/v1/push/influx/write` endpoint
     - `-distributor.influx-endpoint-enabled`
     - `-distributor.max-influx-request-size`
   - Metrics relabeling

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -257,7 +257,7 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc, userL
 
 const PrometheusPushEndpoint = "/api/v1/push"
 const OTLPPushEndpoint = "/otlp/v1/metrics"
-const InfluxPushEndpoint = "/api/v1/influx/push"
+const InfluxPushEndpoint = "/api/v1/push/influx/write"
 
 // RegisterDistributor registers the endpoints associated with the distributor.
 func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distributor.Config, reg prometheus.Registerer, limits *validation.Overrides) {


### PR DESCRIPTION
#### What this PR does

Following on from https://github.com/grafana/mimir/pull/10153/ this PR changes the endpoint to match that of the [influx2cortex code](https://github.com/grafana/influx2cortex/blob/main/pkg/influx/api.go#L30) used as the basis for the influx write proxy.

This moves it from `/api/v1/influx/push` to `/api/v1/push/influx/write` (note change of order of `influx` and `push`, as well as the extra `/write` suffix).

Experimental feature, no further CHANGELOG or documentation updates required.