### PR TITLE
test: Fix flaky TestQuerier_ValidateQueryTimeRange_MaxQueryLength

### DIFF
--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -735,6 +735,7 @@ func TestQuerier_ValidateQueryTimeRange(t *testing.T) {
 
 func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 	const maxQueryLength = 30 * 24 * time.Hour
+	now := time.Now()
 
 	tests := map[string]struct {
 		query          string
@@ -744,26 +745,26 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 	}{
 		"should allow query on short time range and rate time window close to the limit": {
 			query:          "rate(foo[29d])",
-			queryStartTime: time.Now().Add(-time.Hour),
-			queryEndTime:   time.Now(),
+			queryStartTime: now.Add(-time.Hour),
+			queryEndTime:   now,
 			expected:       nil,
 		},
 		"should allow query on large time range close to the limit and short rate time window": {
 			query:          "rate(foo[1m])",
-			queryStartTime: time.Now().Add(-maxQueryLength).Add(time.Hour),
-			queryEndTime:   time.Now(),
+			queryStartTime: now.Add(-maxQueryLength).Add(time.Hour),
+			queryEndTime:   now,
 			expected:       nil,
 		},
 		"should forbid query on short time range and rate time window over the limit": {
 			query:          "rate(foo[31d])",
-			queryStartTime: time.Now().Add(-time.Hour),
-			queryEndTime:   time.Now(),
+			queryStartTime: now.Add(-time.Hour),
+			queryEndTime:   now,
 			expected:       errors.Errorf("expanding series: %s", NewMaxQueryLengthError(745*time.Hour-time.Millisecond, 720*time.Hour)),
 		},
 		"should forbid query on large time range over the limit and short rate time window": {
 			query:          "rate(foo[1m])",
-			queryStartTime: time.Now().Add(-maxQueryLength).Add(-time.Hour),
-			queryEndTime:   time.Now(),
+			queryStartTime: now.Add(-maxQueryLength).Add(-time.Hour),
+			queryEndTime:   now,
 			expected:       errors.Errorf("expanding series: %s", NewMaxQueryLengthError((721*time.Hour)+time.Minute-time.Millisecond, 720*time.Hour)),
 		},
 	}


### PR DESCRIPTION
#### What this PR does

Use a consistent value for "now" to ensure the error message matches the expected error in tests.

#### Which issue(s) this PR fixes or relates to

Fixes #10094

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
