### PR TITLE
Add additional check on reactive limiter queue sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * [BUGFIX] Ingester: Fixed a race condition in the `PostingsForMatchers` cache that may have infrequently returned expired cached postings. #10500
 * [BUGFIX] Distributor: Report partially converted OTLP requests with status 400 Bad Request. #10588
 * [BUGFIX] Ruler: fix issue where rule evaluations could be missed while shutting down a ruler instance if that instance owns many rule groups. prometheus/prometheus#15804 #10762
+* [BUGFIX] Ingester: Add additional check on reactive limiter queue sizes. #10722
 
 ### Mixin
 

--- a/pkg/util/reactivelimiter/prioritylimiter.go
+++ b/pkg/util/reactivelimiter/prioritylimiter.go
@@ -65,9 +65,9 @@ type priorityLimiter struct {
 }
 
 func (l *priorityLimiter) AcquirePermit(ctx context.Context, priority Priority) (Permit, error) {
-	// Generate a granular priority for the request and compare it to the prioritizer threshold
+	// Generate a granular priority for the request and check if we can acquire a permit
 	granularPriority := randomGranularPriority(priority)
-	if granularPriority < l.prioritizer.RejectionThreshold() {
+	if !l.canAcquirePermit(granularPriority) {
 		return nil, ErrExceeded
 	}
 
@@ -76,7 +76,18 @@ func (l *priorityLimiter) AcquirePermit(ctx context.Context, priority Priority) 
 }
 
 func (l *priorityLimiter) CanAcquirePermit(priority Priority) bool {
-	return randomGranularPriority(priority) >= l.prioritizer.RejectionThreshold()
+	return l.canAcquirePermit(randomGranularPriority(priority))
+}
+
+func (l *priorityLimiter) canAcquirePermit(granularPriority int) bool {
+	// Threshold against the limiter's max capacity
+	maxBlocked := int(float64(l.Limit()) * l.config.MaxRejectionFactor)
+	if l.reactiveLimiter.Blocked() >= maxBlocked {
+		return false
+	}
+
+	// Threshold against the prioritizer's rejection threshold
+	return granularPriority >= l.prioritizer.RejectionThreshold()
 }
 
 func (l *priorityLimiter) RejectionRate() float64 {

--- a/pkg/util/reactivelimiter/prioritylimiter_test.go
+++ b/pkg/util/reactivelimiter/prioritylimiter_test.go
@@ -5,6 +5,7 @@ package reactivelimiter
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -19,17 +20,41 @@ func TestPriorityLimiter_AcquirePermit(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("below rejection threshold", func(t *testing.T) {
+	t.Run("below prioritizer rejection threshold", func(t *testing.T) {
 		p.priorityThreshold.Store(200)
 		permit, err := limiter.AcquirePermit(context.Background(), PriorityLow)
 		require.Nil(t, permit)
 		require.Error(t, err, ErrExceeded)
 	})
 
-	t.Run("above rejection threshold", func(t *testing.T) {
+	t.Run("above prioritizer rejection threshold", func(t *testing.T) {
 		p.priorityThreshold.Store(200)
 		permit, err := limiter.AcquirePermit(context.Background(), PriorityHigh)
 		require.NotNil(t, permit)
 		require.NoError(t, err)
+	})
+
+	// Asserts that AcquirePermit fails after the max number of requests is rejected, even if the request exceeds the priority threshold
+	t.Run("above max blocked requests", func(t *testing.T) {
+		config := createLimiterConfig()
+		config.InitialInflightLimit = 1
+		limiter := NewPriorityLimiter(config, p, nil).(*priorityLimiter)
+		p.priorityThreshold.Store(200)
+
+		// Add a request and 3 waiters
+		for i := 0; i < 4; i++ {
+			go func() {
+				permit, err := limiter.AcquirePermit(context.Background(), PriorityHigh)
+				require.NotNil(t, permit)
+				require.NoError(t, err)
+			}()
+		}
+
+		require.Eventually(t, func() bool {
+			return limiter.Blocked() == 3
+		}, 300*time.Millisecond, 10*time.Millisecond)
+		permit, err := limiter.AcquirePermit(context.Background(), PriorityHigh)
+		require.Nil(t, permit)
+		require.ErrorIs(t, err, ErrExceeded)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This change improves on #10574 by adding an additional check for reactive limiter queue sizes that limits the amount of queueing in each limiter based on its individual settings. At present, rejections are based on the prioritizer's threshold, which is computed periodically and looks at queueing across limiters along with request priorities, but this doesn't prevent a large burst of requests from enqueueing before the next calibration takes place. This PR adds an additional guard against this.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
