### PR TITLE
helm: adds optional provisioner job to helm chart

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,7 +28,7 @@ Entries should be ordered as follows:
 Entries should include a reference to the Pull Request that introduced the change.
 
 ## main / unreleased
-* [ENHANCEMENT] Adds option helm update job for provisioning tenants. #10864
+* [ENHANCEMENT] Adds optional helm update job for provisioning tenants. #10864
 * [ENHANCEMENT] Add extra values for KEDA autoscaling, to support authenticaiton, ignoreNullValues, unsafeSsl, and support PromQLLabelSelector. #10265
 * [CHANGE] Tokengen: Added k8s secret storage for the admin token. #5237
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,8 +28,8 @@ Entries should be ordered as follows:
 Entries should include a reference to the Pull Request that introduced the change.
 
 ## main / unreleased
+* [ENHANCEMENT] Adds option helm update job for provisioning tenants. #10864
 * [ENHANCEMENT] Add extra values for KEDA autoscaling, to support authenticaiton, ignoreNullValues, unsafeSsl, and support PromQLLabelSelector. #10265
-
 * [CHANGE] Tokengen: Added k8s secret storage for the admin token. #5237
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318
 * [CHANGE] Ring: relaxed the hash ring heartbeat timeout for store-gateways: #10634

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,7 +28,7 @@ Entries should be ordered as follows:
 Entries should include a reference to the Pull Request that introduced the change.
 
 ## main / unreleased
-* [ENHANCEMENT] Adds optional helm update job for provisioning tenants. #10864
+* [ENHANCEMENT] Add optional helm update job for provisioning tenants. #10864
 * [ENHANCEMENT] Add extra values for KEDA autoscaling, to support authenticaiton, ignoreNullValues, unsafeSsl, and support PromQLLabelSelector. #10265
 * [CHANGE] Tokengen: Added k8s secret storage for the admin token. #5237
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318

--- a/operations/helm/charts/mimir-distributed/ci/offline/test-enterprise-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/test-enterprise-values.yaml
@@ -9,3 +9,11 @@ enterprise:
 gateway:
   ingress:
     enabled: true
+
+provisioner:
+  enabled: true
+  additionalTenants:
+    - name: team-a
+      secretNamespace: '{{ .Release.Namespace }}'
+    - name: team-b
+      secretNamespace: '{{ .Release.Namespace }}'

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -454,6 +454,7 @@ Examples:
   "compactor" "compactor"
   "continuous-test" "continuous_test"
   "distributor" "distributor"
+  "provisioner" "provisioner"
   "federation-frontend" "federation_frontend"
   "gateway" "gateway"
   "gr-aggr-cache" "gr-aggr-cache"

--- a/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
@@ -50,7 +50,7 @@ spec:
           args:
             - -bootstrap-path=/bootstrap
             - -cluster-name={{ include "mimir.clusterName" $ }}
-            - -api-url={{ tpl $.Values.provisioner.apiUrl $ }}
+            - -api-url={{ $.Values.provisioner.apiUrl $ }}
             - -tenant={{ $tenant.name }}
             - -access-policy=write-{{ $tenant.name }}:{{ $tenant.name }}:metrics:write
             - -access-policy=read-{{ $tenant.name }}:{{ $tenant.name }}:metrics:read
@@ -113,7 +113,7 @@ spec:
       volumes:
         - name: admin-token
           secret:
-            secretName: {{ include "mimir.resourceName" (dict "ctx" . "component" "admin-token") }}
+            secretName: {{ .Values.tokengenJob.adminTokenSecret }}
         - name: bootstrap
           emptyDir: {}
 {{- end -}} 

--- a/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
@@ -50,7 +50,7 @@ spec:
           args:
             - -bootstrap-path=/bootstrap
             - -cluster-name={{ include "mimir.clusterName" $ }}
-            - -api-url=http://{{ include "mimir.resourceName" (dict "ctx" $ "component" "admin-api") }}.{{ $.Release.Namespace }}.svc:{{ include "mimir.serverHttpListenPort" $ }}
+            - -api-url={{ tpl $.Values.provisioner.apiUrl $ }}
             - -tenant={{ $tenant.name }}
             - -access-policy=write-{{ $tenant.name }}:{{ $tenant.name }}:metrics:write
             - -access-policy=read-{{ $tenant.name }}:{{ $tenant.name }}:metrics:read

