### PR TITLE
frontend: Fix downstream queries in experimental subquery spin-off feature

### DIFF
--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -197,9 +197,6 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 
 	spanLog.DebugLog("msg", "instant query has been rewritten to spin-off subqueries", "rewritten", spinOffQuery, "regular_downstream_queries", mapperStats.DownstreamQueries(), "subqueries_spun_off", mapperStats.SpunOffSubqueries())
 
-	test := spinOffQuery.String()
-	fmt.Println(test)
-
 	// Update query stats.
 	queryStats := stats.FromContext(ctx)
 	queryStats.AddSpunOffSubqueries(uint32(mapperStats.SpunOffSubqueries()))

--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -197,6 +197,9 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 
 	spanLog.DebugLog("msg", "instant query has been rewritten to spin-off subqueries", "rewritten", spinOffQuery, "regular_downstream_queries", mapperStats.DownstreamQueries(), "subqueries_spun_off", mapperStats.SpunOffSubqueries())
 
+	test := spinOffQuery.String()
+	fmt.Println(test)
+
 	// Update query stats.
 	queryStats := stats.FromContext(ctx)
 	queryStats.AddSpunOffSubqueries(uint32(mapperStats.SpunOffSubqueries()))

--- a/pkg/frontend/querymiddleware/spin_off_subqueries_queryable.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries_queryable.go
@@ -67,7 +67,12 @@ func (q *spinOffSubqueriesQuerier) Select(ctx context.Context, _ bool, hints *st
 
 	switch name {
 	case astmapper.DownstreamQueryMetricName:
-		downstreamReq, err := q.req.WithQuery(astmapper.DownstreamQueryLabelName)
+		query, ok := values[astmapper.DownstreamQueryLabelName]
+		if !ok {
+			return storage.ErrSeriesSet(errors.New("missing required labels for downstream query"))
+		}
+
+		downstreamReq, err := q.req.WithQuery(query)
 		if err != nil {
 			return storage.ErrSeriesSet(err)
 		}


### PR DESCRIPTION
Massive oversight in https://github.com/grafana/mimir/pull/10460

The downstream queries were all just `__query__` instead of the actual query. I also optimized the mapper so that it groups downstream queries further up the tree, which should reduce the number of queries that need to be run.

Most queries when testing were still passing since joining subqueries and non subqueries is pretty rare in practice, it seems
