### PR TITLE
mixin: make federation-frontend remote_cluster variable multi-select

### DIFF
--- a/operations/mimir-mixin-compiled-gem/dashboards/federation-frontend.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/federation-frontend.json
@@ -1428,16 +1428,17 @@
                "useTags": false
             },
             {
-               "allValue": null,
+               "allValue": ".+",
                "current": {
-                  "text": "prod",
-                  "value": "prod"
+                  "selected": true,
+                  "text": "All",
+                  "value": "$__all"
                },
                "datasource": "$datasource",
                "hide": 2,
                "includeAll": true,
                "label": "remote_cluster",
-               "multi": false,
+               "multi": true,
                "name": "remote_cluster",
                "options": [ ],
                "query": "label_values(cortex_federation_frontend_cluster_remote_latency_seconds, remote_cluster)",

--- a/operations/mimir-mixin/dashboards/federation-frontend.libsonnet
+++ b/operations/mimir-mixin/dashboards/federation-frontend.libsonnet
@@ -5,12 +5,11 @@ local filename = 'federation-frontend.json';
   [filename]:
     ($.dashboard('Federation-frontend') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
-    .addTemplate(
+    .addMultiTemplate(
       'remote_cluster',
       'cortex_federation_frontend_cluster_remote_latency_seconds',
       'remote_cluster',
       hide=2,
-      includeAll=true,
     )
     .addRow(
       $.row('Overview')


### PR DESCRIPTION
This works for more grafana versions. Some versions don't default to `All`