--- a/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
@@ -1,0 +1,119 @@
+{{- if and .Values.provisioner.enabled .Values.enterprise.enabled (not .Values.federation_frontend.disableOtherComponents) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "provisioner") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+    {{- with .Values.provisioner.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.provisioner.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    "helm.sh/hook": {{ .Values.enterprise.provisioner.hookType | quote }}
+    "helm.sh/hook-weight": "20"
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  selector:
+  template:
+    metadata:
+      labels:
+        {{- include "mimir.podLabels" (dict "ctx" . "component" "provisioner") | nindent 8 }}
+      annotations:
+        {{- include "mimir.podAnnotations" (dict "ctx" . "component" "provisioner") | nindent 8 }}
+      namespace: {{ .Release.Namespace | quote }}
+    spec:
+      serviceAccountName: {{ include "mimir.resourceName" (dict "ctx" . "component" "provisioner") }}
+      {{- if .Values.provisioner.priorityClassName }}
+      priorityClassName: {{ .Values.provisioner.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- include "mimir.lib.podSecurityContext" (dict "ctx" . "component" "provisioner") | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      initContainers:
+        {{- range $index, $tenant := .Values.provisioner.additionalTenants }}
+        - name: provisioner-{{ $tenant.name }}
+          image: "{{ $.Values.provisioner.image.registry }}/{{ $.Values.provisioner.image.repository }}:{{ $.Values.provisioner.image.tag }}"
+          imagePullPolicy: {{ $.Values.provisioner.image.pullPolicy }}
+          command:
+            - /usr/bin/provisioner
+          args:
+            - -bootstrap-path=/bootstrap
+            - -cluster-name={{ include "mimir.clusterName" $ }}
+            - -api-url=http://{{ include "mimir.resourceName" (dict "ctx" $ "component" "admin-api") }}.{{ $.Release.Namespace }}.svc:{{ include "mimir.serverHttpListenPort" $ }}
+            - -tenant={{ $tenant.name }}
+            - -access-policy=write-{{ $tenant.name }}:{{ $tenant.name }}:metrics:write
+            - -access-policy=read-{{ $tenant.name }}:{{ $tenant.name }}:metrics:read
+            - -token=write-{{ $tenant.name }}
+            - -token=read-{{ $tenant.name }}
+          volumeMounts:
+            {{- if $.Values.provisioner.extraVolumeMounts }}
+              {{ toYaml $.Values.provisioner.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            {{- if $.Values.global.extraVolumeMounts }}
+              {{ toYaml $.Values.global.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            - name: bootstrap
+              mountPath: /bootstrap
+            - name: admin-token
+              mountPath: /bootstrap/token
+              subPath: token
+          {{- with $.Values.provisioner.env }}
+          env:
+            {{ toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      containers:
+        - name: create-secret
+          image: {{ include "mimir.kubectlImage" . }}
+          imagePullPolicy: {{ .Values.kubectlImage.pullPolicy | default "IfNotPresent" }}
+          command:
+            - /bin/bash
+            - -exuc
+            - |
+              # In case, the admin resources have already been created, the provisioner job
+              # does not write the token files to the bootstrap mount.
+              # Therefore, secrets are only created if the respective token files exist.
+              # Note: the following bash commands should always return a success status code. 
+              # Therefore, in case the token file does not exist, the first clause of the 
+              # or-operation is successful.
+              {{- $secretPrefix := .Values.provisioner.provisionedSecretPrefix | default (include "mimir.resourceName" (dict "ctx" . "component" "token")) }}
+              {{- range .Values.provisioner.additionalTenants }}
+              ! test -s /bootstrap/token-write-{{ .name }} || \
+                kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{ $secretPrefix }}-{{ .name }}" \
+                  --from-literal=token-write="$(cat /bootstrap/token-write-{{ .name }})" \
+                  --from-literal=token-read="$(cat /bootstrap/token-read-{{ .name }})"
+              {{- end }}
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /bootstrap
+      {{- with .Values.provisioner.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.provisioner.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.provisioner.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: OnFailure
+      volumes:
+        - name: admin-token
+          secret:
+            secretName: {{ include "mimir.resourceName" (dict "ctx" . "component" "admin-token") }}
+        - name: bootstrap
+          emptyDir: {}
+{{- end -}} 

--- a/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- with .Values.provisioner.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    "helm.sh/hook": {{ .Values.enterprise.provisioner.hookType | quote }}
+    "helm.sh/hook": {{ .Values.provisioner.hookType | quote }}
     "helm.sh/hook-weight": "20"
   namespace: {{ .Release.Namespace | quote }}
 spec:
@@ -50,7 +50,7 @@ spec:
           args:
             - -bootstrap-path=/bootstrap
             - -cluster-name={{ include "mimir.clusterName" $ }}
-            - -api-url={{ $.Values.provisioner.apiUrl $ }}
+            - -api-url={{ tpl $.Values.provisioner.apiUrl $ }}
             - -tenant={{ $tenant.name }}
             - -access-policy=write-{{ $tenant.name }}:{{ $tenant.name }}:metrics:write
             - -access-policy=read-{{ $tenant.name }}:{{ $tenant.name }}:metrics:read
@@ -87,10 +87,9 @@ spec:
               # Note: the following bash commands should always return a success status code. 
               # Therefore, in case the token file does not exist, the first clause of the 
               # or-operation is successful.
-              {{- $secretPrefix := .Values.provisioner.provisionedSecretPrefix | default (include "mimir.resourceName" (dict "ctx" . "component" "token")) }}
               {{- range .Values.provisioner.additionalTenants }}
               ! test -s /bootstrap/token-write-{{ .name }} || \
-                kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{ $secretPrefix }}-{{ .name }}" \
+                kubectl --namespace "{{ .secretNamespace }}" create secret generic "{{ tpl $.Values.provisioner.provisionedSecretPrefix $ }}-{{ .name }}" \
                   --from-literal=token-write="$(cat /bootstrap/token-write-{{ .name }})" \
                   --from-literal=token-read="$(cat /bootstrap/token-read-{{ .name }})"
               {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-rbac.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-rbac.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.provisioner.enabled .Values.enterprise.enabled (not .Values.federation_frontend.disableOtherComponents) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "provisioner") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "provisioner") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "provisioner") }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "provisioner") }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end -}} 

--- a/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-serviceaccount.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.provisioner.enabled .Values.enterprise.enabled (not .Values.federation_frontend.disableOtherComponents) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "provisioner") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "provisioner") | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end -}} 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4144,7 +4144,11 @@ kubectlImage:
   # -- The kubectl image pull policy
   pullPolicy: IfNotPresent
 
