### PR TITLE
chore: Update release dates for 2.16 and 2.17

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,7 +25,8 @@ The following table contains past releases and tentative dates for upcoming rele
 | 2.13.0  | 2024-06-17 | Dimitar Dimitrov   |
 | 2.14.0  | 2024-10-07 | Vladimir Varankin  |
 | 2.15.0  | 2025-01-06 | Casie Chen         |
-| 2.16.0  | 2025-03-10 | _To be announced_  |
+| 2.16.0  | 2025-03-17 | Nick Pillitteri    |
+| 2.17.0  | 2025-06-09 | _To be announced_  |
 
 ## Release shepherd responsibilities
 


### PR DESCRIPTION
2.16 release process is starting this week: #10917
