### PR TITLE
ruler: add "user" and "reason" labels to ruler's queries metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * [CHANGE] Ruler: cap the rate of retries for remote query evaluation to 170/sec. This is configurable via `-ruler.query-frontend.max-retries-rate`. #10375 #10403
 * [CHANGE] Query-frontend: Add `topic` label to `cortex_ingest_storage_reader_last_produced_offset_requests_total`, `cortex_ingest_storage_reader_last_produced_offset_failures_total`, `cortex_ingest_storage_reader_last_produced_offset_request_duration_seconds`, `cortex_ingest_storage_reader_partition_start_offset_requests_total`, `cortex_ingest_storage_reader_partition_start_offset_failures_total`, `cortex_ingest_storage_reader_partition_start_offset_request_duration_seconds` metrics. #10462
 * [CHANGE] Ingester: Set `-ingester.ooo-native-histograms-ingestion-enabled` to true by default. #10483
+* [CHANGE] Ruler: Add `user` and `reason` labels to `cortex_ruler_write_requests_failed_total` and `cortex_ruler_queries_failed_total`; add `user` to
+    `cortex_ruler_write_requests_total` and `cortex_ruler_queries_total` metrics. #10536
 * [FEATURE] Distributor: Add experimental Influx handler. #10153
 * [ENHANCEMENT] Query Frontend: Return server-side `samples_processed` statistics. #10103
 * [ENHANCEMENT] Distributor: OTLP receiver now converts also metric metadata. See also https://github.com/prometheus/prometheus/pull/15416. #10168

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -453,7 +453,7 @@ spec:
             expr: |
               100 * (
               # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
-              sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|$^)"}[1m]))
+              sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|^$)"}[1m]))
                 /
               sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_total[1m]))
               ) > 1
@@ -468,7 +468,7 @@ spec:
             expr: |
               100 * (
               # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
-              sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total{reason=~"(error|$^)"}[1m]))
+              sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total{reason=~"(error|^$)"}[1m]))
                 /
               sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
               ) > 1

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -452,7 +452,7 @@ spec:
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedpushes
             expr: |
               100 * (
-              sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total[1m]))
+              sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total{reason="error"}[1m]))
                 /
               sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_total[1m]))
               ) > 1
@@ -466,7 +466,7 @@ spec:
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedqueries
             expr: |
               100 * (
-              sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total[1m]))
+              sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total{reason="error"}[1m]))
                 /
               sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
               ) > 1

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -452,7 +452,8 @@ spec:
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedpushes
             expr: |
               100 * (
-              sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total{reason="error"}[1m]))
+              # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
+              sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|$^)"}[1m]))
                 /
               sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_total[1m]))
               ) > 1
@@ -466,7 +467,8 @@ spec:
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedqueries
             expr: |
               100 * (
-              sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total{reason="error"}[1m]))
+              # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
+              sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total{reason=~"(error|$^)"}[1m]))
                 /
               sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
               ) > 1

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -431,7 +431,7 @@ groups:
           expr: |
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
-            sum by (cluster, namespace, instance) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|$^)"}[1m]))
+            sum by (cluster, namespace, instance) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|^$)"}[1m]))
               /
             sum by (cluster, namespace, instance) (rate(cortex_ruler_write_requests_total[1m]))
             ) > 1
@@ -446,7 +446,7 @@ groups:
           expr: |
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
-            sum by (cluster, namespace, instance) (rate(cortex_ruler_queries_failed_total{reason=~"(error|$^)"}[1m]))
+            sum by (cluster, namespace, instance) (rate(cortex_ruler_queries_failed_total{reason=~"(error|^$)"}[1m]))
               /
             sum by (cluster, namespace, instance) (rate(cortex_ruler_queries_total[1m]))
             ) > 1

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -430,7 +430,7 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedpushes
           expr: |
             100 * (
-            sum by (cluster, namespace, instance) (rate(cortex_ruler_write_requests_failed_total[1m]))
+            sum by (cluster, namespace, instance) (rate(cortex_ruler_write_requests_failed_total{reason="error"}[1m]))
               /
             sum by (cluster, namespace, instance) (rate(cortex_ruler_write_requests_total[1m]))
             ) > 1
