### PR TITLE
Fix flaky query-frontend integration tests after #10798

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
 	github.com/grafana/dskit v0.0.0-20250303172748-fd4441b85237
-	github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc
+	github.com/grafana/e2e v0.1.2-0.20250306030804-b80b212be908
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.7.11
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -1274,8 +1274,8 @@ github.com/grafana/alerting v0.0.0-20250225150117-15e285d78df2 h1:kESrzm0FcRVLmG
 github.com/grafana/alerting v0.0.0-20250225150117-15e285d78df2/go.mod h1:hdGB3dSl8Ma9Rjo2YiAEAjMkZ5HiNJbNDqRKDefRZrM=
 github.com/grafana/dskit v0.0.0-20250303172748-fd4441b85237 h1:VZagYtPcmjgazfPAuWN7lER6mprG20r51+1eYPpATkw=
 github.com/grafana/dskit v0.0.0-20250303172748-fd4441b85237/go.mod h1:cu2zIOHhAgRaIDuECsERftSp1l7KHq1aX1jgihQCu0c=
-github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc h1:BW+LjKJDz0So5LI8UZfW5neWeKpSkWqhmGjQFzcFfLM=
-github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
+github.com/grafana/e2e v0.1.2-0.20250306030804-b80b212be908 h1:l3pFNUs4heAhiXnMo0thaJQrNWeE4SgLqUOEUmZtC6A=
+github.com/grafana/e2e v0.1.2-0.20250306030804-b80b212be908/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/franz-go v0.0.0-20241009100846-782ba1442937 h1:fwwnG/NcygoS6XbAaEyK2QzMXI/BZIEJvQ3CD+7XZm8=
 github.com/grafana/franz-go v0.0.0-20241009100846-782ba1442937/go.mod h1:NreRdJ2F7dziDY/m6VyspWd6sNxHKXdMZI42UfQ3GXM=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -372,7 +372,9 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 			start := end.Add(-(30*24*time.Hour + 1*time.Hour)) // 30 days + 1 hour. Makes sure we can go above the max partial query length.
 			_, err = c.QueryRange("{instance=~\"hello.*\"}", start, end, time.Hour)
 			require.NoError(t, err)
-			require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(31), "cortex_frontend_split_queries_total"))
+
+			// Depending on what time it is and how that aligns with midnight UTC, the query may be broken into 31 or 32 parts.
+			require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Between(31, 32), "cortex_frontend_split_queries_total"))
 		}
 
 		// No need to repeat the test on start/end time rounding for each user.

--- a/vendor/github.com/grafana/e2e/metrics.go
+++ b/vendor/github.com/grafana/e2e/metrics.go
@@ -127,6 +127,17 @@ func Less(value float64) func(sums ...float64) bool {
 	}
 }
 
+// Between is an isExpected function for WaitSumMetrics that returns true if given single sum is greater than or equal to lower
+// and less than or equal to upper.
+func Between(lower, upper float64) func(sums ...float64) bool {
+	return func(sums ...float64) bool {
+		if len(sums) != 1 {
+			panic("equals: expected one value")
+		}
+		return sums[0] >= lower && sums[0] <= upper
+	}
+}
+
 // EqualsAmongTwo is an isExpected function for WaitSumMetrics that returns true if first sum is equal to the second.
 // NOTE: Be careful on scrapes in between of process that changes two metrics. Those are
 // usually not atomic.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -701,7 +701,7 @@ github.com/grafana/dskit/tenant
 github.com/grafana/dskit/test
 github.com/grafana/dskit/tracing
 github.com/grafana/dskit/user
-# github.com/grafana/e2e v0.1.2-0.20240118170847-db90b84177fc
+# github.com/grafana/e2e v0.1.2-0.20250306030804-b80b212be908
 ## explicit; go 1.19
 github.com/grafana/e2e
 github.com/grafana/e2e/cache


### PR DESCRIPTION
#### What this PR does

Following the changes in #10798, query-frontend integration tests can fail with:

```
    query_frontend_test.go:375: 
        	Error Trace:	/home/runner/work/mimir/mimir/integration/query_frontend_test.go:375
        	            				/home/runner/work/mimir/mimir/integration/query_frontend_test.go:49
        	Error:      	Received unexpected error:
        	            	unable to find metrics [cortex_frontend_split_queries_total] with expected values. Last error: <nil>. Last values: [32]
        	Test:       	TestQueryFrontendWithBlocksStorageViaFlags
```

This happens when the test is being run between 00:00 and 01:00 UTC, as then the query touches data in 32 different days and so is split 32 ways. 

⚠️ This PR depends on https://github.com/grafana/e2e/pull/20.

#### Which issue(s) this PR fixes or relates to

#10798

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
