### PR TITLE
mimir-mixin-compiled-gem: change product to GEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@
 ### Mixin
 
 * [CHANGE] Alerts: Only alert on errors performing cache operations if there are over 10 request/sec to avoid flapping. #10832
-* [FEATURE] Add compiled mixin for GEM installations in `operations/mimir-mixin-compiled-gem`. #10690
+* [FEATURE] Add compiled mixin for GEM installations in `operations/mimir-mixin-compiled-gem`. #10690 #10877
 * [ENHANCEMENT] Dashboards: clarify that the ingester and store-gateway panels on the 'Reads' dashboard show data from all query requests to that component, not just requests from the main query path (ie. requests from the ruler query path are included as well). #10598
 * [ENHANCEMENT] Dashboards: add ingester and store-gateway panels from the 'Reads' dashboard to the 'Remote ruler reads' dashboard as well. #10598
 * [ENHANCEMENT] Dashboards: add ingester and store-gateway panels showing only requests from the respective dashboard's query path to the 'Reads' and 'Remote ruler reads' dashboards. For example, the 'Remote ruler reads' dashboard now has panels showing the ingester query request rate from ruler-queriers. #10598

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -3,7 +3,7 @@ groups:
       rules:
         - alert: MimirIngesterUnhealthy
           annotations:
-            message: Mimir cluster {{ $labels.cluster }}/{{ $labels.namespace }} has {{ printf "%f" $value }} unhealthy ingester(s).
+            message: GEM cluster {{ $labels.cluster }}/{{ $labels.namespace }} has {{ printf "%f" $value }} unhealthy ingester(s).
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterunhealthy
           expr: |
             min by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="ingester"}) > 0
@@ -102,7 +102,7 @@ groups:
         - alert: MimirCacheRequestErrors
           annotations:
             message: |
