### PR TITLE
MQE: enforce consistent formatting for test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,8 @@ images: ## Print all image names.
 PROTO_DEFS := $(shell find . $(DONT_FIND) -type f -name '*.proto' -print)
 PROTO_GOS := $(patsubst %.proto,%.pb.go,$(PROTO_DEFS))
 
+PROMQL_TESTS := $(shell find pkg/streamingpromql/testdata/ours pkg/streamingpromql/testdata/ours-only $(DONT_FIND) -type f -path '*.test' -print)
+
 # Generating OTLP translation code is automated.
 OTLP_GOS := $(shell find ./pkg/distributor/otlp/ -type f -name '*_generated.go' -print)
 
@@ -239,7 +241,7 @@ all: $(UPTODATE_FILES)
 test: protos
 test-with-race: protos
 mod-check: protos
-lint: lint-gh-action lint-packaging-scripts protos
+lint: lint-gh-action lint-packaging-scripts protos check-promql-tests
 mimir-build-image/$(UPTODATE): mimir-build-image/*
 
 # All the boiler plate for building golang follows:
@@ -270,7 +272,7 @@ GOVOLUMES=	-v mimir-go-cache:/go/cache \
 # Mount local ssh credentials to be able to clone private repos when doing `mod-check`
 SSHVOLUME=  -v ~/.ssh/:/root/.ssh:$(CONTAINER_MOUNT_OPTIONS)
 
-exes $(EXES) $(EXES_RACE) protos $(PROTO_GOS) lint lint-gh-action lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests print-go-version: fetch-build-image
+exes $(EXES) $(EXES_RACE) protos $(PROTO_GOS) lint lint-gh-action lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests print-go-version format-promql-tests check-promql-tests: fetch-build-image
 	@echo ">>>> Entering build container: $@"
 	$(SUDO) time docker run --rm $(TTY) -i $(SSHVOLUME) $(GOVOLUMES) $(BUILD_IMAGE) GOOS=$(GOOS) GOARCH=$(GOARCH) BINARY_SUFFIX=$(BINARY_SUFFIX) $@;
 
@@ -487,6 +489,12 @@ mod-check: ## Check the go mod is clean and tidy.
 check-protos: ## Check the protobuf files are up to date.
 check-protos: clean-protos protos
 	@./tools/find-diff-or-untracked.sh $(PROTO_GOS) || (echo "Please rebuild protobuf code by running 'check-protos'" && false)
+
+format-promql-tests:
+	@./tools/format-promql-test.sh $(PROMQL_TESTS)
+
+check-promql-tests: format-promql-tests
+	@./tools/find-diff-or-untracked.sh $(PROMQL_TESTS) || (echo "Please format PromQL test files by running 'format-promql-tests'" && false)
 
 %.md : %.template
 	go run ./tools/doc-generator $< > $@

--- a/pkg/streamingpromql/testdata/ours/aggregators.test
+++ b/pkg/streamingpromql/testdata/ours/aggregators.test
@@ -128,44 +128,44 @@ clear
 
 # Test native histogram aggregations
 load 1m
-	single_histogram{label="value"} {{schema:0 sum:2 count:4 buckets:[1 2 1]}} {{sum:2 count:4 buckets:[1 2 1]}}
-	single_histogram{label="value2"} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:0 sum:2 count:4 buckets:[1 2 1]}} {{schema:0 sum:4 count:6 buckets:[2 2 2]}}
-	single_histogram{label="value2", another="value"} {{schema:1 sum:10 count:9 buckets:[3 3 3]}} {{schema:2 sum:2 count:4 buckets:[1 2 1]}}
+  single_histogram{label="value"} {{schema:0 sum:2 count:4 buckets:[1 2 1]}} {{sum:2 count:4 buckets:[1 2 1]}}
+  single_histogram{label="value2"} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:0 sum:2 count:4 buckets:[1 2 1]}} {{schema:0 sum:4 count:6 buckets:[2 2 2]}}
+  single_histogram{label="value2", another="value"} {{schema:1 sum:10 count:9 buckets:[3 3 3]}} {{schema:2 sum:2 count:4 buckets:[1 2 1]}}
 
 eval instant at 0m sum(single_histogram)
-	{} {{schema:0 sum:17 count:18 buckets:[5 12 1]}}
+  {} {{schema:0 sum:17 count:18 buckets:[5 12 1]}}
 
 eval instant at 0m avg(single_histogram)
-	{} {{schema:0 sum:5.666666666666667 count:6 buckets:[1.6666666666666667 4 0.33333333333333337]}}
+  {} {{schema:0 sum:5.666666666666667 count:6 buckets:[1.6666666666666667 4 0.33333333333333337]}}
 
 eval instant at 0m sum by (label) (single_histogram)
-	{label="value"} {{schema:0 count:4 sum:2 buckets:[1 2 1]}}
-	{label="value2"} {{schema:1 count:14 sum:15 buckets:[4 6 4]}}
+  {label="value"} {{schema:0 count:4 sum:2 buckets:[1 2 1]}}
+  {label="value2"} {{schema:1 count:14 sum:15 buckets:[4 6 4]}}
 
 eval instant at 0m avg by (label) (single_histogram)
-	{label="value"} {{count:4 sum:2 buckets:[1 2 1]}}
-	{label="value2"} {{schema:1 count:7 sum:7.5 buckets:[2 3 2]}}
+  {label="value"} {{count:4 sum:2 buckets:[1 2 1]}}
+  {label="value2"} {{schema:1 count:7 sum:7.5 buckets:[2 3 2]}}
 
 # Test aggregation over a range with lookback behaviour.
 eval range from 0 to 3m step 1m sum(single_histogram)
-	{} {{schema:0 sum:17 count:18 buckets:[5 12 1]}} {{schema:0 sum:6 count:12 buckets:[3 7 2]}} {{schema:0 sum:8 count:14 buckets:[4 7 3]}} {{schema:0 sum:8 count:14 buckets:[4 7 3]}}
+  {} {{schema:0 sum:17 count:18 buckets:[5 12 1]}} {{schema:0 sum:6 count:12 buckets:[3 7 2]}} {{schema:0 sum:8 count:14 buckets:[4 7 3]}} {{schema:0 sum:8 count:14 buckets:[4 7 3]}}
 
 eval range from 2m to 3m step 1m sum(single_histogram)
-	{} {{schema:0 sum:8 count:14 buckets:[4 7 3]}} {{schema:0 sum:8 count:14 buckets:[4 7 3]}}
+  {} {{schema:0 sum:8 count:14 buckets:[4 7 3]}} {{schema:0 sum:8 count:14 buckets:[4 7 3]}}
 
 eval range from 0 to 3m step 1m avg(single_histogram)
-	{} {{schema:0 sum:5.666666666666667 count:6 buckets:[1.6666666666666667 4 0.33333333333333337]}} {{schema:0 sum:2 count:4 buckets:[1 2.333333333333333 0.6666666666666666]}} {{schema:0 sum:2.6666666666666665 count:4.666666666666667 buckets:[1.3333333333333333 2.333333333333333 1]}} {{schema:0 sum:2.6666666666666665 count:4.666666666666667 buckets:[1.3333333333333333 2.333333333333333 1]}}
+  {} {{schema:0 sum:5.666666666666667 count:6 buckets:[1.6666666666666667 4 0.33333333333333337]}} {{schema:0 sum:2 count:4 buckets:[1 2.333333333333333 0.6666666666666666]}} {{schema:0 sum:2.6666666666666665 count:4.666666666666667 buckets:[1.3333333333333333 2.333333333333333 1]}} {{schema:0 sum:2.6666666666666665 count:4.666666666666667 buckets:[1.3333333333333333 2.333333333333333 1]}}
 
 eval range from 2m to 3m step 1m avg(single_histogram)
-	{} {{schema:0 sum:2.6666666666666665 count:4.666666666666667 buckets:[1.3333333333333333 2.333333333333333 1]}} {{schema:0 sum:2.6666666666666665 count:4.666666666666667 buckets:[1.3333333333333333 2.333333333333333 1]}}
+  {} {{schema:0 sum:2.6666666666666665 count:4.666666666666667 buckets:[1.3333333333333333 2.333333333333333 1]}} {{schema:0 sum:2.6666666666666665 count:4.666666666666667 buckets:[1.3333333333333333 2.333333333333333 1]}}
 
 clear
 
 # Test a mix of float and histogram values
 load 1m
-	single_histogram{label="value"}                    0 1 {{schema:0 sum:2 count:4 buckets:[1 2 1]}}  {{sum:2 count:4 buckets:[1 2 1]}}          2
-	single_histogram{label="value2"}                   0 2 {{schema:1 sum:5 count:5 buckets:[1 3 1]}}  {{schema:0 sum:2 count:4 buckets:[1 2 1]}} 4
-	single_histogram{label="value2", another="value"}  0 3 {{schema:1 sum:10 count:9 buckets:[3 3 3]}} {{schema:2 sum:2 count:4 buckets:[1 2 1]}} 6
+  single_histogram{label="value"}                    0 1 {{schema:0 sum:2 count:4 buckets:[1 2 1]}}  {{sum:2 count:4 buckets:[1 2 1]}}          2
+  single_histogram{label="value2"}                   0 2 {{schema:1 sum:5 count:5 buckets:[1 3 1]}}  {{schema:0 sum:2 count:4 buckets:[1 2 1]}} 4
+  single_histogram{label="value2", another="value"}  0 3 {{schema:1 sum:10 count:9 buckets:[3 3 3]}} {{schema:2 sum:2 count:4 buckets:[1 2 1]}} 6
 
 # TODO: Verify if these tests are correct. At the moment they match promql engine.
 # See: https://github.com/prometheus/prometheus/issues/14172
@@ -181,34 +181,34 @@ load 1m
 
 # What both engines return
 eval range from 0 to 4m step 1m  sum by (label) (single_histogram)
-	{label="value"}  0 1 1 1 2
-	{label="value2"} 0 5 5 5 10
+  {label="value"}  0 1 1 1 2
+  {label="value2"} 0 5 5 5 10
 
 eval range from 0 to 4m step 1m  avg by (label) (single_histogram)
-	{label="value"}  0 1   1   1   2
-	{label="value2"} 0 2.5 2.5 2.5 5
+  {label="value"}  0 1   1   1   2
+  {label="value2"} 0 2.5 2.5 2.5 5
 
 clear
 
 # Test a mix of float and histogram values at the same point
 load 1m
-	single_histogram{label="value"}   0 1                                          {{schema:0 sum:2 count:4 buckets:[1 2 1]}} {{sum:2 count:4 buckets:[1 2 1]}} 2 {{sum:2 count:4 buckets:[1 2 1]}}
-	single_histogram{label="value2"}  0 {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:0 sum:2 count:4 buckets:[1 2 1]}} 4                                 6 {{sum:2 count:4 buckets:[1 2 1]}}
+  single_histogram{label="value"}   0 1                                          {{schema:0 sum:2 count:4 buckets:[1 2 1]}} {{sum:2 count:4 buckets:[1 2 1]}} 2 {{sum:2 count:4 buckets:[1 2 1]}}
+  single_histogram{label="value2"}  0 {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:0 sum:2 count:4 buckets:[1 2 1]}} 4                                 6 {{sum:2 count:4 buckets:[1 2 1]}}
 
 # If a float is present, the histogram is ignored.
 # If a float comes after a histogram, a lookback'd float is used instead of the histogram (see: https://github.com/prometheus/prometheus/issues/14172)
 eval range from 0 to 5m step 1m  sum(single_histogram)
-	{} 0 1 1 5 8 {{sum:4 count:8 buckets:[2 4 2]}}
+  {} 0 1 1 5 8 {{sum:4 count:8 buckets:[2 4 2]}}
 
 eval range from 0 to 5m step 1m  avg(single_histogram)
-	{} 0 0.5 0.5 2.5 4 {{sum:2 count:4 buckets:[1 2 1]}}
+  {} 0 0.5 0.5 2.5 4 {{sum:2 count:4 buckets:[1 2 1]}}
 
 clear
 
 # Test a mix of float and histogram values at the same point
 load 1m
-	single_histogram{label="value"}   3
-	single_histogram{label="value2"}  {{sum:5 count:5 buckets:[1 3 1]}}
+  single_histogram{label="value"}   3
+  single_histogram{label="value2"}  {{sum:5 count:5 buckets:[1 3 1]}}
 
 # "If either operator has to aggregate a mix of histogram samples and float samples, the corresponding vector element is removed from the output vector entirely."
 eval_warn instant at 1m sum(single_histogram)
@@ -219,8 +219,8 @@ clear
 
 # Test a mix of float and histogram values at the same point
 load 1m
-	single_histogram{label="value"}   {{sum:5 count:5 buckets:[1 3 1]}}
-	single_histogram{label="value2"}  3
+  single_histogram{label="value"}   {{sum:5 count:5 buckets:[1 3 1]}}
+  single_histogram{label="value2"}  3
 
 # "If either operator has to aggregate a mix of histogram samples and float samples, the corresponding vector element is removed from the output vector entirely."
 eval_warn instant at 1m sum(single_histogram)
@@ -232,9 +232,9 @@ clear
 # Test a mix of float and histogram values at the same point, where after adding 2 conflicting series and removing a point,
 # that a third series doesn't add the point back in.
 load 1m
-	single_histogram{label="value"}   1
-	single_histogram{label="value2"}  {{sum:5 count:5 buckets:[1 3 1]}}
-	single_histogram{label="value3"}  3
+  single_histogram{label="value"}   1
+  single_histogram{label="value2"}  {{sum:5 count:5 buckets:[1 3 1]}}
+  single_histogram{label="value3"}  3
 
 # "If either operator has to aggregate a mix of histogram samples and float samples, the corresponding vector element is removed from the output vector entirely."
 eval_warn instant at 1m sum(single_histogram)
@@ -245,16 +245,16 @@ clear
 
 # Test min/max aggregation with histograms and a mix of histogram+float values
 load 1m
-	series{label="value"}   -10 -10 -10                                        10                                         -10                                        {{schema:1 sum:10 count:5 buckets:[1 3 1]}}
-	series{label="value2"}  0   -9  {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
-	series{label="value3"}  -20 -9  -9                                         {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
-	histogram_only_series   {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
+  series{label="value"}   -10 -10 -10                                        10                                         -10                                        {{schema:1 sum:10 count:5 buckets:[1 3 1]}}
+  series{label="value2"}  0   -9  {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
+  series{label="value3"}  -20 -9  -9                                         {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
+  histogram_only_series   {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
 
 eval_info range from 0 to 5m step 1m max(series)
-	{} 0 -9 -9 10 -10 _
+  {} 0 -9 -9 10 -10 _
 
 eval_info range from 0 to 5m step 1m min(series)
-	{} -20 -10 -10 10 -10 _
+  {} -20 -10 -10 10 -10 _
 
 eval_info range from 0 to 2m step 1m max(histogram_only_series)
 
@@ -264,33 +264,33 @@ clear
 
 # Test min/max with NaN
 load 1m
-	mixed_series{type="float", label="value"}   NaN
-	mixed_series{type="float", label="value2"}  -5
-	mixed_series{type="float", label="value3"}  10
-	mixed_series{type="histogram", label="value"}   {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
-	mixed_series{type="histogram", label="value2"}  NaN
+  mixed_series{type="float", label="value"}   NaN
+  mixed_series{type="float", label="value2"}  -5
+  mixed_series{type="float", label="value3"}  10
+  mixed_series{type="histogram", label="value"}   {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
+  mixed_series{type="histogram", label="value2"}  NaN
   mixed_series{type="onlyNaN"} NaN
 
 eval_info instant at 1m min by (type) (mixed_series)
-	{type="float"} -5
-	{type="histogram"} NaN
+  {type="float"} -5
+  {type="histogram"} NaN
   {type="onlyNaN"} NaN
 
 eval_info instant at 1m max by (type) (mixed_series)
-	{type="float"} 10
-	{type="histogram"} NaN
+  {type="float"} 10
+  {type="histogram"} NaN
   {type="onlyNaN"} NaN
 
 clear
 
 # Test native histogram compaction
 load 1m
-    single_histogram{label="value"}  {{schema:1 sum:5 count:5 buckets:[1 3 1 4 0 2]}}
-    single_histogram{label="value2"} {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
+  single_histogram{label="value"}  {{schema:1 sum:5 count:5 buckets:[1 3 1 4 0 2]}}
+  single_histogram{label="value2"} {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
 
 # Compaction will happen in this sum. It will fail without it.
 eval instant at 1m sum(single_histogram)
-    {} {{schema:1 count:10 sum:10 buckets:[2 6 2 4 0 2]}}
+  {} {{schema:1 count:10 sum:10 buckets:[2 6 2 4 0 2]}}
 
 clear
 
@@ -307,8 +307,8 @@ eval range from 0m to 10m step 5m sum(native_histogram)
 clear
 
 load 1m
-	series{label="a"} {{schema:5 sum:15 count:10 buckets:[3 2 5]}} {{schema:5 sum:20 count:15 buckets:[4 5 6]}} {{schema:5 sum:25 count:20 buckets:[5 7 8]}} {{schema:5 sum:30 count:25 buckets:[6 9 10]}} {{schema:5 sum:35 count:30 buckets:[7 10 13]}}
-	series{label="b"} {{schema:4 sum:12 count:8 buckets:[2 3 3]}} {{schema:4 sum:14 count:9 buckets:[3 3 3]}} _ {{schema:4 sum:16 count:10 buckets:[3 4 3]}} {{schema:4 sum:18 count:11 buckets:[4 4 3]}}
+  series{label="a"} {{schema:5 sum:15 count:10 buckets:[3 2 5]}} {{schema:5 sum:20 count:15 buckets:[4 5 6]}} {{schema:5 sum:25 count:20 buckets:[5 7 8]}} {{schema:5 sum:30 count:25 buckets:[6 9 10]}} {{schema:5 sum:35 count:30 buckets:[7 10 13]}}
+  series{label="b"} {{schema:4 sum:12 count:8 buckets:[2 3 3]}} {{schema:4 sum:14 count:9 buckets:[3 3 3]}} _ {{schema:4 sum:16 count:10 buckets:[3 4 3]}} {{schema:4 sum:18 count:11 buckets:[4 4 3]}}
 
 eval range from 0m to 4m step 1m avg(series)
   {} {{schema:4 count:9 sum:13.5 buckets:[2.5 5 1.5]}} {{schema:4 count:12 sum:17 buckets:[3.5 7 1.5]}} {{schema:4 count:14.5 sum:19.5 buckets:[4 9 1.5]}} {{schema:4 count:17.5 sum:23 buckets:[4.5 11.5 1.5]}} {{schema:4 count:20.5 sum:26.5 buckets:[5.5 13.5 1.5]}}
@@ -317,8 +317,8 @@ clear
 
 # Make sure count and group don't emit a 0 when there are no values
 load 1m
-	series{label="a"} _ 9
-	series{label="b"} _ 9
+  series{label="a"} _ 9
+  series{label="b"} _ 9
 
 eval range from 0m to 1m step 1m count(series)
   {} _ 2

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -1079,9 +1079,9 @@ load 6m
   series{case="0a"} _x11
   series{case="0b"} _x11
   series{case="0"} 0x11
-  series{case="a"} _ 1 _ 1 _ 1 _ 1 _ 1 _ 
-  series{case="b"} _ _ 2 _ 2 _ 2 _ 2 _ 2 
-  series{case="c"} _ _ _ 3 _ _ _ 3 _ _ _ 
+  series{case="a"} _ 1 _ 1 _ 1 _ 1 _ 1 _
+  series{case="b"} _ _ 2 _ 2 _ 2 _ 2 _ 2
+  series{case="c"} _ _ _ 3 _ _ _ 3 _ _ _
 
 eval instant at 0m absent(series)
   # expected no result
@@ -1146,6 +1146,6 @@ eval range from 0s to 66m step 6m absent(histo{case="a"})
   {case="a"} 1
 
 eval range from 0s to 66m step 6m absent(histo{case=~"(0|a)"})
-  {} 1 
+  {} 1
 
 clear

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -301,18 +301,18 @@ clear
 # Otherwise they fail both engines.
 
 load 5m
-	metric_total{env="1"}		0 60 120
-	another_metric_total{env="1"}	60 120 180
+  metric_total{env="1"}		0 60 120
+  another_metric_total{env="1"}	60 120 180
 
 # Allows relabeling (to-be-dropped) __name__  via label_join.
 eval_fail instant at 10m label_join(rate({env="1"}[10m]), "my_name", "_", "__name__")
-	expected_fail_message vector cannot contain metrics with the same labelset
+  expected_fail_message vector cannot contain metrics with the same labelset
 #	{my_name="metric_total", env="1"} 0.2
 #	{my_name="another_metric_total", env="1"} 0.2
 
 # Allows preserving __name__ via label_join.
 eval_fail instant at 10m label_join(rate({env="1"}[10m]), "__name__", "_", "__name__", "env")
-	expected_fail_message vector cannot contain metrics with the same labelset
+  expected_fail_message vector cannot contain metrics with the same labelset
 #	metric_total_1{env="1"} 0.2
 #	another_metric_total_1{env="1"} 0.2
 
@@ -507,13 +507,13 @@ eval range from 0 to 60m step 5m clamp_max(series, scalar(maxes))
 
 # clamp ignores any histograms
 eval range from 0 to 15m step 5m clamp(mixed_metric, 2, 5)
-	{} _ 2 2 3
+  {} _ 2 2 3
 
 eval range from 0 to 15m step 5m clamp_min(mixed_metric, 2)
-	{} _ 2 2 3
+  {} _ 2 2 3
 
 eval range from 0 to 15m step 5m clamp_max(mixed_metric, 2)
-	{} _ 1 2 2
+  {} _ 1 2 2
 
 clear
 
@@ -543,7 +543,7 @@ eval range from 0 to 24m step 6m round(series, scalar(toNearest))
 
 # round ignores any histograms
 eval range from 0 to 18m step 6m round(mixed_metric)
-	{} _ 1 2 3
+  {} _ 1 2 3
 
 clear
 
@@ -751,7 +751,7 @@ clear
 
 # Test time-related functions.
 load 5m
-    histogram_sample {{schema:0 sum:1 count:1}}
+  histogram_sample {{schema:0 sum:1 count:1}}
 
 eval range from 0 to 7m step 1m year()
   {} 1970 1970 1970 1970 1970 1970 1970 1970

--- a/pkg/streamingpromql/testdata/ours/histograms.test
+++ b/pkg/streamingpromql/testdata/ours/histograms.test
@@ -1,167 +1,167 @@
 # Test for NH existing alongside classic histogram labels
 load 6m
-	series{le="0.1"}  2
-	series{le="1"}    1
-	series{le="10"}   5
-	series{le="100"}  4
-	series{le="1000"} 9
-	series{le="+Inf"} 8
-	series{le="2000"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
+  series{le="0.1"}  2
+  series{le="1"}    1
+  series{le="10"}   5
+  series{le="100"}  4
+  series{le="1000"} 9
+  series{le="+Inf"} 8
+  series{le="2000"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
 
 eval_info instant at 0m histogram_quantile(0.8, series)
-	{} 595
-	{le="2000"} 2.29739670999407
+  {} 595
+  {le="2000"} 2.29739670999407
 
 clear
 
 # Check for valid classic histogram
 load 6m
-	series{le="0"}    0
-	series{le="2"}    1
-	series{le="4"}    2
-	series{le="6"}    3
-	series{le="+Inf"} 3
+  series{le="0"}    0
+  series{le="2"}    1
+  series{le="4"}    2
+  series{le="6"}    3
+  series{le="+Inf"} 3
 
 eval instant at 0m histogram_quantile(0.8, series)
-	{} 4.800000000000001
+  {} 4.800000000000001
 
 # Check for missing le label warning
 load 6m
-	series            0 10
+  series            0 10
 
 eval_warn instant at 0m histogram_quantile(0.8, series)
-	{} 4.800000000000001
+  {} 4.800000000000001
 
 clear
 
 # Test for different ph values
 load 6m
-	series{le="0"}    0 0 0 0
-	series{le="2"}    1 1 1 1
-	series{le="4"}    2 2 2 2
-	series{le="6"}    3 3 3 3
-	series{le="+Inf"} 3 3 3 3
-	ph                0.1 0.5 0.6 0.9
+  series{le="0"}    0 0 0 0
+  series{le="2"}    1 1 1 1
+  series{le="4"}    2 2 2 2
+  series{le="6"}    3 3 3 3
+  series{le="+Inf"} 3 3 3 3
+  ph                0.1 0.5 0.6 0.9
 
 eval range from 0m to 18m step 6m histogram_quantile(scalar(ph), series)
-	{} 0.6000000000000001 3 3.5999999999999996 5.4
+  {} 0.6000000000000001 3 3.5999999999999996 5.4
 
 clear
 
 # Test for invalid ph values
 load 6m
-	series{le="0"}    0 0 0 0 0
-	series{le="2"}    1 1 1 1 1
-	series{le="4"}    2 2 2 2 2
-	series{le="6"}    3 3 3 3 3
-	series{le="+Inf"} 3 3 3 3 3
-	ph                -0.5 NaN _ 9 0.9
+  series{le="0"}    0 0 0 0 0
+  series{le="2"}    1 1 1 1 1
+  series{le="4"}    2 2 2 2 2
+  series{le="6"}    3 3 3 3 3
+  series{le="+Inf"} 3 3 3 3 3
+  ph                -0.5 NaN _ 9 0.9
 
 eval_warn range from 0m to 24m step 6m histogram_quantile(scalar(ph), series)
-	{} -Inf NaN NaN Inf 5.4
+  {} -Inf NaN NaN Inf 5.4
 
 clear
 
 # Test for invalid ph value where no points
 load 6m
-	series{le="0"}    0   _   0
-	series{le="2"}    1   _   1
-	series{le="4"}    2   _   2
-	series{le="6"}    3   _   3
-	series{le="+Inf"} 3   _   3
-	ph                0.5 NaN 0.9
+  series{le="0"}    0   _   0
+  series{le="2"}    1   _   1
+  series{le="4"}    2   _   2
+  series{le="6"}    3   _   3
+  series{le="+Inf"} 3   _   3
+  ph                0.5 NaN 0.9
 
 # Both engines output a warning even though there is no point where ph is also invalid.
 eval_warn range from 0m to 12m step 6m histogram_quantile(scalar(ph), series)
-	{} 3 _ 5.4
+  {} 3 _ 5.4
 
 clear
 
 # Test various mixed metric scenarios
 load 6m
-	series{host="a", le="0.1"}  2 _ 1 {{schema:0 sum:5 count:4 buckets:[2 2 2]}}
-	series{host="a", le="1"}    3 _ 2 {{schema:0 sum:5 count:4 buckets:[1 5 1]}}
-	series{host="a", le="10"}   5 _ 3 _ {{schema:0 sum:5 count:4 buckets:[5 2 5]}}
-	series{host="a", le="100"}  6 _ 4 _ {{schema:0 sum:1 count:3 buckets:[6 6 2]}}
-	series{host="a", le="1000"} 8 _ 5
-	series{host="a", le="+Inf"} 9 _ 6
-	series{host="a"}     {{schema:0 sum:5 count:4 buckets:[9 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} _ _ _
-	series{host="b"}     1 {{schema:0 sum:5 count:4 buckets:[0 3 1]}} {{schema:0 sum:5 count:4 buckets:[3 3 1]}} _
+  series{host="a", le="0.1"}  2 _ 1 {{schema:0 sum:5 count:4 buckets:[2 2 2]}}
+  series{host="a", le="1"}    3 _ 2 {{schema:0 sum:5 count:4 buckets:[1 5 1]}}
+  series{host="a", le="10"}   5 _ 3 _ {{schema:0 sum:5 count:4 buckets:[5 2 5]}}
+  series{host="a", le="100"}  6 _ 4 _ {{schema:0 sum:1 count:3 buckets:[6 6 2]}}
+  series{host="a", le="1000"} 8 _ 5
+  series{host="a", le="+Inf"} 9 _ 6
+  series{host="a"}     {{schema:0 sum:5 count:4 buckets:[9 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} _ _ _
+  series{host="b"}     1 {{schema:0 sum:5 count:4 buckets:[0 3 1]}} {{schema:0 sum:5 count:4 buckets:[3 3 1]}} _
 
 eval_warn range from 0m to 24m step 6m histogram_quantile(0.8, series)
-	{host="a"}      _ 2.29739670999407 820.0000000000007
-	{host="a", le="0.1"} _ _ _ 3.0314331330207964
-	{host="a", le="1"} _ _ _ 2.29739670999407
-	{host="a", le="10"} _ _ _ _ 3.1166583186419996
-	{host="a", le="100"} _ _ _ _ 3.2490095854249423
-	{host="b"} _ 2.29739670999407 2.29739670999407
+  {host="a"}      _ 2.29739670999407 820.0000000000007
+  {host="a", le="0.1"} _ _ _ 3.0314331330207964
+  {host="a", le="1"} _ _ _ 2.29739670999407
+  {host="a", le="10"} _ _ _ _ 3.1166583186419996
+  {host="a", le="100"} _ _ _ _ 3.2490095854249423
+  {host="b"} _ 2.29739670999407 2.29739670999407
 
 eval_warn range from 0m to 12m step 6m histogram_quantile(0.8, series{host="a"})
-	{host="a"} _ 2.29739670999407 820.0000000000007
+  {host="a"} _ 2.29739670999407 820.0000000000007
 
 eval_warn range from 0m to 24m step 6m histogram_quantile(0.8, series{host="b"})
-	{host="b"} _ 2.29739670999407 2.29739670999407
+  {host="b"} _ 2.29739670999407 2.29739670999407
 
 clear
 
 # Check edge cases on bucket values
 load 6m
-	series{le="0"}    0 0
-	series{le="2"}    1 Inf
-	series{le="4"}    2 2
-	series{le="6"}    3 3
-	series{le="+Inf"} 3 3
-	noInfinity{le="1"} 2 2
-	noInfinity{le="2"} 4 4
-	notEnoughBuckets{le="1"} 2 2
-	notEnoughBuckets{le="+Inf"} _ 4
-	notEnoughObservations{le="1"} 0 1
-	notEnoughObservations{le="+Inf"} 0 2
+  series{le="0"}    0 0
+  series{le="2"}    1 Inf
+  series{le="4"}    2 2
+  series{le="6"}    3 3
+  series{le="+Inf"} 3 3
+  noInfinity{le="1"} 2 2
+  noInfinity{le="2"} 4 4
+  notEnoughBuckets{le="1"} 2 2
+  notEnoughBuckets{le="+Inf"} _ 4
+  notEnoughObservations{le="1"} 0 1
+  notEnoughObservations{le="+Inf"} 0 2
 
 eval_info range from 0m to 6m step 6m histogram_quantile(0.8, series)
-	{} 4.800000000000001 NaN
+  {} 4.800000000000001 NaN
 
 eval range from 0m to 6m step 6m histogram_quantile(0.8, noInfinity)
-	{} NaN NaN
+  {} NaN NaN
 
 eval range from 0m to 6m step 6m histogram_quantile(0.8, notEnoughBuckets)
-	{} NaN 1
+  {} NaN 1
 
 eval range from 0m to 6m step 6m histogram_quantile(0.8, notEnoughObservations)
-	{} NaN 1
+  {} NaN 1
 
 clear
 
 # Check for empty le label
 # This is treated the same as having `series{} 9` which will emit InvalidQuantileWarning
 load 6m
-	series{le="0"}    0
-	series{le="2"}    1
-	series{le="4"}    2
-	series{le="6"}    3
-	series{le=""}     9
-	series{le="+Inf"} 3
-	series{le="3"}    {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
+  series{le="0"}    0
+  series{le="2"}    1
+  series{le="4"}    2
+  series{le="6"}    3
+  series{le=""}     9
+  series{le="+Inf"} 3
+  series{le="3"}    {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
 
 eval_warn instant at 0m histogram_quantile(0.8, series)
-	{} 4.800000000000001
-	{le="3"} 2.29739670999407
+  {} 4.800000000000001
+  {le="3"} 2.29739670999407
 
 clear
 
 # Check for empty le label with NH
 # This is treated the same as having `series{} NH` which will emit MixedClassicNativeHistogramsWarning
 load 6m
-	series{le="0"}    0
-	series{le="2"}    1
-	series{le="4"}    2
-	series{le="6"}    3
-	series{le=""}     {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
-	series{le="+Inf"} 3
-	series{le="3"}    {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
+  series{le="0"}    0
+  series{le="2"}    1
+  series{le="4"}    2
+  series{le="6"}    3
+  series{le=""}     {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
+  series{le="+Inf"} 3
+  series{le="3"}    {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
 
 eval_warn instant at 0m histogram_quantile(0.8, series)
-	{le="3"} 2.29739670999407
+  {le="3"} 2.29739670999407
 
 clear
 

--- a/pkg/streamingpromql/testdata/ours/native_histograms.test
+++ b/pkg/streamingpromql/testdata/ours/native_histograms.test
@@ -5,67 +5,67 @@
 
 # buckets:[1 2 1] means 1 observation in the 1st bucket, 2 observations in the 2nd and 1 observation in the 3rd (total 4).
 load 5m
-	single_histogram {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:20 count:7 buckets:[9 10 1]}}
+  single_histogram {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:20 count:7 buckets:[9 10 1]}}
 
 eval instant at 5m single_histogram
-	{__name__="single_histogram"} {{schema:0 sum:20 count:7 buckets:[9 10 1]}}
+  {__name__="single_histogram"} {{schema:0 sum:20 count:7 buckets:[9 10 1]}}
 
 eval range from 0 to 5m step 1m single_histogram
-	{__name__="single_histogram"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:20 count:7 buckets:[9 10 1]}}
+  {__name__="single_histogram"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:20 count:7 buckets:[9 10 1]}}
 
 # histogram_avg is sum / count.
 eval range from 0 to 5m step 1m histogram_avg(single_histogram)
-	{} 1.25 1.25 1.25 1.25 1.25 2.857142857142857
+  {} 1.25 1.25 1.25 1.25 1.25 2.857142857142857
 
 # histogram_count extracts the count property from the histogram.
 eval range from 0 to 5m step 1m histogram_count(single_histogram)
-	{} 4 4 4 4 4 7
+  {} 4 4 4 4 4 7
 
 eval range from 0 to 5m step 1m histogram_fraction(0, 2, single_histogram)
-	{} 0.75 0.75 0.75 0.75 0.75 1
+  {} 0.75 0.75 0.75 0.75 0.75 1
 
 eval range from 0 to 5m step 1m histogram_stddev(single_histogram)
-	{} 0.842629429717281 0.842629429717281 0.842629429717281 0.842629429717281 0.842629429717281 2.986282214238901
+  {} 0.842629429717281 0.842629429717281 0.842629429717281 0.842629429717281 0.842629429717281 2.986282214238901
 
 eval range from 0 to 5m step 1m histogram_stdvar(single_histogram)
-	{} 0.7100243558256704 0.7100243558256704 0.7100243558256704 0.7100243558256704 0.7100243558256704 8.917881463079594
+  {} 0.7100243558256704 0.7100243558256704 0.7100243558256704 0.7100243558256704 0.7100243558256704 8.917881463079594
 
 # histogram_sum extracts the sum property from the histogram.
 eval range from 0 to 5m step 1m histogram_sum(single_histogram)
-	{} 5 5 5 5 5 20
+  {} 5 5 5 5 5 20
 
 clear
 
 # Test metric with mixed floats and histograms
 load 1m
-	mixed_metric 1 2 3 {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:8 count:6 buckets:[1 4 1]}}
+  mixed_metric 1 2 3 {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:8 count:6 buckets:[1 4 1]}}
 
 eval range from 0 to 5m step 1m mixed_metric
-	{__name__="mixed_metric"} 1 2 3 {{count:4 sum:5 buckets:[1 2 1]}} {{count:6 sum:8 buckets:[1 4 1]}} {{count:6 sum:8 buckets:[1 4 1]}}
+  {__name__="mixed_metric"} 1 2 3 {{count:4 sum:5 buckets:[1 2 1]}} {{count:6 sum:8 buckets:[1 4 1]}} {{count:6 sum:8 buckets:[1 4 1]}}
 
 eval instant at 3m histogram_avg(mixed_metric)
-	{} 1.25
+  {} 1.25
 
 eval instant at 3m histogram_count(mixed_metric)
-	{} 4
+  {} 4
 
 eval instant at 3m histogram_fraction(0, 1, mixed_metric)
-	{} 0.25
+  {} 0.25
 
 eval instant at 4m histogram_stddev(mixed_metric)
-	{} 0.6650352854715079
+  {} 0.6650352854715079
 
 eval instant at 4m histogram_stdvar(mixed_metric)
-	{} 0.44227193092217004
+  {} 0.44227193092217004
 
 eval instant at 4m histogram_sum(mixed_metric)
-	{} 8
+  {} 8
 
 eval range from 0 to 5m step 1m histogram_count(mixed_metric)
-	{} _ _ _ 4 6 6
+  {} _ _ _ 4 6 6
 
 eval range from 0 to 5m step 1m histogram_sum(mixed_metric)
-	{} _ _ _ 5 8 8
+  {} _ _ _ 5 8 8
 
 # histogram_avg ignores any float values
 eval instant at 2m histogram_avg(mixed_metric)
@@ -89,44 +89,44 @@ clear
 
 # Test multiple histograms
 load 5m
-	route{path="one"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
-	route{path="two"} {{schema:0 sum:10 count:20 buckets:[9 10 1]}}
-	route{path="three"} {{schema:0 sum:12 count:10 buckets:[3 2 5]}}
+  route{path="one"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
+  route{path="two"} {{schema:0 sum:10 count:20 buckets:[9 10 1]}}
+  route{path="three"} {{schema:0 sum:12 count:10 buckets:[3 2 5]}}
 
 eval instant at 0 route
-	route{path="one"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
-	route{path="two"} {{schema:0 sum:10 count:20 buckets:[9 10 1]}}
-	route{path="three"} {{schema:0 sum:12 count:10 buckets:[3 2 5]}}
+  route{path="one"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
+  route{path="two"} {{schema:0 sum:10 count:20 buckets:[9 10 1]}}
+  route{path="three"} {{schema:0 sum:12 count:10 buckets:[3 2 5]}}
 
 eval instant at 0 histogram_avg(route)
-	{path="one"} 1.25
-	{path="two"} 0.5
-	{path="three"} 1.2
+  {path="one"} 1.25
+  {path="two"} 0.5
+  {path="three"} 1.2
 
 eval instant at 0 histogram_count(route)
-	{path="one"} 4
-	{path="two"} 20
-	{path="three"} 10
+  {path="one"} 4
+  {path="two"} 20
+  {path="three"} 10
 
 eval instant at 0 histogram_fraction(-10, 20, route)
-	{path="one"} 1
-	{path="two"} 1
-	{path="three"} 1
+  {path="one"} 1
+  {path="two"} 1
+  {path="three"} 1
 
 eval instant at 0 histogram_stddev(route)
-	{path="one"} 0.842629429717281
-	{path="two"} 0.8415900492770793
-	{path="three"} 1.1865698706402301
+  {path="one"} 0.842629429717281
+  {path="two"} 0.8415900492770793
+  {path="three"} 1.1865698706402301
 
 eval instant at 0 histogram_stdvar(route)
-	{path="one"} 0.7100243558256704
-	{path="two"} 0.7082738110421968
-	{path="three"} 1.4079480579111723
+  {path="one"} 0.7100243558256704
+  {path="two"} 0.7082738110421968
+  {path="three"} 1.4079480579111723
 
 eval instant at 0 histogram_sum(route)
-	{path="one"} 5
-	{path="two"} 10
-	{path="three"} 12
+  {path="one"} 5
+  {path="two"} 10
+  {path="three"} 12
 
 clear
 
@@ -135,7 +135,7 @@ clear
 
 # Test metric with mixed floats and histograms
 load 1m
-	mixed_metric 1 2 3 {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:8 count:6 buckets:[1 4 1]}} 4 5 {{schema:0 sum:18 count:10 buckets:[3 4 3]}}
+  mixed_metric 1 2 3 {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:8 count:6 buckets:[1 4 1]}} 4 5 {{schema:0 sum:18 count:10 buckets:[3 4 3]}}
 
 # This is what we would expect, but it currently fails (disabled)
 # eval range from 0 to 8m step 1m mixed_metric
@@ -149,7 +149,7 @@ load 1m
 
 # Instead this is what we get from both engines.
 eval range from 0 to 8m step 1m mixed_metric
-	{__name__="mixed_metric"} 1 2 3 3 3 4 5 {{schema:0 sum:18 count:10 buckets:[3 4 3]}} {{schema:0 sum:18 count:10 buckets:[3 4 3]}}
+  {__name__="mixed_metric"} 1 2 3 3 3 4 5 {{schema:0 sum:18 count:10 buckets:[3 4 3]}} {{schema:0 sum:18 count:10 buckets:[3 4 3]}}
 
 eval range from 0 to 8m step 1m histogram_avg(mixed_metric)
 {} _ _ _ _ _ _ _ 1.8 1.8
@@ -173,19 +173,19 @@ clear
 
 # Test mixed schema rate and increase
 load 1m
-	incr_histogram	{{schema:3 sum:4 count:4 buckets:[1 2 1]}}+{{schema:5 sum:2 count:1 buckets:[1] offset:1}}x10
+  incr_histogram	{{schema:3 sum:4 count:4 buckets:[1 2 1]}}+{{schema:5 sum:2 count:1 buckets:[1] offset:1}}x10
 
 eval instant at 5m rate(incr_histogram[5m])
-	{} {{schema:3 count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}}
+  {} {{schema:3 count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}}
 
 eval instant at 5m increase(incr_histogram[5m])
-	{} {{schema:3 count:5 sum:10 offset:1 buckets:[5]}}
+  {} {{schema:3 count:5 sum:10 offset:1 buckets:[5]}}
 
 clear
 
 # Test mixed metrics
 load 1m
-	incr_histogram	1 2 3 4 {{schema:5 sum:2 count:1 buckets:[1] offset:1}}
+  incr_histogram	1 2 3 4 {{schema:5 sum:2 count:1 buckets:[1] offset:1}}
 
 # Each element in v that contains a mix of float and native histogram samples within the range, will be missing from the result vector.
 eval_warn instant at 5m rate(incr_histogram[5m])
@@ -198,34 +198,34 @@ clear
 
 # Test mixed metrics and range query
 load 1m
-	incr_histogram_sum	1 2 {{schema:3 sum:4 count:4 buckets:[1 2 1]}}+{{schema:5 sum:2 count:1 buckets:[1] offset:1}}x3
+  incr_histogram_sum	1 2 {{schema:3 sum:4 count:4 buckets:[1 2 1]}}+{{schema:5 sum:2 count:1 buckets:[1] offset:1}}x3
 
 # - The first value isn't enough to calculate a rate/increase
 # - The second value is a rate/increase from two floats
 # - The third value is a rate/increase across a float and histogram (so no value returned)
 # - The remaining values contain the rate/increase across two histograms in the vector
 eval_warn range from 0 to 4m step 1m rate(incr_histogram_sum[1m1s])
-	{} _ 0.016666666666666666 _ {{schema:3 count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}} {{schema:3 count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}}
+  {} _ 0.016666666666666666 _ {{schema:3 count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}} {{schema:3 count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}}
 
 eval_warn range from 0 to 4m step 1m increase(incr_histogram_sum[1m1s])
-	{} _ 1.0166666666666666 _ {{schema:3 count:1.0166666666666666 sum:2.033333333333333 offset:1 buckets:[1.0166666666666666]}} {{schema:3 count:1.0166666666666666 sum:2.033333333333333 offset:1 buckets:[1.0166666666666666]}}
+  {} _ 1.0166666666666666 _ {{schema:3 count:1.0166666666666666 sum:2.033333333333333 offset:1 buckets:[1.0166666666666666]}} {{schema:3 count:1.0166666666666666 sum:2.033333333333333 offset:1 buckets:[1.0166666666666666]}}
 
 clear
 
 # Test multiple output samples covering the same input samples.
 load 1m
-	incr_histogram{env="a"}	{{sum:4 count:3 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x10
-	incr_histogram{env="a",cluster="a"}	{{sum:4 count:3 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x10
-	incr_histogram{env="b"}	{{sum:4 count:3 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x10
-	incr_histogram{env="b",cluster="a"}	{{sum:4 count:3 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x10
+  incr_histogram{env="a"}	{{sum:4 count:3 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x10
+  incr_histogram{env="a",cluster="a"}	{{sum:4 count:3 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x10
+  incr_histogram{env="b"}	{{sum:4 count:3 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x10
+  incr_histogram{env="b",cluster="a"}	{{sum:4 count:3 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x10
 
 eval range from 0 to 4m step 1m sum by (env) (rate(incr_histogram[5m]))
-	{env="a"}	_ {{count:0.01 sum:0.02 offset:1 buckets:[0.01]}} {{count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}} {{count:0.023333333333333334 sum:0.04666666666666667 offset:1 buckets:[0.023333333333333334]}} {{count:0.03333333333333333 sum:0.06666666666666667 offset:1 buckets:[0.03333333333333333]}}
-	{env="b"}	_ {{count:0.01 sum:0.02 offset:1 buckets:[0.01]}} {{count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}} {{count:0.023333333333333334 sum:0.04666666666666667 offset:1 buckets:[0.023333333333333334]}} {{count:0.03333333333333333 sum:0.06666666666666667 offset:1 buckets:[0.03333333333333333]}}
+  {env="a"}	_ {{count:0.01 sum:0.02 offset:1 buckets:[0.01]}} {{count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}} {{count:0.023333333333333334 sum:0.04666666666666667 offset:1 buckets:[0.023333333333333334]}} {{count:0.03333333333333333 sum:0.06666666666666667 offset:1 buckets:[0.03333333333333333]}}
+  {env="b"}	_ {{count:0.01 sum:0.02 offset:1 buckets:[0.01]}} {{count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}} {{count:0.023333333333333334 sum:0.04666666666666667 offset:1 buckets:[0.023333333333333334]}} {{count:0.03333333333333333 sum:0.06666666666666667 offset:1 buckets:[0.03333333333333333]}}
 
 eval range from 0 to 4m step 1m sum by (env) (increase(incr_histogram[5m]))
-	{env="a"}	_ {{count:3 sum:6 offset:1 buckets:[3]}} {{count:5 sum:10 offset:1 buckets:[5]}} {{count:7 sum:14 offset:1 buckets:[7]}} {{count:10 sum:20 offset:1 buckets:[10]}}
-	{env="b"}	_ {{count:3 sum:6 offset:1 buckets:[3]}} {{count:5 sum:10 offset:1 buckets:[5]}} {{count:7 sum:14 offset:1 buckets:[7]}} {{count:10 sum:20 offset:1 buckets:[10]}}
+  {env="a"}	_ {{count:3 sum:6 offset:1 buckets:[3]}} {{count:5 sum:10 offset:1 buckets:[5]}} {{count:7 sum:14 offset:1 buckets:[7]}} {{count:10 sum:20 offset:1 buckets:[10]}}
+  {env="b"}	_ {{count:3 sum:6 offset:1 buckets:[3]}} {{count:5 sum:10 offset:1 buckets:[5]}} {{count:7 sum:14 offset:1 buckets:[7]}} {{count:10 sum:20 offset:1 buckets:[10]}}
 
 clear
 

--- a/pkg/streamingpromql/testdata/ours/native_histograms.test
+++ b/pkg/streamingpromql/testdata/ours/native_histograms.test
@@ -152,22 +152,22 @@ eval range from 0 to 8m step 1m mixed_metric
   {__name__="mixed_metric"} 1 2 3 3 3 4 5 {{schema:0 sum:18 count:10 buckets:[3 4 3]}} {{schema:0 sum:18 count:10 buckets:[3 4 3]}}
 
 eval range from 0 to 8m step 1m histogram_avg(mixed_metric)
-{} _ _ _ _ _ _ _ 1.8 1.8
+  {} _ _ _ _ _ _ _ 1.8 1.8
 
 eval range from 0 to 8m step 1m histogram_count(mixed_metric)
-{} _ _ _ _ _ _ _ 10 10
+  {} _ _ _ _ _ _ _ 10 10
 
 eval range from 0 to 8m step 1m histogram_fraction(0, 1, mixed_metric)
-{} _ _ _ _ _ _ _ 0.3 0.3
+  {} _ _ _ _ _ _ _ 0.3 0.3
 
 eval range from 0 to 8m step 1m histogram_stddev(mixed_metric)
-{} _ _ _ _ _ _ _ 0.8574122997574659 0.8574122997574659
+  {} _ _ _ _ _ _ _ 0.8574122997574659 0.8574122997574659
 
 eval range from 0 to 8m step 1m histogram_stdvar(mixed_metric)
-{} _ _ _ _ _ _ _ 0.7351558517753866 0.7351558517753866
+  {} _ _ _ _ _ _ _ 0.7351558517753866 0.7351558517753866
 
 eval range from 0 to 8m step 1m histogram_sum(mixed_metric)
-{} _ _ _ _ _ _ _ 18 18
+  {} _ _ _ _ _ _ _ 18 18
 
 clear
 

--- a/tools/fmt-promqltest.sh
+++ b/tools/fmt-promqltest.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Ensure all lines except load, eval and clear commands and comments are indented
+sed -E -i '' '/^(load|eval|clear|.*#)/! s/^[[:space:]]*/  /g' "$1"
+
 # Convert leading whitespace to two spaces
 sed -E -i '' 's/^[[:space:]]+/  /g' "$1"
 

