### PR TITLE
ruler notifier: make batch size configurable

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -13052,6 +13052,17 @@
           "fieldCategory": "advanced"
         },
         {
+          "kind": "field",
+          "name": "notification_batch_size",
+          "required": false,
+          "desc": "Maximum number of notifications to send in a single request to the Alertmanager.",
+          "fieldValue": null,
+          "fieldDefaultValue": 64,
+          "fieldFlag": "ruler.notification-batch-size",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
+        },
+        {
           "kind": "block",
           "name": "alertmanager_client",
           "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3053,6 +3053,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
   -ruler.max-rules-per-rule-group-by-namespace value
     	Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group. (default {})
+  -ruler.notification-batch-size int
+    	[experimental] Maximum number of notifications to send in a single request to the Alertmanager. (default 64)
   -ruler.notification-queue-capacity int
     	Capacity of the queue for notifications to be sent to the Alertmanager. (default 10000)
   -ruler.notification-timeout duration

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2053,6 +2053,11 @@ The `ruler` block configures the ruler.
 # CLI flag: -ruler.notification-timeout
 [notification_timeout: <duration> | default = 10s]
 
+# (experimental) Maximum number of notifications to send in a single request to
+# the Alertmanager.
+# CLI flag: -ruler.notification-batch-size
+[notification_batch_size: <int> | default = 64]
+
 alertmanager_client:
   # (advanced) Enable TLS for gRPC client connecting to alertmanager.
   # CLI flag: -ruler.alertmanager-client.tls-enabled

--- a/go.mod
+++ b/go.mod
@@ -299,7 +299,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250313034642-4c5f37509bce
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250318213324-7c3d95cdcf1a
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -1286,8 +1286,8 @@ github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1 h1:vR5nELq+KtGO
 github.com/grafana/gomemcache v0.0.0-20250228145437-da7b95fd2ac1/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20250313034642-4c5f37509bce h1:75LWgFF0hBy7MGfp3ynutO65GM6KHZoBXhpARoKCEEs=
-github.com/grafana/mimir-prometheus v0.0.0-20250313034642-4c5f37509bce/go.mod h1:9Hf/cSfGXNKRswdYnj10nTOt5LUmazcJO2tVsg02+Jo=
+github.com/grafana/mimir-prometheus v0.0.0-20250318213324-7c3d95cdcf1a h1:z+d8yWHl/Z3WZG+b/R18IZDS2/MmKJQv6qOkxLx6KiM=
+github.com/grafana/mimir-prometheus v0.0.0-20250318213324-7c3d95cdcf1a/go.mod h1:9Hf/cSfGXNKRswdYnj10nTOt5LUmazcJO2tVsg02+Jo=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20250305143719-fa9fa7096626 h1:QsMYtDseSPq8hXvoNtA64unFiawJaE5kryizcMsVZWg=

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -300,6 +300,7 @@ func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string) (*notifie
 		QueueCapacity:   r.cfg.NotificationQueueCapacity,
 		DrainOnShutdown: true,
 		Registerer:      reg,
+		MaxBatchSize:    r.cfg.NotificationBatchSize,
 		Do: func(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
 			// Note: The passed-in context comes from the Prometheus notifier
 			// and does *not* contain the userID. So it needs to be added to the context

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -113,6 +113,8 @@ type Config struct {
 	NotificationQueueCapacity int `yaml:"notification_queue_capacity" category:"advanced"`
 	// HTTP timeout duration when sending notifications to the Alertmanager.
 	NotificationTimeout time.Duration `yaml:"notification_timeout" category:"advanced"`
+	// NotificationBatchSize determines how many notifications to send in a single request to the Alertmanager.
+	NotificationBatchSize int `yaml:"notification_batch_size" category:"experimental"`
 	// Client configs for interacting with the Alertmanager
 	Notifier NotifierConfig `yaml:"alertmanager_client"`
 
@@ -188,6 +190,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.DurationVar(&cfg.AlertmanagerRefreshInterval, "ruler.alertmanager-refresh-interval", 1*time.Minute, "How long to wait between refreshing DNS resolutions of Alertmanager hosts.")
 	f.IntVar(&cfg.NotificationQueueCapacity, "ruler.notification-queue-capacity", 10000, "Capacity of the queue for notifications to be sent to the Alertmanager.")
 	f.DurationVar(&cfg.NotificationTimeout, "ruler.notification-timeout", 10*time.Second, "HTTP timeout duration when sending notifications to the Alertmanager.")
+	f.IntVar(&cfg.NotificationBatchSize, "ruler.notification-batch-size", 64, "Maximum number of notifications to send in a single request to the Alertmanager.")
 
 	f.StringVar(&cfg.RulePath, "ruler.rule-path", "./data-ruler/", "Directory to store temporary rule files loaded by the Prometheus rule managers. This directory is not required to be persisted between restarts.")
 	f.BoolVar(&cfg.EnableAPI, "ruler.enable-api", true, "Enable the ruler config API.")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1072,7 +1072,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20250313034642-4c5f37509bce
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20250318213324-7c3d95cdcf1a
 ## explicit; go 1.22.7
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1757,7 +1757,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250313034642-4c5f37509bce
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250318213324-7c3d95cdcf1a
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
We have a theory that increasing the batch size will help with throughput to the alertmanager. Pushing this so I can test

this includes the changes from https://github.com/grafana/mimir-prometheus/pull/843

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
