### PR TITLE
Add a linter to enforce sorted lines using lint:sorted directive.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,6 +454,14 @@ lint: check-makefiles
 		"github.com/twmb/franz-go/pkg/kgo.{AllowAutoTopicCreation}" \
 		./pkg/... ./cmd/... ./tools/... ./integration/...
 
+	# Ensure lines are sorted after lint:sorted directives.
+	go run ./tools/lint-sorted/ \
+		-path ./pkg \
+		-path ./cmd \
+		-path ./tools \
+		-path ./integration \
+		-include '*.go'
+
 format: ## Run gofmt and goimports.
 	find . $(DONT_FIND) -name '*.pb.go' -prune -o -type f -name '*.go' -exec gofmt -w -s {} \;
 	find . $(DONT_FIND) -name '*.pb.go' -prune -o -type f -name '*.go' -exec goimports -w -local github.com/grafana/mimir {} \;

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -72,48 +72,50 @@ import (
 
 // The various modules that make up Mimir.
 const (
-	ActivityTracker                  string = "activity-tracker"
+	//lint:sorted
 	API                              string = "api"
-	SanityCheck                      string = "sanity-check"
-	IngesterRing                     string = "ingester-ring"
-	IngesterPartitionRing            string = "ingester-partitions-ring"
-	RuntimeConfig                    string = "runtime-config"
-	Overrides                        string = "overrides"
-	OverridesExporter                string = "overrides-exporter"
-	Server                           string = "server"
 	ActiveGroupsCleanupService       string = "active-groups-cleanup-service"
-	Distributor                      string = "distributor"
-	DistributorService               string = "distributor-service"
-	Ingester                         string = "ingester"
-	IngesterService                  string = "ingester-service"
-	Flusher                          string = "flusher"
-	Querier                          string = "querier"
-	Queryable                        string = "queryable"
-	StoreQueryable                   string = "store-queryable"
-	QueryFrontend                    string = "query-frontend"
-	QueryFrontendCodec               string = "query-frontend-codec"
-	QueryFrontendTripperware         string = "query-frontend-tripperware"
-	QueryFrontendTopicOffsetsReaders string = "query-frontend-topic-offsets-reader"
-	RulerStorage                     string = "ruler-storage"
-	Ruler                            string = "ruler"
+	ActivityTracker                  string = "activity-tracker"
 	AlertManager                     string = "alertmanager"
-	Compactor                        string = "compactor"
-	StoreGateway                     string = "store-gateway"
-	MemberlistKV                     string = "memberlist-kv"
-	QueryScheduler                   string = "query-scheduler"
-	Vault                            string = "vault"
-	TenantFederation                 string = "tenant-federation"
-	UsageStats                       string = "usage-stats"
 	BlockBuilder                     string = "block-builder"
 	BlockBuilderScheduler            string = "block-builder-scheduler"
+	Compactor                        string = "compactor"
 	ContinuousTest                   string = "continuous-test"
-	All                              string = "all"
 	CostAttributionService           string = "cost-attribution-service"
+	Distributor                      string = "distributor"
+	DistributorService               string = "distributor-service"
+	Flusher                          string = "flusher"
+	Ingester                         string = "ingester"
+	IngesterPartitionRing            string = "ingester-partitions-ring"
+	IngesterRing                     string = "ingester-ring"
+	IngesterService                  string = "ingester-service"
+	MemberlistKV                     string = "memberlist-kv"
+	Overrides                        string = "overrides"
+	OverridesExporter                string = "overrides-exporter"
+	Querier                          string = "querier"
+	QueryFrontend                    string = "query-frontend"
+	QueryFrontendCodec               string = "query-frontend-codec"
+	QueryFrontendTopicOffsetsReaders string = "query-frontend-topic-offsets-reader"
+	QueryFrontendTripperware         string = "query-frontend-tripperware"
+	QueryScheduler                   string = "query-scheduler"
+	Queryable                        string = "queryable"
+	Ruler                            string = "ruler"
+	RulerStorage                     string = "ruler-storage"
+	RuntimeConfig                    string = "runtime-config"
+	SanityCheck                      string = "sanity-check"
+	Server                           string = "server"
+	StoreGateway                     string = "store-gateway"
+	StoreQueryable                   string = "store-queryable"
+	TenantFederation                 string = "tenant-federation"
+	UsageStats                       string = "usage-stats"
+	Vault                            string = "vault"
 
 	// Write Read and Backend are the targets used when using the read-write deployment mode.
 	Write   string = "write"
 	Read    string = "read"
 	Backend string = "backend"
+
+	All string = "all"
 )
 
 var (
@@ -205,35 +207,38 @@ func (t *Mimir) initVault() (services.Service, error) {
 	t.Vault = v
 
 	// Update Configs - KVStore
-	t.Cfg.MemberlistKV.TCPTransport.TLS.Reader = t.Vault
-	t.Cfg.Distributor.HATrackerConfig.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
+	// lint:sorted
 	t.Cfg.Alertmanager.ShardingRing.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
 	t.Cfg.Compactor.ShardingRing.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
 	t.Cfg.Distributor.DistributorRing.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.Ingester.IngesterRing.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
+	t.Cfg.Distributor.HATrackerConfig.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
 	t.Cfg.Ingester.IngesterPartitionRing.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
+	t.Cfg.Ingester.IngesterRing.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
+	t.Cfg.MemberlistKV.TCPTransport.TLS.Reader = t.Vault
+	t.Cfg.OverridesExporter.Ring.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
+	t.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
 	t.Cfg.Ruler.Ring.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
 	t.Cfg.StoreGateway.ShardingRing.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.OverridesExporter.Ring.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
 
 	// Update Configs - Redis Clients
-	t.Cfg.BlocksStorage.BucketStore.IndexCache.BackendConfig.Redis.TLS.Reader = t.Vault
+	// lint:sorted
 	t.Cfg.BlocksStorage.BucketStore.ChunksCache.BackendConfig.Redis.TLS.Reader = t.Vault
+	t.Cfg.BlocksStorage.BucketStore.IndexCache.BackendConfig.Redis.TLS.Reader = t.Vault
 	t.Cfg.BlocksStorage.BucketStore.MetadataCache.BackendConfig.Redis.TLS.Reader = t.Vault
 	t.Cfg.Frontend.QueryMiddleware.ResultsCacheConfig.BackendConfig.Redis.TLS.Reader = t.Vault
 
 	// Update Configs - GRPC Clients
-	t.Cfg.IngesterClient.GRPCClientConfig.TLS.Reader = t.Vault
-	t.Cfg.Worker.QueryFrontendGRPCClientConfig.TLS.Reader = t.Vault
-	t.Cfg.Worker.QuerySchedulerGRPCClientConfig.TLS.Reader = t.Vault
-	t.Cfg.Querier.StoreGatewayClient.TLS.Reader = t.Vault
+	// lint:sorted
+	t.Cfg.Alertmanager.AlertmanagerClient.GRPCClientConfig.TLS.Reader = t.Vault
 	t.Cfg.Frontend.FrontendV2.GRPCClientConfig.TLS.Reader = t.Vault
+	t.Cfg.IngesterClient.GRPCClientConfig.TLS.Reader = t.Vault
+	t.Cfg.Querier.StoreGatewayClient.TLS.Reader = t.Vault
+	t.Cfg.QueryScheduler.GRPCClientConfig.TLS.Reader = t.Vault
 	t.Cfg.Ruler.ClientTLSConfig.TLS.Reader = t.Vault
 	t.Cfg.Ruler.Notifier.TLS.Reader = t.Vault
 	t.Cfg.Ruler.QueryFrontend.GRPCClientConfig.TLS.Reader = t.Vault
-	t.Cfg.Alertmanager.AlertmanagerClient.GRPCClientConfig.TLS.Reader = t.Vault
-	t.Cfg.QueryScheduler.GRPCClientConfig.TLS.Reader = t.Vault
+	t.Cfg.Worker.QueryFrontendGRPCClientConfig.TLS.Reader = t.Vault
+	t.Cfg.Worker.QuerySchedulerGRPCClientConfig.TLS.Reader = t.Vault
 
 	// Update the Server
 	updateServerTLSCfgFunc := func(vault *vault.Vault, tlsConfig *server.TLSConfig) error {
@@ -406,15 +411,16 @@ func (t *Mimir) initRuntimeConfig() (services.Service, error) {
 	//
 	// By doing the initialization here instead of per-module init function, we avoid the problem
 	// of projects based on Mimir forgetting the wiring if they override module's init method (they also don't have access to private symbols).
+	// lint:sorted
 	t.Cfg.Alertmanager.ShardingRing.Common.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
 	t.Cfg.Compactor.ShardingRing.Common.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
 	t.Cfg.Distributor.DistributorRing.Common.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
-	t.Cfg.Ingester.IngesterRing.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
 	t.Cfg.Ingester.IngesterPartitionRing.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
+	t.Cfg.Ingester.IngesterRing.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
+	t.Cfg.OverridesExporter.Ring.Common.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
+	t.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
 	t.Cfg.Ruler.Ring.Common.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
 	t.Cfg.StoreGateway.ShardingRing.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
-	t.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
-	t.Cfg.OverridesExporter.Ring.Common.KVStore.Multi.ConfigProvider = multiClientRuntimeConfigChannel(t.RuntimeConfig)
 
 	return serv, err
 }
@@ -1066,16 +1072,17 @@ func (t *Mimir) initMemberlistKV() (services.Service, error) {
 	t.API.RegisterMemberlistKV(t.Cfg.Server.PathPrefix, t.MemberlistKV)
 
 	// Update the config.
+	// lint:sorted
+	t.Cfg.Alertmanager.ShardingRing.Common.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
+	t.Cfg.Compactor.ShardingRing.Common.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.Distributor.DistributorRing.Common.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.Distributor.HATrackerConfig.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-	t.Cfg.Ingester.IngesterRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.Ingester.IngesterPartitionRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-	t.Cfg.StoreGateway.ShardingRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-	t.Cfg.Compactor.ShardingRing.Common.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-	t.Cfg.Ruler.Ring.Common.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-	t.Cfg.Alertmanager.ShardingRing.Common.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
-	t.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
+	t.Cfg.Ingester.IngesterRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 	t.Cfg.OverridesExporter.Ring.Common.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
+	t.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
+	t.Cfg.Ruler.Ring.Common.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
+	t.Cfg.StoreGateway.ShardingRing.KVStore.MemberlistKV = t.MemberlistKV.GetMemberlistKV
 
 	return t.MemberlistKV, nil
 }
@@ -1157,83 +1164,89 @@ func (t *Mimir) setupModuleManager() error {
 
 	// Register all modules here.
 	// RegisterModule(name string, initFn func()(services.Service, error))
-	mm.RegisterModule(Server, t.initServer, modules.UserInvisibleModule)
-	mm.RegisterModule(ActivityTracker, t.initActivityTracker, modules.UserInvisibleModule)
-	mm.RegisterModule(SanityCheck, t.initSanityCheck, modules.UserInvisibleModule)
+	// lint:sorted
 	mm.RegisterModule(API, t.initAPI, modules.UserInvisibleModule)
-	mm.RegisterModule(RuntimeConfig, t.initRuntimeConfig, modules.UserInvisibleModule)
-	mm.RegisterModule(MemberlistKV, t.initMemberlistKV)
-	mm.RegisterModule(IngesterRing, t.initIngesterRing, modules.UserInvisibleModule)
-	mm.RegisterModule(IngesterPartitionRing, t.initIngesterPartitionRing, modules.UserInvisibleModule)
-	mm.RegisterModule(Overrides, t.initOverrides, modules.UserInvisibleModule)
-	mm.RegisterModule(OverridesExporter, t.initOverridesExporter)
 	mm.RegisterModule(ActiveGroupsCleanupService, t.initActiveGroupsCleanupService, modules.UserInvisibleModule)
+	mm.RegisterModule(ActivityTracker, t.initActivityTracker, modules.UserInvisibleModule)
+	mm.RegisterModule(AlertManager, t.initAlertManager)
+	mm.RegisterModule(BlockBuilder, t.initBlockBuilder)
+	mm.RegisterModule(BlockBuilderScheduler, t.initBlockBuilderScheduler)
+	mm.RegisterModule(Compactor, t.initCompactor)
+	mm.RegisterModule(ContinuousTest, t.initContinuousTest)
 	mm.RegisterModule(CostAttributionService, t.initCostAttributionService, modules.UserInvisibleModule)
 	mm.RegisterModule(Distributor, t.initDistributor)
 	mm.RegisterModule(DistributorService, t.initDistributorService, modules.UserInvisibleModule)
-	mm.RegisterModule(Ingester, t.initIngester)
-	mm.RegisterModule(IngesterService, t.initIngesterService, modules.UserInvisibleModule)
 	mm.RegisterModule(Flusher, t.initFlusher)
-	mm.RegisterModule(Queryable, t.initQueryable, modules.UserInvisibleModule)
+	mm.RegisterModule(Ingester, t.initIngester)
+	mm.RegisterModule(IngesterPartitionRing, t.initIngesterPartitionRing, modules.UserInvisibleModule)
+	mm.RegisterModule(IngesterRing, t.initIngesterRing, modules.UserInvisibleModule)
+	mm.RegisterModule(IngesterService, t.initIngesterService, modules.UserInvisibleModule)
+	mm.RegisterModule(MemberlistKV, t.initMemberlistKV)
+	mm.RegisterModule(Overrides, t.initOverrides, modules.UserInvisibleModule)
+	mm.RegisterModule(OverridesExporter, t.initOverridesExporter)
 	mm.RegisterModule(Querier, t.initQuerier)
-	mm.RegisterModule(StoreQueryable, t.initStoreQueryable, modules.UserInvisibleModule)
-	mm.RegisterModule(QueryFrontendCodec, t.initQueryFrontendCodec, modules.UserInvisibleModule)
-	mm.RegisterModule(QueryFrontendTripperware, t.initQueryFrontendTripperware, modules.UserInvisibleModule)
-	mm.RegisterModule(QueryFrontendTopicOffsetsReaders, t.initQueryFrontendTopicOffsetsReaders, modules.UserInvisibleModule)
 	mm.RegisterModule(QueryFrontend, t.initQueryFrontend)
-	mm.RegisterModule(RulerStorage, t.initRulerStorage, modules.UserInvisibleModule)
-	mm.RegisterModule(Ruler, t.initRuler)
-	mm.RegisterModule(AlertManager, t.initAlertManager)
-	mm.RegisterModule(Compactor, t.initCompactor)
-	mm.RegisterModule(StoreGateway, t.initStoreGateway)
+	mm.RegisterModule(QueryFrontendCodec, t.initQueryFrontendCodec, modules.UserInvisibleModule)
+	mm.RegisterModule(QueryFrontendTopicOffsetsReaders, t.initQueryFrontendTopicOffsetsReaders, modules.UserInvisibleModule)
+	mm.RegisterModule(QueryFrontendTripperware, t.initQueryFrontendTripperware, modules.UserInvisibleModule)
 	mm.RegisterModule(QueryScheduler, t.initQueryScheduler)
+	mm.RegisterModule(Queryable, t.initQueryable, modules.UserInvisibleModule)
+	mm.RegisterModule(Ruler, t.initRuler)
+	mm.RegisterModule(RulerStorage, t.initRulerStorage, modules.UserInvisibleModule)
+	mm.RegisterModule(RuntimeConfig, t.initRuntimeConfig, modules.UserInvisibleModule)
+	mm.RegisterModule(SanityCheck, t.initSanityCheck, modules.UserInvisibleModule)
+	mm.RegisterModule(Server, t.initServer, modules.UserInvisibleModule)
+	mm.RegisterModule(StoreGateway, t.initStoreGateway)
+	mm.RegisterModule(StoreQueryable, t.initStoreQueryable, modules.UserInvisibleModule)
 	mm.RegisterModule(TenantFederation, t.initTenantFederation, modules.UserInvisibleModule)
 	mm.RegisterModule(UsageStats, t.initUsageStats, modules.UserInvisibleModule)
-	mm.RegisterModule(BlockBuilder, t.initBlockBuilder)
-	mm.RegisterModule(BlockBuilderScheduler, t.initBlockBuilderScheduler)
-	mm.RegisterModule(ContinuousTest, t.initContinuousTest)
 	mm.RegisterModule(Vault, t.initVault, modules.UserInvisibleModule)
+
 	mm.RegisterModule(Write, nil)
 	mm.RegisterModule(Read, nil)
 	mm.RegisterModule(Backend, nil)
+
 	mm.RegisterModule(All, nil)
 
 	// Add dependencies
 	deps := map[string][]string{
-		Server:                           {ActivityTracker, SanityCheck, UsageStats},
+		//lint:sorted
 		API:                              {Server},
-		MemberlistKV:                     {API, Vault},
-		RuntimeConfig:                    {API},
-		IngesterRing:                     {API, RuntimeConfig, MemberlistKV, Vault},
-		IngesterPartitionRing:            {MemberlistKV, IngesterRing, API},
-		Overrides:                        {RuntimeConfig},
-		OverridesExporter:                {Overrides, MemberlistKV, Vault},
-		Distributor:                      {DistributorService, API, ActiveGroupsCleanupService, Vault},
-		DistributorService:               {IngesterRing, IngesterPartitionRing, Overrides, Vault, CostAttributionService},
-		CostAttributionService:           {API, Overrides},
-		Ingester:                         {IngesterService, API, ActiveGroupsCleanupService, Vault},
-		IngesterService:                  {IngesterRing, IngesterPartitionRing, Overrides, RuntimeConfig, MemberlistKV, CostAttributionService},
-		Flusher:                          {Overrides, API},
-		Queryable:                        {Overrides, DistributorService, IngesterRing, IngesterPartitionRing, API, StoreQueryable, MemberlistKV},
-		Querier:                          {TenantFederation, Vault},
-		StoreQueryable:                   {Overrides, MemberlistKV},
-		QueryFrontendTripperware:         {API, Overrides, QueryFrontendCodec, QueryFrontendTopicOffsetsReaders},
-		QueryFrontend:                    {QueryFrontendTripperware, MemberlistKV, Vault},
-		QueryFrontendTopicOffsetsReaders: {IngesterPartitionRing},
-		QueryScheduler:                   {API, Overrides, MemberlistKV, Vault},
-		Ruler:                            {DistributorService, StoreQueryable, RulerStorage, Vault},
-		RulerStorage:                     {Overrides},
 		AlertManager:                     {API, MemberlistKV, Overrides, Vault},
-		Compactor:                        {API, MemberlistKV, Overrides, Vault},
-		StoreGateway:                     {API, Overrides, MemberlistKV, Vault},
-		TenantFederation:                 {Queryable},
 		BlockBuilder:                     {API, Overrides},
 		BlockBuilderScheduler:            {API},
+		Compactor:                        {API, MemberlistKV, Overrides, Vault},
 		ContinuousTest:                   {API},
-		Write:                            {Distributor, Ingester},
-		Read:                             {QueryFrontend, Querier},
-		Backend:                          {QueryScheduler, Ruler, StoreGateway, Compactor, AlertManager, OverridesExporter},
-		All:                              {QueryFrontend, Querier, Ingester, Distributor, StoreGateway, Ruler, Compactor},
+		CostAttributionService:           {API, Overrides},
+		Distributor:                      {DistributorService, API, ActiveGroupsCleanupService, Vault},
+		DistributorService:               {IngesterRing, IngesterPartitionRing, Overrides, Vault, CostAttributionService},
+		Flusher:                          {Overrides, API},
+		Ingester:                         {IngesterService, API, ActiveGroupsCleanupService, Vault},
+		IngesterPartitionRing:            {MemberlistKV, IngesterRing, API},
+		IngesterRing:                     {API, RuntimeConfig, MemberlistKV, Vault},
+		IngesterService:                  {IngesterRing, IngesterPartitionRing, Overrides, RuntimeConfig, MemberlistKV, CostAttributionService},
+		MemberlistKV:                     {API, Vault},
+		Overrides:                        {RuntimeConfig},
+		OverridesExporter:                {Overrides, MemberlistKV, Vault},
+		Querier:                          {TenantFederation, Vault},
+		QueryFrontend:                    {QueryFrontendTripperware, MemberlistKV, Vault},
+		QueryFrontendTopicOffsetsReaders: {IngesterPartitionRing},
+		QueryFrontendTripperware:         {API, Overrides, QueryFrontendCodec, QueryFrontendTopicOffsetsReaders},
+		QueryScheduler:                   {API, Overrides, MemberlistKV, Vault},
+		Queryable:                        {Overrides, DistributorService, IngesterRing, IngesterPartitionRing, API, StoreQueryable, MemberlistKV},
+		Ruler:                            {DistributorService, StoreQueryable, RulerStorage, Vault},
+		RulerStorage:                     {Overrides},
+		RuntimeConfig:                    {API},
+		Server:                           {ActivityTracker, SanityCheck, UsageStats},
+		StoreGateway:                     {API, Overrides, MemberlistKV, Vault},
+		StoreQueryable:                   {Overrides, MemberlistKV},
+		TenantFederation:                 {Queryable},
+
+		Backend: {QueryScheduler, Ruler, StoreGateway, Compactor, AlertManager, OverridesExporter},
+		Read:    {QueryFrontend, Querier},
+		Write:   {Distributor, Ingester},
+
+		All: {QueryFrontend, Querier, Ingester, Distributor, StoreGateway, Ruler, Compactor},
 	}
 	for mod, targets := range deps {
 		if err := mm.AddDependency(mod, targets...); err != nil {

--- a/tools/lint-sorted/main.go
+++ b/tools/lint-sorted/main.go
@@ -1,0 +1,113 @@
+package main
+
+/*
+	This linter checks for the presence of a `lint:sorted` directive in a file and verifies that the lines following the directive are sorted lexicographically.
+*/
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/grafana/dskit/flagext"
+)
+
+const directive = "lint:sorted"
+
+func main() {
+	var include string
+	var paths flagext.StringSlice
+	fs := flag.NewFlagSet("lint-sorted", flag.ExitOnError)
+	fs.StringVar(&include, "include", "", "File pattern to include (e.g. \"*.go\")")
+	fs.Var(&paths, "path", "Paths to scan (can specify multiple)")
+	err := flagext.ParseFlagsWithoutArguments(fs)
+
+	if err != nil || include == "" || len(paths) == 0 {
+		if err != nil {
+			log.Printf("Error parsing flags: %v\n", err)
+		}
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	linted := true
+	for _, root := range paths {
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			matched, err := filepath.Match(include, info.Name())
+			if err != nil {
+				return err
+			}
+			if matched {
+				linted = lintFile(path) && linted
+			}
+			return nil
+		})
+		if err != nil {
+			log.Printf("Error walking the path %s: %v\n", root, err)
+		}
+	}
+	if !linted {
+		os.Exit(1)
+	}
+}
+
+// lintFile reads a file and checks for lint directives
+func lintFile(filePath string) bool {
+	file, err := os.Open(filePath)
+	if err != nil {
+		log.Printf("Unable to open file %s: %v\n", filePath, err)
+		return false
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var lines []string
+	lineNum := 0
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	totalLines := len(lines)
+	linted := true
+	for lineNum < totalLines {
+		if strings.Contains(lines[lineNum], directive) {
+			linted = checkSorted(lines, filePath, lineNum+1) && linted
+		}
+		lineNum++
+	}
+	return linted
+
+}
+
+// checkSorted verifies whether lines after the directive are sorted lexicographically
+func checkSorted(lines []string, filePath string, startIdx int) bool {
+	var block []string
+	currentIdx := startIdx
+	for currentIdx < len(lines) {
+		trimmedLine := strings.TrimSpace(lines[currentIdx])
+		if trimmedLine == "" || trimmedLine == "}" {
+			break
+		}
+		block = append(block, trimmedLine)
+		currentIdx++
+	}
+
+	if !sort.StringsAreSorted(block) {
+		fmt.Printf("%s:%d Lines not sorted lexicographically after '%s':\n", filePath, startIdx, directive)
+		for _, bLine := range block {
+			fmt.Printf("  %s\n", bLine)
+		}
+		return false
+	}
+	return true
+}

--- a/tools/lint-sorted/main.go
+++ b/tools/lint-sorted/main.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package main
 
 /*


### PR DESCRIPTION
#### What this PR does

_As someone once commented somewhere: we are not savages._

The lack of sorting in the modules.go modules constant definitions was bothering me big time, especially since CostAttribution was added after All.

This sorts them and adds a linter that is triggered by adding a // lint:sorted comment which would fail if lines aren't sorted.

The linter checks lines from the line containing the directive until the next white space or a line that only contains closing bracket.

#### Which issue(s) this PR fixes or relates to

Fixes my OCD

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
