### PR TITLE
mixin: don't use deprecated panel type in federation-frontend dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@
 * [ENHANCEMENT] Dashboards: 'Writes' dashboard: show write requests broken down by request type. #10599
 * [ENHANCEMENT] Dashboards: clarify when query-frontend and query-scheduler dashboard panels are expected to show no data. #10624
 * [ENHANCEMENT] Alerts: Add warning alert `DistributorGcUsesTooMuchCpu`. #10641
-* [ENHANCEMENT] Dashboards: Add "Federation-frontend" dashboard for GEM. #10697
+* [ENHANCEMENT] Dashboards: Add "Federation-frontend" dashboard for GEM. #10697 #10736
 * [ENHANCEMENT] Alerts: Add "Federation-frontend" alert for remote clusters returning errors. #10698
 * [BUGFIX] Dashboards: fix how we switch between classic and native histograms. #10018
 * [BUGFIX] Alerts: Ignore cache errors performing `delete` operations since these are expected to fail when keys don't exist. #10287

--- a/operations/mimir-mixin-compiled-gem/dashboards/federation-frontend.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/federation-frontend.json
@@ -240,7 +240,7 @@
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "short"
+                        "unit": "ms"
                      },
                      "overrides": [ ]
                   },
@@ -663,7 +663,7 @@
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "req/s"
+                        "unit": "reqps"
                      },
                      "overrides": [ ]
                   },
@@ -711,7 +711,7 @@
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "short"
+                        "unit": "s"
                      },
                      "overrides": [ ]
                   },
@@ -824,7 +824,7 @@
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "ms"
+                        "unit": "short"
                      },
                      "overrides": [ ]
                   },
@@ -865,7 +865,7 @@
                   "type": "timeseries",
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "ms",
                         "label": null,
                         "logBase": 1,
                         "max": null,
@@ -1152,6 +1152,66 @@
                                  }
                               }
                            ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "cancelled"
+                           },
+                           "properties": [
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "yellow",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "client_error"
+                           },
+                           "properties": [
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "orange",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "server_error"
+                           },
+                           "properties": [
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "red",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "success"
+                           },
+                           "properties": [
+                              {
+                                 "id": "color",
+                                 "value": {
+                                    "fixedColor": "green",
+                                    "mode": "fixed"
+                                 }
+                              }
+                           ]
                         }
                      ]
                   },
@@ -1176,68 +1236,46 @@
                      }
                   ],
                   "title": "Remote requests / sec by status",
-                  "type": "timeseries",
-                  "yaxes": [
-                     {
-                        "format": "ops",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": 0,
-                        "show": true
-                     },
-                     {
-                        "format": "short",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": false
-                     }
-                  ]
+                  "type": "timeseries"
                },
                {
-                  "aliasColors": { },
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
                   "datasource": "$datasource",
                   "description": "### Remote requests / sec by request type\nRate of remote requests to $remote_cluster segmented by request type.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
+                           "drawStyle": "line",
                            "fillOpacity": 100,
                            "lineWidth": 0,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
                            "stacking": {
+                              "group": "A",
                               "mode": "normal"
                            }
-                        }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "reqps"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 13,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
                      }
                   },
-                  "fill": 1,
-                  "id": 13,
-                  "legend": {
-                     "avg": false,
-                     "current": false,
-                     "max": false,
-                     "min": false,
-                     "show": true,
-                     "total": false,
-                     "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
-                  "links": [ ],
-                  "nullPointMode": "null as zero",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [ ],
-                  "spaceLength": 10,
                   "span": 4,
-                  "stack": false,
-                  "steppedLine": false,
                   "targets": [
                      {
                         "expr": "sum by (request_type) (rate(cortex_federation_frontend_cluster_remote_latency_seconds_count{remote_cluster=~\"$remote_cluster\", cluster=~\"$cluster\", job=~\"($namespace)/((federation-frontend.*))\"}[$__rate_interval]))",
@@ -1246,73 +1284,47 @@
                         "legendLink": null
                      }
                   ],
-                  "thresholds": [ ],
-                  "timeFrom": null,
-                  "timeShift": null,
                   "title": "Remote requests / sec by request type",
-                  "tooltip": {
-                     "shared": false,
-                     "sort": 0,
-                     "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                     "buckets": null,
-                     "mode": "time",
-                     "name": null,
-                     "show": true,
-                     "values": [ ]
-                  },
-                  "yaxes": [
-                     {
-                        "format": "ops",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": 0,
-                        "show": true
-                     },
-                     {
-                        "format": "short",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": false
-                     }
-                  ]
+                  "type": "timeseries"
                },
                {
-                  "aliasColors": { },
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
                   "datasource": "$datasource",
                   "description": "### Cluster response latency\nDisplays remote latency at different quantiles.\nThis includes all requests sent to the remote clusters.\n\n",
-                  "fill": 1,
-                  "id": 14,
-                  "legend": {
-                     "avg": false,
-                     "current": false,
-                     "max": false,
-                     "min": false,
-                     "show": true,
-                     "total": false,
-                     "values": false
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "s"
+                     },
+                     "overrides": [ ]
                   },
