### PR TITLE
mixin: Add req/sec floor to `MimirCacheRequestErrors`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 
 ### Mixin
 
+* [CHANGE] Alerts: Only alert on errors performing cache operations if there are over 10 request/sec to avoid flapping. #10832
 * [FEATURE] Add compiled mixin for GEM installations in `operations/mimir-mixin-compiled-gem`. #10690
 * [ENHANCEMENT] Dashboards: clarify that the ingester and store-gateway panels on the 'Reads' dashboard show data from all query requests to that component, not just requests from the main query path (ie. requests from the ruler query path are included as well). #10598
 * [ENHANCEMENT] Dashboards: add ingester and store-gateway panels from the 'Reads' dashboard to the 'Remote ruler reads' dashboard as well. #10598

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -124,7 +124,7 @@ spec:
                 /
                 sum by(cluster, namespace, name, operation) (
                   rate(thanos_cache_operations_total{operation!~"add|delete"}[1m])
-                )
+                ) > 10
               ) * 100 > 5
             for: 5m
             labels:

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -112,7 +112,7 @@ groups:
               /
               sum by(cluster, namespace, name, operation) (
                 rate(thanos_cache_operations_total{operation!~"add|delete"}[1m])
-              )
+              ) > 10
             ) * 100 > 5
           for: 5m
           labels:

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -112,7 +112,7 @@ groups:
               /
               sum by(cluster, namespace, name, operation) (
                 rate(thanos_cache_operations_total{operation!~"add|delete"}[1m])
-              )
+              ) > 10
             ) * 100 > 5
           for: 5m
           labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -112,7 +112,7 @@ groups:
               /
               sum by(cluster, namespace, name, operation) (
                 rate(thanos_cache_operations_total{operation!~"add|delete"}[1m])
-              )
+              ) > 10
             ) * 100 > 5
           for: 5m
           labels:


### PR DESCRIPTION
#### What this PR does

Require at least 10 req/sec to the cache to consider alerting on request errors. This avoids noisy alerts in low-traffic clusters

#### Which issue(s) this PR fixes or relates to

Fixes #10831

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
