### PR TITLE
Update grafanabot_reviewer.yml to use app token

### DIFF
--- a/.github/workflows/grafanabot_reviewer.yml
+++ b/.github/workflows/grafanabot_reviewer.yml
@@ -10,8 +10,6 @@ jobs:
   dependabot-reviewer:
     runs-on: ubuntu-latest
 
-    if: ${{ github.event.pull_request.user.login == 'grafanabot' }}
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/grafanabot_reviewer.yml
+++ b/.github/workflows/grafanabot_reviewer.yml
@@ -10,6 +10,8 @@ jobs:
   dependabot-reviewer:
     runs-on: ubuntu-latest
 
+    if: ${{ github.event.pull_request.user.login == 'grafanabot' }}
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/grafanabot_reviewer.yml
+++ b/.github/workflows/grafanabot_reviewer.yml
@@ -4,16 +4,33 @@ on: pull_request_target
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 jobs:
   dependabot-reviewer:
     runs-on: ubuntu-latest
 
     if: ${{ github.event.pull_request.user.login == 'grafanabot' }}
-    
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      - name: Retrieve GitHub App Credentials from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
+        with:
+          repo_secrets: |
+            APP_ID=mimir-github-bot:app_id
+            PRIVATE_KEY=mimir-github-bot:private_key
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Approve and auto-merge
         id: auto-merge

--- a/.github/workflows/grafanabot_reviewer.yml
+++ b/.github/workflows/grafanabot_reviewer.yml
@@ -29,3 +29,23 @@ jobs:
           app-id: ${{ env.APP_ID }}
           private-key: ${{ env.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+
+      - name: Approve and auto-merge
+        id: auto-merge
+        if: contains(github.event.pull_request.head.ref, 'helm-chart-weekly-')
+        run: |
+          gh pr merge --auto --squash "$PR_URL"
+          gh pr review $PR_URL \
+          --approve -b "**I'm approving** this pull request, since it is a helm release."
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+
+      - name: Manual review is required
+        if: steps.auto-merge.conclusion != 'success'
+        run: |
+          gh pr comment $PR_URL --body "**This PR from grafanabot requires manual review.**"
+
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/grafanabot_reviewer.yml
+++ b/.github/workflows/grafanabot_reviewer.yml
@@ -29,23 +29,3 @@ jobs:
           app-id: ${{ env.APP_ID }}
           private-key: ${{ env.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-
-      - name: Approve and auto-merge
-        id: auto-merge
-        if: contains(github.event.pull_request.head.ref, 'helm-chart-weekly-')
-        run: |
-          gh pr merge --auto --squash "$PR_URL"
-          gh pr review $PR_URL \
-          --approve -b "**I'm approving** this pull request, since it is a helm release."
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GH_BOT_ACCESS_TOKEN}}
-
-      - name: Manual review is required
-        if: steps.auto-merge.conclusion != 'success'
-        run: |
-          gh pr comment $PR_URL --body "**This PR from grafanabot requires manual review.**"
-
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/grafanabot_reviewer.yml
+++ b/.github/workflows/grafanabot_reviewer.yml
@@ -41,7 +41,7 @@ jobs:
           --approve -b "**I'm approving** this pull request, since it is a helm release."
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Manual review is required
         if: steps.auto-merge.conclusion != 'success'

--- a/.github/workflows/grafanabot_reviewer.yml
+++ b/.github/workflows/grafanabot_reviewer.yml
@@ -1,5 +1,5 @@
 name: Auto-review Grafanabot PRs
-on: pull_request_target
+on: pull_request
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Due to https://github.com/grafana/deployment_tools/tree/master/docs/platform/continuous-integration#avoid-pull_request_target the workflow had to be changed from `on: pull_request_target` to `on: pull_request`. However that is fine as Grot PRs are created in the upstream repository thus that only makes the workflow safer!