-                The cache {{ $labels.name }} used by Mimir {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors for {{ $labels.operation }} operation.
+                The cache {{ $labels.name }} used by GEM {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors for {{ $labels.operation }} operation.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircacherequesterrors
           expr: |
             (
@@ -119,7 +119,7 @@ groups:
             severity: warning
         - alert: MimirIngesterRestarts
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has restarted {{ printf "%.2f" $value }} times in the last 30 mins.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has restarted {{ printf "%.2f" $value }} times in the last 30 mins.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterrestarts
           expr: |
             (
@@ -137,7 +137,7 @@ groups:
         - alert: MimirKVStoreFailure
           annotations:
             message: |
-                Mimir {{ $labels.pod }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
+                GEM {{ $labels.pod }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkvstorefailure
           expr: |
             (
@@ -161,7 +161,7 @@ groups:
             severity: critical
         - alert: MimirIngesterInstanceHasNoTenants
           annotations:
-            message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no tenants assigned.
+            message: GEM ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no tenants assigned.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
           expr: |
             (
@@ -194,7 +194,7 @@ groups:
             severity: warning
         - alert: MimirRulerInstanceHasNoRuleGroups
           annotations:
-            message: Mimir ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no rule groups assigned.
+            message: GEM ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no rule groups assigned.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
           expr: |
             # Alert on ruler instances in microservices mode that have no rule groups assigned,
@@ -210,7 +210,7 @@ groups:
             severity: warning
         - alert: MimirIngestedDataTooFarInTheFuture
           annotations:
-            message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples with timestamps more than 1h in the future.
+            message: GEM ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples with timestamps more than 1h in the future.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
           expr: |
             max by(cluster, namespace, pod) (
@@ -223,7 +223,7 @@ groups:
             severity: warning
         - alert: MimirStoreGatewayTooManyFailedOperations
           annotations:
-            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
+            message: GEM store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
           expr: |
             sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m])) > 0
@@ -233,7 +233,7 @@ groups:
         - alert: MimirRingMembersMismatch
           annotations:
             message: |
-                Number of members in Mimir ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
+                Number of members in GEM ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirringmembersmismatch
           expr: |
             (
@@ -309,7 +309,7 @@ groups:
         - alert: MimirReachingTCPConnectionsLimit
           annotations:
             message: |
-                Mimir instance {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its TCP connections limit for {{ $labels.protocol }} protocol.
+                GEM instance {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its TCP connections limit for {{ $labels.protocol }} protocol.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirreachingtcpconnectionslimit
           expr: |
             cortex_tcp_connections / cortex_tcp_connections_limit > 0.8 and
@@ -436,7 +436,7 @@ groups:
         - alert: MimirRulerTooManyFailedPushes
           annotations:
             message: |
-                Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% write (push) errors.
+                GEM Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% write (push) errors.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedpushes
           expr: |
             100 * (
@@ -451,7 +451,7 @@ groups:
         - alert: MimirRulerTooManyFailedQueries
           annotations:
             message: |
-                Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.
+                GEM Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedqueries
           expr: |
             100 * (
@@ -466,7 +466,7 @@ groups:
         - alert: MimirRulerMissedEvaluations
           annotations:
             message: |
-                Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
+                GEM Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
           expr: |
             100 * (
@@ -480,7 +480,7 @@ groups:
         - alert: MimirRulerFailedRingCheck
           annotations:
             message: |
-                Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing errors when checking the ring for rule group ownership.
+                GEM Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing errors when checking the ring for rule group ownership.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerfailedringcheck
           expr: |
             sum by (cluster, namespace, job) (rate(cortex_ruler_ring_check_errors_total[1m]))
@@ -491,7 +491,7 @@ groups:
         - alert: MimirRulerRemoteEvaluationFailing
           annotations:
             message: |
-                Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are failing to perform {{ printf "%.2f" $value }}% of remote evaluations through the ruler-query-frontend.
+                GEM rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are failing to perform {{ printf "%.2f" $value }}% of remote evaluations through the ruler-query-frontend.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerremoteevaluationfailing
           expr: |
             (
@@ -506,7 +506,7 @@ groups:
         - alert: MimirRulerRemoteEvaluationFailing
           annotations:
             message: |
-                Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are failing to perform {{ printf "%.2f" $value }}% of remote evaluations through the ruler-query-frontend.
+                GEM rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are failing to perform {{ printf "%.2f" $value }}% of remote evaluations through the ruler-query-frontend.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerremoteevaluationfailing
           expr: |
             (
@@ -522,7 +522,7 @@ groups:
       rules:
         - alert: MimirGossipMembersTooHigh
           annotations:
-            message: One or more Mimir instances in {{ $labels.cluster }}/{{ $labels.namespace }} consistently sees a higher than expected number of gossip members.
+            message: One or more GEM instances in {{ $labels.cluster }}/{{ $labels.namespace }} consistently sees a higher than expected number of gossip members.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmemberstoohigh
           expr: |
             max by (cluster, namespace) (memberlist_client_cluster_members_count)
@@ -533,7 +533,7 @@ groups:
             severity: warning
         - alert: MimirGossipMembersTooLow
           annotations:
-            message: One or more Mimir instances in {{ $labels.cluster }}/{{ $labels.namespace }} consistently sees a lower than expected number of gossip members.
+            message: One or more GEM instances in {{ $labels.cluster }}/{{ $labels.namespace }} consistently sees a lower than expected number of gossip members.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmemberstoolow
           expr: |
             min by (cluster, namespace) (memberlist_client_cluster_members_count)
@@ -544,7 +544,7 @@ groups:
             severity: warning
         - alert: MimirGossipMembersEndpointsOutOfSync
           annotations:
-            message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
+            message: GEM gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
           expr: |
             (
@@ -566,7 +566,7 @@ groups:
             severity: warning
         - alert: MimirGossipMembersEndpointsOutOfSync
           annotations:
-            message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
+            message: GEM gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
           expr: |
             (
@@ -621,7 +621,7 @@ groups:
         - alert: MimirAlertmanagerSyncConfigsFailing
           annotations:
             message: |
-                Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to read tenant configurations from storage.
+                GEM Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to read tenant configurations from storage.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagersyncconfigsfailing
           expr: |
             rate(cortex_alertmanager_sync_configs_failed_total[5m]) > 0
@@ -631,7 +631,7 @@ groups:
         - alert: MimirAlertmanagerRingCheckFailing
           annotations:
             message: |
-                Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is unable to check tenants ownership via the ring.
+                GEM Alertmanager {{ $labels.job }}/{{ $labels.pod }} is unable to check tenants ownership via the ring.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerringcheckfailing
           expr: |
             rate(cortex_alertmanager_ring_check_errors_total[2m]) > 0
@@ -641,7 +641,7 @@ groups:
         - alert: MimirAlertmanagerPartialStateMergeFailing
           annotations:
             message: |
-                Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to merge partial state changes received from a replica.
+                GEM Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to merge partial state changes received from a replica.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerpartialstatemergefailing
           expr: |
             rate(cortex_alertmanager_partial_state_merges_failed_total[2m]) > 0
@@ -651,7 +651,7 @@ groups:
         - alert: MimirAlertmanagerReplicationFailing
           annotations:
             message: |
-                Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to replicating partial state to its replicas.
+                GEM Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to replicating partial state to its replicas.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerreplicationfailing
           expr: |
             rate(cortex_alertmanager_state_replication_failed_total[2m]) > 0
@@ -661,7 +661,7 @@ groups:
         - alert: MimirAlertmanagerPersistStateFailing
           annotations:
             message: |
-                Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is unable to persist full state snaphots to remote storage.
+                GEM Alertmanager {{ $labels.job }}/{{ $labels.pod }} is unable to persist full state snaphots to remote storage.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerpersiststatefailing
           expr: |
             rate(cortex_alertmanager_state_persist_failed_total[15m]) > 0
@@ -671,7 +671,7 @@ groups:
         - alert: MimirAlertmanagerInitialSyncFailed
           annotations:
             message: |
-                Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} was unable to obtain some initial state when starting up.
+                GEM Alertmanager {{ $labels.job }}/{{ $labels.pod }} was unable to obtain some initial state when starting up.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinitialsyncfailed
           expr: |
             increase(cortex_alertmanager_state_initial_sync_completed_total{outcome="failed"}[1m]) > 0
@@ -703,7 +703,7 @@ groups:
             severity: critical
         - alert: MimirAlertmanagerInstanceHasNoTenants
           annotations:
-            message: Mimir alertmanager {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} owns no tenants.
+            message: GEM alertmanager {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} owns no tenants.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinstancehasnotenants
           expr: |
             # Alert on alertmanager instances in microservices mode that own no tenants,
@@ -718,7 +718,7 @@ groups:
       rules:
         - alert: MimirIngesterHasNotShippedBlocks
           annotations:
-            message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
+            message: GEM Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblocks
           expr: |
             (min by(cluster, namespace, pod) (time() - cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 60 * 60 * 4)
@@ -738,7 +738,7 @@ groups:
             severity: critical
         - alert: MimirIngesterHasNotShippedBlocksSinceStart
           annotations:
-            message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
+            message: GEM Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasnotshippedblockssincestart
           expr: |
             (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
@@ -749,7 +749,7 @@ groups:
             severity: critical
         - alert: MimirIngesterHasUnshippedBlocks
           annotations:
-            message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has compacted a block {{ $value | humanizeDuration }} ago but it hasn't been successfully uploaded to the storage yet.
+            message: GEM Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has compacted a block {{ $value | humanizeDuration }} ago but it hasn't been successfully uploaded to the storage yet.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasunshippedblocks
           expr: |
             (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
@@ -760,7 +760,7 @@ groups:
             severity: critical
         - alert: MimirIngesterTSDBHeadCompactionFailed
           annotations:
-            message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to compact TSDB head.
+            message: GEM Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to compact TSDB head.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbheadcompactionfailed
           expr: |
             rate(cortex_ingester_tsdb_compactions_failed_total[5m]) > 0
@@ -769,7 +769,7 @@ groups:
             severity: critical
         - alert: MimirIngesterTSDBHeadTruncationFailed
           annotations:
-            message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB head.
+            message: GEM Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB head.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbheadtruncationfailed
           expr: |
             rate(cortex_ingester_tsdb_head_truncations_failed_total[5m]) > 0
@@ -777,7 +777,7 @@ groups:
             severity: critical
         - alert: MimirIngesterTSDBCheckpointCreationFailed
           annotations:
-            message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to create TSDB checkpoint.
+            message: GEM Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to create TSDB checkpoint.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbcheckpointcreationfailed
           expr: |
             rate(cortex_ingester_tsdb_checkpoint_creations_failed_total[5m]) > 0
@@ -785,7 +785,7 @@ groups:
             severity: critical
         - alert: MimirIngesterTSDBCheckpointDeletionFailed
           annotations:
-            message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to delete TSDB checkpoint.
+            message: GEM Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to delete TSDB checkpoint.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbcheckpointdeletionfailed
           expr: |
             rate(cortex_ingester_tsdb_checkpoint_deletions_failed_total[5m]) > 0
@@ -793,7 +793,7 @@ groups:
             severity: critical
         - alert: MimirIngesterTSDBWALTruncationFailed
           annotations:
-            message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB WAL.
+            message: GEM Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB WAL.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwaltruncationfailed
           expr: |
             rate(cortex_ingester_tsdb_wal_truncations_failed_total[5m]) > 0
@@ -801,7 +801,7 @@ groups:
             severity: warning
         - alert: MimirIngesterTSDBWALCorrupted
           annotations:
-            message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
+            message: GEM Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
           expr: |
             # alert when there are more than one corruptions
@@ -814,7 +814,7 @@ groups:
             severity: critical
         - alert: MimirIngesterTSDBWALCorrupted
           annotations:
-            message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
+            message: GEM Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
           expr: |
             # alert when there are more than one corruptions
@@ -827,7 +827,7 @@ groups:
             severity: critical
         - alert: MimirIngesterTSDBWALWritesFailed
           annotations:
-            message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to write to TSDB WAL.
+            message: GEM Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to write to TSDB WAL.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalwritesfailed
           expr: |
             rate(cortex_ingester_tsdb_wal_writes_failed_total[1m]) > 0
@@ -836,7 +836,7 @@ groups:
             severity: critical
         - alert: MimirStoreGatewayHasNotSyncTheBucket
           annotations:
-            message: Mimir store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully synched the bucket since {{ $value | humanizeDuration }}.
+            message: GEM store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully synched the bucket since {{ $value | humanizeDuration }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewayhasnotsyncthebucket
           expr: |
             (time() - cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="store-gateway"} > 60 * 30)
@@ -847,7 +847,7 @@ groups:
             severity: critical
         - alert: MimirStoreGatewayNoSyncedTenants
           annotations:
-            message: Mimir store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not syncing any blocks for any tenant.
+            message: GEM store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not syncing any blocks for any tenant.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaynosyncedtenants
           expr: |
             min by(cluster, namespace, pod) (cortex_bucket_stores_tenants_synced{component="store-gateway"}) == 0
@@ -856,7 +856,7 @@ groups:
             severity: warning
         - alert: MimirBucketIndexNotUpdated
           annotations:
-            message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
+            message: GEM bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbucketindexnotupdated
           expr: |
             min by(cluster, namespace, user) (time() - cortex_bucket_index_last_successful_update_timestamp_seconds) > 2100
@@ -866,7 +866,7 @@ groups:
       rules:
         - alert: MimirCompactorHasNotSuccessfullyCleanedUpBlocks
           annotations:
-            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully cleaned up blocks in the last 6 hours.
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully cleaned up blocks in the last 6 hours.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullycleanedupblocks
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
@@ -877,7 +877,7 @@ groups:
             severity: critical
         - alert: MimirCompactorHasNotSuccessfullyRunCompaction
           annotations:
-            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullyruncompaction
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
@@ -891,7 +891,7 @@ groups:
             severity: critical
         - alert: MimirCompactorHasNotSuccessfullyRunCompaction
           annotations:
-            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullyruncompaction
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
@@ -903,7 +903,7 @@ groups:
             severity: critical
         - alert: MimirCompactorHasNotSuccessfullyRunCompaction
           annotations:
-            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed to run 2 consecutive compactions.
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed to run 2 consecutive compactions.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotsuccessfullyruncompaction
           expr: |
             increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h]) >= 2
@@ -912,7 +912,7 @@ groups:
             severity: critical
         - alert: MimirCompactorHasRunOutOfDiskSpace
           annotations:
-            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has run out of disk space.
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has run out of disk space.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
           expr: |
             increase(cortex_compactor_disk_out_of_space_errors_total{}[24h]) >= 1
@@ -921,7 +921,7 @@ groups:
             severity: critical
         - alert: MimirCompactorHasNotUploadedBlocks
           annotations:
-            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
           expr: |
             (time() - (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"})) > 60 * 60 * 24)
@@ -937,7 +937,7 @@ groups:
             time_period: 24h
         - alert: MimirCompactorHasNotUploadedBlocks
           annotations:
-            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block since its start.
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block since its start.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
           expr: |
             (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) == 0)
@@ -951,7 +951,7 @@ groups:
             time_period: since-start
         - alert: MimirCompactorSkippedUnhealthyBlocks
           annotations:
-            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has found and ignored unhealthy blocks.
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has found and ignored unhealthy blocks.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorskippedunhealthyblocks
           expr: |
             increase(cortex_compactor_blocks_marked_for_no_compaction_total[5m]) > 0
@@ -960,7 +960,7 @@ groups:
             severity: warning
         - alert: MimirCompactorSkippedUnhealthyBlocks
           annotations:
-            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has found and ignored unhealthy blocks.
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has found and ignored unhealthy blocks.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorskippedunhealthyblocks
           expr: |
             increase(cortex_compactor_blocks_marked_for_no_compaction_total[5m]) > 1
@@ -971,7 +971,7 @@ groups:
       rules:
         - alert: MimirDistributorGcUsesTooMuchCpu
           annotations:
-            message: Mimir distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
+            message: GEM distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
           expr: |
             (quantile by (cluster, namespace) (0.9, sum by (cluster, namespace, pod) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
@@ -1040,7 +1040,7 @@ groups:
       rules:
         - alert: MimirIngesterLastConsumedOffsetCommitFailed
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to commit the last consumed offset.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to commit the last consumed offset.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterlastconsumedoffsetcommitfailed
           expr: |
             sum by(cluster, namespace, pod) (rate(cortex_ingest_storage_reader_offset_commit_failures_total[5m]))
@@ -1052,7 +1052,7 @@ groups:
             severity: critical
         - alert: MimirIngesterFailedToReadRecordsFromKafka
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterfailedtoreadrecordsfromkafka
           expr: |
             sum by(cluster, namespace, pod, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[1m]))
@@ -1062,7 +1062,7 @@ groups:
             severity: critical
         - alert: MimirIngesterKafkaFetchErrorsRateTooHigh
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is receiving fetch errors when reading records from Kafka.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is receiving fetch errors when reading records from Kafka.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkafetcherrorsratetoohigh
           expr: |
             sum by (cluster, namespace, pod) (rate (cortex_ingest_storage_reader_fetch_errors_total[5m]))
@@ -1074,7 +1074,7 @@ groups:
             severity: critical
         - alert: MimirStartingIngesterKafkaReceiveDelayIncreasing
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "starting" phase is not reducing consumption lag of write requests read from Kafka.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "starting" phase is not reducing consumption lag of write requests read from Kafka.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstartingingesterkafkareceivedelayincreasing
           expr: |
             deriv((
@@ -1087,7 +1087,7 @@ groups:
             severity: warning
         - alert: MimirRunningIngesterReceiveDelayTooHigh
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
           expr: |
             (
@@ -1101,7 +1101,7 @@ groups:
             threshold: very_high_for_short_period
         - alert: MimirRunningIngesterReceiveDelayTooHigh
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
           expr: |
             (
@@ -1115,7 +1115,7 @@ groups:
             threshold: relatively_high_for_long_period
         - alert: MimirIngesterFailsToProcessRecordsFromKafka
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to consume write requests read from Kafka due to internal errors.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to consume write requests read from Kafka due to internal errors.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterfailstoprocessrecordsfromkafka
           expr: |
             sum by (cluster, namespace, pod) (
@@ -1129,7 +1129,7 @@ groups:
             severity: critical
         - alert: MimirIngesterStuckProcessingRecordsFromKafka
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is stuck processing write requests from Kafka.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is stuck processing write requests from Kafka.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterstuckprocessingrecordsfromkafka
           expr: |
             # Alert if the reader is not processing any records, but there buffered records to process in the Kafka client.
@@ -1146,7 +1146,7 @@ groups:
             severity: critical
         - alert: MimirIngesterMissedRecordsFromKafka
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} missed processing records from Kafka. There may be data loss.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} missed processing records from Kafka. There may be data loss.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestermissedrecordsfromkafka
           expr: |
             # Alert if the ingester missed some records from Kafka.
@@ -1155,7 +1155,7 @@ groups:
             severity: critical
         - alert: MimirStrongConsistencyEnforcementFailed
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to enforce strong-consistency on read-path.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to enforce strong-consistency on read-path.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyenforcementfailed
           expr: |
             sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_strong_consistency_failures_total[1m])) > 0
@@ -1164,7 +1164,7 @@ groups:
             severity: critical
         - alert: MimirStrongConsistencyOffsetNotPropagatedToIngesters
           annotations:
-            message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.
+            message: GEM ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyoffsetnotpropagatedtoingesters
           expr: |
             sum by (cluster, namespace) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="false"}[1m]))
@@ -1176,7 +1176,7 @@ groups:
             severity: warning
         - alert: MimirKafkaClientBufferedProduceBytesTooHigh
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} Kafka client produce buffer utilization is {{ printf "%.2f" $value }}%.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} Kafka client produce buffer utilization is {{ printf "%.2f" $value }}%.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkafkaclientbufferedproducebytestoohigh
           expr: |
             max by(cluster, namespace, pod) (max_over_time(cortex_ingest_storage_writer_buffered_produce_bytes{quantile="1.0"}[1m]))
@@ -1188,7 +1188,7 @@ groups:
             severity: critical
         - alert: MimirBlockBuilderNoCycleProcessing
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
           expr: |
             max by(cluster, namespace, pod) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[60m]))) == 0
@@ -1197,7 +1197,7 @@ groups:
             severity: critical
         - alert: MimirBlockBuilderLagging
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
           expr: |
             max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
@@ -1206,7 +1206,7 @@ groups:
             severity: warning
         - alert: MimirBlockBuilderLagging
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
           expr: |
             max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
@@ -1215,7 +1215,7 @@ groups:
             severity: critical
         - alert: MimirBlockBuilderCompactAndUploadFailed
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
           expr: |
             sum by (cluster, namespace, pod) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
@@ -1225,7 +1225,7 @@ groups:
       rules:
         - alert: MimirContinuousTestNotRunningOnWrites
           annotations:
-            message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not effectively running because writes are failing.
+            message: GEM continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not effectively running because writes are failing.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestnotrunningonwrites
           expr: |
             sum by(cluster, namespace, test) (rate(mimir_continuous_test_writes_failed_total[5m])) > 0
@@ -1234,7 +1234,7 @@ groups:
             severity: warning
         - alert: MimirContinuousTestNotRunningOnReads
           annotations:
-            message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not effectively running because queries are failing.
+            message: GEM continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not effectively running because queries are failing.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestnotrunningonreads
           expr: |
             sum by(cluster, namespace, test) (rate(mimir_continuous_test_queries_failed_total[5m])) > 0
@@ -1243,7 +1243,7 @@ groups:
             severity: warning
         - alert: MimirContinuousTestFailed
           annotations:
-            message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed when asserting query results.
+            message: GEM continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed when asserting query results.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestfailed
           expr: |
             sum by(cluster, namespace, test) (rate(mimir_continuous_test_query_result_checks_failed_total[10m])) > 0

--- a/operations/mimir-mixin-compiled-gem/dashboards/federation-frontend.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/federation-frontend.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -1361,7 +1362,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1483,7 +1485,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Federation-frontend",
+      "title": "GEM / Federation-frontend",
       "uid": "e260295ba339cb717fc5acf22bd92952",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-alertmanager-resources.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-alertmanager-resources.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -877,7 +878,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -973,7 +975,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Alertmanager resources",
+      "title": "GEM / Alertmanager resources",
       "uid": "a6883fb22799ac74479c7db872451092",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-alertmanager.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-alertmanager.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -2645,7 +2646,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -2772,7 +2774,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Alertmanager",
+      "title": "GEM / Alertmanager",
       "uid": "b0d38d318bbddd80476246d4930f9e55",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-compactor-resources.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-compactor-resources.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -706,7 +707,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -804,7 +806,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Compactor resources",
+      "title": "GEM / Compactor resources",
       "uid": "09a5c49e9cdb2f2b24c6d184574a07fd",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-compactor.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-compactor.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -2137,7 +2138,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -2235,7 +2237,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Compactor",
+      "title": "GEM / Compactor",
       "uid": "1b3443aea86db629e6efdb7d05c53823",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-config.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-config.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -154,7 +155,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -252,7 +254,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Config",
+      "title": "GEM / Config",
       "uid": "5d9d0b4724c0f80d68467088ec61e003",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-object-store.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-object-store.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -718,7 +719,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -816,7 +818,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Object Store",
+      "title": "GEM / Object Store",
       "uid": "e1324ee2a434f4158c00a9ee279d3292",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-overrides.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-overrides.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -145,7 +146,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -260,7 +262,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Overrides",
+      "title": "GEM / Overrides",
       "uid": "1e2c358600ac53f09faea133f811b5bb",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-overview-networking.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-overview-networking.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -950,7 +951,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1046,7 +1048,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Overview networking",
+      "title": "GEM / Overview networking",
       "uid": "e15c71d372cc541367a088f10d9fcd92",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-overview-resources.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-overview-resources.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -1102,7 +1103,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1198,7 +1200,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Overview resources",
+      "title": "GEM / Overview resources",
       "uid": "a9b92d3c4d1af325d872a9e9a7083d71",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-overview.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-overview.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -154,7 +155,7 @@
                   "id": 3,
                   "options": {
                      "alertInstanceLabelFilter": "cluster=~\"$cluster\", namespace=~\"$namespace\"",
-                     "alertName": "Mimir",
+                     "alertName": "GEM",
                      "dashboardAlerts": false,
                      "maxItems": 100,
                      "sortOrder": 3,
@@ -175,7 +176,7 @@
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Mimir cluster health",
+            "title": "GEM cluster health",
             "titleSize": "h6"
          },
          {
@@ -1575,7 +1576,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1702,7 +1704,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Overview",
+      "title": "GEM / Overview",
       "uid": "ffcd83628d7d4b5a03d1cafd159e6c9c",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-queries.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -2444,7 +2445,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -2604,7 +2606,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Queries",
+      "title": "GEM / Queries",
       "uid": "b3abe8d5c040395cc36615cb4334c92d",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-reads-networking.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-reads-networking.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -1637,7 +1638,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1733,7 +1735,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Reads networking",
+      "title": "GEM / Reads networking",
       "uid": "54b2a0a4748b3bd1aefa92ce5559a1c2",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-reads-resources.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-reads-resources.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -2629,7 +2630,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -2725,7 +2727,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Reads resources",
+      "title": "GEM / Reads resources",
       "uid": "cc86fd5aa9301c6528986572ad974db9",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-reads.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-reads.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -145,7 +146,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Range queries per second\nRate of range queries per second being made to\nMimir via the <tt>/prometheus</tt> API.\n\n",
+                  "description": "### Range queries per second\nRate of range queries per second being made to\nGEM via the <tt>/prometheus</tt> API.\n\n",
                   "fill": 1,
                   "format": "reqps",
                   "id": 3,
@@ -227,7 +228,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### \"Label names\" queries per second\nRate of \"label names\" endpoint queries per second being made to\nMimir via the <tt>/prometheus</tt> API.\n\n",
+                  "description": "### \"Label names\" queries per second\nRate of \"label names\" endpoint queries per second being made to\nGEM via the <tt>/prometheus</tt> API.\n\n",
                   "fill": 1,
                   "format": "reqps",
                   "id": 4,
@@ -309,7 +310,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### \"Label values\" queries per second\nRate of specific \"label values\" endpoint queries per second being made to\nMimir via the <tt>/prometheus</tt> API.\n\n",
+                  "description": "### \"Label values\" queries per second\nRate of specific \"label values\" endpoint queries per second being made to\nGEM via the <tt>/prometheus</tt> API.\n\n",
                   "fill": 1,
                   "format": "reqps",
                   "id": 5,
@@ -391,7 +392,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Series queries per second\nRate of series queries per second being made to\nMimir via the <tt>/prometheus</tt> API.\n\n",
+                  "description": "### Series queries per second\nRate of series queries per second being made to\nGEM via the <tt>/prometheus</tt> API.\n\n",
                   "fill": 1,
                   "format": "reqps",
                   "id": 6,
@@ -6193,7 +6194,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -6320,7 +6322,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Reads",
+      "title": "GEM / Reads",
       "uid": "e327503188913dc38ad571c647eef643",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-remote-ruler-reads-networking.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-remote-ruler-reads-networking.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -950,7 +951,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1046,7 +1048,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Remote ruler reads networking",
+      "title": "GEM / Remote ruler reads networking",
       "uid": "9e8cfff65f91632f8a25981c6fe44bc9",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-remote-ruler-reads-resources.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-remote-ruler-reads-resources.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -880,7 +881,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -976,7 +978,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Remote ruler reads resources",
+      "title": "GEM / Remote ruler reads resources",
       "uid": "1940f6ef765a506a171faa2056c956c3",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-remote-ruler-reads.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-remote-ruler-reads.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -3047,7 +3048,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -3174,7 +3176,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Remote ruler reads",
+      "title": "GEM / Remote ruler reads",
       "uid": "f103238f7f5ab2f1345ce650cbfbfe2f",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-rollout-progress.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-rollout-progress.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -1394,7 +1395,8 @@
       "schemaVersion": 27,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1519,7 +1521,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Rollout progress",
+      "title": "GEM / Rollout progress",
       "uid": "7f0b5567d543a1698e695b530eb7f5de",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-ruler.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -1667,7 +1668,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
-                  "description": "### Replicas\nThe minimum, maximum, and current number of ruler-query-frontend replicas.\n\n",
+                  "description": "### Replicas\nThe minimum, maximum, and current number of ruler replicas.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1754,19 +1755,19 @@
                   "span": 3,
                   "targets": [
                      {
-                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"}\n  # Add the scaletargetref_name label for readability\n  * on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    group by (cluster, namespace, horizontalpodautoscaler, scaletargetref_name) (kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"})\n)\n",
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler\"}\n  # Add the scaletargetref_name label for readability\n  * on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    group by (cluster, namespace, horizontalpodautoscaler, scaletargetref_name) (kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler\"})\n)\n",
                         "format": "time_series",
                         "legendFormat": "Max {{ scaletargetref_name }}",
                         "legendLink": null
                      },
                      {
-                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"}\n  # Add the scaletargetref_name label for readability\n  * on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    group by (cluster, namespace, horizontalpodautoscaler, scaletargetref_name) (kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"})\n)\n",
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler\"}\n  # Add the scaletargetref_name label for readability\n  * on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    group by (cluster, namespace, horizontalpodautoscaler, scaletargetref_name) (kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler\"})\n)\n",
                         "format": "time_series",
                         "legendFormat": "Current {{ scaletargetref_name }}",
                         "legendLink": null
                      },
                      {
-                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"}\n  # Add the scaletargetref_name label for readability\n  * on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    group by (cluster, namespace, horizontalpodautoscaler, scaletargetref_name) (kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"})\n)\n",
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler\"}\n  # Add the scaletargetref_name label for readability\n  * on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    group by (cluster, namespace, horizontalpodautoscaler, scaletargetref_name) (kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler\"})\n)\n",
                         "format": "time_series",
                         "legendFormat": "Min {{ scaletargetref_name }}",
                         "legendLink": null
@@ -1815,7 +1816,7 @@
                   "span": 3,
                   "targets": [
                      {
-                        "expr": "sum by (scaler) (\n  # Using `max by ()` so that series churn doesn't break the promQL join\n  max by (cluster, namespace, scaledObject, metric, scaler) (\n    label_replace(\n      keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".*cpu.*\"},\n      \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n    )\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left\n    # Using `max by ()` so that series churn doesn't break the promQL join\n    max by (cluster, namespace, scaledObject, metric) (\n      label_replace(\n        label_replace(\n          kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"},\n          \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n        ),\n        \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(?:mimir-)?(.*)\"\n      )\n    )\n)\n",
+                        "expr": "sum by (scaler) (\n  # Using `max by ()` so that series churn doesn't break the promQL join\n  max by (cluster, namespace, scaledObject, metric, scaler) (\n    label_replace(\n      keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".*cpu.*\"},\n      \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n    )\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left\n    # Using `max by ()` so that series churn doesn't break the promQL join\n    max by (cluster, namespace, scaledObject, metric) (\n      label_replace(\n        label_replace(\n          kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler\"},\n          \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n        ),\n        \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(?:mimir-)?(.*)\"\n      )\n    )\n)\n",
                         "format": "time_series",
                         "legendFormat": "{{ scaler }}",
                         "legendLink": null
@@ -1864,7 +1865,7 @@
                   "span": 3,
                   "targets": [
                      {
-                        "expr": "sum by (scaler) (\n  # Using `max by ()` so that series churn doesn't break the promQL join\n  max by (cluster, namespace, scaledObject, metric, scaler) (\n    label_replace(\n      keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".*memory.*\"},\n      \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n    )\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left\n    # Using `max by ()` so that series churn doesn't break the promQL join\n    max by (cluster, namespace, scaledObject, metric) (\n      label_replace(\n        label_replace(\n          kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"},\n          \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n        ),\n        \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(?:mimir-)?(.*)\"\n      )\n    )\n)\n",
+                        "expr": "sum by (scaler) (\n  # Using `max by ()` so that series churn doesn't break the promQL join\n  max by (cluster, namespace, scaledObject, metric, scaler) (\n    label_replace(\n      keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".*memory.*\"},\n      \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n    )\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left\n    # Using `max by ()` so that series churn doesn't break the promQL join\n    max by (cluster, namespace, scaledObject, metric) (\n      label_replace(\n        label_replace(\n          kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler\"},\n          \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n        ),\n        \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(?:mimir-)?(.*)\"\n      )\n    )\n)\n",
                         "format": "time_series",
                         "legendFormat": "{{ scaler }}",
                         "legendLink": null
@@ -1900,6 +1901,275 @@
                      "overrides": [ ]
                   },
                   "id": 20,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "sum by(cluster, namespace, metric, scaledObject, scaler) (\n  label_replace(\n    rate(keda_scaler_errors[$__rate_interval]),\n    \"namespace\", \"$1\", \"exported_namespace\", \"(.+)\"\n  )\n) +\non(cluster, namespace, metric, scaledObject) group_left\n  # Using `max by ()` so that series churn doesn't break the promQL join\n  max by (cluster, namespace, metric, scaledObject) (\n    label_replace(\n      label_replace(\n          kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler\"} * 0,\n          \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(?:mimir-)?(.*)\"\n      ),\n      \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n    )\n  )\n",
+                        "format": "time_series",
+                        "legendFormat": "{{scaler}} failures",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Autoscaler failures rate",
+                  "type": "timeseries"
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Ruler – autoscaling",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
+               {
+                  "datasource": "$datasource",
+                  "description": "### Replicas\nThe minimum, maximum, and current number of ruler-query-frontend replicas.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/Max .+/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              },
+                              {
+                                 "id": "custom.lineStyle",
+                                 "value": {
+                                    "fill": "dash"
+                                 }
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/Current .+/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              }
+                           ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byRegexp",
+                              "options": "/Min .+/"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              },
+                              {
+                                 "id": "custom.lineStyle",
+                                 "value": {
+                                    "fill": "dash"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "id": 21,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_max_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"}\n  # Add the scaletargetref_name label for readability\n  * on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    group by (cluster, namespace, horizontalpodautoscaler, scaletargetref_name) (kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"})\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "Max {{ scaletargetref_name }}",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_status_current_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"}\n  # Add the scaletargetref_name label for readability\n  * on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    group by (cluster, namespace, horizontalpodautoscaler, scaletargetref_name) (kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"})\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "Current {{ scaletargetref_name }}",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "max by (scaletargetref_name) (\n  kube_horizontalpodautoscaler_spec_min_replicas{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"}\n  # Add the scaletargetref_name label for readability\n  * on (cluster, namespace, horizontalpodautoscaler) group_left (scaletargetref_name)\n    group by (cluster, namespace, horizontalpodautoscaler, scaletargetref_name) (kube_horizontalpodautoscaler_info{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"})\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "Min {{ scaletargetref_name }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Replicas",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Scaling metric (CPU): Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold used.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 22,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "sum by (scaler) (\n  # Using `max by ()` so that series churn doesn't break the promQL join\n  max by (cluster, namespace, scaledObject, metric, scaler) (\n    label_replace(\n      keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".*cpu.*\"},\n      \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n    )\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left\n    # Using `max by ()` so that series churn doesn't break the promQL join\n    max by (cluster, namespace, scaledObject, metric) (\n      label_replace(\n        label_replace(\n          kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"},\n          \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n        ),\n        \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(?:mimir-)?(.*)\"\n      )\n    )\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "{{ scaler }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Scaling metric (CPU): Desired replicas",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Scaling metric (memory): Desired replicas\nThis panel shows the scaling metric exposed by KEDA divided by the target/threshold used.\nIt should represent the desired number of replicas, ignoring the min/max constraints applied later.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 23,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 3,
+                  "targets": [
+                     {
+                        "expr": "sum by (scaler) (\n  # Using `max by ()` so that series churn doesn't break the promQL join\n  max by (cluster, namespace, scaledObject, metric, scaler) (\n    label_replace(\n      keda_scaler_metrics_value{cluster=~\"$cluster\", exported_namespace=~\"$namespace\", scaler=~\".*memory.*\"},\n      \"namespace\", \"$1\", \"exported_namespace\", \"(.*)\"\n    )\n  )\n  /\n  on(cluster, namespace, scaledObject, metric) group_left\n    # Using `max by ()` so that series churn doesn't break the promQL join\n    max by (cluster, namespace, scaledObject, metric) (\n      label_replace(\n        label_replace(\n          kube_horizontalpodautoscaler_spec_target_metric{cluster=~\"$cluster\", namespace=~\"$namespace\", horizontalpodautoscaler=~\"keda-hpa-(?:mimir-)?ruler-query-frontend\"},\n          \"metric\", \"$1\", \"metric_name\", \"(.+)\"\n        ),\n        \"scaledObject\", \"$1\", \"horizontalpodautoscaler\", \"keda-hpa-(?:mimir-)?(.*)\"\n      )\n    )\n)\n",
+                        "format": "time_series",
+                        "legendFormat": "{{ scaler }}",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Scaling metric (memory): Desired replicas",
+                  "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Autoscaler failures rate\nThe rate of failures in the KEDA custom metrics API server. Whenever an error occurs, the KEDA custom\nmetrics server is unable to query the scaling metric from Prometheus so the autoscaler wouldn't work properly.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "short"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 24,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2095,7 +2365,7 @@
                         }
                      ]
                   },
