### PR TITLE
helm: render ruler read path in autoscaling offline tests

### DIFF
--- a/operations/helm/charts/mimir-distributed/ci/offline/keda-autoscaling-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/keda-autoscaling-values.yaml
@@ -18,6 +18,7 @@ distributor:
     targetMemoryUtilizationPercentage: 80
 
 ruler:
+  remoteEvaluationDedicatedQueryPath: true
   kedaAutoscaling:
     enabled: true
     preserveReplicas: true
@@ -42,3 +43,20 @@ query_frontend:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+
+ruler_querier:
+  kedaAutoscaling:
+    enabled: true
+    preserveReplicas: true
+    minReplicaCount: 1
+    maxReplicaCount: 10
+    querySchedulerInflightRequestsThreshold: 13
+
+ruler_query_frontend:
+  kedaAutoscaling:
+    enabled: true
+    minReplicaCount: 1
+    maxReplicaCount: 10
+    preserveReplicas: true
+    targetCPUUtilizationPercentage: 75
+    targetMemoryUtilizationPercentage: 100

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -93,6 +93,8 @@ data:
     ruler:
       alertmanager_url: dnssrvnoa+http://_http-metrics._tcp.keda-autoscaling-values-mimir-alertmanager-headless.citestns.svc.cluster.local./alertmanager
       enable_api: true