--- a/tools/fmt-promqltest.sh
+++ b/tools/fmt-promqltest.sh
@@ -4,3 +4,6 @@ set -euo pipefail
 
 # Convert leading whitespace to two spaces
 sed -E -i '' 's/^[[:space:]]+/  /g' "$1"
+
+# Strip trailing whitespace
+sed -E -i '' 's/[[:space:]]+$//g' "$1"

--- a/tools/fmt-promqltest.sh
+++ b/tools/fmt-promqltest.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+# Convert leading whitespace to two spaces
+sed -E -i '' 's/^[[:space:]]+/  /g' "$1"

--- a/tools/format-promql-test.sh
+++ b/tools/format-promql-test.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 
 set -euo pipefail
 

--- a/tools/format-promql-test.sh
+++ b/tools/format-promql-test.sh
@@ -3,10 +3,10 @@
 set -euo pipefail
 
 # Ensure all lines except load, eval and clear commands and comments are indented
-sed -E -i '' '/^(load|eval|clear|.*#)/! s/^[[:space:]]*/  /g' "$1"
+sed -E -i '' '/^(load|eval|clear|.*#)/! s/^[[:space:]]*/  /g' "$@"
 
 # Convert leading whitespace to two spaces
-sed -E -i '' 's/^[[:space:]]+/  /g' "$1"
+sed -E -i '' 's/^[[:space:]]+/  /g' "$@"
 
 # Strip trailing whitespace