-                  "id": 21,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2143,7 +2413,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 26,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2234,7 +2504,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 23,
+                  "id": 27,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2313,7 +2583,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 28,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2410,7 +2680,7 @@
                         }
                      ]
                   },
-                  "id": 25,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2471,7 +2741,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 26,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2520,7 +2790,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 27,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2569,7 +2839,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 28,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2629,7 +2899,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 29,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2677,7 +2947,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 30,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2725,7 +2995,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 31,
+                  "id": 35,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2785,7 +3055,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 32,
+                  "id": 36,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2845,7 +3115,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 37,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2878,7 +3148,7 @@
                         "unit": "percentunit"
                      }
                   },
-                  "id": 34,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2926,7 +3196,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 39,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3005,7 +3275,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 40,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3096,7 +3366,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 41,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3175,7 +3445,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 38,
+                  "id": 42,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3254,7 +3524,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 39,
+                  "id": 43,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3333,7 +3603,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 40,
+                  "id": 44,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3399,7 +3669,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -3526,7 +3797,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Ruler",
+      "title": "GEM / Ruler",
       "uid": "631e15d5d85afb2ca8e35d62984eeaa0",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-scaling.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-scaling.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -288,7 +289,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -386,7 +388,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Scaling",
+      "title": "GEM / Scaling",
       "uid": "64bbad83507b7289b514725658e10352",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-slow-queries.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-slow-queries.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -1295,7 +1296,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1481,7 +1483,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Slow queries",
