### PR TITLE
Fix exported ingestion_artificial_delay

### DIFF
--- a/pkg/util/validation/exporter/exporter.go
+++ b/pkg/util/validation/exporter/exporter.go
@@ -192,7 +192,7 @@ func setupExportedMetrics(enabledMetrics *util.AllowedTenants, extraMetrics []Ex
 	}
 	if enabledMetrics.IsAllowed(ingestionArtificialDelay) {
 		exportedMetrics = append(exportedMetrics, ExportedMetric{ingestionArtificialDelay, func(limits *validation.Limits) float64 {
-			return float64(time.Duration(limits.IngestionArtificialDelay) / time.Second)
+			return time.Duration(limits.IngestionArtificialDelay).Seconds()
 		}})
 	}
 	if enabledMetrics.IsAllowed(maxGlobalSeriesPerUser) {


### PR DESCRIPTION
#### What this PR does

I did a rounding mistake in https://github.com/grafana/mimir/pull/10549 and the exported value is always 0 if the `ingestion_artificial_delay` is set to a value < 1s. This PR fixes it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
