### PR TITLE
change: Adds k8s secret storage to helm tokengen job

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [CHANGE] Tokengen: Added k8s secret storage for the admin token. #5237
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318
 * [CHANGE] Ring: relaxed the hash ring heartbeat timeout for store-gateways: #10634
   * `-store-gateway.sharding-ring.heartbeat-timeout` set to `10m`

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -734,3 +734,10 @@ mimir.cpuToMilliCPU takes 1 argument
         {{- $value_string | float64 | mulf 1000 | toString }}
     {{- end -}}
 {{- end -}}
+
+{{/*
+kubectl image reference
+*/}}
+{{- define "mimir.kubectlImage" -}}
+{{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag | default "latest" }}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "mimir.podAnnotations" (dict "ctx" . "component" "tokengen") | nindent 8 }}
       namespace: {{ .Release.Namespace | quote }}
     spec:
-      serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      serviceAccountName: {{ include "mimir.serviceAccountName" . }}
       {{- if .Values.tokengenJob.priorityClassName }}
       priorityClassName: {{ .Values.tokengenJob.priorityClassName }}
       {{- end }}
@@ -37,8 +37,6 @@ spec:
       {{- end }}
       {{- end }}
       initContainers:
-        {{- toYaml .Values.tokengenJob.initContainers | nindent 8 }}
-      containers:
         - name: tokengen
           image: {{ include "mimir.imageReference" (dict "ctx" . "component" "tokengen") }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -46,6 +44,7 @@ spec:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
             {{- range $key, $value := .Values.tokengenJob.extraArgs }}
             - -{{ $key }}={{ $value }}
             {{- end }}
@@ -60,28 +59,22 @@ spec:
               mountPath: /etc/mimir
             - name: license
               mountPath: /license
-            - name: active-queries
-              mountPath: /active-query-tracker
-          {{- if or .Values.global.extraEnv .Values.tokengenJob.env }}
-          env:
-            {{- with .Values.global.extraEnv }}
-              {{ toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.tokengenJob.env }}
-              {{ toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
-          {{- if or .Values.global.extraEnvFrom .Values.tokengenJob.extraEnvFrom }}
-          envFrom:
-            {{- with .Values.global.extraEnvFrom }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.tokengenJob.extraEnvFrom }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
-          securityContext:
-            {{- toYaml .Values.tokengenJob.containerSecurityContext | nindent 12 }}
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: create-secret
+          image: {{ include "mimir.kubectlImage" . }}
+          imagePullPolicy: {{ .Values.kubectlImage.pullPolicy | default "IfNotPresent" }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              kubectl create secret generic {{ include "mimir.resourceName" (dict "ctx" . "component" "token") }} \
+                --from-file=token=/shared/admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -98,5 +91,7 @@ spec:
         - name: storage
           emptyDir: {}
         - name: active-queries
+          emptyDir: {}
+        - name: shared
           emptyDir: {}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.enterprise.enabled .Values.tokengenJob.enable -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "tokengen") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "tokengen") | nindent 4 }}
