### PR TITLE
Catch up faster when an idle partition becomes active after some time

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -254,7 +254,7 @@ func (b *BlockBuilder) runningStandaloneMode(ctx context.Context) error {
 	// Examples for interval=1h, buffer=15m:
 	//   (1) current time is 14:12, cycle end is 13:15
 	//   (2) current time is 14:17, cycle end is 14:15
-	cycleEndTime := cycleEndAtStartup(time.Now(), b.cfg.ConsumeInterval, b.cfg.ConsumeIntervalBuffer)
+	cycleEndTime := cycleEndBefore(time.Now(), b.cfg.ConsumeInterval, b.cfg.ConsumeIntervalBuffer)
 	var waitDur time.Duration
 	for {
 		select {
@@ -277,11 +277,20 @@ func (b *BlockBuilder) runningStandaloneMode(ctx context.Context) error {
 	}
 }
 
-// cycleEndAtStartup returns the timestamp of the last cycleEnd that is <=t.
-func cycleEndAtStartup(t time.Time, interval, buffer time.Duration) time.Time {
+// cycleEndBefore returns the timestamp of the last cycleEnd that is <=t.
+func cycleEndBefore(t time.Time, interval, buffer time.Duration) time.Time {
 	cycleEnd := t.Truncate(interval).Add(buffer)
 	if cycleEnd.After(t) {
 		cycleEnd = cycleEnd.Add(-interval)
+	}
+	return cycleEnd
+}
+
+// cycleEndAfter returns the timestamp of the first cycleEnd that is >=t.
+func cycleEndAfter(t time.Time, interval, buffer time.Duration) time.Time {
+	cycleEnd := t.Truncate(interval).Add(buffer)
+	if cycleEnd.Before(t) {
+		cycleEnd = cycleEnd.Add(interval)
 	}
 	return cycleEnd
 }
@@ -450,13 +459,37 @@ func (b *BlockBuilder) consumePartition(ctx context.Context, partition int32, st
 	for !sectionEndTime.After(cycleEndTime) {
 		logger := log.With(logger, "section_end", sectionEndTime, "offset", state.Commit.At)
 		state, err = b.consumePartitionSection(ctx, logger, builder, partition, state, sectionEndTime, cycleEndOffset)
-		if err != nil {
+		if err == nil {
+			sectionEndTime = sectionEndTime.Add(b.cfg.ConsumeInterval)
+			continue
+		}
+
+		var recInFutureErr *errFirstRecordInFuture
+		if !errors.As(err, &recInFutureErr) {
 			return PartitionState{}, fmt.Errorf("consume partition %d: %w", partition, err)
 		}
-		sectionEndTime = sectionEndTime.Add(b.cfg.ConsumeInterval)
+		err = nil
+
+		// The first record in the partition has a timestamp greater than the section end time.
+		// It is possible this was an idle partition that suddenly became active. Instead of trying every interval since
+		// the last commit, we shortcut to the min of first record time or the cycle end time.
+		sectionEndTime = cycleEndAfter(recInFutureErr.recordTs, b.cfg.ConsumeInterval, b.cfg.ConsumeIntervalBuffer)
+		if sectionEndTime.After(cycleEndTime) {
+			sectionEndTime = cycleEndTime
+		}
 	}
 
 	return state, nil
+}
+
+// errFirstRecordInFuture is returned when the first record in the partition has a timestamp greater than the section end time.
+// It contains the timestamp of the first record.
+type errFirstRecordInFuture struct {
+	recordTs time.Time
+}
+
+func (e errFirstRecordInFuture) Error() string {
+	return fmt.Sprintf("first record in the partition has a timestamp greater than the section end time: %s", e.recordTs.UTC().String())
 }
 
 func (b *BlockBuilder) consumePartitionSection(
@@ -592,7 +625,7 @@ consumerLoop:
 	// No records were processed for this cycle.
 	if lastRec == nil {
 		level.Info(logger).Log("msg", "nothing to commit due to first record has a timestamp greater than this section end", "first_rec_offset", firstRec.Offset, "first_rec_ts", firstRec.Timestamp)
-		return state, nil
+		return state, &errFirstRecordInFuture{recordTs: firstRec.Timestamp}
 	}
 
 	// All samples in all records were processed. We can commit the last record's offset.

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -522,7 +522,8 @@ func (b *BlockBuilder) consumePartitionSection(
 
 		dur := time.Since(t)
 
-		if retErr != nil {
+		var temp *errFirstRecordInFuture
+		if retErr != nil && !errors.As(retErr, &temp) {
 			level.Error(logger).Log("msg", "partition consumption failed", "err", retErr, "duration", dur)
 			return
 		}

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -1320,7 +1320,7 @@ func TestFastCatchupOnIdlePartition(t *testing.T) {
 	// The above cycle should try one consumption for the old commit point, then shortcut
 	// to the last 2h records. So we should not have more than 3-4 consumption attempts.
 	// Without the shortcut in place, it will run consumption 48-49 times, one for each hour.
-	consumptionAttempts := getSampleCountFromHistoramVector(t, bb.blockBuilderMetrics.processPartitionDuration)
+	consumptionAttempts := getSampleCountFromHistogramVector(t, bb.blockBuilderMetrics.processPartitionDuration)
 	require.GreaterOrEqual(t, consumptionAttempts, 3)
 	require.LessOrEqual(t, consumptionAttempts, 4)
 
@@ -1331,10 +1331,10 @@ func TestFastCatchupOnIdlePartition(t *testing.T) {
 	)
 }
 
-// getSampleCountFromHistoramVector gets the count field of histogram from the histogram vector.
+// getSampleCountFromHistogramVector gets the count field of histogram from the histogram vector.
 // The histogram vector must have only 1 histogram.
 // This function takes most of its code from promtest.ToFloat64() and adapts to our use case.
-func getSampleCountFromHistoramVector(t *testing.T, m *prometheus.HistogramVec) int {
+func getSampleCountFromHistogramVector(t *testing.T, m *prometheus.HistogramVec) int {
 	var (
 		metrics []prometheus.Metric
 		mChan   = make(chan prometheus.Metric)

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
@@ -109,7 +110,7 @@ func TestBlockBuilder_StartWithExistingCommit(t *testing.T) {
 	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
 
 	// Producing some records
-	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 
 	var producedSamples []mimirpb.Sample
 	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-7 * time.Hour).Add(29 * time.Minute)
@@ -184,7 +185,7 @@ func TestBlockBuilder_StartWithExistingCommit_PullMode(t *testing.T) {
 	cfg, overrides := blockBuilderPullModeConfig(t, kafkaAddr)
 
 	// Producing some records
-	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 
 	var producedSamples []mimirpb.Sample
 	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-7 * time.Hour).Add(29 * time.Minute)
@@ -399,7 +400,7 @@ func TestBlockBuilder_ReachHighWatermarkBeforeLastCycleSection(t *testing.T) {
 
 	// Producing backlog of records in partition 0.
 	// For this test, the last-produced record must belong to the second to last cycle's section; i.e. the last section has nothing to consume.
-	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 
 	var producedSamples []mimirpb.Sample
 	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-5 * time.Hour).Add(29 * time.Minute)
@@ -467,7 +468,7 @@ func TestBlockBuilder_ReachHighWatermarkBeforeLastCycleSection_PullMode(t *testi
 
 	// Producing backlog of records in partition 0.
 	// For this test, the last-produced record must belong to the second to last cycle's section; i.e. the last section has nothing to consume.
-	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 
 	var producedSamples []mimirpb.Sample
 	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-5 * time.Hour).Add(29 * time.Minute)
@@ -575,7 +576,7 @@ func TestBlockBuilder_WithMultipleTenants(t *testing.T) {
 
 	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
 
-	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-cfg.ConsumeInterval)
 
 	producedPerTenantSamples := make(map[string][]mimirpb.Sample, 0)
@@ -631,7 +632,7 @@ func TestBlockBuilder_WithMultipleTenants_PullMode(t *testing.T) {
 
 	cfg, overrides := blockBuilderPullModeConfig(t, kafkaAddr)
 
-	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-cfg.ConsumeInterval)
 	firstTime := kafkaRecTime
 
@@ -706,7 +707,7 @@ func TestBlockBuilder_WithNonMonotonicRecordTimestamps(t *testing.T) {
 
 	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
 
-	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 
 	const tenantID = "1"
 
@@ -799,7 +800,7 @@ func TestBlockBuilder_RetryOnTransientErrors(t *testing.T) {
 	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
 
 	// Producing some records
-	cycleEndStartup := cycleEndAtStartup(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
 
 	var producedSamples []mimirpb.Sample
 	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-1 * time.Hour).Add(29 * time.Minute)
@@ -913,7 +914,7 @@ func TestCycleEndAtStartup(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("now=%s/%s+%s", tc.nowTimeStr, tc.interval, tc.buffer), func(t *testing.T) {
 			now := mustTimeParse(t, time.TimeOnly, tc.nowTimeStr)
-			cycleEnd := cycleEndAtStartup(now, tc.interval, tc.buffer)
+			cycleEnd := cycleEndBefore(now, tc.interval, tc.buffer)
 			tc.testFunc(t, cycleEnd)
 		})
 	}
@@ -1153,7 +1154,8 @@ func TestNoPartiallyConsumedRegions(t *testing.T) {
 		return nil, nil, false
 	})
 
-	bb, err := New(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), overrides)
+	reg := prometheus.NewPedanticRegistry()
+	bb, err := New(cfg, test.NewTestingLogger(t), reg, overrides)
 	require.NoError(t, err)
 
 	require.NoError(t, bb.starting(ctx))
@@ -1252,6 +1254,109 @@ func TestGetBlockCategoryCount(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestFastCatchupOnIdlePartition(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
+	kafkaClient := mustKafkaClient(t, kafkaAddr)
+	kafkaClient.AddConsumeTopics(testTopic)
+
+	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
+	cfg.ConsumeIntervalBuffer = 15 * time.Minute
+
+	reg := prometheus.NewPedanticRegistry()
+	bb, err := New(cfg, test.NewTestingLogger(t), reg, overrides)
+	require.NoError(t, err)
+
+	require.NoError(t, bb.starting(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, bb.stoppingStandaloneMode(nil))
+	})
+
+	// An old record that we will commit. The time between 48h old to now is the idle period.
+	kafkaRecTime := time.Now().Add(-48 * time.Hour)
+	produceSamples(ctx, t, kafkaClient, 0, kafkaRecTime, "1", kafkaRecTime.Add(-time.Minute))
+
+	// Remaining samples for the last couple of hours. No samples in the buffer time for easier comparison later.
+	cycleEnd := cycleEndAfter(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+	var producedSamples []mimirpb.Sample
+	kafkaRecTime = cycleEnd.Truncate(cfg.ConsumeInterval).Add(-2 * time.Hour)
+	for kafkaRecTime.Before(cycleEnd.Add(-cfg.ConsumeIntervalBuffer)) {
+		samples := produceSamples(ctx, t, kafkaClient, 0, kafkaRecTime, "1", kafkaRecTime.Add(-time.Minute))
+		producedSamples = append(producedSamples, samples...)
+		kafkaRecTime = kafkaRecTime.Add(time.Minute)
+	}
+	require.NotEmpty(t, producedSamples)
+
+	// Fetch one record.
+	var recs []*kgo.Record
+	for len(recs) == 0 {
+		fetches := kafkaClient.PollFetches(ctx)
+		require.NoError(t, fetches.Err())
+		recs = append(recs, fetches.Records()...)
+	}
+
+	// Choosing the first old record to commit.
+	commitRec := recs[0]
+	lastRec := commitRec
+	blockEnd := commitRec.Timestamp.Truncate(cfg.ConsumeInterval).Add(cfg.ConsumeInterval)
+	offset := kadm.Offset{
+		Topic:       commitRec.Topic,
+		Partition:   commitRec.Partition,
+		At:          commitRec.Offset + 1,
+		LeaderEpoch: -1, // not a group consumer
+		Metadata:    marshallCommitMeta(commitRec.Timestamp.UnixMilli(), lastRec.Timestamp.UnixMilli(), blockEnd.UnixMilli()),
+	}
+	commitOffset(ctx, t, kafkaClient, testGroup, offset)
+
+	err = bb.nextConsumeCycle(ctx, cycleEnd)
+	require.NoError(t, err)
+
+	// The above cycle should try one consumption for the old commit point, then shortcut
+	// to the last 2h records. So we should not have more than 3-4 consumption attempts.
+	// Without the shortcut in place, it will run consumption 48-49 times, one for each hour.
+	consumptionAttempts := getSampleCountFromHistoramVector(t, bb.blockBuilderMetrics.processPartitionDuration)
+	require.GreaterOrEqual(t, consumptionAttempts, 3)
+	require.LessOrEqual(t, consumptionAttempts, 4)
+
+	compareQueryWithDir(t,
+		path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, "1"),
+		producedSamples, nil,
+		labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
+	)
+}
+
+// getSampleCountFromHistoramVector gets the count field of histogram from the histogram vector.
+// The histogram vector must have only 1 histogram.
+// This function takes most of its code from promtest.ToFloat64() and adapts to our use case.
+func getSampleCountFromHistoramVector(t *testing.T, m *prometheus.HistogramVec) int {
+	var (
+		metrics []prometheus.Metric
+		mChan   = make(chan prometheus.Metric)
+		done    = make(chan struct{})
+	)
+
+	go func() {
+		for m := range mChan {
+			metrics = append(metrics, m)
+		}
+		close(done)
+	}()
+
+	m.Collect(mChan)
+	close(mChan)
+	<-done
+
+	require.Len(t, metrics, 1)
+
+	pb := &dto.Metric{}
+	require.NoError(t, metrics[0].Write(pb))
+	return int(*pb.Histogram.SampleCount)
 }
 
 func blockBuilderPullModeConfig(t *testing.T, addr string) (Config, *validation.Overrides) {


### PR DESCRIPTION
#### What this PR does

Currently when a partition was active and goes idle, its kafka commit point stays in the past. Once that partition gets active, block builder will try to consume every 1h interval since the last commit.

For example if the last commit was on 2025-02-15 00:00 before it went idle, and then later it became active on 2025-03-05, then it would try consuming every hours since Feb 15 to Mar 5, which takes forever to catch up. 

This PR shortcuts this and once it finds that the first record is in the 'future', it shortcuts to the first consumable record or the latest consumption cycle - whichever is earlier.

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
