### PR TITLE
mixin: include absolute value of ruler notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,7 @@
 * [ENHANCEMENT] Alerts: add `MimirIngesterMissedRecordsFromKafka` to detect gaps in consumed records in the ingester when using the experimental Kafka-based storage. #9921 #9972
 * [ENHANCEMENT] Dashboards: Add more panels to 'Mimir / Writes' for concurrent ingestion and fetching when using ingest storage. #10021
 * [ENHANCEMENT] Dashboards: Include CPU and memory resources in 'Mimir / Ruler' dashboard. #10656
+* [ENHANCEMENT] Dashboards: Include absolute number of notifications attempted to alertmanager in 'Mimir / Ruler'. #10918
 * [BUGFIX] Dashboards: Fix autoscaling metrics joins when series churn. #9412 #9450 #9432
 * [BUGFIX] Alerts: Fix autoscaling metrics joins in `MimirAutoscalerNotActive` when series churn. #9412
 * [BUGFIX] Alerts: Exclude failed cache "add" operations from alerting since failures are expected in normal operation. #9658

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Mixin
 
+* [ENHANCEMENT] Dashboards: Include absolute number of notifications attempted to alertmanager in 'Mimir / Ruler'. #10918
+
 ### Jsonnet
 
 ### Mimirtool
@@ -318,7 +320,6 @@
 * [ENHANCEMENT] Alerts: add `MimirIngesterMissedRecordsFromKafka` to detect gaps in consumed records in the ingester when using the experimental Kafka-based storage. #9921 #9972
 * [ENHANCEMENT] Dashboards: Add more panels to 'Mimir / Writes' for concurrent ingestion and fetching when using ingest storage. #10021
 * [ENHANCEMENT] Dashboards: Include CPU and memory resources in 'Mimir / Ruler' dashboard. #10656
-* [ENHANCEMENT] Dashboards: Include absolute number of notifications attempted to alertmanager in 'Mimir / Ruler'. #10918
 * [BUGFIX] Dashboards: Fix autoscaling metrics joins when series churn. #9412 #9450 #9432
 * [BUGFIX] Alerts: Fix autoscaling metrics joins in `MimirAutoscalerNotActive` when series churn. #9412
 * [BUGFIX] Alerts: Exclude failed cache "add" operations from alerting since failures are expected in normal operation. #9658

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -34379,6 +34379,7 @@ data:
                                   "mode": "none"
                                }
                             },
+                            "max": 1,
                             "min": 0,
                             "thresholds": {
                                "mode": "absolute",
@@ -34433,6 +34434,7 @@ data:
                                   "mode": "none"
                                }
                             },
+                            "max": 1,
                             "min": 0,
                             "thresholds": {
                                "mode": "absolute",

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -34303,6 +34303,7 @@ data:
                 "panels": [
                    {
                       "datasource": "$datasource",
+                      "description": "### Notifications\nShows the absolute rate of notification outcomes:\n- Sent: Successfully delivered notifications\n- Errors: Notifications that encountered errors during delivery\n- Dropped: Notifications that were dropped from the sending queue because the queue is full\n\n",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {
@@ -34318,12 +34319,11 @@ data:
                                }
                             },
                             "min": 0,
-                            "noValue": 0,
                             "thresholds": {
                                "mode": "absolute",
                                "steps": [ ]
                             },
-                            "unit": "short"
+                            "unit": "reqps"
                          },
                          "overrides": [ ]
                       },
@@ -34335,23 +34335,36 @@ data:
                          },
                          "tooltip": {
                             "mode": "multi",
-                            "sort": "none"
+                            "sort": "desc"
                          }
                       },
                       "span": 4,
                       "targets": [
                          {
-                            "expr": "sum by(user) (rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  /\nsum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]) > 0)\n> 0\n",
+                            "expr": "sum(rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
                             "format": "time_series",
-                            "legendFormat": "{{ user }}",
+                            "legendFormat": "sent",
+                            "legendLink": null
+                         },
+                         {
+                            "expr": "sum(rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
+                            "format": "time_series",
+                            "legendFormat": "errors",
+                            "legendLink": null
+                         },
+                         {
+                            "expr": "sum(rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
+                            "format": "time_series",
+                            "legendFormat": "dropped",
                             "legendLink": null
                          }
                       ],
