### PR TITLE
docs: Use correct value for Prometheus HTTP prefix

### DIFF
--- a/docs/configurations/prometheus-frontend.yml
+++ b/docs/configurations/prometheus-frontend.yml
@@ -11,7 +11,7 @@ target: query-frontend
 
 # We don't want the default /api/prom or /prometheus prefixes on endpoints.
 api:
-  prometheus_http_prefix: ''
+  prometheus_http_prefix: '/'
 
 server:
   http_listen_port: 9091

--- a/docs/sources/mimir/configure/configure-the-query-frontend-work-with-prometheus.md
+++ b/docs/sources/mimir/configure/configure-the-query-frontend-work-with-prometheus.md
@@ -31,7 +31,7 @@ target: query-frontend
 
 # We don't want the default /api/prom or /prometheus prefixes on endpoints.
 api:
-  prometheus_http_prefix: ''
+  prometheus_http_prefix: '/'
 
 server:
   http_listen_port: 9091


### PR DESCRIPTION
#### What this PR does

Instead of using an empty value for the Prometheus HTTP prefix on the query-frontend API, use the root path `/` which is the intended behavior. Using an empty value for the configuration resulted in the default value being used instead.

#### Which issue(s) this PR fixes or relates to

Fixes #10786

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
