### PR TITLE
Expose query stats in `Server-Timing` header when `X-Mimir-Response-Query-Stats` header is present in the request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [CHANGE] Store-gateway: Include posting sampling rate in sparse index headers. When the sampling rate isn't set in a sparse index header, store gateway rebuilds the sparse header with the configured `blocks-storage.bucket-store.posting-offsets-in-mem-sampling` value. If the sparse header's sampling rate is set but doesn't match the configured rate, store gateway either rebuilds the sparse header or downsamples to the configured sampling rate. #10684 #10878
 * [CHANGE] Distributor: Return specific error message when burst size limit is exceeded. #10835
 * [CHANGE] Ingester: enable native histograms ingestion by default, meaning`ingester.native-histograms-ingestion-enabled` defaults to true. #10867
+* [FEATURE] Query Frontend: Expose query stats in `Server-Timing` header when `X-Mimir-Response-Query-Stats` header is present in the request. #10192
 * [FEATURE] Ingester/Distributor: Add support for exporting cost attribution metrics (`cortex_ingester_attributed_active_series`, `cortex_distributor_received_attributed_samples_total`, and `cortex_discarded_attributed_samples_total`) with labels specified by customers to a custom Prometheus registry. This feature enables more flexible billing data tracking. #10269 #10702
 * [FEATURE] Ruler: Added `/ruler/tenants` endpoints to list the discovered tenants with rule groups. #10738
 * [FEATURE] Distributor: Add experimental Influx handler. #10153

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -39,10 +39,11 @@ import (
 
 const (
 	// StatusClientClosedRequest is the status code for when a client request cancellation of an http request
-	StatusClientClosedRequest = 499
-	ServiceTimingHeaderName   = "Server-Timing"
-	cacheControlHeader        = "Cache-Control"
-	cacheControlLogField      = "header_cache_control"
+	StatusClientClosedRequest    = 499
+	ServiceTimingHeaderName      = "Server-Timing"
+	cacheControlHeader           = "Cache-Control"
+	cacheControlLogField         = "header_cache_control"
+	responseQueryStatsHeaderName = "X-Mimir-Response-Query-Stats"
 )
 
 var (
@@ -177,7 +178,8 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Initialise the queryDetails in the context and make sure it's propagated
 	// down the request chain.
-	if f.cfg.QueryStatsEnabled {
+	queryStatsHeaderNameOk, queryStatsHeaderNameOkErr := strconv.ParseBool(r.Header.Get(responseQueryStatsHeaderName))
+	if f.cfg.QueryStatsEnabled || (queryStatsHeaderNameOk && queryStatsHeaderNameOkErr == nil) {
 		var ctx context.Context
 		queryDetails, ctx = querymiddleware.ContextWithEmptyDetails(r.Context())
 		r = r.WithContext(ctx)
@@ -244,10 +246,6 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		hs[h] = vs
 	}
 
-	if f.cfg.QueryStatsEnabled {
-		writeServiceTimingHeader(queryResponseTime, hs, queryDetails.QuerierStats)
-	}
-
 	w.WriteHeader(resp.StatusCode)
 	// we don't check for copy error as there is no much we can do at this point
 	queryResponseSize, _ := io.Copy(w, resp.Body)
@@ -257,6 +255,17 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if f.cfg.QueryStatsEnabled {
 		f.reportQueryStats(r, params, startTime, queryResponseTime, queryResponseSize, queryDetails, resp.StatusCode, nil)
+	}
+
+	var parts []string
+	if f.cfg.QueryStatsEnabled {
+		parts = getQueryStats(queryResponseTime, queryDetails.QuerierStats)
+	}
+	if queryStatsHeaderNameOk && queryStatsHeaderNameOkErr == nil {
+		parts = append(parts, getResponseQueryStats(queryResponseTime, queryResponseSize, queryDetails)...)
+	}
+	if len(parts) > 0 {
+		hs.Set(ServiceTimingHeaderName, strings.Join(parts, ", "))
 	}
 }
 
@@ -481,26 +490,55 @@ func writeError(w http.ResponseWriter, err error) int {
 	return statusCode
 }
 
-func writeServiceTimingHeader(queryResponseTime time.Duration, headers http.Header, stats *querier_stats.Stats) {
-	if stats != nil {
-		parts := make([]string, 0)
-		parts = append(parts, statsValue("querier_wall_time", stats.LoadWallTime()))
-		parts = append(parts, statsValue("response_time", queryResponseTime))
-		parts = append(parts, statsValue("bytes_processed", stats.LoadFetchedChunkBytes()+stats.LoadFetchedIndexBytes()))
-		parts = append(parts, statsValue("samples_processed", stats.GetSamplesProcessed()))
-		headers.Set(ServiceTimingHeaderName, strings.Join(parts, ", "))
+func getQueryStats(queryResponseTime time.Duration, stats *querier_stats.Stats) []string {
+	if stats == nil {
+		return nil
 	}
+	parts := make([]string, 0)
+	parts = append(parts, statsValue("querier_wall_time", stats.LoadWallTime()))
+	parts = append(parts, statsValue("response_time", queryResponseTime))
+	parts = append(parts, statsValue("bytes_processed", stats.LoadFetchedChunkBytes()+stats.LoadFetchedIndexBytes()))
+	parts = append(parts, statsValue("samples_processed", stats.GetSamplesProcessed()))
+	return parts
+}
+
+// getResponseQueryStats returns the response query stats in the format of Server-Timing header.
+func getResponseQueryStats(queryResponseTime time.Duration, queryResponseSizeBytes int64, details *querymiddleware.QueryDetails) []string {
+	if details == nil {
+		return nil
+	}
+	stats := details.QuerierStats
+	parts := make([]string, 0)
+	parts = append(parts, statsValue("encode", stats.LoadEncodeTime()))
+	parts = append(parts, statsValueWithKey("series_count", "c", stats.LoadEstimatedSeriesCount()))
+	parts = append(parts, statsValueWithKey("chunk_bytes", "c", stats.LoadFetchedChunkBytes()))
+	parts = append(parts, statsValueWithKey("chunks_count", "c", stats.LoadFetchedChunks()))
+	parts = append(parts, statsValueWithKey("index_bytes", "c", stats.LoadFetchedIndexBytes()))
+	parts = append(parts, statsValueWithKey("series_fetched", "c", stats.LoadFetchedSeries()))
+	parts = append(parts, statsValueWithKey("wall_time", "c", stats.LoadWallTime()))
+	parts = append(parts, statsValue("queue", stats.LoadQueueTime()))
+	parts = append(parts, statsValueWithKey("response_size", "c", queryResponseSizeBytes))
+	parts = append(parts, statsValue("response_time", queryResponseTime))
+	parts = append(parts, statsValueWithKey("cache_hit", "c", details.ResultsCacheHitBytes))
+	parts = append(parts, statsValueWithKey("cache_miss", "c", details.ResultsCacheMissBytes))
+	parts = append(parts, statsValueWithKey("sharded", "c", stats.LoadShardedQueries()))
+	parts = append(parts, statsValueWithKey("split", "c", stats.LoadSplitQueries()))
+	return parts
 }
 
 func statsValue(name string, val interface{}) string {
+	return statsValueWithKey(name, "val", val)
+}
+
+func statsValueWithKey(name string, key string, val interface{}) string {
 	switch v := val.(type) {
 	case time.Duration:
 		durationInMs := strconv.FormatFloat(float64(v)/float64(time.Millisecond), 'f', -1, 64)
 		return name + ";dur=" + durationInMs
 	case uint64:
-		return name + ";val=" + strconv.FormatUint(v, 10)
+		return name + ";" + key + "=" + strconv.FormatUint(v, 10)
 	default:
-		return name + ";val=" + fmt.Sprintf("%v", v)
+		return name + ";" + key + "=" + fmt.Sprintf("%v", v)
 	}
 }
 

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -303,8 +304,84 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			expectedActivity:        "user:12345 UA: req:POST /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 			assertHeaders: func(t *testing.T, headers http.Header) {
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "querier_wall_time;dur=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "response_time;dur=1.670167")
 				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "bytes_processed;val=0")
 				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "samples_processed;val=0")
+			},
+		},
+		{
+			name: "handler with QueryStatsEnabled and X-Mimir-Response-Query-Stats in true, check ServiceTimingHeader",
+			cfg:  HandlerConfig{QueryStatsEnabled: true, MaxBodySize: 1024},
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/api/v1/query", strings.NewReader("query=some_metric&time=42"))
+				req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+				req.Header.Add(responseQueryStatsHeaderName, strconv.FormatBool(true))
+				return req
+			},
+			downstreamResponse: makeSuccessfulDownstreamResponse(),
+			expectedStatusCode: 200,
+			expectedParams: url.Values{
+				"query": []string{"some_metric"},
+				"time":  []string{"42"},
+			},
+			expectedMetrics:         0,
+			expectedActivity:        "user:12345 UA: req:POST /api/v1/query query=some_metric&time=42",
+			expectedReadConsistency: "",
+			assertHeaders: func(t *testing.T, headers http.Header) {
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "querier_wall_time;dur=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "response_time;dur=1.670167")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "bytes_processed;val=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "samples_processed;val=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "encode;dur=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "series_count;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "chunk_bytes;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "chunks_count;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "index_bytes;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "series_fetched;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "wall_time;dur=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "queue;dur=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "response_size;c=2")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "response_time;dur=1.906208")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "cache_hit;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "cache_miss;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "sharded;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "split;c=0")
+			},
+		},
+		{
+			name: "handler with X-Mimir-Response-Query-Stats in true, check ServiceTimingHeader",
+			cfg:  HandlerConfig{QueryStatsEnabled: false, MaxBodySize: 1024},
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/api/v1/query", strings.NewReader("query=some_metric&time=42"))
+				req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+				req.Header.Add(responseQueryStatsHeaderName, strconv.FormatBool(true))
+				return req
+			},
+			downstreamResponse: makeSuccessfulDownstreamResponse(),
+			expectedStatusCode: 200,
+			expectedParams: url.Values{
+				"query": []string{"some_metric"},
+				"time":  []string{"42"},
+			},
+			expectedMetrics:         0,
+			expectedActivity:        "user:12345 UA: req:POST /api/v1/query query=some_metric&time=42",
+			expectedReadConsistency: "",
+			assertHeaders: func(t *testing.T, headers http.Header) {
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "encode;dur=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "series_count;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "chunk_bytes;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "chunks_count;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "index_bytes;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "series_fetched;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "wall_time;dur=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "queue;dur=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "response_size;c=2")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "response_time;dur=1.906208")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "cache_hit;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "cache_miss;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "sharded;c=0")
+				assert.Contains(t, headers.Get(ServiceTimingHeaderName), "split;c=0")
 			},
 		},
 	} {
@@ -359,6 +436,11 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, activities)
 
+			// it checks headers when QueryStatsEnabled is true or X-Mimir-Response-Query-Stats is true.
+			if tt.assertHeaders != nil {
+				tt.assertHeaders(t, resp.Header())
+			}
+
 			if tt.cfg.QueryStatsEnabled {
 				require.Len(t, logger.logMessages, 1)
 
@@ -392,9 +474,6 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				// The response size is tracked only for successful requests.
 				if tt.expectedStatusCode >= 200 && tt.expectedStatusCode < 300 {
 					require.Equal(t, int64(len(responseData)), msg["response_size_bytes"])
-				}
-				if tt.assertHeaders != nil {
-					tt.assertHeaders(t, resp.Header())
 				}
 
 				// Check that the HTTP or Protobuf request parameters are logged.


### PR DESCRIPTION
#### What this PR does

Expose query stats in `Server-Timing` header when `X-Mimir-Response-Query-Stats` header is present in the request.

#### Which issue(s) this PR fixes or relates to

Fixes #10192 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
