### PR TITLE
querier: adjust requested limit parameter for downstream requests to series endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 * [ENHANCEMENT] Query-frontend: Allow adjustment of queries looking into the future to a maximum duration with experimental `-query-frontend.max-future-query-window` flag. #10547
 * [ENHANCEMENT] Ruler: Adds support for filtering results from rule status endpoint by `file[]`, `rule_group[]` and `rule_name[]`. #10589
 * [ENHANCEMENT] Query-frontend: Add option to "spin off" subqueries as actual range queries, so that they benefit from query acceleration techniques such as sharding, splitting and caching. To enable this, set the `-query-frontend.spin-off-instant-subqueries-to-url=<url>` option on the frontend and the `instant_queries_with_subquery_spin_off` per-tenant override with regular expressions matching the queries to enable. #10460 #10603 #10621
-* [ENHANCEMENT] Querier, ingester: The series API respects passed `limit` parameter. #10620
+* [ENHANCEMENT] Querier, ingester: The series API respects passed `limit` parameter. #10620 #10652
 * [ENHANCEMENT] Store-gateway: Add experimental settings under `-store-gateway.dynamic-replication` to allow more than the default of 3 store-gateways to own recent blocks. #10382 #10637
 * [ENHANCEMENT] Ingester: Add reactive concurrency limiters to protect push and read operations from overload. #10574
 * [ENHANCEMENT] Compactor: Add experimental `-compactor.max-lookback` option to limit blocks considered in each compaction cycle. Blocks uploaded prior to the lookback period aren't processed. This option helps reduce CPU utilization in tenants with large block metadata files that are processed before each compaction. #10585

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -2757,7 +2757,14 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 	resultLimit := math.MaxInt
 	if hints != nil && hints.Limit > 0 {
 		resultLimit = hints.Limit
-		req.Limit = int64(adjustRequestLimitForReplicationSets(ctx, d, replicationSets, resultLimit))
+
+		userID, err := tenant.TenantID(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		// Adjust the limit passed to the downstream ingester with respect to how series are sharded inside the ring.
+		req.Limit = int64(d.adjustQueryRequestLimit(ctx, userID, resultLimit))
 	}
 
 	resps, err := forReplicationSets(ctx, d, replicationSets, func(ctx context.Context, client ingester_client.IngesterClient) (*ingester_client.MetricsForLabelMatchersResponse, error) {
@@ -2791,28 +2798,35 @@ respsLoop:
 	return result, nil
 }
 
-// adjustRequestLimitForReplicationSets recalculated the limit with respect to replication sets.
-// The returned value is the approximation, a query to an individual instance in the replication sets needs to be limited with.
-func adjustRequestLimitForReplicationSets(ctx context.Context, d *Distributor, replicationSets []ring.ReplicationSet, limit int) int {
+// adjustQueryRequestLimit recalculated the query request limit.
+// The returned value is the approximation, the query to an individual shard needs to be limited with.
+func (d *Distributor) adjustQueryRequestLimit(ctx context.Context, userID string, limit int) int {
 	if limit == 0 {
 		return limit
 	}
 
 	var shardSize int
 	if d.cfg.IngestStorageConfig.Enabled {
-		// When ingest storage is enabled, each partition, represented by one replication set is owned by only one ingester.
-		// So we use the number of replication sets to count the number of shards.
-		shardSize = len(replicationSets)
-	} else if len(replicationSets) == 1 {
-		// We expect to always have exactly 1 replication set when ingest storage is disabled.
-		// In classic Mimir the total number of shards (ingestion-tenant-shard-size) is the number of ingesters in the shard across all zones.
-		shardSize = len(replicationSets[0].Instances) / d.ingestersRing.ReplicationFactor()
+		// Get the number of active partitions in the ring. Here the ShuffleShardSize handles cases when a tenant has 0 or negative
+		// number of shards, or more shards than the number of active partitions in the ring.
+		shardSize = d.partitionsRing.PartitionRing().ShuffleShardSize(d.limits.IngestionPartitionsTenantShardSize(userID))
+	} else {
+		tenantShardSize := d.limits.IngestionTenantShardSize(userID)
+
+		// The ShuffleShard filters out read-only instances, leaving us with the number of active ingesters.
+		subring := d.ingestersRing.ShuffleShard(userID, tenantShardSize)
+		ingestionShardSize := subring.InstancesWithTokensCount()
+		if tenantShardSize > 0 {
+			ingestionShardSize = min(tenantShardSize, ingestionShardSize)
+		}
+		// In classic Mimir the ingestion shard size is the number of ingesters in the shard across all zones.
+		shardSize = int(float64(ingestionShardSize) / float64(subring.ReplicationFactor()))
 	}
 	if shardSize == 0 || limit <= shardSize {
 		return limit
 	}
 
-	// Always round the adjusted limit up so the approximation overcounted, rather undercounted.
+	// Always round the adjusted limit up so the approximation over-counted, rather under-counted.
 	newLimit := int(math.Ceil(float64(limit) / float64(shardSize)))
 
 	spanLog := spanlogger.FromContext(ctx, d.log)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -2763,7 +2763,7 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 			return nil, err
 		}
 
-		// Adjust the limit passed to the downstream ingester with respect to how series are sharded inside the ring.
+		// Adjust the limit passed with the downstream request to ingesters with respect to how series are sharded.
 		req.Limit = int64(d.adjustQueryRequestLimit(ctx, userID, resultLimit))
 	}
 
@@ -2799,7 +2799,7 @@ respsLoop:
 }
 
 // adjustQueryRequestLimit recalculated the query request limit.
-// The returned value is the approximation, the query to an individual shard needs to be limited with.
+// The returned value is the approximation, a query to an individual shard needs to be limited with.
 func (d *Distributor) adjustQueryRequestLimit(ctx context.Context, userID string, limit int) int {
 	if limit == 0 {
 		return limit

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2593,6 +2593,98 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 	}
 }
 
+func TestDistributor_MetricsForLabelMatchers_adjustPushDownLimit(t *testing.T) {
+	const numIngesters = 10
+
+	now := model.Now()
+
+	fixtures := []struct {
+		lbls      []mimirpb.LabelAdapter
+		value     float64
+		timestamp int64
+	}{
+		{labelAdapters(labels.MetricName, "test_1", "status", "2xx"), 1, 100000},
+		{labelAdapters(labels.MetricName, "test_1", "status", "3xx"), 1, 110000},
+		{labelAdapters(labels.MetricName, "test_1", "status", "5xx"), 1, 120000},
+	}
+
+	tests := map[string]struct {
+		setupFunc     func(*prepConfig)
+		hints         *storage.SelectHints
+		expectedLimit int
+	}{
+		"should adjust push-down limit": {
+			hints: &storage.SelectHints{
+				Limit: 50,
+			},
+			expectedLimit: 17,
+		},
+		"should adjust push-down limit if shuffle shard size is set": {
+			setupFunc: func(testConfig *prepConfig) {
+				testConfig.shuffleShardSize = 6
+			},
+			hints: &storage.SelectHints{
+				Limit: 50,
+			},
+			expectedLimit: 25, // the limit is divided between two shards (ingest_shard_size=6; RF=3)
+		},
+		"should adjust push-down limit if ingest-storage is enabled": {
+			setupFunc: func(testConfig *prepConfig) {
+				testConfig.ingestStorageEnabled = true
+				testConfig.limits = prepareDefaultLimits()
+				testConfig.limits.IngestionPartitionsTenantShardSize = 3
+			},
+			hints: &storage.SelectHints{
+				Limit: 50,
+			},
+			expectedLimit: 17,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			testConfig := prepConfig{
+				numIngesters:    numIngesters,
+				happyIngesters:  numIngesters,
+				numDistributors: 1,
+			}
+			if testData.setupFunc != nil {
+				testData.setupFunc(&testConfig)
+			}
+
+			ds, ingesters, _, _ := prepare(t, testConfig)
+
+			// Ensure strong read consistency, required to have no flaky tests when ingest storage is enabled.
+			ctx := user.InjectOrgID(context.Background(), "test")
+			ctx = api.ContextWithReadConsistencyLevel(ctx, api.ReadConsistencyStrong)
+
+			for _, series := range fixtures {
+				req := mockWriteRequest(series.lbls, series.value, series.timestamp)
+				_, err := ds[0].Push(ctx, req)
+				require.NoError(t, err)
+			}
+
+			// In this test, we only assert the side effect of limit's push-down. The behavior of matchers and the returned metrics are already tested above.
+			matchers := []*labels.Matcher{
+				mustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "test_1"),
+			}
+			_, err := ds[0].MetricsForLabelMatchers(ctx, now, now, testData.hints, matchers...)
+			require.NoError(t, err)
+
+			var called bool
+			assertMockIngestersCalledFunc(ingesters, "MetricsForLabelMatchers", func(args ...any) {
+				require.Len(t, args, 2)
+				req := args[1].(*client.MetricsForLabelMatchersRequest)
+				require.EqualValues(t, testData.expectedLimit, req.Limit)
+				called = true
+			})
+			require.True(t, called)
+		})
+	}
+}
+
 func TestDistributor_ActiveSeries(t *testing.T) {
 	const numIngesters = 5
 	const responseSizeLimitBytes = 1024
@@ -6134,13 +6226,14 @@ type mockIngester struct {
 	sync.Mutex
 	client.IngesterClient
 	grpc_health_v1.HealthClient
-	happy                         bool
-	stats                         client.UsersStatsResponse
-	timeseries                    map[uint32]*mimirpb.PreallocTimeseries
-	metadata                      map[uint32]map[mimirpb.MetricMetadata]struct{}
-	queryDelay                    time.Duration
-	pushDelay                     time.Duration
-	calls                         map[string]int
+	happy      bool
+	stats      client.UsersStatsResponse
+	timeseries map[uint32]*mimirpb.PreallocTimeseries
+	metadata   map[uint32]map[mimirpb.MetricMetadata]struct{}
+	queryDelay time.Duration
+	pushDelay  time.Duration
+	// calls is a map from a methodName to list the method's invocations; each invocation is a list of the call's arguments.
+	calls                         map[string][][]any
 	zone                          string
 	labelNamesStreamResponseDelay time.Duration
 	timeOut                       bool
@@ -6231,7 +6324,7 @@ func (i *mockIngester) Close() error {
 }
 
 func (i *mockIngester) Push(ctx context.Context, req *mimirpb.WriteRequest, _ ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
-	i.trackCall("Push")
+	i.trackCall("Push", ctx, req)
 
 	time.Sleep(i.pushDelay)
 
@@ -6311,7 +6404,7 @@ func makeWireChunk(c chunk.EncodedChunk) client.Chunk {
 }
 
 func (i *mockIngester) QueryStream(ctx context.Context, req *client.QueryRequest, _ ...grpc.CallOption) (client.Ingester_QueryStreamClient, error) {
-	i.trackCall("QueryStream")
+	i.trackCall("QueryStream", ctx, req)
 
 	if err := i.enforceReadConsistency(ctx); err != nil {
 		return nil, err
@@ -6546,7 +6639,7 @@ func (i *mockIngester) QueryExemplars(ctx context.Context, req *client.ExemplarQ
 }
 
 func (i *mockIngester) MetricsForLabelMatchers(ctx context.Context, req *client.MetricsForLabelMatchersRequest, _ ...grpc.CallOption) (*client.MetricsForLabelMatchersResponse, error) {
-	i.trackCall("MetricsForLabelMatchers")
+	i.trackCall("MetricsForLabelMatchers", ctx, req)
 
 	if err := i.enforceReadConsistency(ctx); err != nil {
 		return nil, err
@@ -6585,7 +6678,7 @@ func (i *mockIngester) MetricsForLabelMatchers(ctx context.Context, req *client.
 }
 
 func (i *mockIngester) LabelValues(ctx context.Context, req *client.LabelValuesRequest, _ ...grpc.CallOption) (*client.LabelValuesResponse, error) {
-	i.trackCall("LabelValues")
+	i.trackCall("LabelValues", ctx, req)
 
 	if err := i.enforceReadConsistency(ctx); err != nil {
 		return nil, err
@@ -6639,7 +6732,7 @@ func (i *mockIngester) LabelValues(ctx context.Context, req *client.LabelValuesR
 }
 
 func (i *mockIngester) LabelNames(ctx context.Context, req *client.LabelNamesRequest, _ ...grpc.CallOption) (*client.LabelNamesResponse, error) {
-	i.trackCall("LabelNames")
+	i.trackCall("LabelNames", ctx, req)
 
 	if err := i.enforceReadConsistency(ctx); err != nil {
 		return nil, err
@@ -6757,7 +6850,7 @@ func (s *labelNamesAndValuesMockStream) Recv() (*client.LabelNamesAndValuesRespo
 }
 
 func (i *mockIngester) LabelValuesCardinality(ctx context.Context, req *client.LabelValuesCardinalityRequest, _ ...grpc.CallOption) (client.Ingester_LabelValuesCardinalityClient, error) {
-	i.trackCall("LabelValuesCardinality")
+	i.trackCall("LabelValuesCardinality", ctx, req)
 
 	if err := i.enforceReadConsistency(ctx); err != nil {
 		return nil, err
@@ -6831,7 +6924,7 @@ func (s *labelValuesCardinalityStream) Recv() (*client.LabelValuesCardinalityRes
 }
 
 func (i *mockIngester) ActiveSeries(ctx context.Context, req *client.ActiveSeriesRequest, _ ...grpc.CallOption) (client.Ingester_ActiveSeriesClient, error) {
-	i.trackCall("ActiveSeries")
+	i.trackCall("ActiveSeries", ctx, req)
 
 	if err := i.enforceReadConsistency(ctx); err != nil {
 		return nil, err
@@ -6897,22 +6990,31 @@ func (s *activeSeriesStream) CloseSend() error {
 	return nil
 }
 
-func (i *mockIngester) trackCall(name string) {
+func (i *mockIngester) trackCall(name string, args ...any) {
 	i.Lock()
 	defer i.Unlock()
 
 	if i.calls == nil {
-		i.calls = map[string]int{}
+		i.calls = make(map[string][][]any)
 	}
 
-	i.calls[name]++
+	i.calls[name] = append(i.calls[name], args)
 }
 
 func (i *mockIngester) countCalls(name string) int {
 	i.Lock()
 	defer i.Unlock()
 
-	return i.calls[name]
+	return len(i.calls[name])
+}
+
+func (i *mockIngester) assertCalledFunc(name string, assertionFunc func(args ...any)) {
+	i.Lock()
+	defer i.Unlock()
+
+	for _, call := range i.calls[name] {
+		assertionFunc(call...)
+	}
 }
 
 func (i *mockIngester) enforceReadConsistency(ctx context.Context) error {
@@ -7270,6 +7372,12 @@ func countMockIngestersCalled(ingesters []*mockIngester, name string) int {
 		}
 	}
 	return count
+}
+
+func assertMockIngestersCalledFunc(ingesters []*mockIngester, name string, assertionFunc func(args ...any)) {
+	for _, i := range ingesters {
+		i.assertCalledFunc(name, assertionFunc)
+	}
 }
 
 // TestDistributor_MetricsWithRequestModifications tests that the distributor metrics are properly updated when

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -6559,7 +6559,7 @@ func (i *mockIngester) MetricsForLabelMatchers(ctx context.Context, req *client.
 		return nil, errFail
 	}
 
-	_, multiMatchers, err := client.FromMetricsForLabelMatchersRequest(req)
+	hints, multiMatchers, err := client.FromMetricsForLabelMatchersRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -6578,6 +6578,9 @@ func (i *mockIngester) MetricsForLabelMatchers(ctx context.Context, req *client.
 		return mimirpb.CompareLabelAdapters(m1.Labels, m2.Labels)
 	})
 
+	if hints != nil && hints.Limit > 0 && len(response.Metric) > hints.Limit {
+		response.Metric = response.Metric[:hints.Limit]
+	}
 	return &response, nil
 }
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2626,9 +2626,18 @@ func TestDistributor_MetricsForLabelMatchers_adjustPushDownLimit(t *testing.T) {
 			hints: &storage.SelectHints{
 				Limit: 50,
 			},
-			expectedLimit: 25, // the limit is divided between two shards (ingest_shard_size=6; RF=3)
+			expectedLimit: 25, // the pushed-down limit is divided between two shards (ingest_shard_size=6; RF=3)
 		},
 		"should adjust push-down limit if ingest-storage is enabled": {
+			setupFunc: func(testConfig *prepConfig) {
+				testConfig.ingestStorageEnabled = true
+			},
+			hints: &storage.SelectHints{
+				Limit: 50,
+			},
+			expectedLimit: 5, // the pushed-down limit is divided by the number of ingesters
+		},
+		"should adjust push-down limit if ingest-storage is enabled and partition shard size is set": {
 			setupFunc: func(testConfig *prepConfig) {
 				testConfig.ingestStorageEnabled = true
 				testConfig.limits = prepareDefaultLimits()
@@ -2637,7 +2646,7 @@ func TestDistributor_MetricsForLabelMatchers_adjustPushDownLimit(t *testing.T) {
 			hints: &storage.SelectHints{
 				Limit: 50,
 			},
-			expectedLimit: 17,
+			expectedLimit: 17, // the pushed-down limit is divided by number of partitions (ingest_shard_size=3)
 		},
 	}
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -345,7 +345,7 @@ func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHin
 		"hint.func", sp.Func,
 		"start", util.TimeFromMillis(sp.Start).UTC().String(),
 		"end", util.TimeFromMillis(sp.End).UTC().String(),
-		"limit", sp.Limit,
+		"limit", sp.Limit, // Note that Prometheus does +1 to the original request's limit to emit a warning in the response (ref "toHintLimit" in web/api/v1/api.go).
 		"step", sp.Step,
 		"matchers", util.MatchersStringer(matchers),
 	)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -316,7 +316,7 @@ func (mq multiQuerier) getQueriers(ctx context.Context, matchers ...*labels.Matc
 }
 
 // Select implements storage.Querier interface.
-// The bool passed is ignored because the series is always sorted.
+// The bool passed is ignored because the series are always sorted.
 func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, mq.logger, "querier.Select")
 	defer spanLog.Span.Finish()
@@ -341,8 +341,14 @@ func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHin
 	}
 	now := time.Now()
 
-	level.Debug(spanLog).Log("hint.func", sp.Func, "start", util.TimeFromMillis(sp.Start).UTC().String(), "end",
-		util.TimeFromMillis(sp.End).UTC().String(), "step", sp.Step, "matchers", util.MatchersStringer(matchers))
+	level.Debug(spanLog).Log(
+		"hint.func", sp.Func,
+		"start", util.TimeFromMillis(sp.Start).UTC().String(),
+		"end", util.TimeFromMillis(sp.End).UTC().String(),
+		"limit", sp.Limit,
+		"step", sp.Step,
+		"matchers", util.MatchersStringer(matchers),
+	)
 
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does

This is a follow-up to https://github.com/grafana/mimir/pull/10620

Here I'm updating the `MetricsForLabelMatchers` to adjust the `limit` parameter passed to the downstream ingesters, base on the replication sets. The idea, suggested by @pracucci is to approximate the limit as:

```
L / (<shard-size> / <replication-factor>)
```

Note that for ingest storage, the above formula is equivalent to `L / <partition-shard-size>`.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
