### PR TITLE
block-builder: Proactively consume on startup

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -250,17 +250,12 @@ func (b *BlockBuilder) stoppingStandaloneMode(_ error) error {
 // where we consume from statically assigned partitions.
 func (b *BlockBuilder) runningStandaloneMode(ctx context.Context) error {
 	// Do initial consumption on start using current time as the point up to which we are consuming.
-	// To avoid small blocks at startup, we consume until the <consume interval> boundary + buffer.
+	// The cycle end time on startup is the last consumption time w.r.t. the current time.
+	// Examples for interval=1h, buffer=15m:
+	//   (1) current time is 14:12, cycle end is 13:15
+	//   (2) current time is 14:17, cycle end is 14:15
 	cycleEndTime := cycleEndAtStartup(time.Now(), b.cfg.ConsumeInterval, b.cfg.ConsumeIntervalBuffer)
-	err := b.nextConsumeCycle(ctx, cycleEndTime)
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			return nil
-		}
-		return err
-	}
-
-	cycleEndTime, waitDur := nextCycleEnd(cycleEndTime, b.cfg.ConsumeInterval, b.cfg.ConsumeIntervalBuffer)
+	var waitDur time.Duration
 	for {
 		select {
 		case <-time.After(waitDur):
@@ -282,8 +277,7 @@ func (b *BlockBuilder) runningStandaloneMode(ctx context.Context) error {
 	}
 }
 
-// cycleEndAtStartup returns the timestamp of the first cycleEnd relative to the start time t.
-// One cycle is a duration of one interval plus extra time buffer.
+// cycleEndAtStartup returns the timestamp of the last cycleEnd that is <=t.
 func cycleEndAtStartup(t time.Time, interval, buffer time.Duration) time.Time {
 	cycleEnd := t.Truncate(interval).Add(buffer)
 	if cycleEnd.After(t) {

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -260,7 +260,7 @@ func (b *BlockBuilder) runningStandaloneMode(ctx context.Context) error {
 		return err
 	}
 
-	cycleEndTime, waitDur := nextCycleEnd(time.Now(), b.cfg.ConsumeInterval, b.cfg.ConsumeIntervalBuffer)
+	cycleEndTime, waitDur := nextCycleEnd(cycleEndTime, b.cfg.ConsumeInterval, b.cfg.ConsumeIntervalBuffer)
 	for {
 		select {
 		case <-time.After(waitDur):


### PR DESCRIPTION
#### What this PR does

Here is an example of the issue this PR fixes, copy pasted from @narqo's message:

1. Block builder restarted around 10:10
2. It has been catching up until 10:17
3. because of (1) and (2) it skipped that cycle at 10:15
4. At 11:15 it woke up, and had to process two hours of work in one cycle (it managed, but the alert fired for NoCycleProcessing)

With this change, we will proactively consume the cycle of 10:15 on startup. This change is hard to test because of `time.Now()` in the picture. I think it is fine to not write a test for this specific thing.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
