### PR TITLE
MQE: lint that list of functions is sorted

### DIFF
--- a/pkg/streamingpromql/functions.go
+++ b/pkg/streamingpromql/functions.go
@@ -551,7 +551,7 @@ func SortOperatorFactory(descending bool) InstantVectorFunctionOperatorFactory {
 
 // These functions return an instant-vector.
 var instantVectorFunctionOperatorFactories = map[string]InstantVectorFunctionOperatorFactory{
-	// Please keep this list sorted alphabetically.
+	//lint:sorted
 	"abs":                InstantVectorTransformationFunctionOperatorFactory("abs", functions.Abs),
 	"absent":             AbsentFunctionOperatorFactory,
 	"acos":               InstantVectorTransformationFunctionOperatorFactory("acos", functions.Acos),
@@ -569,10 +569,10 @@ var instantVectorFunctionOperatorFactories = map[string]InstantVectorFunctionOpe
 	"cos":                InstantVectorTransformationFunctionOperatorFactory("cos", functions.Cos),
 	"cosh":               InstantVectorTransformationFunctionOperatorFactory("cosh", functions.Cosh),
 	"count_over_time":    FunctionOverRangeVectorOperatorFactory("count_over_time", functions.CountOverTime),
-	"days_in_month":      TimeTransformationFunctionOperatorFactory("days_in_month", functions.DaysInMonth),
 	"day_of_month":       TimeTransformationFunctionOperatorFactory("day_of_month", functions.DayOfMonth),
 	"day_of_week":        TimeTransformationFunctionOperatorFactory("day_of_week", functions.DayOfWeek),
 	"day_of_year":        TimeTransformationFunctionOperatorFactory("day_of_year", functions.DayOfYear),
+	"days_in_month":      TimeTransformationFunctionOperatorFactory("days_in_month", functions.DaysInMonth),
 	"deg":                InstantVectorTransformationFunctionOperatorFactory("deg", functions.Deg),
 	"delta":              FunctionOverRangeVectorOperatorFactory("delta", functions.Delta),
 	"deriv":              FunctionOverRangeVectorOperatorFactory("deriv", functions.Deriv),

--- a/pkg/streamingpromql/functions_test.go
+++ b/pkg/streamingpromql/functions_test.go
@@ -78,7 +78,7 @@ func TestFunctionDeduplicateAndMerge(t *testing.T) {
 	step := time.Minute
 
 	expressions := map[string]string{
-		// Please keep this list sorted alphabetically.
+		//lint:sorted
 		"abs":                `abs({__name__=~"float.*"})`,
 		"absent":             `<skip>`,
 		"acos":               `acos({__name__=~"float.*"})`,
@@ -96,10 +96,10 @@ func TestFunctionDeduplicateAndMerge(t *testing.T) {
 		"cos":                `cos({__name__=~"float.*"})`,
 		"cosh":               `cosh({__name__=~"float.*"})`,
 		"count_over_time":    `count_over_time({__name__=~"float.*"}[1m])`,
-		"days_in_month":      `days_in_month({__name__=~"float.*"})`,
 		"day_of_month":       `day_of_month({__name__=~"float.*"})`,
 		"day_of_week":        `day_of_week({__name__=~"float.*"})`,
 		"day_of_year":        `day_of_year({__name__=~"float.*"})`,
+		"days_in_month":      `days_in_month({__name__=~"float.*"})`,
 		"deg":                `deg({__name__=~"float.*"})`,
 		"delta":              `delta({__name__=~"float.*"}[1m])`,
 		"deriv":              `deriv({__name__=~"float.*"}[1m])`,


### PR DESCRIPTION
#### What this PR does

This PR makes use of the linter added in https://github.com/grafana/mimir/pull/10765 to enforce that the list of functions in MQE remains sorted.

#### Which issue(s) this PR fixes or relates to

#10067

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
