### PR TITLE
store-gateway: avoid unnecessarily writing lazy-loaded blocks snapshot

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -383,7 +383,7 @@ func (s *BucketStore) InitialSync(ctx context.Context) error {
 	return nil
 }
 
-func (s *BucketStore) tryRestoreLoadedBlocksSet() map[ulid.ULID]int64 {
+func (s *BucketStore) tryRestoreLoadedBlocksSet() map[ulid.ULID]struct{} {
 	previouslyLoadedBlocks, err := indexheader.RestoreLoadedBlocks(s.dir)
 	if err != nil {
 		level.Warn(s.logger).Log(
@@ -397,7 +397,7 @@ func (s *BucketStore) tryRestoreLoadedBlocksSet() map[ulid.ULID]int64 {
 	return previouslyLoadedBlocks
 }
 
-func (s *BucketStore) loadBlocks(ctx context.Context, blocks map[ulid.ULID]int64) {
+func (s *BucketStore) loadBlocks(ctx context.Context, blocks map[ulid.ULID]struct{}) {
 	// This is not happening during a request so we can ignore the stats.
 	ignoredStats := newSafeQueryStats()
 	// We ignore the time the block was used because it can only be in the map if it was still loaded before the shutdown

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -687,49 +687,37 @@ func TestBucketStore_EagerLoading(t *testing.T) {
 	testCases := map[string]struct {
 		eagerLoadReaderEnabled       bool
 		expectedEagerLoadedBlocks    int
-		createLoadedBlocksSnapshotFn func([]ulid.ULID) map[ulid.ULID]struct{}
+		createLoadedBlocksSnapshotFn func([]ulid.ULID) []ulid.ULID
 	}{
 		"block is present in pre-shutdown loaded blocks and eager-loading is disabled": {
 			eagerLoadReaderEnabled:    false,
 			expectedEagerLoadedBlocks: 0,
-			createLoadedBlocksSnapshotFn: func(blockIDs []ulid.ULID) map[ulid.ULID]struct{} {
-				snapshot := make(map[ulid.ULID]struct{})
-				for _, blockID := range blockIDs {
-					snapshot[blockID] = struct{}{}
-				}
-				return snapshot
+			createLoadedBlocksSnapshotFn: func(blockIDs []ulid.ULID) []ulid.ULID {
+				return blockIDs
 			},
 		},
 		"block is present in pre-shutdown loaded blocks and eager-loading is enabled, loading index header during initial sync": {
 			eagerLoadReaderEnabled:    true,
 			expectedEagerLoadedBlocks: 6,
-			createLoadedBlocksSnapshotFn: func(blockIDs []ulid.ULID) map[ulid.ULID]struct{} {
-				snapshot := make(map[ulid.ULID]struct{})
-				for _, blockID := range blockIDs {
-					snapshot[blockID] = struct{}{}
-				}
-				return snapshot
+			createLoadedBlocksSnapshotFn: func(blockIDs []ulid.ULID) []ulid.ULID {
+				return blockIDs
 			},
 		},
 		"block is present in pre-shutdown loaded blocks and eager-loading is enabled, loading index header after initial sync": {
 			eagerLoadReaderEnabled:    true,
 			expectedEagerLoadedBlocks: 6,
-			createLoadedBlocksSnapshotFn: func(blockIDs []ulid.ULID) map[ulid.ULID]struct{} {
-				snapshot := make(map[ulid.ULID]struct{})
-				for _, blockID := range blockIDs {
-					snapshot[blockID] = struct{}{}
-				}
-				return snapshot
+			createLoadedBlocksSnapshotFn: func(blockIDs []ulid.ULID) []ulid.ULID {
+				return blockIDs
 			},
 		},
 		"block is not present in pre-shutdown loaded blocks snapshot and eager-loading is enabled": {
 			eagerLoadReaderEnabled:    true,
 			expectedEagerLoadedBlocks: 0, // although eager loading is enabled, this test will not do eager loading because the block ID is not in the lazy loaded file.
-			createLoadedBlocksSnapshotFn: func(_ []ulid.ULID) map[ulid.ULID]struct{} {
+			createLoadedBlocksSnapshotFn: func(_ []ulid.ULID) []ulid.ULID {
 				// let's create a random fake blockID to be stored in lazy loaded headers file
 				fakeBlockID := ulid.MustNew(ulid.Now(), nil)
 				// this snapshot will refer to fake block, hence eager load wouldn't be executed for the real block that we test
-				return map[ulid.ULID]struct{}{fakeBlockID: {}}
+				return []ulid.ULID{fakeBlockID}
 			},
 		},
 		"pre-shutdown loaded blocks snapshot doesn't exist and eager-loading is enabled": {
@@ -764,7 +752,8 @@ func TestBucketStore_EagerLoading(t *testing.T) {
 			if testData.createLoadedBlocksSnapshotFn != nil {
 				// Create the snapshot manually so that we don't rely on the periodic snapshotting.
 				loadedBlocks := store.store.blockSet.openBlocksULIDs()
-				staticLoader := staticLoadedBlocks(testData.createLoadedBlocksSnapshotFn(loadedBlocks))
+				blocksSlice := testData.createLoadedBlocksSnapshotFn(loadedBlocks)
+				staticLoader := staticLoadedBlocks(blocksSlice)
 				snapshotter := indexheader.NewSnapshotter(cfg.logger, indexheader.SnapshotterConfig{
 					PersistInterval: time.Hour,
 					Path:            cfg.tempDir,
@@ -825,9 +814,9 @@ func TestBucketStore_PersistsLazyLoadedBlocks(t *testing.T) {
 	}, persistInterval*5, persistInterval/2)
 }
 
-type staticLoadedBlocks map[ulid.ULID]struct{}
+type staticLoadedBlocks []ulid.ULID
 
-func (b staticLoadedBlocks) LoadedBlocks() map[ulid.ULID]struct{} {
+func (b staticLoadedBlocks) LoadedBlocks() []ulid.ULID {
 	return b
 }
 

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -152,8 +152,6 @@ func (p *ReaderPool) onLazyReaderClosed(r *LazyBinaryReader) {
 	delete(p.lazyReaders, r)
 }
 
-// LoadedBlocks returns a new map of lazy-loaded block IDs.
-// We no longer track the last time blocks were used.
 func (p *ReaderPool) LoadedBlocks() map[ulid.ULID]struct{} {
 	p.lazyReadersMx.Lock()
 	defer p.lazyReadersMx.Unlock()

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -152,16 +152,17 @@ func (p *ReaderPool) onLazyReaderClosed(r *LazyBinaryReader) {
 	delete(p.lazyReaders, r)
 }
 
-// LoadedBlocks returns a new map of lazy-loaded block IDs and the last time they were used in milliseconds.
-func (p *ReaderPool) LoadedBlocks() map[ulid.ULID]int64 {
+// LoadedBlocks returns a new map of lazy-loaded block IDs.
+// We no longer track the last time blocks were used.
+func (p *ReaderPool) LoadedBlocks() map[ulid.ULID]struct{} {
 	p.lazyReadersMx.Lock()
 	defer p.lazyReadersMx.Unlock()
 
-	blocks := make(map[ulid.ULID]int64, len(p.lazyReaders))
+	blocks := make(map[ulid.ULID]struct{}, len(p.lazyReaders))
 	for r := range p.lazyReaders {
 		usedAt := r.usedAt.Load()
 		if usedAt != 0 {
-			blocks[r.blockID] = usedAt / int64(time.Millisecond)
+			blocks[r.blockID] = struct{}{}
 		}
 	}
 

--- a/pkg/storegateway/indexheader/reader_pool.go
+++ b/pkg/storegateway/indexheader/reader_pool.go
@@ -152,15 +152,15 @@ func (p *ReaderPool) onLazyReaderClosed(r *LazyBinaryReader) {
 	delete(p.lazyReaders, r)
 }
 
-func (p *ReaderPool) LoadedBlocks() map[ulid.ULID]struct{} {
+func (p *ReaderPool) LoadedBlocks() []ulid.ULID {
 	p.lazyReadersMx.Lock()
 	defer p.lazyReadersMx.Unlock()
 
-	blocks := make(map[ulid.ULID]struct{}, len(p.lazyReaders))
+	blocks := make([]ulid.ULID, 0, len(p.lazyReaders))
 	for r := range p.lazyReaders {
 		usedAt := r.usedAt.Load()
 		if usedAt != 0 {
-			blocks[r.blockID] = struct{}{}
+			blocks = append(blocks, r.blockID)
 		}
 	}
 

--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -138,7 +138,8 @@ func TestReaderPool_LoadedBlocks(t *testing.T) {
 		lazyReaderEnabled: true,
 		lazyReaders:       map[*LazyBinaryReader]struct{}{&lb: {}},
 	}
-	require.Equal(t, map[ulid.ULID]struct{}{id: {}}, rp.LoadedBlocks())
+	loadedBlocks := rp.LoadedBlocks()
+	require.Equal(t, []ulid.ULID{id}, loadedBlocks)
 }
 
 func prepareReaderPool(t *testing.T) (context.Context, string, *filesystem.Bucket, ulid.ULID, *ReaderPoolMetrics) {

--- a/pkg/storegateway/indexheader/reader_pool_test.go
+++ b/pkg/storegateway/indexheader/reader_pool_test.go
@@ -138,7 +138,7 @@ func TestReaderPool_LoadedBlocks(t *testing.T) {
 		lazyReaderEnabled: true,
 		lazyReaders:       map[*LazyBinaryReader]struct{}{&lb: {}},
 	}
-	require.Equal(t, map[ulid.ULID]int64{id: usedAt.UnixMilli()}, rp.LoadedBlocks())
+	require.Equal(t, map[ulid.ULID]struct{}{id: {}}, rp.LoadedBlocks())
 }
 
 func prepareReaderPool(t *testing.T) (context.Context, string, *filesystem.Bucket, ulid.ULID, *ReaderPoolMetrics) {

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -56,7 +56,7 @@ func NewSnapshotter(logger log.Logger, conf SnapshotterConfig, bl BlocksLoader) 
 }
 
 type BlocksLoader interface {
-	LoadedBlocks() map[ulid.ULID]struct{}
+	LoadedBlocks() []ulid.ULID
 }
 
 func (s *Snapshotter) persist(context.Context) error {
@@ -74,7 +74,7 @@ func (s *Snapshotter) PersistLoadedBlocks() error {
 
 	// Convert to the format we store on disk for backward compatibility
 	indexHeaderLastUsedTime := make(map[ulid.ULID]int64, len(loadedBlocks))
-	for blockID := range loadedBlocks {
+	for _, blockID := range loadedBlocks {
 		// We use a constant timestamp since we no longer care about the actual timestamp
 		indexHeaderLastUsedTime[blockID] = 1
 	}

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -5,6 +5,7 @@ package indexheader
 import (
 	"bytes"
 	"context"
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -37,6 +38,11 @@ type Snapshotter struct {
 	conf   SnapshotterConfig
 
 	bl BlocksLoader
+
+	// lastChecksum stores the checksum of the last persisted JSON data
+	// to avoid writing the same data repeatedly, reducing IOPS.
+	// This is useful when running with many tenants on low-performance disks.
+	lastChecksum [sha1.Size]byte
 }
 
 func NewSnapshotter(logger log.Logger, conf SnapshotterConfig, bl BlocksLoader) *Snapshotter {
@@ -50,7 +56,7 @@ func NewSnapshotter(logger log.Logger, conf SnapshotterConfig, bl BlocksLoader) 
 }
 
 type BlocksLoader interface {
-	LoadedBlocks() map[ulid.ULID]int64
+	LoadedBlocks() map[ulid.ULID]struct{}
 }
 
 func (s *Snapshotter) persist(context.Context) error {
@@ -64,20 +70,44 @@ func (s *Snapshotter) persist(context.Context) error {
 }
 
 func (s *Snapshotter) PersistLoadedBlocks() error {
+	// Get the loaded blocks
+	loadedBlocks := s.bl.LoadedBlocks()
+
+	// Convert to the format we store on disk (for backward compatibility)
+	indexHeaderLastUsedTime := make(map[ulid.ULID]int64, len(loadedBlocks))
+	for blockID := range loadedBlocks {
+		// We use a constant timestamp since we no longer care about the actual timestamp
+		indexHeaderLastUsedTime[blockID] = 1
+	}
+
 	snapshot := &indexHeadersSnapshot{
-		IndexHeaderLastUsedTime: s.bl.LoadedBlocks(),
+		IndexHeaderLastUsedTime: indexHeaderLastUsedTime,
 		UserID:                  s.conf.UserID,
 	}
+
 	data, err := json.Marshal(snapshot)
 	if err != nil {
 		return err
 	}
 
+	// The json marshalling is deterministic, so the checksum will be the same for the same map contents.
+	// CRC-64 is chosen for its low CPU impact compared to cryptographic hashes.
+	checksum := sha1.Sum(data)
+	if checksum == s.lastChecksum {
+		level.Debug(s.logger).Log("msg", "skipping persistence of index headers snapshot as data hasn't changed", "user", s.conf.UserID)
+		return nil
+	}
+
 	finalPath := filepath.Join(s.conf.Path, lazyLoadedHeadersListFileName)
-	return atomicfs.CreateFile(finalPath, bytes.NewReader(data))
+	err = atomicfs.CreateFile(finalPath, bytes.NewReader(data))
+	if err == nil {
+		// Only update the checksum if the write was successful
+		s.lastChecksum = checksum
+	}
+	return err
 }
 
-func RestoreLoadedBlocks(directory string) (map[ulid.ULID]int64, error) {
+func RestoreLoadedBlocks(directory string) (map[ulid.ULID]struct{}, error) {
 	var (
 		snapshot indexHeadersSnapshot
 		multiErr = multierror.MultiError{}
@@ -99,11 +129,20 @@ func RestoreLoadedBlocks(directory string) (map[ulid.ULID]int64, error) {
 			multiErr.Add(fmt.Errorf("removing the lazy-loaded index-header snapshot: %w", err))
 		}
 	}
-	return snapshot.IndexHeaderLastUsedTime, multiErr.Err()
+
+	// Snapshots used to be stored with their las-used timestamp. But that wasn't used and lead to constant file churn, so we removed it.
+	result := make(map[ulid.ULID]struct{}, len(snapshot.IndexHeaderLastUsedTime))
+	for blockID := range snapshot.IndexHeaderLastUsedTime {
+		result[blockID] = struct{}{}
+	}
+
+	return result, multiErr.Err()
 }
 
 type indexHeadersSnapshot struct {
-	// IndexHeaderLastUsedTime is map of index header ulid.ULID to timestamp in millisecond.
+	// IndexHeaderLastUsedTime is map of index header ulid.ULID to the number 1.
+	// The number used to be the last-used timestamp of each block.
+	// We keep this format for backward compatibility, but we no longer care about the timestamps.
 	IndexHeaderLastUsedTime map[ulid.ULID]int64 `json:"index_header_last_used_time"`
 	UserID                  string              `json:"user_id"`
 }

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -70,10 +70,9 @@ func (s *Snapshotter) persist(context.Context) error {
 }
 
 func (s *Snapshotter) PersistLoadedBlocks() error {
-	// Get the loaded blocks
 	loadedBlocks := s.bl.LoadedBlocks()
 
-	// Convert to the format we store on disk (for backward compatibility)
+	// Convert to the format we store on disk for backward compatibility
 	indexHeaderLastUsedTime := make(map[ulid.ULID]int64, len(loadedBlocks))
 	for blockID := range loadedBlocks {
 		// We use a constant timestamp since we no longer care about the actual timestamp
@@ -91,7 +90,6 @@ func (s *Snapshotter) PersistLoadedBlocks() error {
 	}
 
 	// The json marshalling is deterministic, so the checksum will be the same for the same map contents.
-	// CRC-64 is chosen for its low CPU impact compared to cryptographic hashes.
 	checksum := sha1.Sum(data)
 	if checksum == s.lastChecksum {
 		level.Debug(s.logger).Log("msg", "skipping persistence of index headers snapshot as data hasn't changed", "user", s.conf.UserID)
@@ -130,7 +128,7 @@ func RestoreLoadedBlocks(directory string) (map[ulid.ULID]struct{}, error) {
 		}
 	}
 
-	// Snapshots used to be stored with their las-used timestamp. But that wasn't used and lead to constant file churn, so we removed it.
+	// Snapshots used to be stored with their last-used timestamp. But that wasn't used and lead to constant file churn, so we removed it.
 	result := make(map[ulid.ULID]struct{}, len(snapshot.IndexHeaderLastUsedTime))
 	for blockID := range snapshot.IndexHeaderLastUsedTime {
 		result[blockID] = struct{}{}

--- a/pkg/storegateway/indexheader/snapshotter.go
+++ b/pkg/storegateway/indexheader/snapshotter.go
@@ -5,7 +5,7 @@ package indexheader
 import (
 	"bytes"
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -42,7 +42,7 @@ type Snapshotter struct {
 	// lastChecksum stores the checksum of the last persisted JSON data
 	// to avoid writing the same data repeatedly, reducing IOPS.
 	// This is useful when running with many tenants on low-performance disks.
-	lastChecksum [sha1.Size]byte
+	lastChecksum [sha256.Size]byte
 }
 
 func NewSnapshotter(logger log.Logger, conf SnapshotterConfig, bl BlocksLoader) *Snapshotter {
@@ -90,7 +90,7 @@ func (s *Snapshotter) PersistLoadedBlocks() error {
 	}
 
 	// The json marshalling is deterministic, so the checksum will be the same for the same map contents.
-	checksum := sha1.Sum(data)
+	checksum := sha256.Sum256(data)
 	if checksum == s.lastChecksum {
 		level.Debug(s.logger).Log("msg", "skipping persistence of index headers snapshot as data hasn't changed", "user", s.conf.UserID)
 		return nil

--- a/pkg/storegateway/indexheader/snapshotter_test.go
+++ b/pkg/storegateway/indexheader/snapshotter_test.go
@@ -20,13 +20,11 @@ import (
 func TestSnapshotter_PersistAndRestoreLoadedBlocks(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	usedAt := time.Now()
 	testBlockID := ulid.MustNew(ulid.Now(), rand.Reader)
 
-	origBlocks := map[ulid.ULID]int64{
-		testBlockID: usedAt.UnixMilli(),
-	}
-	testBlocksLoader := testBlocksLoaderFunc(func() map[ulid.ULID]int64 { return origBlocks })
+	origBlocks := map[ulid.ULID]struct{}{testBlockID: {}}
+
+	testBlocksLoader := testBlocksLoaderFunc(func() map[ulid.ULID]struct{} { return origBlocks })
 
 	config := SnapshotterConfig{
 		Path:   tmpDir,
@@ -42,7 +40,7 @@ func TestSnapshotter_PersistAndRestoreLoadedBlocks(t *testing.T) {
 	data, err := os.ReadFile(persistedFile)
 	require.NoError(t, err)
 
-	expected := fmt.Sprintf(`{"index_header_last_used_time":{"%s":%d},"user_id":"anonymous"}`, testBlockID, usedAt.UnixMilli())
+	expected := fmt.Sprintf(`{"index_header_last_used_time":{"%s":1},"user_id":"anonymous"}`, testBlockID)
 	require.JSONEq(t, expected, string(data))
 
 	restoredBlocks, err := RestoreLoadedBlocks(config.Path)
@@ -50,14 +48,98 @@ func TestSnapshotter_PersistAndRestoreLoadedBlocks(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSnapshotter_ChecksumOptimization(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	firstBlockID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	origBlocks := map[ulid.ULID]struct{}{
+		firstBlockID: {},
+	}
+	testBlocksLoader := testBlocksLoaderFunc(func() map[ulid.ULID]struct{} { return origBlocks })
+
+	config := SnapshotterConfig{
+		Path:   tmpDir,
+		UserID: "anonymous",
+	}
+
+	// Create snapshotter and persist data
+	s := NewSnapshotter(log.NewNopLogger(), config, testBlocksLoader)
+
+	err := s.PersistLoadedBlocks()
+	require.NoError(t, err)
+
+	// Verify the content of the file using RestoreLoadedBlocks
+	restoredBlocks, err := RestoreLoadedBlocks(config.Path)
+	require.NoError(t, err)
+	require.Equal(t, origBlocks, restoredBlocks, "Restored blocks should match original blocks")
+
+	// Get file info after first write
+	persistedFile := filepath.Join(tmpDir, lazyLoadedHeadersListFileName)
+	firstStat, err := os.Stat(persistedFile)
+	require.NoError(t, err)
+	firstModTime := firstStat.ModTime()
+
+	// Wait a moment to ensure modification time would be different if file is written
+	time.Sleep(10 * time.Millisecond)
+
+	// Call persist again with the same data
+	err = s.PersistLoadedBlocks()
+	require.NoError(t, err)
+
+	// Get file info after second write attempt
+	secondStat, err := os.Stat(persistedFile)
+	require.NoError(t, err)
+	secondModTime := secondStat.ModTime()
+
+	// File should not have been modified since the data hasn't changed
+	require.Equal(t, firstModTime, secondModTime, "File was modified even though data hasn't changed")
+
+	// Verify the content has not changed using RestoreLoadedBlocks
+	restoredBlocksAfterSecondPersist, err := RestoreLoadedBlocks(config.Path)
+	require.NoError(t, err)
+	require.Equal(t, origBlocks, restoredBlocksAfterSecondPersist, "Restored blocks should match original blocks")
+
+	// Now change the data and persist again
+	secondBlockID := ulid.MustNew(ulid.Now(), rand.Reader)
+	newBlocks := map[ulid.ULID]struct{}{
+		firstBlockID:  {},
+		secondBlockID: {},
+	}
+
+	// Create a new loader with updated data
+	updatedBlocksLoader := testBlocksLoaderFunc(func() map[ulid.ULID]struct{} { return newBlocks })
+	s.bl = updatedBlocksLoader
+
+	// Wait a moment to ensure modification time would be different if file is written
+	time.Sleep(10 * time.Millisecond)
+
+	// Persist the new data
+	err = s.PersistLoadedBlocks()
+	require.NoError(t, err)
+
+	// Get file info after third write
+	thirdStat, err := os.Stat(persistedFile)
+	require.NoError(t, err)
+	thirdModTime := thirdStat.ModTime()
+
+	// File should have been modified since the data has changed
+	require.NotEqual(t, secondModTime, thirdModTime, "File was not modified even though data has changed")
+
+	// Verify the content has changed using RestoreLoadedBlocks
+	restoredBlocksAfterThirdPersist, err := RestoreLoadedBlocks(config.Path)
+	require.NoError(t, err)
+	require.Equal(t, newBlocks, restoredBlocksAfterThirdPersist, "Restored blocks should match new blocks")
+}
+
 func TestSnapshotter_StartStop(t *testing.T) {
 	t.Run("stop after start", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
-		testBlocksLoader := testBlocksLoaderFunc(func() map[ulid.ULID]int64 {
+		testBlocksLoader := testBlocksLoaderFunc(func() map[ulid.ULID]struct{} {
 			// We don't care about the content of the index header in this test.
-			return map[ulid.ULID]int64{
-				ulid.MustNew(ulid.Now(), rand.Reader): time.Now().UnixMilli(),
+			return map[ulid.ULID]struct{}{
+				ulid.MustNew(ulid.Now(), rand.Reader): {},
 			}
 		})
 
@@ -78,8 +160,8 @@ func TestSnapshotter_StartStop(t *testing.T) {
 	})
 }
 
-type testBlocksLoaderFunc func() map[ulid.ULID]int64
+type testBlocksLoaderFunc func() map[ulid.ULID]struct{}
 
-func (f testBlocksLoaderFunc) LoadedBlocks() map[ulid.ULID]int64 {
+func (f testBlocksLoaderFunc) LoadedBlocks() map[ulid.ULID]struct{} {
 	return f()
 }


### PR DESCRIPTION
### Summary

This PR introduces two key optimizations to the `indexheader.Snapshotter` 

1. Checksum Mechanism: Added a checksum-based optimization to avoid persisting unchanged JSON data, reducing unnecessary IOPS. We're using sha256 because the linters think sha1 is not secure

2. Simplified Snapshot Format: Changed the snapshot format from `map[ulid.ULID]int64` to `map[ulid.ULID]struct{}`, eliminating unused timestamp data.

### Motivation

In clusters with many tenants, the `Snapshotter` component can generate significant disk I/O by repeatedly writing identical JSON data to disk. This is particularly problematic on systems with low-performance disks. Additionally, the previous implementation stored timestamps that were never actually used in practice.

### Compatibility Considerations

#### Backward Compatibility

This approach maintains backward compatibility. `RestoreLoadedBlocks()`  still reads the old format with timestamps and converts it to the new format. The JSON structure remains the same. This ensures that existing snapshots continue to work without requiring any migration.

### Forward Compatibility

Forward compatibility is maintained because we continue to write the same JSON structure, just with simplified content. The `indexHeaderLastUsedTime` field is still present in the JSON, ensuring that older code can still parse the structure. Since older code only cares about the keys (block IDs) and not the values (timestamps), the change in value type doesn't affect functionality.

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
