### PR TITLE
MQE: benchmark tool improvements

### DIFF
--- a/tools/benchmark-query-engine/main.go
+++ b/tools/benchmark-query-engine/main.go
@@ -110,6 +110,8 @@ func (a *app) runBenchmarks(filteredNames []string) error {
 		return fmt.Errorf("benchmark binary failed validation: %w", err)
 	}
 
+	slog.Info("running benchmarks...")
+
 	haveRunAnyTests := false
 
 	for _, name := range filteredNames {
@@ -195,6 +197,8 @@ func (a *app) createTempDir() error {
 }
 
 func (a *app) buildBinary() error {
+	slog.Info("building binary...")
+
 	a.binaryPath = filepath.Join(a.tempDir, "benchmark-binary")
 
 	cmd := exec.Command("go", "test", "-c", "-o", a.binaryPath, "-tags", "stringlabels", ".")

--- a/tools/benchmark-query-engine/main.go
+++ b/tools/benchmark-query-engine/main.go
@@ -47,6 +47,7 @@ type app struct {
 	justRunIngester bool
 	cpuProfilePath  string
 	memProfilePath  string
+	benchtime       string
 }
 
 func (a *app) run() error {
@@ -151,6 +152,7 @@ func (a *app) parseArgs() error {
 	flag.StringVar(&a.ingesterAddress, "use-existing-ingester", "", "use existing ingester rather than creating a new one")
 	flag.StringVar(&a.cpuProfilePath, "cpuprofile", "", "write CPU profile to file, only supported when running a single iteration of one benchmark")
 	flag.StringVar(&a.memProfilePath, "memprofile", "", "write memory profile to file, only supported when running a single iteration of one benchmark")
+	flag.StringVar(&a.benchtime, "benchtime", "", "value passed to benchmark binary as -benchtime flag")
 
 	if err := flagext.ParseFlagsWithoutArguments(flag.CommandLine); err != nil {
 		fmt.Printf("%v\n", err)
@@ -316,6 +318,10 @@ func (a *app) runTestCase(name string, printBenchmarkHeader bool) error {
 
 	if a.memProfilePath != "" {
 		args = append(args, "-test.memprofile="+a.memProfilePath)
+	}
+
+	if a.benchtime != "" {
+		args = append(args, "-test.benchtime="+a.benchtime)
 	}
 
 	cmd := exec.Command(a.binaryPath, args...)


### PR DESCRIPTION
#### What this PR does

This PR makes two small changes to `tools/benchmark-query-engine`:

* it adds some additional logging before long-running operations
* it adds support for setting the value of `-benchtime` passed to the test binary, which is useful when running slow benchmarks to ensure enough iterations are run with warm pools

#### Which issue(s) this PR fixes or relates to

#10067

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
