### PR TITLE
Return context.Cause(ctx) as error so we can use custom timeout errors

### DIFF
--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -251,6 +251,9 @@ func (rt limitedParallelismRoundTripper) RoundTrip(r *http.Request) (*http.Respo
 	response, err := rt.middleware.Wrap(
 		HandlerFunc(func(ctx context.Context, r MetricsQueryRequest) (Response, error) {
 			if err := sem.Acquire(ctx, 1); err != nil {
+				// Without this change, using WithTimeoutCause has no effect when calling Do on
+				// limitedParallelismRoundTripper, since that would need to return the cause as error,
+				// which is the normal behaviour except that semaphore does not do that.
 				if errors.Is(err, ctx.Err()) {
 					err = context.Cause(ctx)
 				}


### PR DESCRIPTION
#### What this PR does

To use https://pkg.go.dev/context#WithTimeoutCause , we need to return the cause as error, which is the normal behaviour, except that when we use https://github.com/golang/sync/blob/master/semaphore/semaphore.go#L49 in this code, it does not use the cause as error. To fix that, we check the error returned from there and replace it with the cause if relevant. Without this change, using `WithTimeoutCause` has no effect when calling `Do` on `limitedParallelismRoundTripper`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Minor change which by itself should not result in any user-facing changes, but this makes other changes possible.