@@ -444,7 +444,7 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedqueries
           expr: |
             100 * (
-            sum by (cluster, namespace, instance) (rate(cortex_ruler_queries_failed_total[1m]))
+            sum by (cluster, namespace, instance) (rate(cortex_ruler_queries_failed_total{reason="error"}[1m]))
               /
             sum by (cluster, namespace, instance) (rate(cortex_ruler_queries_total[1m]))
             ) > 1

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -430,7 +430,8 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedpushes
           expr: |
             100 * (
-            sum by (cluster, namespace, instance) (rate(cortex_ruler_write_requests_failed_total{reason="error"}[1m]))
+            # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
+            sum by (cluster, namespace, instance) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|$^)"}[1m]))
               /
             sum by (cluster, namespace, instance) (rate(cortex_ruler_write_requests_total[1m]))
             ) > 1
@@ -444,7 +445,8 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedqueries
           expr: |
             100 * (
-            sum by (cluster, namespace, instance) (rate(cortex_ruler_queries_failed_total{reason="error"}[1m]))
+            # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
+            sum by (cluster, namespace, instance) (rate(cortex_ruler_queries_failed_total{reason=~"(error|$^)"}[1m]))
               /
             sum by (cluster, namespace, instance) (rate(cortex_ruler_queries_total[1m]))
             ) > 1

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -440,7 +440,8 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedpushes
           expr: |
             100 * (
-            sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total{reason="error"}[1m]))
+            # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
+            sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|$^)"}[1m]))
               /
             sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_total[1m]))
             ) > 1
@@ -454,7 +455,8 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedqueries
           expr: |
             100 * (
-            sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total{reason="error"}[1m]))
+            # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
+            sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total{reason=~"(error|$^)"}[1m]))
               /
             sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
             ) > 1

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -441,7 +441,7 @@ groups:
           expr: |
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
-            sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|$^)"}[1m]))
+            sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|^$)"}[1m]))
               /
             sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_total[1m]))
             ) > 1
@@ -456,7 +456,7 @@ groups:
           expr: |
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
-            sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total{reason=~"(error|$^)"}[1m]))
+            sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total{reason=~"(error|^$)"}[1m]))
               /
             sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
             ) > 1

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -440,7 +440,7 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedpushes
           expr: |
             100 * (
-            sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total[1m]))
+            sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_failed_total{reason="error"}[1m]))
               /
             sum by (cluster, namespace, pod) (rate(cortex_ruler_write_requests_total[1m]))
             ) > 1
@@ -454,7 +454,7 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedqueries
           expr: |
             100 * (
-            sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total[1m]))
+            sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_failed_total{reason="error"}[1m]))
               /
             sum by (cluster, namespace, pod) (rate(cortex_ruler_queries_total[1m]))
             ) > 1

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -681,7 +681,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('RulerTooManyFailedPushes'),
           expr: |||
             100 * (
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_failed_total{reason="error"}[%(range_interval)s]))
+            # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|$^)"}[%(range_interval)s]))
               /
             sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_total[%(range_interval)s]))
             ) > 1
@@ -702,7 +703,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('RulerTooManyFailedQueries'),
           expr: |||
             100 * (
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_failed_total{reason="error"}[%(range_interval)s]))
+            # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_failed_total{reason=~"(error|$^)"}[%(range_interval)s]))
               /
             sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_total[%(range_interval)s]))
             ) > 1

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -681,7 +681,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('RulerTooManyFailedPushes'),
           expr: |||
             100 * (
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_failed_total[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_failed_total{reason="error"}[%(range_interval)s]))
               /
             sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_total[%(range_interval)s]))
             ) > 1

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -682,7 +682,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr: |||
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|$^)"}[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|^$)"}[%(range_interval)s]))
               /
             sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_total[%(range_interval)s]))
             ) > 1