-
+# Settings for the provisioner job. Can only be enabled if enterprise.enabled is true - requires license.
+# The provisioner job creates tenants, read and write access policies and associated tokens based on configuration
+# provided in the additionalTenants section and creates secrets to store the provisioned tokens.
+# It does not affect any existing tenants, access policies and tokens.
+# Note: Uses tokengenJob.adminTokenSecret value to mount the admin token used to call the admin api.
 provisioner:
   # -- Whether the job should be part of the deployment
   enabled: false
@@ -4155,8 +4159,8 @@ provisioner:
   # -- URL for the admin API service.
   apiUrl: ""
   # -- Additional tenants to be created. Each tenant will get a read and write policy
-  # and associated token. Tenant must have a name and a namespace for the secret containting
-  # the token to be created in. For example
+  # and associated token. Tenant must have a name and a namespace for the secret containing
+  # the token to be created in. For example:
   # additionalTenants:
   #   - name: mimir
   #     secretNamespace: grafana

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4152,6 +4152,8 @@ provisioner:
   provisionedSecretPrefix: null
   # -- Hook type(s) to customize when the job runs.  defaults to post-install
   hookType: "post-install"
+  # -- URL for the admin API service. Defaults to the admin API service URL from the enterprise gateway.
+  apiUrl: "{{ .Values.enterpriseGateway.proxy.admin_api.url }}"
   # -- Additional tenants to be created. Each tenant will get a read and write policy
   # and associated token. Tenant must have a name and a namespace for the secret containting
   # the token to be created in. For example

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4144,6 +4144,56 @@ kubectlImage:
   # -- The kubectl image pull policy
   pullPolicy: IfNotPresent
 
