### PR TITLE
mimir: assert on unexpected value in ingester_partitions_shard_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
   * `querier_topology_spread_max_skew`
   * `ruler_topology_spread_max_skew`
   * `ruler_querier_topology_spread_max_skew`
+* [ENHANCEMENT] Validate the `$._config.shuffle_sharding.ingester_partitions_shard_size` value when partition shuffle sharding is enabled in the ingest-storage mode. #10746
 * [BUGFIX] Ports in container rollout-operator. #10273
 * [BUGFIX] When downscaling is enabled, the components must annotate `prepare-downscale-http-port` with the value set in `$._config.server_http_port`. #10367
 

--- a/operations/mimir/shuffle-sharding.libsonnet
+++ b/operations/mimir/shuffle-sharding.libsonnet
@@ -43,6 +43,12 @@
       shuffle_sharding_enabled &&
       $._config.shuffle_sharding.ingest_storage_partitions_enabled,
 
+    // ingester_shard_size is expected to be multi-zone ready, so here we divide its value by 3 (the assumed RF) to get ingester_partitions_shard_size.
+    // When the partitions sharding becomes the default, the "ingester_shard_size" configuration will be a noop, so this assertion can be removed.
+    assert !partitions_shuffle_sharding_enabled ||
+           ($._config.shuffle_sharding.ingester_partitions_shard_size == $._config.shuffle_sharding.ingester_shard_size / 3)
+           : 'with $._config.shuffle_sharding.ingest_storage_partitions_enabled, "ingester_partitions_shard_size" must be equal to "ingester_shard_size / 3"',
+
     local roundUpToMultipleOfThree(n) = std.ceil(n / 3) * 3,
 
     // The ingesters shard size has been computed this way:


### PR DESCRIPTION
#### What this PR does

This PR adds a new assertion to the mimir Jsonnet bundle, that verifies the value set in the `$._config.shuffle_sharding.ingester_partitions_shard_size` to be derived from the existing `ingester_shard_size`.

As outlined in the code comments, we, generally, assume that the `RF=3` (_replciation factor_) in the classic architecture, and so expect the `ingester_partitions_shard_size == ingester_shard_size / RF`.

#### Which issue(s) this PR fixes or relates to

Relates to #7804

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
