### PR TITLE
MQE: fix issue where `group_left` / `group_right` could return series with incorrect labels

### DIFF
--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -416,7 +416,9 @@ func (g *GroupedVectorVectorBinaryOperation) manySideGroupKeyFunc() func(manySid
 	labelsToRemove := g.VectorMatching.Include
 
 	if g.shouldRemoveMetricNameFromManySide() {
+		labelsToRemove = make([]string, 0, len(g.VectorMatching.Include)+1)
 		labelsToRemove = append(labelsToRemove, labels.MetricName)
+		labelsToRemove = append(labelsToRemove, g.VectorMatching.Include...)
 		slices.Sort(labelsToRemove)
 	}
 

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1616,3 +1616,12 @@ eval range from 0 to 24m step 6m side_b > bool ignoring(pod, region, dc, ignored
   {env="test", pod="a", region="au", dc="2"} _ 1 _ _ 0
   {env="test", pod="a", region="us", dc="1"} 0 _ _ 1 _
   {env="test", pod="a", region="us", dc="2"} _ 0 _ _ 1
+
+clear
+
+load 1m
+  left_side{pod="pod-1"} 1
+  right_side{base_name="base-1", region="region-1", system_name="system-1", pod="pod-1"} 1
+
+eval instant at 0m left_side{pod="pod-1"} * on(pod) group_left(base_name, region, system_name) right_side{pod="pod-1"}
+  {base_name="base-1", region="region-1", system_name="system-1", pod="pod-1"} 1


### PR DESCRIPTION
#### What this PR does

This PR fixes a bug where MQE's implementation of `group_left` / `group_right` could sometimes return incorrect labels for a series.

In particular, this could happen if the number of additional labels in the `group_left(...)` or `group_right(...)` modifier was not a power of two. `VectorMatching.Include` was effectively being mutated in `manySideGroupKeyFunc` to include `__name__` and drop the last label (rather than being copied to a new slice with `__name__` appended), and so the incorrect set of additional label names was used in `outputSeriesLabelsFunc`. 

If the list of additional labels had a length that was a power of two, then the `append` in `manySideGroupKeyFunc` caused a new underlying array to be created and so the bug was not triggered.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