+      "title": "GEM / Slow queries",
       "uid": "6089e1ce1e678788f46312a0a1e647e6",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-tenants.json
@@ -39,10 +39,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -2576,7 +2577,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -2740,7 +2742,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Tenants",
+      "title": "GEM / Tenants",
       "uid": "35fa247ce651ba189debf33d7ae41611",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-top-tenants.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-top-tenants.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -1605,7 +1606,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1736,7 +1738,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Top tenants",
+      "title": "GEM / Top tenants",
       "uid": "bc6e12d4fe540e4a1785b9d3ca0ffdd9",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes-networking.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes-networking.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -950,7 +951,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1046,7 +1048,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Writes networking",
+      "title": "GEM / Writes networking",
       "uid": "978c1cb452585c96697a238eaac7fe2d",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes-resources.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -1366,7 +1367,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -1462,7 +1464,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Writes resources",
+      "title": "GEM / Writes resources",
       "uid": "bc9160e50b52e89e0e49c840fea3d379",
       "version": 0
    }

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes.json
@@ -21,10 +21,11 @@
             "includeVars": true,
             "keepTime": true,
             "tags": [
-               "mimir"
+               "mimir",
+               "gem"
             ],
             "targetBlank": false,
-            "title": "Mimir dashboards",
+            "title": "GEM dashboards",
             "type": "dashboards"
          }
       ],
