### PR TITLE
chore: bump golang versions (#10708)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr10481-6c395eeace
+LATEST_BUILD_IMAGE_TAG ?= pr10708-6841577474
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr10716-6841577474
+LATEST_BUILD_IMAGE_TAG ?= pr10716-f819d30595
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/grafana/mimir
 
-go 1.22.7
+go 1.22.11
 
 // Please note that this directive is ignored when building with the Mimir build image,
 // that will always use its bundled toolchain.
-toolchain go1.23.3
+toolchain go1.23.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.5.0

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM registry.k8s.io/kustomize/kustomize:v5.4.3 as kustomize
 FROM alpine/helm:3.14.4 as helm
-FROM golang:1.23.5-bookworm
+FROM golang:1.23.6-bookworm
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -9,7 +9,7 @@ FROM golang:1.23.6-bookworm
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"
-# Override toolchain directive in go.mod, to ensure the image's Go version is used.
+# Override the toolchain directive in go.mod, to ensure the image's Go version is used.
 # Be aware that the official Go Dockerfiles already do this, but let's be explicit.
 # https://github.com/docker-library/golang/issues/472
 ENV GOTOOLCHAIN=local

--- a/mimir-build-image/build.sh
+++ b/mimir-build-image/build.sh
@@ -9,9 +9,9 @@ set -eu
 SRC_PATH=$GOPATH/src/github.com/grafana/mimir
 
 # If we run make directly, any files created on the bind mount
-# will have awkward ownership.  So we switch to a user with the
-# same user and group IDs as source directory.  We have to set a
-# few things up so that sudo works without complaining later on.
+# will have awkward ownership.  So instead we switch to a user with
+# the same user and group IDs as source directory.  We have to set
+# a few things up so that sudo works without complaining later on.
 uid=$(stat --format="%u" $SRC_PATH)
 gid=$(stat --format="%g" $SRC_PATH)
 echo "weave:x:$uid:$gid::$SRC_PATH:/bin/sh" >>/etc/passwd


### PR DESCRIPTION
* chore: bump golang versions

* Update build image version to pr10708-6841577474

backport #10708 to `r330`