### PR TITLE
Fix flaky `TestConcurrentFetchers_fetchSingle`

### DIFF
--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -945,7 +945,6 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 			fetchers             = createConcurrentFetchers(ctx, t, client, topic, partitionID, 0, 1, 0)
 		)
 		t.Cleanup(cluster.Close)
-		t.Cleanup(fetchers.Stop)
 
 		// Produce some records.
 		produceRecord(ctx, t, client, topic, partitionID, []byte("record-1"))

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -987,7 +987,6 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 
 	t.Run("should return an error response if the Fetch request fails", func(t *testing.T) {
 		fetchers, cluster, ctx := setup(t)
-		// Control only the next request, then drop it.
 		cluster.ControlKey(kmsg.Fetch.Int16(), func(_ kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			return nil, errors.New("failed request"), true

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -937,7 +937,7 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 		partitionID = 1
 	)
 
-	setup := func() (*concurrentFetchers, *kfake.Cluster, context.Context) {
+	setup := func(t *testing.T) (*concurrentFetchers, *kfake.Cluster, context.Context) {
 		var (
 			ctx                  = context.Background()
 			cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topic)
@@ -955,7 +955,7 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 	}
 
 	t.Run("should fetch records honoring the start offset", func(t *testing.T) {
-		fetchers, _, ctx := setup()
+		fetchers, _, ctx := setup(t)
 		res := fetchers.fetchSingle(ctx, fetchWant{
 			startOffset:             1,
 			endOffset:               5,
@@ -970,7 +970,7 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 	})
 
 	t.Run("should return an empty non-error response if context is canceled", func(t *testing.T) {
-		fetchers, _, ctx := setup()
+		fetchers, _, ctx := setup(t)
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
 
@@ -986,7 +986,7 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 	})
 
 	t.Run("should return an error response if the Fetch request fails", func(t *testing.T) {
-		fetchers, cluster, ctx := setup()
+		fetchers, cluster, ctx := setup(t)
 		// Control only the next request, then drop it.
 		cluster.ControlKey(kmsg.Fetch.Int16(), func(_ kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
@@ -1005,7 +1005,7 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 	})
 
 	t.Run("should return an error response if the Fetch request contains an error", func(t *testing.T) {
-		fetchers, cluster, ctx := setup()
+		fetchers, cluster, ctx := setup(t)
 		cluster.ControlKey(kmsg.Fetch.Int16(), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			req := kreq.(*kmsg.FetchRequest)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### Why it's falky

The test was failing because the control function was used up by the periodic fetch loop of the started `concurrentFetchers`. This meant that the test sometimes ran when we don't have a control function registered and didn't inject an error.

At the same time the test cases didn't retain their control functions so that they don't interfere with each other.

#### What this PR does

This change makes the test cases independent, so we can use `KeepControl`.


#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/9916

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