-                      "title": "Delivery errors",
+                      "title": "Notifications",
                       "type": "timeseries"
                    },
                    {
                       "datasource": "$datasource",
+                      "description": "### Undelivered notifications (per tenant)\nShows the percentage of notifications that resulted in errors or were dropped, per tenant:\n- Errors: Percentage of notifications that encountered errors during delivery\n- Dropped: Percentage of notifications that were dropped from the queue\n\nBoth percentages are calculated as proportion of total notifications (sent + dropped).\n\n",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {
@@ -34366,7 +34379,6 @@ data:
                                   "mode": "none"
                                }
                             },
-                            "max": 1,
                             "min": 0,
                             "thresholds": {
                                "mode": "absolute",
@@ -34390,13 +34402,19 @@ data:
                       "span": 4,
                       "targets": [
                          {
-                            "expr": "sum by(user) (cortex_prometheus_notifications_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"})\n  /\nsum by(user) (cortex_prometheus_notifications_queue_capacity{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}) > 0\n",
+                            "expr": "sum by(user) (rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\n(\n  sum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  +\n  sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n)\n> 0\n",
                             "format": "time_series",
-                            "legendFormat": "{{ user }}",
+                            "legendFormat": "{{user}} - errors",
+                            "legendLink": null
+                         },
+                         {
+                            "expr": "sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\n(\n  sum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  +\n  sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n)\n> 0\n",
+                            "format": "time_series",
+                            "legendFormat": "{{user}} - dropped",
                             "legendLink": null
                          }
                       ],
-                      "title": "Queue length",
+                      "title": "Undelivered notifications (per tenant)",
                       "type": "timeseries"
                    },
                    {
@@ -34416,12 +34434,11 @@ data:
                                }
                             },
                             "min": 0,
-                            "noValue": 0,
                             "thresholds": {
                                "mode": "absolute",
                                "steps": [ ]
                             },
-                            "unit": "short"
+                            "unit": "percentunit"
                          },
                          "overrides": [ ]
                       },
@@ -34439,13 +34456,13 @@ data:
                       "span": 4,
                       "targets": [
                          {
-                            "expr": "sum by (user) (increase(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0\n",
+                            "expr": "sum by(user) (cortex_prometheus_notifications_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"})\n  /\nsum by(user) (cortex_prometheus_notifications_queue_capacity{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}) > 0\n",
                             "format": "time_series",
                             "legendFormat": "{{ user }}",
                             "legendLink": null
                          }
                       ],
-                      "title": "Dropped",
+                      "title": "Queue length",
                       "type": "timeseries"
                    }
                 ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
@@ -1864,6 +1864,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
+                  "description": "### Notifications\nShows the absolute rate of notification outcomes:\n- Sent: Successfully delivered notifications\n- Errors: Notifications that encountered errors during delivery\n- Dropped: Notifications that were dropped from the sending queue because the queue is full\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1879,12 +1880,11 @@
                            }
                         },
                         "min": 0,
-                        "noValue": 0,
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "short"
+                        "unit": "reqps"
                      },
                      "overrides": [ ]
                   },
@@ -1896,23 +1896,36 @@
                      },
                      "tooltip": {
                         "mode": "multi",
-                        "sort": "none"
+                        "sort": "desc"
                      }
                   },
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(user) (rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  /\nsum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]) > 0)\n> 0\n",
+                        "expr": "sum(rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
                         "format": "time_series",
-                        "legendFormat": "{{ user }}",
+                        "legendFormat": "sent",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum(rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
+                        "format": "time_series",
+                        "legendFormat": "errors",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum(rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
+                        "format": "time_series",
+                        "legendFormat": "dropped",
                         "legendLink": null
                      }
                   ],
-                  "title": "Delivery errors",
+                  "title": "Notifications",
                   "type": "timeseries"
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Undelivered notifications (per tenant)\nShows the percentage of notifications that resulted in errors or were dropped, per tenant:\n- Errors: Percentage of notifications that encountered errors during delivery\n- Dropped: Percentage of notifications that were dropped from the queue\n\nBoth percentages are calculated as proportion of total notifications (sent + dropped).\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1927,7 +1940,6 @@
                               "mode": "none"
                            }
                         },
