### PR TITLE
Fix instance where context cancellation error was cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277
+* [BUGFIX] Query-frontend: Fix an issue where transient errors could be inadvertently cached. #10537
 * [BUGFIX] Ruler: fix indeterminate rules being always run concurrently (instead of never) when `-ruler.max-independent-rule-evaluation-concurrency` is set. https://github.com/prometheus/prometheus/pull/15560 #10258
 * [BUGFIX] PromQL: Fix various UTF-8 bugs related to quoting. https://github.com/prometheus/prometheus/pull/15531 #10258
 * [BUGFIX] Ruler: Fixed an issue when using the experimental `-ruler.max-independent-rule-evaluation-concurrency` feature, where if a rule group was eligible for concurrency, it would flap between running concurrently or not based on the time it took after running concurrently. #9726 #10189

--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -253,7 +253,8 @@ std.manifestYamlDoc({
 
   jaeger:: {
     jaeger: {
-      image: 'jaegertracing/all-in-one',
+      // Use 1.62 specifically since 1.63 removes the agent which we depend on for now.
+      image: 'jaegertracing/all-in-one:1.62.0',
       ports: ['16686:16686', '14268'],
     },
   },

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -24,7 +24,7 @@
     "volumes":
       - "./config:/etc/agent-config"
   "jaeger":
-    "image": "jaegertracing/all-in-one"
+    "image": "jaegertracing/all-in-one:1.62.0"
     "ports":
       - "16686:16686"
       - "14268"

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -418,7 +418,8 @@ std.manifestYamlDoc({
 
   jaeger:: {
     jaeger: {
-      image: 'jaegertracing/all-in-one',
+      // Use 1.62 specifically since 1.63 removes the agent which we depend on for now.
+      image: 'jaegertracing/all-in-one:1.62.0',
       ports: ['16686:16686', '14268'],
     },
   },

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -282,7 +282,7 @@
       - "./activity:/activity"
       - ".data-ingester-3:/tmp/mimir-tsdb-ingester:delegated"
   "jaeger":
-    "image": "jaegertracing/all-in-one"
+    "image": "jaegertracing/all-in-one:1.62.0"
     "ports":
       - "16686:16686"
       - "14268"

--- a/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
+++ b/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
@@ -50,7 +50,8 @@ services:
       - 9091:9091
 
   jaeger:
-    image: jaegertracing/all-in-one
+    # Use 1.62 specifically since 1.63 removes the agent which we depend on for now.
+    image: jaegertracing/all-in-one:1.62.0
     ports:
       - 16686:16686
       - "14268"

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -71,7 +71,8 @@ services:
       - 9092:9092
 
   jaeger:
-    image: jaegertracing/all-in-one
+    # Use 1.62 specifically since 1.63 removes the agent which we depend on for now.
+    image: jaegertracing/all-in-one:1.62.0
     ports:
       - 16681:16686
       - "14268"

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -254,6 +254,13 @@ func mapEngineError(err error) error {
 		cause = err
 	}
 
+	// The engine sometimes returns context.Canceled without mapping it to one of the expected
+	// error types. Handle that specially here since we rely on the error type for errors being
+	// accurate.
+	if errors.Is(cause, context.Canceled) {
+		return apierror.New(apierror.TypeCanceled, cause.Error())
+	}
+
 	// By default, all errors returned by engine.Eval() are execution errors,
 	// This is the same as Prometheus API does: http://github.com/prometheus/prometheus/blob/076109fa1910ad2198bf2c447a174fee31114982/web/api/v1/api.go#L550-L550
 	errorType := apierror.TypeExec


### PR DESCRIPTION
#### What this PR does

This change fixes the error mapping done in the query sharding middleware to correctly map all possible errors from the PromQL engine to an appropriate APIError type. This fixes an issue where `context.Canceled` was treated as an execution error and cached for subsequent requests.

As part of this, instrumentation for the error caching middleware was improved and Jaeger tracing in various Docker compose setups was fixed by pinning the image used.

#### Which issue(s) this PR fixes or relates to

Internal escalation.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