@@ -704,7 +704,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr: |||
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_failed_total{reason=~"(error|$^)"}[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_failed_total{reason=~"(error|^$)"}[%(range_interval)s]))
               /
             sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_total[%(range_interval)s]))
             ) > 1

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -702,7 +702,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('RulerTooManyFailedQueries'),
           expr: |||
             100 * (
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_failed_total[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_failed_total{reason="error"}[%(range_interval)s]))
               /
             sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_total[%(range_interval)s]))
             ) > 1

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -38,8 +37,8 @@ type Pusher interface {
 }
 
 type PusherAppender struct {
-	failedWrites prometheus.Counter
-	totalWrites  prometheus.Counter
+	failedWrites *prometheus.CounterVec
+	totalWrites  *prometheus.CounterVec
 
 	ctx             context.Context
 	pusher          Pusher
@@ -91,7 +90,7 @@ func (a *PusherAppender) AppendHistogramCTZeroSample(storage.SeriesRef, labels.L
 }
 
 func (a *PusherAppender) Commit() error {
-	a.totalWrites.Inc()
+	a.totalWrites.WithLabelValues(a.userID).Inc()
 
 	// Since a.pusher is distributor, client.ReuseSlice will be called in a.pusher.Push.
 	// We shouldn't call client.ReuseSlice here.
@@ -100,11 +99,13 @@ func (a *PusherAppender) Commit() error {
 	_, err := a.pusher.Push(user.InjectOrgID(a.ctx, a.userID), req)
 
 	if err != nil {
-		// Don't report client errors, which are the same ones that would be reported with 4xx HTTP status code
-		// (e.g. series limits, duplicate samples, out of order, etc.)
-		if !mimirpb.IsClientError(err) {
-			a.failedWrites.Inc()
+		failureReason := "error"
+		if mimirpb.IsClientError(err) {
+			// Client errors, which are the same ones that would be reported with 4xx HTTP status code
+			// (e.g. series limits, duplicate samples, out of order, etc.) are reported with a separate reason.
+			failureReason = "4xx"
 		}
+		a.failedWrites.WithLabelValues(a.userID, failureReason).Inc()
 	}
 
 	a.labels = nil
@@ -123,11 +124,11 @@ type PusherAppendable struct {
 	pusher Pusher
 	userID string
 
-	totalWrites  prometheus.Counter
-	failedWrites prometheus.Counter
+	totalWrites  *prometheus.CounterVec
+	failedWrites *prometheus.CounterVec
 }
 
-func NewPusherAppendable(pusher Pusher, userID string, totalWrites, failedWrites prometheus.Counter) *PusherAppendable {
+func NewPusherAppendable(pusher Pusher, userID string, totalWrites, failedWrites *prometheus.CounterVec) *PusherAppendable {
 	return &PusherAppendable{
 		pusher:       pusher,
 		userID:       userID,
@@ -209,16 +210,16 @@ type RulesLimits interface {
 	RulerMaxIndependentRuleEvaluationConcurrencyPerTenant(userID string) int64
 }
 
-func MetricsQueryFunc(qf rules.QueryFunc, queries, failedQueries prometheus.Counter, remoteQuerier bool) rules.QueryFunc {
+func MetricsQueryFunc(qf rules.QueryFunc, userID string, queries, failedQueries *prometheus.CounterVec, remoteQuerier bool) rules.QueryFunc {
 	return func(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
-		queries.Inc()
+		queries.WithLabelValues(userID).Inc()
+
 		result, err := qf(ctx, qs, t)
 		if err == nil {
 			return result, nil
 		}
 
-		// We only care about errors returned by underlying Queryable. Errors returned by PromQL engine are "user-errors",
-		// and not interesting here.
+		failureReason := "error"
 		qerr := QueryableError{}
 		if errors.As(err, &qerr) {
 			origErr := qerr.Unwrap()
@@ -233,17 +234,17 @@ func MetricsQueryFunc(qf rules.QueryFunc, queries, failedQueries prometheus.Coun
 			// All errors will still be counted towards "evaluation failures" metrics and logged by Prometheus Ruler,
 			// but we only want internal errors here.
 			if _, ok := querier.TranslateToPromqlAPIError(origErr).(promql.ErrStorage); ok {
-				failedQueries.Inc()
+				failedQueries.WithLabelValues(userID, failureReason).Inc()
 			}
 
 			// Return unwrapped error.
 			return result, origErr
 		} else if remoteQuerier {
-			// When remote querier enabled, consider anything an error except those with 4xx status code.
-			st, ok := grpcutil.ErrorToStatus(err)
-			if !(ok && st.Code()/100 == 4) {
-				failedQueries.Inc()
+			// When remote querier enabled, consider anything an "error" except those with 4xx status code.
+			if mimirpb.IsClientError(err) {
+				failureReason = "4xx"
 			}
+			failedQueries.WithLabelValues(userID, failureReason).Inc()
 		}
 		return result, err
 	}
@@ -329,23 +330,23 @@ func DefaultTenantManagerFactory(
 	overrides RulesLimits,
 	reg prometheus.Registerer,
 ) ManagerFactory {
-	totalWrites := promauto.With(reg).NewCounter(prometheus.CounterOpts{
+	totalWrites := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_ruler_write_requests_total",
 		Help: "Number of write requests to ingesters.",
-	})
-	failedWrites := promauto.With(reg).NewCounter(prometheus.CounterOpts{
+	}, []string{"user"})
+	failedWrites := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_ruler_write_requests_failed_total",
 		Help: "Number of failed write requests to ingesters.",
-	})
+	}, []string{"user", "reason"})
 
-	totalQueries := promauto.With(reg).NewCounter(prometheus.CounterOpts{
+	totalQueries := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_ruler_queries_total",
 		Help: "Number of queries executed by ruler.",
-	})
-	failedQueries := promauto.With(reg).NewCounter(prometheus.CounterOpts{
+	}, []string{"user"})
+	failedQueries := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_ruler_queries_failed_total",
 		Help: "Number of failed queries by ruler.",
-	})
+	}, []string{"user", "reason"})
 	var rulerQuerySeconds *prometheus.CounterVec
 	var zeroFetchedSeriesQueries *prometheus.CounterVec
 	if cfg.EnableQueryStats {
@@ -368,7 +369,7 @@ func DefaultTenantManagerFactory(
 
 		// Wrap the query function with our custom logic.
 		wrappedQueryFunc := WrapQueryFuncWithReadConsistency(queryFunc, logger)
-		wrappedQueryFunc = MetricsQueryFunc(wrappedQueryFunc, totalQueries, failedQueries, cfg.QueryFrontend.Address != "")
+		wrappedQueryFunc = MetricsQueryFunc(wrappedQueryFunc, userID, totalQueries, failedQueries, cfg.QueryFrontend.Address != "")
 		wrappedQueryFunc = RecordAndReportRuleQueryMetrics(wrappedQueryFunc, queryTime, zeroFetchedSeriesCount, logger)
 
 		// Wrap the queryable with our custom logic.

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -31,6 +31,8 @@ import (
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
+const defaultFailureReason = "error"
+
 // Pusher is an ingester server that accepts pushes.
 type Pusher interface {
 	Push(context.Context, *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error)
@@ -99,7 +101,7 @@ func (a *PusherAppender) Commit() error {
 	_, err := a.pusher.Push(user.InjectOrgID(a.ctx, a.userID), req)
 
 	if err != nil {
-		failureReason := "error"
+		failureReason := defaultFailureReason
 		if mimirpb.IsClientError(err) {
 			// Client errors, which are the same ones that would be reported with 4xx HTTP status code
 			// (e.g. series limits, duplicate samples, out of order, etc.) are reported with a separate reason.
@@ -219,7 +221,7 @@ func MetricsQueryFunc(qf rules.QueryFunc, userID string, queries, failedQueries 
 			return result, nil
 		}
 
-		failureReason := "error"
+		failureReason := defaultFailureReason
 		qerr := QueryableError{}
 		if errors.As(err, &qerr) {
 			origErr := qerr.Unwrap()

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -236,7 +236,7 @@ func TestPusherErrors(t *testing.T) {
 			returnedError:         httpgrpc.Errorf(http.StatusBadRequest, "test error"),
 			expectedWrites:        1,
 			expectedFailures:      1,
-			expectedFailureReason: "4xx",
+			expectedFailureReason: failureReasonClientError,
 		},
 		"a 500 HTTPgRPC error is reported as failure": {
 			returnedError:    httpgrpc.Errorf(http.StatusInternalServerError, "test error"),
@@ -247,7 +247,7 @@ func TestPusherErrors(t *testing.T) {
 			returnedError:         mustStatusWithDetails(codes.FailedPrecondition, mimirpb.BAD_DATA).Err(),
 			expectedWrites:        1,
 			expectedFailures:      1,
-			expectedFailureReason: "4xx",
+			expectedFailureReason: failureReasonClientError,
 		},
 		"a METHOD_NOT_ALLOWED push error is reported as failure": {
 			returnedError:    mustStatusWithDetails(codes.Unimplemented, mimirpb.METHOD_NOT_ALLOWED).Err(),
@@ -287,7 +287,7 @@ func TestPusherErrors(t *testing.T) {
 
 			expectedFailureReason := tc.expectedFailureReason
 			if expectedFailureReason == "" {
-				expectedFailureReason = defaultFailureReason
+				expectedFailureReason = failureReasonServerError
 			}
 			require.Equal(t, tc.expectedFailures, int(testutil.ToFloat64(failures.WithLabelValues("user-1", expectedFailureReason))))
 		})
@@ -354,7 +354,7 @@ func TestMetricsQueryFuncErrors(t *testing.T) {
 			expectedError:         httpgrpc.Errorf(http.StatusBadRequest, "test error"),
 			expectedQueries:       1,
 			expectedFailedQueries: 1,
-			expectedFailedReason:  "4xx", // 400 errors coming from remote querier are reported as their own reason.
+			expectedFailedReason:  failureReasonClientError, // 400 errors coming from remote querier are reported as their own reason.
 			remoteQuerier:         true,
 		},
 		"httpgrpc 500 error": {
@@ -407,7 +407,7 @@ func TestMetricsQueryFuncErrors(t *testing.T) {
 
 			expectedFailedReason := tc.expectedFailedReason
 			if expectedFailedReason == "" {
-				expectedFailedReason = "error"
+				expectedFailedReason = failureReasonServerError
 			}
 			require.Equal(t, tc.expectedFailedQueries, int(testutil.ToFloat64(failures.WithLabelValues("user-1", expectedFailedReason))))
 		})

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -59,7 +59,12 @@ func (p *fakePusher) Push(_ context.Context, r *mimirpb.WriteRequest) (*mimirpb.
 
 func TestPusherAppendable(t *testing.T) {
 	pusher := &fakePusher{}
-	pa := NewPusherAppendable(pusher, "user-1", promauto.With(nil).NewCounter(prometheus.CounterOpts{}), promauto.With(nil).NewCounter(prometheus.CounterOpts{}))
+	pa := NewPusherAppendable(
+		pusher,
+		"user-1",
+		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
+		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user", "reason"}),
+	)
 
 	type sample struct {
 		series         string
@@ -218,28 +223,31 @@ func TestPusherAppendable(t *testing.T) {
 
 func TestPusherErrors(t *testing.T) {
 	for name, tc := range map[string]struct {
-		returnedError    error
-		expectedWrites   int
-		expectedFailures int
+		returnedError         error
+		expectedWrites        int
+		expectedFailures      int
+		expectedFailureReason string // default to "error"
 	}{
 		"no error": {
 			expectedWrites:   1,
 			expectedFailures: 0,
 		},
-		"a 400 HTTPgRPC error is not reported as failure": {
-			returnedError:    httpgrpc.Errorf(http.StatusBadRequest, "test error"),
-			expectedWrites:   1,
-			expectedFailures: 0,
+		"a 400 HTTPgRPC error is reported as client failure": {
+			returnedError:         httpgrpc.Errorf(http.StatusBadRequest, "test error"),
+			expectedWrites:        1,
+			expectedFailures:      1,
+			expectedFailureReason: "4xx",
 		},
 		"a 500 HTTPgRPC error is reported as failure": {
 			returnedError:    httpgrpc.Errorf(http.StatusInternalServerError, "test error"),
 			expectedWrites:   1,
 			expectedFailures: 1,
 		},
-		"a BAD_DATA push error is not reported as failure": {
-			returnedError:    mustStatusWithDetails(codes.FailedPrecondition, mimirpb.BAD_DATA).Err(),
-			expectedWrites:   1,
-			expectedFailures: 0,
+		"a BAD_DATA push error is reported as client failure": {
+			returnedError:         mustStatusWithDetails(codes.FailedPrecondition, mimirpb.BAD_DATA).Err(),
+			expectedWrites:        1,
+			expectedFailures:      1,
+			expectedFailureReason: "4xx",
 		},
 		"a METHOD_NOT_ALLOWED push error is reported as failure": {
 			returnedError:    mustStatusWithDetails(codes.Unimplemented, mimirpb.METHOD_NOT_ALLOWED).Err(),
@@ -262,8 +270,8 @@ func TestPusherErrors(t *testing.T) {
 
 			pusher := &fakePusher{err: tc.returnedError, response: &mimirpb.WriteResponse{}}
 
-			writes := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
-			failures := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
+			writes := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"})
+			failures := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user", "reason"})
 			pa := NewPusherAppendable(pusher, "user-1", writes, failures)
 
 			lbls, err := parser.ParseMetric("foo_bar")
@@ -275,8 +283,13 @@ func TestPusherErrors(t *testing.T) {
 
 			require.Equal(t, tc.returnedError, a.Commit())
 
-			require.Equal(t, tc.expectedWrites, int(testutil.ToFloat64(writes)))
-			require.Equal(t, tc.expectedFailures, int(testutil.ToFloat64(failures)))
+			require.Equal(t, tc.expectedWrites, int(testutil.ToFloat64(writes.WithLabelValues("user-1"))))
+
+			expectedFailureReason := tc.expectedFailureReason
+			if expectedFailureReason == "" {
+				expectedFailureReason = "error"
+			}
+			require.Equal(t, tc.expectedFailures, int(testutil.ToFloat64(failures.WithLabelValues("user-1", expectedFailureReason))))
 		})
 	}
 }
@@ -331,6 +344,7 @@ func TestMetricsQueryFuncErrors(t *testing.T) {
 		expectedError         error
 		expectedQueries       int
 		expectedFailedQueries int
+		expectedFailedReason  string // default "error"
 		remoteQuerier         bool
 	}
 	// Add special cases to test first.
@@ -339,10 +353,10 @@ func TestMetricsQueryFuncErrors(t *testing.T) {
 			returnedError:         httpgrpc.Errorf(http.StatusBadRequest, "test error"),
 			expectedError:         httpgrpc.Errorf(http.StatusBadRequest, "test error"),
 			expectedQueries:       1,
-			expectedFailedQueries: 0, // 400 errors not reported as failures.
+			expectedFailedQueries: 1,
+			expectedFailedReason:  "4xx", // 400 errors coming from remote querier are reported as their own reason.
 			remoteQuerier:         true,
 		},
-
 		"httpgrpc 500 error": {
 			returnedError:         httpgrpc.Errorf(http.StatusInternalServerError, "test error"),
 			expectedError:         httpgrpc.Errorf(http.StatusInternalServerError, "test error"),
@@ -350,7 +364,6 @@ func TestMetricsQueryFuncErrors(t *testing.T) {
 			expectedFailedQueries: 1, // 500 errors are failures
 			remoteQuerier:         true,
 		},
-
 		"unknown but non-queryable error from remote": {
 			returnedError:         errors.New("test error"),
 			expectedError:         errors.New("test error"),
@@ -379,19 +392,24 @@ func TestMetricsQueryFuncErrors(t *testing.T) {
 	}
 	for name, tc := range allCases {
 		t.Run(name, func(t *testing.T) {
-			queries := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
-			failures := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
+			queries := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"})
+			failures := promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user", "reason"})
 
 			mockFunc := func(context.Context, string, time.Time) (promql.Vector, error) {
 				return promql.Vector{}, tc.returnedError
 			}
-			qf := MetricsQueryFunc(mockFunc, queries, failures, tc.remoteQuerier)
+			qf := MetricsQueryFunc(mockFunc, "user-1", queries, failures, tc.remoteQuerier)
 
 			_, err := qf(context.Background(), "test", time.Now())
 			require.Equal(t, tc.expectedError, err)
 
-			require.Equal(t, tc.expectedQueries, int(testutil.ToFloat64(queries)))
-			require.Equal(t, tc.expectedFailedQueries, int(testutil.ToFloat64(failures)))
+			require.Equal(t, tc.expectedQueries, int(testutil.ToFloat64(queries.WithLabelValues("user-1"))))
+
+			expectedFailedReason := tc.expectedFailedReason
+			if expectedFailedReason == "" {
+				expectedFailedReason = "error"
+			}
+			require.Equal(t, tc.expectedFailedQueries, int(testutil.ToFloat64(failures.WithLabelValues("user-1", expectedFailedReason))))
 		})
 	}
 }

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -287,7 +287,7 @@ func TestPusherErrors(t *testing.T) {
 
 			expectedFailureReason := tc.expectedFailureReason
 			if expectedFailureReason == "" {
-				expectedFailureReason = "error"
+				expectedFailureReason = defaultFailureReason
 			}
 			require.Equal(t, tc.expectedFailures, int(testutil.ToFloat64(failures.WithLabelValues("user-1", expectedFailureReason))))
 		})


### PR DESCRIPTION
#### What this PR does

In this PR I'm adding the `user` and `reason` labels to the `cortex_ruler_queries_failed_total` and `cortex_ruler_write_requests_failed_total` metrics. The idea behind the change is to allow tenants segregate and track separately the failures, that happened due to issues on the server vs. those happened due to issues on the client-side (e.g. bad rule).

The exact list of "reasons" is up for a discussion. I've noticed that Loki uses `error` and `upstream_error` ([code](https://github.com/grafana/loki/blob/4df8c60b6ba9f89ee3c8965e78dfae376e0ed929/pkg/ruler/evaluator_remote.go#L260-L273)). I'm not sure if those are well translated into what we want. Opinions are welcome.

For now, I've chosen to have only two reasons: 

- `error` for everything 
- `4xx` for the case when there is *a client-side error in the remote-querier* — I think, this will create the most value to start with. I think, we can expand/change the groups in the future. What do you think?

Note, for consistency, I also added the `user` labels to `cortex_ruler_write_requests_total` and `cortex_ruler_queries_total`.

---

**TODO**

- [ ] Decide the set of "reason" values
- [x] Update the existing alerts, that currently expect only server-side failures

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
