### PR TITLE
Add warning alert for too high distributor GC CPU utilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@
 * [ENHANCEMENT] Dashboards: add ingester and store-gateway panels showing only requests from the respective dashboard's query path to the 'Reads' and 'Remote ruler reads' dashboards. For example, the 'Remote ruler reads' dashboard now has panels showing the ingester query request rate from ruler-queriers. #10598
 * [ENHANCEMENT] Dashboards: 'Writes' dashboard: show write requests broken down by request type. #10599
 * [ENHANCEMENT] Dashboards: clarify when query-frontend and query-scheduler dashboard panels are expected to show no data. #10624
-* [ENHANCEMENT] Alerts: Add warning and critical versions of alert `DistributorGcUsesTooMuchCpu`. #10641
+* [ENHANCEMENT] Alerts: Add warning alert `DistributorGcUsesTooMuchCpu`. #10641
 * [BUGFIX] Dashboards: fix how we switch between classic and native histograms. #10018
 * [BUGFIX] Alerts: Ignore cache errors performing `delete` operations since these are expected to fail when keys don't exist. #10287
 * [BUGFIX] Dashboards: fix "Mimir / Rollout Progress" latency comparison when gateway is enabled. #10495

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
 * [ENHANCEMENT] Ingester: Add reactive concurrency limiters to protect push and read operations from overload. #10574
 * [ENHANCEMENT] Compactor: Add experimental `-compactor.max-lookback` option to limit blocks considered in each compaction cycle. Blocks uploaded prior to the lookback period aren't processed. This option helps reduce CPU utilization in tenants with large block metadata files that are processed before each compaction. #10585
 * [ENHANCEMENT] Distributor: Optionally expose the current HA replica for each tenant in the `cortex_ha_tracker_elected_replica_status` metric. This is enabled with the `-distributor.ha-tracker.enable-elected-replica-metric=true` flag. #10644
+* [ENHANCEMENT] Enable three Go runtime metrics: #10641
+  * `go_cpu_classes_gc_total_cpu_seconds_total`
+  * `go_cpu_classes_total_cpu_seconds_total`
+  * `go_cpu_classes_idle_cpu_seconds_total`
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277
@@ -78,6 +82,7 @@
 * [ENHANCEMENT] Dashboards: add ingester and store-gateway panels showing only requests from the respective dashboard's query path to the 'Reads' and 'Remote ruler reads' dashboards. For example, the 'Remote ruler reads' dashboard now has panels showing the ingester query request rate from ruler-queriers. #10598
 * [ENHANCEMENT] Dashboards: 'Writes' dashboard: show write requests broken down by request type. #10599
 * [ENHANCEMENT] Dashboards: clarify when query-frontend and query-scheduler dashboard panels are expected to show no data. #10624
+* [ENHANCEMENT] Alerts: Add warning and critical versions of alert `DistributorGcUsesTooMuchCpu`. #10641
 * [BUGFIX] Dashboards: fix how we switch between classic and native histograms. #10018
 * [BUGFIX] Alerts: Ignore cache errors performing `delete` operations since these are expected to fail when keys don't exist. #10287
 * [BUGFIX] Dashboards: fix "Mimir / Rollout Progress" latency comparison when gateway is enabled. #10495

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -163,6 +163,15 @@ How to **fix** it:
 1. Ensure shuffle-sharding is enabled in the Mimir cluster
 1. Assuming shuffle-sharding is enabled, scaling up ingesters will lower the number of tenants per ingester. However, the effect of this change will be visible only after `-blocks-storage.tsdb.close-idle-tsdb-timeout` period so you may have to temporarily increase the limit
 
+### MimirDistributorGcUsesTooMuchCpu
+
+This alert fires when distributors spend too much CPU time on garbage collection.
+This should be a symptom of GOMEMLIMIT being set too low, so GC gets triggered too frequently.
+
+How to **fix** it:
+
+1. Ensure that distributor horizontal pod auto-scaling works properly, so that distributors are scaled out horizontally in response to CPU pressure.
+
 ### MimirDistributorReachingInflightPushRequestLimit
 
 This alert fires when the `cortex_distributor_inflight_push_requests` per distributor instance limit is enabled and the actual number of in-flight push requests is approaching the set limit. Once the limit is reached, push requests to the distributor will fail (5xx) for new requests, while existing in-flight push requests will continue to succeed.

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -166,7 +166,7 @@ How to **fix** it:
 ### MimirDistributorGcUsesTooMuchCpu
 
 This alert fires when distributors spend too much CPU time on garbage collection.
