### PR TITLE
Jsonnet: change default multi-AZ topology toleration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
 
 * [CHANGE] Update rollout-operator version to 0.22.0. #10229
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318
+* [CHANGE] Change multi-AZ deployments default toleration value from 'multi-az' to 'secondary-az', and make it configurable via the following settings: #10596
+  * `_config.multi_zone_schedule_toleration` (default)
+  * `_config.multi_zone_distributor_schedule_toleration` (distributor's override)
+  * `_config.multi_zone_etcd_schedule_toleration` (etcd's override)
 * [ENHANCEMENT] Enforce `persistentVolumeClaimRetentionPolicy` `Retain` policy on partition ingesters during migration to experimental ingest storage. #10395
 * [ENHANCEMENT] Allow to not configure `topologySpreadConstraints` by setting the following configuration options to a negative value: #10540
   * `distributor_topology_spread_max_skew`

--- a/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
@@ -792,7 +792,7 @@ spec:
       - effect: NoSchedule
         key: topology
         operator: Equal
-        value: multi-az
+        value: secondary-az
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -902,7 +902,7 @@ spec:
       - effect: NoSchedule
         key: topology
         operator: Equal
-        value: multi-az
+        value: secondary-az
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
@@ -2397,6 +2397,6 @@ spec:
     - effect: NoSchedule
       key: topology
       operator: Equal
-      value: multi-az
+      value: secondary-az
   size: 3
   version: 3.3.13

--- a/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
+++ b/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
@@ -923,7 +923,7 @@ spec:
       - effect: NoSchedule
         key: topology
         operator: Equal
-        value: multi-az
+        value: secondary-az
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -1033,7 +1033,7 @@ spec:
       - effect: NoSchedule
         key: topology
         operator: Equal
-        value: multi-az
+        value: secondary-az
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:

--- a/operations/mimir/multi-zone-distributor.libsonnet
+++ b/operations/mimir/multi-zone-distributor.libsonnet
@@ -6,6 +6,7 @@
     multi_zone_distributor_enabled: false,
     multi_zone_availability_zones: [],
     multi_zone_distributor_replicas: std.length($._config.multi_zone_availability_zones),
+    multi_zone_distributor_schedule_toleration: $._config.multi_zone_schedule_toleration,
   },
 
   local container = $.core.v1.container,
@@ -79,10 +80,10 @@
 
     $.newDistributorDeployment(name, container, nodeAffinityMatchers) +
     deployment.mixin.spec.withReplicas(std.ceil($._config.multi_zone_distributor_replicas / std.length($._config.multi_zone_availability_zones))) +
-    deployment.spec.template.spec.withTolerationsMixin([
+    deployment.spec.template.spec.withTolerationsMixin(if $._config.multi_zone_distributor_schedule_toleration == '' then [] else [
       $.core.v1.toleration.withKey('topology') +
       $.core.v1.toleration.withOperator('Equal') +
-      $.core.v1.toleration.withValue('multi-az') +
+      $.core.v1.toleration.withValue($._config.multi_zone_distributor_schedule_toleration) +
       $.core.v1.toleration.withEffect('NoSchedule'),
     ]),
 

--- a/operations/mimir/multi-zone-etcd.libsonnet
+++ b/operations/mimir/multi-zone-etcd.libsonnet
@@ -1,6 +1,7 @@
 {
   _config+:: {
     multi_zone_etcd_enabled: false,
+    multi_zone_etcd_schedule_toleration: $._config.multi_zone_schedule_toleration,
   },
 
   // Enforcing the spread of etcd pods across multi-AZ is not easy because we're limited
@@ -28,10 +29,10 @@
         },
 
         tolerations+:
-          deployment.spec.template.spec.withTolerationsMixin([
+          deployment.spec.template.spec.withTolerationsMixin(if $._config.multi_zone_etcd_schedule_toleration == '' then [] else [
             $.core.v1.toleration.withKey('topology') +
             $.core.v1.toleration.withOperator('Equal') +
-            $.core.v1.toleration.withValue('multi-az') +
+            $.core.v1.toleration.withValue($._config.multi_zone_etcd_schedule_toleration) +
             $.core.v1.toleration.withEffect('NoSchedule'),
           ]).spec.template.spec.tolerations,
       },

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -30,6 +30,8 @@
       'store-gateway.sharding-ring.zone-awareness-enabled': 'true',
       'store-gateway.sharding-ring.prefix': 'multi-zone/',
     },
+
+    multi_zone_schedule_toleration: 'secondary-az',
   },
 
   //


### PR DESCRIPTION
#### What this PR does

In this PR I'm changing the default multi-AZ topology toleration from `multi-az` to `secondary-az`, but also making it configurable.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
