### PR TITLE
Alertmanager: De-duplicate Grafana receivers

### DIFF
--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -40,7 +40,7 @@ func (am *MultitenantAlertmanager) createUsableGrafanaConfig(gCfg alertspb.Grafa
 	}
 
 	// Check for duplicate receiver names.
-	nameToReceiver := make(map[string]*definition.PostableApiReceiver)
+	nameToReceiver := make(map[string]*definition.PostableApiReceiver, len(amCfg.AlertmanagerConfig.Receivers))
 	for _, receiver := range amCfg.AlertmanagerConfig.Receivers {
 		if existing, ok := nameToReceiver[receiver.Name]; ok {
 			itypes := make([]string, 0, len(existing.GrafanaManagedReceivers))

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -4,13 +4,17 @@ package alertmanager
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/grafana/alerting/definition"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
 )
+
+const grafanaConfigWithDuplicateReceiverName = `{"template_files":{},"alertmanager_config":{"route":{"receiver":"test-receiver","group_by":["grafana_folder","alertname"]},"templates":null,"receivers":[{"name":"test-receiver","grafana_managed_receiver_configs":[{"uid":"dde6ntuob69dtf","name":"test-receiver","type":"webhook","disableResolveMessage":false,"settings":{"url":"http://localhost:8080","username":"test"},"secureSettings":{"password":"test"}}]},{"name":"test-receiver","grafana_managed_receiver_configs":[{"uid":"dde7ntuob69dtf","name":"test-receiver","type":"webhook","disableResolveMessage":false,"settings":{"url":"http://localhost:8080","username":"test"},"secureSettings":{"password":"test"}}]}]}}`
 
 func TestCreateUsableGrafanaConfig(t *testing.T) {
 	tests := []struct {
@@ -50,6 +54,16 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 			"",
 		},
 		{
+			"duplicate grafana receiver name config",
+			alertspb.GrafanaAlertConfigDesc{
+				ExternalUrl:   "http://test:3000",
+				RawConfig:     grafanaConfigWithDuplicateReceiverName,
+				StaticHeaders: map[string]string{"test": "test"},
+			},
+			"",
+			"",
+		},
+		{
 			"non-empty mimir config",
 			alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl:   "http://test:3000",
@@ -63,7 +77,8 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg, err := createUsableGrafanaConfig(test.grafanaConfig, test.mimirConfig)
+			am := MultitenantAlertmanager{logger: log.NewNopLogger()}
+			cfg, err := am.createUsableGrafanaConfig(test.grafanaConfig, test.mimirConfig)
 			if test.expErr != "" {
 				require.Error(t, err)
 				require.Equal(t, test.expErr, err.Error())
@@ -89,7 +104,16 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 
 				require.Equal(t, string(b), cfg.RawConfig)
 			}
+
+			// Receiver names should be unique.
+			var finalCfg definition.PostableApiAlertingConfig
+			require.NoError(t, json.Unmarshal([]byte(cfg.RawConfig), &finalCfg))
+			receiverNames := map[string]struct{}{}
+			for _, rcv := range finalCfg.Receivers {
+				_, ok := receiverNames[rcv.Name]
+				require.False(t, ok, fmt.Sprintf("duplicate receiver name %q found in final configuration", rcv.Name))
+				receiverNames[rcv.Name] = struct{}{}
+			}
 		})
 	}
-
 }

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -738,7 +738,7 @@ func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs)
 	// If the Mimir configuration is either default or empty, use the Grafana configuration.
 	if cfgs.Mimir.RawConfig == am.fallbackConfig || cfgs.Mimir.RawConfig == "" {
 		level.Debug(am.logger).Log("msg", "using grafana config with the default globals", "user", cfgs.Mimir.User)
-		cfg, err := createUsableGrafanaConfig(cfgs.Grafana, am.fallbackConfig)
+		cfg, err := am.createUsableGrafanaConfig(cfgs.Grafana, am.fallbackConfig)
 		return cfg, true, err
 	}
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -410,7 +410,7 @@ templates:
 	require.Len(t, am.alertmanagers, 4)
 
 	// The Mimir configuration was empty, so the Grafana configuration should be chosen for user 4.
-	amCfg, err := createUsableGrafanaConfig(userGrafanaCfg, am.fallbackConfig)
+	amCfg, err := am.createUsableGrafanaConfig(userGrafanaCfg, am.fallbackConfig)
 	require.NoError(t, err)
 	grafanaAlertConfigDesc := amCfg.AlertConfigDesc
 	require.Equal(t, grafanaAlertConfigDesc, am.cfgs["user4"])


### PR DESCRIPTION
### Description

Receiver names can be duplicated in Grafana Alertmanager configurations. Grafana handles this by logging a warning and only using the last receiver with a given name. Still, Mimir fails to start the Alertmanager for a tenant with duplicate receiver names.

This PR uses an approach similar to https://github.com/grafana/mimir/pull/10534 to de-duplicate receivers with the same name, leaving only the last one.

### Testing locally

1. From `main`, start Mimir with `alertmanager.grafana_alertmanager_compatibility_enabled` and `multitenancy_enabled` set to `true` in `mimir.yaml`
2. Upload a configuration with a duplicate receiver name, the Alertmanager for the tenant should fail to start

<details><summary>Example `curl` command</summary>

```bash
curl http://localhost:8706/api/v1/grafana/config -H 'X-Scope-OrgID: test-grafana' -d '{
  "configuration": {
    "alertmanager_config": {
      "route": {
        "receiver": "grafana-default-email",
        "group_by": [
          "grafana_folder",
          "alertname"
        ],
        "routes": [
          {
            "receiver": "grafana-default-email",
            "object_matchers": [
              [
                "__grafana_autogenerated__",
                "=",
                "true"
              ]
            ],
            "routes": [
              {
                "receiver": "grafana-default-email",
                "group_by": [
                  "grafana_folder",
                  "alertname"
                ],
                "object_matchers": [
                  [
                    "__grafana_receiver__",
                    "=",
                    "grafana-default-email"
                  ]
                ]
              }
            ]
          }
        ]
      },
      "receivers": [
        {
          "name": "grafana-default-email",
          "grafana_managed_receiver_configs": [
            {
              "uid": "eeayniwhs0fswb",
              "name": "email receiver",
              "type": "email",
              "disableResolveMessage": false,
              "settings": {
                "addresses": "\u003cexample@email.com\u003e"
              }
            }
          ]
        },
        {
          "name": "grafana-default-email",
          "grafana_managed_receiver_configs": [
            {
              "uid": "eeayncwhs0fswb",
              "name": "email receiver",
              "type": "email",
              "disableResolveMessage": false,
              "settings": {
                "addresses": "\u003cexample@email.com\u003e"
              }
            }
          ]
        }
      ]
    }
  },
  "configuration_hash": "09dcbb49e7e768830c7838b24ece54a6",
  "created": 1737725994,
  "default": false,
  "promoted": true,
  "external_url": "http://localhost:3000/",
  "static_headers": null
}'
```
</details>

3. Check out to this branch and start Mimir again, the Alertmanager should start successfully