### PR TITLE
StoreGateway: Parallelize Object Storage Requests While Building Index Headers

### DIFF
--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
-	"golang.org/x/sync/errgroup"
 	"hash"
 	"hash/crc32"
 	"io"
@@ -25,6 +24,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/thanos-io/objstore"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 )

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"golang.org/x/sync/errgroup"
 	"hash"
 	"hash/crc32"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/runutil"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
@@ -93,16 +95,48 @@ func WriteBinary(ctx context.Context, bkt objstore.BucketReader, id ulid.ULID, f
 		return errors.Wrap(err, "add index meta")
 	}
 
-	if err := ir.CopySymbols(bw.SymbolsWriter(), buf); err != nil {
-		return err
+	// Copying symbols and posting offsets into the encbuffer both require a range request against
+	// the objstore provider. We make these calls in parallel and then syncronize before writing to buf
+	var g errgroup.Group
+	var sym, tbl io.ReadCloser
+	g.Go(func() (err error) {
+		sym, err = ir.bkt.GetRange(ir.ctx, ir.path, int64(ir.toc.Symbols), int64(ir.toc.Series-ir.toc.Symbols))
+		if err != nil {
+			return errors.Wrapf(err, "get symbols from object storage of %s", ir.path)
+		}
+		return
+	})
+
+	g.Go(func() (err error) {
+		tbl, err = ir.bkt.GetRange(ir.ctx, ir.path, int64(ir.toc.PostingsTable), int64(ir.size-ir.toc.PostingsTable))
+		if err != nil {
+			return errors.Wrapf(err, "get posting offset table from object storage of %s", ir.path)
+		}
+		return
+	})
+
+	merr := multierror.MultiError{}
+	defer func() {
+		merr.Add(errors.Wrapf(sym.Close(), "close symbol reader"))
+		merr.Add(errors.Wrapf(tbl.Close(), "close posting offsets reader"))
+	}()
+
+	// wait until both GetRange requets have completed before writing bytes
+	if err := g.Wait(); err != nil {
+		merr.Add(err)
+		return merr.Err()
+	}
+
+	if _, err := io.CopyBuffer(bw.SymbolsWriter(), sym, buf); err != nil {
+		return errors.Wrap(err, "copy posting offsets")
 	}
 
 	if err := bw.f.Flush(); err != nil {
 		return errors.Wrap(err, "flush")
 	}
 
-	if err := ir.CopyPostingsOffsets(bw.PostingOffsetsWriter(), buf); err != nil {
-		return err
+	if _, err := io.CopyBuffer(bw.PostingOffsetsWriter(), tbl, buf); err != nil {
+		return errors.Wrap(err, "copy posting offsets")
 	}
 
 	if err := bw.f.Flush(); err != nil {

--- a/pkg/storegateway/indexheader/binary_reader.go
+++ b/pkg/storegateway/indexheader/binary_reader.go
@@ -117,8 +117,12 @@ func WriteBinary(ctx context.Context, bkt objstore.BucketReader, id ulid.ULID, f
 
 	merr := multierror.MultiError{}
 	defer func() {
-		merr.Add(errors.Wrapf(sym.Close(), "close symbol reader"))
-		merr.Add(errors.Wrapf(tbl.Close(), "close posting offsets reader"))
+		if sym != nil {
+			merr.Add(errors.Wrapf(sym.Close(), "close symbol reader"))
+		}
+		if tbl != nil {
+			merr.Add(errors.Wrapf(tbl.Close(), "close posting offsets reader"))
+		}
 	}()
 
 	// wait until both GetRange requets have completed before writing bytes

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/gate"
@@ -25,6 +26,7 @@ import (
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
 
+	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/util/test"
 )
@@ -416,6 +418,35 @@ func BenchmarkBinaryWrite(t *testing.B) {
 	t.ResetTimer()
 	for i := 0; i < t.N; i++ {
 		require.NoError(t, WriteBinary(ctx, bkt, m.ULID, fn))
+	}
+}
+
+func BenchmarkBinaryWrite_DelayedBucket(t *testing.B) {
+
+	tests := []struct {
+		delay time.Duration
+	}{
+		{10 * time.Millisecond},
+		{20 * time.Millisecond},
+		{50 * time.Millisecond},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("max_delay_%d_ms", test.delay.Milliseconds()), func(t *testing.B) {
+			ctx := context.Background()
+			tmpDir := t.TempDir()
+			bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+			require.NoError(t, err)
+			delaybkt := bucket.NewDelayedBucketClient(bkt, 0, test.delay)
+			defer func() { require.NoError(t, delaybkt.Close()) }()
+
+			m := prepareIndexV2Block(t, tmpDir, delaybkt)
+			fn := filepath.Join(tmpDir, m.ULID.String(), block.IndexHeaderFilename)
+			t.ResetTimer()
+			for i := 0; i < t.N; i++ {
+				require.NoError(t, WriteBinary(ctx, delaybkt, m.ULID, fn))
+			}
+		})
 	}
 }
 

--- a/pkg/storegateway/indexheader/header_test.go
+++ b/pkg/storegateway/indexheader/header_test.go
@@ -404,7 +404,7 @@ func labelValuesTestCases(t test.TB) (tests map[string][]labelValuesTestCase, bl
 	return tests, id, tmpDir
 }
 
-func BenchmarkBinaryWrite(t *testing.B) {
+func BenchmarkWriteBinary(t *testing.B) {
 	ctx := context.Background()
 
 	tmpDir := t.TempDir()
@@ -421,7 +421,7 @@ func BenchmarkBinaryWrite(t *testing.B) {
 	}
 }
 
-func BenchmarkBinaryWrite_DelayedBucket(t *testing.B) {
+func BenchmarkWriteBinary_DelayedBucket(t *testing.B) {
 
 	tests := []struct {
 		delay time.Duration


### PR DESCRIPTION
#### What this PR does

- Improves the performance of `WriteBinary` by refactoring two sequential calls to object storage to run in parallel. The Store Gateway calls `syncBlocks` on startup and periodically while running (see: `blocks-storage.bucket-store.sync-interval`)  to refresh the bucket index and look for new blocks shipped by ingesters or blocks deleted by retention/ compaction. Part of this sync involves calling `WriteBinary` which updates a local index-header file using pieces of the index in object storage. The requests for these pieces of the index file can be sent in parallel if we write them to the local index-header in the correct order.

- Adds a new benchmark, `WriteBinary_DelayedBucket`, which uses a mock bucket with a built-in delay to simulate calls to remote providers. 

```text
pkg: github.com/grafana/mimir/pkg/storegateway/indexheader
                                            │   old.txt    │               new.txt               │
                                            │    sec/op    │   sec/op     vs base                │
WriteBinary-8                                 9.156m ±  1%   9.994m ± 5%   +9.15% (p=0.000 n=10)
WriteBinary_DelayedBucket/max_delay_10_ms-8   66.72m ±  4%   58.33m ± 4%  -12.57% (p=0.000 n=10)
WriteBinary_DelayedBucket/max_delay_20_ms-8   120.8m ±  8%   105.4m ± 4%  -12.72% (p=0.000 n=10)
WriteBinary_DelayedBucket/max_delay_50_ms-8   285.8m ± 11%   224.3m ± 9%  -21.53% (p=0.000 n=10)
```

#### Which issue(s) this PR fixes or relates to

#8166

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
