### PR TITLE
Update to latest dskit commit for DNS resolver improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 * [ENHANCEMENT] gRPC clients: Add `cortex_client_request_invalid_cluster_validation_labels_total` metrics, that are used by Mimir's gRPC clients to track invalid cluster validations. #10767
 * [ENHANCEMENT] Add experimental metric `cortex_distributor_dropped_native_histograms_total` to measure native histograms silently dropped when native histograms are disabled for a tenant. #10760
 * [ENHANCEMENT] Compactor: Add experimental `-compactor.upload-sparse-index-headers` option. When enabled, the compactor will attempt to upload sparse index headers to object storage. This prevents latency spikes after adding store-gateway replicas. #10684
-* [ENHANCEMENT] Memcached; Add experimental `-<prefix>.memcached.addresses-provider` flag to use alternate DNS service discovery backends when discovering Memcached hosts. #10895
+* [ENHANCEMENT] Memcached: Add experimental `-<prefix>.memcached.addresses-provider` flag to use alternate DNS service discovery backends when discovering Memcached hosts. #10895
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * [ENHANCEMENT] gRPC clients: Add `cortex_client_request_invalid_cluster_validation_labels_total` metrics, that are used by Mimir's gRPC clients to track invalid cluster validations. #10767
 * [ENHANCEMENT] Add experimental metric `cortex_distributor_dropped_native_histograms_total` to measure native histograms silently dropped when native histograms are disabled for a tenant. #10760
 * [ENHANCEMENT] Compactor: Add experimental `-compactor.upload-sparse-index-headers` option. When enabled, the compactor will attempt to upload sparse index headers to object storage. This prevents latency spikes after adding store-gateway replicas. #10684
