### PR TITLE
Stop Nginx socket listening on IPv6 when IPv6 is disabled

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -41,6 +41,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Set resources for smoke-test job. #10608
 * [BUGFIX] Create proper in-cluster remote URLs when gateway and nginx are disabled. #10625
 * [BUGFIX] Fix calculation of `mimir.siToBytes` and use floating point arithmetics. #10044
+* [BUGFIX] Fix Nginx listening sockets when IPv6 is disabled on in Helm values.
 
 ## 5.6.0
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3233,7 +3233,9 @@ nginx:
         proxy_read_timeout 300;
         server {
           listen 8080;
+          {{- if .Values.gateway.nginx.config.enableIPv6 }}
           listen [::]:8080;
+          {{- end }}
 
           {{- if .Values.nginx.basicAuth.enabled }}
           auth_basic           "Mimir";


### PR DESCRIPTION
#### What this PR does
Fixes an issue where the Nginx deployment would still bing to IPv6 even if we set `gateway.nginx.config.enableIPv6` to false.
This causes the deployment to crash if IPv6 is disabled on the host.

~~~
✗ k logs deploy/mimir-nginx
/docker-entrypoint.sh: No files found in /docker-entrypoint.d/, skipping configuration
2025/03/03 10:06:22 [emerg] 1#1: socket() [::]:8080 failed (97: Address family not supported by protocol)
nginx: [emerg] socket() [::]:8080 failed (97: Address family not supported by protocol)
~~~

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