+
+provisioner:
+  # -- Whether the job should be part of the deployment
+  enabled: false
+  # -- Name of the secret to store provisioned tokens in
+  provisionedSecretPrefix: null
+  # -- Hook type(s) to customize when the job runs.  defaults to post-install
+  hookType: "post-install"
+  # -- Additional tenants to be created. Each tenant will get a read and write policy
+  # and associated token. Tenant must have a name and a namespace for the secret containting
+  # the token to be created in. For example
+  # additionalTenants:
+  #   - name: mimir
+  #     secretNamespace: grafana
+  additionalTenants: []
+  # -- Additional Kubernetes environment
+  env: []
+  # -- Additional labels for the `provisioner` Job
+  labels: {}
+  # -- Additional annotations for the `provisioner` Job
+  annotations: {}
+  # -- Affinity for tokengen Pods
+  affinity: {}
+  # -- Node selector for tokengen Pods
+  nodeSelector: {}
+  # -- Tolerations for tokengen Pods
+  tolerations: []
+  # -- The name of the PriorityClass for provisioner Job
+  priorityClassName: null
+  # -- Run containers as nonroot user (uid=10001)`
+  securityContext:
+    runAsNonRoot: true
+    runAsGroup: 10001
+    runAsUser: 10001
+    fsGroup: 10001
+  # -- Provisioner image to Utilize
+  image:
+    # -- The Docker registry
+    registry: us-docker.pkg.dev
+    # -- Docker image repository
+    repository: grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner
+    # -- Overrides the image tag whose default is the chart's appVersion
+    tag: null
+    # -- Overrides the image tag with an image digest
+    digest: null
+    # -- Docker image pull policy
+    pullPolicy: IfNotPresent
+  # -- Volume mounts to add to the provisioner pods
+  extraVolumeMounts: []
+
 # Settings for the admin_api service providing authentication and authorization service.
 # Can only be enabled if enterprise.enabled is true - requires license.
 admin_api:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4152,8 +4152,8 @@ provisioner:
   provisionedSecretPrefix: null
   # -- Hook type(s) to customize when the job runs.  defaults to post-install
   hookType: "post-install"
-  # -- URL for the admin API service. Defaults to the admin API service URL from the enterprise gateway.
-  apiUrl: "{{ .Values.enterpriseGateway.proxy.admin_api.url }}"
+  # -- URL for the admin API service.
+  apiUrl: ""
   # -- Additional tenants to be created. Each tenant will get a read and write policy
   # and associated token. Tenant must have a name and a namespace for the secret containting
   # the token to be created in. For example

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4193,8 +4193,6 @@ provisioner:
     repository: grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner
     # -- Overrides the image tag whose default is the chart's appVersion
     tag: latest
-    # -- Overrides the image tag with an image digest
-    digest: null
     # -- Docker image pull policy
     pullPolicy: IfNotPresent
   # -- Volume mounts to add to the provisioner pods

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4153,11 +4153,11 @@ provisioner:
   # -- Whether the job should be part of the deployment
   enabled: false
   # -- Name of the secret to store provisioned tokens in
-  provisionedSecretPrefix: null
+  provisionedSecretPrefix: '{{ template "mimir.fullname" . }}'
   # -- Hook type(s) to customize when the job runs.  defaults to post-install
-  hookType: "post-install"
+  hookType: "post-install,post-upgrade"
   # -- URL for the admin API service.
-  apiUrl: ""
+  apiUrl: 'http://{{ template "mimir.fullname" . }}-admin-api.{{ .Release.Namespace }}.svc:{{ include "mimir.serverHttpListenPort" . }}'
   # -- Additional tenants to be created. Each tenant will get a read and write policy
   # and associated token. Tenant must have a name and a namespace for the secret containing
   # the token to be created in. For example:
@@ -4192,7 +4192,7 @@ provisioner:
     # -- Docker image repository
     repository: grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner
     # -- Overrides the image tag whose default is the chart's appVersion
