### PR TITLE
feat: synchronize cache update with KV store modification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * [BUGFIX] Distributor: Fix panics in `DurationWithJitter` util functions when computed variance is zero. #10507
 * [BUGFIX] Ingester: Fixed a race condition in the `PostingsForMatchers` cache that may have infrequently returned expired cached postings. #10500
 * [BUGFIX] Distributor: Report partially converted OTLP requests with status 400 Bad Request. #10588
+* [ENHANCEMENT] Distributor: synchronize cache update with KV store modification for ha_tracker. #10714
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,6 @@
 * [BUGFIX] Distributor: Fix panics in `DurationWithJitter` util functions when computed variance is zero. #10507
 * [BUGFIX] Ingester: Fixed a race condition in the `PostingsForMatchers` cache that may have infrequently returned expired cached postings. #10500
 * [BUGFIX] Distributor: Report partially converted OTLP requests with status 400 Bad Request. #10588
-* [ENHANCEMENT] Distributor: synchronize cache update with KV store modification for ha_tracker. #10714
 
 ### Mixin
 

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -668,9 +668,7 @@ func (h *defaultHaTracker) updateKVStore(ctx context.Context, userID, cluster, r
 	// If cache is currently empty, add the data we either stored or received from KVStore
 	if err == nil && desc != nil {
 		h.electedLock.Lock()
-		if h.clusters[userID][cluster] == nil {
-			h.updateCache(userID, cluster, desc)
-		}
+		h.updateCache(userID, cluster, desc)
 		h.electedLock.Unlock()
 	}
 	return err

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -665,7 +665,7 @@ func (h *defaultHaTracker) updateKVStore(ctx context.Context, userID, cluster, r
 		return desc, true, nil
 	})
 	h.kvCASCalls.WithLabelValues(userID, cluster).Inc()
-	// If cache is currently empty, add the data we either stored or received from KVStore
+	// Add data stored or received from KVStore, if available.
 	if err == nil && desc != nil {
 		h.electedLock.Lock()
 		h.updateCache(userID, cluster, desc)

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -318,6 +318,8 @@ func TestHaTrackerWithMemberList(t *testing.T) {
 	// Update KVStore - this should elect replica 2.
 	tracker.updateKVStoreAll(context.Background(), now)
 
+	checkReplicaTimestamp(t, 100*time.Millisecond, tracker, "user", cluster, replica2, now, now)
+
 	// Now we should accept from replica 2.
 	err = tracker.checkReplica(context.Background(), "user", cluster, replica2, now)
 	assert.NoError(t, err)
@@ -602,6 +604,9 @@ func TestHATrackerCheckReplicaOverwriteTimeout(t *testing.T) {
 	// Update KVStore - this should elect replica 2.
 	c.updateKVStoreAll(context.Background(), now)
 
+	// Validate Replica
+	checkReplicaTimestamp(t, 100*time.Millisecond, c, "user", "test", replica2, now, now)
+
 	// Now we should accept from replica 2.
 	err = c.checkReplica(context.Background(), "user", "test", replica2, now)
 	assert.NoError(t, err)
@@ -709,6 +714,8 @@ func TestHATrackerCheckReplicaMultiClusterTimeout(t *testing.T) {
 	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
 	assert.Error(t, err)
 	c.updateKVStoreAll(context.Background(), now)
+
+	checkReplicaTimestamp(t, 100*time.Millisecond, c, "user", "c1", replica2, now, now)
 
 	// Accept a sample from c1/replica2.
 	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -318,9 +318,6 @@ func TestHaTrackerWithMemberList(t *testing.T) {
 	// Update KVStore - this should elect replica 2.
 	tracker.updateKVStoreAll(context.Background(), now)
 
-	// Evaluate up to 10 seconds to verify whether the tracker’s cache replica has been updated to r2.
-	checkReplicaTimestamp(t, 10*time.Second, tracker, "user", cluster, replica2, now, now)
-
 	// Now we should accept from replica 2.
 	err = tracker.checkReplica(context.Background(), "user", cluster, replica2, now)
 	assert.NoError(t, err)
@@ -605,8 +602,6 @@ func TestHATrackerCheckReplicaOverwriteTimeout(t *testing.T) {
 	// Update KVStore - this should elect replica 2.
 	c.updateKVStoreAll(context.Background(), now)
 
-	checkReplicaTimestamp(t, 2*time.Second, c, "user", "test", replica2, now, now)
-
 	// Now we should accept from replica 2.
 	err = c.checkReplica(context.Background(), "user", "test", replica2, now)
 	assert.NoError(t, err)
@@ -714,7 +709,6 @@ func TestHATrackerCheckReplicaMultiClusterTimeout(t *testing.T) {
 	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
 	assert.Error(t, err)
 	c.updateKVStoreAll(context.Background(), now)
-	checkReplicaTimestamp(t, 2*time.Second, c, "user", "c1", replica2, now, now)
 
 	// Accept a sample from c1/replica2.
 	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

With this change we make the `updateCache` synchronous with the kvStore change. Since the KVstore is the source of truth , regarding the correct ha_tracker entry  it makes sense to update the cache immediately.



##### Would it have any performance impact ?

This change will add a few map accesses for Replicas that have an actual change. **Not for every Replica**.  This operation was already happening from [processKVStoreEntry](https://github.com/grafana/mimir/blob/c86963a119123161ca9f1deae538f8ac281b3a8a/pkg/distributor/ha_tracker.go#L380-L379), so we just do the change earlier.   So no impact is expected.

Thanks @dimitarvdimitrov  for pointing this out.

#### Which issue(s) this PR fixes or relates to

Fix
- https://github.com/grafana/mimir/issues/10350#issuecomment-2672294698
- https://github.com/grafana/mimir/issues/10688#issuecomment-2669235048


#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