+* [ENHANCEMENT] Memcached; Add experimental `-<prefix>.memcached.addresses-provider` flag to use alternate DNS service discovery backends when discovering Memcached hosts. #10895
 * [BUGFIX] Distributor: Use a boolean to track changes while merging the ReplicaDesc components, rather than comparing the objects directly. #10185
 * [BUGFIX] Querier: fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #10154
 * [BUGFIX] Query-frontend and querier: show warning/info annotations in some cases where they were missing (if a lazy querier was used). #10277

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -6516,6 +6516,17 @@
                 },
                 {
                   "kind": "field",
+                  "name": "addresses_provider",
+                  "required": false,
+                  "desc": "DNS provider used for resolving memcached addresses. Available providers golang, miekgdns, miekgdns2",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "miekgdns",
+                  "fieldFlag": "query-frontend.results-cache.memcached.addresses-provider",
+                  "fieldType": "string",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
                   "name": "timeout",
                   "required": false,
                   "desc": "The socket read/write timeout.",
@@ -8671,6 +8682,17 @@
                     },
                     {
                       "kind": "field",
+                      "name": "addresses_provider",
+                      "required": false,
+                      "desc": "DNS provider used for resolving memcached addresses. Available providers golang, miekgdns, miekgdns2",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "miekgdns",
+                      "fieldFlag": "blocks-storage.bucket-store.index-cache.memcached.addresses-provider",
+                      "fieldType": "string",
+                      "fieldCategory": "experimental"
+                    },
+                    {
+                      "kind": "field",
                       "name": "timeout",
                       "required": false,
                       "desc": "The socket read/write timeout.",
@@ -9242,6 +9264,17 @@
                       "fieldDefaultValue": "",
                       "fieldFlag": "blocks-storage.bucket-store.chunks-cache.memcached.addresses",
                       "fieldType": "string"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "addresses_provider",
+                      "required": false,
+                      "desc": "DNS provider used for resolving memcached addresses. Available providers golang, miekgdns, miekgdns2",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "miekgdns",
+                      "fieldFlag": "blocks-storage.bucket-store.chunks-cache.memcached.addresses-provider",
+                      "fieldType": "string",
+                      "fieldCategory": "experimental"
                     },
                     {
                       "kind": "field",
@@ -9840,6 +9873,17 @@
                       "fieldDefaultValue": "",
                       "fieldFlag": "blocks-storage.bucket-store.metadata-cache.memcached.addresses",
                       "fieldType": "string"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "addresses_provider",
+                      "required": false,
+                      "desc": "DNS provider used for resolving memcached addresses. Available providers golang, miekgdns, miekgdns2",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "miekgdns",
+                      "fieldFlag": "blocks-storage.bucket-store.metadata-cache.memcached.addresses-provider",
+                      "fieldType": "string",
+                      "fieldCategory": "experimental"
                     },
                     {
                       "kind": "field",
@@ -15202,6 +15246,17 @@
                   "fieldDefaultValue": "",
                   "fieldFlag": "ruler-storage.cache.memcached.addresses",
                   "fieldType": "string"
+                },
+                {
+                  "kind": "field",
+                  "name": "addresses_provider",
+                  "required": false,
+                  "desc": "DNS provider used for resolving memcached addresses. Available providers golang, miekgdns, miekgdns2",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "miekgdns",
+                  "fieldFlag": "ruler-storage.cache.memcached.addresses-provider",
+                  "fieldType": "string",
+                  "fieldCategory": "experimental"
                 },
                 {
                   "kind": "field",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -439,6 +439,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of sub-GetRange requests that a single GetRange request can be split into when fetching chunks. Zero or negative value = unlimited number of sub-requests. (default 3)
   -blocks-storage.bucket-store.chunks-cache.memcached.addresses comma-separated-list-of-strings
     	Comma-separated list of memcached addresses. Each address can be an IP address, hostname, or an entry specified in the DNS Service Discovery format.
+  -blocks-storage.bucket-store.chunks-cache.memcached.addresses-provider value
+    	[experimental] DNS provider used for resolving memcached addresses. Available providers golang, miekgdns, miekgdns2 (default "miekgdns")
   -blocks-storage.bucket-store.chunks-cache.memcached.connect-timeout duration
     	The connection timeout. (default 200ms)
   -blocks-storage.bucket-store.chunks-cache.memcached.dns-ignore-startup-failures
@@ -545,6 +547,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum size in bytes of in-memory index cache used to speed up blocks index lookups (shared between all tenants). (default 1073741824)
   -blocks-storage.bucket-store.index-cache.memcached.addresses comma-separated-list-of-strings
     	Comma-separated list of memcached addresses. Each address can be an IP address, hostname, or an entry specified in the DNS Service Discovery format.
+  -blocks-storage.bucket-store.index-cache.memcached.addresses-provider value
+    	[experimental] DNS provider used for resolving memcached addresses. Available providers golang, miekgdns, miekgdns2 (default "miekgdns")
   -blocks-storage.bucket-store.index-cache.memcached.connect-timeout duration
     	The connection timeout. (default 200ms)
   -blocks-storage.bucket-store.index-cache.memcached.dns-ignore-startup-failures
@@ -669,6 +673,8 @@ Usage of ./cmd/mimir/mimir:
     	How long to cache list of chunks for a block. (default 24h0m0s)
   -blocks-storage.bucket-store.metadata-cache.memcached.addresses comma-separated-list-of-strings
     	Comma-separated list of memcached addresses. Each address can be an IP address, hostname, or an entry specified in the DNS Service Discovery format.
+  -blocks-storage.bucket-store.metadata-cache.memcached.addresses-provider value
+    	[experimental] DNS provider used for resolving memcached addresses. Available providers golang, miekgdns, miekgdns2 (default "miekgdns")
   -blocks-storage.bucket-store.metadata-cache.memcached.connect-timeout duration
     	The connection timeout. (default 200ms)
   -blocks-storage.bucket-store.metadata-cache.memcached.dns-ignore-startup-failures
@@ -2423,6 +2429,8 @@ Usage of ./cmd/mimir/mimir:
     	Enable cache compression, if not empty. Supported values are: snappy.
   -query-frontend.results-cache.memcached.addresses comma-separated-list-of-strings
     	Comma-separated list of memcached addresses. Each address can be an IP address, hostname, or an entry specified in the DNS Service Discovery format.
+  -query-frontend.results-cache.memcached.addresses-provider value
+    	[experimental] DNS provider used for resolving memcached addresses. Available providers golang, miekgdns, miekgdns2 (default "miekgdns")
   -query-frontend.results-cache.memcached.connect-timeout duration
     	The connection timeout. (default 200ms)
   -query-frontend.results-cache.memcached.dns-ignore-startup-failures
@@ -2693,6 +2701,8 @@ Usage of ./cmd/mimir/mimir:
     	Backend for ruler storage cache, if not empty. The cache is supported for any storage backend except "local". Supported values: memcached, redis.
   -ruler-storage.cache.memcached.addresses comma-separated-list-of-strings
     	Comma-separated list of memcached addresses. Each address can be an IP address, hostname, or an entry specified in the DNS Service Discovery format.
+  -ruler-storage.cache.memcached.addresses-provider value
+    	[experimental] DNS provider used for resolving memcached addresses. Available providers golang, miekgdns, miekgdns2 (default "miekgdns")
   -ruler-storage.cache.memcached.connect-timeout duration
     	The connection timeout. (default 200ms)
   -ruler-storage.cache.memcached.dns-ignore-startup-failures

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -245,6 +245,8 @@ The following features are currently experimental:
   - Customise write and read buffer size
     - `-<prefix>.memcached.write-buffer-size-bytes`
     - `-<prefix>.memcached.read-buffer-size-bytes`
+  - Alternate DNS service discovery backend
+    - `-<prefix>.memcached.addresses-provider`
 - Timeseries Unmarshal caching optimization in distributor (`-timeseries-unmarshal-caching-optimization-enabled`)
 - Reusing buffers for marshalling write requests in distributors (`-distributor.write-requests-buffer-pooling-enabled`)
 - Logging of requests that did not send any HTTP request: `-server.http-log-closed-connections-without-response-enabled`.

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -5186,6 +5186,11 @@ The `memcached` block configures the Memcached-based caching backend. The suppor
 # CLI flag: -<prefix>.memcached.addresses
 [addresses: <string> | default = ""]
 
+# (experimental) DNS provider used for resolving memcached addresses. Available
+# providers golang, miekgdns, miekgdns2
+# CLI flag: -<prefix>.memcached.addresses-provider
+[addresses_provider: <string> | default = "miekgdns"]
+
 # The socket read/write timeout.
 # CLI flag: -<prefix>.memcached.timeout
 [timeout: <duration> | default = 200ms]

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20250312185509-4320c75000d9
+	github.com/grafana/dskit v0.0.0-20250314184143-8abd91ce153f
 	github.com/grafana/e2e v0.1.2-0.20250306030804-b80b212be908
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.7.11

--- a/go.sum
+++ b/go.sum
@@ -1274,8 +1274,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20250310104713-16b885f1c79e h1:noJzp/qZGIto4XdZkvj2EKQ1bQeqCRs0bedxdJN17sQ=
 github.com/grafana/alerting v0.0.0-20250310104713-16b885f1c79e/go.mod h1:HfvjmU3UqCIpoy9Z2wgKGrZ4A5vz+yQlP9ZXvCfEkiA=
-github.com/grafana/dskit v0.0.0-20250312185509-4320c75000d9 h1:KJXiYEXsaI2C2x0wquKwH1O6A71BEalr/EOuhXt9s6c=
-github.com/grafana/dskit v0.0.0-20250312185509-4320c75000d9/go.mod h1:XG+m+dyFETjmwcds1Sde6L0KQvtUUfvjs+n7MdrTrAM=
+github.com/grafana/dskit v0.0.0-20250314184143-8abd91ce153f h1:EpKxS54XgalLZgxE6t6N4qcvtPMtJfBtrxqq2f8dCsE=
+github.com/grafana/dskit v0.0.0-20250314184143-8abd91ce153f/go.mod h1:XG+m+dyFETjmwcds1Sde6L0KQvtUUfvjs+n7MdrTrAM=
 github.com/grafana/e2e v0.1.2-0.20250306030804-b80b212be908 h1:l3pFNUs4heAhiXnMo0thaJQrNWeE4SgLqUOEUmZtC6A=
 github.com/grafana/e2e v0.1.2-0.20250306030804-b80b212be908/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/franz-go v0.0.0-20241009100846-782ba1442937 h1:fwwnG/NcygoS6XbAaEyK2QzMXI/BZIEJvQ3CD+7XZm8=

--- a/vendor/github.com/grafana/dskit/dns/miekgdns2/resolver.go
+++ b/vendor/github.com/grafana/dskit/dns/miekgdns2/resolver.go
@@ -1,0 +1,435 @@
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/discovery/dns/miekgdns/resolver.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package miekgdns2
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/miekg/dns"
+
+	"github.com/grafana/dskit/multierror"
+)
+
+const (
+	DefaultResolvConfPath   = "/etc/resolv.conf"
+	defaultResolvConfReload = time.Second * 5
+	defaultMaxConnsPerHost  = 2
+)
+
+type Client interface {
+	Exchange(ctx context.Context, msg *dns.Msg, server string) (*dns.Msg, time.Duration, error)
+	Clean(known []string)
+}
+
+// Resolver is a DNS service discovery backend that retries on errors, only uses TCP,
+// and pools connections to nameservers to increase reliability.
+//
+// This backend:
+// * Does _not_ use search domains, all names are assumed to be fully qualified
+// * Only uses TCP connections to the nameservers
+// * Keeps several connections to each nameserver open
+// * Reads resolv.conf periodically, using stale configuration if this fails
+// * Closes connections to unknown nameservers periodically
+//
+// The following parts of resolv.conf are supported:
+// * `nameserver` setting
+// * `attempts` option
+//
+// The following parts of resolv.conf are NOT supported.
+// * `search` setting
+// * `timeout` option
+// * `ndots` option
+type Resolver struct {
+	client       Client
+	logger       log.Logger
+	confPath     string
+	reloadPeriod time.Duration
+	stop         chan struct{}
+
+	mtx  sync.RWMutex
+	conf *dns.ClientConfig
+}
+
+// NewResolver creates a new Resolver that uses the provided resolv.conf configuration
+// to perform DNS queries. Configuration from resolv.conf will be periodically reloaded.
+func NewResolver(resolvConf string, logger log.Logger) *Resolver {
+	return NewResolverWithClient(resolvConf, logger, defaultResolvConfReload, NewPoolingClient(defaultMaxConnsPerHost))
+}
+
+// NewResolverWithClient creates a new Resolver that uses the provided resolv.conf configuration,
+// reload period, and Client implementation to perform DNS queries. Configuration from resolv.conf
+// will be periodically reloaded.
+func NewResolverWithClient(resolvConf string, logger log.Logger, reloadPeriod time.Duration, client Client) *Resolver {
+	r := &Resolver{
+		client:       client,
+		logger:       logger,
+		confPath:     resolvConf,
+		reloadPeriod: reloadPeriod,
+		stop:         make(chan struct{}),
+	}
+
+	// Attempt an initial load of the configuration but fallback to defaults if it fails. The file
+	// missing should not be fatal according to `man 5 resolv.conf`.
+	if err := r.loadConfig(); err != nil {
+		level.Warn(r.logger).Log("msg", "unable to load resolv.conf, using default values", "path", r.confPath, "err", err)
+		r.conf = defaultClientConfig()
+	}
+
+	// Attempt to reload configuration periodically. If the reloads fail, old values are used.
+	go r.loop()
+	return r
+}
+
+// Stop stops periodic tasks run by the Resolver. The resolver should not be used after it is stopped.
+func (r *Resolver) Stop() {
+	close(r.stop)
+}
+
+func (r *Resolver) IsNotFound(error) bool {
+	// We don't return an error when there are no hosts found so this is
+	// always false. Instead, we return the empty DNS response with the
+	// appropriate return code set.
+	return false
+}
+
+func (r *Resolver) LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	return r.lookupSRV(ctx, r.getConfig(), service, proto, name)
+}
+
+func (r *Resolver) lookupSRV(ctx context.Context, conf *dns.ClientConfig, service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	var target string
+	if service == "" && proto == "" {
+		target = name
+	} else {
+		target = "_" + service + "._" + proto + "." + name
+	}
+
+	response, err := r.query(ctx, conf, target, dns.Type(dns.TypeSRV))
+	if err != nil {
+		return "", nil, err
+	}
+
+	for _, record := range response.Answer {
+		switch addr := record.(type) {
+		case *dns.SRV:
+			addrs = append(addrs, &net.SRV{
+				Weight:   addr.Weight,
+				Target:   addr.Target,
+				Priority: addr.Priority,
+				Port:     addr.Port,
+			})
+		default:
+			return "", nil, fmt.Errorf("invalid SRV response record %s", record)
+		}
+	}
+
+	return "", addrs, err
+}
+
+func (r *Resolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	return r.lookupIPAddr(ctx, r.getConfig(), host, 1, 8)
+}
+
+func (r *Resolver) lookupIPAddr(ctx context.Context, conf *dns.ClientConfig, host string, currIteration, maxIterations int) ([]net.IPAddr, error) {
+	// We want to protect from infinite loops when resolving DNS records recursively.
+	if currIteration > maxIterations {
+		return nil, fmt.Errorf("maximum number of recursive iterations reached (%d)", maxIterations)
+	}
+
+	response, err := r.query(ctx, conf, host, dns.Type(dns.TypeAAAA))
+	if err != nil || len(response.Answer) == 0 {
+		// Ugly fallback to A lookup.
+		response, err = r.query(ctx, conf, host, dns.Type(dns.TypeA))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var resp []net.IPAddr
+	for _, record := range response.Answer {
+		switch addr := record.(type) {
+		case *dns.A:
+			resp = append(resp, net.IPAddr{IP: addr.A})
+		case *dns.AAAA:
+			resp = append(resp, net.IPAddr{IP: addr.AAAA})
+		case *dns.CNAME:
+			// Recursively resolve it.
+			addrs, err := r.lookupIPAddr(ctx, conf, addr.Target, currIteration+1, maxIterations)
+			if err != nil {
+				return nil, fmt.Errorf("%w: recursively resolve %s", err, addr.Target)
+			}
+			resp = append(resp, addrs...)
+		default:
+			return nil, fmt.Errorf("invalid A, AAAA or CNAME response record %s", record)
+		}
+	}
+	return resp, nil
+}
+
+func (r *Resolver) query(ctx context.Context, conf *dns.ClientConfig, name string, qType dns.Type) (*dns.Msg, error) {
+	// We don't support search domains, all names are assumed to be fully qualified already.
+	msg := new(dns.Msg).SetQuestion(dns.Fqdn(name), uint16(qType))
+
+	merr := multierror.New()
+	// `man 5 resolv.conf` says that we should try each server, continuing to the next if
+	// there is a timeout. We should repeat this process up to "attempt" times trying to get
+	// a viable response.
+	//
+	// > (The algorithm used is to try a name server, and if the query times out, try the next,
+	// > until out of name servers, then repeat trying all the name servers until a maximum number
+	// > of retries are made.)
+	for i := 0; i < conf.Attempts; i++ {
+		for _, ip := range conf.Servers {
+			server := net.JoinHostPort(ip, conf.Port)
+			response, _, err := r.client.Exchange(ctx, msg, server)
+			if err != nil {
+				merr.Add(fmt.Errorf("resolution against server %s: %w", server, err))
+				continue
+			}
+
+			if response.Truncated {
+				merr.Add(fmt.Errorf("resolution against server %s: response truncated", server))
+				continue
+			}
+
+			if response.Rcode == dns.RcodeSuccess || response.Rcode == dns.RcodeNameError {
+				return response, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("could not resolve %s: no servers returned a viable answer. Errs %s", name, merr.Err())
+}
+
+// loop periodically reloads configuration from resolv.conf until the resolver is stopped.
+func (r *Resolver) loop() {
+	ticker := time.NewTicker(r.reloadPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := r.loadConfig(); err != nil {
+				level.Warn(r.logger).Log("msg", "unable to reload resolv.conf, using old values", "path", r.confPath, "err", err)
+			}
+		case <-r.stop:
+			return
+		}
+	}
+}
+
+// loadConfig loads and updates configuration from the configured resolv.conf path,
+// closing connections to defunct servers that are no longer configured, and returning
+// an error if the configuration file couldn't be opened or parsed. If an error is
+// returned, connections are not closed and the stored configuration is not updated.
+func (r *Resolver) loadConfig() error {
+	conf, err := dns.ClientConfigFromFile(r.confPath)
+	if err != nil {
+		return fmt.Errorf("could not load %s: %w", r.confPath, err)
+	}
+
+	// Note that we're building the list of known servers for the r.client.Clean method
+	// below from the newly read configuration before updating r.conf so that we know
+	// that the configuration can't be modified by another thread.
+	servers := make([]string, len(conf.Servers))
+	for i, ip := range conf.Servers {
+		servers[i] = net.JoinHostPort(ip, conf.Port)
+	}
+
+	r.mtx.Lock()
+	r.conf = conf
+	r.mtx.Unlock()
+
+	// Close connections to any servers that are no longer in resolv.conf.
+	r.client.Clean(servers)
+
+	return nil
+}
+
+func (r *Resolver) getConfig() *dns.ClientConfig {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	return &dns.ClientConfig{
+		Servers:  r.conf.Servers,
+		Search:   r.conf.Search,
+		Port:     r.conf.Port,
+		Ndots:    r.conf.Ndots,
+		Timeout:  r.conf.Timeout,
+		Attempts: r.conf.Attempts,
+	}
+}
+
+// defaultClientConfig returns Default values if resolv.conf can't be loaded, picked based on values from `man 5 resolv.conf`
+func defaultClientConfig() *dns.ClientConfig {
+	return &dns.ClientConfig{
+		Servers:  []string{"127.0.0.1"},
+		Search:   []string{},
+		Port:     "53",
+		Ndots:    1,
+		Timeout:  5,
+		Attempts: 2,
+	}
+}
+
+// PoolingClient is a DNS client that pools TCP connections to each nameserver.
+type PoolingClient struct {
+	network string
+	maxOpen int
+
+	mtx   sync.Mutex
+	pools map[string]*Pool
+}
+
+// NewPoolingClient creates a new PoolingClient instance that keeps up to maxOpen connections to each nameserver.
+func NewPoolingClient(maxOpen int) *PoolingClient {
+	return &PoolingClient{
+		network: "tcp",
+		maxOpen: maxOpen,
+		pools:   make(map[string]*Pool),
+	}
+}
+
+// Exchange sends the DNS msg to the nameserver using a pooled connection. The nameserver must be
+// of the form "ip:port".
+func (c *PoolingClient) Exchange(ctx context.Context, msg *dns.Msg, server string) (*dns.Msg, time.Duration, error) {
+	pool := c.getPool(server)
+	conn, err := pool.Get(ctx, c.network, server)
+	if err != nil {
+		return nil, 0, fmt.Errorf("unable to create connection to %s via %s: %w", server, c.network, err)
+	}
+
+	connOk := true
+	defer func() {
+		if connOk {
+			_ = pool.Put(conn)
+		} else {
+			pool.Discard(conn)
+		}
+	}()
+
+	client := &dns.Client{Net: c.network}
+	response, rtt, err := client.ExchangeWithConnContext(ctx, msg, conn)
+	if err != nil {
+		connOk = false
+	}
+
+	return response, rtt, err
+}
+
+// Clean closes connections to any nameservers that are _not_ part of list of known
+// nameservers. The nameservers must be of the form "ip:port", the same format as the
+// Exchange method.
+func (c *PoolingClient) Clean(known []string) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	for server, pool := range c.pools {
+		if slices.Contains(known, server) {
+			continue
+		}
+
+		pool.Close()
+		delete(c.pools, server)
+	}
+}
+
+func (c *PoolingClient) getPool(server string) *Pool {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	p, ok := c.pools[server]
+	if !ok {
+		p = NewPool(c.maxOpen)
+		c.pools[server] = p
+	}
+
+	return p
+}
+
+// Pool is a pool of DNS connections for a single DNS server.
+type Pool struct {
+	mtx    sync.RWMutex
+	conns  chan *dns.Conn
+	closed bool
+}
+
+// NewPool creates a new DNS connection Pool, keeping up to maxConns open.
+func NewPool(maxConns int) *Pool {
+	return &Pool{
+		conns: make(chan *dns.Conn, maxConns),
+	}
+}
+
+// Get gets an existing connection from the pool or creates a new one if there are no
+// pooled connections available. If the pool has been closed, an error is returned.
+func (p *Pool) Get(ctx context.Context, network string, server string) (*dns.Conn, error) {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	if p.closed {
+		return nil, fmt.Errorf("connection pool for %s %s is closed", network, server)
+	}
+
+	select {
+	case conn := <-p.conns:
+		return conn, nil
+	default:
+		return p.newConn(ctx, network, server)
+	}
+}
+
+// Put returns a healthy connection to the pool, potentially closing it if the pool is
+// already at capacity. If the pool has been closed, the connection will be closed immediately.
+func (p *Pool) Put(conn *dns.Conn) error {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+
+	if p.closed {
+		return conn.Close()
+	}
+
+	select {
+	case p.conns <- conn:
+		return nil
+	default:
+		return conn.Close()
+	}
+}
+
+// Discard closes and does not return the given broken connection to the pool.
+func (p *Pool) Discard(conn *dns.Conn) {
+	_ = conn.Close()
+}
+
+// Close shuts down this pool, closing all existing connections and preventing new connections
+// from being created. Any attempts to get a connection from this pool after it is closed will
+// result in an error.
+func (p *Pool) Close() {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	p.closed = true
+	for {
+		select {
+		case c := <-p.conns:
+			_ = c.Close()
+		default:
+			return
+		}
+	}
+}
+
+func (p *Pool) newConn(ctx context.Context, network string, server string) (*dns.Conn, error) {
+	client := &dns.Client{Net: network}
+	return client.DialContext(ctx, server)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -645,7 +645,7 @@ github.com/grafana/alerting/receivers/webex
 github.com/grafana/alerting/receivers/webhook
 github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
-# github.com/grafana/dskit v0.0.0-20250312185509-4320c75000d9
+# github.com/grafana/dskit v0.0.0-20250314184143-8abd91ce153f
 ## explicit; go 1.21
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast
@@ -657,6 +657,7 @@ github.com/grafana/dskit/crypto/tls
 github.com/grafana/dskit/dns
 github.com/grafana/dskit/dns/godns
 github.com/grafana/dskit/dns/miekgdns
+github.com/grafana/dskit/dns/miekgdns2
 github.com/grafana/dskit/flagext
 github.com/grafana/dskit/gate
 github.com/grafana/dskit/grpcclient


### PR DESCRIPTION
#### What this PR does

Update to https://github.com/grafana/dskit/commit/8abd91ce153f15ce4852d7f51e243816b3855eb8 to pull in grafana/dskit#660. This adds an additional experimental DNS backend for service discovery of Memcached servers that is disabled by default.

Notable changes:
* Does not use search domains
* Always uses TCP instead of UDP
* Keeps connections to the server open if possible
* Retries on timeouts and other network issues

#### Which issue(s) this PR fixes or relates to

Related grafana/dskit#660

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
