### PR TITLE
Compactor: Turn block upload metrics from gauges to counters

### DIFF
--- a/pkg/compactor/block_upload_test.go
+++ b/pkg/compactor/block_upload_test.go
@@ -1512,9 +1512,9 @@ func TestMultitenantCompactor_ValidateAndComplete(t *testing.T) {
 				logger:            log.NewNopLogger(),
 				bucketClient:      injectedBkt,
 				cfgProvider:       cfgProvider,
-				blockUploadBlocks: promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{tenantID}),
-				blockUploadBytes:  promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{tenantID}),
-				blockUploadFiles:  promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{tenantID}),
+				blockUploadBlocks: promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{tenantID}),
+				blockUploadBytes:  promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{tenantID}),
+				blockUploadFiles:  promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{tenantID}),
 			}
 			userBkt := bucket.NewUserBucketClient(tenantID, injectedBkt, cfgProvider)
 
@@ -2097,9 +2097,9 @@ func TestMultitenantCompactor_MarkBlockComplete(t *testing.T) {
 				logger:            log.NewNopLogger(),
 				bucketClient:      injectedBkt,
 				cfgProvider:       cfgProvider,
-				blockUploadBlocks: promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{tenantID}),
-				blockUploadBytes:  promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{tenantID}),
-				blockUploadFiles:  promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{tenantID}),
+				blockUploadBlocks: promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{tenantID}),
+				blockUploadBytes:  promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{tenantID}),
+				blockUploadFiles:  promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{tenantID}),
 			}
 			userBkt := bucket.NewUserBucketClient(tenantID, injectedBkt, cfgProvider)
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -300,9 +300,9 @@ type MultitenantCompactor struct {
 	syncerMetrics *aggregatedSyncerMetrics
 
 	// Block upload metrics
-	blockUploadBlocks      *prometheus.GaugeVec
-	blockUploadBytes       *prometheus.GaugeVec
-	blockUploadFiles       *prometheus.GaugeVec
+	blockUploadBlocks      *prometheus.CounterVec
+	blockUploadBytes       *prometheus.CounterVec
+	blockUploadFiles       *prometheus.CounterVec
 	blockUploadValidations atomic.Int64
 
 	// Per-tenant meta caches that are passed to MetaFetcher.
@@ -405,15 +405,15 @@ func newMultitenantCompactor(
 			Help:        blocksMarkedForDeletionHelp,
 			ConstLabels: prometheus.Labels{"reason": "compaction"},
 		}),
-		blockUploadBlocks: promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{
+		blockUploadBlocks: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_block_upload_api_blocks_total",
 			Help: "Total number of blocks successfully uploaded and validated using the block upload API.",
 		}, []string{"user"}),
-		blockUploadBytes: promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{
+		blockUploadBytes: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_block_upload_api_bytes_total",
 			Help: "Total number of bytes from successfully uploaded and validated blocks using block upload API.",
 		}, []string{"user"}),
-		blockUploadFiles: promauto.With(registerer).NewGaugeVec(prometheus.GaugeOpts{
+		blockUploadFiles: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_block_upload_api_files_total",
 			Help: "Total number of files from successfully uploaded and validated blocks using block upload API.",
 		}, []string{"user"}),


### PR DESCRIPTION
We only ever increase these metrics. They should be counters, not gauges.