### PR TITLE
Upgrade mimir-prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 * [BUGFIX] Ingester: Add additional check on reactive limiter queue sizes. #10722
 * [BUGFIX] TSDB: fix unknown series errors and possible lost data during WAL replay when series are removed from the head due to inactivity and reappear before the next WAL checkpoint. https://github.com/prometheus/prometheus/pull/16060 #10824
 * [BUGFIX] Querier: fix issue where `label_join` could incorrectly return multiple series with the same labels rather than failing with `vector cannot contain metrics with the same labelset`. https://github.com/prometheus/prometheus/pull/15975 #10826
+* [BUGFIX] Querier: fix issue where counter resets on native histograms could be incorrectly under- or over-counted when using subqueries. https://github.com/prometheus/prometheus/pull/15987 #10871
 
 ### Mixin
 

--- a/go.mod
+++ b/go.mod
@@ -299,7 +299,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250307031102-9ba23e267c3d
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250313034642-4c5f37509bce
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -1286,8 +1286,8 @@ github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1 h1:vR5nELq+KtGO
 github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20250307031102-9ba23e267c3d h1:62ia0+nFFVwSKKpza8GZhK1dzZN8wDbt3uzaaXAicJQ=
-github.com/grafana/mimir-prometheus v0.0.0-20250307031102-9ba23e267c3d/go.mod h1:9Hf/cSfGXNKRswdYnj10nTOt5LUmazcJO2tVsg02+Jo=
+github.com/grafana/mimir-prometheus v0.0.0-20250313034642-4c5f37509bce h1:75LWgFF0hBy7MGfp3ynutO65GM6KHZoBXhpARoKCEEs=
+github.com/grafana/mimir-prometheus v0.0.0-20250313034642-4c5f37509bce/go.mod h1:9Hf/cSfGXNKRswdYnj10nTOt5LUmazcJO2tVsg02+Jo=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20250211112812-e32be5e2a455 h1:yidC1xzk4fedLZ/iXEqSJopkw3jPZPwoMqqzue4eFEA=

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1321,7 +1321,7 @@ func TestSubqueries(t *testing.T) {
 						Metric: labels.FromStrings(labels.MetricName, "other_metric", "type", "floats"),
 					},
 					{
-						H:      &histogram.FloatHistogram{Count: 6, CounterResetHint: histogram.NotCounterReset},
+						H:      &histogram.FloatHistogram{Count: 6},
 						T:      30000,
 						Metric: labels.FromStrings(labels.MetricName, "other_metric", "type", "histograms"),
 					},

--- a/pkg/streamingpromql/testdata/upstream/subquery.test
+++ b/pkg/streamingpromql/testdata/upstream/subquery.test
@@ -102,10 +102,10 @@ eval instant at 1000s rate(sum_over_time(metric1_total[30s:10s])[50s:10s])
 
 eval instant at 1000s rate(sum_over_time(metric2_total[30s:10s])[50s:10s])
   {} 0.6000000000000001
-  
+
 eval instant at 1000s rate(sum_over_time(metric3_total[30s:10s])[50s:10s])
   {} 0.9
-  
+
 eval instant at 1000s rate(sum_over_time((metric1_total+metric2_total+metric3_total)[30s:10s])[30s:10s])
   {} 1.8
 
@@ -139,3 +139,19 @@ eval instant at 20s min_over_time(metric_total[15s:10s])
 eval instant at 20m min_over_time(rate(metric_total[5m])[20m:1m])
   {} 0.12119047619047618
 
+clear
+
+# This native histogram series has a counter reset at 5m.
+# TODO(beorn7): Write this more nicely once https://github.com/prometheus/prometheus/issues/15984 is fixed.
+load 1m
+  native_histogram {{sum:100 count:100}} {{sum:103 count:103}} {{sum:106 count:106}} {{sum:109 count:109}} {{sum:112 count:112}} {{sum:3 count:3 counter_reset_hint:reset}} {{sum:6 count:6}}+{{sum:3 count:3}}x5
+
+# This sub-query has to detect the counter reset even if it does
+# not include the exact sample where the counter reset has happened.
+eval instant at 10m increase(native_histogram[10m:3m])
+  {} {{count:25 sum:25}}
+# This sub-query must not detect the counter reset multiple times
+# even though the sample where the counter reset happened is returned
+# by the sub-query multiple times.
+eval instant at 10m increase(native_histogram[10m:15s])
+  {} {{count:30.769230769230766 sum:30.769230769230766}}