-                        "max": 1,
                         "min": 0,
                         "thresholds": {
                            "mode": "absolute",
@@ -1951,13 +1963,19 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(user) (cortex_prometheus_notifications_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"})\n  /\nsum by(user) (cortex_prometheus_notifications_queue_capacity{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}) > 0\n",
+                        "expr": "sum by(user) (rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\n(\n  sum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  +\n  sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n)\n> 0\n",
                         "format": "time_series",
-                        "legendFormat": "{{ user }}",
+                        "legendFormat": "{{user}} - errors",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\n(\n  sum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  +\n  sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n)\n> 0\n",
+                        "format": "time_series",
+                        "legendFormat": "{{user}} - dropped",
                         "legendLink": null
                      }
                   ],
-                  "title": "Queue length",
+                  "title": "Undelivered notifications (per tenant)",
                   "type": "timeseries"
                },
                {
@@ -1977,12 +1995,11 @@
                            }
                         },
                         "min": 0,
-                        "noValue": 0,
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "short"
+                        "unit": "percentunit"
                      },
                      "overrides": [ ]
                   },
@@ -2000,13 +2017,13 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by (user) (increase(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0\n",
+                        "expr": "sum by(user) (cortex_prometheus_notifications_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"})\n  /\nsum by(user) (cortex_prometheus_notifications_queue_capacity{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}) > 0\n",
                         "format": "time_series",
                         "legendFormat": "{{ user }}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Dropped",
+                  "title": "Queue length",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-ruler.json
@@ -1940,6 +1940,7 @@
                               "mode": "none"
                            }
                         },
+                        "max": 1,
                         "min": 0,
                         "thresholds": {
                            "mode": "absolute",
@@ -1994,6 +1995,7 @@
                               "mode": "none"
                            }
                         },
+                        "max": 1,
                         "min": 0,
                         "thresholds": {
                            "mode": "absolute",

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-ruler.json
@@ -2912,6 +2912,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
+                  "description": "### Notifications\nShows the absolute rate of notification outcomes:\n- Sent: Successfully delivered notifications\n- Errors: Notifications that encountered errors during delivery\n- Dropped: Notifications that were dropped from the sending queue because the queue is full\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -2927,12 +2928,11 @@
                            }
                         },
                         "min": 0,
-                        "noValue": 0,
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "short"
+                        "unit": "reqps"
                      },
                      "overrides": [ ]
                   },
@@ -2944,23 +2944,36 @@
                      },
                      "tooltip": {
                         "mode": "multi",
-                        "sort": "none"
+                        "sort": "desc"
                      }
                   },
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(user) (rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  /\nsum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]) > 0)\n> 0\n",
+                        "expr": "sum(rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
                         "format": "time_series",
-                        "legendFormat": "{{ user }}",
+                        "legendFormat": "sent",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum(rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
+                        "format": "time_series",
+                        "legendFormat": "errors",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum(rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
+                        "format": "time_series",
+                        "legendFormat": "dropped",
                         "legendLink": null
                      }
                   ],
-                  "title": "Delivery errors",
+                  "title": "Notifications",
                   "type": "timeseries"
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Undelivered notifications (per tenant)\nShows the percentage of notifications that resulted in errors or were dropped, per tenant:\n- Errors: Percentage of notifications that encountered errors during delivery\n- Dropped: Percentage of notifications that were dropped from the queue\n\nBoth percentages are calculated as proportion of total notifications (sent + dropped).\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -2975,7 +2988,6 @@
                               "mode": "none"
                            }
                         },
-                        "max": 1,
                         "min": 0,
                         "thresholds": {
                            "mode": "absolute",
@@ -2999,13 +3011,19 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(user) (cortex_prometheus_notifications_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"})\n  /\nsum by(user) (cortex_prometheus_notifications_queue_capacity{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}) > 0\n",
+                        "expr": "sum by(user) (rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\n(\n  sum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  +\n  sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n)\n> 0\n",
                         "format": "time_series",
-                        "legendFormat": "{{ user }}",
+                        "legendFormat": "{{user}} - errors",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\n(\n  sum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  +\n  sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n)\n> 0\n",
+                        "format": "time_series",
+                        "legendFormat": "{{user}} - dropped",
                         "legendLink": null
                      }
                   ],
