### PR TITLE
Reduce estimated duration for strong read consistency rule evaluations

### DIFF
--- a/tools/rule-group-evals/main.go
+++ b/tools/rule-group-evals/main.go
@@ -16,15 +16,16 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/mimir/pkg/ruler"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/rules"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/mimir/pkg/ruler"
 )
 
 // The estimated latency overhead to execute 1 strong read consistency query.
-const estimatedStrongConsistencyLatencyOverhead = 3 * time.Second
+const estimatedStrongConsistencyLatencyOverhead = time.Duration(1.5 * float64(time.Second))
 
 type Result struct {
 	Data Data `json:"data"`

--- a/tools/rule-group-evals/rule.go
+++ b/tools/rule-group-evals/rule.go
@@ -30,7 +30,7 @@ func (r *Rule) Labels() labels.Labels {
 	panic("Rule.Labels() is not supported")
 }
 
-func (r *Rule) Eval(ctx context.Context, queryOffset time.Duration, evaluationTime time.Time, queryFunc rules.QueryFunc, externalURL *url.URL, limit int) (promql.Vector, error) {
+func (r *Rule) Eval(_ context.Context, _ time.Duration, _ time.Time, _ rules.QueryFunc, _ *url.URL, _ int) (promql.Vector, error) {
 	panic("Rule.Eval() is not supported")
 }
 


### PR DESCRIPTION
#### What this PR does

We recently discussed that the 3s latency for rule evaluation with strong read consistency (which includes both enforcing the consistency + writing to the ingest storage) may be too pessimistic. In prod we actually see about 1s for consistency + 500ms for writing to ingest storage, on average. I propose to lower it to 1.5s.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
