### PR TITLE
Simplify github workflows to use auto-generater CI token

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -6,31 +6,11 @@ on:
       - closed
       - labeled
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   main:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Retrieve GitHub App credentials from Vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
-        with:
-          repo_secrets: |
-            APP_ID=mimir-github-bot:app_id
-            PRIVATE_KEY=mimir-github-bot:private_key
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ env.APP_ID }}
-          private-key: ${{ env.PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout Actions
         uses: actions/checkout@v4
         with:
@@ -46,6 +26,6 @@ jobs:
       - name: Run backport
         uses: ./actions/backport
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           labelsToAdd: "backport"
           title: "[{{base}}] {{originalTitle}}"

--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -2,14 +2,9 @@ name: helm-weekly-release-pr
 
 on:
   schedule:
-    - cron: '0 10 * * 1-5' # 10 UTC on weekdays; if we miss published images one day, they should align the day after
+    - cron: "0 10 * * 1-5" # 10 UTC on weekdays; if we miss published images one day, they should align the day after
 
   workflow_dispatch: # for manual testing
-
-# These permissions are needed to assume roles from Github's OIDC.
-permissions:
-  contents: read
-  id-token: write
 
 jobs:
   weekly-release-pr:
@@ -18,22 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: imjasonh/setup-crane@v0.4
 
-      - name: Retrieve GitHub App credentials from Vault
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
-        with:
-          repo_secrets: |
-            APP_ID=mimir-github-bot:app_id
-            PRIVATE_KEY=mimir-github-bot:private_key
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ env.APP_ID }}
-          private-key: ${{ env.PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Update/regenerate files
         id: update
         run: bash .github/workflows/scripts/helm-weekly-release.sh
@@ -41,11 +20,10 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           title: Release mimir-distributed Helm chart ${{ steps.update.outputs.new_chart_version }}
           body: Automated PR created by [helm-weekly-release-pr.yaml](https://github.com/grafana/mimir/blob/main/.github/workflows/helm-weekly-release-pr.yaml)
           commit-message: Update mimir-distributed chart to ${{ steps.update.outputs.new_chart_version }}
-          author: grafanabot <grafanabot@grafana.com>
           branch: helm-chart-weekly-${{ steps.update.outputs.new_chart_version }}
           base: main
           labels: helm

--- a/.github/workflows/scripts/helm-weekly-release.sh
+++ b/.github/workflows/scripts/helm-weekly-release.sh
@@ -104,4 +104,4 @@ update_yaml_node $chart_file .version $new_chart_version
 
 make TTY='' doc
 
-echo "::set-output name=new_chart_version::$new_chart_version"
+echo "new_chart_version=$new_chart_version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
#### What this PR does

This is the follow-up to #10819, #10820, etc.

The two workflows (backport and weekly-helm-release) don't need the private token to do the job. That is, these workflows only open a new PR, and, thus, don't act as a "maintainer". Switching the workflows to the temporal auto-generated `GITHUB_TOKEN` (ref [GitHub docs][1]) makes two things simpler:

1. We can use private Mimir token to auto-review the weekly PRs (this has been [broken since forever](https://github.com/grafana/mimir/pull/10254#issuecomment-2560989258)).
2. Backporting of the PRs opened by the contributors will just work, because the contributors won't try to access the private Vault — it's [broken now](https://github.com/grafana/mimir/actions/runs/13930549296)).

Closes #10828 (mine fixes the same problem but in a simpler way).

Note that Tempo is currently doing the same (ref [grafana/tempo][2]).

[1]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
[2]: https://github.com/grafana/tempo/blob/9bc9043e66d8af65fa22f9b61a35b55ffcaa1195/.github/workflows/backport.yml