### PR TITLE
test: increase check time for entryRemoval from the cache

### DIFF
--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -396,7 +396,7 @@ func TestHaTrackerWithMemberlistWhenReplicaDescIsMarkedDeletedThenKVStoreUpdateI
 	})
 	require.NoError(t, err)
 
-	condition := waitForHaTrackerCacheEntryRemoval(t, tracker, tenant, cluster, 2*time.Second, 50*time.Millisecond)
+	condition := waitForHaTrackerCacheEntryRemoval(t, tracker, tenant, cluster, 10*time.Second, 50*time.Millisecond)
 	require.True(t, condition)
 
 	now = now.Add(failoverTimeoutPlus100ms)


### PR DESCRIPTION
#### What this PR does
- Increases the check time from 2 to 10s for `waitForHaTrackerCacheEntryRemoval` in order to cover cases where test concurrency

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>
- Should fix https://github.com/grafana/mimir/issues/10687
#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
