### PR TITLE
Fix panics in DurationWithJitter utils when computed variance is zero.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 * [BUGFIX] Query-frontend: Add flag `-query-frontend.prom2-range-compat` and corresponding YAML to rewrite queries with ranges that worked in Prometheus 2 but are invalid in Prometheus 3. #10445 #10461 #10502
 * [BUGFIX] Distributor: Fix edge case at the HA-tracker with memberlist as KVStore, where when a replica in the KVStore is marked as deleted but not yet removed, it fails to update the KVStore. #10443
 * [BUGFIX] Ingester: Fixed a race condition in the `PostingsForMatchers` cache that may have infrequently returned expired cached postings. #10500
-* [BUGFIX] Fix a panic in `util.DurationWithJitter` when the computed variance is zero. #10507
+* [BUGFIX] Fix panics in `DurationWithJitter` util functions when computed variance is zero. #10507
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@
 * [BUGFIX] Distributor: return HTTP status 415 Unsupported Media Type instead of 200 Success for Remote Write 2.0 until we support it. #10423
 * [BUGFIX] Query-frontend: Add flag `-query-frontend.prom2-range-compat` and corresponding YAML to rewrite queries with ranges that worked in Prometheus 2 but are invalid in Prometheus 3. #10445 #10461 #10502
 * [BUGFIX] Distributor: Fix edge case at the HA-tracker with memberlist as KVStore, where when a replica in the KVStore is marked as deleted but not yet removed, it fails to update the KVStore. #10443
+* [BUGFIX] Distributor: Fix panics in `DurationWithJitter` util functions when computed variance is zero. #10507
 * [BUGFIX] Ingester: Fixed a race condition in the `PostingsForMatchers` cache that may have infrequently returned expired cached postings. #10500
-* [BUGFIX] Fix panics in `DurationWithJitter` util functions when computed variance is zero. #10507
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [BUGFIX] Query-frontend: Add flag `-query-frontend.prom2-range-compat` and corresponding YAML to rewrite queries with ranges that worked in Prometheus 2 but are invalid in Prometheus 3. #10445 #10461 #10502
 * [BUGFIX] Distributor: Fix edge case at the HA-tracker with memberlist as KVStore, where when a replica in the KVStore is marked as deleted but not yet removed, it fails to update the KVStore. #10443
 * [BUGFIX] Ingester: Fixed a race condition in the `PostingsForMatchers` cache that may have infrequently returned expired cached postings. #10500