+      query_frontend:
+        address: dns:///keda-autoscaling-values-mimir-ruler-query-frontend.citestns.svc:9095
       rule_path: /data
     ruler_storage:
       backend: s3

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
@@ -1,0 +1,121 @@
+---
+# Source: mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-querier
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: keda-autoscaling-values
+      app.kubernetes.io/component: ruler-querier
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: keda-autoscaling-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ruler-querier
+        app.kubernetes.io/part-of: memberlist
+      annotations:
+    spec:
+      serviceAccountName: keda-autoscaling-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ruler-querier
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=querier"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-querier.scheduler-address=keda-autoscaling-values-mimir-ruler-query-scheduler-headless.citestns.svc:9095"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mimir
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: storage
+              mountPath: "/data"
+              subPath: 
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "5"
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "5000"
+          envFrom:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: keda-autoscaling-values
+            app.kubernetes.io/component: ruler-querier
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: config
+          configMap:
+            name: keda-autoscaling-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: keda-autoscaling-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-pdb.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/ruler-querier/ruler-querier-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-querier
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: keda-autoscaling-values
+      app.kubernetes.io/component: ruler-querier
+  maxUnavailable: 1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
@@ -1,0 +1,53 @@
+---
+# Source: mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-querier
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 10
+          stabilizationWindowSeconds: 600
+        scaleUp:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 50
+          - periodSeconds: 120
+            type: Pods
+            value: 15
+          stabilizationWindowSeconds: 60
+  maxReplicaCount: 10
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    name: keda-autoscaling-values-mimir-ruler-querier
+    apiVersion: apps/v1
+    kind: Deployment
+  triggers:
+  - metadata:
+      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="ruler-query-scheduler",namespace="citestns",quantile="0.5"}[1m]))
+      serverAddress: http://keda-autoscaling-values-mimir-nginx.citestns.svc:80/prometheus 
+      threshold: "13"
+    name: cortex_querier_hpa_default
+    type: prometheus
+  - metadata:
+      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="ruler-querier",namespace="citestns"}[1m]))
+      serverAddress: http://keda-autoscaling-values-mimir-nginx.citestns.svc:80/prometheus 
+      threshold: "13"
+    name: cortex_querier_hpa_default_requests_duration
+    type: prometheus

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-svc.yaml
@@ -1,0 +1,30 @@
+---
+# Source: mimir-distributed/templates/ruler-querier/ruler-querier-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-querier
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-querier
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-querier

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
@@ -1,0 +1,118 @@
+---
+# Source: mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-frontend
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  # If replicas is not number (when using values file it's float64, when using --set arg it's int64) and is false (i.e. null) don't set it
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: keda-autoscaling-values
+      app.kubernetes.io/component: ruler-query-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: keda-autoscaling-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ruler-query-frontend
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: keda-autoscaling-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ruler-query-frontend
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=query-frontend"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+            - "-query-frontend.cache-results=false"
+            - "-query-frontend.scheduler-address=keda-autoscaling-values-mimir-ruler-query-scheduler-headless.citestns.svc:9095"
+            # Reduce the likelihood of queries hitting terminated query-frontends.
+            - "-server.grpc.keepalive.max-connection-age=30s"
+            - "-shutdown-delay=90s"
+          volumeMounts:
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: config
+              mountPath: /etc/mimir
+            - name: storage
+              mountPath: /data
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
+              value: "5000"
+          envFrom:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: keda-autoscaling-values
+            app.kubernetes.io/component: ruler-query-frontend
+      terminationGracePeriodSeconds: 390
+      volumes:
+        - name: config
+          configMap:
+            name: keda-autoscaling-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: keda-autoscaling-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-pdb.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-frontend
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: keda-autoscaling-values
+      app.kubernetes.io/component: ruler-query-frontend
+  maxUnavailable: 1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
@@ -1,0 +1,41 @@
+---
+# Source: mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-frontend
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 10
+  maxReplicaCount: 10
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    name: keda-autoscaling-values-mimir-ruler-query-frontend
+    apiVersion: apps/v1
+    kind: Deployment
+  triggers:
+  - metadata:
+      query: max_over_time(sum(sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="citestns"}[5m])) and max by (pod) (up{container="ruler-query-frontend",namespace="citestns"}) > 0)[15m:]) * 1000
+      serverAddress: http://keda-autoscaling-values-mimir-nginx.citestns.svc:80/prometheus
+      threshold: "75"
+    type: prometheus
+  - metadata:
+      query: max_over_time(sum((sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="citestns"}) and max by (pod) (up{container="ruler-query-frontend",namespace="citestns"}) > 0) or vector(0))[15m:]) + sum(sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="ruler-query-frontend",namespace="citestns", resource="memory"}[15m])) and max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-query-frontend",namespace="citestns"}[15m]) > 0) and max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend",namespace="citestns", reason="OOMKilled"}) or vector(0))
+      serverAddress: http://keda-autoscaling-values-mimir-nginx.citestns.svc:80/prometheus
+      threshold: "134217728"
+    type: prometheus

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-query-frontend
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-frontend
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-frontend

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-dep.yaml
@@ -1,0 +1,109 @@
+---
+# Source: mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-dep.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-query-scheduler
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: keda-autoscaling-values
+      app.kubernetes.io/component: ruler-query-scheduler
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: keda-autoscaling-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: ruler-query-scheduler
+      annotations:
+    spec:
+      serviceAccountName: keda-autoscaling-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ruler-query-scheduler
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=query-scheduler"
+            - "-config.expand-env=true"
+            - "-config.file=/etc/mimir/mimir.yaml"
+          volumeMounts:
+            - name: runtime-config
+              mountPath: /var/mimir
+            - name: config
+              mountPath: /etc/mimir
+            - name: storage
+              mountPath: /data
+            - name: active-queries
+              mountPath: /active-query-tracker
+          ports:
+            - name: http-metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          livenessProbe:
+            null
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http-metrics
+            initialDelaySeconds: 45
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          envFrom:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: mimir
+            app.kubernetes.io/instance: keda-autoscaling-values
+            app.kubernetes.io/component: ruler-query-scheduler
+      terminationGracePeriodSeconds: 180
+      volumes:
+        - name: config
+          configMap:
+            name: keda-autoscaling-values-mimir-config
+            items:
+              - key: "mimir.yaml"
+                path: "mimir.yaml"
+        - name: runtime-config
+          configMap:
+            name: keda-autoscaling-values-mimir-runtime
+        - name: storage
+          emptyDir: {}
+        - name: active-queries
+          emptyDir: {}

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-pdb.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-query-scheduler
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: keda-autoscaling-values
+      app.kubernetes.io/component: ruler-query-scheduler
+  maxUnavailable: 1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc-headless.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc-headless.yaml
@@ -1,0 +1,32 @@
+---
+# Source: mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-query-scheduler-headless
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-scheduler
+    app.kubernetes.io/managed-by: Helm
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-scheduler

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc.yaml
@@ -1,0 +1,29 @@
+---
+# Source: mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-autoscaling-values-mimir-ruler-query-scheduler
+  namespace: "citestns"
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-scheduler
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/component: ruler-query-scheduler


### PR DESCRIPTION
it's more complete that way
