### PR TITLE
ruler: Cache rule group contents if caching is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Ruler: Remove experimental CLI flag `-ruler-storage.cache.rule-group-enabled` to enable or disable caching the contents of rule groups. Caching rule group contents is now always enabled when a cache is configured for the ruler. #10949
 * [ENHANCEMENT] Ingester: Add support for exporting native histogram cost attribution metrics (`cortex_ingester_attributed_active_native_histogram_series` and `cortex_ingester_attributed_active_native_histogram_buckets`) with labels specified by customers to a custom Prometheus registry. #10892
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -15210,17 +15210,6 @@
           "blockEntries": [
             {
               "kind": "field",
-              "name": "rule_group_enabled",
-              "required": false,
-              "desc": "Enabling caching of rule group contents if a cache backend is configured.",
-              "fieldValue": null,
-              "fieldDefaultValue": false,
-              "fieldFlag": "ruler-storage.cache.rule-group-enabled",
-              "fieldType": "boolean",
-              "fieldCategory": "experimental"
-            },
-            {
-              "kind": "field",
               "name": "backend",
               "required": false,
               "desc": "Backend for ruler storage cache, if not empty. The cache is supported for any storage backend except \"local\". Supported values: memcached, redis.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2795,8 +2795,6 @@ Usage of ./cmd/mimir/mimir:
     	[deprecated] Username to use when connecting to Redis.
   -ruler-storage.cache.redis.write-timeout duration
     	[deprecated] Client write timeout. (default 3s)
-  -ruler-storage.cache.rule-group-enabled
-    	[experimental] Enabling caching of rule group contents if a cache backend is configured.
   -ruler-storage.filesystem.dir string
     	Local filesystem storage directory. (default "ruler")
   -ruler-storage.gcs.bucket-name string

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -88,8 +88,6 @@ The following features are currently experimental:
   - Allow control over rule sync intervals.
     - `ruler.outbound-sync-queue-poll-interval`
     - `ruler.inbound-sync-queue-poll-interval`
-  - Cache rule group contents.
-    - `-ruler-storage.cache.rule-group-enabled`
 - Distributor
   - Influx ingestion
     - `/api/v1/push/influx/write` endpoint

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2375,11 +2375,6 @@ local:
   [directory: <string> | default = ""]
 
 cache:
-  # (experimental) Enabling caching of rule group contents if a cache backend is
-  # configured.
-  # CLI flag: -ruler-storage.cache.rule-group-enabled
-  [rule_group_enabled: <boolean> | default = false]
-
   # Backend for ruler storage cache, if not empty. The cache is supported for
   # any storage backend except "local". Supported values: memcached, redis.
   # CLI flag: -ruler-storage.cache.backend

--- a/pkg/ruler/rulestore/config.go
+++ b/pkg/ruler/rulestore/config.go
@@ -29,21 +29,8 @@ type Config struct {
 	bucket.Config `yaml:",inline"`
 	Local         LocalStoreConfig `yaml:"local"`
 
-	// RulerCache holds the configuration used for the ruler storage cache.
-	RulerCache RulerCacheConfig `yaml:"cache"`
-}
-
-// RulerCacheConfig is configuration for the cache used by ruler storage as well as
-// additional ruler storage specific configuration.
-//
-// NOTE: This is temporary while caching of rule groups is being tested. This will be removed
-// in the future and cache.BackendConfig will be moved back to the Config struct above.
-type RulerCacheConfig struct {
-	// RuleGroupEnabled enables caching of rule group contents
-	RuleGroupEnabled bool `yaml:"rule_group_enabled" category:"experimental"`
-
 	// Cache holds the configuration used for the ruler storage cache.
-	Cache cache.BackendConfig `yaml:",inline"`
+	Cache cache.BackendConfig `yaml:"cache"`
 }
 
 // RegisterFlags registers the backend storage config.
@@ -54,10 +41,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.Local.RegisterFlagsWithPrefix(prefix, f)
 	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "ruler", f)
 
-	f.BoolVar(&cfg.RulerCache.RuleGroupEnabled, prefix+"cache.rule-group-enabled", false, "Enabling caching of rule group contents if a cache backend is configured.")
-	f.StringVar(&cfg.RulerCache.Cache.Backend, prefix+"cache.backend", "", fmt.Sprintf("Backend for ruler storage cache, if not empty. The cache is supported for any storage backend except %q. Supported values: %s.", BackendLocal, strings.Join(supportedCacheBackends, ", ")))
-	cfg.RulerCache.Cache.Memcached.RegisterFlagsWithPrefix(prefix+"cache.memcached.", f)
-	cfg.RulerCache.Cache.Redis.RegisterFlagsWithPrefix(prefix+"cache.redis.", f)
+	f.StringVar(&cfg.Cache.Backend, prefix+"cache.backend", "", fmt.Sprintf("Backend for ruler storage cache, if not empty. The cache is supported for any storage backend except %q. Supported values: %s.", BackendLocal, strings.Join(supportedCacheBackends, ", ")))
+	cfg.Cache.Memcached.RegisterFlagsWithPrefix(prefix+"cache.memcached.", f)
+	cfg.Cache.Redis.RegisterFlagsWithPrefix(prefix+"cache.redis.", f)
 }
 
 func (cfg *Config) Validate() error {
@@ -65,7 +51,7 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 
-	return cfg.RulerCache.Cache.Validate()
+	return cfg.Cache.Validate()
 }
 
 // IsDefaults returns true if the storage options have not been set.


### PR DESCRIPTION
#### What this PR does

When caching is configured for the ruler, cache the contents of rule groups. This removes the experimental CLI flag to enable or disable this specific functionality when caching was configured for the ruler.

#### Which issue(s) this PR fixes or relates to

Related #9595

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
