### PR TITLE
fix: increment error caching counter when trace not sampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277
-* [BUGFIX] Query-frontend: Fix an issue where transient errors could be inadvertently cached. #10537
+* [BUGFIX] Query-frontend: Fix an issue where transient errors could be inadvertently cached. #10537 #10631
 * [BUGFIX] Ruler: fix indeterminate rules being always run concurrently (instead of never) when `-ruler.max-independent-rule-evaluation-concurrency` is set. https://github.com/prometheus/prometheus/pull/15560 #10258
 * [BUGFIX] PromQL: Fix various UTF-8 bugs related to quoting. https://github.com/prometheus/prometheus/pull/15531 #10258
 * [BUGFIX] Ruler: Fixed an issue when using the experimental `-ruler.max-independent-rule-evaluation-concurrency` feature, where if a rule group was eligible for concurrency, it would flap between running concurrently or not based on the time it took after running concurrently. #9726 #10189

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277
-* [BUGFIX] Query-frontend: Fix an issue where transient errors could be inadvertently cached. #10537 #10631
+* [BUGFIX] Query-frontend: Fix an issue where transient errors are inadvertently cached. #10537 #10631
 * [BUGFIX] Ruler: fix indeterminate rules being always run concurrently (instead of never) when `-ruler.max-independent-rule-evaluation-concurrency` is set. https://github.com/prometheus/prometheus/pull/15560 #10258
 * [BUGFIX] PromQL: Fix various UTF-8 bugs related to quoting. https://github.com/prometheus/prometheus/pull/15531 #10258
 * [BUGFIX] Ruler: Fixed an issue when using the experimental `-ruler.max-independent-rule-evaluation-concurrency` feature, where if a rule group was eligible for concurrency, it would flap between running concurrently or not based on the time it took after running concurrently. #9726 #10189

--- a/pkg/frontend/querymiddleware/error_caching.go
+++ b/pkg/frontend/querymiddleware/error_caching.go
@@ -195,8 +195,10 @@ func (e *errorCachingHandler) isCacheable(apiErr *apierror.APIError) (bool, stri
 }
 
 func addWithExemplar(ctx context.Context, counter prometheus.Counter, val float64) {
-	// TODO: Add this to dskit as instrument.AddWithExemplar just like instrument.ObserveWithExemplar
 	if traceID, traceOK := tracing.ExtractSampledTraceID(ctx); traceOK {
 		counter.(prometheus.ExemplarAdder).AddWithExemplar(val, prometheus.Labels{"trace_id": traceID, "traceID": traceID})
+	} else {
+		// If there is no trace ID, just add to the counter.
+		counter.Add(val)
 	}
 }


### PR DESCRIPTION
#### What this PR does

Fixes an issue introduced in  where a counter was only incremented when a particular trace was sampled instead of always.

#### Which issue(s) this PR fixes or relates to

Related #10537

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
