### PR TITLE
MQE: add support for `timestamp`

### DIFF
--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -105,9 +105,9 @@ func TestCases(metricSizes []int) []BenchCase {
 		//{
 		//	Expr: "holt_winters(a_X[1d], 0.3, 0.3)",
 		//},
-		//{
-		//	Expr: "changes(a_X[1d])",
-		//},
+		{
+			Expr: "changes(a_X[1d])",
+		},
 		{
 			Expr: "rate(a_X[1d])",
 		},
@@ -140,11 +140,11 @@ func TestCases(metricSizes []int) []BenchCase {
 		{
 			Expr: "sum(sum_over_time(a_X[10m:3m]))",
 		},
-		//// Unary operators.
-		//{
-		//	Expr: "-a_X",
-		//},
-		//// Binary operators.
+		// Unary operators.
+		{
+			Expr: "-a_X",
+		},
+		// Binary operators.
 		{
 			Expr: "a_X - b_X",
 		},
@@ -261,7 +261,7 @@ func TestCases(metricSizes []int) []BenchCase {
 		//{
 		//	Expr: "topk(5, a_X)",
 		//},
-		//// Combinations.
+		// Combinations.
 		{
 			Expr: "rate(a_X[1m]) + rate(b_X[1m])",
 		},
@@ -283,23 +283,19 @@ func TestCases(metricSizes []int) []BenchCase {
 		{
 			Expr: "histogram_quantile(0.9, nh_X)",
 		},
-		//// Many-to-one join.
-		//{
-		//	Expr: "a_X + on(l) group_right a_one",
-		//},
-		//// Label compared to blank string.
-		//{
-		//	Expr:  "count({__name__!=\"\"})",
-		//	Steps: 1,
-		//},
-		//{
-		//	Expr:  "count({__name__!=\"\",l=\"\"})",
-		//	Steps: 1,
-		//},
-		//// Functions which have special handling inside eval()
-		//{
-		//	Expr: "timestamp(a_X)",
-		//},
+		// Label compared to blank string.
+		{
+			Expr:  "count({__name__!=\"\"})",
+			Steps: 1,
+		},
+		{
+			Expr:  "count({__name__!=\"\",l=\"\"})",
+			Steps: 1,
+		},
+		// Functions which have special handling inside eval()
+		{
+			Expr: "timestamp(a_X)",
+		},
 	}
 
 	// X in an expr will be replaced by different metric sizes.

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -2764,6 +2764,7 @@ func TestCompareVariousMixedMetricsFunctions(t *testing.T) {
 		expressions = append(expressions, fmt.Sprintf(`histogram_stddev(series{label=~"(%s)"})`, labelRegex))
 		expressions = append(expressions, fmt.Sprintf(`histogram_stdvar(series{label=~"(%s)"})`, labelRegex))
 		expressions = append(expressions, fmt.Sprintf(`histogram_sum(series{label=~"(%s)"})`, labelRegex))
+		expressions = append(expressions, fmt.Sprintf(`timestamp(series{label=~"(%s)"})`, labelRegex))
 	}
 
 	// We skip comparing the annotation results as Prometheus does not output any series name

--- a/pkg/streamingpromql/functions_test.go
+++ b/pkg/streamingpromql/functions_test.go
@@ -136,6 +136,7 @@ func TestFunctionDeduplicateAndMerge(t *testing.T) {
 		"sum_over_time":      `sum_over_time({__name__=~"float.*"}[1m])`,
 		"tan":                `tan({__name__=~"float.*"})`,
 		"tanh":               `tanh({__name__=~"float.*"})`,
+		"timestamp":          `timestamp({__name__=~"float.*"})`,
 		"vector":             `<skip>`, // vector() takes a scalar, so this test doesn't apply.
 		"year":               `year({__name__=~"float.*"})`,
 	}

--- a/pkg/streamingpromql/operators/functions/timestamp.go
+++ b/pkg/streamingpromql/operators/functions/timestamp.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/promql/engine.go
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/promql/functions.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors
+
+package functions
+
+import (
+	"github.com/prometheus/prometheus/promql"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+var Timestamp = FunctionOverInstantVectorDefinition{
+	SeriesMetadataFunction: DropSeriesName,
+	SeriesDataFunc:         timestamp,
+}
+
+func timestamp(data types.InstantVectorSeriesData, _ []types.ScalarData, _ types.QueryTimeRange, memoryConsumptionTracker *limiting.MemoryConsumptionTracker) (types.InstantVectorSeriesData, error) {
+	output := types.InstantVectorSeriesData{}
+
+	defer types.HPointSlicePool.Put(data.Histograms, memoryConsumptionTracker)
+
+	if len(data.Histograms) > 0 {
+		defer types.FPointSlicePool.Put(data.Floats, memoryConsumptionTracker)
+
+		var err error
+		output.Floats, err = types.FPointSlicePool.Get(len(data.Floats)+len(data.Histograms), memoryConsumptionTracker)
+
+		if err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
+	} else {
+		// Only have floats, so it's safe to reuse the input float slice.
+		output.Floats = data.Floats[:0]
+	}
+
+	it := types.InstantVectorSeriesDataIterator{}
+	it.Reset(data)
+
+	t, _, _, _, ok := it.Next()
+
+	for ok {
+		output.Floats = append(output.Floats, promql.FPoint{T: t, F: float64(t) / 1000})
+		t, _, _, _, ok = it.Next()
+	}
+
+	return output, nil
+}

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -822,3 +822,20 @@ eval range from 0 to 7m step 1m year(some_metric{case="series1"} + another_metri
   {case="series1"} 1970 2022 2075 2128 2181 2234 2287 2340
 
 clear
+
+load 30s
+  some_metric{case="floats only"} 1 2 _ 3 4
+  some_metric{case="histograms only"} {{count:1}} {{count:2}} _ {{count:3}} {{count:4}}
+  some_metric{case="floats and histograms"} 1 2 _ {{count:3}} {{count:4}}
+
+# If timestamp() is used over a selector, it returns the timestamps of the underlying samples.
+eval range from 0 to 2m step 1m timestamp(some_metric)
+  {case="floats only"} 0 30 120
+  {case="histograms only"} 0 30 120
+  {case="floats and histograms"} 0 30 120
+
+# If timestamp() is used over something that is not a selector, it returns the timestamps of the points returned.
+eval range from 0 to 2m step 1m timestamp(some_metric * 2)
+  {case="floats only"} 0 60 120
+  {case="histograms only"} 0 60 120
+  {case="floats and histograms"} 0 60 120

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -839,3 +839,7 @@ eval range from 0 to 2m step 1m timestamp(some_metric * 2)
   {case="floats only"} 0 60 120
   {case="histograms only"} 0 60 120
   {case="floats and histograms"} 0 60 120
+
+eval_info range from 0 to 2m step 1m timestamp(rate(some_metric{case=~".* only"}[2m]))
+  {case="floats only"} _ 60 120
+  {case="histograms only"} _ 60 120

--- a/pkg/streamingpromql/testdata/upstream/at_modifier.test
+++ b/pkg/streamingpromql/testdata/upstream/at_modifier.test
@@ -171,19 +171,16 @@ eval instant at 10s minute(metric @ 1500)
   {job="2"} 5
 
 # timestamp() takes the time of the sample and not the evaluation time.
-# Unsupported by streaming engine.
-# eval instant at 10m timestamp(metric{job="1"} @ 10)
-#   {job="1"} 10
+eval instant at 10m timestamp(metric{job="1"} @ 10)
+  {job="1"} 10
 
 # The result of inner timestamp() will have the timestamp as the
 # eval time, hence entire expression is not step invariant and depends on eval time.
-# Unsupported by streaming engine.
-# eval instant at 10m timestamp(timestamp(metric{job="1"} @ 10))
-#   {job="1"} 600
+eval instant at 10m timestamp(timestamp(metric{job="1"} @ 10))
+  {job="1"} 600
 
-# Unsupported by streaming engine.
-# eval instant at 15m timestamp(timestamp(metric{job="1"} @ 10))
-#   {job="1"} 900
+eval instant at 15m timestamp(timestamp(metric{job="1"} @ 10))
+  {job="1"} 900
 
 # Time functions inside a subquery.
 
@@ -213,16 +210,14 @@ eval instant at 0s sum_over_time(vector(time())[100s:1s] @ 3000 offset 600s)
   {} 235050
 
 # timestamp() takes the time of the sample and not the evaluation time.
-# Unsupported by streaming engine.
-# eval instant at 0s sum_over_time(timestamp(metric{job="1"} @ 10)[100s:10s] @ 3000)
-#   {job="1"} 100
+eval instant at 0s sum_over_time(timestamp(metric{job="1"} @ 10)[100s:10s] @ 3000)
+  {job="1"} 100
 
 # The result of inner timestamp() will have the timestamp as the
 # eval time, hence entire expression is not step invariant and depends on eval time.
 # Here eval time is determined by the subquery.
-# Unsupported by streaming engine.
-# eval instant at 0s sum_over_time(timestamp(timestamp(metric{job="1"} @ 999))[10s:1s] @ 10)
-#   {job="1"} 55
+eval instant at 0s sum_over_time(timestamp(timestamp(metric{job="1"} @ 999))[10s:1s] @ 10)
+  {job="1"} 55
 
 
 clear

--- a/pkg/streamingpromql/testdata/upstream/functions.test
+++ b/pkg/streamingpromql/testdata/upstream/functions.test
@@ -437,25 +437,20 @@ clear
 load 10s
   metric 1 1
 
-# Unsupported by streaming engine.
-# eval instant at 0s timestamp(metric)
-#   {} 0
+eval instant at 0s timestamp(metric)
+  {} 0
 
-# Unsupported by streaming engine.
-# eval instant at 5s timestamp(metric)
-#   {} 0
+eval instant at 5s timestamp(metric)
+  {} 0
 
-# Unsupported by streaming engine.
-# eval instant at 5s timestamp(((metric)))
-#   {} 0
+eval instant at 5s timestamp(((metric)))
+  {} 0
 
-# Unsupported by streaming engine.
-# eval instant at 10s timestamp(metric)
-#   {} 10
+eval instant at 10s timestamp(metric)
+  {} 10
 
-# Unsupported by streaming engine.
-# eval instant at 10s timestamp(((metric)))
-#   {} 10
+eval instant at 10s timestamp(((metric)))
+  {} 10
 
 # Tests for label_join.
 load 5m
@@ -1604,9 +1599,8 @@ load 1m
   metric 0+1x1000
 
 # We expect the value to be 0 for t=0s to t=59s (inclusive), then 60 for t=60s and t=61s.
-# Unsupported by streaming engine.
-# eval range from 0 to 61s step 1s timestamp(metric)
-#   {} 0x59 60 60
+eval range from 0 to 61s step 1s timestamp(metric)
+  {} 0x59 60 60
 
 clear
 


### PR DESCRIPTION
#### What this PR does

This PR adds support for the `timestamp` function to MQE.

Compared to Prometheus' engine, `timestamp` runs up to 60% faster in MQE in our benchmarks:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/streamingpromql/benchmarks
cpu: Apple M1 Pro
                                                        │  Prometheus  │               Mimir                │
                                                        │    sec/op    │   sec/op     vs base               │
Query/timestamp(a_1),_instant_query-10                     142.5µ ± 2%   139.4µ ± 1%   -2.16% (p=0.002 n=6)
Query/timestamp(a_1),_range_query_with_100_steps-10        163.6µ ± 1%   146.2µ ± 1%  -10.67% (p=0.002 n=6)
Query/timestamp(a_1),_range_query_with_1000_steps-10       361.5µ ± 4%   193.7µ ± 1%  -46.41% (p=0.002 n=6)
Query/timestamp(a_100),_instant_query-10                   931.7µ ± 1%   775.5µ ± 6%  -16.76% (p=0.002 n=6)
Query/timestamp(a_100),_range_query_with_100_steps-10      2.111m ± 1%   1.269m ± 0%  -39.91% (p=0.002 n=6)
Query/timestamp(a_100),_range_query_with_1000_steps-10    12.139m ± 0%   5.401m ± 0%  -55.51% (p=0.002 n=6)
Query/timestamp(a_2000),_instant_query-10                  12.37m ± 1%   10.48m ± 2%  -15.31% (p=0.002 n=6)
Query/timestamp(a_2000),_range_query_with_100_steps-10     36.39m ± 1%   19.30m ± 1%  -46.98% (p=0.002 n=6)
Query/timestamp(a_2000),_range_query_with_1000_steps-10   238.41m ± 0%   95.11m ± 1%  -60.11% (p=0.002 n=6)
geomean                                                    3.031m        1.948m       -35.74%

```

Compared to `main`, the changes to `InstantVectorSelector` do introduce some additional latency, but the absolute differences are small and would likely be noise in the context of a more complex query:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/streamingpromql/benchmarks
cpu: Apple M1 Pro
                                                                                      │   main.txt   │             after.txt              │
                                                                                      │    sec/op    │    sec/op     vs base              │
Query/a_1,_instant_query/engine=Mimir-10                                                138.6µ ±  5%   147.5µ ±  8%  +6.38% (p=0.004 n=6)
Query/a_1,_range_query_with_100_steps/engine=Mimir-10                                   147.6µ ± 12%   152.2µ ±  2%       ~ (p=0.394 n=6)
Query/a_1,_range_query_with_1000_steps/engine=Mimir-10                                  191.5µ ± 11%   203.7µ ±  2%       ~ (p=0.065 n=6)
Query/a_100,_instant_query/engine=Mimir-10                                              777.4µ ±  4%   794.4µ ±  1%       ~ (p=0.394 n=6)
Query/a_100,_range_query_with_100_steps/engine=Mimir-10                                 1.288m ±  4%   1.310m ±  3%       ~ (p=0.180 n=6)
Query/a_100,_range_query_with_1000_steps/engine=Mimir-10                                5.378m ±  0%   5.618m ±  3%  +4.45% (p=0.002 n=6)
Query/a_2000,_instant_query/engine=Mimir-10                                             10.39m ±  1%   10.53m ±  1%  +1.27% (p=0.002 n=6)
Query/a_2000,_range_query_with_100_steps/engine=Mimir-10                                19.23m ±  1%   19.48m ±  2%  +1.30% (p=0.002 n=6)
Query/a_2000,_range_query_with_1000_steps/engine=Mimir-10                               94.38m ±  1%   95.71m ±  1%  +1.41% (p=0.002 n=6)
Query/nh_1,_instant_query/engine=Mimir-10                                               180.3µ ± 10%   190.8µ ±  4%  +5.82% (p=0.041 n=6)
Query/nh_1,_range_query_with_100_steps/engine=Mimir-10                                  225.6µ ±  5%   242.4µ ±  7%  +7.45% (p=0.004 n=6)
Query/nh_1,_range_query_with_1000_steps/engine=Mimir-10                                 722.4µ ±  8%   728.2µ ±  7%       ~ (p=0.589 n=6)
Query/nh_100,_instant_query/engine=Mimir-10                                             4.681m ±  7%   4.824m ±  5%       ~ (p=0.310 n=6)
Query/nh_100,_range_query_with_100_steps/engine=Mimir-10                                8.680m ±  1%   8.836m ±  4%  +1.80% (p=0.004 n=6)
Query/nh_100,_range_query_with_1000_steps/engine=Mimir-10                               46.19m ±  1%   46.43m ±  3%       ~ (p=0.180 n=6)
Query/nh_2000,_instant_query/engine=Mimir-10                                            84.42m ±  1%   84.68m ±  4%  +0.31% (p=0.041 n=6)
Query/nh_2000,_range_query_with_100_steps/engine=Mimir-10                               153.6m ±  1%   154.1m ±  1%       ~ (p=0.818 n=6)
Query/nh_2000,_range_query_with_1000_steps/engine=Mimir-10                              802.4m ±  2%   812.3m ±  2%       ~ (p=0.310 n=6)
```

There are no noticeable changes to peak memory utilisation in our benchmarks.

#### Which issue(s) this PR fixes or relates to

Part of #10067

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
