### PR TITLE
PoC: fuzz streamingpromql package

### DIFF
--- a/pkg/streamingpromql/testdata/fuzz/FuzzQueries/4e4acd575c534b40
+++ b/pkg/streamingpromql/testdata/fuzz/FuzzQueries/4e4acd575c534b40
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("some_metric[0]@1m")

--- a/pkg/streamingpromql/testdata/fuzz/FuzzQueries/7b1529dd4de57775
+++ b/pkg/streamingpromql/testdata/fuzz/FuzzQueries/7b1529dd4de57775
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("time()")

--- a/pkg/streamingpromql/testutils/utils.go
+++ b/pkg/streamingpromql/testutils/utils.go
@@ -103,6 +103,8 @@ func RequireEqualResults(t testing.TB, expr string, expected, actual *promql.Res
 		}
 	case parser.ValueTypeString:
 		require.Equal(t, expected.String(), actual.String())
+	case parser.ValueTypeScalar:
+		requireInEpsilonIfNotZeroOrInf(t, expected.Value.(promql.Scalar).V, actual.Value.(promql.Scalar).V)
 	default:
 		require.Fail(t, "unexpected value type", "type: %v", expected.Value.Type())
 	}


### PR DESCRIPTION
This is a PoC imlementation of a fuzz test for streaming promql just taking the inputs and data from the two surrounding tests (it doesn't even try functions, etc.).

This detected that the comparision function doesn't check scalars (which I fixed), and now it fails on the `some_metric[0]@1m` query, which returns results for Prometheus but doesn't return any for streamingpromql.

This is a PoC because it's missing:
- Consistent and rich data input: I took two random inputs from surrounding tests, but it would be nice it we fed more data into the storage before running the queries, as that would increase the chances of hitting the bugs.
- Add functions to the corpus: one example query for each one of the functions would be great.
- Add timestamps to the corpus: right now we're running the query always at the same unix timestamp, but it would be better to have that as the second argument of the corpus.