### PR TITLE
frontend: More versatile configuration for subquery spin-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * [ENHANCEMENT] Distributor, querier, ingester and store-gateway: Add support for `limit` parameter for label names and values requests. #10410
 * [ENHANCEMENT] Query-frontend: Allow adjustment of queries looking into the future to a maximum duration with experimental `-query-frontend.max-future-query-window` flag. #10547
 * [ENHANCEMENT] Ruler: Adds support for filtering results from rule status endpoint by `file[]`, `rule_group[]` and `rule_name[]`. #10589
-* [ENHANCEMENT] Query-frontend: Add option to "spin off" subqueries as actual range queries, so that they benefit from query acceleration techniques such as sharding, splitting and caching. To enable this, set the `-query-frontend.spin-off-instant-subqueries-to-url=<url>` option on the frontend and the `instant_queries_with_subquery_spin_off` per-tenant override with regular expressions matching the queries to enable. #10460 #10603 #10621
+* [ENHANCEMENT] Query-frontend: Add option to "spin off" subqueries as actual range queries, so that they benefit from query acceleration techniques such as sharding, splitting and caching. To enable this, set the `-query-frontend.instant-subquery-spin-off.url=<url>` option on the frontend and the `instant_subquery_spin_off_enabled_regexp` per-tenant override with regular expressions matching the queries to enable. #10460 #10603 #10621 #10696
 * [ENHANCEMENT] Querier, ingester: The series API respects passed `limit` parameter. #10620
 * [ENHANCEMENT] Store-gateway: Add experimental settings under `-store-gateway.dynamic-replication` to allow more than the default of 3 store-gateways to own recent blocks. #10382 #10637
 * [ENHANCEMENT] Ingester: Add reactive concurrency limiters to protect push and read operations from overload. #10574

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4719,7 +4719,18 @@
         },
         {
           "kind": "field",
-          "name": "instant_queries_with_subquery_spin_off",
+          "name": "max_future_query_window",
+          "required": false,
+          "desc": "Mutate incoming queries that look far into the future to only look into the future by the set duration. 0 to disable.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "query-frontend.max-future-query-window",
+          "fieldType": "duration",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "instant_subquery_spin_off_enabled_regexp",
           "required": false,
           "desc": "List of regular expression patterns matching instant queries. Subqueries within those instant queries will be spun off as range queries to optimize their performance.",
           "fieldValue": null,
@@ -4729,12 +4740,12 @@
         },
         {
           "kind": "field",
-          "name": "max_future_query_window",
+          "name": "instant_subquery_spin_off_min_range_duration",
           "required": false,
-          "desc": "Mutate incoming queries that look far into the future to only look into the future by the set duration. 0 to disable.",
+          "desc": "Minimum range duration of subqueries for subquery spin-off to be enabled.",
           "fieldValue": null,
-          "fieldDefaultValue": 0,
-          "fieldFlag": "query-frontend.max-future-query-window",
+          "fieldDefaultValue": 43200000000000,
+          "fieldFlag": "query-frontend.instant-subquery-spin-off.min-range-duration",
           "fieldType": "duration",
           "fieldCategory": "experimental"
         },