-This should be a symptom of GOMEMLIMIT being set too low, so GC gets triggered too frequently.
+This is a symptom of setting GOMEMLIMIT too low, so GC is triggered too frequently.
 
 How to **fix** it:
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -983,7 +983,7 @@ spec:
         rules:
           - alert: MimirDistributorGcUsesTooMuchCpu
             annotations:
-              message: Mimir Distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+              message: Mimir distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
             expr: |
               (quantile by (cluster, namespace) (0.9, sum by (cluster, namespace, pod) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -983,36 +983,23 @@ spec:
         rules:
           - alert: MimirDistributorGcUsesTooMuchCpu
             annotations:
-              message: Mimir Distributor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+              message: Mimir Distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
             expr: |
-              (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
+              (quantile by (cluster, namespace) (0.9, sum by (cluster, namespace, pod) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
                 /
                 (
-                  sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
+                  sum by (cluster, namespace, pod) (rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
                   -
-                  sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
+                  sum by (cluster, namespace, pod) (rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
                 )
               ) * 100) > 10
+  
+              # Alert only for namespaces with Mimir clusters.
+              and (count by (cluster, namespace) (mimir_build_info) > 0)
             for: 10m
             labels:
               severity: warning
-          - alert: MimirDistributorGcUsesTooMuchCpu
-            annotations:
-              message: Mimir Distributor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
-            expr: |
-              (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
-                /
-                (
-                  sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
-                  -
-                  sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
-                )
-              ) * 100) > 20
-            for: 10m
-            labels:
-              severity: critical
       - name: mimir_autoscaling
         rules:
           - alert: MimirAutoscalerNotActive

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -979,6 +979,40 @@ spec:
             for: 30m
             labels:
               severity: critical
+      - name: mimir_distributor_alerts
+        rules:
+          - alert: MimirDistributorGcUsesTooMuchCpu
+            annotations:
+              message: Mimir Distributor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
+            expr: |
+              (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
+                /
+                (
+                  sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
+                  -
+                  sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
+                )
+              ) * 100) > 10
+            for: 10m
+            labels:
+              severity: warning
+          - alert: MimirDistributorGcUsesTooMuchCpu
+            annotations:
+              message: Mimir Distributor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
+            expr: |
+              (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
+                /
+                (
+                  sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
+                  -
+                  sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
+                )
+              ) * 100) > 20
+            for: 10m
+            labels:
+              severity: critical
       - name: mimir_autoscaling
         rules:
           - alert: MimirAutoscalerNotActive

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -953,6 +953,40 @@ groups:
           for: 30m
           labels:
             severity: critical
+    - name: mimir_distributor_alerts
+      rules:
+        - alert: MimirDistributorGcUsesTooMuchCpu
+          annotations:
+            message: Mimir Distributor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
+          expr: |
+            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
+              /
+              (
+                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
+                -
+                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
+              )
+            ) * 100) > 10
+          for: 10m
+          labels:
+            severity: warning
+        - alert: MimirDistributorGcUsesTooMuchCpu
+          annotations:
+            message: Mimir Distributor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
+          expr: |
+            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
+              /
+              (
+                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
+                -
+                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
+              )
+            ) * 100) > 20
+          for: 10m
+          labels:
+            severity: critical
     - name: mimir_autoscaling
       rules:
         - alert: MimirAutoscalerNotActive

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -957,7 +957,7 @@ groups:
       rules:
         - alert: MimirDistributorGcUsesTooMuchCpu
           annotations:
-            message: Mimir Distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+            message: Mimir distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
           expr: |
             (quantile by (cluster, namespace) (0.9, sum by (cluster, namespace, instance) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -957,36 +957,23 @@ groups:
       rules:
         - alert: MimirDistributorGcUsesTooMuchCpu
           annotations:
-            message: Mimir Distributor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+            message: Mimir Distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
           expr: |
-            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
+            (quantile by (cluster, namespace) (0.9, sum by (cluster, namespace, instance) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
               /
               (
-                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
+                sum by (cluster, namespace, instance) (rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
                 -
-                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
+                sum by (cluster, namespace, instance) (rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
               )
             ) * 100) > 10
+
+            # Alert only for namespaces with Mimir clusters.
+            and (count by (cluster, namespace) (mimir_build_info) > 0)
           for: 10m
           labels:
             severity: warning
-        - alert: MimirDistributorGcUsesTooMuchCpu
-          annotations:
-            message: Mimir Distributor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
-          expr: |
-            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
-              /
-              (
-                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
-                -
-                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
-              )
-            ) * 100) > 20
-          for: 10m
-          labels:
-            severity: critical
     - name: mimir_autoscaling
       rules:
         - alert: MimirAutoscalerNotActive

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -971,7 +971,7 @@ groups:
       rules:
         - alert: MimirDistributorGcUsesTooMuchCpu
           annotations:
-            message: Mimir Distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+            message: Mimir distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
           expr: |
             (quantile by (cluster, namespace) (0.9, sum by (cluster, namespace, pod) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -971,36 +971,23 @@ groups:
       rules:
         - alert: MimirDistributorGcUsesTooMuchCpu
           annotations:
-            message: Mimir Distributor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+            message: Mimir Distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
           expr: |
-            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
+            (quantile by (cluster, namespace) (0.9, sum by (cluster, namespace, pod) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
               /
               (
-                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
+                sum by (cluster, namespace, pod) (rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
                 -
-                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
+                sum by (cluster, namespace, pod) (rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
               )
             ) * 100) > 10
+
+            # Alert only for namespaces with Mimir clusters.
+            and (count by (cluster, namespace) (mimir_build_info) > 0)
           for: 10m
           labels:
             severity: warning
-        - alert: MimirDistributorGcUsesTooMuchCpu
-          annotations:
-            message: Mimir Distributor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
-          expr: |
-            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
-              /
-              (
-                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
-                -
-                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
-              )
-            ) * 100) > 20
-          for: 10m
-          labels:
-            severity: critical
     - name: mimir_autoscaling
       rules:
         - alert: MimirAutoscalerNotActive

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -967,6 +967,40 @@ groups:
           for: 30m
           labels:
             severity: critical
+    - name: mimir_distributor_alerts
+      rules:
+        - alert: MimirDistributorGcUsesTooMuchCpu
+          annotations:
+            message: Mimir Distributor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
+          expr: |
+            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
+              /
+              (
+                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
+                -
+                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
+              )
+            ) * 100) > 10
+          for: 10m
+          labels:
+            severity: warning
+        - alert: MimirDistributorGcUsesTooMuchCpu
+          annotations:
+            message: Mimir Distributor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
+          expr: |
+            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
+              /
+              (
+                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[5m]))
+                -
+                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[5m]))
+              )
+            ) * 100) > 20
+          for: 10m
+          labels:
+            severity: critical
     - name: mimir_autoscaling
       rules:
         - alert: MimirAutoscalerNotActive

--- a/operations/mimir-mixin/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts.libsonnet
@@ -5,6 +5,7 @@
     (import 'alerts/alertmanager.libsonnet') +
     (import 'alerts/blocks.libsonnet') +
     (import 'alerts/compactor.libsonnet') +
+    (import 'alerts/distributor.libsonnet') +
     (import 'alerts/autoscaling.libsonnet') +
     (if $._config.ingest_storage_enabled then import 'alerts/ingest-storage.libsonnet' else {}) +
     (import 'alerts/continuous-test.libsonnet'),

--- a/operations/mimir-mixin/alerts/distributor.libsonnet
+++ b/operations/mimir-mixin/alerts/distributor.libsonnet
@@ -8,22 +8,25 @@
           alert: $.alertName('DistributorGcUsesTooMuchCpu'),
           'for': '10m',
           expr: |||
-            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+            (quantile by (%(alert_aggregation_labels)s) (0.9, sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
               /
               (
-                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+                sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
                 -
-                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+                sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
               )
             ) * 100) > 10
-          ||| % {
+
+            # Alert only for namespaces with Mimir clusters.
+            and (count by (cluster, namespace) (mimir_build_info) > 0)
+          ||| % $._config {
             range_interval: $.alertRangeInterval(5),
           },
           labels: {
             severity: 'warning',
           },
           annotations: {
-            message: '%(product)s Distributor %(alert_instance_variable)s in %(alert_aggregation_variables)s GC CPU utilization is too high.' % $._config,
+            message: '%(product)s Distributors in %(alert_aggregation_variables)s GC CPU utilization is too high.' % $._config,
           },
         },
       ],

--- a/operations/mimir-mixin/alerts/distributor.libsonnet
+++ b/operations/mimir-mixin/alerts/distributor.libsonnet
@@ -18,7 +18,7 @@
             ) * 100) > 10
 
             # Alert only for namespaces with Mimir clusters.