-                  "title": "Queue length",
+                  "title": "Undelivered notifications (per tenant)",
                   "type": "timeseries"
                },
                {
@@ -3025,12 +3043,11 @@
                            }
                         },
                         "min": 0,
-                        "noValue": 0,
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "short"
+                        "unit": "percentunit"
                      },
                      "overrides": [ ]
                   },
@@ -3048,13 +3065,13 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by (user) (increase(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0\n",
+                        "expr": "sum by(user) (cortex_prometheus_notifications_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"})\n  /\nsum by(user) (cortex_prometheus_notifications_queue_capacity{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}) > 0\n",
                         "format": "time_series",
                         "legendFormat": "{{ user }}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Dropped",
+                  "title": "Queue length",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-ruler.json
@@ -2988,6 +2988,7 @@
                               "mode": "none"
                            }
                         },
+                        "max": 1,
                         "min": 0,
                         "thresholds": {
                            "mode": "absolute",
@@ -3042,6 +3043,7 @@
                               "mode": "none"
                            }
                         },
+                        "max": 1,
                         "min": 0,
                         "thresholds": {
                            "mode": "absolute",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -1964,6 +1964,7 @@
                               "mode": "none"
                            }
                         },
+                        "max": 1,
                         "min": 0,
                         "thresholds": {
                            "mode": "absolute",
@@ -2018,6 +2019,7 @@
                               "mode": "none"
                            }
                         },
+                        "max": 1,
                         "min": 0,
                         "thresholds": {
                            "mode": "absolute",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-ruler.json
@@ -1888,6 +1888,7 @@
             "panels": [
                {
                   "datasource": "$datasource",
+                  "description": "### Notifications\nShows the absolute rate of notification outcomes:\n- Sent: Successfully delivered notifications\n- Errors: Notifications that encountered errors during delivery\n- Dropped: Notifications that were dropped from the sending queue because the queue is full\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1903,12 +1904,11 @@
                            }
                         },
                         "min": 0,
-                        "noValue": 0,
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "short"
+                        "unit": "reqps"
                      },
                      "overrides": [ ]
                   },
@@ -1920,23 +1920,36 @@
                      },
                      "tooltip": {
                         "mode": "multi",
-                        "sort": "none"
+                        "sort": "desc"
                      }
                   },
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(user) (rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  /\nsum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]) > 0)\n> 0\n",
+                        "expr": "sum(rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
                         "format": "time_series",
-                        "legendFormat": "{{ user }}",
+                        "legendFormat": "sent",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum(rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
+                        "format": "time_series",
+                        "legendFormat": "errors",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum(rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0",
+                        "format": "time_series",
+                        "legendFormat": "dropped",
                         "legendLink": null
                      }
                   ],
-                  "title": "Delivery errors",
+                  "title": "Notifications",
                   "type": "timeseries"
                },
                {
                   "datasource": "$datasource",
+                  "description": "### Undelivered notifications (per tenant)\nShows the percentage of notifications that resulted in errors or were dropped, per tenant:\n- Errors: Percentage of notifications that encountered errors during delivery\n- Dropped: Percentage of notifications that were dropped from the queue\n\nBoth percentages are calculated as proportion of total notifications (sent + dropped).\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {
@@ -1951,7 +1964,6 @@
                               "mode": "none"
                            }
                         },
-                        "max": 1,
                         "min": 0,
                         "thresholds": {
                            "mode": "absolute",
@@ -1975,13 +1987,19 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by(user) (cortex_prometheus_notifications_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"})\n  /\nsum by(user) (cortex_prometheus_notifications_queue_capacity{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}) > 0\n",
+                        "expr": "sum by(user) (rate(cortex_prometheus_notifications_errors_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\n(\n  sum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  +\n  sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n)\n> 0\n",
                         "format": "time_series",
-                        "legendFormat": "{{ user }}",
+                        "legendFormat": "{{user}} - errors",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n/\n(\n  sum by(user) (rate(cortex_prometheus_notifications_sent_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n  +\n  sum by(user) (rate(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval]))\n)\n> 0\n",
+                        "format": "time_series",
+                        "legendFormat": "{{user}} - dropped",
                         "legendLink": null
                      }
                   ],
-                  "title": "Queue length",
+                  "title": "Undelivered notifications (per tenant)",
                   "type": "timeseries"
                },
                {
@@ -2001,12 +2019,11 @@
                            }
                         },
                         "min": 0,
