### PR TITLE
test: verify that the cache has the right value before proceeding to …

### DIFF
--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -1419,6 +1419,8 @@ func TestHATrackerChangeInElectedReplicaClearsLastSeenTimestamp(t *testing.T) {
 		require.Zero(t, info.electedLastSeenTimestamp)
 	}
 
+	// We add a polling check for t2, up to 2 seconds, to allow the cache to be populated with the correct value (secondReplica) before proceeding
+	// with the checkReplica for firstReplica.
 	checkReplicaTimestamp(t, 2*time.Second, t2, userID, cluster, secondReplica, secondReplicaReceivedAtT2, secondReplicaReceivedAtT2)
 
 	// Continuing the test, say both t1 and t2 receive request from "first" replica now.

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -1419,6 +1419,8 @@ func TestHATrackerChangeInElectedReplicaClearsLastSeenTimestamp(t *testing.T) {
 		require.Zero(t, info.electedLastSeenTimestamp)
 	}
 
+	checkReplicaTimestamp(t, 2*time.Second, t2, userID, cluster, secondReplica, secondReplicaReceivedAtT2, secondReplicaReceivedAtT2)
+
 	// Continuing the test, say both t1 and t2 receive request from "first" replica now.
 	// They both reject it.
 	now = now.Add(9 * time.Second)
@@ -1431,7 +1433,7 @@ func TestHATrackerChangeInElectedReplicaClearsLastSeenTimestamp(t *testing.T) {
 	// Now t1 updates the KV Store.
 	t1.updateKVStoreAll(context.Background(), now)
 
-	// t2 is reading updates from KV store, and should see "second" replica being the elected one.
+	// t2 is reading updates from KV store, and should see "first" replica being the elected one.
 	checkReplicaTimestamp(t, 2*time.Second, t2, userID, cluster, firstReplica, firstReceivedAtT1, firstReceivedAtT1)
 
 	// Since t2 has seen new elected replica too, we should have non-zero "electedLastSeenTimestamp".


### PR DESCRIPTION

#### What this PR does

his test is not related to `memberlist`. After running it with a -1000 value, it was failing quite often. In this PR, we add a check with a delay of up to 2 seconds to allow the cache of ha_tracker t2 to be populated before proceeding to the next step.


I ran  to verify ⬇️ 
```
go test -v -failfast ./pkg/distributor/ -run TestHATrackerChangeInElectedReplicaClearsLastSeenTimestamp -count=1000
```


#### Which issue(s) this PR fixes or relates to

Should fix https://github.com/grafana/mimir/issues/10688

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