-                  "lines": true,
-                  "linewidth": 1,
+                  "id": 14,
                   "links": [ ],
-                  "nullPointMode": "null as zero",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [ ],
-                  "spaceLength": 10,
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
                   "span": 4,
-                  "stack": false,
-                  "steppedLine": false,
                   "targets": [
                      {
                         "expr": "histogram_quantile(0.99, sum by(le, remote_cluster) (rate(cortex_federation_frontend_cluster_remote_latency_seconds_bucket{remote_cluster=~\"$remote_cluster\", cluster=~\"$cluster\", job=~\"($namespace)/((federation-frontend.*))\"}[$__rate_interval])))",
@@ -1333,41 +1345,8 @@
                         "legendLink": null
                      }
                   ],
-                  "thresholds": [ ],
-                  "timeFrom": null,
-                  "timeShift": null,
                   "title": "Remote latency",
-                  "tooltip": {
-                     "shared": false,
-                     "sort": 0,
-                     "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                     "buckets": null,
-                     "mode": "time",
-                     "name": null,
-                     "show": true,
-                     "values": [ ]
-                  },
-                  "yaxes": [
-                     {
-                        "format": "short",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": 0,
-                        "show": true
-                     },
-                     {
-                        "format": "short",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": false
-                     }
-                  ]
+                  "type": "timeseries"
                }
             ],
             "repeat": "remote_cluster",

--- a/operations/mimir-mixin-compiled-gem/dashboards/federation-frontend.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/federation-frontend.json
@@ -35,19 +35,26 @@
             "height": "250px",
             "panels": [
                {
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
                   "datasource": "$datasource",
                   "description": "### Requests / sec\nThe number of requests per second to the federation-frontend.\nThis includes all read requests: instant & range queries, series, label values, label names, etc.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
+                           "drawStyle": "line",
                            "fillOpacity": 100,
                            "lineWidth": 0,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
                            "stacking": {
+                              "group": "A",
                               "mode": "normal"
                            }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
                         },
                         "unit": "reqps"
                      },
@@ -189,30 +196,18 @@
                         }
                      ]
                   },
-                  "fill": 1,
                   "id": 1,
