### PR TITLE
Writes dashboard: show write requests broken down by request type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 
 ### Mixin
 
+* [ENHANCEMENT] Dashboards: 'Writes' dashboard: show write requests broken down by request type. #10599
 * [BUGFIX] Dashboards: fix how we switch between classic and native histograms. #10018
 * [BUGFIX] Alerts: Ignore cache errors performing `delete` operations since these are expected to fail when keys don't exist. #10287
 * [BUGFIX] Dashboards: fix "Mimir / Rollout Progress" latency comparison when gateway is enabled. #10495

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -92,6 +92,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       namespaceMatcher: $.namespaceMatcher(),
       storeGatewayMatcher: $.jobMatcher($._config.job_names.store_gateway),
       rulerQueryFrontendMatcher: $.jobMatcher($._config.job_names.ruler_query_frontend),
+      writePromHTTPRoutesRegex: $.queries.write_prom_http_routes_regex,
+      writeOTLPHTTPRoutesRegex: $.queries.write_otlp_http_routes_regex,
       writeHTTPRoutesRegex: $.queries.write_http_routes_regex,
       writeDistributorRoutesRegex: std.join('|', [$.queries.write_grpc_distributor_routes_regex, $.queries.write_http_routes_regex]),
       writeGRPCIngesterRoute: $.queries.write_grpc_ingester_route,
@@ -106,7 +108,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
     },
 
     requests_per_second_metric: 'cortex_request_duration_seconds',
-    write_http_routes_regex: 'api_(v1|prom)_push|otlp_v1_metrics',
+    write_prom_http_routes_regex: 'api_(v1|prom)_push',
+    write_otlp_http_routes_regex: 'otlp_v1_metrics',
+    write_http_routes_regex: self.write_prom_http_routes_regex + '|' + self.write_otlp_http_routes_regex,
     write_grpc_distributor_routes_regex: '/distributor.Distributor/Push|/httpgrpc.*',
     write_grpc_ingester_route: '/cortex.Ingester/Push',
     read_http_routes_regex: '(prometheus|api_prom)_api_v1_.+',
@@ -122,6 +126,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       local p = self,
       requestsPerSecondMetric: $.queries.requests_per_second_metric,
       writeRequestsPerSecondSelector: '%(gatewayMatcher)s, route=~"%(writeHTTPRoutesRegex)s"' % variables,
+      promWriteRequestsPerSecondSelector: '%(gatewayMatcher)s, route=~"%(writePromHTTPRoutesRegex)s"' % variables,
+      otlpWriteRequestsPerSecondSelector: '%(gatewayMatcher)s, route=~"%(writeOTLPHTTPRoutesRegex)s"' % variables,
       readRequestsPerSecondSelector: '%(gatewayMatcher)s, route=~"%(readHTTPRoutesRegex)s"' % variables,
 
       // Write failures rate as percentage of total requests.

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -103,7 +103,7 @@ local filename = 'mimir-writes.json';
     )
     .addRowIf(
       $._config.gateway_enabled,
-      $.row('Gateway')
+      $.row('Gateway - all write requests')
       .addPanel(
         $.timeseriesPanel('Requests / sec') +
         $.qpsPanelNativeHistogram($.queries.gateway.requestsPerSecondMetric, $.queries.gateway.writeRequestsPerSecondSelector)
@@ -115,6 +115,38 @@ local filename = 'mimir-writes.json';
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
         $.perInstanceLatencyPanelNativeHistogram('0.99', $.queries.gateway.requestsPerSecondMetric, $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', $.queries.write_http_routes_regex)])
+      )
+    )
+    .addRowIf(
+      $._config.gateway_enabled,
+      $.row('Gateway - Prometheus remote write requests')
+      .addPanel(
+        $.timeseriesPanel('Requests / sec') +
+        $.qpsPanelNativeHistogram($.queries.gateway.requestsPerSecondMetric, $.queries.gateway.promWriteRequestsPerSecondSelector)
+      )
+      .addPanel(
+        $.timeseriesPanel('Latency') +
+        $.latencyRecordingRulePanelNativeHistogram($.queries.gateway.requestsPerSecondMetric, $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', $.queries.write_prom_http_routes_regex)])
+      )
+      .addPanel(
+        $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.perInstanceLatencyPanelNativeHistogram('0.99', $.queries.gateway.requestsPerSecondMetric, $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', $.queries.write_prom_http_routes_regex)])
+      )
+    )
+    .addRowIf(
+      $._config.gateway_enabled,
+      $.row('Gateway - OTLP write requests')
+      .addPanel(
+        $.timeseriesPanel('Requests / sec') +
+        $.qpsPanelNativeHistogram($.queries.gateway.requestsPerSecondMetric, $.queries.gateway.otlpWriteRequestsPerSecondSelector)
+      )
+      .addPanel(
+        $.timeseriesPanel('Latency') +
+        $.latencyRecordingRulePanelNativeHistogram($.queries.gateway.requestsPerSecondMetric, $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', $.queries.write_otlp_http_routes_regex)])
+      )
+      .addPanel(
+        $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
+        $.perInstanceLatencyPanelNativeHistogram('0.99', $.queries.gateway.requestsPerSecondMetric, $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', $.queries.write_otlp_http_routes_regex)])
       )
     )
     .addRow(


### PR DESCRIPTION
#### What this PR does

This PR extends the 'Writes' dashboard to add two new rows showing incoming write requests - one for Prometheus remote write requests, and the other for OTLP write requests:

<img width="1500" alt="Screenshot 2025-02-07 at 1 07 33 pm" src="https://github.com/user-attachments/assets/face4e41-f03f-4371-8372-a70a8b3cf65b" />


I've chosen to show this data from gateways as this is the easiest place to differentiate requests based on the route - distributors convert all requests to `/cortex.Ingester/Push` requests to ingesters, and distributors receive some requests over httpgrpc.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
