### PR TITLE
[release-2.16] Fix goroutines and memory leak in parallelStorageShards (#10915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 * [BUGFIX] TSDB: fix unknown series errors and possible lost data during WAL replay when series are removed from the head due to inactivity and reappear before the next WAL checkpoint. https://github.com/prometheus/prometheus/pull/16060 #10824
 * [BUGFIX] Querier: fix issue where `label_join` could incorrectly return multiple series with the same labels rather than failing with `vector cannot contain metrics with the same labelset`. https://github.com/prometheus/prometheus/pull/15975 #10826
 * [BUGFIX] Querier: fix issue where counter resets on native histograms could be incorrectly under- or over-counted when using subqueries. https://github.com/prometheus/prometheus/pull/15987 #10871
+* [BUGFIX] Ingester: fix goroutines and memory leak when experimental ingest storage enabled and a server-side error occurs during metrics ingestion. #10915
 
 ### Mixin
 


### PR DESCRIPTION
Backport of https://github.com/grafana/mimir/pull/10915

* Fix goroutines and memory leak in parallelStorageShards

Signed-off-by: Marco Pracucci <marco@pracucci.com>

* Fix issues

Signed-off-by: Marco Pracucci <marco@pracucci.com>

* Fix issues

Signed-off-by: Marco Pracucci <marco@pracucci.com>

* Update CHANGELOG

Signed-off-by: Marco Pracucci <marco@pracucci.com>

---------

Signed-off-by: Marco Pracucci <marco@pracucci.com>
(cherry picked from commit 4226b7015112ac5576f09b9538ea7eaf7288be13)


