### PR TITLE
block-builder: Dedicated consumePartitionSectionPullMode for the scheduler

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -214,6 +214,7 @@ func (b *BlockBuilder) runningPullMode(ctx context.Context) error {
 			continue
 		}
 
+		// TODO: pass on the last offset consumed to the scheduler. It may not be the end offset always.
 		if _, err := b.consumeJob(ctx, key, spec); err != nil {
 			level.Error(b.logger).Log("msg", "failed to consume job", "job_id", key.Id, "epoch", key.Epoch, "err", err)
 			continue
@@ -228,20 +229,16 @@ func (b *BlockBuilder) runningPullMode(ctx context.Context) error {
 }
 
 // consumeJob performs block consumption from Kafka into object storage based on the given job spec.
-func (b *BlockBuilder) consumeJob(ctx context.Context, key schedulerpb.JobKey, spec schedulerpb.JobSpec) (PartitionState, error) {
-	state := PartitionState{
-		Commit: kadm.Offset{
-			Topic:     spec.Topic,
-			Partition: spec.Partition,
-			At:        spec.StartOffset,
-		},
-		CommitRecordTimestamp: spec.CommitRecTs,
-		LastSeenOffset:        spec.LastSeenOffset,
-		LastBlockEnd:          spec.LastBlockEndTs,
-	}
+func (b *BlockBuilder) consumeJob(ctx context.Context, key schedulerpb.JobKey, spec schedulerpb.JobSpec) (lastOffset int64, err error) {
+	sp, ctx := spanlogger.NewWithLogger(ctx, b.logger, "BlockBuilder.consumeJob")
+	defer sp.Finish()
 
-	logger := log.With(b.logger, "job_id", key.Id, "job_epoch", key.Epoch)
-	return b.consumePartition(ctx, spec.Partition, state, spec.CycleEndTs, spec.CycleEndOffset, logger)
+	logger := log.With(sp, "partition", spec.Partition, "job_id", key.Id, "job_epoch", key.Epoch)
+
+	builder := NewTSDBBuilder(logger, b.cfg.DataDir, b.cfg.BlocksStorage, b.limits, b.tsdbBuilderMetrics, b.cfg.ApplyMaxGlobalSeriesPerUserBelow)
+	defer runutil.CloseWithErrCapture(&err, builder, "closing tsdb builder")
+
+	return b.consumePartitionSectionPullMode(ctx, logger, builder, spec.Partition, spec.StartOffset, spec.EndOffset)
 }
 
 func (b *BlockBuilder) stoppingStandaloneMode(_ error) error {
@@ -671,6 +668,123 @@ consumerLoop:
 	}
 
 	return newState, nil
+}
+
+// consumePartitionSectionPullMode is for the use of scheduler based architecture.
+// Both startOffset and endOffset are inclusive, and must be valid offsets and not something in the future.
+// All the records and samples between these offsets will be consumed and put into a block.
+// The returned lastConsumedOffset is the offset of the last record consumed. It is the caller's responsibility to commit this offset.
+func (b *BlockBuilder) consumePartitionSectionPullMode(
+	ctx context.Context,
+	logger log.Logger,
+	builder *TSDBBuilder,
+	partition int32,
+	startOffset, endOffset int64,
+) (lastConsumedOffset int64, retErr error) {
+	lastConsumedOffset = startOffset
+	if startOffset > endOffset {
+		level.Info(logger).Log("msg", "nothing to consume")
+		return
+	}
+
+	var blockMetas []tsdb.BlockMeta
+	defer func(t time.Time) {
+		// No need to log or track time of the unfinished section. Just bail out.
+		if errors.Is(retErr, context.Canceled) {
+			return
+		}
+
+		dur := time.Since(t)
+
+		if retErr != nil {
+			level.Error(logger).Log("msg", "partition consumption failed", "err", retErr, "duration", dur)
+			return
+		}
+
+		b.blockBuilderMetrics.processPartitionDuration.WithLabelValues(fmt.Sprintf("%d", partition)).Observe(dur.Seconds())
+		level.Info(logger).Log("msg", "done consuming", "duration", dur, "partition", partition,
+			"start_offset", startOffset, "end_offset", endOffset,
+			"last_consumed_offset", lastConsumedOffset, "num_blocks", len(blockMetas))
+	}(time.Now())
+
+	b.kafkaClient.AddConsumePartitions(map[string]map[int32]kgo.Offset{
+		b.cfg.Kafka.Topic: {
+			partition: kgo.NewOffset().At(startOffset),
+		},
+	})
+	defer b.kafkaClient.RemoveConsumePartitions(map[string][]int32{b.cfg.Kafka.Topic: {partition}})
+
+	level.Info(logger).Log("msg", "start consuming", "partition", partition, "start_offset", startOffset, "end_offset", endOffset)
+
+	var (
+		firstRec *kgo.Record
+		lastRec  *kgo.Record
+	)
+
+consumerLoop:
+	for recOffset := int64(-1); recOffset <= endOffset; {
+		if err := context.Cause(ctx); err != nil {
+			return 0, err
+		}
+
+		// PollFetches can return a non-failed fetch with zero records. In such a case, with only the fetches at hands,
+		// we cannot tell if the consumer has already reached the latest end of the partition, i.e. no more records to consume,
+		// or there is more data in the backlog, and we must retry the poll. That's why the consumer loop above has to guard
+		// the iterations against the cycleEndOffset, so it retried the polling up until the expected end of the partition is reached.
+		// TODO: update the above comment. Not fully applicable.
+		fetches := b.kafkaClient.PollFetches(ctx)
+		fetches.EachError(func(_ string, _ int32, err error) {
+			if !errors.Is(err, context.Canceled) {
+				level.Error(logger).Log("msg", "failed to fetch records", "err", err)
+				b.blockBuilderMetrics.fetchErrors.WithLabelValues(fmt.Sprintf("%d", partition)).Inc()
+			}
+		})
+
+		for recIter := fetches.RecordIter(); !recIter.Done(); {
+			rec := recIter.Next()
+			recOffset = rec.Offset
+
+			if firstRec == nil {
+				firstRec = rec
+			}
+
+			// Stop consuming after we crossed the endOffset.
+			if recOffset > endOffset {
+				break consumerLoop
+			}
+
+			// Process everything in this record.
+			_, err := builder.Process(ctx, rec, 0, 0, false, true)
+			if err != nil {
+				// All "non-terminal" errors are handled by the TSDBBuilder.
+				return 0, fmt.Errorf("process record in partition %d at offset %d: %w", rec.Partition, rec.Offset, err)
+			}
+			lastRec = rec
+		}
+	}
+
+	// Nothing was consumed from Kafka at all.
+	if firstRec == nil {
+		level.Info(logger).Log("msg", "no records were consumed")
+		return
+	}
+
+	// No records were processed for this cycle.
+	if lastRec == nil {
+		level.Info(logger).Log("msg", "nothing to commit due to first record has a timestamp greater than this section end", "first_rec_offset", firstRec.Offset, "first_rec_ts", firstRec.Timestamp)
+		// TODO: scheduler should be able to understand this state and catch up quickly.
+		return startOffset, nil
+	}
+
+	var err error
+	blockMetas, err = builder.CompactAndUpload(ctx, b.uploadBlocks)
+	if err != nil {
+		return 0, err
+	}
+
+	// TODO: figure out a way to track the blockCounts metrics if possible.
+
+	return lastRec.Offset, nil
 }
 
 func getBlockCategoryCount(sectionEndTime time.Time, blockMetas []tsdb.BlockMeta) (prev, curr, next int) {

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -214,7 +214,6 @@ func (b *BlockBuilder) runningPullMode(ctx context.Context) error {
 			continue
 		}
 
-		// TODO: pass on the last offset consumed to the scheduler. It may not be the end offset always.
 		if _, err := b.consumeJob(ctx, key, spec); err != nil {
 			level.Error(b.logger).Log("msg", "failed to consume job", "job_id", key.Id, "epoch", key.Epoch, "err", err)
 			continue
@@ -722,7 +721,7 @@ func (b *BlockBuilder) consumePartitionSectionPullMode(
 	)
 
 consumerLoop:
-	for recOffset := int64(-1); recOffset <= endOffset; {
+	for recOffset := int64(-1); recOffset < endOffset; {
 		if err := context.Cause(ctx); err != nil {
 			return 0, err
 		}

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -729,7 +729,7 @@ consumerLoop:
 		// PollFetches can return a non-failed fetch with zero records. In such a case, with only the fetches at hands,
 		// we cannot tell if the consumer has already reached the latest end of the partition, i.e. no more records to consume,
 		// or there is more data in the backlog, and we must retry the poll. That's why the consumer loop above has to guard
-		// the iterations against the endOffset, so it retried the polling up until the expected end of the partition is reached.
+		// the iterations against the endOffset, so it retries the polling up until the expected end of the partition is reached.
 		fetches := b.kafkaClient.PollFetches(ctx)
 		fetches.EachError(func(_ string, _ int32, err error) {
 			if !errors.Is(err, context.Canceled) {

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -174,90 +174,117 @@ func TestBlockBuilder_StartWithExistingCommit(t *testing.T) {
 	)
 }
 
-func TestBlockBuilder_StartWithExistingCommit_PullMode(t *testing.T) {
+func TestBlockBuilder_PullMode(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
 
-	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
-	kafkaClient := mustKafkaClient(t, kafkaAddr)
-	kafkaClient.AddConsumeTopics(testTopic)
+	tenants := []string{"1", "2", "3"}
+	samplesPerTenant := 10
 
-	cfg, overrides := blockBuilderPullModeConfig(t, kafkaAddr)
-
-	// Producing some records
-	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
-
-	var producedSamples []mimirpb.Sample
-	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-7 * time.Hour).Add(29 * time.Minute)
-	for kafkaRecTime.Before(cycleEndStartup) {
-		samples := produceSamples(ctx, t, kafkaClient, 0, kafkaRecTime, "1", kafkaRecTime.Add(-time.Minute))
-		producedSamples = append(producedSamples, samples...)
-
-		kafkaRecTime = kafkaRecTime.Add(cfg.ConsumeInterval / 2)
-	}
-	require.NotEmpty(t, producedSamples)
-
-	// Fetch all the records that were produced to choose one to commit.
-	var recs []*kgo.Record
-	for len(recs) < len(producedSamples) {
-		fetches := kafkaClient.PollFetches(ctx)
-		require.NoError(t, fetches.Err())
-		recs = append(recs, fetches.Records()...)
-	}
-	require.Len(t, recs, len(producedSamples))
-
-	// Choosing the midpoint record to commit and as the last seen record as well.
-	commitRec := recs[len(recs)/2]
-	require.NotNil(t, commitRec)
-
-	lastRec := commitRec
-	blockEnd := commitRec.Timestamp.Truncate(cfg.ConsumeInterval).Add(cfg.ConsumeInterval)
-
-	scheduler := &mockSchedulerClient{}
-	scheduler.addJob(
-		schedulerpb.JobKey{
-			Id:    "test-job-4898",
-			Epoch: 90000,
+	// We have 10 records per tenant. And there are 3 tenants.
+	cases := []struct {
+		name                   string
+		startOffset, endOffset int64
+		// For per tenant slice.
+		expSampleRangeStart int
+		expSampleRangeEnd   int
+	}{
+		{
+			name:                "first offset till somewhere in between",
+			startOffset:         0,
+			endOffset:           (3 * 6) - 1,
+			expSampleRangeStart: 0,
+			expSampleRangeEnd:   6,
 		},
-		schedulerpb.JobSpec{
-			Topic:          testTopic,
-			Partition:      0,
-			StartOffset:    commitRec.Offset + 1,
-			EndOffset:      3000000,
-			CommitRecTs:    commitRec.Timestamp,
-			LastSeenOffset: lastRec.Offset,
-			LastBlockEndTs: blockEnd,
-			CycleEndTs:     cycleEndStartup,
-			CycleEndOffset: int64(len(producedSamples)),
+		{
+			name:                "somewhere in between till last offset",
+			startOffset:         int64(3 * 6),
+			endOffset:           3*10 - 1,
+			expSampleRangeStart: 6,
+			expSampleRangeEnd:   10,
 		},
-	)
+		{
+			name:                "somewhere in between to somewhere in between",
+			startOffset:         int64(3 * 3),
+			endOffset:           3*6 - 1,
+			expSampleRangeStart: 3,
+			expSampleRangeEnd:   6,
+		},
+		{
+			name:                "entire partition",
+			startOffset:         0,
+			endOffset:           3*10 - 1,
+			expSampleRangeStart: 0,
+			expSampleRangeEnd:   10,
+		},
+	}
 
-	bb, err := newWithSchedulerClient(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), overrides, scheduler)
-	require.NoError(t, err)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
+			kafkaClient := mustKafkaClient(t, kafkaAddr)
+			kafkaClient.AddConsumeTopics(testTopic)
 
-	require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
-	t.Cleanup(func() {
-		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
-	})
+			cfg, overrides := blockBuilderPullModeConfig(t, kafkaAddr)
 
-	// Wait for end of the cycles. We expect at least several cycles because of how the pushed records were structured.
-	require.Eventually(t, func() bool {
-		return scheduler.completeJobCallCount() > 0
-	}, 5*time.Second, 100*time.Millisecond, "expected job completion")
+			producedSamples := make(map[string][]mimirpb.Sample, 0)
+			recsPerTenant := 0
+			kafkaRecTime := time.Now().Add(-time.Hour)
+			for range samplesPerTenant {
+				for _, tenant := range tenants {
+					samples := produceSamples(ctx, t, kafkaClient, 0, kafkaRecTime, tenant, kafkaRecTime.Add(-time.Minute))
+					producedSamples[tenant] = append(producedSamples[tenant], samples...)
+				}
+				recsPerTenant++
 
-	require.EqualValues(t,
-		[]schedulerpb.JobKey{{Id: "test-job-4898", Epoch: 90000}},
-		scheduler.completeJobCalls,
-	)
+				kafkaRecTime = kafkaRecTime.Add(10 * time.Minute)
+			}
+			require.NotEmpty(t, producedSamples)
 
-	// Because there is a commit, on startup, block-builder must consume samples only after the commit.
-	expSamples := producedSamples[1+(len(producedSamples)/2):]
+			scheduler := &mockSchedulerClient{}
+			scheduler.addJob(
+				schedulerpb.JobKey{
+					Id:    "test-job-4898",
+					Epoch: 90000,
+				},
+				schedulerpb.JobSpec{
+					Topic:       testTopic,
+					Partition:   0,
+					StartOffset: c.startOffset,
+					EndOffset:   c.endOffset,
+				},
+			)
 
-	compareQueryWithDir(t,
-		path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, "1"),
-		expSamples, nil,
-		labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
-	)
+			bb, err := newWithSchedulerClient(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), overrides, scheduler)
+			require.NoError(t, err)
+
+			require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
+			})
+
+			require.Eventually(t, func() bool {
+				return scheduler.completeJobCallCount() > 0
+			}, 5*time.Second, 100*time.Millisecond, "expected job completion")
+
+			require.EqualValues(t,
+				[]schedulerpb.JobKey{{Id: "test-job-4898", Epoch: 90000}},
+				scheduler.completeJobCalls,
+			)
+
+			for _, tenant := range tenants {
+				expSamples := producedSamples[tenant][c.expSampleRangeStart:c.expSampleRangeEnd]
+
+				compareQueryWithDir(t,
+					path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, tenant),
+					expSamples, nil,
+					labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
+				)
+			}
+
+		})
+	}
+
 }
 
 // When there is no commit on startup, and the first cycleEnd is at T, and all the samples are from before T-lookback, then
