### PR TITLE
Fix MimirAutoscalerNotActive alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,6 @@
 * [BUGFIX] PromQL: Fix <aggr_over_time> functions with histograms https://github.com/prometheus/prometheus/pull/15711 #10400
 * [BUGFIX] MQE: Fix <aggr_over_time> functions with histograms #10400
 * [BUGFIX] Distributor: return HTTP status 415 Unsupported Media Type instead of 200 Success for Remote Write 2.0 until we support it. #10423
-* [BUGFIX] Query-frontend: Add flag `-query-frontend.prom2-range-compat` and corresponding YAML to rewrite queries with ranges that worked in Prometheus 2 but are invalid in Prometheus 3. #10445 #10461
-* [BUGFIX] mixin: fix autoscaling panels. #10473
 * [BUGFIX] Query-frontend: Add flag `-query-frontend.prom2-range-compat` and corresponding YAML to rewrite queries with ranges that worked in Prometheus 2 but are invalid in Prometheus 3. #10445 #10461 #10502
 * [BUGFIX] Distributor: Fix edge case at the HA-tracker with memberlist as KVStore, where when a replica in the KVStore is marked as deleted but not yet removed, it fails to update the KVStore. #10443
 * [BUGFIX] Distributor: Fix panics in `DurationWithJitter` util functions when computed variance is zero. #10507
@@ -65,6 +63,8 @@
 * [BUGFIX] Dashboards: fix how we switch between classic and native histograms. #10018
 * [BUGFIX] Alerts: Ignore cache errors performing `delete` operations since these are expected to fail when keys don't exist. #10287
 * [BUGFIX] Dashboards: fix "Mimir / Rollout Progress" latency comparison when gateway is enabled. #10495
+* [BUGFIX] Dashboards: fix autoscaling panels when Mimir is deployed using Helm. #10473
+* [BUGFIX] Alerts: fix `MimirAutoscalerNotActive` alert. #10564
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -992,7 +992,7 @@ spec:
                     # Add "metric" label.
                     + on(cluster, namespace, horizontalpodautoscaler) group_right
                       # Using `max by ()` so that series churn doesn't break the promQL join
-                      max by (cluster, namespace, horizontalpodautoscaler) (
+                      max by (cluster, namespace, horizontalpodautoscaler, metric) (
                         label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
                       )
                     > 0),

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -966,7 +966,7 @@ groups:
                   # Add "metric" label.
                   + on(cluster, namespace, horizontalpodautoscaler) group_right
                     # Using `max by ()` so that series churn doesn't break the promQL join
-                    max by (cluster, namespace, horizontalpodautoscaler) (
+                    max by (cluster, namespace, horizontalpodautoscaler, metric) (
                       label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
                     )
                   > 0),

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -980,7 +980,7 @@ groups:
                   # Add "metric" label.
                   + on(cluster, namespace, horizontalpodautoscaler) group_right
                     # Using `max by ()` so that series churn doesn't break the promQL join
-                    max by (cluster, namespace, horizontalpodautoscaler) (
+                    max by (cluster, namespace, horizontalpodautoscaler, metric) (
                       label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
                     )
                   > 0),

--- a/operations/mimir-mixin/alerts/autoscaling.libsonnet
+++ b/operations/mimir-mixin/alerts/autoscaling.libsonnet
@@ -15,7 +15,7 @@
                   # Add "metric" label.
                   + on(%(aggregation_labels)s, horizontalpodautoscaler) group_right
                     # Using `max by ()` so that series churn doesn't break the promQL join
-                    max by (%(aggregation_labels)s, horizontalpodautoscaler) (
+                    max by (%(aggregation_labels)s, horizontalpodautoscaler, metric) (
                       label_replace(kube_horizontalpodautoscaler_spec_target_metric*0, "metric", "$1", "metric_name", "(.+)")
                     )
                   > 0),


### PR DESCRIPTION
#### What this PR does

While reviewing https://github.com/grafana/mimir/pull/10473 I noticed that the MimirAutoscalerNotActive alert is not working because of the missing `metric` aggregation. This PR fixes it.

To manually test it I've flipped the `{condition="ScalingActive",status="false"}` to `{condition="ScalingActive",status="true"}`, so that all HPAs match.

**Before** (no matching series):

![Screenshot 2025-02-03 at 10 40 53](https://github.com/user-attachments/assets/6821275d-8b46-4631-ab05-8272785e72e7)

**After** (231 matching series):

![Screenshot 2025-02-03 at 10 41 13](https://github.com/user-attachments/assets/278c422d-7127-4c17-b977-b014d16ee8e9)


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
