### PR TITLE
Revert "Update jaegertracing/all-in-one Docker tag to v1.65.0 (#10563)"

### DIFF
--- a/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
+++ b/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
@@ -51,7 +51,7 @@ services:
 
   jaeger:
     # Use 1.62 specifically since 1.63 removes the agent which we depend on for now.
-    image: jaegertracing/all-in-one:1.65.0
+    image: jaegertracing/all-in-one:1.62.0
     ports:
       - 16686:16686
       - "14268"

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -72,7 +72,7 @@ services:
 
   jaeger:
     # Use 1.62 specifically since 1.63 removes the agent which we depend on for now.
-    image: jaegertracing/all-in-one:1.65.0
+    image: jaegertracing/all-in-one:1.62.0
     ports:
       - 16681:16686
       - "14268"


### PR DESCRIPTION
#### What this PR does

Revert update of jaegertracing/all-in-one, since it's supposed to be pinned at v1.62. This reverts commit e5d998b8a875aadb5bdf3c8dc52c0d0a756c1637.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