+* [BUGFIX] Fix a panic in `util.DurationWithJitter` when the computed variance is zero. #10507
 
 ### Mixin
 

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -66,13 +66,8 @@ func ParseDurationMS(s string) (int64, error) {
 
 // DurationWithJitter returns random duration from "input - input*variance" to "input + input*variance" interval.
 func DurationWithJitter(input time.Duration, variancePerc float64) time.Duration {
-	// No duration? No jitter.
-	if input == 0 {
-		return 0
-	}
-
 	variance := int64(float64(input) * variancePerc)
-	if variance == 0 {
+	if variance <= 0 {
 		return 0
 	}
 
@@ -83,13 +78,8 @@ func DurationWithJitter(input time.Duration, variancePerc float64) time.Duration
 
 // DurationWithPositiveJitter returns random duration from "input" to "input + input*variance" interval.
 func DurationWithPositiveJitter(input time.Duration, variancePerc float64) time.Duration {
-	// No duration? No jitter.
-	if input == 0 {
-		return 0
-	}
-
 	variance := int64(float64(input) * variancePerc)
-	if variance == 0 {
+	if variance <= 0 {
 		return 0
 	}
 
@@ -100,13 +90,8 @@ func DurationWithPositiveJitter(input time.Duration, variancePerc float64) time.
 
 // DurationWithNegativeJitter returns random duration from "input - input*variance" to "input" interval.
 func DurationWithNegativeJitter(input time.Duration, variancePerc float64) time.Duration {
-	// No duration? No jitter.
-	if input == 0 {
-		return 0
-	}
-
 	variance := int64(float64(input) * variancePerc)
-	if variance == 0 {
+	if variance <= 0 {
 		return 0
 	}
 

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -72,6 +72,10 @@ func DurationWithJitter(input time.Duration, variancePerc float64) time.Duration
 	}
 
 	variance := int64(float64(input) * variancePerc)
+	if variance == 0 {
+		return 0
+	}
+
 	jitter := rand.Int63n(variance*2) - variance
 
 	return input + time.Duration(jitter)

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -89,6 +89,10 @@ func DurationWithPositiveJitter(input time.Duration, variancePerc float64) time.
 	}
 
 	variance := int64(float64(input) * variancePerc)
+	if variance == 0 {
+		return 0
+	}
+
 	jitter := rand.Int63n(variance)
 
 	return input + time.Duration(jitter)
@@ -102,6 +106,10 @@ func DurationWithNegativeJitter(input time.Duration, variancePerc float64) time.
 	}
 
 	variance := int64(float64(input) * variancePerc)
+	if variance == 0 {
+		return 0
+	}
+
 	jitter := rand.Int63n(variance)
 
 	return input - time.Duration(jitter)

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -73,7 +73,7 @@ func TestDurationWithJitter_ZeroInputDuration(t *testing.T) {
 }
 
 func TestDurationWithJitter_SmallInput(t *testing.T) {
-	assert.Equal(t, time.Duration(0), DurationWithJitter(time.Duration(0x7), 0.1))
+	assert.Equal(t, time.Duration(0), DurationWithJitter(time.Duration(7), 0.1))
 }
 
 func TestDurationWithPositiveJitter(t *testing.T) {
@@ -90,6 +90,10 @@ func TestDurationWithPositiveJitter_ZeroInputDuration(t *testing.T) {
 	assert.Equal(t, time.Duration(0), DurationWithPositiveJitter(time.Duration(0), 0.5))
 }
 
+func TestDurationWithPositiveJitter_SmallInputDuration(t *testing.T) {
+	assert.Equal(t, time.Duration(0), DurationWithPositiveJitter(time.Duration(7), 0.1))
+}
+
 func TestDurationWithNegativeJitter(t *testing.T) {
 	const numRuns = 1000
 
@@ -102,6 +106,10 @@ func TestDurationWithNegativeJitter(t *testing.T) {
 
 func TestDurationWithNegativeJitter_ZeroInputDuration(t *testing.T) {
 	assert.Equal(t, time.Duration(0), DurationWithNegativeJitter(time.Duration(0), 0.5))
+}
+
+func TestDurationWithNegativeJitter_SmallInputDuration(t *testing.T) {
+	assert.Equal(t, time.Duration(0), DurationWithNegativeJitter(time.Duration(7), 0.1))
 }
 
 func TestParseTime(t *testing.T) {

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -68,14 +68,6 @@ func TestDurationWithJitter(t *testing.T) {
 	}
 }
 
-func TestDurationWithJitter_ZeroInputDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(0), DurationWithJitter(time.Duration(0), 0.5))
-}
-
-func TestDurationWithJitter_SmallInput(t *testing.T) {
-	assert.Equal(t, time.Duration(0), DurationWithJitter(time.Duration(7), 0.1))
-}
-
 func TestDurationWithPositiveJitter(t *testing.T) {
 	const numRuns = 1000
 
@@ -84,14 +76,6 @@ func TestDurationWithPositiveJitter(t *testing.T) {
 		assert.GreaterOrEqual(t, int64(actual), int64(60*time.Second))
 		assert.LessOrEqual(t, int64(actual), int64(90*time.Second))
 	}
-}
-
-func TestDurationWithPositiveJitter_ZeroInputDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(0), DurationWithPositiveJitter(time.Duration(0), 0.5))
-}
-
-func TestDurationWithPositiveJitter_SmallInputDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(0), DurationWithPositiveJitter(time.Duration(7), 0.1))
 }
 
 func TestDurationWithNegativeJitter(t *testing.T) {
@@ -104,12 +88,16 @@ func TestDurationWithNegativeJitter(t *testing.T) {
 	}
 }
 
-func TestDurationWithNegativeJitter_ZeroInputDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(0), DurationWithNegativeJitter(time.Duration(0), 0.5))
-}
+func TestDurationWithJitterFamily_ZeroOutputs(t *testing.T) {
+	// Make sure all of these functions return zero when the computed variance is <= 0.
 
-func TestDurationWithNegativeJitter_SmallInputDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(0), DurationWithNegativeJitter(time.Duration(7), 0.1))
+	type durFunc func(time.Duration, float64) time.Duration
+	for _, f := range []durFunc{DurationWithJitter, DurationWithNegativeJitter, DurationWithPositiveJitter} {
+		assert.Equal(t, time.Duration(0), f(time.Duration(0), 0.5))
+		assert.Equal(t, time.Duration(0), f(time.Duration(7), 0.1))
+		assert.Equal(t, time.Duration(0), f(time.Duration(7), -0.1))
+		assert.Equal(t, time.Duration(0), f(10*time.Minute, -0.1))
+	}
 }
 
 func TestParseTime(t *testing.T) {

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -72,6 +72,10 @@ func TestDurationWithJitter_ZeroInputDuration(t *testing.T) {
 	assert.Equal(t, time.Duration(0), DurationWithJitter(time.Duration(0), 0.5))
 }
 
+func TestDurationWithJitter_SmallInput(t *testing.T) {
+	assert.Equal(t, time.Duration(0), DurationWithJitter(time.Duration(0x7), 0.1))
+}
+
 func TestDurationWithPositiveJitter(t *testing.T) {
 	const numRuns = 1000
 


### PR DESCRIPTION
#### What this PR does

Fixes a panic in `DurationWithJitter`, `DurationWithPositiveJitter`, `DurationWithNegativeJitter` when small inputs result in a variance of zero, because `rand.Int63n` panics on zero.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