--- a/vendor/github.com/prometheus/prometheus/discovery/manager.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/manager.go
@@ -101,12 +101,12 @@ func NewManager(ctx context.Context, logger *slog.Logger, registerer prometheus.
 
 	// Register the metrics.
 	// We have to do this after setting all options, so that the name of the Manager is set.
-	if metrics, err := NewManagerMetrics(registerer, mgr.name); err == nil {
-		mgr.metrics = metrics
-	} else {
+	metrics, err := NewManagerMetrics(registerer, mgr.name)
+	if err != nil {
 		logger.Error("Failed to create discovery manager metrics", "manager", mgr.name, "err", err)
 		return nil
 	}
+	mgr.metrics = metrics
 
 	return mgr
 }

--- a/vendor/github.com/prometheus/prometheus/model/textparse/interface.go
+++ b/vendor/github.com/prometheus/prometheus/model/textparse/interface.go
@@ -57,11 +57,10 @@ type Parser interface {
 	// The returned byte slice becomes invalid after the next call to Next.
 	Comment() []byte
 
-	// Metric writes the labels of the current sample into the passed labels.
-	// It returns the string from which the metric was parsed.
+	// Labels writes the labels of the current sample into the passed labels.
 	// The values of the "le" labels of classic histograms and "quantile" labels
 	// of summaries should follow the OpenMetrics formatting rules.
-	Metric(l *labels.Labels) string
+	Labels(l *labels.Labels)
 
 	// Exemplar writes the exemplar of the current sample into the passed
 	// exemplar. It can be called repeatedly to retrieve multiple exemplars

--- a/vendor/github.com/prometheus/prometheus/model/textparse/nhcbparse.go
+++ b/vendor/github.com/prometheus/prometheus/model/textparse/nhcbparse.go
@@ -67,8 +67,7 @@ type NHCBParser struct {
 	h     *histogram.Histogram
 	fh    *histogram.FloatHistogram
 	// For Metric.
-	lset         labels.Labels
-	metricString string
+	lset labels.Labels
 	// For Type.
 	bName []byte
 	typ   model.MetricType
@@ -141,13 +140,12 @@ func (p *NHCBParser) Comment() []byte {
 	return p.parser.Comment()
 }
 
-func (p *NHCBParser) Metric(l *labels.Labels) string {
+func (p *NHCBParser) Labels(l *labels.Labels) {
 	if p.state == stateEmitting {
 		*l = p.lsetNHCB
-		return p.metricStringNHCB
+		return
 	}
 	*l = p.lset
-	return p.metricString
 }
 
 func (p *NHCBParser) Exemplar(ex *exemplar.Exemplar) bool {
@@ -200,7 +198,7 @@ func (p *NHCBParser) Next() (Entry, error) {
 		switch p.entry {
 		case EntrySeries:
 			p.bytes, p.ts, p.value = p.parser.Series()
-			p.metricString = p.parser.Metric(&p.lset)
+			p.parser.Labels(&p.lset)
 			// Check the label set to see if we can continue or need to emit the NHCB.
 			var isNHCB bool
 			if p.compareLabels() {
@@ -224,7 +222,7 @@ func (p *NHCBParser) Next() (Entry, error) {
 			return p.entry, p.err
 		case EntryHistogram:
 			p.bytes, p.ts, p.h, p.fh = p.parser.Histogram()
-			p.metricString = p.parser.Metric(&p.lset)
+			p.parser.Labels(&p.lset)
 			p.storeExponentialLabels()
 		case EntryType:
 			p.bName, p.typ = p.parser.Type()

--- a/vendor/github.com/prometheus/prometheus/model/textparse/openmetricsparse.go
+++ b/vendor/github.com/prometheus/prometheus/model/textparse/openmetricsparse.go
@@ -197,11 +197,9 @@ func (p *OpenMetricsParser) Comment() []byte {
 	return p.text
 }
 
-// Metric writes the labels of the current sample into the passed labels.
-// It returns the string from which the metric was parsed.
-func (p *OpenMetricsParser) Metric(l *labels.Labels) string {
-	// Copy the buffer to a string: this is only necessary for the return value.
-	s := string(p.series)
+// Labels writes the labels of the current sample into the passed labels.
+func (p *OpenMetricsParser) Labels(l *labels.Labels) {
+	s := yoloString(p.series)
 
 	p.builder.Reset()
 	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])
@@ -220,8 +218,6 @@ func (p *OpenMetricsParser) Metric(l *labels.Labels) string {
 
 	p.builder.Sort()
 	*l = p.builder.Labels()
-
-	return s
 }
 
 // Exemplar writes the exemplar of the current sample into the passed exemplar.

--- a/vendor/github.com/prometheus/prometheus/model/textparse/promparse.go
+++ b/vendor/github.com/prometheus/prometheus/model/textparse/promparse.go
@@ -223,11 +223,9 @@ func (p *PromParser) Comment() []byte {
 	return p.text
 }
 
-// Metric writes the labels of the current sample into the passed labels.
-// It returns the string from which the metric was parsed.
-func (p *PromParser) Metric(l *labels.Labels) string {
-	// Copy the buffer to a string: this is only necessary for the return value.
-	s := string(p.series)
+// Labels writes the labels of the current sample into the passed labels.
+func (p *PromParser) Labels(l *labels.Labels) {
+	s := yoloString(p.series)
 
 	p.builder.Reset()
 	metricName := unreplace(s[p.offsets[0]-p.start : p.offsets[1]-p.start])
@@ -246,8 +244,6 @@ func (p *PromParser) Metric(l *labels.Labels) string {
 
 	p.builder.Sort()
 	*l = p.builder.Labels()
-
-	return s
 }
 
 // Exemplar implements the Parser interface. However, since the classic

--- a/vendor/github.com/prometheus/prometheus/model/textparse/protobufparse.go
+++ b/vendor/github.com/prometheus/prometheus/model/textparse/protobufparse.go
@@ -296,9 +296,9 @@ func (p *ProtobufParser) Comment() []byte {
 	return nil
 }
 
-// Metric writes the labels of the current sample into the passed labels.
+// Labels writes the labels of the current sample into the passed labels.
 // It returns the string from which the metric was parsed.
-func (p *ProtobufParser) Metric(l *labels.Labels) string {
+func (p *ProtobufParser) Labels(l *labels.Labels) {
 	p.builder.Reset()
 	p.builder.Add(labels.MetricName, p.getMagicName())
 
@@ -312,8 +312,6 @@ func (p *ProtobufParser) Metric(l *labels.Labels) string {
 	// Sort labels to maintain the sorted labels invariant.
 	p.builder.Sort()
 	*l = p.builder.Labels()
-
-	return p.metricBytes.String()
 }
 
 // Exemplar writes the exemplar of the current sample into the passed

--- a/vendor/github.com/prometheus/prometheus/promql/engine.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine.go
@@ -1549,6 +1549,28 @@ func (ev *evaluator) evalSubquery(ctx context.Context, subq *parser.SubqueryExpr
 		VectorSelector: vs,
 	}
 	for _, s := range mat {
+		// Set any "NotCounterReset" and "CounterReset" hints in native
+		// histograms to "UnknownCounterReset" because we might
+		// otherwise miss a counter reset happening in samples not
+		// returned by the subquery, or we might over-detect counter
+		// resets if the sample with a counter reset is returned
+		// multiple times by a high-res subquery. This intentionally
+		// does not attempt to be clever (like detecting if we are
+		// really missing underlying samples or returning underlying
+		// samples multiple times) because subqueries on counters are
+		// inherently problematic WRT counter reset handling, so we
+		// cannot really solve the problem for good. We only want to
+		// avoid problems that happen due to the explicitly set counter
+		// reset hints and go back to the behavior we already know from
+		// float samples.
+		for i, hp := range s.Histograms {
+			switch hp.H.CounterResetHint {
+			case histogram.NotCounterReset, histogram.CounterReset:
+				h := *hp.H // Shallow copy is sufficient, we only change CounterResetHint.
+				h.CounterResetHint = histogram.UnknownCounterReset
+				s.Histograms[i].H = &h
+			}
+		}
 		vs.Series = append(vs.Series, NewStorageSeries(s))
 	}
 	return ms, mat.TotalSamples(), ws
@@ -3554,11 +3576,11 @@ func formatDate(t time.Time) string {
 // unwrapParenExpr does the AST equivalent of removing parentheses around a expression.
 func unwrapParenExpr(e *parser.Expr) {
 	for {
-		if p, ok := (*e).(*parser.ParenExpr); ok {
-			*e = p.Expr
-		} else {
+		p, ok := (*e).(*parser.ParenExpr)
+		if !ok {
 			break
 		}
+		*e = p.Expr
 	}
 }
 

--- a/vendor/github.com/prometheus/prometheus/promql/promqltest/testdata/subquery.test
+++ b/vendor/github.com/prometheus/prometheus/promql/promqltest/testdata/subquery.test
@@ -134,3 +134,19 @@ eval instant at 20s min_over_time(metric_total[15s:10s])
 eval instant at 20m min_over_time(rate(metric_total[5m])[20m:1m])
   {} 0.12119047619047618
 
+clear
+
+# This native histogram series has a counter reset at 5m.
+# TODO(beorn7): Write this more nicely once https://github.com/prometheus/prometheus/issues/15984 is fixed.
+load 1m
+  native_histogram {{sum:100 count:100}} {{sum:103 count:103}} {{sum:106 count:106}} {{sum:109 count:109}} {{sum:112 count:112}} {{sum:3 count:3 counter_reset_hint:reset}} {{sum:6 count:6}}+{{sum:3 count:3}}x5
+
+# This sub-query has to detect the counter reset even if it does
+# not include the exact sample where the counter reset has happened.
+eval instant at 10m increase(native_histogram[10m:3m])
+  {} {{count:25 sum:25}}
+# This sub-query must not detect the counter reset multiple times
+# even though the sample where the counter reset happened is returned
+# by the sub-query multiple times.
+eval instant at 10m increase(native_histogram[10m:15s])
+  {} {{count:30.769230769230766 sum:30.769230769230766}}

--- a/vendor/github.com/prometheus/prometheus/scrape/scrape.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/scrape.go
@@ -1714,7 +1714,7 @@ loop:
 			lset = ce.lset
 			hash = ce.hash
 		} else {
-			p.Metric(&lset)
+			p.Labels(&lset)
 			hash = lset.Hash()
 
 			// Hash label set as it is seen local to the target. Then add target labels

--- a/vendor/github.com/prometheus/prometheus/storage/remote/azuread/azuread.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/azuread/azuread.go
@@ -349,11 +349,10 @@ func (tokenProvider *tokenProvider) getToken(ctx context.Context) error {
 func (tokenProvider *tokenProvider) updateRefreshTime(accessToken azcore.AccessToken) error {
 	tokenExpiryTimestamp := accessToken.ExpiresOn.UTC()
 	deltaExpirytime := time.Now().Add(time.Until(tokenExpiryTimestamp) / 2)
-	if deltaExpirytime.After(time.Now().UTC()) {
-		tokenProvider.refreshTime = deltaExpirytime
-	} else {
+	if !deltaExpirytime.After(time.Now().UTC()) {
 		return errors.New("access token expiry is less than the current time")
 	}
+	tokenProvider.refreshTime = deltaExpirytime
 	return nil
 }
 

--- a/vendor/github.com/prometheus/prometheus/tsdb/isolation.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/isolation.go
@@ -275,12 +275,11 @@ func (txr *txRing) cleanupAppendIDsBelow(bound uint64) {
 	pos := int(txr.txIDFirst)
 
 	for txr.txIDCount > 0 {
-		if txr.txIDs[pos] < bound {
-			txr.txIDFirst++
-			txr.txIDCount--
-		} else {
+		if txr.txIDs[pos] >= bound {
 			break
 		}
+		txr.txIDFirst++
+		txr.txIDCount--
 
 		pos++
 		if pos == len(txr.txIDs) {

--- a/vendor/github.com/prometheus/prometheus/util/httputil/compression.go
+++ b/vendor/github.com/prometheus/prometheus/util/httputil/compression.go
@@ -56,8 +56,13 @@ func (c *compressedResponseWriter) Close() {
 
 // Constructs a new compressedResponseWriter based on client request headers.
 func newCompressedResponseWriter(writer http.ResponseWriter, req *http.Request) *compressedResponseWriter {
-	encodings := strings.Split(req.Header.Get(acceptEncodingHeader), ",")
-	for _, encoding := range encodings {
+	raw := req.Header.Get(acceptEncodingHeader)
+	var (
+		encoding   string
+		commaFound bool
+	)
+	for {
+		encoding, raw, commaFound = strings.Cut(raw, ",")
 		switch strings.TrimSpace(encoding) {
 		case gzipEncoding:
 			writer.Header().Set(contentEncodingHeader, gzipEncoding)
@@ -71,6 +76,9 @@ func newCompressedResponseWriter(writer http.ResponseWriter, req *http.Request) 
 				ResponseWriter: writer,
 				writer:         zlib.NewWriter(writer),
 			}
+		}
+		if !commaFound {
+			break
 		}
 	}
 	return &compressedResponseWriter{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1071,7 +1071,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20250307031102-9ba23e267c3d
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20250313034642-4c5f37509bce
 ## explicit; go 1.22.7
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1756,7 +1756,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250307031102-9ba23e267c3d
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250313034642-4c5f37509bce
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
#### What this PR does

This PR upgrades mimir-prometheus to include the changes from https://github.com/grafana/mimir-prometheus/pull/840.

Most of the changes aren't relevant for Mimir and so I have added a changelog entry for the sole user-visible behaviour change.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
