### PR TITLE
OTLP: Set Content-Length header on responses

### DIFF
--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -380,6 +381,7 @@ func writeOTLPResponse(r *http.Request, w http.ResponseWriter, httpCode int, pay
 	}
 
 	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(httpCode)
 	if len(body) == 0 {
 		return

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -1246,6 +1246,7 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 			},
 			expectedResponse: &httpgrpc.HTTPResponse{Code: 415,
 				Headers: []*httpgrpc.Header{
+					{Key: "Content-Length", Values: []string{"86"}},
 					{Key: "Content-Type", Values: []string{"application/x-protobuf"}},
 					{Key: "X-Content-Type-Options", Values: []string{"nosniff"}},
 				},
@@ -1264,6 +1265,7 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 			},
 			expectedResponse: &httpgrpc.HTTPResponse{Code: 400,
 				Headers: []*httpgrpc.Header{
+					{Key: "Content-Length", Values: []string{"140"}},
 					{Key: "Content-Type", Values: []string{"application/json"}},
 					{Key: "X-Content-Type-Options", Values: []string{"nosniff"}},
 				},
@@ -1282,6 +1284,7 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 			},
 			expectedResponse: &httpgrpc.HTTPResponse{Code: 400,
 				Headers: []*httpgrpc.Header{
+					{Key: "Content-Length", Values: []string{"19"}},
 					{Key: "Content-Type", Values: []string{"application/x-protobuf"}},
 					{Key: "X-Content-Type-Options", Values: []string{"nosniff"}},
 				},
@@ -1301,6 +1304,7 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 			},
 			expectedResponse: &httpgrpc.HTTPResponse{Code: 400,
 				Headers: []*httpgrpc.Header{
+					{Key: "Content-Length", Values: []string{"267"}},
 					{Key: "Content-Type", Values: []string{"application/json"}},
 					{Key: "X-Content-Type-Options", Values: []string{"nosniff"}},
 				},
@@ -1319,6 +1323,7 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 			},
 			expectedResponse: &httpgrpc.HTTPResponse{Code: 200,
 				Headers: []*httpgrpc.Header{
+					{Key: "Content-Length", Values: []string{"2"}},
 					{Key: "Content-Type", Values: []string{"application/json"}},
 					{Key: "X-Content-Type-Options", Values: []string{"nosniff"}},
 				},
@@ -1337,6 +1342,7 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 			},
 			expectedResponse: &httpgrpc.HTTPResponse{Code: 200,
 				Headers: []*httpgrpc.Header{
+					{Key: "Content-Length", Values: []string{"0"}},
 					{Key: "Content-Type", Values: []string{"application/x-protobuf"}},
 					{Key: "X-Content-Type-Options", Values: []string{"nosniff"}},
 				},
@@ -1356,6 +1362,7 @@ func TestOTLPPushHandlerErrorsAreReportedCorrectlyViaHttpgrpc(t *testing.T) {
 			},
 			expectedResponse: &httpgrpc.HTTPResponse{Code: 503,
 				Headers: []*httpgrpc.Header{
+					{Key: "Content-Length", Values: []string{"46"}},
 					{Key: "Content-Type", Values: []string{"application/json"}},
 					{Key: "X-Content-Type-Options", Values: []string{"nosniff"}},
 				},


### PR DESCRIPTION
#### What this PR does

Modify OTLP distributor endpoint to set the `Content-Length` header on responses. Follow-up to #10852, where @charleskorn suggested we set also `Content-Length`.

Also improve OTLP tests to check for `Content-Type` and `Content-Length` headers, for both protobuf and JSON requests.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
