### PR TITLE
ruler: Remove dependency on dskit cache package

### DIFF
--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/user"
 	ot "github.com/opentracing/opentracing-go"
@@ -60,7 +59,7 @@ type DefaultMultiTenantManager struct {
 	rulerIsRunning atomic.Bool
 }
 
-func NewDefaultMultiTenantManager(cfg Config, managerFactory ManagerFactory, reg prometheus.Registerer, logger log.Logger, dnsResolver cache.AddressProvider) (*DefaultMultiTenantManager, error) {
+func NewDefaultMultiTenantManager(cfg Config, managerFactory ManagerFactory, reg prometheus.Registerer, logger log.Logger, dnsResolver AddressProvider) (*DefaultMultiTenantManager, error) {
 	refreshMetrics := discovery.NewRefreshMetrics(reg)
 	ncfg, err := buildNotifierConfig(&cfg, dnsResolver, refreshMetrics)
 	if err != nil {

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -15,7 +15,6 @@ import (
 
 	gklog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/crypto/tls"
 	"github.com/grafana/dskit/flagext"
@@ -142,7 +141,7 @@ func (rn *rulerNotifier) stop() {
 
 // Builds a Prometheus config.Config from a ruler.Config with just the required
 // options to configure notifications to Alertmanager.
-func buildNotifierConfig(rulerConfig *Config, resolver cache.AddressProvider, rmi discovery.RefreshMetricsManager) (*config.Config, error) {
+func buildNotifierConfig(rulerConfig *Config, resolver AddressProvider, rmi discovery.RefreshMetricsManager) (*config.Config, error) {
 	if rulerConfig.AlertmanagerURL == "" {
 		// no AM URLs were provided, so we can just return a default config without errors
 		return &config.Config{}, nil

--- a/pkg/ruler/notifier_test.go
+++ b/pkg/ruler/notifier_test.go
@@ -190,8 +190,8 @@ func TestBuildNotifierConfig(t *testing.T) {
 							PathPrefix: "/alertmanager",
 							ServiceDiscoveryConfigs: discovery.Configs{
 								dnsServiceDiscovery{
-									Host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
-									QType: dns.SRV,
+									host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
+									qType: dns.SRV,
 								},
 							},
 						},
@@ -247,9 +247,9 @@ func TestBuildNotifierConfig(t *testing.T) {
 							PathPrefix: "/alertmanager",
 							ServiceDiscoveryConfigs: discovery.Configs{
 								dnsServiceDiscovery{
-									Host:            "alertmanager.mimir.svc.cluster.local:8080",
-									RefreshInterval: time.Second,
-									QType:           dns.A,
+									host:            "alertmanager.mimir.svc.cluster.local:8080",
+									refreshInterval: time.Second,
+									qType:           dns.A,
 								},
 							},
 						},
@@ -259,9 +259,9 @@ func TestBuildNotifierConfig(t *testing.T) {
 							PathPrefix: "/am",
 							ServiceDiscoveryConfigs: discovery.Configs{
 								dnsServiceDiscovery{
-									Host:            "_http._tcp.alertmanager2.mimir.svc.cluster.local",
-									RefreshInterval: time.Second,
-									QType:           dns.SRV,
+									host:            "_http._tcp.alertmanager2.mimir.svc.cluster.local",
+									refreshInterval: time.Second,
+									qType:           dns.SRV,
 								},
 							},
 						},
@@ -292,8 +292,8 @@ func TestBuildNotifierConfig(t *testing.T) {
 							PathPrefix: "/alertmanager",
 							ServiceDiscoveryConfigs: discovery.Configs{
 								dnsServiceDiscovery{
-									Host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
-									QType: dns.SRV,
+									host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
+									qType: dns.SRV,
 								},
 							},
 						},
@@ -329,8 +329,8 @@ func TestBuildNotifierConfig(t *testing.T) {
 							PathPrefix: "/alertmanager",
 							ServiceDiscoveryConfigs: discovery.Configs{
 								dnsServiceDiscovery{
-									Host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
-									QType: dns.SRV,
+									host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
+									qType: dns.SRV,
 								},
 							},
 						},
@@ -368,8 +368,8 @@ func TestBuildNotifierConfig(t *testing.T) {
 							PathPrefix: "/alertmanager",
 							ServiceDiscoveryConfigs: discovery.Configs{
 								dnsServiceDiscovery{
-									Host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
-									QType: dns.SRV,
+									host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
+									qType: dns.SRV,
 								},
 							},
 						},
@@ -413,8 +413,8 @@ func TestBuildNotifierConfig(t *testing.T) {
 							PathPrefix: "/alertmanager",
 							ServiceDiscoveryConfigs: discovery.Configs{
 								dnsServiceDiscovery{
-									Host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
-									QType: dns.SRV,
+									host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
+									qType: dns.SRV,
 								},
 							},
 						},
@@ -459,8 +459,8 @@ func TestBuildNotifierConfig(t *testing.T) {
 							PathPrefix: "/alertmanager",
 							ServiceDiscoveryConfigs: discovery.Configs{
 								dnsServiceDiscovery{
-									Host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
-									QType: dns.SRV,
+									host:  "_http._tcp.alertmanager-0.default.svc.cluster.local",
+									qType: dns.SRV,
 								},
 							},
 						},

--- a/pkg/ruler/service_discovery.go
+++ b/pkg/ruler/service_discovery.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/dns"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,14 +25,31 @@ func init() {
 	discovery.RegisterConfig(dnsServiceDiscovery{})
 }
 
+// AddressProvider performs node address resolution given a list of addresses.
+type AddressProvider interface {
+	// Resolve resolves the provided list of addresses to the actual nodes
+	Resolve(context.Context, []string) error
+
+	// Addresses returns the nodes
+	Addresses() []string
+}
+
 type dnsServiceDiscovery struct {
-	refreshMetrics discovery.RefreshMetricsInstantiator
+	refreshMetrics  discovery.RefreshMetricsInstantiator
+	resolver        AddressProvider
+	refreshInterval time.Duration
+	qType           dns.QType
+	host            string
+}
 
-	Resolver cache.AddressProvider
-
-	RefreshInterval time.Duration
-	QType           dns.QType
-	Host            string
+func dnsSD(rulerConfig *Config, resolver AddressProvider, qType dns.QType, url *url.URL, rmi discovery.RefreshMetricsInstantiator) discovery.Config {
+	return dnsServiceDiscovery{
+		resolver:        resolver,
+		refreshInterval: rulerConfig.AlertmanagerRefreshInterval,
+		host:            url.Host,
+		qType:           qType,
+		refreshMetrics:  rmi,
+	}
 }
 
 func (dnsServiceDiscovery) Name() string {
@@ -44,7 +60,7 @@ func (c dnsServiceDiscovery) NewDiscoverer(opts discovery.DiscovererOptions) (di
 	return refresh.NewDiscovery(refresh.Options{
 		Logger:              opts.Logger,
 		Mech:                mechanismName,
-		Interval:            c.RefreshInterval,
+		Interval:            c.refreshInterval,
 		RefreshF:            c.resolve,
 		MetricsInstantiator: c.refreshMetrics,
 	}), nil
@@ -55,11 +71,11 @@ func (c dnsServiceDiscovery) NewDiscovererMetrics(prometheus.Registerer, discove
 }
 
 func (c dnsServiceDiscovery) resolve(ctx context.Context) ([]*targetgroup.Group, error) {
-	if err := c.Resolver.Resolve(ctx, []string{string(c.QType) + "+" + c.Host}); err != nil {
+	if err := c.resolver.Resolve(ctx, []string{string(c.qType) + "+" + c.host}); err != nil {
 		return nil, err
 	}
 
-	resolved := c.Resolver.Addresses()
+	resolved := c.resolver.Addresses()
 	targets := make([]model.LabelSet, len(resolved))
 	for i, r := range resolved {
 		targets[i] = model.LabelSet{
@@ -69,20 +85,10 @@ func (c dnsServiceDiscovery) resolve(ctx context.Context) ([]*targetgroup.Group,
 
 	tg := &targetgroup.Group{
 		Targets: targets,
-		Source:  c.Host,
+		Source:  c.host,
 	}
 
 	return []*targetgroup.Group{tg}, nil
-}
-
-func dnsSD(rulerConfig *Config, resolver cache.AddressProvider, qType dns.QType, url *url.URL, rmi discovery.RefreshMetricsInstantiator) discovery.Config {
-	return dnsServiceDiscovery{
-		Resolver:        resolver,
-		RefreshInterval: rulerConfig.AlertmanagerRefreshInterval,
-		Host:            url.Host,
-		QType:           qType,
-		refreshMetrics:  rmi,
-	}
 }
 
 func staticTarget(url *url.URL) discovery.Config {

--- a/pkg/ruler/service_discovery_test.go
+++ b/pkg/ruler/service_discovery_test.go
@@ -71,10 +71,10 @@ func TestConfig_TranslatesToPrometheusTargetGroup(t *testing.T) {
 			reg := prometheus.NewRegistry()
 			refreshMetrics := discovery.NewRefreshMetrics(reg)
 			cfg := dnsServiceDiscovery{
-				RefreshInterval: time.Millisecond,
-				Resolver:        resolver,
-				QType:           dns.A,
-				Host:            sourceAddress,
+				refreshInterval: time.Millisecond,
+				resolver:        resolver,
+				qType:           dns.A,
+				host:            sourceAddress,
 				refreshMetrics:  refreshMetrics,
 			}
 			discoverer, err := cfg.NewDiscoverer(discovery.DiscovererOptions{})
@@ -129,10 +129,10 @@ func TestConfig_ConstructsLookupNamesCorrectly(t *testing.T) {
 			reg := prometheus.NewRegistry()
 			refreshMetrics := discovery.NewRefreshMetrics(reg)
 			cfg := dnsServiceDiscovery{
-				RefreshInterval: time.Millisecond,
-				Resolver:        resolver,
-				QType:           tc.qType,
-				Host:            tc.host,
+				refreshInterval: time.Millisecond,
+				resolver:        resolver,
+				qType:           tc.qType,
+				host:            tc.host,
 				refreshMetrics:  refreshMetrics,
 			}
 			discoverer, err := cfg.NewDiscoverer(discovery.DiscovererOptions{})


### PR DESCRIPTION
#### What this PR does

Remove a dependency on dskit/cache that was used only for a DNS service discovery interface. Instead, define the expected interface where it is consumed in the ruler.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