-            and (count by (cluster, namespace) (mimir_build_info) > 0)
+            and (count by (%(alert_aggregation_labels)s) (mimir_build_info) > 0)
           ||| % $._config {
             range_interval: $.alertRangeInterval(5),
           },

--- a/operations/mimir-mixin/alerts/distributor.libsonnet
+++ b/operations/mimir-mixin/alerts/distributor.libsonnet
@@ -26,7 +26,7 @@
             severity: 'warning',
           },
           annotations: {
-            message: '%(product)s Distributors in %(alert_aggregation_variables)s GC CPU utilization is too high.' % $._config,
+            message: '%(product)s distributors in %(alert_aggregation_variables)s GC CPU utilization is too high.' % $._config,
           },
         },
       ],

--- a/operations/mimir-mixin/alerts/distributor.libsonnet
+++ b/operations/mimir-mixin/alerts/distributor.libsonnet
@@ -26,29 +26,6 @@
             message: '%(product)s Distributor %(alert_instance_variable)s in %(alert_aggregation_variables)s GC CPU utilization is too high.' % $._config,
           },
         },
-        {
-          // Alert if distributor GC CPU utilization is too high.
-          alert: $.alertName('DistributorGcUsesTooMuchCpu'),
-          'for': '10m',
-          expr: |||
-            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
-              /
-              (
-                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
-                -
-                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
-              )
-            ) * 100) > 20
-          ||| % {
-            range_interval: $.alertRangeInterval(5),
-          },
-          labels: {
-            severity: 'critical',
-          },
-          annotations: {
-            message: '%(product)s Distributor %(alert_instance_variable)s in %(alert_aggregation_variables)s GC CPU utilization is too high.' % $._config,
-          },
-        },
       ],
     },
   ],

--- a/operations/mimir-mixin/alerts/distributor.libsonnet
+++ b/operations/mimir-mixin/alerts/distributor.libsonnet
@@ -1,0 +1,57 @@
+(import 'alerts-utils.libsonnet') {
+  local alertGroups = [
+    {
+      name: 'mimir_distributor_alerts',
+      rules: [
+        {
+          // Alert if distributor GC CPU utilization is too high.
+          alert: $.alertName('DistributorGcUsesTooMuchCpu'),
+          'for': '10m',
+          expr: |||
+            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+              /
+              (
+                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+                -
+                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+              )
+            ) * 100) > 10
+          ||| % {
+            range_interval: $.alertRangeInterval(5),
+          },
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s Distributor %(alert_instance_variable)s in %(alert_aggregation_variables)s GC CPU utilization is too high.' % $._config,
+          },
+        },
+        {
+          // Alert if distributor GC CPU utilization is too high.
+          alert: $.alertName('DistributorGcUsesTooMuchCpu'),
+          'for': '10m',
+          expr: |||
+            (quantile(0.9, sum(rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+              /
+              (
+                sum(rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+                -
+                sum(rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+              )
+            ) * 100) > 20
+          ||| % {
+            range_interval: $.alertRangeInterval(5),
+          },
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: '%(product)s Distributor %(alert_instance_variable)s in %(alert_aggregation_variables)s GC CPU utilization is too high.' % $._config,
+          },
+        },
+      ],
+    },
+  ],
+
+  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
+}

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -817,6 +817,12 @@ func setUpGoRuntimeMetrics(cfg Config, reg prometheus.Registerer) {
 	rules := []collectors.GoRuntimeMetricsRule{
 		// Enable the mutex wait time metric.
 		{Matcher: goregexp.MustCompile(`^/sync/mutex/wait/total:seconds$`)},
+		// Enable the GC total CPU time metric.
+		{Matcher: goregexp.MustCompile(`^/cpu/classes/gc/total:cpu-seconds$`)},
+		// Enable the total available CPU time metric.
+		{Matcher: goregexp.MustCompile(`^/cpu/classes/total:cpu-seconds$`)},
+		// Enable the total idle CPU time metric.
+		{Matcher: goregexp.MustCompile(`^/cpu/classes/idle:cpu-seconds$`)},
 	}
 
 	if cfg.EnableGoRuntimeMetrics {


### PR DESCRIPTION
#### What this PR does

Add a warning severity alert for too high distributor garbage collection CPU utilization. The motivation is to be alerted if `GOMEMLIMIT` causes distributors to garbage collect too often.

Additionally, enable three CPU runtime metrics required by the alerts:

* `/cpu/classes/gc/total:cpu-seconds`
* `/cpu/classes/total:cpu-seconds`
* `/cpu/classes/idle:cpu-seconds`

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
