### PR TITLE
Subquery Spin-Off: Prioritize query sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [ENHANCEMENT] Distributor, querier, ingester and store-gateway: Add support for `limit` parameter for label names and values requests. #10410
 * [ENHANCEMENT] Query-frontend: Allow adjustment of queries looking into the future to a maximum duration with experimental `-query-frontend.max-future-query-window` flag. #10547
 * [ENHANCEMENT] Ruler: Adds support for filtering results from rule status endpoint by `file[]`, `rule_group[]` and `rule_name[]`. #10589
+* [ENHANCEMENT] Query-frontend: Add option to "spin off" subqueries as actual range queries. This is enabled by setting the `-query-frontend.spin-off-instant-subqueries-to-url=<url>` option on the frontend and the `instant_queries_with_subquery_spin_off` per-tenant override with regex expressions matching the queries to enable. #10460 #10603 #10621
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [ENHANCEMENT] Distributor, querier, ingester and store-gateway: Add support for `limit` parameter for label names and values requests. #10410
 * [ENHANCEMENT] Query-frontend: Allow adjustment of queries looking into the future to a maximum duration with experimental `-query-frontend.max-future-query-window` flag. #10547
 * [ENHANCEMENT] Ruler: Adds support for filtering results from rule status endpoint by `file[]`, `rule_group[]` and `rule_name[]`. #10589
-* [ENHANCEMENT] Query-frontend: Add option to "spin off" subqueries as actual range queries. To enable this, set the `-query-frontend.spin-off-instant-subqueries-to-url=<url>` option on the frontend and the `instant_queries_with_subquery_spin_off` per-tenant override with regular expressions matching the queries to enable. #10460 #10603 #10621
+* [ENHANCEMENT] Query-frontend: Add option to "spin off" subqueries as actual range queries, so that they benefit from query acceleration techniques such as sharding, splitting and caching. To enable this, set the `-query-frontend.spin-off-instant-subqueries-to-url=<url>` option on the frontend and the `instant_queries_with_subquery_spin_off` per-tenant override with regular expressions matching the queries to enable. #10460 #10603 #10621
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 * [ENHANCEMENT] Distributor, querier, ingester and store-gateway: Add support for `limit` parameter for label names and values requests. #10410
 * [ENHANCEMENT] Query-frontend: Allow adjustment of queries looking into the future to a maximum duration with experimental `-query-frontend.max-future-query-window` flag. #10547
 * [ENHANCEMENT] Ruler: Adds support for filtering results from rule status endpoint by `file[]`, `rule_group[]` and `rule_name[]`. #10589
-* [ENHANCEMENT] Query-frontend: Add option to "spin off" subqueries as actual range queries. This is enabled by setting the `-query-frontend.spin-off-instant-subqueries-to-url=<url>` option on the frontend and the `instant_queries_with_subquery_spin_off` per-tenant override with regex expressions matching the queries to enable. #10460 #10603 #10621
+* [ENHANCEMENT] Query-frontend: Add option to "spin off" subqueries as actual range queries. To enable this, set the `-query-frontend.spin-off-instant-subqueries-to-url=<url>` option on the frontend and the `instant_queries_with_subquery_spin_off` per-tenant override with regular expressions matching the queries to enable. #10460 #10603 #10621
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277

