### PR TITLE
ruler: add /ruler/tenants service API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [FEATURE] Ingester/Distributor: Add support for exporting cost attribution metrics (`cortex_ingester_attributed_active_series`, `cortex_distributor_received_attributed_samples_total`, and `cortex_discarded_attributed_samples_total`) with labels specified by customers to a custom Prometheus registry. This feature enables more flexible billing data tracking. #10269 #10702
+* [FEATURE] Ruler: Added `/ruler/tenants` endpoints to list the discovered tenants with rule groups. #10738
 * [CHANGE] Querier: pass context to queryable `IsApplicable` hook. #10451
 * [CHANGE] Distributor: OTLP and push handler replace all non-UTF8 characters with the unicode replacement character `\uFFFD` in error messages before propagating them. #10236
 * [CHANGE] Querier: pass query matchers to queryable `IsApplicable` hook. #10256

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -340,6 +340,7 @@ func (a *API) RegisterIngester(i Ingester) {
 func (a *API) RegisterRuler(r *ruler.Ruler) {
 	a.indexPage.AddLinks(defaultWeight, "Ruler", []IndexPageLink{
 		{Desc: "Ring status", Path: "/ruler/ring"},
+		{Desc: "Ruler tenants", Path: "/ruler/tenants"},
 	})
 	a.RegisterRoute("/ruler/ring", r, false, true, "GET", "POST")
 
@@ -348,6 +349,10 @@ func (a *API) RegisterRuler(r *ruler.Ruler) {
 
 	// List all user rule groups
 	a.RegisterRoute("/ruler/rule_groups", http.HandlerFunc(r.ListAllRules), false, true, "GET")
+
+	// List all tenants with the rule groups
+	a.RegisterRoute("/ruler/tenants", http.HandlerFunc(r.ListAllUsers), false, true, "GET")
+	a.RegisterRoute("/ruler/tenant/{tenant}/rule_groups", http.HandlerFunc(r.ListUserRuleGroups), false, true, "GET")
 
 	ruler.RegisterRulerServer(a.server.GRPC, r)
 }

--- a/pkg/ruler/rule_groups.gohtml
+++ b/pkg/ruler/rule_groups.gohtml
@@ -1,0 +1,30 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/ruler.ruleGroupsPageContents*/ -}}
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/html">
+<head>
+    <meta charset="UTF-8">
+    <title>Ruler: bucket tenant rule groups</title>
+</head>
+<body>
+<h1>Ruler: bucket tenant rule groups</h1>
+<p>Current time: {{ .Now }}</p>
+<p>Showing rule groups for tenant: <strong>{{ .Tenant }}</strong></p>
+<table border="1" cellpadding="5" style="border-collapse: collapse">
+    <thead>
+    <tr>
+        <th>Namespace</th>
+        <th>Name</th>
+    </tr>
+    </thead>
+    <tbody style="font-family: monospace;">
+    {{ $page := . }}
+    {{ range .Groups }}
+        <tr>
+            <td>{{ .Namespace }}</td>
+            <td>{{ .Name }}</td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>

--- a/pkg/ruler/tenants.gohtml
+++ b/pkg/ruler/tenants.gohtml
@@ -1,0 +1,26 @@
+{{- /*gotype: github.com/grafana/mimir/pkg/ruler.tenantsPageContents*/ -}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Ruler: bucket tenants</title>
+</head>
+<body>
+<h1>Ruler: bucket tenants</h1>
+<p>Current time: {{ .Now }}</p>
+<table border="1" cellpadding="5" style="border-collapse: collapse">
+    <thead>
+    <tr>
+        <th>Tenant</th>
+    </tr>
+    </thead>
+    <tbody style="font-family: monospace;">
+    {{ range .Tenants }}
+        <tr>
+            <td><a href="tenant/{{ . }}/rule_groups">{{ . }}</a></td>
+        </tr>
+    {{ end }}
+    </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
#### What this PR does

This PR adds a new `/ruler/tenants` endpoint to list tenants, the `ruler` service discovered in its storage. The idea here is to provide an external operator-component a way to observe which tenants have rules, without asking Mimir to retrieve the actual rules.

The API endpoint is complementary to the existing `/store-gateway/tenants`, `/compactor/tenants`, and `/ingesters/tenants`.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
