### PR TITLE
Ingester: Ensure cost attribution tracker is updated when configuration changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Grafana Mimir
 
-* [FEATURE] Ingester/Distributor: Add support for exporting cost attribution metrics (`cortex_ingester_attributed_active_series`, `cortex_distributor_received_attributed_samples_total`, and `cortex_discarded_attributed_samples_total`) with labels specified by customers to a custom Prometheus registry. This feature enables more flexible billing data tracking. #10269
+* [FEATURE] Ingester/Distributor: Add support for exporting cost attribution metrics (`cortex_ingester_attributed_active_series`, `cortex_distributor_received_attributed_samples_total`, and `cortex_discarded_attributed_samples_total`) with labels specified by customers to a custom Prometheus registry. This feature enables more flexible billing data tracking. #10269 #10702
 * [CHANGE] Querier: pass context to queryable `IsApplicable` hook. #10451
 * [CHANGE] Distributor: OTLP and push handler replace all non-UTF8 characters with the unicode replacement character `\uFFFD` in error messages before propagating them. #10236
 * [CHANGE] Querier: pass query matchers to queryable `IsApplicable` hook. #10256
@@ -56,7 +56,6 @@
   * `go_cpu_classes_gc_total_cpu_seconds_total`
   * `go_cpu_classes_total_cpu_seconds_total`
   * `go_cpu_classes_idle_cpu_seconds_total`
-* [BUGFIX] Ingester: Ensure cost attribution tracker is updated when configuration changes. #10702
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
   * `go_cpu_classes_gc_total_cpu_seconds_total`
   * `go_cpu_classes_total_cpu_seconds_total`
   * `go_cpu_classes_idle_cpu_seconds_total`
+* [BUGFIX] Ingester: Ensure cost attribution tracker is updated when configuration changes. #10702
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277

--- a/pkg/costattribution/active_tracker.go
+++ b/pkg/costattribution/active_tracker.go
@@ -34,7 +34,7 @@ type ActiveSeriesTracker struct {
 	overflowCounter atomic.Int64
 }
 
