### PR TITLE
fix(mixin/dashboards/tenants): use 'per_instance_label' for legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [ENHANCEMENT] Dashboards: Include absolute number of notifications attempted to alertmanager in 'Mimir / Ruler'. #10918
 * [ENHANCEMENT] Alerts: Make `MimirRolloutStuck` a critical alert if it has been firing for 6h. #10890
+* [BUGFIX] Dashboards: fix "Mimir / Tenants" legends for non-Kubernetes deployments. #10891
 
 ### Jsonnet
 

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -237,7 +237,7 @@
                      {
                         "expr": "cortex_ingester_memory_series_created_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n- cortex_ingester_memory_series_removed_total{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n",
                         "format": "time_series",
-                        "legendFormat": "{{pod}}",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],
@@ -314,7 +314,7 @@
                      {
                         "expr": "cortex_ingester_owned_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir|mimir-write.*))\", user=\"$user\"}\n",
                         "format": "time_series",
-                        "legendFormat": "{{pod}}",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -105,7 +105,7 @@ local filename = 'mimir-tenants.json';
           ],
           [
             'local limit ({{job}})',
-            '{{pod}}',
+            '{{%(per_instance_label)s}}' % $._config.per_instance_label,
           ],
         ) +
         $.showAllTooltip +
@@ -150,7 +150,7 @@ local filename = 'mimir-tenants.json';
           ],
           [
             'local limit ({{job}})',
-            '{{pod}}',
+            '{{%(per_instance_label)s}}' % $._config.per_instance_label,
           ],
         ) +
         $.showAllTooltip +


### PR DESCRIPTION
#### What this PR does

The tenants dashboard previously used hardcoded values (`pod`) for the legends of the following panels:

- `In-memory series per ingester`
- `Owned series per ingester`

In baremetal deployments, the `per_instance_label` is often overridden with something more meaningful like `instance`. Since the `pod` label does not exist in such cases, the legend popup displayed all labels, making it unreadable.

By using a variable for the legend values, the dashboard now correctly handles both "cloud" and "baremetal" deployments.

#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
