### PR TITLE
jsonnet, helm: Increase default metadata cache replicas to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
   * `_config.multi_zone_etcd_schedule_toleration` (etcd's override)
 * [CHANGE] Ring: relaxed the hash ring heartbeat timeout for store-gateways: #10634
   * `-store-gateway.sharding-ring.heartbeat-timeout` set to `10m`
+* [CHANGE] Memcached: Use 3 replicas for all cache types by default. #10739
 * [ENHANCEMENT] Enforce `persistentVolumeClaimRetentionPolicy` `Retain` policy on partition ingesters during migration to experimental ingest storage. #10395
 * [ENHANCEMENT] Allow to not configure `topologySpreadConstraints` by setting the following configuration options to a negative value: #10540
   * `distributor_topology_spread_max_skew`

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318
 * [CHANGE] Ring: relaxed the hash ring heartbeat timeout for store-gateways: #10634
   * `-store-gateway.sharding-ring.heartbeat-timeout` set to `10m`
+* [CHANGE] Memcached: Use 3 replicas for all cache types by default in `large.yaml` and `small.yaml`. #10739
 * [ENHANCEMENT] Minio: update subchart to v5.4.0. #10346
 * [ENHANCEMENT] Individual mimir components can override their container images via the *.image values. The component's image definitions always override the values set in global `image` or `enterprise.image`. #10340
 * [ENHANCEMENT] Alertmanager, compactor, ingester, and store-gateway StatefulSets can configure their PVC template name via the corresponding *.persistentVolume.name values. #10376

--- a/operations/helm/charts/mimir-distributed/large.yaml
+++ b/operations/helm/charts/mimir-distributed/large.yaml
@@ -90,22 +90,23 @@ ingester:
 
 admin-cache:
   enabled: true
-  replicas: 2
+  replicas: 3
 
 chunks-cache:
   enabled: true
-  replicas: 4
+  replicas: 3
 
 index-cache:
   enabled: true
-  replicas: 4
+  replicas: 3
 
 metadata-cache:
   enabled: true
+  replicas: 3
 
 results-cache:
   enabled: true
-  replicas: 4
+  replicas: 3
   allocatedMemory: 1024
 
 minio:

--- a/operations/helm/charts/mimir-distributed/small.yaml
+++ b/operations/helm/charts/mimir-distributed/small.yaml
@@ -90,11 +90,11 @@ ingester:
 
 admin-cache:
   enabled: true
-  replicas: 2
+  replicas: 3
 
 chunks-cache:
   enabled: true
-  replicas: 2
+  replicas: 3
 
 index-cache:
   enabled: true
@@ -102,10 +102,11 @@ index-cache:
 
 metadata-cache:
   enabled: true
+  replicas: 3
 
 results-cache:
   enabled: true
-  replicas: 2
+  replicas: 3
 
 minio:
   enabled: false

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
-  replicas: 4
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
-  replicas: 4
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
-  replicas: 4
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -1379,7 +1379,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
@@ -1379,7 +1379,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
@@ -1388,7 +1388,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -1381,7 +1381,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -1380,7 +1380,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-all-components-without-pod-topology-constraints-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-pod-topology-constraints-generated.yaml
@@ -1351,7 +1351,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1887,7 +1887,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -1960,7 +1960,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1734,7 +1734,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1734,7 +1734,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -1247,7 +1247,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -1247,7 +1247,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1750,7 +1750,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -2226,7 +2226,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1618,7 +1618,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -1177,7 +1177,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -1123,7 +1123,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -2276,7 +2276,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1383,7 +1383,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -1123,7 +1123,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1427,7 +1427,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1486,7 +1486,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -2421,7 +2421,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -2421,7 +2421,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -2421,7 +2421,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -2278,7 +2278,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -2789,7 +2789,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -2254,7 +2254,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -2258,7 +2258,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -2802,7 +2802,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -2824,7 +2824,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -2822,7 +2822,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -2822,7 +2822,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -2822,7 +2822,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -2351,7 +2351,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -2367,7 +2367,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -2367,7 +2367,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -2195,7 +2195,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -2421,7 +2421,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1379,7 +1379,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1385,7 +1385,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1391,7 +1391,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1385,7 +1385,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1750,7 +1750,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1835,7 +1835,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1835,7 +1835,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1835,7 +1835,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1835,7 +1835,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1382,7 +1382,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1379,7 +1379,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
@@ -2045,7 +2045,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
@@ -1887,7 +1887,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1887,7 +1887,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -2054,7 +2054,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1967,7 +1967,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -1123,7 +1123,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
+++ b/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
@@ -1223,7 +1223,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -1625,7 +1625,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1760,7 +1760,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1799,7 +1799,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1410,7 +1410,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1398,7 +1398,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1384,7 +1384,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -814,7 +814,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -815,7 +815,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1741,7 +1741,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1739,7 +1739,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1388,7 +1388,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
@@ -1392,7 +1392,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1389,7 +1389,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
+++ b/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
@@ -2176,7 +2176,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1389,7 +1389,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1379,7 +1379,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1384,7 +1384,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -1026,7 +1026,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       name: memcached-metadata

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -113,7 +113,7 @@
     memcached_frontend_replicas: 3,
     memcached_index_queries_replicas: 3,
     memcached_chunks_replicas: 3,
-    memcached_metadata_replicas: 1,
+    memcached_metadata_replicas: 3,
 
     cache_frontend_enabled: true,
     cache_frontend_max_item_size_mb: 5,


### PR DESCRIPTION
#### What this PR does

Even though the cache isn't used very much, we should have more than a single replica for availability.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