-sed -E -i '' 's/[[:space:]]+$//g' "$1"
+sed -E -i '' 's/[[:space:]]+$//g' "$@"

--- a/tools/format-promql-test.sh
+++ b/tools/format-promql-test.sh
@@ -2,11 +2,17 @@
 
 set -euo pipefail
 
+if [[ "$(uname)" == "Darwin" ]]; then
+  EDIT_IN_PLACE=(-i '')
+else
+  EDIT_IN_PLACE=(-i'')
+fi
+
 # Ensure all lines except load, eval and clear commands and comments are indented
-sed -E -i '' '/^(load|eval|clear|.*#)/! s/^[[:space:]]*/  /g' "$@"
+sed -E "${EDIT_IN_PLACE[@]}" '/^(load|eval|clear|.*#)/! s/^[[:space:]]*/  /g' "$@"
 
 # Convert leading whitespace to two spaces
-sed -E -i '' 's/^[[:space:]]+/  /g' "$@"
+sed -E "${EDIT_IN_PLACE[@]}" 's/^[[:space:]]+/  /g' "$@"
 
 # Strip trailing whitespace
-sed -E -i '' 's/[[:space:]]+$//g' "$@"
+sed -E "${EDIT_IN_PLACE[@]}" 's/[[:space:]]+$//g' "$@"

