### PR TITLE
MQE: add support for `count_values`

### DIFF
--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -259,7 +259,11 @@ func TestCases(metricSizes []int) []BenchCase {
 			Expr: "avg by (l)(nh_X)",
 		},
 		{
-			Expr:  "count_values('value', h_X)",
+			Expr:  "count_values('value', h_X)", // Every sample has a different value, so this expression will produce X * 100 output series.
+			Steps: 100,
+		},
+		{
+			Expr:  "count_values('value', h_X * 0)", // Every sample has the same value (0), so this expression will produce 1 series.
 			Steps: 100,
 		},
 		{

--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -258,10 +258,10 @@ func TestCases(metricSizes []int) []BenchCase {
 		{
 			Expr: "avg by (l)(nh_X)",
 		},
-		//{
-		//	Expr: "count_values('value', h_X)",
-		//  Steps: 100,
-		//},
+		{
+			Expr:  "count_values('value', h_X)",
+			Steps: 100,
+		},
 		{
 			Expr: "topk(1, a_X)",
 		},

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -2997,6 +2997,8 @@ func TestCompareVariousMixedMetricsAggregations(t *testing.T) {
 			expressions = append(expressions, fmt.Sprintf(`%s by (group) (series{label=~"(%s)"})`, aggFunc, labelRegex))
 			expressions = append(expressions, fmt.Sprintf(`%s without (group) (series{label=~"(%s)"})`, aggFunc, labelRegex))
 		}
+
+		expressions = append(expressions, fmt.Sprintf(`count_values("value", series{label="%s"})`, labelRegex))
 	}
 
 	runMixedMetricsTests(t, expressions, pointsPerSeries, seriesData, false)

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -50,8 +50,7 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 	// The goal of this is not to list every conceivable expression that is unsupported, but to cover all the
 	// different cases and make sure we produce a reasonable error message when these cases are encountered.
 	unsupportedExpressions := map[string]string{
-		`count_values("foo", metric{})`: "'count_values' aggregation with parameter",
-		"quantile(0.95, metric{})":      "'quantile' aggregation with parameter",
+		"quantile(0.95, metric{})": "'quantile' aggregation with parameter",
 	}
 
 	for expression, expectedError := range unsupportedExpressions {

--- a/pkg/streamingpromql/operators/aggregations/count_values.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/promql/engine.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Prometheus Authors
+
+package aggregations
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+type CountValues struct {
+	Inner                    types.InstantVectorOperator
+	LabelName                types.StringOperator
+	TimeRange                types.QueryTimeRange
+	Grouping                 []string // If this is a 'without' aggregation, NewAggregation will ensure that this slice contains __name__.
+	Without                  bool
+	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
+
+	expressionPosition posrange.PositionRange
+
+	resolvedLabelName string
+
+	series [][]promql.FPoint
+
+	// Reuse instances used to generate series labels rather than recreating them every time.
+	labelsBuilder     *labels.Builder
+	labelsBytesBuffer []byte
+}
+
+var _ types.InstantVectorOperator = &CountValues{}
+
+func NewCountValues(
+	inner types.InstantVectorOperator,
+	labelName types.StringOperator,
+	timeRange types.QueryTimeRange,
+	grouping []string,
+	without bool,
+	memoryConsumptionTracker *limiting.MemoryConsumptionTracker,
+	expressionPosition posrange.PositionRange,
+) *CountValues {
+	return &CountValues{
+		Inner:                    inner,
+		LabelName:                labelName,
+		TimeRange:                timeRange,
+		Grouping:                 grouping,
+		Without:                  without,
+		MemoryConsumptionTracker: memoryConsumptionTracker,
+		expressionPosition:       expressionPosition,
+	}
+}
+
+type countValuesSeries struct {
+	labels           labels.Labels
+	outputPointCount int
+	count            []int // One entry per timestamp.
+}
+
+func (c *CountValues) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
+	if err := c.loadLabelName(); err != nil {
+		return nil, err
+	}
+
+	innerMetadata, err := c.Inner.SeriesMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	defer types.PutSeriesMetadataSlice(innerMetadata)
+
+	c.labelsBuilder = labels.NewBuilder(labels.EmptyLabels())
+	c.labelsBytesBuffer = make([]byte, 0, 1024) // Why 1024 bytes? It's what labels.Labels.String() uses as a buffer size, so we use that as a sensible starting point too.
+	defer func() {
+		// Don't hold onto the instances used to generate series labels for longer than necessary.
+		c.labelsBuilder = nil
+		c.labelsBytesBuffer = nil
+	}()
+
+	accumulator := map[string]*countValuesSeries{}
+
+	for _, s := range innerMetadata {
+		data, err := c.Inner.NextSeries(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, p := range data.Floats {
+			if err := c.incrementCount(s.Labels, p.T, strconv.FormatFloat(p.F, 'f', -1, 64), accumulator); err != nil {
+				return nil, err
+			}
+		}
+
+		for _, p := range data.Histograms {
+			if err := c.incrementCount(s.Labels, p.T, p.H.String(), accumulator); err != nil {
+				return nil, err
+			}
+		}
+
+		types.PutInstantVectorSeriesData(data, c.MemoryConsumptionTracker)
+	}
+
+	outputMetadata := types.GetSeriesMetadataSlice(len(accumulator))
+	c.series = make([][]promql.FPoint, 0, len(accumulator))
+
+	for _, s := range accumulator {
+		outputMetadata = append(outputMetadata, types.SeriesMetadata{Labels: s.labels})
+
+		points, err := s.ToPoints(c.MemoryConsumptionTracker, c.TimeRange)
+		if err != nil {
+			return nil, err
+		}
+
+		c.series = append(c.series, points)
+
+		types.IntSlicePool.Put(s.count, c.MemoryConsumptionTracker)
+	}
+
+	return outputMetadata, nil
+}
+
+func (c *CountValues) loadLabelName() error {
+	c.resolvedLabelName = c.LabelName.GetValue()
+	if !model.LabelName(c.resolvedLabelName).IsValid() {
+		return fmt.Errorf("invalid label name %q for count_values", c.resolvedLabelName)
+	}
+
+	if c.Without {
+		c.Grouping = append(c.Grouping, labels.MetricName)
+	}
+
+	slices.Sort(c.Grouping)
+	return nil
+}
+
+func (c *CountValues) incrementCount(seriesLabels labels.Labels, t int64, value string, accumulator map[string]*countValuesSeries) error {
+	l := c.computeOutputLabels(seriesLabels, value)
+	c.labelsBytesBuffer = l.Bytes(c.labelsBytesBuffer)
+	series, exists := accumulator[string(c.labelsBytesBuffer)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
+
+	if !exists {
+		series = &countValuesSeries{
+			labels: l,
+		}
+
+		var err error
+		series.count, err = types.IntSlicePool.Get(c.TimeRange.StepCount, c.MemoryConsumptionTracker)
+		if err != nil {
+			return err
+		}
+
+		series.count = series.count[:c.TimeRange.StepCount]
+		accumulator[string(c.labelsBytesBuffer)] = series
+	}
+
+	idx := c.TimeRange.PointIndex(t)
+
+	if series.count[idx] == 0 {
+		series.outputPointCount++
+	}
+
+	series.count[idx]++
+
+	return nil
+}
+
+func (c *CountValues) computeOutputLabels(seriesLabels labels.Labels, value string) labels.Labels {
+	c.labelsBuilder.Reset(seriesLabels)
+
+	if c.Without {
+		c.labelsBuilder.Del(c.Grouping...)
+	} else {
+		c.labelsBuilder.Keep(c.Grouping...)
+	}
+
+	c.labelsBuilder.Set(c.resolvedLabelName, value)
+
+	return c.labelsBuilder.Labels()
+}
+
+func (s *countValuesSeries) ToPoints(memoryConsumptionTracker *limiting.MemoryConsumptionTracker, timeRange types.QueryTimeRange) ([]promql.FPoint, error) {
+	p, err := types.FPointSlicePool.Get(s.outputPointCount, memoryConsumptionTracker)
+	if err != nil {
+		return nil, err
+	}
+
+	for idx, count := range s.count {
+		if count == 0 {
+			continue
+		}
+
+		t := timeRange.IndexTime(int64(idx))
+		p = append(p, promql.FPoint{T: t, F: float64(count)})
+	}
+
+	return p, nil
+}
+
+func (c *CountValues) NextSeries(_ context.Context) (types.InstantVectorSeriesData, error) {
+	if len(c.series) == 0 {
+		return types.InstantVectorSeriesData{}, types.EOS
+	}
+
+	p := c.series[0]
+	c.series = c.series[1:]
+
+	return types.InstantVectorSeriesData{Floats: p}, nil
+}
+
+func (c *CountValues) ExpressionPosition() posrange.PositionRange {
+	return c.expressionPosition
+}
+
+func (c *CountValues) Close() {
+	c.Inner.Close()
+	c.LabelName.Close()
+}

--- a/pkg/streamingpromql/operators/aggregations/count_values.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values.go
@@ -25,7 +25,7 @@ type CountValues struct {
 	Inner                    types.InstantVectorOperator
 	LabelName                types.StringOperator
 	TimeRange                types.QueryTimeRange
-	Grouping                 []string // If this is a 'without' aggregation, NewAggregation will ensure that this slice contains __name__.
+	Grouping                 []string // If this is a 'without' aggregation, NewCountValues will ensure that this slice contains __name__.
 	Without                  bool
 	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
 
@@ -52,6 +52,12 @@ func NewCountValues(
 	memoryConsumptionTracker *limiting.MemoryConsumptionTracker,
 	expressionPosition posrange.PositionRange,
 ) *CountValues {
+	if without {
+		grouping = append(grouping, labels.MetricName)
+	}
+
+	slices.Sort(grouping)
+
 	return &CountValues{
 		Inner:                    inner,
 		LabelName:                labelName,
@@ -146,11 +152,6 @@ func (c *CountValues) loadLabelName() error {
 		return fmt.Errorf("invalid label name %q for count_values", c.resolvedLabelName)
 	}
 
-	if c.Without {
-		c.Grouping = append(c.Grouping, labels.MetricName)
-	}
-
-	slices.Sort(c.Grouping)
 	return nil
 }
 

--- a/pkg/streamingpromql/operators/aggregations/count_values.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values.go
@@ -125,7 +125,7 @@ func (c *CountValues) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadat
 	for _, s := range accumulator {
 		outputMetadata = append(outputMetadata, types.SeriesMetadata{Labels: s.labels})
 
-		points, err := s.ToPoints(c.MemoryConsumptionTracker, c.TimeRange)
+		points, err := s.toPoints(c.MemoryConsumptionTracker, c.TimeRange)
 		if err != nil {
 			return nil, err
 		}
@@ -208,7 +208,7 @@ func (c *CountValues) computeOutputLabels(seriesLabels labels.Labels, value stri
 	return c.labelsBuilder.Labels()
 }
 
-func (s *countValuesSeries) ToPoints(memoryConsumptionTracker *limiting.MemoryConsumptionTracker, timeRange types.QueryTimeRange) ([]promql.FPoint, error) {
+func (s *countValuesSeries) toPoints(memoryConsumptionTracker *limiting.MemoryConsumptionTracker, timeRange types.QueryTimeRange) ([]promql.FPoint, error) {
 	p, err := types.FPointSlicePool.Get(s.outputPointCount, memoryConsumptionTracker)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/operators/aggregations/count_values_test.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values_test.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package aggregations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/operators"
+	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func TestCountValues_GroupLabelling(t *testing.T) {
+	testCases := map[string]struct {
+		grouping                    []string
+		without                     bool
+		inputSeries                 labels.Labels
+		expectedOutputSeries        labels.Labels
+		overrideExpectedOutputBytes []byte
+	}{
+		"grouping to a single series": {
+			grouping:                    []string{},
+			inputSeries:                 labels.FromStrings(labels.MetricName, "my_metric", "env", "prod"),
+			expectedOutputSeries:        labels.FromStrings("value", "123"),
+			overrideExpectedOutputBytes: []byte{}, // Special case for grouping to a single series.
+		},
+
+		// Grouping with 'by'
+		"grouping with 'by', single grouping label, input has only metric name": {
+			grouping:             []string{"env"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric"),
+			expectedOutputSeries: labels.FromStrings("value", "123"),
+		},
+		"grouping with 'by', single grouping label, input does not have grouping label": {
+			grouping:             []string{"env"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "foo", "bar"),
+			expectedOutputSeries: labels.FromStrings("value", "123"),
+		},
+		"grouping with 'by', single grouping label, input does have grouping label": {
+			grouping:             []string{"env"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "foo", "bar"),
+			expectedOutputSeries: labels.FromStrings("env", "prod", "value", "123"),
+		},
+		"grouping with 'by', multiple grouping labels, input has only metric name": {
+			grouping:             []string{"cluster", "env"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric"),
+			expectedOutputSeries: labels.FromStrings("value", "123"),
+		},
+		"grouping with 'by', multiple grouping labels, input does not have any grouping labels": {
+			grouping:             []string{"cluster", "env"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "foo", "bar"),
+			expectedOutputSeries: labels.FromStrings("value", "123"),
+		},
+		"grouping with 'by', multiple grouping labels, input has some grouping labels": {
+			grouping:             []string{"cluster", "env"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "foo", "bar"),
+			expectedOutputSeries: labels.FromStrings("env", "prod", "value", "123"),
+		},
+		"grouping with 'by', multiple grouping labels, input has superset of grouping labels": {
+			grouping:             []string{"cluster", "env"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "foo", "bar"),
+			expectedOutputSeries: labels.FromStrings("env", "prod", "cluster", "cluster-1", "value", "123"),
+		},
+		"grouping with 'by', multiple grouping labels, input has all grouping labels and no others": {
+			grouping:             []string{"cluster", "env"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1"),
+			expectedOutputSeries: labels.FromStrings("env", "prod", "cluster", "cluster-1", "value", "123"),
+		},
+		"grouping with 'by', unsorted grouping labels": {
+			grouping:             []string{"env", "cluster"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "foo", "bar"),
+			expectedOutputSeries: labels.FromStrings("env", "prod", "cluster", "cluster-1", "value", "123"),
+		},
+		"grouping with 'by', some grouping labels sort after value label": {
+			grouping:             []string{"env", "cluster", "z-label"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "foo", "bar", "z-label", "z-value"),
+			expectedOutputSeries: labels.FromStrings("env", "prod", "cluster", "cluster-1", "value", "123", "z-label", "z-value"),
+		},
+		"grouping with 'by', grouping labels include __name__": {
+			grouping:             []string{"cluster", "env", "__name__"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "foo", "bar"),
+			expectedOutputSeries: labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "value", "123"),
+		},
+
+		// Grouping with 'without'
+		"grouping with 'without', single grouping label, input has only metric name": {
+			grouping:             []string{"env"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric"),
+			expectedOutputSeries: labels.FromStrings("value", "123"),
+		},
+		"grouping with 'without', single grouping label, input does not have grouping label": {
+			grouping:             []string{"env"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "a-label", "a-value", "f-label", "f-value"),
+			expectedOutputSeries: labels.FromStrings("a-label", "a-value", "f-label", "f-value", "value", "123"),
+		},
+		"grouping with 'without', single grouping label, input does have grouping label": {
+			grouping:             []string{"env"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "a-label", "a-value", "f-label", "f-value"),
+			expectedOutputSeries: labels.FromStrings("a-label", "a-value", "f-label", "f-value", "value", "123"),
+		},
+		"grouping with 'without', multiple grouping labels, input has only metric name": {
+			grouping:             []string{"cluster", "env"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric"),
+			expectedOutputSeries: labels.FromStrings("value", "123"),
+		},
+		"grouping with 'without', multiple grouping labels, input does not have any grouping labels": {
+			grouping:             []string{"cluster", "env"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "a-label", "a-value", "d-label", "d-value", "f-label", "f-value"),
+			expectedOutputSeries: labels.FromStrings("a-label", "a-value", "d-label", "d-value", "f-label", "f-value", "value", "123"),
+		},
+		"grouping with 'without', multiple grouping labels, input has some grouping labels": {
+			grouping:             []string{"cluster", "env"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "a-label", "a-value", "d-label", "d-value", "f-label", "f-value"),
+			expectedOutputSeries: labels.FromStrings("a-label", "a-value", "d-label", "d-value", "f-label", "f-value", "value", "123"),
+		},
+		"grouping with 'without', multiple grouping labels, input has superset of grouping labels": {
+			grouping:             []string{"cluster", "env"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "a-label", "a-value", "d-label", "d-value", "f-label", "f-value"),
+			expectedOutputSeries: labels.FromStrings("a-label", "a-value", "d-label", "d-value", "f-label", "f-value", "value", "123"),
+		},
+		"grouping with 'without', multiple grouping labels, input has all grouping labels and no others": {
+			grouping:             []string{"cluster", "env"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1"),
+			expectedOutputSeries: labels.FromStrings("value", "123"),
+		},
+		"grouping with 'without', unsorted grouping labels": {
+			grouping:             []string{"env", "cluster"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "a-label", "a-value", "d-label", "d-value", "f-label", "f-value"),
+			expectedOutputSeries: labels.FromStrings("a-label", "a-value", "d-label", "d-value", "f-label", "f-value", "value", "123"),
+		},
+		"grouping with 'without', some grouping labels sort after value label": {
+			grouping:             []string{"env", "cluster", "z-label"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "a-label", "a-value", "d-label", "d-value", "f-label", "f-value", "z-label", "z-value"),
+			expectedOutputSeries: labels.FromStrings("a-label", "a-value", "d-label", "d-value", "f-label", "f-value", "value", "123"),
+		},
+		"grouping with 'without', grouping labels include __name__": {
+			grouping:             []string{"cluster", "env", "__name__"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "a-label", "a-value", "d-label", "d-value", "f-label", "f-value"),
+			expectedOutputSeries: labels.FromStrings("a-label", "a-value", "d-label", "d-value", "f-label", "f-value", "value", "123"),
+		},
+		"grouping with 'without', grouping labels include duplicates": {
+			grouping:             []string{"cluster", "env", "cluster"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "a-label", "a-value", "d-label", "d-value", "f-label", "f-value"),
+			expectedOutputSeries: labels.FromStrings("a-label", "a-value", "d-label", "d-value", "f-label", "f-value", "value", "123"),
+		},
+		"grouping with 'without', grouping labels include label that sorts before __name__": {
+			grouping:             []string{"cluster", "env", "__aaa__"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "__aaa__", "foo", "a-label", "a-value", "d-label", "d-value", "f-label", "f-value"),
+			expectedOutputSeries: labels.FromStrings("a-label", "a-value", "d-label", "d-value", "f-label", "f-value", "value", "123"),
+		},
+
+		"grouping with 'without', multiple grouping labels, input has all grouping labels and value label": {
+			grouping:             []string{"cluster", "env"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "value", "foo"),
+			expectedOutputSeries: labels.FromStrings("value", "123"),
+		},
+		"grouping with 'without', multiple grouping labels including value label, input has all grouping labels and value label": {
+			grouping:             []string{"cluster", "env", "value"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "value", "foo"),
+			expectedOutputSeries: labels.FromStrings("value", "123"),
+		},
+		"grouping with 'without', multiple grouping labels including value label, input has all grouping labels and not value label": {
+			grouping:             []string{"cluster", "env", "value"},
+			without:              true,
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1"),
+			expectedOutputSeries: labels.FromStrings("value", "123"),
+		},
+
+		"grouping with 'by', multiple grouping labels, input has all grouping labels and value label": {
+			grouping:             []string{"cluster", "env"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "value", "foo"),
+			expectedOutputSeries: labels.FromStrings("env", "prod", "cluster", "cluster-1", "value", "123"),
+		},
+		"grouping with 'by', multiple grouping labels including value label, input has all grouping labels and value label": {
+			grouping:             []string{"cluster", "env", "value"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1", "value", "foo"),
+			expectedOutputSeries: labels.FromStrings("env", "prod", "cluster", "cluster-1", "value", "123"),
+		},
+		"grouping with 'by', multiple grouping labels including value label, input has all grouping labels and not value label": {
+			grouping:             []string{"cluster", "env", "value"},
+			inputSeries:          labels.FromStrings(labels.MetricName, "my_metric", "env", "prod", "cluster", "cluster-1"),
+			expectedOutputSeries: labels.FromStrings("env", "prod", "cluster", "cluster-1", "value", "123"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+			floats, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+			require.NoError(t, err)
+			floats = append(floats, promql.FPoint{T: 0, F: 123})
+
+			inner := &operators.TestOperator{
+				Series: []labels.Labels{testCase.inputSeries},
+				Data: []types.InstantVectorSeriesData{
+					{Floats: floats},
+				},
+			}
+
+			labelName := operators.NewStringLiteral("value", posrange.PositionRange{})
+			aggregator := NewCountValues(inner, labelName, types.NewInstantQueryTimeRange(timestamp.Time(0)), testCase.grouping, testCase.without, memoryConsumptionTracker, posrange.PositionRange{})
+
+			metadata, err := aggregator.SeriesMetadata(context.Background())
+			require.NoError(t, err)
+
+			require.Equal(t, testutils.LabelsToSeriesMetadata([]labels.Labels{testCase.expectedOutputSeries}), metadata)
+		})
+	}
+}

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -192,6 +192,13 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr, timeRange types
 				}
 
 				return topkbottomk.New(inner, param, timeRange, e.Grouping, e.Without, e.Op == parser.TOPK, q.memoryConsumptionTracker, q.annotations, e.PosRange), nil
+			case parser.COUNT_VALUES:
+				param, err := q.convertToStringOperator(e.Param)
+				if err != nil {
+					return nil, err
+				}
+
+				return aggregations.NewCountValues(inner, param, timeRange, e.Grouping, e.Without, q.memoryConsumptionTracker, e.PosRange), nil
 			default:
 				return nil, compat.NewNotSupportedError(fmt.Sprintf("'%s' aggregation with parameter", e.Op))
 			}

--- a/pkg/streamingpromql/testdata/ours/aggregators.test
+++ b/pkg/streamingpromql/testdata/ours/aggregators.test
@@ -578,3 +578,50 @@ eval range from 0 to 12m step 6m bottomk(2, series)
 
 eval range from 0 to 12m step 6m bottomk(1, series)
   series{case="-Inf"}  -Inf -Inf
+
+clear
+
+# Test count_values.
+load 6m
+  series{idx="0", case="Inf"}   Inf  Inf  Inf
+  series{idx="0", case="-Inf"}  -Inf -Inf _
+  series{idx="0", case="NaN"}   NaN  NaN  NaN
+  series{idx="0", case="1"}     1    1    _
+  series{idx="1", case="Inf"}   Inf  _    _
+  series{idx="1", case="-Inf"}  -Inf _    _
+  series{idx="1", case="NaN"}   NaN  _    NaN
+  series{idx="1", case="1"}     1    _    _
+
+eval range from 0 to 12m step 6m count_values("value", series)
+  {value="+Inf"} 2 1 1
+  {value="-Inf"} 2 1 _
+  {value="NaN"}  2 1 2
+  {value="1"}    2 1 _
+
+eval range from 0 to 12m step 6m count_values by (case) ("value", series)
+  {case="Inf", value="+Inf"}  2 1 1
+  {case="-Inf", value="-Inf"} 2 1 _
+  {case="NaN", value="NaN"}   2 1 2
+  {case="1", value="1"}       2 1 _
+
+eval range from 0 to 12m step 6m count_values by (idx) ("value", series)
+  {idx="0", value="+Inf"} 1 1 1
+  {idx="0", value="-Inf"} 1 1 _
+  {idx="0", value="NaN"}  1 1 1
+  {idx="0", value="1"}    1 1 _
+  {idx="1", value="+Inf"} 1 _ _
+  {idx="1", value="-Inf"} 1 _ _
+  {idx="1", value="NaN"}  1 _ 1
+  {idx="1", value="1"}    1 _ _
+
+# Overwrite grouping label with value.
+eval range from 0 to 12m step 6m count_values by (idx) ("idx", series)
+  {idx="+Inf"} 2 1 1
+  {idx="-Inf"} 2 1 _
+  {idx="NaN"}  2 1 2
+  {idx="1"}    2 1 _
+
+# Prometheus' engine quotes the label name twice: see https://github.com/prometheus/prometheus/pull/16054.
+# Once that fix is vendored into Mimir, we can remove the two (\\")? groups below.
+eval_fail instant at 0 count_values("a\xc5z", series)
+  expected_fail_regexp invalid label name "(\\")?a\\(\\)?xc5z(\\")?"( for count_values)?

--- a/pkg/streamingpromql/testdata/upstream/aggregators.test
+++ b/pkg/streamingpromql/testdata/upstream/aggregators.test
@@ -402,43 +402,38 @@ load 5m
 	version{job="app-server", instance="2", group="canary"}		{{schema:0 sum:10 count:20 z_bucket_w:0.001 z_bucket:2 buckets:[1 2] n_buckets:[1 2]}}
 	version{job="app-server", instance="3", group="canary"}		{{schema:0 sum:10 count:20 z_bucket_w:0.001 z_bucket:2 buckets:[1 2] n_buckets:[1 2]}}
 
-# Unsupported by streaming engine.
-# eval instant at 1m count_values("version", version)
-# 	{version="6"} 5
-# 	{version="7"} 2
-# 	{version="8"} 2
-#     {version="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}"} 2
+eval instant at 1m count_values("version", version)
+	{version="6"} 5
+	{version="7"} 2
+	{version="8"} 2
+    {version="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}"} 2
 
-# Unsupported by streaming engine.
-# eval instant at 1m count_values(((("version"))), version)
-#     {version="6"} 5
-#     {version="7"} 2
-#     {version="8"} 2
-#     {version="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}"} 2
+eval instant at 1m count_values(((("version"))), version)
+    {version="6"} 5
+    {version="7"} 2
+    {version="8"} 2
+    {version="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}"} 2
 
-# Unsupported by streaming engine.
-# eval instant at 1m count_values without (instance)("version", version)
-# 	{job="api-server", group="production", version="6"} 3
-# 	{job="api-server", group="canary", version="8"} 2
-# 	{job="app-server", group="production", version="6"} 2
-# 	{job="app-server", group="canary", version="7"} 2
-#     {job="app-server", group="canary", version="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}"} 2
+eval instant at 1m count_values without (instance)("version", version)
+	{job="api-server", group="production", version="6"} 3
+	{job="api-server", group="canary", version="8"} 2
+	{job="app-server", group="production", version="6"} 2
+	{job="app-server", group="canary", version="7"} 2
+    {job="app-server", group="canary", version="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}"} 2
 
 # Overwrite label with output. Don't do this.
-# Unsupported by streaming engine.
-# eval instant at 1m count_values without (instance)("job", version)
-# 	{job="6", group="production"} 5
-# 	{job="8", group="canary"} 2
-# 	{job="7", group="canary"} 2
-#     {job="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}", group="canary"} 2
+eval instant at 1m count_values without (instance)("job", version)
+	{job="6", group="production"} 5
+	{job="8", group="canary"} 2
+	{job="7", group="canary"} 2
+    {job="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}", group="canary"} 2
 
 # Overwrite label with output. Don't do this.
-# Unsupported by streaming engine.
-# eval instant at 1m count_values by (job, group)("job", version)
-# 	{job="6", group="production"} 5
-# 	{job="8", group="canary"} 2
-# 	{job="7", group="canary"} 2
-#     {job="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}", group="canary"} 2
+eval instant at 1m count_values by (job, group)("job", version)
+	{job="6", group="production"} 5
+	{job="8", group="canary"} 2
+	{job="7", group="canary"} 2
+    {job="{count:20, sum:10, [-2,-1):2, [-1,-0.5):1, [-0.001,0.001]:2, (0.5,1]:1, (1,2]:2}", group="canary"} 2
 
 # Tests for quantile.
 clear


### PR DESCRIPTION
#### What this PR does

This PR adds support for `count_values` in MQE.

Benchmark results are mixed. MQE's implementation always consumes less memory than Prometheus' engine in our benchmarks, but in some cases runs slower, and in others runs faster. MQE is up to 36% faster for the common case where many series have only a handful of values, but up to 20% slower for the uncommon case where every sample has a different value.

The `count_values('value', h_X)` cases exercise the scenario where every sample has a different value, resulting in `X × 100` output series. The `count_values('value', h_X * 0)` cases exercise the scenario where every sample has the same value, resulting in 1 output series.

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/streamingpromql/benchmarks
cpu: Apple M1 Pro
                                                                       │ Prometheus  │               Mimir                │
                                                                       │   sec/op    │   sec/op     vs base               │
Query/count_values('value',_h_1),_range_query_with_100_steps-10          833.8µ ± 1%   733.8µ ± 3%  -11.99% (p=0.002 n=6)
Query/count_values('value',_h_100),_range_query_with_100_steps-10        70.70m ± 1%   84.77m ± 4%  +19.91% (p=0.002 n=6)
Query/count_values('value',_h_2000),_range_query_with_100_steps-10        2.300 ± 2%    2.574 ± 2%  +11.92% (p=0.002 n=6)
Query/count_values('value',_h_1_*_0),_range_query_with_100_steps-10      384.5µ ± 2%   266.9µ ± 1%  -30.59% (p=0.002 n=6)
Query/count_values('value',_h_100_*_0),_range_query_with_100_steps-10    19.00m ± 5%   13.54m ± 3%  -28.71% (p=0.002 n=6)
Query/count_values('value',_h_2000_*_0),_range_query_with_100_steps-10   413.2m ± 1%   264.3m ± 1%  -36.04% (p=0.002 n=6)
geomean                                                                  27.25m        23.13m       -15.12%

                                                                       │  Prometheus   │                Mimir                 │
                                                                       │       B       │       B        vs base               │
Query/count_values('value',_h_1),_range_query_with_100_steps-10           64.55Mi ± 1%   65.10Mi ±  1%        ~ (p=0.074 n=6)
Query/count_values('value',_h_100),_range_query_with_100_steps-10         298.2Mi ± 2%   271.9Mi ± 11%   -8.81% (p=0.002 n=6)
Query/count_values('value',_h_2000),_range_query_with_100_steps-10        2.579Gi ± 1%   1.834Gi ±  1%  -28.88% (p=0.002 n=6)
Query/count_values('value',_h_1_*_0),_range_query_with_100_steps-10       63.30Mi ± 1%   63.24Mi ±  1%        ~ (p=0.729 n=6)
Query/count_values('value',_h_100_*_0),_range_query_with_100_steps-10     67.12Mi ± 1%   61.92Mi ±  2%   -7.74% (p=0.002 n=6)
Query/count_values('value',_h_2000_*_0),_range_query_with_100_steps-10   149.60Mi ± 3%   66.44Mi ±  1%  -55.59% (p=0.002 n=6)
geomean                                                                   178.5Mi        143.3Mi        -19.72%
```

The difference in performance for the uncommon case is because Prometheus' engine uses a hash of the  series labels to identify output series, which runs the risk of hash collisions, while MQE uses a string representation of the series labels to identify output series. In the case where there are many output series, this means MQE must allocate many strings, which causes the performance impact we see here.

Given `count_values` is a relatively uncommonly used PromQL feature, the performance of the common case is significantly better than Prometheus' engine, and MQE's implementation avoids possible hash collisions, I'm OK with this performance regression.

#### Which issue(s) this PR fixes or relates to

#10067

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
