### PR TITLE
mixin: add alert for GEM's federation-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * [ENHANCEMENT] Dashboards: add ingester and store-gateway panels showing only requests from the respective dashboard's query path to the 'Reads' and 'Remote ruler reads' dashboards. For example, the 'Remote ruler reads' dashboard now has panels showing the ingester query request rate from ruler-queriers. #10598
 * [ENHANCEMENT] Dashboards: 'Writes' dashboard: show write requests broken down by request type. #10599
 * [ENHANCEMENT] Dashboards: clarify when query-frontend and query-scheduler dashboard panels are expected to show no data. #10624
+* [ENHANCEMENT] Alerts: Add GEM alerts for federation-frontend component. This is now included in the default compiled mixin. Set `_config.gem_enabled: false` to disable the mixin. 
 * [BUGFIX] Dashboards: fix how we switch between classic and native histograms. #10018
 * [BUGFIX] Alerts: Ignore cache errors performing `delete` operations since these are expected to fail when keys don't exist. #10287
 * [BUGFIX] Dashboards: fix "Mimir / Rollout Progress" latency comparison when gateway is enabled. #10495

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@
 * [ENHANCEMENT] Dashboards: add ingester and store-gateway panels showing only requests from the respective dashboard's query path to the 'Reads' and 'Remote ruler reads' dashboards. For example, the 'Remote ruler reads' dashboard now has panels showing the ingester query request rate from ruler-queriers. #10598
 * [ENHANCEMENT] Dashboards: 'Writes' dashboard: show write requests broken down by request type. #10599
 * [ENHANCEMENT] Dashboards: clarify when query-frontend and query-scheduler dashboard panels are expected to show no data. #10624
-* [ENHANCEMENT] Alerts: Add GEM alerts for federation-frontend component. This is now included in the default compiled mixin. Set `_config.gem_enabled: false` to disable the mixin. 
+* [ENHANCEMENT] Alerts: Add GEM alerts for federation-frontend component. This is now included in the default compiled mixin. Set `_config.gem_enabled: false` to disable the mixin. #10643
 * [BUGFIX] Dashboards: fix how we switch between classic and native histograms. #10018
 * [BUGFIX] Alerts: Ignore cache errors performing `delete` operations since these are expected to fail when keys don't exist. #10287
 * [BUGFIX] Dashboards: fix "Mimir / Rollout Progress" latency comparison when gateway is enabled. #10495

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1477,6 +1477,16 @@ How to **investigate** and **fix** it:
 
   - After the resizing process finishes, revert this change.
 
+### MimirFederationFrontendRemoteClusterErrors
+
+This alert fires when the GEM component federation-frontend is experiencing errors from remote clusters.
+
+How to **investigate**:
+
+- Check the federation frontend logs to find more details about the error.
+- Check if there are alerts firing for the downstream clusters.
+- Check the federation frontend configuration to ensure it's correctly configured to talk to the downstream clusters.
+
 ## Mimir ingest storage (experimental)
 
 This section contains runbooks for alerts related to experimental Mimir ingest storage.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1212,6 +1212,22 @@ spec:
               sum by (cluster, namespace, pod) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
             labels:
               severity: critical
+      - name: gem_alerts
+        rules:
+          - alert: MimirFederationFrontendRemoteClusterErrors
+            annotations:
+              message: Upstream clusters are returning more than 1%% errors over 15 minutes.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirfederationfrontendremoteclustererrors
+            expr: |
+              100 * (
+                sum(rate(cortex_federation_frontend_cluster_remote_latency_seconds_count{status="server_error"}[1m]))
+                /
+                sum(rate(cortex_federation_frontend_cluster_remote_latency_seconds_count[1m]))
+              ) > 1
+            for: 15m
+            labels:
+              service: federation-frontend
+              severity: critical
       - name: mimir_continuous_test
         rules:
           - alert: MimirContinuousTestNotRunningOnWrites

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1186,6 +1186,22 @@ groups:
             sum by (cluster, namespace, instance) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
           labels:
             severity: critical
