### PR TITLE
frontend: Add back split and cache to range middlewares

### DIFF
--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -400,6 +400,8 @@ func newQueryMiddlewares(
 			log,
 			registerer,
 		)
+
+		queryRangeMiddleware = append(queryRangeMiddleware, newInstrumentMiddleware("split_by_interval_and_results_cache", metrics), splitAndCacheMiddleware)
 	}
 
 	queryInstantMiddleware = append(queryInstantMiddleware,

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -673,6 +673,7 @@ func TestMiddlewaresConsistency(t *testing.T) {
 	var allNames []string
 	for _, middlewares := range middlewaresByRequestType {
 		allNames = append(allNames, getMiddlewareNames(middlewares.instances)...)
+		allNames = append(allNames, middlewares.exceptions...)
 	}
 	slices.Sort(allNames)
 	allNames = slices.Compact(allNames)


### PR DESCRIPTION
It was removed here: https://github.com/grafana/mimir/pull/10742 by mistake

Also, change `TestMiddlewaresConsistency` so that we catch those

#### Checklist

- [x] Tests updated.
- [N/A] Documentation added.
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
