### PR TITLE
Renovate: Disable updating of jaegertracing/all-in-one Docker image

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -41,6 +41,14 @@
         "managers": ["npm"],
         "enabled": true
       }
+      {
+        "description": "Pin jaegertracing/all-in-one Docker image, since newer versions lack the agent we depend on",
+        "matchPackageNames": ["jaegertracing/all-in-one"],
+        "matchDatasources": [
+          "docker",
+        ],
+        "enabled": false
+      },
     ],
     "branchPrefix": "deps-update/",
     "vulnerabilityAlerts": {


### PR DESCRIPTION
#### What this PR does

Configure Renovate to disable updating of the `jaegertracing/all-in-one` Docker image, since we want to stay at v1.62.0.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
