### PR TITLE
continuous-test: Add WithAdditionalHeaders req option to client

### DIFF
--- a/pkg/continuoustest/client_test.go
+++ b/pkg/continuoustest/client_test.go
@@ -321,6 +321,7 @@ func TestClient_QueryHeaders(t *testing.T) {
 
 	testCases := map[string]struct {
 		cfgMutator func(*ClientConfig)
+		reqOptions []RequestOption
 
 		// There may be other headers on the resulting request, but we'll only check these:
 		expectedHeaders      map[string]string
@@ -385,6 +386,14 @@ func TestClient_QueryHeaders(t *testing.T) {
 				"User-Agent": "other-user-agent",
 			},
 		},
+		"additional headers": {
+			reqOptions: []RequestOption{
+				WithAdditionalHeaders(map[string]string{"added": "header-val"}),
+			},
+			expectedHeaders: map[string]string{
+				"added": "header-val",
+			},
+		},
 	}
 
 	for testName, tc := range testCases {
@@ -404,7 +413,7 @@ func TestClient_QueryHeaders(t *testing.T) {
 
 			ctx := context.Background()
 
-			_, err = c.Query(ctx, "up", time.Unix(0, 0))
+			_, err = c.Query(ctx, "up", time.Unix(0, 0), tc.reqOptions...)
 			require.NoError(t, err)
 
 			require.Len(t, receivedRequests, 1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR allows users to specify arbitrary additional headers for the continuous-test client's requests. This allows the client to set headers such as the `X-Filter-Queryables` header added in https://github.com/grafana/mimir/pull/10552.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