@@ -4306,7 +4307,8 @@
       "schemaVersion": 14,
       "style": "dark",
       "tags": [
-         "mimir"
+         "mimir",
+         "gem"
       ],
       "templating": {
          "list": [
@@ -4433,7 +4435,7 @@
          ]
       },
       "timezone": "utc",
-      "title": "Mimir / Writes",
+      "title": "GEM / Writes",
       "uid": "8280707b8f16e7b87b840fc1cc92d4c5",
       "version": 0
    }

--- a/operations/mimir-mixin/alerts/alerts-utils.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts-utils.libsonnet
@@ -1,13 +1,7 @@
 {
-  _config+:: {
-    alert_cluster_variable: '{{ $labels.%s }}' % $._config.per_cluster_label,
-    alert_instance_variable: '{{ $labels.%s }}' % $._config.per_instance_label,
-    alert_node_variable: '{{ $labels.%s }}' % $._config.per_cluster_label,
-  },
-
   // The alert name is prefixed with the product name (eg. AlertName -> MimirAlertName).
   alertName(name)::
-    $._config.product + name,
+    $._config.alert_product + name,
 
   jobMatcher(job)::
     '%s=~"%s%s"' % [$._config.per_job_label, $._config.alert_job_prefix, formatJobForQuery(job)],

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -220,6 +220,15 @@
     // Used as the job prefix in alerts that select on job label (e.g. GossipMembersTooHigh, RingMembersMismatch). This can be set to a known namespace to prevent those alerts from firing incorrectly due to selecting similar metrics from Loki/Tempo.
     alert_job_prefix: '.*/',
 
+    alert_cluster_variable: '{{ $labels.%s }}' % $._config.per_cluster_label,
+
+    alert_instance_variable: '{{ $labels.%s }}' % $._config.per_instance_label,
+
+    alert_node_variable: '{{ $labels.%s }}' % $._config.per_cluster_label,
+
+    // The alertname is used to create a hyperlink to the runbooks. Currenlty we only have a single set of runbooks, so different products (e.g. GEM) should still use the same runbooks.
+    alert_product: $._config.product,
+
     // Whether alerts for experimental ingest storage are enabled.
     ingest_storage_enabled: true,
 

--- a/operations/mimir-mixin/mixin-compiled-gem.libsonnet
+++ b/operations/mimir-mixin/mixin-compiled-gem.libsonnet
@@ -1,6 +1,10 @@
 (import 'mixin.libsonnet') + {
   // This config enables features that are relevant to most GEM deployments.
   _config+:: {
+    product: 'GEM',
+    alert_product: 'Mimir',
+    tags+: ['gem'],
+
     gem_enabled: true,
 
     gateway_enabled: true,
@@ -19,6 +23,9 @@
         enabled: true,
       },
       ruler_query_frontend+: {
+        enabled: true,
+      },
+      ruler+: {
         enabled: true,
       },
     },


### PR DESCRIPTION

#### What this PR does


This changes the product from `Mimir` to `GEM`, but keeps the alert prefixes as `Mimir` so that the runbook links still work.

To do that I needed to add a new config option: `_config.alert_product`

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
