### PR TITLE
Add warnings and infos to metadata responses

### DIFF
--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -733,6 +733,8 @@ type PrometheusLabelsResponse struct {
 	ErrorType string              `json:"errorType,omitempty"`
 	Error     string              `json:"error,omitempty"`
 	Headers   []*PrometheusHeader `json:"-"`
+	Warnings  []string            `json:"warnings,omitempty"`
+	Infos     []string            `json:"infos,omitempty"`
 }
 
 func (m *PrometheusLabelsResponse) GetHeaders() []*PrometheusHeader {
@@ -756,6 +758,8 @@ type PrometheusSeriesResponse struct {
 	ErrorType string              `json:"errorType,omitempty"`
 	Error     string              `json:"error,omitempty"`
 	Headers   []*PrometheusHeader `json:"-"`
+	Warnings  []string            `json:"warnings,omitempty"`
+	Infos     []string            `json:"infos,omitempty"`
 }
 
 func (m *PrometheusSeriesResponse) GetHeaders() []*PrometheusHeader {


### PR DESCRIPTION
#### What this PR does

Add warnings and infos to PrometheusLabelsResponse and PrometheusSeriesResponse to match the [standard HTTP API response for Prometheus](https://prometheus.io/docs/prometheus/latest/querying/api/#format-overview), allowing us to include those fields for the label names/values and series endpoints.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
