### PR TITLE
Upgrade mimir-prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -298,7 +298,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250227233049-0c8e28d13db8
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250302213708-bd234c29eed4
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -1284,8 +1284,8 @@ github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1 h1:vR5nELq+KtGO
 github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20250227233049-0c8e28d13db8 h1:HMH5igbkbJvH01RV8bnjAsFUBLLyoEK8ab6Rb+/p+js=
-github.com/grafana/mimir-prometheus v0.0.0-20250227233049-0c8e28d13db8/go.mod h1:TRDP3hIlMiItiCmzGthWfWxgsltR8keKOQW0MmUfkKk=
+github.com/grafana/mimir-prometheus v0.0.0-20250302213708-bd234c29eed4 h1:z3cxARHOrF+l39pYXGhQ5ykMy35VP6xpavZHSeCv6Bw=
+github.com/grafana/mimir-prometheus v0.0.0-20250302213708-bd234c29eed4/go.mod h1:TRDP3hIlMiItiCmzGthWfWxgsltR8keKOQW0MmUfkKk=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20250211112812-e32be5e2a455 h1:yidC1xzk4fedLZ/iXEqSJopkw3jPZPwoMqqzue4eFEA=

--- a/pkg/streamingpromql/testdata/upstream/functions.test
+++ b/pkg/streamingpromql/testdata/upstream/functions.test
@@ -497,6 +497,7 @@ load 5m
 	test_clamp{src="clamp-a"}	-50
 	test_clamp{src="clamp-b"}	0
 	test_clamp{src="clamp-c"}	100
+	test_clamp{src="histogram"} {{schema:0 sum:1 count:1}}
 
 eval instant at 0m clamp_max(test_clamp, 75)
 	{src="clamp-a"}	-50
@@ -1232,7 +1233,67 @@ eval instant at 1m count_over_time({__name__=~"data(_histogram)?"}[2m])
 
 clear
 
-# Test for absent()
+# Test for abs, ceil(), floor(), round().
+
+load 5m
+	data{type="positive"} 2.5
+	data{type="whole"} 2
+	data{type="negative"} -2.5
+	data{type="nwhole"} -2
+	data{type="zero"} 0
+	data{type="nzero"} -0
+	data{type="inf"} +Inf
+	data{type="ninf"} -Inf
+	data{type="nan"} NaN
+	data{type="histogram"} {{schema:0 sum:1 count:1}}
+
+eval instant at 0m abs(data)
+	{type="positive"} 2.5
+	{type="whole"} 2
+	{type="negative"} 2.5
+	{type="nwhole"} 2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} +Inf
+	{type="nan"} NaN
+
+eval instant at 0m ceil(data)
+	{type="positive"} 3
+	{type="whole"} 2
+	{type="negative"} -2
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
+eval instant at 0m floor(data)
+	{type="positive"} 2
+	{type="whole"} 2
+	{type="negative"} -3
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
+eval instant at 0m round(data)
+	{type="positive"} 3
+	{type="whole"} 2
+	{type="negative"} -2
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
+clear
+
+# Test for absent().
 eval instant at 50m absent(nonexistent)
 	{} 1
 

--- a/vendor/github.com/prometheus/prometheus/promql/promqltest/testdata/functions.test
+++ b/vendor/github.com/prometheus/prometheus/promql/promqltest/testdata/functions.test
@@ -492,6 +492,7 @@ load 5m
 	test_clamp{src="clamp-a"}	-50
 	test_clamp{src="clamp-b"}	0
 	test_clamp{src="clamp-c"}	100
+	test_clamp{src="histogram"} {{schema:0 sum:1 count:1}}
 
 eval instant at 0m clamp_max(test_clamp, 75)
 	{src="clamp-a"}	-50
@@ -1209,7 +1210,67 @@ eval instant at 1m count_over_time({__name__=~"data(_histogram)?"}[2m])
 
 clear
 
-# Test for absent()
+# Test for abs, ceil(), floor(), round().
+
+load 5m
+	data{type="positive"} 2.5
+	data{type="whole"} 2
+	data{type="negative"} -2.5
+	data{type="nwhole"} -2
+	data{type="zero"} 0
+	data{type="nzero"} -0
+	data{type="inf"} +Inf
+	data{type="ninf"} -Inf
+	data{type="nan"} NaN
+	data{type="histogram"} {{schema:0 sum:1 count:1}}
+
+eval instant at 0m abs(data)
+	{type="positive"} 2.5
+	{type="whole"} 2
+	{type="negative"} 2.5
+	{type="nwhole"} 2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} +Inf
+	{type="nan"} NaN
+
+eval instant at 0m ceil(data)
+	{type="positive"} 3
+	{type="whole"} 2
+	{type="negative"} -2
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
+eval instant at 0m floor(data)
+	{type="positive"} 2
+	{type="whole"} 2
+	{type="negative"} -3
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
+eval instant at 0m round(data)
+	{type="positive"} 3
+	{type="whole"} 2
+	{type="negative"} -2
+	{type="nwhole"} -2
+	{type="zero"} 0
+	{type="nzero"} 0
+	{type="inf"} +Inf
+	{type="ninf"} -Inf
+	{type="nan"} NaN
+
+clear
+
+# Test for absent().
 eval instant at 50m absent(nonexistent)
 	{} 1
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1075,7 +1075,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20250227233049-0c8e28d13db8
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20250302213708-bd234c29eed4
 ## explicit; go 1.22.7
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1759,7 +1759,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250227233049-0c8e28d13db8
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250302213708-bd234c29eed4
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
#### What this PR does

This PR brings in the latest version of mimir-prometheus, which includes the changes from https://github.com/grafana/mimir-prometheus/pull/832.

Given neither of the included changes has any user-visible impact, I haven't added a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