@@ -310,76 +337,6 @@ func TestBlockBuilder_StartWithLookbackOnNoCommit(t *testing.T) {
 	`), "cortex_blockbuilder_consumer_lag_records"))
 
 	// There should be no samples in the tsdb.
-	compareQueryWithDir(t,
-		path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, "1"),
-		nil, nil,
-		labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
-	)
-}
-
-// When there is no commit on startup, and the first cycleEnd is at T, and all the samples are from before T-lookback, then
-// the first consumption cycle skips all the records.
-func TestBlockBuilder_StartWithLookbackOnNoCommit_PullMode(t *testing.T) {
-	t.Parallel()
-
-	ctx, cancel := context.WithCancelCause(context.Background())
-	t.Cleanup(func() { cancel(errors.New("test done")) })
-
-	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
-	kafkaClient := mustKafkaClient(t, kafkaAddr)
-
-	cfg, overrides := blockBuilderPullModeConfig(t, kafkaAddr)
-	cfg.LookbackOnNoCommit = 3 * time.Hour
-
-	// Producing some records, all before LookbackOnNoCommit
-	var firstRecordTime time.Time
-	kafkaRecTime := time.Now().Truncate(cfg.ConsumeInterval).Add(-7 * time.Hour).Add(29 * time.Minute)
-	for range 3 {
-		kafkaRecTime = kafkaRecTime.Add(cfg.ConsumeInterval / 2)
-		if firstRecordTime.IsZero() {
-			firstRecordTime = kafkaRecTime
-		}
-		produceSamples(ctx, t, kafkaClient, 0, kafkaRecTime, "1", kafkaRecTime.Add(-time.Minute))
-	}
-
-	fallback := time.Now().Add(-cfg.LookbackOnNoCommit)
-
-	scheduler := &mockSchedulerClient{}
-	scheduler.addJob(
-		schedulerpb.JobKey{
-			Id:    "test-job-4898",
-			Epoch: 90001,
-		},
-		schedulerpb.JobSpec{
-			Topic:          testTopic,
-			Partition:      0,
-			StartOffset:    1,
-			EndOffset:      5,
-			CommitRecTs:    fallback,
-			LastSeenOffset: 0,
-			LastBlockEndTs: time.UnixMilli(0),
-			CycleEndTs:     kafkaRecTime,
-			CycleEndOffset: 3,
-		},
-	)
-
-	bb, err := newWithSchedulerClient(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), overrides, scheduler)
-	require.NoError(t, err)
-
-	require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
-	t.Cleanup(func() {
-		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
-	})
-
-	require.Eventually(t, func() bool {
-		return bb.jobIteration.Load() > 0
-	}, 5*time.Second, 100*time.Millisecond, "expected job completion")
-
-	require.EqualValues(t,
-		[]schedulerpb.JobKey{{Id: "test-job-4898", Epoch: 90001}},
-		scheduler.completeJobCalls,
-	)
-
 	compareQueryWithDir(t,
 		path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, "1"),
 		nil, nil,
@@ -457,112 +414,6 @@ func TestBlockBuilder_ReachHighWatermarkBeforeLastCycleSection(t *testing.T) {
 	)
 }
 
-// When there are no records to consume before the last cycle section, the whole cycle should bail.
-func TestBlockBuilder_ReachHighWatermarkBeforeLastCycleSection_PullMode(t *testing.T) {
-	ctx, cancel := context.WithCancelCause(context.Background())
-	t.Cleanup(func() { cancel(errors.New("test done")) })
-
-	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
-	kafkaClient := mustKafkaClient(t, kafkaAddr)
-	cfg, overrides := blockBuilderPullModeConfig(t, kafkaAddr)
-
-	// Producing backlog of records in partition 0.
-	// For this test, the last-produced record must belong to the second to last cycle's section; i.e. the last section has nothing to consume.
-	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
-
-	var producedSamples []mimirpb.Sample
-	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-5 * time.Hour).Add(29 * time.Minute)
-	firstKafkaRecTime := kafkaRecTime.Add(-time.Minute)
-	lastKafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-cfg.ConsumeInterval)
-	for kafkaRecTime.Before(lastKafkaRecTime) {
-		samples := produceSamples(ctx, t, kafkaClient, 0, kafkaRecTime, "1", kafkaRecTime.Add(-time.Minute))
-		producedSamples = append(producedSamples, samples...)
-
-		kafkaRecTime = kafkaRecTime.Add(cfg.ConsumeInterval / 2)
-	}
-	require.NotEmpty(t, producedSamples)
-
-	var p1RecTime time.Time
-
-	// Produce extra record to partition 1 to verify that block-builder finished the whole cycle and didn't get stuck consuming partition 0.
-	{
-		const partition = 1
-		kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-time.Minute)
-		p1RecTime = kafkaRecTime
-		samples := floatSample(kafkaRecTime.UnixMilli(), 100)
-		val := createWriteRequest(t, "1", samples, nil)
-		produceRecords(ctx, t, kafkaClient, kafkaRecTime, "1", testTopic, partition, val)
-		producedSamples = append(producedSamples, samples...)
-	}
-
-	scheduler := &mockSchedulerClient{}
-	scheduler.addJob(
-		schedulerpb.JobKey{
-			Id:    "test-job-p0-4898",
-			Epoch: 90002,
-		},
-		schedulerpb.JobSpec{
-			Topic:          testTopic,
-			Partition:      0,
-			StartOffset:    0,
-			EndOffset:      int64(len(producedSamples)),
-			CommitRecTs:    firstKafkaRecTime,
-			LastSeenOffset: 0,
-			LastBlockEndTs: time.UnixMilli(0),
-			CycleEndTs:     kafkaRecTime,
-			CycleEndOffset: int64(len(producedSamples) - 2),
-		},
-	)
-	// A second job to include the extra record in partition 1.
-	scheduler.addJob(
-		schedulerpb.JobKey{
-			Id:    "test-job-p1-4899",
-			Epoch: 90070,
-		},
-		schedulerpb.JobSpec{
-			Topic:          testTopic,
-			Partition:      1,
-			StartOffset:    0,
-			EndOffset:      1,
-			CommitRecTs:    p1RecTime,
-			LastSeenOffset: 0,
-			LastBlockEndTs: time.UnixMilli(0),
-			CycleEndTs:     p1RecTime.Add(1 * time.Minute),
-			CycleEndOffset: 1,
-		},
-	)
-
-	reg := prometheus.NewPedanticRegistry()
-	bb, err := newWithSchedulerClient(cfg, test.NewTestingLogger(t), reg, overrides, scheduler)
-	require.NoError(t, err)
-
-	require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
-	t.Cleanup(func() {
-		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
-	})
-
-	// Wait for both jobs to complete.
-	require.Eventually(t, func() bool {
-		return bb.jobIteration.Load() >= 2
-	}, 20*time.Second, 100*time.Millisecond, "expected job completion")
-
-	assert.Equal(t, 1, scheduler.runCallCount())
-	assert.Equal(t, 3, scheduler.getJobCallCount(), "expect 2 completed getJob calls and one in-flight")
-	assert.Equal(t, 2, scheduler.completeJobCallCount())
-	assert.Equal(t, 0, scheduler.closeCallCount())
-
-	require.EqualValues(t,
-		[]schedulerpb.JobKey{{Id: "test-job-p0-4898", Epoch: 90002}, {Id: "test-job-p1-4899", Epoch: 90070}},
-		scheduler.completeJobCalls,
-	)
-
-	compareQueryWithDir(t,
-		path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, "1"),
-		producedSamples, nil,
-		labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
-	)
-}
-
 func TestBlockBuilder_WithMultipleTenants(t *testing.T) {
 	t.Parallel()
 
@@ -609,82 +460,6 @@ func TestBlockBuilder_WithMultipleTenants(t *testing.T) {
 
 	// Wait for end of the cycles. We expect at least several cycles because of how the pushed records were structured.
 	require.Eventually(t, func() bool { return kafkaCommits.Load() > 1 }, 5*time.Second, 100*time.Millisecond, "expected kafka commits")
-
-	for _, tenant := range tenants {
-		compareQueryWithDir(t,
-			path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, tenant),
-			producedPerTenantSamples[tenant], nil,
-			labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
-		)
-	}
-}
-
-func TestBlockBuilder_WithMultipleTenants_PullMode(t *testing.T) {
-	t.Parallel()
-
-	ctx, cancel := context.WithCancelCause(context.Background())
-	t.Cleanup(func() { cancel(errors.New("test done")) })
-
-	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
-
-	kafkaClient := mustKafkaClient(t, kafkaAddr)
-	kafkaClient.AddConsumeTopics(testTopic)
-
-	cfg, overrides := blockBuilderPullModeConfig(t, kafkaAddr)
-
-	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
-	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-cfg.ConsumeInterval)
-	firstTime := kafkaRecTime
-
-	scheduler := &mockSchedulerClient{}
-	scheduler.addJob(
-		schedulerpb.JobKey{
-			Id:    "test-job-4898",
-			Epoch: 90003,
-		},
-		schedulerpb.JobSpec{
-			Topic:          testTopic,
-			Partition:      0,
-			StartOffset:    0,
-			EndOffset:      30,
-			CommitRecTs:    firstTime,
-			LastSeenOffset: 0,
-			LastBlockEndTs: firstTime,
-			CycleEndTs:     cycleEndStartup,
-			CycleEndOffset: 30,
-		},
-	)
-
-	producedPerTenantSamples := make(map[string][]mimirpb.Sample, 0)
-	tenants := []string{"1", "2", "3"}
-
-	// Producing some records for multiple tenants
-	for range 10 {
-		for _, tenant := range tenants {
-			samples := produceSamples(ctx, t, kafkaClient, 0, kafkaRecTime, tenant, kafkaRecTime)
-			producedPerTenantSamples[tenant] = append(producedPerTenantSamples[tenant], samples...)
-		}
-
-		kafkaRecTime = kafkaRecTime.Add(15 * time.Second)
-	}
-
-	bb, err := newWithSchedulerClient(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), overrides, scheduler)
-	require.NoError(t, err)
-
-	require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
-	t.Cleanup(func() {
-		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
-	})
-
-	// Wait for end of the cycles. We expect at least several cycles because of how the pushed records were structured.
-	require.Eventually(t, func() bool {
-		return scheduler.completeJobCallCount() > 0
-	}, 5*time.Second, 100*time.Millisecond, "expected job completion")
-
-	require.EqualValues(t,
-		[]schedulerpb.JobKey{{Id: "test-job-4898", Epoch: 90003}},
-		scheduler.completeJobCalls,
-	)
 
 	for _, tenant := range tenants {
 		compareQueryWithDir(t,


### PR DESCRIPTION
#### What this PR does

Adds a dedicated function that consumes between given start and end offset with no partially consumed region. This is only for the use of scheduler.


#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
