### PR TITLE
Feat/dynamic step

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7145,6 +7145,28 @@
         },
         {
           "kind": "field",
+          "name": "dynamic_step_enabled",
+          "required": false,
+          "desc": "True to enable dynamic step calculation for range queries.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-frontend.dynamic-step-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "dynamic_step_complexity_threshold",
+          "required": false,
+          "desc": "The minimum number of series by step in a query result set to enable dynamic step calculation. If the number of series in a query result set is less than this value, the step is not changed.",
+          "fieldValue": null,
+          "fieldDefaultValue": 1,
+          "fieldFlag": "query-frontend.dynamic-step-complexity-threshold",
+          "fieldType": "float",
+          "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
           "name": "use_active_series_decoder",
           "required": false,
           "desc": "Set to true to use the zero-allocation response decoder for active series queries.",

--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -140,6 +140,8 @@ frontend:
   parallelize_shardable_queries: true
   cache_results: true
   shard_active_series_queries: true
+  dynamic_step_enabled: true
+  dynamic_step_complexity_threshold: 1
 
   # Uncomment when using "dns" service discovery mode for query-scheduler.
   # scheduler_address: "query-scheduler:9011"

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1876,6 +1876,14 @@ results_cache:
 # CLI flag: -query-frontend.shard-active-series-queries
 [shard_active_series_queries: <boolean> | default = false]
 
+# (experimental) True to enable dynamic step calculation for range series queries.
+# CLI flag: -query-frontend.dynamic_step_enabled
+[dynamic_step_enabled: <boolean> | default = false]
+
+# (experimental) The maximum complexity level to allow in a query when dynamic
+# step calculation is enabled.
+[dynamic_step_complexity_threshold: <float> | default = 1]
+
 # (experimental) Set to true to use the zero-allocation response decoder for
 # active series queries.
 # CLI flag: -query-frontend.use-active-series-decoder

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -123,6 +123,8 @@ type MetricsQueryRequest interface {
 	GetEnd() int64
 	// GetStep returns the step of the request in milliseconds.
 	GetStep() int64
+	// SetStep sets the step of the request in milliseconds.
+	SetStep(newStep int64)
 	// GetQuery returns the query of the request.
 	GetQuery() string
 	// GetMinT returns the minimum timestamp in milliseconds of data to be queried,

--- a/pkg/frontend/querymiddleware/dynamic_step.go
+++ b/pkg/frontend/querymiddleware/dynamic_step.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"context"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"math"
+	"strconv"
+)
+
+const (
+	complexityThreshold = 1
+)
+
+// dynamicStep is a MetricsQueryHandler that change the step of a query dynamically
+// based on the complexity of the query.
+type dynamicStep struct {
+	next   MetricsQueryHandler
+	logger log.Logger
+
+	dynamicStepUsageCount prometheus.CounterVec
+	complexityThreshold   float64
+}
+
+func newDynamicStepMiddleware(complexityThreshold float64, logger log.Logger, registerer prometheus.Registerer) MetricsQueryMiddleware {
+	dynamicStepUsageCount := promauto.With(registerer).NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mimir_query_frontend_dynamic_step_usage_count",
+			Help: "Number of queries whose step has been adjusted dynamically.",
+		},
+		[]string{"cardinality", "step", "new_step"},
+	)
+	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
+		return &dynamicStep{
+			next:   next,
+			logger: logger,
+
+			dynamicStepUsageCount: *dynamicStepUsageCount,
+			complexityThreshold:   complexityThreshold,
+		}
+	})
+}
+
+// Do change the step of a query dynamically based on the complexity of the query in the request.
+func (d *dynamicStep) Do(ctx context.Context, request MetricsQueryRequest) (Response, error) {
+
+	// Get the cardinality of the query
+
+	hints := request.GetHints()
+
+	if hints == nil || hints.GetCardinalityEstimate() == nil {
+		level.Debug(d.logger).Log("msg", "no cardinality estimation required for dynamic step. Skipping it")
+		return d.next.Do(ctx, request)
+	}
+
+	cardinality := hints.GetCardinalityEstimate().EstimatedSeriesCount
+
+	// Get the step of the query
+	step := request.GetStep()
+
+	newStep := d.getNewStep(cardinality, step)
+
+	if newStep > step {
+		level.Warn(d.logger).Log("msg", "query step adjusted", "step", step, "new_step", newStep, "cardinality", cardinality)
+		request.SetStep(newStep)
+		d.dynamicStepUsageCount.With(
+			prometheus.Labels{
+				"cardinality": strconv.FormatUint(cardinality, 10),
+				"step":        strconv.FormatInt(step, 10),
+				"new_step":    strconv.FormatInt(newStep, 10),
+			}).Inc()
+	}
+
+	return d.next.Do(ctx, request)
+}
+
+// getNewStep returns the new step based on the complexity of the query and the current step.
+func (d *dynamicStep) getNewStep(cardinality uint64, step int64) int64 {
+
+	complexity := float64(cardinality) / float64(step)
+
+	if complexity > d.complexityThreshold {
+		// Calculate the new step based on the complexity
+		step = 100 * int64(10*math.Pow(complexity/d.complexityThreshold, 1.2))
+	}
+	return step
+}