-    tag: null
+    tag: latest
     # -- Overrides the image tag with an image digest
     digest: null
     # -- Docker image pull policy

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/provisioner/provisioner-job.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/provisioner/provisioner-job.yaml
@@ -1,0 +1,111 @@
+---
+# Source: mimir-distributed/templates/provisioner/provisioner-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: test-enterprise-values-mimir-provisioner
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/component: provisioner
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "20"
+  namespace: "citestns"
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  selector:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-enterprise-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: provisioner
+      annotations:
+      namespace: "citestns"
+    spec:
+      serviceAccountName: test-enterprise-values-mimir-provisioner
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: provisioner-team-a
+          image: "us-docker.pkg.dev/grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/bin/provisioner
+          args:
+            - -bootstrap-path=/bootstrap
+            - -cluster-name=test-enterprise-values
+            - -api-url=http://test-enterprise-values-mimir-admin-api.citestns.svc:8080
+            - -tenant=team-a
+            - -access-policy=write-team-a:team-a:metrics:write
+            - -access-policy=read-team-a:team-a:metrics:read
+            - -token=write-team-a
+            - -token=read-team-a
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /bootstrap
+            - name: admin-token
+              mountPath: /bootstrap/token
+              subPath: token
+        - name: provisioner-team-b
+          image: "us-docker.pkg.dev/grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/bin/provisioner
+          args:
+            - -bootstrap-path=/bootstrap
+            - -cluster-name=test-enterprise-values
+            - -api-url=http://test-enterprise-values-mimir-admin-api.citestns.svc:8080
+            - -tenant=team-b
+            - -access-policy=write-team-b:team-b:metrics:write
+            - -access-policy=read-team-b:team-b:metrics:read
+            - -token=write-team-b
+            - -token=read-team-b
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /bootstrap
+            - name: admin-token
+              mountPath: /bootstrap/token
+              subPath: token
+      containers:
+        - name: create-secret
+          image: bitnami/kubectl:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -exuc
+            - |
+              # In case, the admin resources have already been created, the provisioner job
+              # does not write the token files to the bootstrap mount.
+              # Therefore, secrets are only created if the respective token files exist.
+              # Note: the following bash commands should always return a success status code. 
+              # Therefore, in case the token file does not exist, the first clause of the 
+              # or-operation is successful.
+              ! test -s /bootstrap/token-write-team-a || \
+                kubectl --namespace "{{ .Release.Namespace }}" create secret generic "test-enterprise-values-mimir-team-a" \
+                  --from-literal=token-write="$(cat /bootstrap/token-write-team-a)" \
+                  --from-literal=token-read="$(cat /bootstrap/token-read-team-a)"
+              ! test -s /bootstrap/token-write-team-b || \
+                kubectl --namespace "{{ .Release.Namespace }}" create secret generic "test-enterprise-values-mimir-team-b" \
+                  --from-literal=token-write="$(cat /bootstrap/token-write-team-b)" \
+                  --from-literal=token-read="$(cat /bootstrap/token-read-team-b)"
+          volumeMounts:
+            - name: bootstrap
+              mountPath: /bootstrap
+      restartPolicy: OnFailure
+      volumes:
+        - name: admin-token
+          secret:
+            secretName: admin-token
+        - name: bootstrap
+          emptyDir: {}

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/provisioner/provisioner-rbac.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/provisioner/provisioner-rbac.yaml
@@ -1,0 +1,36 @@
+---
+# Source: mimir-distributed/templates/provisioner/provisioner-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-values-mimir-provisioner
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/component: provisioner
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+---
+# Source: mimir-distributed/templates/provisioner/provisioner-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-values-mimir-provisioner
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/component: provisioner
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-enterprise-values-mimir-provisioner
+subjects:
+- kind: ServiceAccount
+  name: test-enterprise-values-mimir-provisioner
+  namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/provisioner/provisioner-serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/provisioner/provisioner-serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: mimir-distributed/templates/provisioner/provisioner-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-enterprise-values-mimir-provisioner
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/component: provisioner
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"


### PR DESCRIPTION
#### What this PR does

Grafana's Federal Cloud offering needs to utilize [enterprise provisioner](https://github.com/grafana/enterprise-provisioner) via configuration to ensure tenants are created properly in a security constrained environment. This change provides consistent tenant management across Grafana products (aligning with Loki and Tempo).

This PR adds an optional job that runs via helm post-install hook that calls the Grafana Enterprise Provisioner app to create tenants, access policies and tokens via the admin api based on configuration in the helm values.

#### Which issue(s) this PR fixes or relates to

Fixes #10864 
Fixes #deployment_tools/211067

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
