### PR TITLE
updates doc on otel resource attributes promoted to labels

### DIFF
--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -107,6 +107,38 @@ service:
       exporters: [..., prometheusremotewrite]
 ```
 
+## Work with default OpenTelemetry labels
+
+OpenTelemetry metrics use resource attributes to describe the set of characteristics associated with a given resource, or entity producing telemetry data. For example, a host resource might have multiple attributes, including an ID, and image, and a type.
+
+To optimize the storage of and ability to query this data, Mimir automatically assigns the following OTel resource attributes as labels, with with periods (`.`) replaced by underscores (`_`):
+
+- `service.instance.id`
+- `service.name`
+- `service.namespace`
+- `service.version`
+- `cloud.availability_zone`
+- `cloud region`
+- `container.name`
+- `deployment.environment.name`
+- `k8s.cluster.name`
+- `k8s.container.name`
+- `k8s.cronjob.name`
+- `k8s.daemonset.name`
+- `k8s.deployment.name`
+- `k8s.job.name`
+- `k8s.namespace.name`
+- `k8s.pod.name`
+- `k8s.replicaset.name`
+- `k8s.statefulset.name`
+
+All the rest.
+
+How to update.
+If you are using Grafana Cloud, contact support to configure this setting.
+
+To learn more about OpenTelemetry resource attributes, refer to link.
+
 ## Format considerations
 
 We follow the official [OTLP Metric points to Prometheus](https://opentelemetry.io/docs/reference/specification/compatibility/prometheus_and_openmetrics/#otlp-metric-points-to-prometheus) specification.

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -111,7 +111,7 @@ service:
 
 OpenTelemetry metrics use resource attributes to describe the set of characteristics associated with a given resource, or entity producing telemetry data. For example, a host resource might have multiple attributes, including an ID, and image, and a type.
 
-To optimize the storage of and ability to query this data, Mimir automatically assigns the following OTel resource attributes as labels, with with periods (`.`) replaced by underscores (`_`):
+To optimize the storage of and ability to query this data, Mimir automatically assigns the following OTel resource attributes as labels at the time of ingestion, with periods (`.`) replaced by underscores (`_`):
 
 - `service.instance.id`
 - `service.name`
@@ -132,10 +132,14 @@ To optimize the storage of and ability to query this data, Mimir automatically a
 - `k8s.replicaset.name`
 - `k8s.statefulset.name`
 
-All the rest.
+{{< admonition type="note" >}}
+Some of these labels are mutually exclusive.
+{{< /admonition >}}
 
-How to update.
+To update this list, 
 If you are using Grafana Cloud, contact support to configure this setting.
+
+Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.
 
 To learn more about OpenTelemetry resource attributes, refer to link.
 

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -136,7 +136,7 @@ To optimize the storage of and ability to query this data, Mimir automatically a
 Some of these labels are mutually exclusive.
 {{< /admonition >}}
 
-Contact support to update this list of attributes.
+Contact support to update this list.
 
 Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.
 

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -109,7 +109,7 @@ service:
 
 ## Work with default OpenTelemetry labels
 
-OpenTelemetry metrics use resource attributes to describe the set of characteristics associated with a given resource, or entity producing telemetry data. For example, a host resource might have multiple attributes, including an ID, an image, and a type.
+OpenTelemetry metrics use resource attributes to describe the set of characteristics associated with a given resource, or entity, producing telemetry data. For example, a host resource might have multiple attributes, including an ID, an image, and a type.
 
 To optimize the storage of and ability to query this data, Mimir automatically assigns the following OTel resource attributes as labels at the time of ingestion, with periods (`.`) replaced by underscores (`_`):
 

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -136,10 +136,6 @@ Grafana Cloud automatically promotes the following OTel resource attributes to l
 
 Contact support to disable this setting or to update this list.
 
-{{< admonition type="note" >}}
-Some of these labels are mutually exclusive. If you don't need a particular label, you can aggregate it using Adaptive Metrics. For more information about Adaptive Metrics, refer to [Reduce metrics costs via Adaptive Metrics](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-metrics/).
-{{< /admonition >}}
-
 Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.
 
 To learn more about OpenTelemetry resource attributes, refer to [Resources](https://opentelemetry.io/docs/languages/js/resources/) in the OpenTelemetry documentation.

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -135,7 +135,7 @@ Grafana Cloud automatically promotes the following OTel resource attributes to l
 - `k8s.statefulset.name`
 
 {{< admonition type="note" >}}
-To disable this setting or to update this list, contact support.
+To disable this setting or to update this list, contact Grafana Labs Support.
 {{< /admonition >}}
 
 Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -136,8 +136,7 @@ To optimize the storage of and ability to query this data, Mimir automatically a
 Some of these labels are mutually exclusive.
 {{< /admonition >}}
 
-To update this list, ...
-If you are using Grafana Cloud, contact support to configure this setting.
+Contact support to update this list of attributes.
 
 Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.
 

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -132,11 +132,11 @@ To optimize the storage of and ability to query this data, Mimir automatically a
 - `k8s.replicaset.name`
 - `k8s.statefulset.name`
 
-{{< admonition type="note" >}}
-Some of these labels are mutually exclusive.
-{{< /admonition >}}
+If you are using Grafana Cloud, contact support to disable this setting or to update this list.
 
-Contact support to update this list.
+{{< admonition type="note" >}}
+Some of these labels are mutually exclusive. If you don't need a particular label, you can aggregate it using Adaptive Metrics. For more information about Adaptive Metrics, refer to [Reduce metrics costs via Adaptive Metrics](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-metrics/).
+{{< /admonition >}}
 
 Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.
 

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -134,7 +134,9 @@ Grafana Cloud automatically promotes the following OTel resource attributes to l
 - `k8s.replicaset.name`
 - `k8s.statefulset.name`
 
-Contact support to disable this setting or to update this list.
+{{< admonition type="note" >}}
+To disable this setting or to update this list, contact support.
+{{< /admonition >}}
 
 Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.
 

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -111,7 +111,9 @@ service:
 
 OpenTelemetry metrics use resource attributes to describe the set of characteristics associated with a given resource, or entity, producing telemetry data. For example, a host resource might have multiple attributes, including an ID, an image, and a type.
 
-To optimize the storage of and ability to query this data, Mimir automatically assigns the following OTel resource attributes as labels at the time of ingestion, with periods (`.`) replaced by underscores (`_`):
+To optimize the storage of and ability to query this data, you can configure Mimir to promote specified OTel resource attributes to labels at the time of ingestion, with periods (`.`) replaced by underscores (`_`).
+
+Grafana Cloud automatically promotes the following OTel resource attributes to labels:
 
 - `service.instance.id`
 - `service.name`
@@ -132,7 +134,7 @@ To optimize the storage of and ability to query this data, Mimir automatically a
 - `k8s.replicaset.name`
 - `k8s.statefulset.name`
 
-If you are using Grafana Cloud, contact support to disable this setting or to update this list.
+Contact support to disable this setting or to update this list.
 
 {{< admonition type="note" >}}
 Some of these labels are mutually exclusive. If you don't need a particular label, you can aggregate it using Adaptive Metrics. For more information about Adaptive Metrics, refer to [Reduce metrics costs via Adaptive Metrics](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-metrics/).

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -109,7 +109,7 @@ service:
 
 ## Work with default OpenTelemetry labels
 
-OpenTelemetry metrics use resource attributes to describe the set of characteristics associated with a given resource, or entity producing telemetry data. For example, a host resource might have multiple attributes, including an ID, and image, and a type.
+OpenTelemetry metrics use resource attributes to describe the set of characteristics associated with a given resource, or entity producing telemetry data. For example, a host resource might have multiple attributes, including an ID, an image, and a type.
 
 To optimize the storage of and ability to query this data, Mimir automatically assigns the following OTel resource attributes as labels at the time of ingestion, with periods (`.`) replaced by underscores (`_`):
 
@@ -136,12 +136,12 @@ To optimize the storage of and ability to query this data, Mimir automatically a
 Some of these labels are mutually exclusive.
 {{< /admonition >}}
 
-To update this list, 
+To update this list, ...
 If you are using Grafana Cloud, contact support to configure this setting.
 
 Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.
 
-To learn more about OpenTelemetry resource attributes, refer to link.
+To learn more about OpenTelemetry resource attributes, refer to [Resources](https://opentelemetry.io/docs/languages/js/resources/) in the OpenTelemetry documentation.
 
 ## Format considerations
 


### PR DESCRIPTION
#### What this PR does

This PR adds documentation for OTel resource attributes being automatically promoted to labels in Mimir.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/2727

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
