### PR TITLE
Use new GitHub app in workflows instead of token

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -24,7 +24,7 @@ jobs:
   goversion:
     runs-on: ubuntu-latest
     needs: prepare
-    container: 
+    container:
       image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +46,25 @@ jobs:
       with:
         go-version: ${{ needs.goversion.outputs.version }}
     - uses: helm/kind-action@v1.12.0
+
+    # Retrieve GitHub App Credentials from Vault
+    - name: Retrieve GitHub App Credentials from Vault
+      id: get-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
+      with:
+        repo_secrets: |
+          APP_ID=mimir-github-bot:app_id
+          PRIVATE_KEY=mimir-github-bot:private_key
+
+    # Generate GitHub App Token
+    - name: Generate GitHub App Token
+      id: app-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ steps.get-secrets.outputs.APP_ID }}
+        private-key: ${{ steps.get-secrets.outputs.PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
     - name: Download yq
       uses: dsaltares/fetch-gh-release-asset@1.1.2
       with:
@@ -53,7 +72,8 @@ jobs:
         version: 'tags/v4.30.6'
         file: 'yq_linux_amd64'
         target: 'bin/yq'
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
+
     - name: Download tk
       uses: dsaltares/fetch-gh-release-asset@1.1.2
       with:
@@ -61,7 +81,8 @@ jobs:
         version: 'tags/v0.22.1'
         file: 'tk-linux-amd64'
         target: 'bin/tk'
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
+
     - name: Download jb
       uses: dsaltares/fetch-gh-release-asset@1.1.2
       with:
@@ -69,7 +90,8 @@ jobs:
         version: 'tags/v0.5.1'
         file: 'jb-linux-amd64'
         target: 'bin/jb'
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
+
     - name: Configure dependencies
       run: |
         set -e
@@ -78,11 +100,13 @@ jobs:
         chmod +x $PWD/bin/jb
         echo $PWD/bin >> $GITHUB_PATH
         set +e
+
     - name: Make dependencies
       run: |
         # Make dependencies first to have their output in another step
         make operations/helm/charts/mimir-distributed/charts
         make build-jsonnet-tests
+
     - name: Compare manifests
       id: compare-manifests
       run: |

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -52,6 +52,7 @@ jobs:
       id: get-secrets
       uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
       with:
+        vault_instance: dev
         repo_secrets: |
           APP_ID=mimir-github-bot:app_id
           PRIVATE_KEY=mimir-github-bot:private_key

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -46,26 +46,6 @@ jobs:
       with:
         go-version: ${{ needs.goversion.outputs.version }}
     - uses: helm/kind-action@v1.12.0
-
-    # Retrieve GitHub App Credentials from Vault
-    - name: Retrieve GitHub App Credentials from Vault
-      id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
-      with:
-        vault_instance: dev
-        repo_secrets: |
-          APP_ID=mimir-github-bot:app_id
-          PRIVATE_KEY=mimir-github-bot:private_key
-
-    # Generate GitHub App Token
-    - name: Generate GitHub App Token
-      id: app-token
-      uses: actions/create-github-app-token@v1
-      with:
-        app-id: ${{ steps.get-secrets.outputs.APP_ID }}
-        private-key: ${{ steps.get-secrets.outputs.PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
-
     - name: Download yq
       uses: dsaltares/fetch-gh-release-asset@1.1.2
       with:
@@ -73,8 +53,7 @@ jobs:
         version: 'tags/v4.30.6'
         file: 'yq_linux_amd64'
         target: 'bin/yq'
-        token: ${{ steps.app-token.outputs.token }}
-
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Download tk
       uses: dsaltares/fetch-gh-release-asset@1.1.2
       with:
@@ -82,8 +61,7 @@ jobs:
         version: 'tags/v0.22.1'
         file: 'tk-linux-amd64'
         target: 'bin/tk'
-        token: ${{ steps.app-token.outputs.token }}
-
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Download jb
       uses: dsaltares/fetch-gh-release-asset@1.1.2
       with:
@@ -91,8 +69,7 @@ jobs:
         version: 'tags/v0.5.1'
         file: 'jb-linux-amd64'
         target: 'bin/jb'
-        token: ${{ steps.app-token.outputs.token }}
-
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Configure dependencies
       run: |
         set -e
@@ -101,13 +78,11 @@ jobs:
         chmod +x $PWD/bin/jb
         echo $PWD/bin >> $GITHUB_PATH
         set +e
-
     - name: Make dependencies
       run: |
         # Make dependencies first to have their output in another step
         make operations/helm/charts/mimir-distributed/charts
         make build-jsonnet-tests
-
     - name: Compare manifests
       id: compare-manifests
       run: |

--- a/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
+++ b/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
@@ -11,7 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-jobs: 
+jobs:
   prepare:
     if: github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
@@ -31,30 +31,49 @@ jobs:
     container:
       image: ${{ needs.prepare.outputs.build_image }}
     steps:
+      # Retrieve GitHub App Credentials from Vault
+      - name: Retrieve GitHub App Credentials from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
+        with:
+          vault_instance: dev
+          repo_secrets: |
+            APP_ID=mimir-github-bot:app_id
+            PRIVATE_KEY=mimir-github-bot:private_key
+
+      # Generate GitHub App Token
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.get-secrets.outputs.APP_ID }}
+          private-key: ${{ steps.get-secrets.outputs.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run Git Config
         run: |
           git config --global --add safe.directory '*'
           git config --global user.email "${{ github.event.pull_request.user.login }}@users.noreply.github.com"
           git config --global user.name "${{ github.event.pull_request.user.login }}"
-  
+
       - name: Install the gh cli
         uses: ksivamuthu/actions-setup-gh-cli@v2
 
       - name: Checkout Pull Request Branch
         run: gh pr checkout ${{ github.event.pull_request.number }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Run make targets
         id: update
         run: |
           make BUILD_IN_CONTAINER=false doc build-helm-tests
-      
+
       - name: Check Updates
         id: check_updates
         run: |

--- a/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
+++ b/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
@@ -36,7 +36,6 @@ jobs:
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
         with:
-          vault_instance: dev
           repo_secrets: |
             APP_ID=mimir-github-bot:app_id
             PRIVATE_KEY=mimir-github-bot:private_key

--- a/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
+++ b/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
@@ -36,6 +36,7 @@ jobs:
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
         with:
+          vault_instance: dev
           repo_secrets: |
             APP_ID=mimir-github-bot:app_id
             PRIVATE_KEY=mimir-github-bot:private_key

--- a/.github/workflows/grafanabot_reviewer.yml
+++ b/.github/workflows/grafanabot_reviewer.yml
@@ -18,6 +18,7 @@ jobs:
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
         with:
+          vault_instance: dev
           repo_secrets: |
             APP_ID=mimir-github-bot:app_id
             PRIVATE_KEY=mimir-github-bot:private_key

--- a/.github/workflows/grafanabot_reviewer.yml
+++ b/.github/workflows/grafanabot_reviewer.yml
@@ -1,4 +1,5 @@
 name: Auto-review Grafanabot PRs
+
 on: pull_request_target
 
 permissions:
@@ -10,8 +11,26 @@ jobs:
     runs-on: ubuntu-latest
 
     if: ${{ github.event.pull_request.user.login == 'grafanabot' }}
-    
+
     steps:
+      # Retrieve GitHub App Credentials from Vault for mimir-github-bot
+      - name: Retrieve GitHub App Credentials from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
+        with:
+          repo_secrets: |
+            APP_ID=mimir-github-bot:app_id
+            PRIVATE_KEY=mimir-github-bot:private_key
+
+      # Generate GitHub App Token for PR approval and auto-merge
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.get-secrets.outputs.APP_ID }}
+          private-key: ${{ steps.get-secrets.outputs.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout Repository
         uses: actions/checkout@v4
 
@@ -23,8 +42,8 @@ jobs:
           gh pr review $PR_URL \
           --approve -b "**I'm approving** this pull request, since it is a helm release."
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Manual review is required
         if: steps.auto-merge.conclusion != 'success'
@@ -32,5 +51,5 @@ jobs:
           gh pr comment $PR_URL --body "**This PR from grafanabot requires manual review.**"
 
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -26,10 +26,28 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      # Retrieve GitHub App Credentials from Vault
+      - name: Retrieve GitHub App Credentials from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
+        with:
+          repo_secrets: |
+            APP_ID=mimir-github-bot:app_id
+            PRIVATE_KEY=mimir-github-bot:private_key
+
+      # Generate GitHub App Token
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.get-secrets.outputs.APP_ID }}
+          private-key: ${{ steps.get-secrets.outputs.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout Pull Request Branch
         run: gh pr checkout ${{ github.event.pull_request.number }}
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
@@ -76,7 +94,7 @@ jobs:
 
       - name: Add Comment to the PR
         id: notification
-        run: | 
+        run: |
           if [ ${{ steps.check_build.outputs.build }} == 'true' ]; then
            gh pr comment $PR_NUMBER --body "**Building new version of mimir-build-image**. After image is built and pushed to Docker Hub, \
            a new commit will automatically be added to this PR with new image version \`$IMAGE:$TAG\`. This can take up to 1 hour."
@@ -86,7 +104,7 @@ jobs:
           fi
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.compute_hash.outputs.tag }}
           IMAGE: ${{ steps.prepare.outputs.image }}
 
@@ -126,6 +144,6 @@ jobs:
             git push origin HEAD
           fi
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.compute_hash.outputs.tag }}
           MAIN_TAG: ${{ steps.prepare.outputs.main_image_tag }}

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -31,6 +31,7 @@ jobs:
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
         with:
+          vault_instance: dev
           repo_secrets: |
             APP_ID=mimir-github-bot:app_id
             PRIVATE_KEY=mimir-github-bot:private_key

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -112,8 +112,28 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
+
+      # Retrieve GitHub App Credentials from Vault for mimir-github-bot
+      - name: Retrieve GitHub App Credentials from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
+        with:
+          repo_secrets: |
+            APP_ID=mimir-github-bot:app_id
+            PRIVATE_KEY=mimir-github-bot:private_key
+
+      # Generate GitHub App Token for PR approval and auto-merge
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.get-secrets.outputs.APP_ID }}
+          private-key: ${{ steps.get-secrets.outputs.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Run doc-validator tool (mimir)
         run: >
           doc-validator
@@ -127,7 +147,8 @@ jobs:
           --name=doc-validator
           --reporter=github-pr-review
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          REVIEWDOG_GITHUB_API_TOKEN: "${{ steps.app-token.outputs.token }}"
+
       - name: Run doc-validator tool (helm-charts)
         run: >
           doc-validator
@@ -140,7 +161,7 @@ jobs:
           --name=doc-validator
           --reporter=github-pr-review
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          REVIEWDOG_GITHUB_API_TOKEN: "${{ steps.app-token.outputs.token }}"
 
   lint-jsonnet:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -121,6 +121,7 @@ jobs:
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
         with:
+          vault_instance: dev
           repo_secrets: |
             APP_ID=mimir-github-bot:app_id
             PRIVATE_KEY=mimir-github-bot:private_key

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -34,6 +34,11 @@ jobs:
           repo_secrets: |
             APP_ID=mimir-github-bot:app_id
             PRIVATE_KEY=mimir-github-bot:private_key
+      # Use the secrets, they will be obfuscated but that way we'll know they're accessible
+      - name: Echo
+        run: |
+          echo "${{ env.APP_ID }}"
+          echo "${{ env.PRIVATE_KEY }}"
     outputs:
       build_image: ${{ steps.build_image_step.outputs.build_image }}
       # Determine if we will deploy (aka push) the image to the registry.

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -130,6 +130,12 @@ jobs:
             APP_ID=mimir-github-bot:app_id
             PRIVATE_KEY=mimir-github-bot:private_key
 
+      # Use the secrets, they will be obfuscated but that way we'll know they're accessible
+      - name: Echo secrets
+        run: |
+          echo "${{ env.APP_ID }}"
+          echo "${{ env.PRIVATE_KEY }}"
+
       # Generate GitHub App Token for PR approval and auto-merge
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -25,26 +25,10 @@ jobs:
       - name: Get build image from Makefile
         id: build_image_step
         run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
-      # Retrieve GitHub App Credentials from Vault for mimir-github-bot
-      - name: Retrieve GitHub App Credentials from Vault
-        id: get_secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
-        with:
-          vault_instance: dev
-          repo_secrets: |
-            APP_ID=mimir-github-bot:app_id
-            PRIVATE_KEY=mimir-github-bot:private_key
-      # Use the secrets, they will be obfuscated but that way we'll know they're accessible
-      - name: Echo
-        run: |
-          echo "${{ env.APP_ID }}"
-          echo "${{ env.PRIVATE_KEY }}"
     outputs:
       build_image: ${{ steps.build_image_step.outputs.build_image }}
       # Determine if we will deploy (aka push) the image to the registry.
       is_deploy: ${{ (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r')) && github.event_name == 'push' && github.repository == 'grafana/mimir' }}
-      app_id: ${{ steps.get_secrets.outputs.APP_ID }}
-      private_key: ${{ steps.get_secrets.outputs.PRIVATE_KEY }}
 
   goversion:
     runs-on: ubuntu-latest
@@ -132,13 +116,22 @@ jobs:
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
 
+      # Retrieve GitHub App Credentials from Vault for mimir-github-bot
+      - name: Retrieve GitHub App Credentials from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
+        with:
+          repo_secrets: |
+            APP_ID=mimir-github-bot:app_id
+            PRIVATE_KEY=mimir-github-bot:private_key
+
       # Generate GitHub App Token for PR approval and auto-merge
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ needs.prepare.outputs.app_id }}
-          private-key: ${{ needs.prepare.outputs.private_key }}
+          app-id: ${{ steps.get-secrets.outputs.APP_ID }}
+          private-key: ${{ steps.get-secrets.outputs.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Run doc-validator tool (mimir)

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -9,6 +9,10 @@ on:
       - mimir-[0-9]+.[0-9]+.[0-9]+**
   pull_request:
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   # Cancel any running workflow for the same branch when new commits are pushed.
   # We group both by ref_name (available when CI is triggered by a push to a branch/tag)

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -25,10 +25,21 @@ jobs:
       - name: Get build image from Makefile
         id: build_image_step
         run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
+      # Retrieve GitHub App Credentials from Vault for mimir-github-bot
+      - name: Retrieve GitHub App Credentials from Vault
+        id: get_secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
+        with:
+          vault_instance: dev
+          repo_secrets: |
+            APP_ID=mimir-github-bot:app_id
+            PRIVATE_KEY=mimir-github-bot:private_key
     outputs:
       build_image: ${{ steps.build_image_step.outputs.build_image }}
       # Determine if we will deploy (aka push) the image to the registry.
       is_deploy: ${{ (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r')) && github.event_name == 'push' && github.repository == 'grafana/mimir' }}
+      app_id: ${{ steps.get_secrets.outputs.APP_ID }}
+      private_key: ${{ steps.get_secrets.outputs.PRIVATE_KEY }}
 
   goversion:
     runs-on: ubuntu-latest
@@ -116,23 +127,13 @@ jobs:
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
 
-      # Retrieve GitHub App Credentials from Vault for mimir-github-bot
-      - name: Retrieve GitHub App Credentials from Vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
-        with:
-          vault_instance: dev
-          repo_secrets: |
-            APP_ID=mimir-github-bot:app_id
-            PRIVATE_KEY=mimir-github-bot:private_key
-
       # Generate GitHub App Token for PR approval and auto-merge
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ steps.get-secrets.outputs.APP_ID }}
-          private-key: ${{ steps.get-secrets.outputs.PRIVATE_KEY }}
+          app-id: ${{ needs.prepare.outputs.app_id }}
+          private-key: ${{ needs.prepare.outputs.private_key }}
           owner: ${{ github.repository_owner }}
 
       - name: Run doc-validator tool (mimir)

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -123,6 +123,7 @@ jobs:
       # Retrieve GitHub App Credentials from Vault for mimir-github-bot
       - name: Retrieve GitHub App Credentials from Vault
         id: get-secrets
+        shell: sh
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
         with:
           repo_secrets: |


### PR DESCRIPTION
This uses the same GitHub app as the one we use in backend-enterprise. This should allow us to stop using the GitHub token we were previously using.