-                        "noValue": 0,
                         "thresholds": {
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "short"
+                        "unit": "percentunit"
                      },
                      "overrides": [ ]
                   },
@@ -2024,13 +2041,13 @@
                   "span": 4,
                   "targets": [
                      {
-                        "expr": "sum by (user) (increase(cortex_prometheus_notifications_dropped_total{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}[$__rate_interval])) > 0\n",
+                        "expr": "sum by(user) (cortex_prometheus_notifications_queue_length{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"})\n  /\nsum by(user) (cortex_prometheus_notifications_queue_capacity{cluster=~\"$cluster\", job=~\"($namespace)/((ruler|cortex|mimir|mimir-backend.*))\"}) > 0\n",
                         "format": "time_series",
                         "legendFormat": "{{ user }}",
                         "legendLink": null
                      }
                   ],
-                  "title": "Dropped",
+                  "title": "Queue length",
                   "type": "timeseries"
                }
             ],

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -192,14 +192,93 @@ local filename = 'mimir-ruler.json';
     .addRow(
       $.row('Notifications')
       .addPanel(
-        $.timeseriesPanel('Delivery errors') +
-        $.queryPanel(|||
-          sum by(user) (rate(cortex_prometheus_notifications_errors_total{%s}[$__rate_interval]))
+        $.timeseriesPanel('Notifications') +
+        $.queryPanel([
+          'sum(rate(cortex_prometheus_notifications_sent_total{%s}[$__rate_interval])) > 0' % $.jobMatcher($._config.job_names.ruler),
+          'sum(rate(cortex_prometheus_notifications_errors_total{%s}[$__rate_interval])) > 0' % $.jobMatcher($._config.job_names.ruler),
+          'sum(rate(cortex_prometheus_notifications_dropped_total{%s}[$__rate_interval])) > 0' % $.jobMatcher($._config.job_names.ruler),
+        ], [
+          'sent',
+          'errors',
+          'dropped',
+        ]) +
+        {
+          fieldConfig+: {
+            defaults+: {
+              unit: 'reqps',
+            },
+          },
+          options+: {
+            tooltip: {
+              mode: 'multi',
+              sort: 'desc',
+            },
+          },
+        } +
+        $.panelDescription(
+          'Notifications',
+          |||
+            Shows the absolute rate of notification outcomes:
+            - Sent: Successfully delivered notifications
+            - Errors: Notifications that encountered errors during delivery
+            - Dropped: Notifications that were dropped from the sending queue because the queue is full
+          |||
+        )
+      )
+      .addPanel(
+        $.timeseriesPanel('Undelivered notifications (per tenant)') +
+        $.queryPanel([
+          // Error notifications percentage
+          |||
+            sum by(user) (rate(cortex_prometheus_notifications_errors_total{%s}[$__rate_interval]))
             /
-          sum by(user) (rate(cortex_prometheus_notifications_sent_total{%s}[$__rate_interval]) > 0)
-          > 0
-        ||| % [$.jobMatcher($._config.job_names.ruler), $.jobMatcher($._config.job_names.ruler)], '{{ user }}') +
-        { fieldConfig+: { defaults+: { unit: 'short', noValue: 0 } } }
+            (
+              sum by(user) (rate(cortex_prometheus_notifications_sent_total{%s}[$__rate_interval]))
+              +
+              sum by(user) (rate(cortex_prometheus_notifications_dropped_total{%s}[$__rate_interval]))
+            )
+            > 0
+          ||| % [
+            $.jobMatcher($._config.job_names.ruler),
+            $.jobMatcher($._config.job_names.ruler),
+            $.jobMatcher($._config.job_names.ruler),
+          ],
+          // Dropped notifications percentage
+          |||
+            sum by(user) (rate(cortex_prometheus_notifications_dropped_total{%s}[$__rate_interval]))
+            /
+            (
+              sum by(user) (rate(cortex_prometheus_notifications_sent_total{%s}[$__rate_interval]))
+              +
+              sum by(user) (rate(cortex_prometheus_notifications_dropped_total{%s}[$__rate_interval]))
+            )
+            > 0
+          ||| % [
+            $.jobMatcher($._config.job_names.ruler),
+            $.jobMatcher($._config.job_names.ruler),
+            $.jobMatcher($._config.job_names.ruler),
+          ],
+        ], [
+          '{{user}} - errors',
+          '{{user}} - dropped',
+        ]) +
+        {
+          fieldConfig+: {
+            defaults+: {
+              unit: 'percentunit',
+            },
+          },
+        } +
+        $.panelDescription(
+          'Undelivered notifications (per tenant)',
+          |||
+            Shows the percentage of notifications that resulted in errors or were dropped, per tenant:
+            - Errors: Percentage of notifications that encountered errors during delivery
+            - Dropped: Percentage of notifications that were dropped from the queue
+
+            Both percentages are calculated as proportion of total notifications (sent + dropped).
+          |||
+        )
       )
       .addPanel(
         $.timeseriesPanel('Queue length') +
@@ -207,15 +286,8 @@ local filename = 'mimir-ruler.json';
           sum by(user) (cortex_prometheus_notifications_queue_length{%s})
             /
           sum by(user) (cortex_prometheus_notifications_queue_capacity{%s}) > 0
-        ||| % [$.jobMatcher($._config.job_names.ruler), $.jobMatcher($._config.job_names.ruler)], '{{ user }}')
-        { fieldConfig+: { defaults+: { unit: 'percentunit', min: 0, max: 1 } } },
-      )
-      .addPanel(
-        $.timeseriesPanel('Dropped') +
-        $.queryPanel(|||
-          sum by (user) (increase(cortex_prometheus_notifications_dropped_total{%s}[$__rate_interval])) > 0
-        ||| % $.jobMatcher($._config.job_names.ruler), '{{ user }}') +
-        { fieldConfig+: { defaults+: { unit: 'short', noValue: 0 } } }
+        ||| % [$.jobMatcher($._config.job_names.ruler), $.jobMatcher($._config.job_names.ruler)], '{{ user }}') +
+        { fieldConfig+: { defaults+: { unit: 'percentunit' } } }
       )
     )
     .addRow(

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -262,13 +262,7 @@ local filename = 'mimir-ruler.json';
           '{{user}} - errors',
           '{{user}} - dropped',
         ]) +