+    - name: gem_alerts
+      rules:
+        - alert: MimirFederationFrontendRemoteClusterErrors
+          annotations:
+            message: Upstream clusters are returning more than 1%% errors over 15 minutes.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirfederationfrontendremoteclustererrors
+          expr: |
+            100 * (
+              sum(rate(cortex_federation_frontend_cluster_remote_latency_seconds_count{status="server_error"}[1m]))
+              /
+              sum(rate(cortex_federation_frontend_cluster_remote_latency_seconds_count[1m]))
+            ) > 1
+          for: 15m
+          labels:
+            service: federation-frontend
+            severity: critical
     - name: mimir_continuous_test
       rules:
         - alert: MimirContinuousTestNotRunningOnWrites

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1200,6 +1200,22 @@ groups:
             sum by (cluster, namespace, pod) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
           labels:
             severity: critical
+    - name: gem_alerts
+      rules:
+        - alert: MimirFederationFrontendRemoteClusterErrors
+          annotations:
+            message: Upstream clusters are returning more than 1%% errors over 15 minutes.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirfederationfrontendremoteclustererrors
+          expr: |
+            100 * (
+              sum(rate(cortex_federation_frontend_cluster_remote_latency_seconds_count{status="server_error"}[1m]))
+              /
+              sum(rate(cortex_federation_frontend_cluster_remote_latency_seconds_count[1m]))
+            ) > 1
+          for: 15m
+          labels:
+            service: federation-frontend
+            severity: critical
     - name: mimir_continuous_test
       rules:
         - alert: MimirContinuousTestNotRunningOnWrites

--- a/operations/mimir-mixin/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts.libsonnet
@@ -7,5 +7,6 @@
     (import 'alerts/compactor.libsonnet') +
     (import 'alerts/autoscaling.libsonnet') +
     (if $._config.ingest_storage_enabled then import 'alerts/ingest-storage.libsonnet' else {}) +
+    (if $._config.gem_enabled then import 'alerts/gem.libsonnet' else {}) +
     (import 'alerts/continuous-test.libsonnet'),
 }

--- a/operations/mimir-mixin/alerts/gem.libsonnet
+++ b/operations/mimir-mixin/alerts/gem.libsonnet
@@ -1,0 +1,29 @@
+(import 'alerts-utils.libsonnet') {
+  local alertGroups = if !$._config.gem_enabled then [] else [
+    {
+      name: 'gem_alerts',
+      rules: [
+        {
+          alert: $.alertName('FederationFrontendRemoteClusterErrors'),
+          expr: |||
+            100 * (
+              sum(rate(cortex_federation_frontend_cluster_remote_latency_seconds_count{status="server_error"}[%(rate_interval)s]))
+              /
+              sum(rate(cortex_federation_frontend_cluster_remote_latency_seconds_count[%(rate_interval)s]))
+            ) > 1
+          ||| % { rate_interval: $.alertRangeInterval(1) },
+          'for': '15m',
+          labels: {
+            severity: 'critical',
+            service: 'federation-frontend',
+          },
+          annotations: {
+            message: 'Upstream clusters are returning more than 1%% errors over 15 minutes.',
+          },
+        },
+      ],
+    },
+  ],
+
+  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
+}

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -6,6 +6,9 @@
     // The product name used when building dashboards.
     product: 'Mimir',
 
+    // Enable GEM alerts.
+    gem_enabled: false,
+
     // The prefix including product name used when building dashboards.
     dashboard_prefix: '%(product)s / ' % $._config.product,
     // Controls tooltip and hover highlight behavior across different panels

--- a/operations/mimir-mixin/mixin-compiled.libsonnet
+++ b/operations/mimir-mixin/mixin-compiled.libsonnet
@@ -13,5 +13,6 @@
         enabled: true,
       },
     },
+    gem_enabled: true,
   },
 }


### PR DESCRIPTION
#### What this PR does

Strangely I couldn't find a good place to add GEM-specific alerts. So I'm adding them here. The goal is for them to be available rendered somewhere (`mimir-mixin-compiled`) and allow exporting them in the cloud-onboarding repo (Grafana Cloud integrations) 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