--- a/tools/format-promql-test.sh
+++ b/tools/format-promql-test.sh
@@ -11,6 +11,9 @@ fi
 # Ensure all lines except load, eval and clear commands and comments are indented
 sed -E "${EDIT_IN_PLACE[@]}" '/^(load|eval|clear|.*#)/! s/^[[:space:]]*/  /g' "$@"
 
+# Ensure load, eval and clear commands are not indented
+sed -E "${EDIT_IN_PLACE[@]}" 's/^[[:space:]]+(load|eval|clear)/\1/g' "$@"
+
 # Convert leading whitespace to two spaces
 sed -E "${EDIT_IN_PLACE[@]}" 's/^[[:space:]]+/  /g' "$@"
 

--- a/tools/format-promql-test.sh
+++ b/tools/format-promql-test.sh
@@ -20,3 +20,7 @@ sed -E "${EDIT_IN_PLACE[@]}" 's/^[[:space:]]+/  /g' "$@"
 
 # Strip trailing whitespace
 sed -E "${EDIT_IN_PLACE[@]}" 's/[[:space:]]+$//g' "$@"
+
+# Strip multiple consecutive blank lines
+# https://unix.stackexchange.com/a/216550/22142 explains the incantation below
+sed -E "${EDIT_IN_PLACE[@]}" '$!N;/^\n$/!P;D' "$@"


### PR DESCRIPTION
#### What this PR does

This PR adds a script to enforce consistent formatting of PromQL test files.

I've chosen two spaces as the default indentation given that seems to be what most of our existing test files already use.

I've introduced each of the changes incrementally in their own commit.

If we find this useful, I'll also propose adding it upstream in Prometheus.

#### Which issue(s) this PR fixes or relates to

#10067

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