@@ -6957,12 +6968,23 @@
         },
         {
           "kind": "field",
-          "name": "spin_off_instant_subqueries_to_url",
+          "name": "instant_subquery_spin_off_enabled_by_default",
           "required": false,
-          "desc": "If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to set `instant_queries_with_subquery_spin_off` for the tenant.",
+          "desc": "If set, subqueries in instant queries are spun off as range queries by default. This parameter also requires you to set `-query-frontend.instant-subquery-spin-off.url=\u003curl\u003e`.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-frontend.instant-subquery-spin-off.enable-by-default",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "instant_subquery_spin_off_url",
+          "required": false,
+          "desc": "If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to enable the feature with `-query-frontend.instant-subquery-spin-off.enable-by-default` or by setting `instant_subquery_spin_off_enabled_regexp` for the tenant.",
           "fieldValue": null,
           "fieldDefaultValue": "",
-          "fieldFlag": "query-frontend.spin-off-instant-subqueries-to-url",
+          "fieldFlag": "query-frontend.instant-subquery-spin-off.url",
           "fieldType": "string",
           "fieldCategory": "experimental"
         },

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4730,9 +4730,20 @@
         },
         {
           "kind": "field",
+          "name": "instant_subquery_spin_off_enabled",
+          "required": false,
+          "desc": "Enable subquery spin-off for instant queries. Subqueries within those instant queries will be spun off as range queries to optimize their performance.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-frontend.instant-subquery-spin-off.enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "instant_subquery_spin_off_enabled_regexp",
           "required": false,
-          "desc": "List of regular expression patterns matching instant queries. Subqueries within those instant queries will be spun off as range queries to optimize their performance.",
+          "desc": "List of regular expression patterns matching instant queries. If this is set, only those queries will be considered for subquery spin off.",
           "fieldValue": null,
           "fieldDefaultValue": [],
           "fieldType": "list of strings",
@@ -6968,20 +6979,9 @@
         },
         {
           "kind": "field",
-          "name": "instant_subquery_spin_off_enabled_by_default",
-          "required": false,
-          "desc": "If set, subqueries in instant queries are spun off as range queries by default. This parameter also requires you to set `-query-frontend.instant-subquery-spin-off.url=\u003curl\u003e`.",
-          "fieldValue": null,
-          "fieldDefaultValue": false,
-          "fieldFlag": "query-frontend.instant-subquery-spin-off.enable-by-default",
-          "fieldType": "boolean",
-          "fieldCategory": "experimental"
-        },
-        {
-          "kind": "field",
           "name": "instant_subquery_spin_off_url",
           "required": false,
-          "desc": "If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to enable the feature with `-query-frontend.instant-subquery-spin-off.enable-by-default` or by setting `instant_subquery_spin_off_enabled_regexp` for the tenant.",
+          "desc": "If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to enable the feature with `-query-frontend.instant-subquery-spin-off.enabled` or the `instant_subquery_spin_off_enabled` per-tenant override.",
           "fieldValue": null,
           "fieldDefaultValue": "",
           "fieldFlag": "query-frontend.instant-subquery-spin-off.url",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2339,12 +2339,12 @@ Usage of ./cmd/mimir/mimir:
     	List of network interface names to look up when finding the instance IP address. This address is sent to query-scheduler and querier, which uses it to send the query response back to query-frontend. (default [<private network interfaces>])
   -query-frontend.instance-port int
     	Port to advertise to querier (via scheduler) (defaults to server.grpc-listen-port).
-  -query-frontend.instant-subquery-spin-off.enable-by-default
-    	[experimental] If set, subqueries in instant queries are spun off as range queries by default. This parameter also requires you to set `-query-frontend.instant-subquery-spin-off.url=<url>`.
+  -query-frontend.instant-subquery-spin-off.enabled
+    	[experimental] Enable subquery spin-off for instant queries. Subqueries within those instant queries will be spun off as range queries to optimize their performance.
   -query-frontend.instant-subquery-spin-off.min-range-duration duration
     	[experimental] Minimum range duration of subqueries for subquery spin-off to be enabled. (default 12h)
   -query-frontend.instant-subquery-spin-off.url string
-    	[experimental] If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to enable the feature with `-query-frontend.instant-subquery-spin-off.enable-by-default` or by setting `instant_subquery_spin_off_enabled_regexp` for the tenant.
+    	[experimental] If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to enable the feature with `-query-frontend.instant-subquery-spin-off.enabled` or the `instant_subquery_spin_off_enabled` per-tenant override.
   -query-frontend.log-queries-longer-than duration
     	Log queries that are slower than the specified duration. Set to 0 to disable. Set to < 0 to enable on all queries.
   -query-frontend.log-query-request-headers comma-separated-list-of-strings

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2339,6 +2339,12 @@ Usage of ./cmd/mimir/mimir:
     	List of network interface names to look up when finding the instance IP address. This address is sent to query-scheduler and querier, which uses it to send the query response back to query-frontend. (default [<private network interfaces>])
   -query-frontend.instance-port int
     	Port to advertise to querier (via scheduler) (defaults to server.grpc-listen-port).
+  -query-frontend.instant-subquery-spin-off.enable-by-default
+    	[experimental] If set, subqueries in instant queries are spun off as range queries by default. This parameter also requires you to set `-query-frontend.instant-subquery-spin-off.url=<url>`.
+  -query-frontend.instant-subquery-spin-off.min-range-duration duration
+    	[experimental] Minimum range duration of subqueries for subquery spin-off to be enabled. (default 12h)
+  -query-frontend.instant-subquery-spin-off.url string
+    	[experimental] If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to enable the feature with `-query-frontend.instant-subquery-spin-off.enable-by-default` or by setting `instant_subquery_spin_off_enabled_regexp` for the tenant.
   -query-frontend.log-queries-longer-than duration
     	Log queries that are slower than the specified duration. Set to 0 to disable. Set to < 0 to enable on all queries.
   -query-frontend.log-query-request-headers comma-separated-list-of-strings
@@ -2493,8 +2499,6 @@ Usage of ./cmd/mimir/mimir:
     	Number of concurrent workers forwarding queries to single query-scheduler. (default 5)
   -query-frontend.shard-active-series-queries
     	[experimental] True to enable sharding of active series queries.
-  -query-frontend.spin-off-instant-subqueries-to-url string
-    	[experimental] If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to set `instant_queries_with_subquery_spin_off` for the tenant.
   -query-frontend.split-instant-queries-by-interval duration
     	[experimental] Split instant queries by an interval and execute in parallel. 0 to disable it.
   -query-frontend.split-queries-by-interval duration

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -215,7 +215,7 @@ The following features are currently experimental:
   - Server-side write timeout for responses to active series requests (`-query-frontend.active-series-write-timeout`)
   - Caching of non-transient error responses (`-query-frontend.cache-errors`, `-query-frontend.results-cache-ttl-for-errors`)
   - Blocking HTTP requests on a per-tenant basis (configured with the `blocked_requests` limit)
-  - Spinning off (as actual range queries) subqueries from instant queries (`-query-frontend.spin-off-instant-subqueries-to-url` and the `instant_queries_with_subquery_spin_off` per-tenant limit)
+  - Spinning off (as actual range queries) subqueries from instant queries (`-query-frontend.instant-subquery-spin-off.url` and the `instant_subquery_spin_off_enabled_regexp` per-tenant limit)
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
 - Store-gateway

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1865,15 +1865,9 @@ results_cache:
 [use_active_series_decoder: <boolean> | default = false]
 
 # (experimental) If set, subqueries in instant queries are spun off as range
-# queries by default. This parameter also requires you to set
-# `-query-frontend.instant-subquery-spin-off.url=<url>`.
-# CLI flag: -query-frontend.instant-subquery-spin-off.enable-by-default
-[instant_subquery_spin_off_enabled_by_default: <boolean> | default = false]
-
-# (experimental) If set, subqueries in instant queries are spun off as range
 # queries and sent to the given URL. This parameter also requires you to enable
-# the feature with `-query-frontend.instant-subquery-spin-off.enable-by-default`
-# or by setting `instant_subquery_spin_off_enabled_regexp` for the tenant.
+# the feature with `-query-frontend.instant-subquery-spin-off.enabled` or the
+# `instant_subquery_spin_off_enabled` per-tenant override.
 # CLI flag: -query-frontend.instant-subquery-spin-off.url
 [instant_subquery_spin_off_url: <string> | default = ""]
 
@@ -3767,9 +3761,14 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -query-frontend.max-future-query-window
 [max_future_query_window: <duration> | default = 0s]
 
+# (experimental) Enable subquery spin-off for instant queries. Subqueries within
+# those instant queries will be spun off as range queries to optimize their
+# performance.
+# CLI flag: -query-frontend.instant-subquery-spin-off.enabled
+[instant_subquery_spin_off_enabled: <boolean> | default = false]
+
 # (experimental) List of regular expression patterns matching instant queries.
-# Subqueries within those instant queries will be spun off as range queries to
-# optimize their performance.
+# If this is set, only those queries will be considered for subquery spin off.
 [instant_subquery_spin_off_enabled_regexp: <list of strings> | default = ]
 
 # (experimental) Minimum range duration of subqueries for subquery spin-off to

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1865,10 +1865,17 @@ results_cache:
 [use_active_series_decoder: <boolean> | default = false]
 
 # (experimental) If set, subqueries in instant queries are spun off as range
-# queries and sent to the given URL. This parameter also requires you to set
-# `instant_queries_with_subquery_spin_off` for the tenant.
-# CLI flag: -query-frontend.spin-off-instant-subqueries-to-url
-[spin_off_instant_subqueries_to_url: <string> | default = ""]
+# queries by default. This parameter also requires you to set
+# `-query-frontend.instant-subquery-spin-off.url=<url>`.
+# CLI flag: -query-frontend.instant-subquery-spin-off.enable-by-default
+[instant_subquery_spin_off_enabled_by_default: <boolean> | default = false]
+
+# (experimental) If set, subqueries in instant queries are spun off as range
+# queries and sent to the given URL. This parameter also requires you to enable
+# the feature with `-query-frontend.instant-subquery-spin-off.enable-by-default`
+# or by setting `instant_subquery_spin_off_enabled_regexp` for the tenant.
+# CLI flag: -query-frontend.instant-subquery-spin-off.url
+[instant_subquery_spin_off_url: <string> | default = ""]
 
 # Format to use when retrieving query results from queriers. Supported values:
 # json, protobuf
@@ -3755,15 +3762,20 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -query-frontend.prom2-range-compat
 [prom2_range_compat: <boolean> | default = false]
 
-# (experimental) List of regular expression patterns matching instant queries.
-# Subqueries within those instant queries will be spun off as range queries to
-# optimize their performance.
-[instant_queries_with_subquery_spin_off: <list of strings> | default = ]
-
 # (experimental) Mutate incoming queries that look far into the future to only
 # look into the future by the set duration. 0 to disable.
 # CLI flag: -query-frontend.max-future-query-window
 [max_future_query_window: <duration> | default = 0s]
+
+# (experimental) List of regular expression patterns matching instant queries.
+# Subqueries within those instant queries will be spun off as range queries to
+# optimize their performance.
+[instant_subquery_spin_off_enabled_regexp: <list of strings> | default = ]
+
+# (experimental) Minimum range duration of subqueries for subquery spin-off to
+# be enabled.
+# CLI flag: -query-frontend.instant-subquery-spin-off.min-range-duration
+[instant_subquery_spin_off_min_range_duration: <duration> | default = 12h]
 
 # Enables endpoints used for cardinality analysis.
 # CLI flag: -querier.cardinality-analysis-enabled

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -117,8 +117,11 @@ type Limits interface {
 	// IngestStorageReadConsistency returns the default read consistency for the tenant.
 	IngestStorageReadConsistency(userID string) string
 
-	// InstantSubquerySpinOffEnabledRegexp returns a list of regexp patterns of instant queries that can be optimized by spinning off range queries.
-	// If the list is empty, the feature is disabled.
+	// InstantSubquerySpinOffEnabled returns whether instant queries can be optimized by spinning off range queries.
+	InstantSubquerySpinOffEnabled(userID string) bool
+
+	// InstantSubquerySpinOffEnabledRegexp returns a list of regexp patterns of instant queries that will be considered for spin-off.
+	// If the list is empty, all instant queries will be considered.
 	InstantSubquerySpinOffEnabledRegexp(userID string) []string
 
 	// InstantSubquerySpinOffMinRangeDuration returns the minimum range duration for subquery spin-off. Defaults to 12h.

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -117,9 +117,12 @@ type Limits interface {
 	// IngestStorageReadConsistency returns the default read consistency for the tenant.
 	IngestStorageReadConsistency(userID string) string
 
-	// InstantQueriesWithSubquerySpinOff returns a list of regexp patterns of instant queries that can be optimized by spinning off range queries.
+	// InstantSubquerySpinOffEnabledRegexp returns a list of regexp patterns of instant queries that can be optimized by spinning off range queries.
 	// If the list is empty, the feature is disabled.
-	InstantQueriesWithSubquerySpinOff(userID string) []string
+	InstantSubquerySpinOffEnabledRegexp(userID string) []string
+
+	// InstantSubquerySpinOffMinRangeDuration returns the minimum range duration for subquery spin-off. Defaults to 12h.
+	InstantSubquerySpinOffMinRangeDuration(userID string) time.Duration
 
 	// MaxFutureQueryWindow returns the maximum duration into the future a query can be executed for the tenant.
 	MaxFutureQueryWindow(userID string) time.Duration

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -692,41 +692,46 @@ func (m multiTenantMockLimits) BlockedRequests(userID string) []*validation.Bloc
 	return m.byTenant[userID].blockedRequests
 }
 
-func (m multiTenantMockLimits) InstantQueriesWithSubquerySpinOff(userID string) []string {
-	return m.byTenant[userID].instantQueriesWithSubquerySpinOff
+func (m multiTenantMockLimits) InstantSubquerySpinOffEnabledRegexp(userID string) []string {
+	return m.byTenant[userID].instantSubquerySpinOffEnabledRegexp
+}
+
+func (m multiTenantMockLimits) InstantSubquerySpinOffMinRangeDuration(userID string) time.Duration {
+	return m.byTenant[userID].InstantSubquerySpinOffMinRangeDuration(userID)
 }
 
 type mockLimits struct {
-	maxQueryLookback                     time.Duration
-	maxQueryLength                       time.Duration
-	maxTotalQueryLength                  time.Duration
-	maxQueryExpressionSizeBytes          int
-	maxCacheFreshness                    time.Duration
-	maxQueryParallelism                  int
-	maxShardedQueries                    int
-	maxRegexpSizeBytes                   int
-	maxFutureQueryWindow                 time.Duration
-	splitInstantQueriesInterval          time.Duration
-	totalShards                          int
-	compactorShards                      int
-	compactorBlocksRetentionPeriod       time.Duration
-	outOfOrderTimeWindow                 time.Duration
-	creationGracePeriod                  time.Duration
-	nativeHistogramsIngestionEnabled     bool
-	resultsCacheTTL                      time.Duration
-	resultsCacheOutOfOrderWindowTTL      time.Duration
-	resultsCacheTTLForCardinalityQuery   time.Duration
-	resultsCacheTTLForLabelsQuery        time.Duration
-	resultsCacheTTLForErrors             time.Duration
-	resultsCacheForUnalignedQueryEnabled bool
-	enabledPromQLExperimentalFunctions   []string
-	prom2RangeCompat                     bool
-	blockedQueries                       []*validation.BlockedQuery
-	blockedRequests                      []*validation.BlockedRequest
-	alignQueriesWithStep                 bool
-	queryIngestersWithin                 time.Duration
-	ingestStorageReadConsistency         string
-	instantQueriesWithSubquerySpinOff    []string
+	maxQueryLookback                       time.Duration
+	maxQueryLength                         time.Duration
+	maxTotalQueryLength                    time.Duration
+	maxQueryExpressionSizeBytes            int
+	maxCacheFreshness                      time.Duration
+	maxQueryParallelism                    int
+	maxShardedQueries                      int
+	maxRegexpSizeBytes                     int
+	maxFutureQueryWindow                   time.Duration
+	splitInstantQueriesInterval            time.Duration
+	totalShards                            int
+	compactorShards                        int
+	compactorBlocksRetentionPeriod         time.Duration
+	outOfOrderTimeWindow                   time.Duration
+	creationGracePeriod                    time.Duration
+	nativeHistogramsIngestionEnabled       bool
+	resultsCacheTTL                        time.Duration
+	resultsCacheOutOfOrderWindowTTL        time.Duration
+	resultsCacheTTLForCardinalityQuery     time.Duration
+	resultsCacheTTLForLabelsQuery          time.Duration
+	resultsCacheTTLForErrors               time.Duration
+	resultsCacheForUnalignedQueryEnabled   bool
+	enabledPromQLExperimentalFunctions     []string
+	prom2RangeCompat                       bool
+	blockedQueries                         []*validation.BlockedQuery
+	blockedRequests                        []*validation.BlockedRequest
+	alignQueriesWithStep                   bool
+	queryIngestersWithin                   time.Duration
+	ingestStorageReadConsistency           string
+	instantSubquerySpinOffEnabledRegexp    []string
+	instantSubquerySpinOffMinRangeDuration time.Duration
 }
 
 func (m mockLimits) MaxQueryLookback(string) time.Duration {
@@ -847,8 +852,15 @@ func (m mockLimits) BlockedRequests(string) []*validation.BlockedRequest {
 	return m.blockedRequests
 }
 
-func (m mockLimits) InstantQueriesWithSubquerySpinOff(string) []string {
-	return m.instantQueriesWithSubquerySpinOff
+func (m mockLimits) InstantSubquerySpinOffEnabledRegexp(string) []string {
+	return m.instantSubquerySpinOffEnabledRegexp
+}
+
+func (m mockLimits) InstantSubquerySpinOffMinRangeDuration(string) time.Duration {
+	if m.instantSubquerySpinOffMinRangeDuration == 0 {
+		return 12 * time.Hour // Flag default.
+	}
+	return m.instantSubquerySpinOffMinRangeDuration
 }
 
 type mockHandler struct {

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -692,6 +692,10 @@ func (m multiTenantMockLimits) BlockedRequests(userID string) []*validation.Bloc
 	return m.byTenant[userID].blockedRequests
 }
 
+func (m multiTenantMockLimits) InstantSubquerySpinOffEnabled(userID string) bool {
+	return m.byTenant[userID].instantSubquerySpinOffEnabled
+}
+
 func (m multiTenantMockLimits) InstantSubquerySpinOffEnabledRegexp(userID string) []string {
 	return m.byTenant[userID].instantSubquerySpinOffEnabledRegexp
 }
@@ -730,6 +734,7 @@ type mockLimits struct {
 	alignQueriesWithStep                   bool
 	queryIngestersWithin                   time.Duration
 	ingestStorageReadConsistency           string
+	instantSubquerySpinOffEnabled          bool
 	instantSubquerySpinOffEnabledRegexp    []string
 	instantSubquerySpinOffMinRangeDuration time.Duration
 }
@@ -850,6 +855,10 @@ func (m mockLimits) IngestStorageReadConsistency(string) string {
 
 func (m mockLimits) BlockedRequests(string) []*validation.BlockedRequest {
 	return m.blockedRequests
+}
+
+func (m mockLimits) InstantSubquerySpinOffEnabled(string) bool {
+	return m.instantSubquerySpinOffEnabled
 }
 
 func (m mockLimits) InstantSubquerySpinOffEnabledRegexp(string) []string {

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -69,10 +69,7 @@ type Config struct {
 	TargetSeriesPerShard             uint64        `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
 	ShardActiveSeriesQueries         bool          `yaml:"shard_active_series_queries" category:"experimental"`
 	UseActiveSeriesDecoder           bool          `yaml:"use_active_series_decoder" category:"experimental"`
-
-	// Subquery Spin-off feature
-	InstantSubquerySpinOffDefaultEnable bool   `yaml:"instant_subquery_spin_off_enabled_by_default" category:"experimental"`
-	InstantSubquerySpinOffURL           string `yaml:"instant_subquery_spin_off_url" category:"experimental"`
+	InstantSubquerySpinOffURL        string        `yaml:"instant_subquery_spin_off_url" category:"experimental"`
 
 	// CacheKeyGenerator allows to inject a CacheKeyGenerator to use for generating cache keys.
 	// If nil, the querymiddleware package uses a DefaultCacheKeyGenerator with SplitQueriesByInterval.
@@ -105,8 +102,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatProtobuf, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
 	f.BoolVar(&cfg.ShardActiveSeriesQueries, "query-frontend.shard-active-series-queries", false, "True to enable sharding of active series queries.")
 	f.BoolVar(&cfg.UseActiveSeriesDecoder, "query-frontend.use-active-series-decoder", false, "Set to true to use the zero-allocation response decoder for active series queries.")
-	f.BoolVar(&cfg.InstantSubquerySpinOffDefaultEnable, "query-frontend.instant-subquery-spin-off.enable-by-default", false, "If set, subqueries in instant queries are spun off as range queries by default. This parameter also requires you to set `-query-frontend.instant-subquery-spin-off.url=<url>`.")
-	f.StringVar(&cfg.InstantSubquerySpinOffURL, "query-frontend.instant-subquery-spin-off.url", "", "If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to enable the feature with `-query-frontend.instant-subquery-spin-off.enable-by-default` or by setting `instant_subquery_spin_off_enabled_regexp` for the tenant.")
+	f.StringVar(&cfg.InstantSubquerySpinOffURL, "query-frontend.instant-subquery-spin-off.url", "", "If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to enable the feature with `-query-frontend.instant-subquery-spin-off.enabled` or the `instant_subquery_spin_off_enabled` per-tenant override.")
 	cfg.ResultsCacheConfig.RegisterFlags(f)
 }
 
@@ -399,7 +395,7 @@ func newQueryMiddlewares(
 			queryInstantMiddleware = append(
 				queryInstantMiddleware,
 				newInstrumentMiddleware("spin_off_subqueries", metrics),
-				newSpinOffSubqueriesMiddleware(limits, log, engine, spinOffQueryHandler, registerer, defaultStepFunc, cfg.InstantSubquerySpinOffDefaultEnable),
+				newSpinOffSubqueriesMiddleware(limits, log, engine, spinOffQueryHandler, registerer, defaultStepFunc),
 			)
 		}
 	}

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -69,7 +69,10 @@ type Config struct {
 	TargetSeriesPerShard             uint64        `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
 	ShardActiveSeriesQueries         bool          `yaml:"shard_active_series_queries" category:"experimental"`
 	UseActiveSeriesDecoder           bool          `yaml:"use_active_series_decoder" category:"experimental"`
-	SpinOffInstantSubqueriesToURL    string        `yaml:"spin_off_instant_subqueries_to_url" category:"experimental"`
+
+	// Subquery Spin-off feature
+	InstantSubquerySpinOffDefaultEnable bool   `yaml:"instant_subquery_spin_off_enabled_by_default" category:"experimental"`
+	InstantSubquerySpinOffURL           string `yaml:"instant_subquery_spin_off_url" category:"experimental"`
 
 	// CacheKeyGenerator allows to inject a CacheKeyGenerator to use for generating cache keys.
 	// If nil, the querymiddleware package uses a DefaultCacheKeyGenerator with SplitQueriesByInterval.
@@ -102,7 +105,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatProtobuf, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
 	f.BoolVar(&cfg.ShardActiveSeriesQueries, "query-frontend.shard-active-series-queries", false, "True to enable sharding of active series queries.")
 	f.BoolVar(&cfg.UseActiveSeriesDecoder, "query-frontend.use-active-series-decoder", false, "Set to true to use the zero-allocation response decoder for active series queries.")
-	f.StringVar(&cfg.SpinOffInstantSubqueriesToURL, "query-frontend.spin-off-instant-subqueries-to-url", "", "If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to set `instant_queries_with_subquery_spin_off` for the tenant.")
+	f.BoolVar(&cfg.InstantSubquerySpinOffDefaultEnable, "query-frontend.instant-subquery-spin-off.enable-by-default", false, "If set, subqueries in instant queries are spun off as range queries by default. This parameter also requires you to set `-query-frontend.instant-subquery-spin-off.url=<url>`.")
+	f.StringVar(&cfg.InstantSubquerySpinOffURL, "query-frontend.instant-subquery-spin-off.url", "", "If set, subqueries in instant queries are spun off as range queries and sent to the given URL. This parameter also requires you to enable the feature with `-query-frontend.instant-subquery-spin-off.enable-by-default` or by setting `instant_subquery_spin_off_enabled_regexp` for the tenant.")
 	cfg.ResultsCacheConfig.RegisterFlags(f)
 }
 
@@ -382,7 +386,7 @@ func newQueryMiddlewares(
 		newStepAlignMiddleware(limits, log, registerer),
 	)
 
-	if spinOffURL := cfg.SpinOffInstantSubqueriesToURL; spinOffURL != "" {
+	if spinOffURL := cfg.InstantSubquerySpinOffURL; spinOffURL != "" {
 		// Spin-off subqueries to a remote URL (or localhost)
 		// Add the retry middleware to the spin-off query handler.
 		// Spun-off queries are terminated in that handler (they don't call "next" so the retry middleware has to be added here).
@@ -395,7 +399,7 @@ func newQueryMiddlewares(
 			queryInstantMiddleware = append(
 				queryInstantMiddleware,
 				newInstrumentMiddleware("spin_off_subqueries", metrics),
-				newSpinOffSubqueriesMiddleware(limits, log, engine, spinOffQueryHandler, registerer, defaultStepFunc),
+				newSpinOffSubqueriesMiddleware(limits, log, engine, spinOffQueryHandler, registerer, defaultStepFunc, cfg.InstantSubquerySpinOffDefaultEnable),
 			)
 		}
 	}

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -594,7 +594,7 @@ func TestMiddlewaresConsistency(t *testing.T) {
 	cfg.ShardedQueries = true
 	cfg.PrunedQueries = true
 	cfg.BlockPromQLExperimentalFunctions = true
-	cfg.SpinOffInstantSubqueriesToURL = "http://localhost"
+	cfg.InstantSubquerySpinOffURL = "http://localhost"
 
 	// Ensure all features are enabled, so that we assert on all middlewares.
 	require.NotZero(t, cfg.CacheResults)

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -1563,12 +1563,16 @@ user1:
 func TestInstantSubquerySpinOffDefaults(t *testing.T) {
 	inputYAML := `
 user1:
-  instant_subquery_spin_off_min_range_duration: 4h
+  instant_subquery_spin_off_enabled: true
   instant_subquery_spin_off_enabled_regexp:
     - ".*"
+  instant_subquery_spin_off_min_range_duration: 4h
 user2:
+  instant_subquery_spin_off_enabled: true
   instant_subquery_spin_off_enabled_regexp: 
     - "123"
+user3:
+  instant_subquery_spin_off_enabled: true
 `
 	overrides := map[string]*Limits{}
 	err := yaml.Unmarshal([]byte(inputYAML), &overrides)
@@ -1584,6 +1588,11 @@ user2:
 	require.Equal(t, []string{".*"}, ov.InstantSubquerySpinOffEnabledRegexp("user1"))
 	require.Equal(t, []string{"123"}, ov.InstantSubquerySpinOffEnabledRegexp("user2"))
 	require.Empty(t, ov.InstantSubquerySpinOffEnabledRegexp("user3"))
+
+	require.True(t, ov.InstantSubquerySpinOffEnabled("user1"))
+	require.True(t, ov.InstantSubquerySpinOffEnabled("user2"))
+	require.True(t, ov.InstantSubquerySpinOffEnabled("user3"))
+	require.False(t, ov.InstantSubquerySpinOffEnabled("user4"))
 }
 
 func getDefaultLimits() Limits {


### PR DESCRIPTION
Expands on https://github.com/grafana/mimir/pull/10460

Testing has shown nice results for the feature. In our main Mimir cell, the overall runtime of all instant queries containing the "subquery pattern" (`[<range>:(<step>)?]`) has gone down by half, and the feature allows for queries further into the past by sharding by time

Currently, this is only configurable with `-query-frontend.spin-off-instant-subqueries-to-url` + a required per-tenant `instant_queries_with_subquery_spin_off` opt-in (list of regexp)

This PR makes the configs more consistent and allows for a global enable. Here are the new configs:
- `-query-frontend.instant-subquery-spin-off.enabled`. False by default, set to true to enable for all tenants. This is overridden with `instant_subquery_spin_off_enabled` on tenants. There is an extra list of regexp that can be given per-tenant as well: `instant_subquery_spin_off_enabled_regexp`. This can be useful to roll out the feature one query at a time
- `-query-frontend.instant-subquery-spin-off.min-range-duration`. Defaults to 12h. This is overridden with `instant_subquery_spin_off_min_range_duration` on tenants
- `-query-frontend.instant-subquery-spin-off.url`. The frontend config part of the feature. Required


#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
