### PR TITLE
Add a flag to adjust queries to some max future time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
   * `cortex_ingester_tsdb_block_postings_for_matchers_cache_evictions_total`
 * [ENHANCEMENT] Compactor: Shuffle users' order in `BlocksCleaner`. Prevents bucket indexes from going an extended period without cleanup during compactor restarts. #10513
 * [ENHANCEMENT] Distributor, querier, ingester and store-gateway: Add support for `limit` parameter for label names and values requests. #10410
-* [ENHANCEMENT] Query-frontend: Allow adjustment of queries looking into future to a max duration with `-query-frontend.adjust-to-max-future-window`. #10547
+* [ENHANCEMENT] Query-frontend: Allow adjustment of queries looking into the future to a maximum duration with experimental `-query-frontend.max-future-query-window` flag. #10547
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   * `cortex_ingester_tsdb_block_postings_for_matchers_cache_evictions_total`
 * [ENHANCEMENT] Compactor: Shuffle users' order in `BlocksCleaner`. Prevents bucket indexes from going an extended period without cleanup during compactor restarts. #10513
 * [ENHANCEMENT] Distributor, querier, ingester and store-gateway: Add support for `limit` parameter for label names and values requests. #10410
+* [ENHANCEMENT] Query-frontend: Allow adjustment of queries looking into future to a max duration with `-query-frontend.adjust-to-max-future-window`. #10547
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4397,7 +4397,7 @@
           "desc": "Mutate incoming queries that look far into the future to only look into the future by the set duration. 0 to disable.",
           "fieldValue": null,
           "fieldDefaultValue": 0,
