### PR TITLE
test: Ensure ingester is active in ring before tests

### DIFF
--- a/pkg/ingester/downscale_test.go
+++ b/pkg/ingester/downscale_test.go
@@ -39,10 +39,11 @@ func TestIngester_PrepareInstanceRingDownscaleHandler(t *testing.T) {
 				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), i))
 			})
 
-			// Wait until it's healthy
-			test.Poll(t, 5*time.Second, 1, func() interface{} {
-				return i.lifecycler.HealthyInstancesCount()
-			})
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			// Tests require that we've joined the ring so ensure that here.
+			require.NoError(t, ring.WaitInstanceState(ctx, ingestersRing, cfg.IngesterRing.InstanceID, ring.ACTIVE))
 		}
 
 		return i, ingestersRing


### PR DESCRIPTION
#### What this PR does

Fix flake in TestIngester_PrepareInstanceRingDownscaleHandler when tests were run before an ingester had actually joined the ring.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/9494

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