+  annotations:
+    {{- if .Values.tokengenJob.annotations }}
+    {{- toYaml .Values.tokengenJob.annotations | nindent 4 }}
+    {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "tokengen") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "tokengen") | nindent 4 }}
+  annotations:
+    {{- if .Values.tokengenJob.annotations }}
+    {{- toYaml .Values.tokengenJob.annotations | nindent 4 }}
+    {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "mimir.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "tokengen") }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4088,6 +4088,19 @@ tokengenJob:
   # -- The name of the PriorityClass for tokenjobgen pods
   priorityClassName: null
 
+# -- kubetclImage is used in the enterprise provisioner and tokengen jobs
+kubectlImage:
+  # -- The Docker registry
+  registry: docker.io
+  # -- Docker image repository
+  repository: bitnami/kubectl
+  # -- Overrides the image tag whose default is the chart's appVersion
+  tag: null
+  # -- Overrides the image tag with an image digest
+  digest: null
+  # -- Docker image pull policy
+  pullPolicy: IfNotPresent
+
 # Settings for the admin_api service providing authentication and authorization service.
 # Can only be enabled if enterprise.enabled is true - requires license.
 admin_api:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -36,27 +36,34 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        []
-      containers:
         - name: tokengen
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir
             - name: license
               mountPath: /license
-            - name: active-queries
-              mountPath: /active-query-tracker
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              kubectl create secret generic gateway-enterprise-values-mimir-token \
+                --from-file=token=/shared/admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -71,4 +78,6 @@ spec:
         - name: storage
           emptyDir: {}
         - name: active-queries
+          emptyDir: {}
+        - name: shared
           emptyDir: {}

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-enterprise-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: gateway-enterprise-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-enterprise-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: gateway-enterprise-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+subjects:
+- kind: ServiceAccount
+  name: gateway-enterprise-values-mimir
+  namespace: "citestns"
+roleRef:
+  kind: Role
+  name: gateway-enterprise-values-mimir-tokengen
+  apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -36,27 +36,34 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        []
-      containers:
         - name: tokengen
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir
             - name: license
               mountPath: /license
-            - name: active-queries
-              mountPath: /active-query-tracker
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              kubectl create secret generic graphite-enabled-values-mimir-token \
+                --from-file=token=/shared/admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -71,4 +78,6 @@ spec:
         - name: storage
           emptyDir: {}
         - name: active-queries
+          emptyDir: {}
+        - name: shared
           emptyDir: {}

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: graphite-enabled-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: graphite-enabled-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: graphite-enabled-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: graphite-enabled-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+subjects:
+- kind: ServiceAccount
+  name: graphite-enabled-values-mimir
+  namespace: "citestns"
+roleRef:
+  kind: Role
+  name: graphite-enabled-values-mimir-tokengen
+  apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -33,27 +33,34 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        []
-      containers:
         - name: tokengen
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir
             - name: license
               mountPath: /license
-            - name: active-queries
-              mountPath: /active-query-tracker
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              kubectl create secret generic openshift-values-mimir-token \
+                --from-file=token=/shared/admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -68,4 +75,6 @@ spec:
         - name: storage
           emptyDir: {}
         - name: active-queries
+          emptyDir: {}
+        - name: shared
           emptyDir: {}

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+subjects:
+- kind: ServiceAccount
+  name: openshift-values-mimir
+  namespace: "citestns"
+roleRef:
+  kind: Role
+  name: openshift-values-mimir-tokengen
+  apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -36,27 +36,34 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        []
-      containers:
         - name: tokengen
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir
             - name: license
               mountPath: /license
-            - name: active-queries
-              mountPath: /active-query-tracker
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              kubectl create secret generic test-enterprise-component-image-values-mimir-token \
+                --from-file=token=/shared/admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -71,4 +78,6 @@ spec:
         - name: storage
           emptyDir: {}
         - name: active-queries
+          emptyDir: {}
+        - name: shared
           emptyDir: {}

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-component-image-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-component-image-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-component-image-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-component-image-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+subjects:
+- kind: ServiceAccount
+  name: test-enterprise-component-image-values-mimir
+  namespace: "citestns"
+roleRef:
+  kind: Role
+  name: test-enterprise-component-image-values-mimir-tokengen
+  apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -37,30 +37,34 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        []
-      containers:
         - name: tokengen
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir
             - name: license
               mountPath: /license
-            - name: active-queries
-              mountPath: /active-query-tracker
-          envFrom:
-            - secretRef:
-                name: mimir-minio-secret
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              kubectl create secret generic test-enterprise-configmap-values-mimir-token \
+                --from-file=token=/shared/admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -75,4 +79,6 @@ spec:
         - name: storage
           emptyDir: {}
         - name: active-queries
+          emptyDir: {}
+        - name: shared
           emptyDir: {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-configmap-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-configmap-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-configmap-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-configmap-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+subjects:
+- kind: ServiceAccount
+  name: test-enterprise-configmap-values-mimir
+  namespace: "citestns"
+roleRef:
+  kind: Role
+  name: test-enterprise-configmap-values-mimir-tokengen
+  apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-enterprise-federation-frontend-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/tests/test-enterprise-federation-frontend-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-federation-frontend-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-federation-frontend-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-federation-frontend-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-federation-frontend-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+subjects:
+- kind: ServiceAccount
+  name: test-enterprise-federation-frontend-values-mimir
+  namespace: "citestns"
+roleRef:
+  kind: Role
+  name: test-enterprise-federation-frontend-values-mimir-tokengen
+  apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -36,27 +36,34 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        []
-      containers:
         - name: tokengen
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir
             - name: license
               mountPath: /license
-            - name: active-queries
-              mountPath: /active-query-tracker
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              kubectl create secret generic test-enterprise-k8s-1.25-values-mimir-token \
+                --from-file=token=/shared/admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -71,4 +78,6 @@ spec:
         - name: storage
           emptyDir: {}
         - name: active-queries
+          emptyDir: {}
+        - name: shared
           emptyDir: {}

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-k8s-1.25-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-k8s-1.25-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+subjects:
+- kind: ServiceAccount
+  name: test-enterprise-k8s-1.25-values-mimir
+  namespace: "citestns"
+roleRef:
+  kind: Role
+  name: test-enterprise-k8s-1.25-values-mimir-tokengen
+  apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -35,27 +35,34 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        []
-      containers:
         - name: tokengen
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir
             - name: license
               mountPath: /license
-            - name: active-queries
-              mountPath: /active-query-tracker
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              kubectl create secret generic test-enterprise-legacy-label-values-enterprise-metrics-token \
+                --from-file=token=/shared/admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -67,4 +74,6 @@ spec:
         - name: storage
           emptyDir: {}
         - name: active-queries
+          emptyDir: {}
+        - name: shared
           emptyDir: {}

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,36 @@
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-legacy-label-values-enterprise-metrics-tokengen
+  labels:
+    app: enterprise-metrics-tokengen
+    heritage: Helm
+    release: test-enterprise-legacy-label-values
+  annotations:
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-legacy-label-values-enterprise-metrics-tokengen
+  labels:
+    app: enterprise-metrics-tokengen
+    heritage: Helm
+    release: test-enterprise-legacy-label-values
+  annotations:
+  namespace: "citestns"
+subjects:
+- kind: ServiceAccount
+  name: test-enterprise-legacy-label-values-enterprise-metrics
+  namespace: "citestns"
+roleRef:
+  kind: Role
+  name: test-enterprise-legacy-label-values-enterprise-metrics-tokengen
+  apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -36,27 +36,34 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        []
-      containers:
         - name: tokengen
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir
             - name: license
               mountPath: /license
-            - name: active-queries
-              mountPath: /active-query-tracker
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              kubectl create secret generic test-enterprise-values-mimir-token \
+                --from-file=token=/shared/admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -68,4 +75,6 @@ spec:
         - name: storage
           emptyDir: {}
         - name: active-queries
+          emptyDir: {}
+        - name: shared
           emptyDir: {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+subjects:
+- kind: ServiceAccount
+  name: test-enterprise-values-mimir
+  namespace: "citestns"
+roleRef:
+  kind: Role
+  name: test-enterprise-values-mimir-tokengen
+  apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/tokengen/tokengen-job.yaml
@@ -36,27 +36,34 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        []
-      containers:
         - name: tokengen
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tokengen"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+            - "-tokengen.token-file=/shared/admin-token"
           volumeMounts:
             - name: config
               mountPath: /etc/mimir
             - name: license
               mountPath: /license
-            - name: active-queries
-              mountPath: /active-query-tracker
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            readOnlyRootFilesystem: true
+            - name: shared
+              mountPath: /shared
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              kubectl create secret generic test-oss-topology-spread-constraints-values-mimir-token \
+                --from-file=token=/shared/admin-token \
+                --dry-run=client -o yaml | kubectl apply -f -
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
       restartPolicy: OnFailure
       volumes:
         - name: config
@@ -71,4 +78,6 @@ spec:
         - name: storage
           emptyDir: {}
         - name: active-queries
+          emptyDir: {}
+        - name: shared
           emptyDir: {}

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/tokengen/tokengen-rbac.yaml
@@ -1,0 +1,38 @@
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-oss-topology-spread-constraints-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]
+---
+# Source: mimir-distributed/templates/tokengen/tokengen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-oss-topology-spread-constraints-values-mimir-tokengen
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
+    app.kubernetes.io/component: tokengen
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: "citestns"
+subjects:
+- kind: ServiceAccount
+  name: test-oss-topology-spread-constraints-values-mimir
+  namespace: "citestns"
+roleRef:
+  kind: Role
+  name: test-oss-topology-spread-constraints-values-mimir-tokengen
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
#### What this PR does

Adds k8s secret storage to the tokengen job exactly as Loki has it.  This is needed for FedRAMP deployment and day 2 operations.

#### Which issue(s) this PR fixes or relates to

Fixes #5237 #deployment_tools/218045

#### Checklist

- [x] Tests updated.
- [] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
