### PR TITLE
Alertmanager: Broadcast oversized Grafana state

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -586,8 +586,8 @@ func (am *Alertmanager) mergePartialExternalState(part *clusterpb.Part) error {
 	return am.state.MergePartialState(part)
 }
 
-func (am *Alertmanager) mergeFullExternalState(fs *clusterpb.FullState) error {
-	return am.state.MergeFullStates([]*clusterpb.FullState{fs})
+func (am *Alertmanager) mergeFullGrafanaState(fs *clusterpb.FullState) error {
+	return am.state.MergeGrafanaState([]*clusterpb.FullState{fs})
 }
 
 func (am *Alertmanager) getFullState() (*clusterpb.FullState, error) {

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -816,7 +816,7 @@ func (am *MultitenantAlertmanager) syncStates(ctx context.Context, cfg amConfig)
 		}
 	}
 
-	if err := userAM.mergeFullExternalState(s.State); err != nil {
+	if err := userAM.mergeFullGrafanaState(s.State); err != nil {
 		return err
 	}
 	userAM.usingGrafanaState.Store(true)

--- a/pkg/alertmanager/state_replication_test.go
+++ b/pkg/alertmanager/state_replication_test.go
@@ -439,3 +439,44 @@ func TestStateReplication_GetFullState(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeGrafanaState(t *testing.T) {
+	// Oversized messages should be broadcasted for Grafana state taken from object storage.
+	replicator := newFakeReplicator()
+	replicator.read = readStateResult{res: nil, err: nil}
+
+	store := newFakeAlertStore()
+
+	reg := prometheus.NewPedanticRegistry()
+	s := newReplicatedStates("test", 3, replicator, store, log.NewNopLogger(), reg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, services.StartAndAwaitRunning(ctx, s))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), s))
+	})
+
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		require.NoError(t, s.WaitReady(ctx))
+	}
+
+	// Cancel the context to avoid other goroutines pulling the broadcasted messages from <-s.msgc.
+	cancel()
+
+	// Send the oversized state in a separate goroutine.
+	data := []byte(strings.Repeat("a", 1000))
+	go func() {
+		s.MergeGrafanaState([]*clusterpb.FullState{{
+			Parts: []clusterpb.Part{{
+				Key:  "sil:test",
+				Data: data,
+			}},
+		}})
+	}()
+
+	// Check for broadcasted messages.
+	p := <-s.msgc
+	require.Equal(t, data, p.Data)
+}

--- a/pkg/alertmanager/state_replication_test.go
+++ b/pkg/alertmanager/state_replication_test.go
@@ -468,12 +468,12 @@ func TestMergeGrafanaState(t *testing.T) {
 	// Send the oversized state in a separate goroutine.
 	data := []byte(strings.Repeat("a", 1000))
 	go func() {
-		s.MergeGrafanaState([]*clusterpb.FullState{{
+		require.NoError(t, s.MergeGrafanaState([]*clusterpb.FullState{{
 			Parts: []clusterpb.Part{{
 				Key:  "sil:test",
 				Data: data,
 			}},
-		}})
+		}}))
 	}()
 
 	// Check for broadcasted messages.


### PR DESCRIPTION
When the Grafana configuration is promoted, Mimir fetches the Grafana state from object storage and merges it with its own, incorporating any silences and nflog entries. After merging the Grafana state and broadcasting it to other pods, it deletes it from object storage. The resulting state is persisted as normal Mimir Alertmanager state.

As we use upstream code to perform the state merge, [oversized messages are dropped](https://github.com/grafana/mimir/blob/d6c7e94e46d51e7851b15dfa9522c7abfca9f13c/vendor/github.com/prometheus/alertmanager/silence/silence.go#L942-L967). As these oversized silences are not broadcasted, other pods that could not reach the Grafana state before it was deleted won't have those silences.

<details><summary>Grafana Alertmanager tenants with silences larger than Prometheus' message size limit will only have their silences in the Alertmanager pod that merged them before they were deleted.</summary>
<br/>
Only one out of three Alertmanagers picked up the silence.

![image](https://github.com/user-attachments/assets/43629dc6-0006-46db-898c-fe099bf711b6)

</details>

<details><summary>To fix this, this PR checks for silences larger than Prometheus' message size limit and broadcasts them.</summary>
<br/>

The silence was gossiped to all Alertmanager instances.
![image](https://github.com/user-attachments/assets/03a26084-645d-4c77-941b-a4196a1e4dea)

</details>