### PR TITLE
[Docs] Remove deprecated config: align_queries_with_step

### DIFF
--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3602,11 +3602,6 @@ The `limits` block configures default and per-tenant limits imposed by component
 # (experimental) List of http requests to block.
 [blocked_requests: <blocked_requests_config...> | default = ]
 
-# Mutate incoming queries to align their start and end with their step to
-# improve result caching.
-# CLI flag: -query-frontend.align-queries-with-step
-[align_queries_with_step: <boolean> | default = false]
-
 # (experimental) Enable certain experimental PromQL functions, which are subject
 # to being changed or removed at any time, on a per-tenant basis. Defaults to
 # empty which means all experimental functions are disabled. Set to 'all' to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Remove deprecated config that was removed since 2.14. 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
