### PR TITLE
chore: Update goland debug config to match jsonnet

### DIFF
--- a/development/mimir-microservices-mode/goland/TSDB Query-frontend (using scheduler).run.xml
+++ b/development/mimir-microservices-mode/goland/TSDB Query-frontend (using scheduler).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="TSDB Query-frontend (using scheduler)" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18012">
+  <configuration default="false" name="TSDB Query-frontend (using scheduler)" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18007">
     <option name="disconnectOption" value="ASK" />
     <method v="2" />
   </configuration>

--- a/development/mimir-microservices-mode/goland/TSDB Query-scheduler.run.xml
+++ b/development/mimir-microservices-mode/goland/TSDB Query-scheduler.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="TSDB Query-scheduler" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18011">
+  <configuration default="false" name="TSDB Query-scheduler" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18008">
     <option name="disconnectOption" value="ASK" />
     <method v="2" />
   </configuration>

--- a/development/mimir-microservices-mode/goland/distributor-1.run.xml
+++ b/development/mimir-microservices-mode/goland/distributor-1.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Distributor-1" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18000">
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/mimir-microservices-mode/goland/distributor-2.run.xml
+++ b/development/mimir-microservices-mode/goland/distributor-2.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Distributor-2" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18001">
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/mimir-microservices-mode/goland/distributor.run.xml
+++ b/development/mimir-microservices-mode/goland/distributor.run.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="TSDB Distributor" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18001">
-    <method v="2" />
-  </configuration>
-</component>

--- a/development/mimir-microservices-mode/goland/ingester-3.run.xml
+++ b/development/mimir-microservices-mode/goland/ingester-3.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Ingester-3" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18004">
+    <method v="2" />
+  </configuration>
+</component>

--- a/development/mimir-microservices-mode/goland/store-gateway-1.run.xml
+++ b/development/mimir-microservices-mode/goland/store-gateway-1.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="TSDB Store-gateway-1" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18008">
+  <configuration default="false" name="TSDB Store-gateway-1" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18011">
     <method v="2" />
   </configuration>
 </component>

--- a/development/mimir-microservices-mode/goland/store-gateway-2.run.xml
+++ b/development/mimir-microservices-mode/goland/store-gateway-2.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="TSDB Store-gateway-2" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18009">
+  <configuration default="false" name="TSDB Store-gateway-2" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18012">
     <method v="2" />
   </configuration>
 </component>

--- a/development/mimir-microservices-mode/goland/store-gateway-3.run.xml
+++ b/development/mimir-microservices-mode/goland/store-gateway-3.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TSDB Store-gateway-3" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" port="18013">
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
#### What this PR does

Update the goland debug profiles in mimir-microservices-mode to match the ports used for each service in the jsonnet

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