-          "fieldFlag": "query-frontend.adjust-to-max-future-query-window",
+          "fieldFlag": "query-frontend.max-future-query-window",
           "fieldType": "duration",
           "fieldCategory": "experimental"
         },

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4392,6 +4392,17 @@
         },
         {
           "kind": "field",
+          "name": "max_future_query_window",
+          "required": false,
+          "desc": "Mutate incoming queries that look far into the future to only look into the future by the set duration. 0 to disable.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "query-frontend.adjust-to-max-future-query-window",
+          "fieldType": "duration",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "cardinality_analysis_enabled",
           "required": false,
           "desc": "Enables endpoints used for cardinality analysis.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2215,6 +2215,8 @@ Usage of ./cmd/mimir/mimir:
     	The timeout for a query. This config option should be set on query-frontend too when query sharding is enabled. This also applies to queries evaluated by the ruler (internally or remotely). (default 2m0s)
   -query-frontend.active-series-write-timeout duration
     	[experimental] Timeout for writing active series responses. 0 means the value from `-server.http-write-timeout` is used. (default 5m0s)
+  -query-frontend.adjust-to-max-future-query-window duration
+    	[experimental] Mutate incoming queries that look far into the future to only look into the future by the set duration. 0 to disable.
   -query-frontend.align-queries-with-step
     	Mutate incoming queries to align their start and end with their step to improve result caching.
   -query-frontend.block-promql-experimental-functions

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2215,8 +2215,6 @@ Usage of ./cmd/mimir/mimir:
     	The timeout for a query. This config option should be set on query-frontend too when query sharding is enabled. This also applies to queries evaluated by the ruler (internally or remotely). (default 2m0s)
   -query-frontend.active-series-write-timeout duration
     	[experimental] Timeout for writing active series responses. 0 means the value from `-server.http-write-timeout` is used. (default 5m0s)
-  -query-frontend.adjust-to-max-future-query-window duration
-    	[experimental] Mutate incoming queries that look far into the future to only look into the future by the set duration. 0 to disable.
   -query-frontend.align-queries-with-step
     	Mutate incoming queries to align their start and end with their step to improve result caching.
   -query-frontend.block-promql-experimental-functions
@@ -2291,6 +2289,8 @@ Usage of ./cmd/mimir/mimir:
     	Max body size for downstream prometheus. (default 10485760)
   -query-frontend.max-cache-freshness duration
     	Most recent allowed cacheable result per-tenant, to prevent caching very recent results that might still be in flux. (default 10m)
+  -query-frontend.max-future-query-window duration
+    	[experimental] Mutate incoming queries that look far into the future to only look into the future by the set duration. 0 to disable.
   -query-frontend.max-queriers-per-tenant int
     	Maximum number of queriers that can handle requests for a single tenant. If set to 0 or value higher than number of available queriers, *all* queriers will handle requests for the tenant. Each frontend (or query-scheduler, if used) will select the same set of queriers for the same tenant (given that all queriers are connected to all frontends / query-schedulers). This option only works with queriers connecting to the query-frontend / query-scheduler, not when using downstream URL.
   -query-frontend.max-query-expression-size-bytes int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3625,6 +3625,11 @@ The `limits` block configures default and per-tenant limits imposed by component
 # optimize their performance.
 [instant_queries_with_subquery_spin_off: <list of strings> | default = ]
 
+# (experimental) Mutate incoming queries that look far into the future to only
+# look into the future by the set duration. 0 to disable.
+# CLI flag: -query-frontend.adjust-to-max-future-query-window
+[max_future_query_window: <duration> | default = 0s]
+
 # Enables endpoints used for cardinality analysis.
 # CLI flag: -querier.cardinality-analysis-enabled
 [cardinality_analysis_enabled: <boolean> | default = false]

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3627,7 +3627,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 
 # (experimental) Mutate incoming queries that look far into the future to only
 # look into the future by the set duration. 0 to disable.
-# CLI flag: -query-frontend.adjust-to-max-future-query-window
+# CLI flag: -query-frontend.max-future-query-window
 [max_future_query_window: <duration> | default = 0s]
 
 # Enables endpoints used for cardinality analysis.

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -218,7 +218,7 @@ func (l limitsMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Respon
 
 		if r.GetEnd() > maxAllowedTs {
 			level.Debug(log).Log(
-				"msg", "the end time of the query has been manipulated because of the 'adjust-to-max-future-window' setting",
+				"msg", "the end time of the query has been manipulated because of the 'max-future-query-window' setting",
 				"original", util.FormatTimeMillis(r.GetEnd()),
 				"updated", util.FormatTimeMillis(maxAllowedTs),
 				"maxFutureWindow", maxFutureQueryWindow,

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -192,6 +192,7 @@ type Limits struct {
 	EnabledPromQLExperimentalFunctions     flagext.StringSliceCSV `yaml:"enabled_promql_experimental_functions" json:"enabled_promql_experimental_functions" category:"experimental"`
 	Prom2RangeCompat                       bool                   `yaml:"prom2_range_compat" json:"prom2_range_compat" category:"experimental"`
 	InstantQueriesWithSubquerySpinOff      []string               `yaml:"instant_queries_with_subquery_spin_off" json:"instant_queries_with_subquery_spin_off" doc:"nocli|description=List of regular expression patterns matching instant queries. Subqueries within those instant queries will be spun off as range queries to optimize their performance." category:"experimental"`
+	MaxFutureQueryWindow                   model.Duration         `yaml:"max_future_query_window" json:"max_future_query_window" category:"experimental"`
 
 	// Cardinality
 	CardinalityAnalysisEnabled                    bool `yaml:"cardinality_analysis_enabled" json:"cardinality_analysis_enabled"`
@@ -394,6 +395,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.AlignQueriesWithStep, alignQueriesWithStepFlag, false, "Mutate incoming queries to align their start and end with their step to improve result caching.")
 	f.Var(&l.EnabledPromQLExperimentalFunctions, "query-frontend.enabled-promql-experimental-functions", "Enable certain experimental PromQL functions, which are subject to being changed or removed at any time, on a per-tenant basis. Defaults to empty which means all experimental functions are disabled. Set to 'all' to enable all experimental functions.")
 	f.BoolVar(&l.Prom2RangeCompat, "query-frontend.prom2-range-compat", false, "Rewrite queries using the same range selector and resolution [X:X] which don't work in Prometheus 3.0 to a nearly identical form that works with Prometheus 3.0 semantics")
+	f.Var(&l.MaxFutureQueryWindow, "query-frontend.adjust-to-max-future-query-window", "Mutate incoming queries that look far into the future to only look into the future by the set duration. 0 to disable.")
 
 	// Store-gateway.
 	f.IntVar(&l.StoreGatewayTenantShardSize, "store-gateway.tenant-shard-size", 0, "The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.")
@@ -858,6 +860,10 @@ func (o *Overrides) OutOfOrderTimeWindow(userID string) time.Duration {
 // OutOfOrderBlocksExternalLabelEnabled returns if the shipper is flagging out-of-order blocks with an external label.
 func (o *Overrides) OutOfOrderBlocksExternalLabelEnabled(userID string) bool {
 	return o.getOverridesForUser(userID).OutOfOrderBlocksExternalLabelEnabled
+}
+
+func (o *Overrides) MaxFutureQueryWindow(userID string) time.Duration {
+	return time.Duration(o.getOverridesForUser(userID).MaxFutureQueryWindow)
 }
 
 // SeparateMetricsGroupLabel returns the custom label used to separate specific metrics

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -65,7 +65,7 @@ const (
 	AlertmanagerMaxGrafanaStateSizeFlag       = "alertmanager.max-grafana-state-size-bytes"
 	costAttributionLabelsFlag                 = "validation.cost-attribution-labels"
 	maxCostAttributionLabelsPerUserFlag       = "validation.max-cost-attribution-labels-per-user"
-	maxFutureQueryWindowFlag                  = "query-frontend.adjust-to-max-future-query-window"
+	maxFutureQueryWindowFlag                  = "query-frontend.max-future-query-window"
 
 	// MinCompactorPartialBlockDeletionDelay is the minimum partial blocks deletion delay that can be configured in Mimir.
 	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR introduces an experimental flag, `query-frontend.adjust-to-max-future-query-window`. When set with a duration, any range queries querying farther than `now + maxFutureWindow` into the future will be adjusted to query only up to `now + maxFutureWindow`. 

#### Which issue(s) this PR fixes or relates to

Fixes #

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
