### PR TITLE
Update ruler and mimirtool to deal with modified ruler core models

### DIFF
--- a/pkg/mimirtool/analyze/ruler.go
+++ b/pkg/mimirtool/analyze/ruler.go
@@ -37,11 +37,11 @@ func ParseMetricsInRuleGroup(mir *MetricsInRuler, group rwrulefmt.RuleGroup, ns 
 	)
 
 	for _, rule := range group.Rules {
-		if rule.Record.Value != "" {
-			ruleMetrics[rule.Record.Value] = struct{}{}
+		if rule.Record != "" {
+			ruleMetrics[rule.Record] = struct{}{}
 		}
 
-		query := rule.Expr.Value
+		query := rule.Expr
 		expr, err := parser.ParseExpr(query)
 		if err != nil {
 			parseErrors = append(parseErrors, errors.Wrapf(err, "query=%v", query))

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -726,7 +726,7 @@ func (r *RuleCommand) prepare(_ *kingpin.ParseContext) error {
 	}
 
 	// Do not apply the aggregation label to excluded rule groups.
-	applyTo := func(group rwrulefmt.RuleGroup, _ rulefmt.RuleNode) bool {
+	applyTo := func(group rwrulefmt.RuleGroup, _ rulefmt.Rule) bool {
 		_, excluded := r.aggregationLabelExcludedRuleGroupsList[group.Name]
 		return !excluded
 	}
@@ -862,11 +862,11 @@ func checkDuplicates(groups []rwrulefmt.RuleGroup) []compareRuleType {
 	return duplicates
 }
 
-func ruleMetric(rule rulefmt.RuleNode) string {
-	if rule.Alert.Value != "" {
-		return rule.Alert.Value
+func ruleMetric(rule rulefmt.Rule) string {
+	if rule.Alert != "" {
+		return rule.Alert
 	}
-	return rule.Record.Value
+	return rule.Record
 }
 
 // End taken from https://github.com/prometheus/prometheus/blob/8c8de46003d1800c9d40121b4a5e5de8582ef6e1/cmd/promtool/main.go#L403

--- a/pkg/mimirtool/commands/rules_test.go
+++ b/pkg/mimirtool/commands/rules_test.go
@@ -75,14 +75,14 @@ func TestCheckDuplicates(t *testing.T) {
 			in: []rwrulefmt.RuleGroup{{
 				RuleGroup: rulefmt.RuleGroup{
 					Name: "rulegroup",
-					Rules: []rulefmt.RuleNode{
+					Rules: []rulefmt.Rule{
 						{
-							Record: yaml.Node{Value: "up"},
-							Expr:   yaml.Node{Value: "up==1"},
+							Record: "up",
+							Expr:   "up==1",
 						},
 						{
-							Record: yaml.Node{Value: "down"},
-							Expr:   yaml.Node{Value: "up==0"},
+							Record: "down",
+							Expr:   "up==0",
 						},
 					},
 				},
@@ -95,14 +95,14 @@ func TestCheckDuplicates(t *testing.T) {
 			in: []rwrulefmt.RuleGroup{{
 				RuleGroup: rulefmt.RuleGroup{
 					Name: "rulegroup",
-					Rules: []rulefmt.RuleNode{
+					Rules: []rulefmt.Rule{
 						{
-							Record: yaml.Node{Value: "up"},
-							Expr:   yaml.Node{Value: "up==1"},
+							Record: "up",
+							Expr:   "up==1",
 						},
 						{
-							Record: yaml.Node{Value: "up"},
-							Expr:   yaml.Node{Value: "up==0"},
+							Record: "up",
+							Expr:   "up==0",
 						},
 					},
 				},
@@ -118,61 +118,61 @@ func TestCheckDuplicates(t *testing.T) {
 }
 
 func TestRuleCommand_checkRules(t *testing.T) {
-	completelyBadRuleName := rulefmt.RuleNode{
-		Record: yaml.Node{Value: "up", Kind: yaml.ScalarNode},
-		Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+	completelyBadRuleName := rulefmt.Rule{
+		Record: "up",
+		Expr:   "up==1",
 	}
-	strictlyBadRuleName := rulefmt.RuleNode{
-		Record: yaml.Node{Value: "up:onecolonmissing", Kind: yaml.ScalarNode},
-		Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+	strictlyBadRuleName := rulefmt.Rule{
+		Record: "up:onecolonmissing",
+		Expr:   "up==1",
 	}
-	validRule1 := rulefmt.RuleNode{
-		Record: yaml.Node{Value: "rule:up:nothing", Kind: yaml.ScalarNode},
-		Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+	validRule1 := rulefmt.Rule{
+		Record: "rule:up:nothing",
+		Expr:   "up==1",
 	}
-	validRule2 := rulefmt.RuleNode{
-		Record: yaml.Node{Value: "rule:down:nothing", Kind: yaml.ScalarNode},
-		Expr:   yaml.Node{Value: "up==0", Kind: yaml.ScalarNode},
+	validRule2 := rulefmt.Rule{
+		Record: "rule:down:nothing",
+		Expr:   "up==0",
 	}
 	for _, tc := range []struct {
 		name       string
-		rules      []rulefmt.RuleNode
+		rules      []rulefmt.Rule
 		strict     bool
 		shouldFail bool
 	}{
 		{
 			name:       "completely bad rule name, not strict fails too",
-			rules:      []rulefmt.RuleNode{validRule1, completelyBadRuleName, validRule2},
+			rules:      []rulefmt.Rule{validRule1, completelyBadRuleName, validRule2},
 			strict:     false,
 			shouldFail: true,
 		},
 		{
 			name:       "strictly bad rule name, strict",
-			rules:      []rulefmt.RuleNode{validRule1, strictlyBadRuleName, validRule2},
+			rules:      []rulefmt.Rule{validRule1, strictlyBadRuleName, validRule2},
 			strict:     true,
 			shouldFail: true,
 		},
 		{
 			name:       "strictly bad rule name, not strict",
-			rules:      []rulefmt.RuleNode{validRule1, strictlyBadRuleName, validRule2},
+			rules:      []rulefmt.Rule{validRule1, strictlyBadRuleName, validRule2},
 			strict:     false,
 			shouldFail: false,
 		},
 		{
 			name:       "no duplicates, strict",
-			rules:      []rulefmt.RuleNode{validRule1, validRule2},
+			rules:      []rulefmt.Rule{validRule1, validRule2},
 			strict:     true,
 			shouldFail: false,
 		},
 		{
 			name:       "with duplicates, not strict",
-			rules:      []rulefmt.RuleNode{validRule1, validRule1},
+			rules:      []rulefmt.Rule{validRule1, validRule1},
 			strict:     false,
 			shouldFail: false,
 		},
 		{
 			name:       "with duplicates, strict",
-			rules:      []rulefmt.RuleNode{validRule1, validRule1},
+			rules:      []rulefmt.Rule{validRule1, validRule1},
 			strict:     true,
 			shouldFail: true,
 		},
@@ -218,10 +218,10 @@ func TestRuleSaveToFile_NamespaceRuleGroup(t *testing.T) {
 		rule1 := []rwrulefmt.RuleGroup{{
 			RuleGroup: rulefmt.RuleGroup{
 				Name: "group-1",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: yaml.Node{Value: "up"},
-						Expr:   yaml.Node{Value: "up==1"},
+						Record: "up",
+						Expr:   "up==1",
 					},
 				},
 			},
@@ -235,10 +235,10 @@ func TestRuleSaveToFile_NamespaceRuleGroup(t *testing.T) {
 		rule1 := []rwrulefmt.RuleGroup{{
 			RuleGroup: rulefmt.RuleGroup{
 				Name: "group-1",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: yaml.Node{Value: "up", Kind: yaml.ScalarNode},
-						Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+						Record: "up",
+						Expr:   "up==1",
 					},
 				},
 			},
@@ -252,10 +252,10 @@ func TestRuleSaveToFile_NamespaceRuleGroup(t *testing.T) {
 		rule1 := []rwrulefmt.RuleGroup{{
 			RuleGroup: rulefmt.RuleGroup{
 				Name: "group-1",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: yaml.Node{Value: "up", Kind: yaml.ScalarNode},
-						Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+						Record: "up",
+						Expr:   "up==1",
 					},
 				},
 			},
@@ -280,10 +280,10 @@ groups:
 		rule1 := []rwrulefmt.RuleGroup{{
 			RuleGroup: rulefmt.RuleGroup{
 				Name: "group-1",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Alert: yaml.Node{Value: "up", Kind: yaml.ScalarNode},
-						Expr:  yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+						Alert: "up",
+						Expr:  "up==1",
 					},
 				},
 			},

--- a/pkg/mimirtool/rules/compare.go
+++ b/pkg/mimirtool/rules/compare.go
@@ -192,10 +192,10 @@ func stringSlicesElementsMatch(s1, s2 []string) bool {
 	return true
 }
 
-func rulesEqual(a, b *rulefmt.RuleNode) bool {
-	if a.Alert.Value != b.Alert.Value ||
-		a.Record.Value != b.Record.Value ||
-		a.Expr.Value != b.Expr.Value ||
+func rulesEqual(a, b *rulefmt.Rule) bool {
+	if a.Alert != b.Alert ||
+		a.Record != b.Record ||
+		a.Expr != b.Expr ||
 		a.For != b.For {
 		return false
 	}

--- a/pkg/mimirtool/rules/compare_test.go
+++ b/pkg/mimirtool/rules/compare_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/mimirtool/rules/rwrulefmt"
 )
@@ -70,21 +69,21 @@ func TestNamespaceChange_ToOperations(t *testing.T) {
 func Test_rulesEqual(t *testing.T) {
 	tests := []struct {
 		name string
-		a    *rulefmt.RuleNode
-		b    *rulefmt.RuleNode
+		a    *rulefmt.Rule
+		b    *rulefmt.Rule
 		want bool
 	}{
 		{
 			name: "rule_node_identical",
-			a: &rulefmt.RuleNode{
-				Record:      yaml.Node{Value: "one"},
-				Expr:        yaml.Node{Value: "up"},
+			a: &rulefmt.Rule{
+				Record:      "one",
+				Expr:        "up",
 				Annotations: map[string]string{"a": "b", "c": "d"},
 				Labels:      nil,
 			},
-			b: &rulefmt.RuleNode{
-				Record:      yaml.Node{Value: "one"},
-				Expr:        yaml.Node{Value: "up"},
+			b: &rulefmt.Rule{
+				Record:      "one",
+				Expr:        "up",
 				Annotations: map[string]string{"c": "d", "a": "b"},
 				Labels:      nil,
 			},
@@ -92,53 +91,53 @@ func Test_rulesEqual(t *testing.T) {
 		},
 		{
 			name: "rule_node_diff",
-			a: &rulefmt.RuleNode{
-				Record: yaml.Node{Value: "one"},
-				Expr:   yaml.Node{Value: "up"},
+			a: &rulefmt.Rule{
+				Record: "one",
+				Expr:   "up",
 			},
-			b: &rulefmt.RuleNode{
-				Record: yaml.Node{Value: "two"},
-				Expr:   yaml.Node{Value: "up"},
+			b: &rulefmt.Rule{
+				Record: "two",
+				Expr:   "up",
 			},
 			want: false,
 		},
 		{
 			name: "rule_node_annotations_diff",
-			a: &rulefmt.RuleNode{
-				Record:      yaml.Node{Value: "one"},
-				Expr:        yaml.Node{Value: "up"},
+			a: &rulefmt.Rule{
+				Record:      "one",
+				Expr:        "up",
 				Annotations: map[string]string{"a": "b"},
 			},
-			b: &rulefmt.RuleNode{
-				Record:      yaml.Node{Value: "one", Column: 10},
-				Expr:        yaml.Node{Value: "up"},
+			b: &rulefmt.Rule{
+				Record:      "one",
+				Expr:        "up",
 				Annotations: map[string]string{"c": "d"},
 			},
 			want: false,
 		},
 		{
 			name: "rule_node_annotations_nil_diff",
-			a: &rulefmt.RuleNode{
-				Record:      yaml.Node{Value: "one"},
-				Expr:        yaml.Node{Value: "up"},
+			a: &rulefmt.Rule{
+				Record:      "one",
+				Expr:        "up",
 				Annotations: map[string]string{"a": "b"},
 			},
-			b: &rulefmt.RuleNode{
-				Record:      yaml.Node{Value: "one", Column: 10},
-				Expr:        yaml.Node{Value: "up"},
+			b: &rulefmt.Rule{
+				Record:      "one",
+				Expr:        "up",
 				Annotations: nil,
 			},
 			want: false,
 		},
 		{
 			name: "rule_node_yaml_diff",
-			a: &rulefmt.RuleNode{
-				Record: yaml.Node{Value: "one"},
-				Expr:   yaml.Node{Value: "up"},
+			a: &rulefmt.Rule{
+				Record: "one",
+				Expr:   "up",
 			},
-			b: &rulefmt.RuleNode{
-				Record: yaml.Node{Value: "one", Column: 10},
-				Expr:   yaml.Node{Value: "up"},
+			b: &rulefmt.Rule{
+				Record: "one",
+				Expr:   "up",
 			},
 			want: true,
 		},
@@ -153,9 +152,9 @@ func Test_rulesEqual(t *testing.T) {
 }
 
 func TestCompareGroups(t *testing.T) {
-	ruleOne := rulefmt.RuleNode{
-		Record:      yaml.Node{Value: "one"},
-		Expr:        yaml.Node{Value: "up"},
+	ruleOne := rulefmt.Rule{
+		Record:      "one",
+		Expr:        "up",
 		Annotations: map[string]string{"a": "b", "c": "d"},
 		Labels:      nil,
 	}
@@ -171,13 +170,13 @@ func TestCompareGroups(t *testing.T) {
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 			},
 			expectedErr: nil,
@@ -188,14 +187,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-2", "tenant-1"},
-					Rules:         []rulefmt.RuleNode{ruleOne},
+					Rules:         []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-2"},
-					Rules:         []rulefmt.RuleNode{ruleOne},
+					Rules:         []rulefmt.Rule{ruleOne},
 				},
 			},
 			expectedErr: nil,
@@ -205,13 +204,13 @@ func TestCompareGroups(t *testing.T) {
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne, ruleOne},
+					Rules: []rulefmt.Rule{ruleOne, ruleOne},
 				},
 			},
 			expectedErr: errDiffRuleLen,
@@ -221,7 +220,7 @@ func TestCompareGroups(t *testing.T) {
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost"},
@@ -230,7 +229,7 @@ func TestCompareGroups(t *testing.T) {
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost"},
@@ -243,7 +242,7 @@ func TestCompareGroups(t *testing.T) {
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost"},
@@ -252,7 +251,7 @@ func TestCompareGroups(t *testing.T) {
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost"},
@@ -266,7 +265,7 @@ func TestCompareGroups(t *testing.T) {
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost"},
@@ -275,7 +274,7 @@ func TestCompareGroups(t *testing.T) {
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 				RWConfigs: []rwrulefmt.RemoteWriteConfig{
 					{URL: "localhost2"},
@@ -289,14 +288,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-3"},
-					Rules:         []rulefmt.RuleNode{ruleOne},
+					Rules:         []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-2"},
-					Rules:         []rulefmt.RuleNode{ruleOne},
+					Rules:         []rulefmt.Rule{ruleOne},
 				},
 			},
 			expectedErr: errDiffSourceTenants,
@@ -307,14 +306,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-2"},
-					Rules:         []rulefmt.RuleNode{ruleOne},
+					Rules:         []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-1"},
-					Rules:         []rulefmt.RuleNode{ruleOne},
+					Rules:         []rulefmt.Rule{ruleOne},
 				},
 			},
 			expectedErr: errDiffSourceTenants,
@@ -325,14 +324,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1"},
-					Rules:         []rulefmt.RuleNode{ruleOne},
+					Rules:         []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:          "example_group",
 					SourceTenants: []string{"tenant-1", "tenant-1"},
-					Rules:         []rulefmt.RuleNode{ruleOne},
+					Rules:         []rulefmt.Rule{ruleOne},
 				},
 			},
 			expectedErr: nil,
@@ -342,14 +341,14 @@ func TestCompareGroups(t *testing.T) {
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:            "example_group",
 					EvaluationDelay: pointerOf[model.Duration](model.Duration(2 * time.Minute)),
-					Rules:           []rulefmt.RuleNode{ruleOne},
+					Rules:           []rulefmt.Rule{ruleOne},
 				},
 			},
 			expectedErr: errDiffEvaluationDelay,
@@ -360,14 +359,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:            "example_group",
 					EvaluationDelay: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
-					Rules:           []rulefmt.RuleNode{ruleOne},
+					Rules:           []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:            "example_group",
 					EvaluationDelay: pointerOf[model.Duration](model.Duration(2 * time.Minute)),
-					Rules:           []rulefmt.RuleNode{ruleOne},
+					Rules:           []rulefmt.Rule{ruleOne},
 				},
 			},
 			expectedErr: errDiffEvaluationDelay,
@@ -378,14 +377,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:            "example_group",
 					EvaluationDelay: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
-					Rules:           []rulefmt.RuleNode{ruleOne},
+					Rules:           []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:            "example_group",
 					EvaluationDelay: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
-					Rules:           []rulefmt.RuleNode{ruleOne},
+					Rules:           []rulefmt.Rule{ruleOne},
 				},
 			},
 		},
@@ -394,14 +393,14 @@ func TestCompareGroups(t *testing.T) {
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:            "example_group",
 					EvaluationDelay: pointerOf[model.Duration](model.Duration(0)),
-					Rules:           []rulefmt.RuleNode{ruleOne},
+					Rules:           []rulefmt.Rule{ruleOne},
 				},
 			},
 		},
@@ -410,14 +409,14 @@ func TestCompareGroups(t *testing.T) {
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:        "example_group",
 					QueryOffset: pointerOf[model.Duration](model.Duration(2 * time.Minute)),
-					Rules:       []rulefmt.RuleNode{ruleOne},
+					Rules:       []rulefmt.Rule{ruleOne},
 				},
 			},
 			expectedErr: errDiffQueryOffset,
@@ -428,14 +427,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:        "example_group",
 					QueryOffset: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
-					Rules:       []rulefmt.RuleNode{ruleOne},
+					Rules:       []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:        "example_group",
 					QueryOffset: pointerOf[model.Duration](model.Duration(2 * time.Minute)),
-					Rules:       []rulefmt.RuleNode{ruleOne},
+					Rules:       []rulefmt.Rule{ruleOne},
 				},
 			},
 			expectedErr: errDiffQueryOffset,
@@ -446,14 +445,14 @@ func TestCompareGroups(t *testing.T) {
 				RuleGroup: rulefmt.RuleGroup{
 					Name:        "example_group",
 					QueryOffset: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
-					Rules:       []rulefmt.RuleNode{ruleOne},
+					Rules:       []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:        "example_group",
 					QueryOffset: pointerOf[model.Duration](model.Duration(5 * time.Minute)),
-					Rules:       []rulefmt.RuleNode{ruleOne},
+					Rules:       []rulefmt.Rule{ruleOne},
 				},
 			},
 		},
@@ -462,14 +461,14 @@ func TestCompareGroups(t *testing.T) {
 			groupOne: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:  "example_group",
-					Rules: []rulefmt.RuleNode{ruleOne},
+					Rules: []rulefmt.Rule{ruleOne},
 				},
 			},
 			groupTwo: rwrulefmt.RuleGroup{
 				RuleGroup: rulefmt.RuleGroup{
 					Name:        "example_group",
 					QueryOffset: pointerOf[model.Duration](model.Duration(0)),
-					Rules:       []rulefmt.RuleNode{ruleOne},
+					Rules:       []rulefmt.Rule{ruleOne},
 				},
 			},
 		},

--- a/pkg/mimirtool/rules/parser_test.go
+++ b/pkg/mimirtool/rules/parser_test.go
@@ -35,7 +35,7 @@ func TestParseFiles(t *testing.T) {
 						{
 							RuleGroup: rulefmt.RuleGroup{
 								Name: "example_rule_group",
-								Rules: []rulefmt.RuleNode{
+								Rules: []rulefmt.Rule{
 									{
 										// currently the tests only check length
 									},
@@ -68,7 +68,7 @@ func TestParseFiles(t *testing.T) {
 						{
 							RuleGroup: rulefmt.RuleGroup{
 								Name: "example_rule_group",
-								Rules: []rulefmt.RuleNode{
+								Rules: []rulefmt.Rule{
 									{
 										// currently the tests only check length
 									},
@@ -83,7 +83,7 @@ func TestParseFiles(t *testing.T) {
 						{
 							RuleGroup: rulefmt.RuleGroup{
 								Name: "other_example_rule_group",
-								Rules: []rulefmt.RuleNode{
+								Rules: []rulefmt.Rule{
 									{
 										// currently the tests only check length
 									},
@@ -108,7 +108,7 @@ func TestParseFiles(t *testing.T) {
 							RuleGroup: rulefmt.RuleGroup{
 								SourceTenants: []string{"tenant-1", "tenant-2"},
 								Name:          "example_federated_rule_group",
-								Rules: []rulefmt.RuleNode{
+								Rules: []rulefmt.Rule{
 									{
 										// currently, the tests only check length
 									},

--- a/pkg/mimirtool/rules/rules.go
+++ b/pkg/mimirtool/rules/rules.go
@@ -107,7 +107,7 @@ func (r RuleNamespace) CheckRecordingRules(strict bool) int {
 // AggregateBy modifies the aggregation rules in groups to include a given Label.
 // If the applyTo function is provided, the aggregation is applied only to rules
 // for which the applyTo function returns true.
-func (r RuleNamespace) AggregateBy(label string, applyTo func(group rwrulefmt.RuleGroup, rule rulefmt.RuleNode) bool) (int, int, error) {
+func (r RuleNamespace) AggregateBy(label string, applyTo func(group rwrulefmt.RuleGroup, rule rulefmt.Rule) bool) (int, int, error) {
 	// `count` represents the number of rules we evaluated.
 	// `mod` represents the number of rules we modified - a modification can either be a lint or adding the
 	// label in the aggregation.
@@ -127,7 +127,7 @@ func (r RuleNamespace) AggregateBy(label string, applyTo func(group rwrulefmt.Ru
 			}
 
 			log.WithFields(log.Fields{"rule": getRuleName(rule)}).Debugf("evaluating...")
-			exp, err := parser.ParseExpr(rule.Expr.Value)
+			exp, err := parser.ParseExpr(rule.Expr)
 			if err != nil {
 				return count, mod, err
 			}
@@ -139,14 +139,14 @@ func (r RuleNamespace) AggregateBy(label string, applyTo func(group rwrulefmt.Ru
 			parser.Inspect(exp, f)
 
 			// Only modify the ones that actually changed.
-			if rule.Expr.Value != exp.String() {
+			if rule.Expr != exp.String() {
 				log.WithFields(log.Fields{
 					"rule":        getRuleName(rule),
 					"currentExpr": rule.Expr,
 					"afterExpr":   exp.String(),
 				}).Debugf("expression differs")
 				mod++
-				r.Groups[i].Rules[j].Expr.Value = exp.String()
+				r.Groups[i].Rules[j].Expr = exp.String()
 			}
 		}
 	}

--- a/pkg/mimirtool/rules/rules_test.go
+++ b/pkg/mimirtool/rules/rules_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/mimirtool/rules/rwrulefmt"
 )
@@ -20,7 +19,7 @@ func TestAggregateBy(t *testing.T) {
 	tt := []struct {
 		name            string
 		rn              RuleNamespace
-		applyTo         func(group rwrulefmt.RuleGroup, rule rulefmt.RuleNode) bool
+		applyTo         func(group rwrulefmt.RuleGroup, rule rulefmt.Rule) bool
 		expectedExpr    []string
 		count, modified int
 		expect          error
@@ -36,8 +35,8 @@ func TestAggregateBy(t *testing.T) {
 				Groups: []rwrulefmt.RuleGroup{
 					{
 						RuleGroup: rulefmt.RuleGroup{
-							Name: "WithoutAggregation", Rules: []rulefmt.RuleNode{
-								{Alert: yaml.Node{Value: "WithoutAggregation"}, Expr: yaml.Node{Value: "up != 1"}},
+							Name: "WithoutAggregation", Rules: []rulefmt.Rule{
+								{Alert: "WithoutAggregation", Expr: "up != 1"},
 							},
 						},
 					},
@@ -53,19 +52,17 @@ func TestAggregateBy(t *testing.T) {
 					{
 						RuleGroup: rulefmt.RuleGroup{
 							Name: "SkipWithout",
-							Rules: []rulefmt.RuleNode{
+							Rules: []rulefmt.Rule{
 								{
-									Alert: yaml.Node{Value: "SkipWithout"},
-									Expr: yaml.Node{
-										Value: `
-											min without (alertmanager) (
-												rate(prometheus_notifications_errors_total{job="default/prometheus"}[5m])
-											/
-												rate(prometheus_notifications_sent_total{job="default/prometheus"}[5m])
-											)
-											* 100
+									Alert: "SkipWithout",
+									Expr: `
+										min without (alertmanager) (
+											rate(prometheus_notifications_errors_total{job="default/prometheus"}[5m])
+										/
+											rate(prometheus_notifications_sent_total{job="default/prometheus"}[5m])
+										)
+										* 100
 											> 3`,
-									},
 								},
 							},
 						},
@@ -82,16 +79,14 @@ func TestAggregateBy(t *testing.T) {
 					{
 						RuleGroup: rulefmt.RuleGroup{
 							Name: "WithAggregation",
-							Rules: []rulefmt.RuleNode{
+							Rules: []rulefmt.Rule{
 								{
-									Alert: yaml.Node{Value: "WithAggregation"},
-									Expr: yaml.Node{
-										Value: `
+									Alert: "WithAggregation",
+									Expr: `
 										sum(rate(cortex_prometheus_rule_evaluation_failures_total[1m])) by (namespace, job)
 										/
 										sum(rate(cortex_prometheus_rule_evaluations_total[1m])) by (namespace, job)
 										> 0.01`,
-									},
 								},
 							},
 						},
@@ -108,15 +103,11 @@ func TestAggregateBy(t *testing.T) {
 					{
 						RuleGroup: rulefmt.RuleGroup{
 							Name: "CountAggregation",
-							Rules: []rulefmt.RuleNode{
+							Rules: []rulefmt.Rule{
 								{
-									Alert: yaml.Node{
-										Value: "CountAggregation",
-									},
-									Expr: yaml.Node{
-										Value: `
+									Alert: "CountAggregation",
+									Expr: `
 										count(count by (gitVersion) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1`,
-									},
 								},
 							},
 						},
@@ -133,10 +124,10 @@ func TestAggregateBy(t *testing.T) {
 					{
 						RuleGroup: rulefmt.RuleGroup{
 							Name: "BinaryExpressions",
-							Rules: []rulefmt.RuleNode{
+							Rules: []rulefmt.Rule{
 								{
-									Alert: yaml.Node{Value: "VectorMatching"},
-									Expr:  yaml.Node{Value: `count by (cluster, node) (sum by (node, cpu, cluster) (node_cpu_seconds_total{job="default/node-exporter"} * on (namespace, instance) group_left (node) node_namespace_pod:kube_pod_info:))`},
+									Alert: "VectorMatching",
+									Expr:  `count by (cluster, node) (sum by (node, cpu, cluster) (node_cpu_seconds_total{job="default/node-exporter"} * on (namespace, instance) group_left (node) node_namespace_pod:kube_pod_info:))`,
 								},
 							},
 						},
@@ -153,35 +144,27 @@ func TestAggregateBy(t *testing.T) {
 					{
 						RuleGroup: rulefmt.RuleGroup{
 							Name: "CountAggregation",
-							Rules: []rulefmt.RuleNode{
+							Rules: []rulefmt.Rule{
 								{
-									Alert: yaml.Node{
-										Value: "CountAggregation",
-									},
-									Expr: yaml.Node{
-										Value: `count by (namespace) (test_series) > 1`,
-									},
+									Alert: "CountAggregation",
+									Expr:  `count by (namespace) (test_series) > 1`,
 								},
 							},
 						},
 					}, {
 						RuleGroup: rulefmt.RuleGroup{
 							Name: "CountSkipped",
-							Rules: []rulefmt.RuleNode{
+							Rules: []rulefmt.Rule{
 								{
-									Alert: yaml.Node{
-										Value: "CountSkipped",
-									},
-									Expr: yaml.Node{
-										Value: `count by (namespace) (test_series) > 1`,
-									},
+									Alert: "CountSkipped",
+									Expr:  `count by (namespace) (test_series) > 1`,
 								},
 							},
 						},
 					},
 				},
 			},
-			applyTo: func(group rwrulefmt.RuleGroup, _ rulefmt.RuleNode) bool {
+			applyTo: func(group rwrulefmt.RuleGroup, _ rulefmt.Rule) bool {
 				return group.Name != "CountSkipped"
 			},
 			expectedExpr: []string{`count by (namespace, cluster) (test_series) > 1`, `count by (namespace) (test_series) > 1`},
@@ -194,25 +177,25 @@ func TestAggregateBy(t *testing.T) {
 					{
 						RuleGroup: rulefmt.RuleGroup{
 							Name: "Test",
-							Rules: []rulefmt.RuleNode{
+							Rules: []rulefmt.Rule{
 								{
-									Alert: yaml.Node{Value: "TestWithGroupLeft"},
-									Expr:  yaml.Node{Value: `(count by (namespace) (metric_1) > 0) * on (namespace) group_left (service) group by (service, namespace) (metric_2)`},
+									Alert: "TestWithGroupLeft",
+									Expr:  `(count by (namespace) (metric_1) > 0) * on (namespace) group_left (service) group by (service, namespace) (metric_2)`,
 								}, {
-									Alert: yaml.Node{Value: "TestWithGroupLeftAndAggregationLabelAlreadyPresentInOnClause"},
-									Expr:  yaml.Node{Value: `(count by (namespace, cluster) (metric_1) > 0) * on (namespace, cluster) group_left (service) group by (service, namespace, cluster) (metric_2)`},
+									Alert: "TestWithGroupLeftAndAggregationLabelAlreadyPresentInOnClause",
+									Expr:  `(count by (namespace, cluster) (metric_1) > 0) * on (namespace, cluster) group_left (service) group by (service, namespace, cluster) (metric_2)`,
 								}, {
-									Alert: yaml.Node{Value: "TestWithGroupLeftAndAggregationLabelAlreadyPresentInGroupLeftClause"},
-									Expr:  yaml.Node{Value: `(count by (namespace) (metric_1) > 0) * on (namespace) group_left (cluster) group by (cluster, namespace) (metric_2)`},
+									Alert: "TestWithGroupLeftAndAggregationLabelAlreadyPresentInGroupLeftClause",
+									Expr:  `(count by (namespace) (metric_1) > 0) * on (namespace) group_left (cluster) group by (cluster, namespace) (metric_2)`,
 								}, {
-									Alert: yaml.Node{Value: "TestWithGroupRight"},
-									Expr:  yaml.Node{Value: `(count by (namespace, service) (metric_1) > 0) * on (namespace) group_right (service) group by (namespace) (metric_2)`},
+									Alert: "TestWithGroupRight",
+									Expr:  `(count by (namespace, service) (metric_1) > 0) * on (namespace) group_right (service) group by (namespace) (metric_2)`,
 								}, {
-									Alert: yaml.Node{Value: "TestWithGroupRightAndAggregationLabelAlreadyPresentInOnClause"},
-									Expr:  yaml.Node{Value: `(count by (namespace, service, cluster) (metric_1) > 0) * on (namespace, cluster) group_right (service) group by (namespace, cluster) (metric_2)`},
+									Alert: "TestWithGroupRightAndAggregationLabelAlreadyPresentInOnClause",
+									Expr:  `(count by (namespace, service, cluster) (metric_1) > 0) * on (namespace, cluster) group_right (service) group by (namespace, cluster) (metric_2)`,
 								}, {
-									Alert: yaml.Node{Value: "TestWithGroupRightAndAggregationLabelAlreadyPresentInGroupRightClause"},
-									Expr:  yaml.Node{Value: `(count by (namespace, service, cluster) (metric_1) > 0) * on (namespace, service) group_right (cluster) group by (namespace, service) (metric_2)`},
+									Alert: "TestWithGroupRightAndAggregationLabelAlreadyPresentInGroupRightClause",
+									Expr:  `(count by (namespace, service, cluster) (metric_1) > 0) * on (namespace, service) group_right (cluster) group by (namespace, service) (metric_2)`,
 								},
 							},
 						},
@@ -245,7 +228,7 @@ func TestAggregateBy(t *testing.T) {
 			expectedIdx := 0
 			for _, g := range tc.rn.Groups {
 				for _, r := range g.Rules {
-					require.Equal(t, tc.expectedExpr[expectedIdx], r.Expr.Value)
+					require.Equal(t, tc.expectedExpr[expectedIdx], r.Expr)
 					expectedIdx++
 				}
 			}
@@ -303,10 +286,10 @@ func TestLintExpressions(t *testing.T) {
 			r := RuleNamespace{Groups: []rwrulefmt.RuleGroup{
 				{
 					RuleGroup: rulefmt.RuleGroup{
-						Rules: []rulefmt.RuleNode{
+						Rules: []rulefmt.Rule{
 							{
-								Alert: yaml.Node{Value: "AName"},
-								Expr:  yaml.Node{Value: tc.expr},
+								Alert: "AName",
+								Expr:  tc.expr,
 							},
 						},
 					},
@@ -316,7 +299,7 @@ func TestLintExpressions(t *testing.T) {
 
 			backend := MimirBackend
 			c, m, err := r.LintExpressions(backend)
-			rexpr := r.Groups[0].Rules[0].Expr.Value
+			rexpr := r.Groups[0].Rules[0].Expr
 
 			require.Equal(t, tc.count, c)
 			require.Equal(t, tc.modified, m)
@@ -374,10 +357,11 @@ func TestCheckRecordingRules(t *testing.T) {
 				Groups: []rwrulefmt.RuleGroup{
 					{
 						RuleGroup: rulefmt.RuleGroup{
-							Rules: []rulefmt.RuleNode{
+							Rules: []rulefmt.Rule{
 								{
-									Record: yaml.Node{Value: tc.ruleName},
-									Expr:   yaml.Node{Value: "rate(some_metric_total)[5m]"}},
+									Record: tc.ruleName,
+									Expr:   "rate(some_metric_total)[5m]",
+								},
 							},
 						},
 					},

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -438,10 +438,10 @@ func (r *DefaultMultiTenantManager) ValidateRuleGroup(g rulefmt.RuleGroup) []err
 	for i, r := range g.Rules {
 		for _, err := range r.Validate() {
 			var ruleName string
-			if r.Alert.Value != "" {
-				ruleName = r.Alert.Value
+			if r.Alert != "" {
+				ruleName = r.Alert
 			} else {
-				ruleName = r.Record.Value
+				ruleName = r.Record
 			}
 			errs = append(errs, &rulefmt.Error{
 				Group:    g.Name,

--- a/pkg/ruler/mapper_test.go
+++ b/pkg/ruler/mapper_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -41,31 +40,27 @@ var (
 )
 
 func setupRuleSets() {
-	recordNode := yaml.Node{}
-	recordNode.SetString("example_rule")
-	exprNode := yaml.Node{}
-	exprNode.SetString("example_expr")
-	recordNodeUpdated := yaml.Node{}
-	recordNodeUpdated.SetString("example_ruleupdated")
-	exprNodeUpdated := yaml.Node{}
-	exprNodeUpdated.SetString("example_exprupdated")
+	const record = "example_rule"
+	const expr = "example_expr"
+	const recordUpdated = "example_ruleupdated"
+	const exprUpdated = "example_exprupdated"
 	initialRuleSet = map[string][]rulefmt.RuleGroup{
 		"file /one": {
 			{
 				Name: "rulegroup_one",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
 			{
 				Name: "rulegroup_two",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
@@ -75,19 +70,19 @@ func setupRuleSets() {
 		"file /one": {
 			{
 				Name: "rulegroup_two",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
 			{
 				Name: "rulegroup_one",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
@@ -97,28 +92,28 @@ func setupRuleSets() {
 		"file /one": {
 			{
 				Name: "rulegroup_one",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
 			{
 				Name: "rulegroup_two",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
 			{
 				Name: "rulegroup_three",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
@@ -128,19 +123,19 @@ func setupRuleSets() {
 		"file /one": {
 			{
 				Name: "rulegroup_one",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
 			{
 				Name: "rulegroup_two",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
@@ -148,10 +143,10 @@ func setupRuleSets() {
 		"file /two": {
 			{
 				Name: "rulegroup_one",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
@@ -161,19 +156,19 @@ func setupRuleSets() {
 		"file /one": {
 			{
 				Name: "rulegroup_one",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
 			{
 				Name: "rulegroup_two",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
@@ -181,10 +176,10 @@ func setupRuleSets() {
 		"file /two": {
 			{
 				Name: "rulegroup_one",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNodeUpdated,
-						Expr:   exprNodeUpdated,
+						Record: recordUpdated,
+						Expr:   exprUpdated,
 					},
 				},
 			},
@@ -194,19 +189,19 @@ func setupRuleSets() {
 		"file /one": {
 			{
 				Name: "rulegroup_one",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
 			{
 				Name: "rulegroup_two",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},
@@ -216,10 +211,10 @@ func setupRuleSets() {
 		specialCharFile: {
 			{
 				Name: "rulegroup_one",
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: recordNode,
-						Expr:   exprNode,
+						Record: record,
+						Expr:   expr,
 					},
 				},
 			},

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/thanos-io/objstore"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
-	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/ruler/rulespb"
@@ -1476,10 +1475,10 @@ func TestRuler_DeleteTenantConfiguration_ShouldDeleteTenantConfigurationAndTrigg
 
 	// "upload" rule groups
 	for _, key := range ruleGroups {
-		desc := rulespb.ToProto(key.user, key.namespace, rulefmt.RuleGroup{Name: key.group, Rules: []rulefmt.RuleNode{
+		desc := rulespb.ToProto(key.user, key.namespace, rulefmt.RuleGroup{Name: key.group, Rules: []rulefmt.Rule{
 			{
-				Record: yaml.Node{Value: "up", Kind: yaml.ScalarNode},
-				Expr:   yaml.Node{Value: "up==1", Kind: yaml.ScalarNode},
+				Record: "up",
+				Expr:   "up==1",
 			},
 		}})
 		require.NoError(t, rs.SetRuleGroup(context.Background(), key.user, key.namespace, desc))

--- a/pkg/ruler/rulespb/compat_test.go
+++ b/pkg/ruler/rulespb/compat_test.go
@@ -117,7 +117,7 @@ func TestToProto(t *testing.T) {
 			input: rulefmt.RuleGroup{
 				Name:     "group",
 				Interval: model.Duration(60 * time.Second),
-				Rules:    []rulefmt.RuleNode{},
+				Rules:    []rulefmt.Rule{},
 			},
 			expected: &RuleGroupDesc{
 				Name:            "group",
@@ -133,7 +133,7 @@ func TestToProto(t *testing.T) {
 				Name:            "group",
 				Interval:        model.Duration(60 * time.Second),
 				EvaluationDelay: pointerOf[model.Duration](model.Duration(5 * time.Second)),
-				Rules:           []rulefmt.RuleNode{},
+				Rules:           []rulefmt.Rule{},
 			},
 			expected: &RuleGroupDesc{
 				Name:            "group",
@@ -149,7 +149,7 @@ func TestToProto(t *testing.T) {
 				Name:        "group",
 				Interval:    model.Duration(60 * time.Second),
 				QueryOffset: pointerOf[model.Duration](model.Duration(2 * time.Second)),
-				Rules:       []rulefmt.RuleNode{},
+				Rules:       []rulefmt.Rule{},
 			},
 			expected: &RuleGroupDesc{
 				Name:        "group",
@@ -166,7 +166,7 @@ func TestToProto(t *testing.T) {
 				Interval:        model.Duration(60 * time.Second),
 				EvaluationDelay: pointerOf[model.Duration](model.Duration(5 * time.Second)),
 				QueryOffset:     pointerOf[model.Duration](model.Duration(2 * time.Second)),
-				Rules:           []rulefmt.RuleNode{},
+				Rules:           []rulefmt.Rule{},
 			},
 			expected: &RuleGroupDesc{
 				Name:            "group",
@@ -213,7 +213,7 @@ func TestFromProto(t *testing.T) {
 			expected: rulefmt.RuleGroup{
 				Name:     "group",
 				Interval: model.Duration(60 * time.Second),
-				Rules:    []rulefmt.RuleNode{},
+				Rules:    []rulefmt.Rule{},
 			},
 		},
 		"with evaluation delay": {
@@ -229,7 +229,7 @@ func TestFromProto(t *testing.T) {
 				Name:            "group",
 				Interval:        model.Duration(60 * time.Second),
 				EvaluationDelay: pointerOf[model.Duration](model.Duration(5 * time.Second)),
-				Rules:           []rulefmt.RuleNode{},
+				Rules:           []rulefmt.Rule{},
 			},
 		},
 		"with query offset": {
@@ -245,7 +245,7 @@ func TestFromProto(t *testing.T) {
 				Name:        "group",
 				Interval:    model.Duration(60 * time.Second),
 				QueryOffset: pointerOf[model.Duration](model.Duration(2 * time.Second)),
-				Rules:       []rulefmt.RuleNode{},
+				Rules:       []rulefmt.Rule{},
 			},
 		},
 		"with both evaluation delay and query offset": {
@@ -263,7 +263,7 @@ func TestFromProto(t *testing.T) {
 				Interval:        model.Duration(60 * time.Second),
 				EvaluationDelay: pointerOf[model.Duration](model.Duration(5 * time.Second)),
 				QueryOffset:     pointerOf[model.Duration](model.Duration(2 * time.Second)),
-				Rules:           []rulefmt.RuleNode{},
+				Rules:           []rulefmt.Rule{},
 			},
 		},
 	}

--- a/pkg/ruler/rulestore/bucketclient/bucket_client_test.go
+++ b/pkg/ruler/rulestore/bucketclient/bucket_client_test.go
@@ -98,7 +98,7 @@ func TestListRules(t *testing.T) {
 func TestLoadRules(t *testing.T) {
 	rs := NewBucketRuleStore(objstore.NewInMemBucket(), nil, log.NewNopLogger())
 	groups := []testGroup{
-		{user: "user1", namespace: "hello", ruleGroup: rulefmt.RuleGroup{Name: "first testGroup", Interval: model.Duration(time.Minute), Rules: []rulefmt.RuleNode{{
+		{user: "user1", namespace: "hello", ruleGroup: rulefmt.RuleGroup{Name: "first testGroup", Interval: model.Duration(time.Minute), Rules: []rulefmt.Rule{{
 			For:           model.Duration(5 * time.Minute),
 			KeepFiringFor: model.Duration(2 * time.Minute),
 			Labels:        map[string]string{"label1": "value1"},

--- a/pkg/ruler/rulestore/local/local_test.go
+++ b/pkg/ruler/rulestore/local/local_test.go
@@ -36,10 +36,10 @@ func TestClient_LoadRuleGroups(t *testing.T) {
 			{
 				Name:     "rule",
 				Interval: model.Duration(100 * time.Second),
-				Rules: []rulefmt.RuleNode{
+				Rules: []rulefmt.Rule{
 					{
-						Record: yaml.Node{Kind: yaml.ScalarNode, Value: "test_rule"},
-						Expr:   yaml.Node{Kind: yaml.ScalarNode, Value: "up"},
+						Record: "test_rule",
+						Expr:   "up",
 					},
 				},
 			},


### PR DESCRIPTION
Updates lots of things except the hard one so far. (rule.Validate())
Several buckets of tests now pass that didn't before - rulestore, isolated mimirtool tests, anything not in the chain of one of our two Validate calls.

Linter and CI should fail because it leaves compile errors around validate(). this pr should never target main branch