-                  "legend": {
-                     "avg": false,
-                     "current": false,
-                     "max": false,
-                     "min": false,
-                     "show": true,
-                     "total": false,
-                     "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
                   "links": [ ],
-                  "nullPointMode": "null as zero",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [ ],
-                  "spaceLength": 10,
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
                   "span": 4,
-                  "stack": false,
-                  "steppedLine": false,
                   "targets": [
                      {
                         "expr": "sum by (status) (\n  label_replace(label_replace(rate(cortex_request_duration_seconds_count{cluster=~\"$cluster\", job=~\"($namespace)/((federation-frontend.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n",
@@ -221,72 +216,47 @@
                         "refId": "A"
                      }
                   ],
-                  "thresholds": [ ],
-                  "timeFrom": null,
-                  "timeShift": null,
                   "title": "Requests / sec",
-                  "tooltip": {
-                     "shared": false,
-                     "sort": 0,
-                     "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                     "buckets": null,
-                     "mode": "time",
-                     "name": null,
-                     "show": true,
-                     "values": [ ]
-                  },
-                  "yaxes": [
-                     {
-                        "format": "short",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": 0,
-                        "show": true
-                     },
-                     {
-                        "format": "short",
-                        "label": null,
-                        "logBase": 1,
-                        "max": null,
-                        "min": null,
-                        "show": false
-                     }
-                  ]
+                  "type": "timeseries"
                },
                {
-                  "aliasColors": { },
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
                   "datasource": "$datasource",
-                  "fill": 1,
-                  "id": 2,
-                  "legend": {
-                     "avg": false,
-                     "current": false,
-                     "max": false,
-                     "min": false,
-                     "show": true,
-                     "total": false,
-                     "values": false
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
                   },
-                  "lines": true,
-                  "linewidth": 1,
+                  "id": 2,
                   "links": [ ],
                   "nullPointMode": "null as zero",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [ ],
-                  "spaceLength": 10,
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
                   "span": 4,
-                  "stack": false,
-                  "steppedLine": false,
                   "targets": [
                      {
                         "expr": "histogram_quantile(0.99, sum by (le) (cluster_job_route:cortex_request_duration_seconds_bucket:sum_rate{cluster=~\"$cluster\", job=~\"($namespace)/((federation-frontend.*))\", route=~\"(prometheus|api_prom)_api_v1_.+\"})) * 1e3",
@@ -307,23 +277,8 @@
                         "refId": "C"
                      }
                   ],
-                  "thresholds": [ ],
-                  "timeFrom": null,
-                  "timeShift": null,
                   "title": "Latency",
-                  "tooltip": {
-                     "shared": false,
-                     "sort": 0,
-                     "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                     "buckets": null,
-                     "mode": "time",
-                     "name": null,
-                     "show": true,
-                     "values": [ ]
-                  },
+                  "type": "timeseries",
                   "yaxes": [
                      {
                         "format": "ms",
@@ -848,41 +803,44 @@
                   "type": "timeseries"
                },
                {
-                  "aliasColors": { },
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
                   "datasource": "$datasource",
                   "description": "### Number of sharded queries per shardable query\nThe number of sharded queries that have been executed for a single input query.\nIt only tracks queries that have been successfully rewritten in a shardable way.\nIf a query is shardable, then there is at least one sharded query per remote cluster.\nIf the query is more complex, then there may be more queries per remote cluster.\nFor example, `sum(foo) + sum(bar)` will result in two queries per remote cluster.\n\n",
                   "fieldConfig": {
                      "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
                         "unit": "ms"
-                     }
+                     },
+                     "overrides": [ ]
                   },
-                  "fill": 1,
                   "id": 10,
-                  "legend": {
-                     "avg": false,
-                     "current": false,
-                     "max": false,
-                     "min": false,
-                     "show": true,
-                     "total": false,
-                     "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
                   "links": [ ],
                   "nullPointMode": "null as zero",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [ ],
-                  "spaceLength": 10,
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
                   "span": 4,
-                  "stack": false,
-                  "steppedLine": false,
                   "targets": [
                      {
                         "expr": "histogram_quantile(0.99, sum(rate(cortex_federation_frontend_cluster_sharded_queries_per_query_bucket{cluster=~\"$cluster\", job=~\"($namespace)/((federation-frontend.*))\"}[$__rate_interval])) by (le)) * 1",
@@ -903,23 +861,8 @@
                         "refId": "C"
                      }
                   ],
-                  "thresholds": [ ],
-                  "timeFrom": null,
-                  "timeShift": null,
                   "title": "Number of sharded queries per query",
-                  "tooltip": {
-                     "shared": false,
-                     "sort": 0,
-                     "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                     "buckets": null,
-                     "mode": "time",
-                     "name": null,
-                     "show": true,
-                     "values": [ ]
-                  },
+                  "type": "timeseries",
                   "yaxes": [
                      {
                         "format": "short",
@@ -1051,19 +994,26 @@
             "height": "250px",
             "panels": [
                {
-                  "bars": false,
-                  "dashLength": 10,
-                  "dashes": false,
                   "datasource": "$datasource",
                   "description": "### Remote requests / sec by status\nRate of remote requests to $remote_cluster segmented by status.\nThis includes all requests sent to the remote clusters.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
+                           "drawStyle": "line",
                            "fillOpacity": 100,
                            "lineWidth": 0,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
                            "stacking": {
+                              "group": "A",
                               "mode": "normal"
                            }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
                         },
                         "unit": "reqps"
                      },
@@ -1205,30 +1155,18 @@
                         }
                      ]
                   },
-                  "fill": 1,
                   "id": 12,
-                  "legend": {
-                     "avg": false,
-                     "current": false,
-                     "max": false,
-                     "min": false,
-                     "show": true,
-                     "total": false,
-                     "values": false
-                  },
-                  "lines": true,
-                  "linewidth": 1,
                   "links": [ ],
-                  "nullPointMode": "null as zero",
-                  "percentage": false,
-                  "pointradius": 5,
-                  "points": false,
-                  "renderer": "flot",
-                  "seriesOverrides": [ ],
-                  "spaceLength": 10,
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
                   "span": 4,
-                  "stack": false,
-                  "steppedLine": false,
                   "targets": [
                      {
                         "expr": "sum by (status) (\n  label_replace(label_replace(rate(cortex_federation_frontend_cluster_remote_latency_seconds_count{remote_cluster=~\"$remote_cluster\", cluster=~\"$cluster\", job=~\"($namespace)/((federation-frontend.*))\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n",
@@ -1237,23 +1175,8 @@
                         "refId": "A"
                      }
                   ],
-                  "thresholds": [ ],
-                  "timeFrom": null,
-                  "timeShift": null,
                   "title": "Remote requests / sec by status",
-                  "tooltip": {
-                     "shared": false,
-                     "sort": 0,
-                     "value_type": "individual"
-                  },
-                  "type": "graph",
-                  "xaxis": {
-                     "buckets": null,
-                     "mode": "time",
-                     "name": null,
-                     "show": true,
-                     "values": [ ]
-                  },
+                  "type": "timeseries",
                   "yaxes": [
                      {
                         "format": "ops",

--- a/operations/mimir-mixin/dashboards/federation-frontend.libsonnet
+++ b/operations/mimir-mixin/dashboards/federation-frontend.libsonnet
@@ -15,7 +15,7 @@ local filename = 'federation-frontend.json';
     .addRow(
       $.row('Overview')
       .addPanel(
-        $.panel('Requests / sec') +
+        $.timeseriesPanel('Requests / sec') +
         $.qpsPanel('cortex_request_duration_seconds_count{%s, route=~"%s"}' % [$.jobMatcher($._config.job_names.federation_frontend), $.queries.read_http_routes_regex]) +
         $.panelDescription(
           'Requests / sec',
@@ -26,7 +26,7 @@ local filename = 'federation-frontend.json';
         )
       )
       .addPanel(
-        $.panel('Latency') +
+        $.timeseriesPanel('Latency') +
         // This uses a latency recording rule for "cortex_request_duration_seconds"
         utils.latencyRecordingRulePanel(
           'cortex_request_duration_seconds',
@@ -102,7 +102,7 @@ local filename = 'federation-frontend.json';
         )
       )
       .addPanel(
-        $.panel('Number of sharded queries per query') +
+        $.timeseriesPanel('Number of sharded queries per query') +
         $.latencyPanel('cortex_federation_frontend_cluster_sharded_queries_per_query', '{%s}' % $.jobMatcher($._config.job_names.federation_frontend), multiplier=1) +
         { yaxes: $.yaxes('short') } +
         $.panelDescription(
@@ -156,7 +156,7 @@ local filename = 'federation-frontend.json';
         repeatDirection: 'h',
       }
       .addPanel(
-        $.panel('Remote requests / sec by status') +
+        $.timeseriesPanel('Remote requests / sec by status') +
         $.qpsPanel('cortex_federation_frontend_cluster_remote_latency_seconds_count{remote_cluster=~"$remote_cluster", %s}' % $.jobMatcher($._config.job_names.federation_frontend)) +
         {
           yaxes: $.yaxes('ops'),

--- a/operations/mimir-mixin/dashboards/federation-frontend.libsonnet
+++ b/operations/mimir-mixin/dashboards/federation-frontend.libsonnet
@@ -32,7 +32,8 @@ local filename = 'federation-frontend.json';
           'cortex_request_duration_seconds',
           $.jobSelector($._config.job_names.federation_frontend) +
           [utils.selector.re('route', $.queries.read_http_routes_regex)]
-        )
+        ) +
+        { fieldConfig+: { defaults+: { unit: 'ms' } } }
       )
       .addPanel(
         $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
@@ -67,7 +68,8 @@ local filename = 'federation-frontend.json';
           'sum by (route) (rate(cortex_request_duration_seconds_count{%s, route=~"%s"}[$__rate_interval]))' %
           [$.jobMatcher($._config.job_names.federation_frontend), $.queries.read_http_routes_regex],
           '{{route}}'
-        ) { fieldConfig+: { defaults+: { unit: 'req/s' } } }
+        ) +
+        { fieldConfig+: { defaults+: { unit: 'reqps' } } }
       )
       .addPanel(
         $.timeseriesPanel('P99 latency by route') +
@@ -76,7 +78,8 @@ local filename = 'federation-frontend.json';
           'histogram_quantile(0.99, sum by(le, route) (rate(cortex_request_duration_seconds_bucket{%s, route=~"%s"}[$__rate_interval])))' %
           [$.jobMatcher($._config.job_names.federation_frontend), $.queries.read_http_routes_regex],
           '{{route}}'
-        )
+        ) +
+        { fieldConfig+: { defaults+: { unit: 's' } } }
       )
     )
     .addRow(
@@ -104,7 +107,7 @@ local filename = 'federation-frontend.json';
       .addPanel(
         $.timeseriesPanel('Number of sharded queries per query') +
         $.latencyPanel('cortex_federation_frontend_cluster_sharded_queries_per_query', '{%s}' % $.jobMatcher($._config.job_names.federation_frontend), multiplier=1) +
-        { yaxes: $.yaxes('short') } +
+        { fieldConfig+: { defaults+: { unit: 'short' } } } +
         $.panelDescription(
           'Number of sharded queries per shardable query',
           |||
@@ -158,14 +161,13 @@ local filename = 'federation-frontend.json';
       .addPanel(
         $.timeseriesPanel('Remote requests / sec by status') +
         $.qpsPanel('cortex_federation_frontend_cluster_remote_latency_seconds_count{remote_cluster=~"$remote_cluster", %s}' % $.jobMatcher($._config.job_names.federation_frontend)) +
-        {
-          yaxes: $.yaxes('ops'),
-          aliasColors: {
-            client_error: 'orange',
-            server_error: 'red',
-            success: 'green',
-          },
-        } +
+        { fieldConfig+: { defaults+: { unit: 'reqps' } } } +
+        $.aliasColors({
+          client_error: 'orange',
+          server_error: 'red',
+          success: 'green',
+          cancelled: 'yellow',
+        }) +
         $.panelDescription(
           'Remote requests / sec by status',
           |||
@@ -175,13 +177,13 @@ local filename = 'federation-frontend.json';
         )
       )
       .addPanel(
-        $.panel('Remote requests / sec by request type') +
+        $.timeseriesPanel('Remote requests / sec by request type') +
         $.queryPanel(
           'sum by (request_type) (rate(cortex_federation_frontend_cluster_remote_latency_seconds_count{remote_cluster=~"$remote_cluster", %s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.federation_frontend),
           ['{{request_type}}'],
         ) +
         $.stack +
-        { yaxes: $.yaxes('ops') } +
+        { fieldConfig+: { defaults+: { unit: 'reqps' } } } +
         $.panelDescription(
           'Remote requests / sec by request type',
           |||
@@ -190,7 +192,7 @@ local filename = 'federation-frontend.json';
         )
       )
       .addPanel(
-        $.panel('Remote latency') +
+        $.timeseriesPanel('Remote latency') +
         $.queryPanel(
           [
             'histogram_quantile(0.99, sum by(le, remote_cluster) (rate(cortex_federation_frontend_cluster_remote_latency_seconds_bucket{remote_cluster=~"$remote_cluster", %s}[$__rate_interval])))' % $.jobMatcher($._config.job_names.federation_frontend),
@@ -206,6 +208,7 @@ local filename = 'federation-frontend.json';
           ],
           ['99th Percentile', '50th Percentile', 'Average']
         ) +
+        { fieldConfig+: { defaults+: { unit: 's' } } } +
         $.panelDescription(
           'Cluster response latency',
           |||


### PR DESCRIPTION
#### What this PR does

This PR fixes the federation-frontend dashboard to not use the deprecated Angular panel type.

I've tested these changes locally and the dashboard behaviour is identical with the preferred replacement panel type.

Screenshot of updated dashboard:

<img width="1209" alt="Screenshot 2025-02-25 at 7 54 12 pm" src="https://github.com/user-attachments/assets/505121c7-9307-4c38-b3fc-37a5482f0fae" />

#### Which issue(s) this PR fixes or relates to

#10697

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