-        {
-          fieldConfig+: {
-            defaults+: {
-              unit: 'percentunit',
-            },
-          },
-        } +
+        { fieldConfig+: { defaults+: { unit: 'percentunit', min: 0, max: 1 } } } +
         $.panelDescription(
           'Undelivered notifications (per tenant)',
           |||
@@ -287,7 +281,7 @@ local filename = 'mimir-ruler.json';
             /
           sum by(user) (cortex_prometheus_notifications_queue_capacity{%s}) > 0
         ||| % [$.jobMatcher($._config.job_names.ruler), $.jobMatcher($._config.job_names.ruler)], '{{ user }}') +
-        { fieldConfig+: { defaults+: { unit: 'percentunit' } } }
+        { fieldConfig+: { defaults+: { unit: 'percentunit', min: 0, max: 1 } } }
       )
     )
     .addRow(


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does


the rate of dropped notifications in the previous version was out of context so it was hard to determine if we were dropping all notifications or only a portion of them. This PR puts some absolute numbers and combines dropped with errors in a single panel


**Before** 
<img width="1731" alt="Screenshot 2025-03-17 at 16 39 13" src="https://github.com/user-attachments/assets/1e3028e3-8092-4245-89b7-e6e4c70c8b90" />


**After**


<img width="1722" alt="Screenshot 2025-03-17 at 16 44 30" src="https://github.com/user-attachments/assets/461a0bc7-84e8-4bab-9f6d-c3c98d237624" />


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