-func newActiveSeriesTracker(userID string, trackedLabels []string, limit int, cooldownDuration time.Duration, logger log.Logger) *ActiveSeriesTracker {
+func NewActiveSeriesTracker(userID string, trackedLabels []string, limit int, cooldownDuration time.Duration, logger log.Logger) *ActiveSeriesTracker {
 	// Create a map for overflow labels to export when overflow happens
 	overflowLabels := make([]string, len(trackedLabels)+2)
 	for i := range trackedLabels {

--- a/pkg/costattribution/manager.go
+++ b/pkg/costattribution/manager.go
@@ -132,7 +132,7 @@ func (m *Manager) ActiveSeriesTracker(userID string) *ActiveSeriesTracker {
 	orderedLables := slices.Clone(labels)
 	slices.Sort(orderedLables)
 
-	tracker = newActiveSeriesTracker(userID, orderedLables, maxCardinality, cooldownDuration, m.logger)
+	tracker = NewActiveSeriesTracker(userID, orderedLables, maxCardinality, cooldownDuration, m.logger)
 	m.activeTrackersByUserID[userID] = tracker
 	return tracker
 }
@@ -195,7 +195,7 @@ func (m *Manager) updateTracker(userID string) (*SampleTracker, *ActiveSeriesTra
 
 	if !at.hasSameLabels(lbls) || at.maxCardinality != newMaxCardinality || st.cooldownDuration != newCooldownDuration {
 		m.atmtx.Lock()
-		at = newActiveSeriesTracker(userID, lbls, newMaxCardinality, newCooldownDuration, m.logger)
+		at = NewActiveSeriesTracker(userID, lbls, newMaxCardinality, newCooldownDuration, m.logger)
 		m.activeTrackersByUserID[userID] = at
 		m.atmtx.Unlock()
 	}

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -46,7 +46,7 @@ type ActiveSeries struct {
 	stripes [numStripes]seriesStripe
 	deleted deletedSeries
 
-	// configMutex protects matchers and lastMatchersUpdate. it used by both matchers and cat
+	// configMutex protects matchers, cat and lastMatchersUpdate. shared by matchers and cat
 	configMutex      sync.RWMutex
 	matchers         *asmodel.Matchers
 	lastConfigUpdate time.Time

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -117,11 +117,11 @@ func (c *ActiveSeries) ConfigDiffers(ctCfg asmodel.CustomTrackersConfig, caCfg *
 func (c *ActiveSeries) ReloadMatchersAndTrackers(asm *asmodel.Matchers, cat *costattribution.ActiveSeriesTracker, now time.Time) {
 	c.configMutex.Lock()
 	defer c.configMutex.Unlock()
-	c.cat = cat
 	for i := 0; i < numStripes; i++ {
-		c.stripes[i].reinitialize(asm, &c.deleted, c.cat)
+		c.stripes[i].reinitialize(asm, &c.deleted, cat)
 	}
 	c.matchers = asm
+	c.cat = cat
 	c.lastConfigUpdate = now
 }
 

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -50,8 +50,7 @@ type ActiveSeries struct {
 	configMutex      sync.RWMutex
 	matchers         *asmodel.Matchers
 	lastConfigUpdate time.Time
-
-	cat *costattribution.ActiveSeriesTracker
+	cat              *costattribution.ActiveSeriesTracker
 
 	// The duration after which series become inactive.
 	// Also used to determine if enough time has passed since configuration reload for valid results.

--- a/pkg/ingester/activeseries/active_series.go
+++ b/pkg/ingester/activeseries/active_series.go
@@ -114,10 +114,10 @@ func (c *ActiveSeries) ConfigDiffers(ctCfg asmodel.CustomTrackersConfig, caCfg *
 	return ctCfg.String() != c.matchers.Config().String() || caCfg != c.cat
 }
 
-func (c *ActiveSeries) ReloadMatchers(asm *asmodel.Matchers, now time.Time) {
+func (c *ActiveSeries) ReloadMatchersAndTrackers(asm *asmodel.Matchers, cat *costattribution.ActiveSeriesTracker, now time.Time) {
 	c.configMutex.Lock()
 	defer c.configMutex.Unlock()
-
+	c.cat = cat
 	for i := 0; i < numStripes; i++ {
 		c.stripes[i].reinitialize(asm, &c.deleted, c.cat)
 	}

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -800,7 +800,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 	assert.Equal(t, 1, allActive)
 	assert.Equal(t, []int{1}, activeMatching)
 
-	c.ReloadMatchers(asm, currentTime)
+	c.ReloadMatchersAndTrackers(asm, nil, currentTime)
 	valid = c.Purge(currentTime, nil)
 	assert.False(t, valid)
 
@@ -815,7 +815,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 	assert.Equal(t, []int{2}, activeMatching)
 
 	asmWithLessMatchers := asmodel.NewMatchers(MustNewCustomTrackersConfigFromMap(t, map[string]string{}))
-	c.ReloadMatchers(asmWithLessMatchers, currentTime)
+	c.ReloadMatchersAndTrackers(asmWithLessMatchers, nil, currentTime)
 
 	// Adding timeout time to make Purge results valid.
 	currentTime = currentTime.Add(DefaultTimeout)
@@ -830,7 +830,7 @@ func TestActiveSeries_ReloadSeriesMatchers(t *testing.T) {
 		"a": `{a="3"}`,
 		"b": `{a="4"}`,
 	}))
-	c.ReloadMatchers(asmWithMoreMatchers, currentTime)
+	c.ReloadMatchersAndTrackers(asmWithMoreMatchers, nil, currentTime)
 
 	// Adding timeout time to make Purge results valid.
 	currentTime = currentTime.Add(DefaultTimeout)
@@ -869,7 +869,7 @@ func TestActiveSeries_ReloadSeriesMatchers_LessMatchers(t *testing.T) {
 		"foo": `{a=~.+}`,
 	}))
 
-	c.ReloadMatchers(asm, currentTime)
+	c.ReloadMatchersAndTrackers(asm, nil, currentTime)
 	c.purge(time.Time{}, nil)
 	// Adding timeout time to make Purge results valid.
 	currentTime = currentTime.Add(DefaultTimeout)
@@ -908,7 +908,7 @@ func TestActiveSeries_ReloadSeriesMatchers_SameSizeNewLabels(t *testing.T) {
 		"bar": `{b=~.+}`,
 	}))
 
-	c.ReloadMatchers(asm, currentTime)
+	c.ReloadMatchersAndTrackers(asm, nil, currentTime)
 	c.purge(time.Time{}, nil)
 	// Adding timeout time to make Purge results valid.
 	currentTime = currentTime.Add(DefaultTimeout)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -787,9 +787,9 @@ func (i *Ingester) metricsUpdaterServiceRunning(ctx context.Context) error {
 	}
 }
 
-func (i *Ingester) replaceMatchers(asm *asmodel.Matchers, userDB *userTSDB, now time.Time) {
+func (i *Ingester) replaceMatchersAndTrackers(asm *asmodel.Matchers, cat *costattribution.ActiveSeriesTracker, userDB *userTSDB, now time.Time) {
 	i.metrics.deletePerUserCustomTrackerMetrics(userDB.userID, userDB.activeSeries.CurrentMatcherNames())
-	userDB.activeSeries.ReloadMatchers(asm, now)
+	userDB.activeSeries.ReloadMatchersAndTrackers(asm, cat, now)
 }
 
 func (i *Ingester) updateActiveSeries(now time.Time) {
@@ -802,7 +802,7 @@ func (i *Ingester) updateActiveSeries(now time.Time) {
 		newMatchersConfig := i.limits.ActiveSeriesCustomTrackersConfig(userID)
 		newCostAttributionActiveSeriesTracker := i.costAttributionMgr.ActiveSeriesTracker(userID)
 		if userDB.activeSeries.ConfigDiffers(newMatchersConfig, newCostAttributionActiveSeriesTracker) {
-			i.replaceMatchers(asmodel.NewMatchers(newMatchersConfig), userDB, now)
+			i.replaceMatchersAndTrackers(asmodel.NewMatchers(newMatchersConfig), newCostAttributionActiveSeriesTracker, userDB, now)
 		}
 
 		idx := userDB.Head().MustIndex()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

This bug was discovered during deployment. The issue occurs because while we compare configuration differences, we never update the tracker in the ingester. As a result, the tracker remains in conflict mode, continuously exporting `cortex_ingester_active_series_loading`. This fix ensures proper config consolidation and resolves the issue. Additionally, the unit test included in this PR would fail without the fixed code, confirming the correctness of the fix.


The test showed on dev with fix, similar to usage group update, after ttl, the active series sum is correct
<img width="1080" alt="Screenshot 2025-02-20 at 16 16 38" src="https://github.com/user-attachments/assets/e5404455-83d2-4439-ba65-7a361d7f2593" />

without fix, the active series are just gone for good.
<img width="762" alt="Screenshot 2025-02-20 at 17 03 52" src="https://github.com/user-attachments/assets/747c6ef7-d0c4-47e3-908c-244577c8a3c6" />





#### Checklist

- [x] Tests updated.
- na Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- na [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
