### PR TITLE
Jsonnet: Remove depracated KEDA parameters

### DIFF
--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -122,11 +122,6 @@
             serverAddress: $._config.autoscaling_prometheus_url,
             query: trigger.query,
 
-            // The metric name uniquely identifies a metric in the KEDA metrics server.
-            // This is deprecatd in KEDA 2.10, and is instead set to a default based on the trigger type (e.g. `s0-prometheus`).
-            // Instead we use the metric_name as the name for the trigger (above). This appears as the `scaler` label on `keda_scaler_metrics_value`.
-            metricName: trigger.metric_name,
-
             // The threshold value is set to the HPA's targetAverageValue. The number of desired replicas is computed
             // by HPA as:
             //   desiredReplicas = ceil[currentReplicas * ( currentMetricValue / desiredMetricValue )]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This parameter is deprecated in KEDA 2.10 and now KEDA is 2.15. All the relevant metrics have been updated in the previous PR and this parameter has not been used anymore.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
