### PR TITLE
Logging: detect log level through layers of wrappers

### DIFF
--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/middleware"
@@ -37,6 +36,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
+	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -888,7 +888,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 
 			logs := &concurrency.SyncBuffer{}
 			retryConfig := RetryConfig{Enabled: true, MinBackoff: 5 * time.Second, MaxBackoff: 5 * time.Second}
-			handler := OTLPHandler(tt.maxMsgSize, nil, nil, limits, tt.resourceAttributePromotionConfig, retryConfig, false, pusher, nil, nil, level.NewFilter(log.NewLogfmtLogger(logs), level.AllowInfo()))
+			handler := OTLPHandler(tt.maxMsgSize, nil, nil, limits, tt.resourceAttributePromotionConfig, retryConfig, false, pusher, nil, nil, util_log.MakeLeveledLogger(logs, "info"))
 
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -30,10 +30,8 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/kv"
-	dslog "github.com/grafana/dskit/log"
 	dskit_metrics "github.com/grafana/dskit/metrics"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/ring"
@@ -71,6 +69,7 @@ import (
 	"github.com/grafana/mimir/pkg/usagestats"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/globalerror"
+	util_log "github.com/grafana/mimir/pkg/util/log"
 	util_test "github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -11654,10 +11653,7 @@ type loggerWithBuffer struct {
 }
 
 func newLoggerWithCounter(t *testing.T, buf *bytes.Buffer) *loggerWithBuffer {
-	var lvl dslog.Level
-	require.NoError(t, lvl.Set("info"))
-	logger := dslog.NewGoKitWithWriter(dslog.LogfmtFormat, buf)
-	level.NewFilter(logger, lvl.Option)
+	logger := util_log.MakeLeveledLogger(buf, "info")
 	return &loggerWithBuffer{
 		logger: logger,
 		buf:    buf,

--- a/pkg/mimirtool/commands/alerts.go
+++ b/pkg/mimirtool/commands/alerts.go
@@ -19,8 +19,6 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
-	gokitlog "github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/cancellation"
 	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/config"
@@ -35,6 +33,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/mimirtool/client"
 	"github.com/grafana/mimir/pkg/mimirtool/printer"
+	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
 // AlertmanagerCommand configures and executes rule related mimir api operations
@@ -128,7 +127,7 @@ func (a *AlertmanagerCommand) setup(_ *kingpin.ParseContext) error {
 	// warning to stdout. It is possible to disable to fallback, and use just the UTF-8
 	// parser, with the -utf8-strict-mode flag. This will help operators ensure their
 	// configurations are compatible with the new parser going forward.
-	l := level.NewFilter(gokitlog.NewLogfmtLogger(os.Stdout), level.AllowInfo())
+	l := util_log.MakeLeveledLogger(os.Stdout, "info")
 	features := ""
 	if a.UTF8StrictMode {
 		features = featurecontrol.FeatureUTF8StrictMode

--- a/pkg/ruler/mapper_test.go
+++ b/pkg/ruler/mapper_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+
+	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
 var (
@@ -223,8 +224,7 @@ func setupRuleSets() {
 }
 
 func Test_mapper_MapRules(t *testing.T) {
-	l := log.NewLogfmtLogger(os.Stdout)
-	l = level.NewFilter(l, level.AllowInfo())
+	l := util_log.MakeLeveledLogger(os.Stdout, "info")
 	setupRuleSets()
 	m := &mapper{
 		Path:   "/rules",
@@ -280,8 +280,7 @@ func Test_mapper_MapRules(t *testing.T) {
 }
 
 func Test_mapper_MapRulesMultipleFiles(t *testing.T) {
-	l := log.NewLogfmtLogger(os.Stdout)
-	l = level.NewFilter(l, level.AllowInfo())
+	l := util_log.MakeLeveledLogger(os.Stdout, "info")
 	setupRuleSets()
 	m := &mapper{
 		Path:   "/rules",
@@ -351,8 +350,7 @@ func Test_mapper_MapRulesMultipleFiles(t *testing.T) {
 }
 
 func Test_mapper_MapRulesSpecialCharNamespace(t *testing.T) {
-	l := log.NewLogfmtLogger(os.Stdout)
-	l = level.NewFilter(l, level.AllowInfo())
+	l := util_log.MakeLeveledLogger(os.Stdout, "info")
 	setupRuleSets()
 	m := &mapper{
 		Path:   "/rules",

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -39,12 +39,12 @@ func InitLogger(logFormat string, logLevel dslog.Level, buffered bool, rateLimit
 	logger := dslog.NewGoKitWithWriter(logFormat, writer)
 
 	if rateLimitedCfg.Enabled {
-		// use UTC timestamps and skip 6 stack frames if rate limited logger is needed.
-		logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", spanlogger.Caller(6))
+		// use UTC timestamps and skip 7 stack frames if rate limited logger is needed.
+		logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", spanlogger.Caller(7))
 		logger = dslog.NewRateLimitedLogger(logger, rateLimitedCfg.LogsPerSecond, rateLimitedCfg.LogsBurstSize, rateLimitedCfg.Registry)
 	} else {
-		// use UTC timestamps and skip 5 stack frames if no rate limited logger is needed.
-		logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", spanlogger.Caller(5))
+		// use UTC timestamps and skip 6 stack frames if no rate limited logger is needed.
+		logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", spanlogger.Caller(6))
 	}
 	// Must put the level filter last for efficiency.
 	logger = newFilter(logger, logLevel)

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -54,6 +54,17 @@ func InitLogger(logFormat string, logLevel dslog.Level, buffered bool, rateLimit
 	return logger
 }
 
+// MakeLeveledLogger makes a logger wrapped with the same level filter used in the global logger.
+// Intended for use in tests that don't set the global logger.
+func MakeLeveledLogger(writer io.Writer, level string) log.Logger {
+	var logLevel dslog.Level
+	if err := logLevel.Set(level); err != nil {
+		panic(err)
+	}
+	logger := log.NewLogfmtLogger(writer)
+	return newFilter(logger, logLevel)
+}
+
 type logLevel int
 
 const (

--- a/pkg/util/log/slogadapter.go
+++ b/pkg/util/log/slogadapter.go
@@ -12,20 +12,20 @@ import (
 // SlogFromGoKit returns slog adapter for logger.
 func SlogFromGoKit(logger log.Logger) *slog.Logger {
 	var sl slog.Level
-	x, ok := logger.(leveledLogger)
-	if !ok {
+	x := privateLevelDetector{
+		string:   "This struct is expected to be used with levelLogger only",
+		logLevel: debugLevel,
+	}
+	logger.Log("test", &x)
+	switch x.logLevel {
+	case infoLevel:
+		sl = slog.LevelInfo
+	case warnLevel:
+		sl = slog.LevelWarn
+	case errorLevel:
+		sl = slog.LevelError
+	default:
 		sl = slog.LevelDebug
-	} else {
-		switch x.level() {
-		case infoLevel:
-			sl = slog.LevelInfo
-		case warnLevel:
-			sl = slog.LevelWarn
-		case errorLevel:
-			sl = slog.LevelError
-		default:
-			sl = slog.LevelDebug
-		}
 	}
 
 	lvl := slog.LevelVar{}

--- a/pkg/util/log/slogadapter.go
+++ b/pkg/util/log/slogadapter.go
@@ -13,10 +13,11 @@ import (
 func SlogFromGoKit(logger log.Logger) *slog.Logger {
 	var sl slog.Level
 	x := privateLevelDetector{
-		string:   "This struct is expected to be used with levelLogger only",
+		string:   "internal message: if you see this, probably log initialization has gone wrong",
 		logLevel: debugLevel,
 	}
-	logger.Log("test", &x)
+	// This is a probing message; it should reach levelFilter.Log() no matter how many levels of wrapper are around logger.
+	logger.Log("probe", &x)
 	switch x.logLevel {
 	case infoLevel:
 		sl = slog.LevelInfo

--- a/pkg/util/log/slogadapter_test.go
+++ b/pkg/util/log/slogadapter_test.go
@@ -62,6 +62,7 @@ func TestSlogFromGoKit(t *testing.T) {
 
 	t.Run("enabled for the right slog levels when go-kit level not configured", func(t *testing.T) {
 		mLogger := &mockLogger{}
+		mLogger.On("Log", "test", mock.AnythingOfType("*log.privateLevelDetector")).Return(nil) // Probing call from SlogFromGoKit.
 		slogger := SlogFromGoKit(mLogger)
 
 		for _, sl := range slogLevels {
@@ -71,6 +72,7 @@ func TestSlogFromGoKit(t *testing.T) {
 
 	t.Run("wraps go-kit logger", func(*testing.T) {
 		mLogger := &mockLogger{}
+		mLogger.On("Log", "test", mock.AnythingOfType("*log.privateLevelDetector")).Return(nil) // Probing call from SlogFromGoKit.
 		slogger := SlogFromGoKit(mLogger)
 
 		for _, l := range levels {

--- a/pkg/util/log/slogadapter_test.go
+++ b/pkg/util/log/slogadapter_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	dslog "github.com/grafana/dskit/log"
 	"github.com/stretchr/testify/assert"
@@ -90,3 +91,29 @@ func TestSlogFromGoKit(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkSlogFromGoKit(b *testing.B) {
+	// Set up a logger with a stack of wrappers, similar to what tsdb gets.
+	var lvl dslog.Level
+	_ = lvl.Set("info")
+	var logger log.Logger
+	logger = noopLogger{}
+	logger = newFilter(logger, lvl)
+	logger = WithUserID("userID", logger)
+
+	sl := SlogFromGoKit(logger)
+	b.Run("log", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sl.Info("msg", "foo", "bar", "more", "data")
+		}
+	})
+	b.Run("debuglog", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sl.Debug("msg", "foo", "bar", "more", "data")
+		}
+	})
+}
+
+type noopLogger struct{}
+
+func (noopLogger) Log(...interface{}) error { return nil }

--- a/pkg/util/log/slogadapter_test.go
+++ b/pkg/util/log/slogadapter_test.go
@@ -62,7 +62,7 @@ func TestSlogFromGoKit(t *testing.T) {
 
 	t.Run("enabled for the right slog levels when go-kit level not configured", func(t *testing.T) {
 		mLogger := &mockLogger{}
-		mLogger.On("Log", "test", mock.AnythingOfType("*log.privateLevelDetector")).Return(nil) // Probing call from SlogFromGoKit.
+		mLogger.On("Log", "probe", mock.AnythingOfType("*log.privateLevelDetector")).Return(nil) // Probing call from SlogFromGoKit.
 		slogger := SlogFromGoKit(mLogger)
 
 		for _, sl := range slogLevels {
@@ -72,7 +72,7 @@ func TestSlogFromGoKit(t *testing.T) {
 
 	t.Run("wraps go-kit logger", func(*testing.T) {
 		mLogger := &mockLogger{}
-		mLogger.On("Log", "test", mock.AnythingOfType("*log.privateLevelDetector")).Return(nil) // Probing call from SlogFromGoKit.
+		mLogger.On("Log", "probe", mock.AnythingOfType("*log.privateLevelDetector")).Return(nil) // Probing call from SlogFromGoKit.
 		slogger := SlogFromGoKit(mLogger)
 
 		for _, l := range levels {


### PR DESCRIPTION
#### What this PR does

Expose log level through log wrappers, so that `Debug()` calls are fast when debug logging is disabled.

It works by making a `Log()` call so it reaches the bottom layer.

However, if `SlogFromGoKit` is used with a logger outside of this package, you will get a spurious log line.

#### Which issue(s) this PR fixes or relates to

Inspired by https://github.com/prometheus/prometheus/pull/15993

This is a competitor to #10604.  Credit @dimitarvdimitrov for the idea.

Before:
```
BenchmarkSlogFromGoKit/log-28             981555              1176 ns/op            1008 B/op         16 allocs/op
BenchmarkSlogFromGoKit/debuglog-28        949378              1175 ns/op            1008 B/op         16 allocs/op
BenchmarkDebugLog-28                    26430567                44.55 ns/op           96 B/op          2 allocs/op
```

After:
```
BenchmarkSlogFromGoKit/log-28             994729              1165 ns/op            1008 B/op         16 allocs/op
BenchmarkSlogFromGoKit/debuglog-28      358293070                3.342 ns/op           0 B/op          0 allocs/op
BenchmarkDebugLog-28                    24998392                45.67 ns/op           96 B/op          2 allocs/op
```

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