--- a/pkg/frontend/querymiddleware/astmapper/subquery_spin_off.go
+++ b/pkg/frontend/querymiddleware/astmapper/subquery_spin_off.go
@@ -136,6 +136,11 @@ func (m *subquerySpinOffMapper) MapExpr(expr parser.Expr) (mapped parser.Expr, f
 
 		return downstreamQuery(expr)
 	default:
+		// If we encounter a parallelizable expression, we can pass it through to the downstream execution path.
+		// Querysharding is proven to be fast enough that we don't need to spin off subqueries.
+		if CanParallelize(expr, m.logger) {
+			return downstreamQuery(expr)
+		}
 		// If there's no subquery in the children, we can abort early and pass the expression through to the downstream execution path.
 		if !hasSubqueryInChildren(expr) {
 			return downstreamQuery(expr)

--- a/pkg/frontend/querymiddleware/astmapper/subquery_spin_off_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/subquery_spin_off_test.go
@@ -259,6 +259,13 @@ func TestSubquerySpinOffMapper(t *testing.T) {
 			expectedSubqueries:        1,
 			expectedDownstreamQueries: 1,
 		},
+		{
+			name:                      "prioritize query sharding",
+			in:                        "sum by (group_1) (avg_over_time(rate(hello{}[3d])[1d:1m]))",
+			out:                       `__downstream_query__{__query__="sum by (group_1) (avg_over_time(rate(hello[3d])[1d:1m]))"}`,
+			expectedSubqueries:        0,
+			expectedDownstreamQueries: 1,
+		},
 	} {
 		tt := tt
 

--- a/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
@@ -86,40 +86,40 @@ func TestSubquerySpinOff_Correctness(t *testing.T) {
 					)`,
 			expectedSpunOffSubqueries: 1,
 		},
-		"sum of subquery min": {
-			query:                     `sum by(group_1) (min_over_time((changes(metric_counter[5m]))[2d:2m]))`,
+		"subquery min 2": {
+			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
 			expectedSpunOffSubqueries: 1,
 		},
-		"sum of subquery min with small offset": {
-			query:                     `sum by(group_1) (min_over_time((changes(metric_counter[5m]))[1d:1m] offset 20s))`,
+		"subquery min with small offset": {
+			query:                     `min_over_time((changes(metric_counter[5m]))[1d:1m] offset 20s)`,
 			expectedSpunOffSubqueries: 1,
 		},
-		"sum of subquery min with offset": {
-			query:                     `sum by(group_1) (min_over_time((changes(metric_counter[5m]))[1d:1m] offset 1d))`,
+		"subquery min with offset": {
+			query:                     `min_over_time((changes(metric_counter[5m]))[1d:1m] offset 1d)`,
 			expectedSpunOffSubqueries: 1,
 		},
-		"sum of subquery min: offset query time -10m": {
-			query:                     `sum by(group_1) (min_over_time((changes(metric_counter[5m]))[2d:2m]))`,
+		"subquery min: offset query time -10m": {
+			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
 			expectedSpunOffSubqueries: 1,
 			offsetQueryTime:           -10 * time.Minute,
 		},
-		"sum of subquery min: offset query time +10m": {
-			query:                     `sum by(group_1) (min_over_time((changes(metric_counter[5m]))[2d:2m]))`,
+		"subquery min: offset query time +10m": {
+			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
 			expectedSpunOffSubqueries: 1,
 			offsetQueryTime:           10 * time.Minute,
 		},
-		"sum of subquery min: offset query time -33s": {
-			query:                     `sum by(group_1) (min_over_time((changes(metric_counter[5m]))[2d:2m]))`,
+		"subquery min: offset query time -33s": {
+			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
 			expectedSpunOffSubqueries: 1,
 			offsetQueryTime:           -33 * time.Second,
 		},
-		"sum of subquery min: offset query time +33s": {
-			query:                     `sum by(group_1) (min_over_time((changes(metric_counter[5m]))[2d:2m]))`,
+		"subquery min: offset query time +33s": {
+			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
 			expectedSpunOffSubqueries: 1,
 			offsetQueryTime:           33 * time.Second,
 		},
-		"sum of subquery min: offset query time +1h": {
-			query:                     `sum by(group_1) (min_over_time((changes(metric_counter[5m]))[2d:2m]))`,
+		"subquery min: offset query time +1h": {
+			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
 			expectedSpunOffSubqueries: 1,
 			offsetQueryTime:           1 * time.Hour,
 		},


### PR DESCRIPTION
In cases where we aggregate the results of a subquery, sharding is faster in some cases, slower in some. Overall, the impact of the feature seems to be near-zero.

Since:
- we're not gaining anything
- subquery spin-off is the newer feature, and it would be preferrable not to introduce a regression on existing queries
- subquery spin-off has an additional overhead of running a second query

I think we can give query sharding the priority

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