--- a/pkg/frontend/querymiddleware/dynamic_step_test.go
+++ b/pkg/frontend/querymiddleware/dynamic_step_test.go
@@ -1,0 +1,104 @@
+package querymiddleware
+
+import (
+	"context"
+	"github.com/go-kit/log"
+	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_dynamicStep_getNewStep(t *testing.T) {
+	type args struct {
+		cardinality int
+		step        int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "cardinality too low to change the query step",
+			args: args{
+				cardinality: 900,
+				step:        2000,
+			},
+			want: 2000,
+		},
+		{
+			name: "complex query detected",
+			args: args{
+				cardinality: 2000,
+				step:        500,
+			},
+			want: 5200,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &dynamicStep{
+				logger:              log.NewNopLogger(),
+				complexityThreshold: complexityThreshold,
+			}
+			assert.Equal(t, int64(tt.want), d.getNewStep(uint64(tt.args.cardinality), int64(tt.args.step)))
+		})
+	}
+}
+
+func Test_dynamicStep_Do(t *testing.T) {
+	tests := []struct {
+		name        string
+		oldStep     int
+		cardinality int
+		handler     MetricsQueryHandler
+		wantBigger  bool
+	}{
+		{
+			name: "complexity is less than the threshold",
+			handler: &dynamicStep{
+				logger: log.NewNopLogger(),
+			},
+			wantBigger:  false,
+			oldStep:     1000,
+			cardinality: 900,
+		},
+		{
+			name:       "complexity is greater than the threshold",
+			wantBigger: true,
+			handler: &dynamicStep{
+				logger: log.NewNopLogger(),
+			},
+			oldStep:     500,
+			cardinality: 1900,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newDynamicStepMiddleware(complexityThreshold, log.NewNopLogger(), prometheus.NewRegistry())
+			_, ctx := stats.ContextWithEmptyStats(context.Background())
+			handle := d.Wrap(&mockNextHandler{t, true})
+
+			req := PrometheusRangeQueryRequest{
+				start:     parseTimeRFC3339(t, "2023-01-31T09:00:00Z").Unix() * 1000,
+				end:       parseTimeRFC3339(t, "2023-01-31T10:00:00Z").Unix() * 1000,
+				queryExpr: parseQuery(t, "up"),
+				step:      int64(tt.oldStep),
+				hints: &Hints{
+					CardinalityEstimate: &EstimatedSeriesCount{
+						EstimatedSeriesCount: uint64(tt.cardinality),
+					},
+				},
+			}
+			_, err := handle.Do(ctx, &req)
+			assert.NoError(t, err)
+
+			if tt.wantBigger {
+				assert.Greater(t, req.step, int64(tt.oldStep))
+			} else {
+				assert.Equal(t, int64(tt.oldStep), req.step)
+			}
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -126,6 +126,10 @@ func (r *PrometheusRangeQueryRequest) GetStep() int64 {
 	return r.step
 }
 
+func (r *PrometheusRangeQueryRequest) SetStep(newStep int64) {
+	r.step = newStep
+}
+
 func (r *PrometheusRangeQueryRequest) GetQuery() string {
 	if r.queryExpr != nil {
 		return r.queryExpr.String()
@@ -328,6 +332,8 @@ func (r *PrometheusInstantQueryRequest) GetEnd() int64 {
 func (r *PrometheusInstantQueryRequest) GetStep() int64 {
 	return 0
 }
+
+func (r *PrometheusInstantQueryRequest) SetStep(newStep int64) {}
 
 // GetMinT returns the minimum timestamp in milliseconds of data to be queried,
 // as determined from the start timestamp and any range vector or offset in the query.

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -246,6 +246,9 @@ func (r *remoteReadQueryRequest) GetStep() int64 {
 	return 0
 }
 
+func (r *remoteReadQueryRequest) SetStep(newStep int64) {
+}
+
 func (r *remoteReadQueryRequest) GetID() int64 {
 	return 0
 }


### PR DESCRIPTION
# What this PR does
This PR introduces a middleware for the Mimir frontend to dynamically optimize query step sizes for complex queries.

### Problem Statement
Many queries from Grafana dashboards, especially those involving high-cardinality data, can take more than 10 seconds to execute. This is often due to:
- Queries with a low step size (step) and a long time range, which significantly increase the amount of data fetched.
- Users importing large dashboards without adjusting the step size to match their dataset's growth over time. Initially, when data volume was lower, these settings may have worked fine, but as data complexity increases, queries become slower.

### Proposed Solution
This middleware detects "complex" queries—specifically, high-cardinality queries with a low step size—and dynamically adjusts the step parameter to improve query performance. By increasing the step size where appropriate, we can:
- Reduce query execution time.
- Improve dashboard responsiveness.
- Allow users to retrieve more granular data on demand rather than by default.

### Notes
The mathematical function and step-size limits used in this implementation are preliminary estimates and have not yet been validated in a high-load production environment. Further tuning and real-world testing will be required.

#### Checklist

- [*] Tests updated.
- [*] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
