### PR TITLE
fix(distributor): relax content-type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@
 * [BUGFIX] MQE: Fix deriv with histograms #10383
 * [BUGFIX] PromQL: Fix <aggr_over_time> functions with histograms https://github.com/prometheus/prometheus/pull/15711 #10400
 * [BUGFIX] MQE: Fix <aggr_over_time> functions with histograms #10400
-* [BUGFIX] Distributor: return HTTP status 415 Unsupported Media Type instead of 200 Success for Remote Write 2.0 until we support it. #10423
+* [BUGFIX] Distributor: return HTTP status 415 Unsupported Media Type instead of 200 Success for Remote Write 2.0 until we support it. #10423 #10916
 * [BUGFIX] Query-frontend: Add flag `-query-frontend.prom2-range-compat` and corresponding YAML to rewrite queries with ranges that worked in Prometheus 2 but are invalid in Prometheus 3. #10445 #10461 #10502
 * [BUGFIX] Distributor: Fix edge case at the HA-tracker with memberlist as KVStore, where when a replica in the KVStore is marked as deleted but not yet removed, it fails to update the KVStore. #10443
 * [BUGFIX] Distributor: Fix panics in `DurationWithJitter` util functions when computed variance is zero. #10507

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -251,7 +251,9 @@ func isRemoteWrite2(r *http.Request) (bool, error) {
 	}
 	parts := strings.Split(contentType, ";")
 	if parts[0] != appProtoContentType {
-		return false, fmt.Errorf("expected %v as the first (media) part, got %v content-type", appProtoContentType, contentType)
+		// We didn't use to check the content type so if someone wrote for
+		// example text/plain here, we'll accept and assume it is v1.
+		return false, nil
 	}
 
 	// Parse potential https://www.rfc-editor.org/rfc/rfc9110#parameter


### PR DESCRIPTION
#### What this PR does

We used to allow content type == text/plain for Prometheus remote write v1 push. Let's continue to not impact users.

#### Which issue(s) this PR fixes or relates to

Fixes : N/A (support case)
Follows: #10423 

#### Checklist

- [x] Tests updated.
- [N/A] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
