### PR TITLE
[mimir-distributed-release-5.7] Update Mimir and GEM image versions

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/_index.md
@@ -8,8 +8,8 @@ keywords:
   - Grafana Enterprise Metrics
   - Grafana metrics
 cascade:
-  MIMIR_VERSION: "v2.15.x"
-  GEM_VERSION: "v2.15.x"
+  MIMIR_VERSION: "v2.16.x"
+  GEM_VERSION: "v2.16.x"
   ALLOY_VERSION: "latest"
 ---
 

--- a/docs/sources/helm-charts/mimir-distributed/release-notes/v5.7.md
+++ b/docs/sources/helm-charts/mimir-distributed/release-notes/v5.7.md
@@ -1,0 +1,30 @@
+---
+title: "Grafana Mimir Helm chart version 5.7 release notes"
+menuTitle: "V5.7 release notes"
+description: "Release notes for Grafana Mimir Helm chart version 5.7"
+weight: 300
+---
+
+# Grafana Mimir Helm chart version 5.7 release notes
+
+Grafana Labs is excited to announce version 5.7 of the Grafana Mimir Helm chart, which is compatible with Grafana Mimir v2.16 and Grafana Enterprise Metrics (GEM) v2.16. The `mimir-distributed` Helm chart is the best way to install Mimir on Kubernetes.
+
+The highlights that follow include the top features, enhancements, and bug fixes in this release. For a comprehensive list of changes, see the [Helm chart changelog](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/CHANGELOG.md).
+
+## Important changes
+
+The ring heartbeat timeout for store-gateways has been increased to 10 minutes.
+
+Memcached has been updated to version 1.6.34.
+
+All Memcached statefulsets now default to three replicas in `small.yaml` and `large.yaml`.
+
+Hostnames for Memcached instances now include the `global.clusterDomain` setting.
+
+## Features and enhancements
+
+Individual mimir components can override their container images via the \*.image values. The component's image definitions always override the values set in global `image` or `enterprise.image`.
+
+All components can expose additional ports with their respective services via the \*.service.extraPorts values. This allows exposing the containers that components declare in `extraContainers`.
+
+An optional Helm update job for provisioning tenants in Grafana Enterprise Metrics has been added.

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -37,6 +37,7 @@ Entries should include a reference to the Pull Request that introduced the chang
   * `-store-gateway.sharding-ring.heartbeat-timeout` set to `10m`
 * [CHANGE] Memcached: Use 3 replicas for all cache types by default in `large.yaml` and `small.yaml`. #10739
 * [CHANGE] Memcached: Honor `global.clusterDomain` when building hostnames for each cache cluster. #10858
+* [ENHANCEMENT] Upgrade Mimir and GEM to [2.16.0](https://github.com/grafana/mimir/blob/main/CHANGELOG.md#2160). #10962
 * [ENHANCEMENT] Minio: update subchart to v5.4.0. #10346
 * [ENHANCEMENT] Individual mimir components can override their container images via the *.image values. The component's image definitions always override the values set in global `image` or `enterprise.image`. #10340
 * [ENHANCEMENT] Alertmanager, compactor, ingester, and store-gateway StatefulSets can configure their PVC template name via the corresponding *.persistentVolume.name values. #10376

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 5.7.0-weekly.334
-appVersion: r334
+version: 5.7.0-rc.0
+appVersion: 2.16.0-rc.0
 description: "Grafana Mimir"
 home: https://grafana.com/docs/helm-charts/mimir-distributed/latest/
 icon: https://grafana.com/static/img/logos/logo-mimir.svg

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/latest/)
 
 For the full documentation, visit [Grafana mimir-distributed Helm chart documentation](https://grafana.com/docs/helm-charts/mimir-distributed/latest/).
 
-> **Note:** The documentation version is derived from the Helm chart version which is 5.7.0-weekly.334.
+> **Note:** The documentation version is derived from the Helm chart version which is 5.7.0-rc.0.
 
 When upgrading from Helm chart version 4.X, please see [Migrate the Helm chart from version 4.x to 5.0](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-helm-chart-4.x-to-5.0/).
 When upgrading from Helm chart version 3.x, please see [Migrate from single zone to zone-aware replication with Helm](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-from-single-zone-with-helm/).
@@ -14,7 +14,7 @@ When upgrading from Helm chart version 2.1, please see [Upgrade the Grafana Mimi
 
 # mimir-distributed
 
-![Version: 5.7.0-weekly.334](https://img.shields.io/badge/Version-5.7.0--weekly.334-informational?style=flat-square) ![AppVersion: r334](https://img.shields.io/badge/AppVersion-r334-informational?style=flat-square)
+![Version: 5.7.0-rc.0](https://img.shields.io/badge/Version-5.7.0--rc.0-informational?style=flat-square) ![AppVersion: 2.16.0-rc.0](https://img.shields.io/badge/AppVersion-2.16.0--rc.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -34,7 +34,7 @@ image:
   # -- Grafana Mimir container image repository. Note: for Grafana Enterprise Metrics use the value 'enterprise.image.repository'
   repository: grafana/mimir
   # -- Grafana Mimir container image tag. Note: for Grafana Enterprise Metrics use the value 'enterprise.image.tag'
-  tag: r334-c301d43
+  tag: 2.16.0-rc.0
   # -- Container pull policy - shared between Grafana Mimir and Grafana Enterprise Metrics
   pullPolicy: IfNotPresent
   # -- Optionally specify an array of imagePullSecrets - shared between Grafana Mimir and Grafana Enterprise Metrics


### PR DESCRIPTION
Update Mimir to 2.16.0-rc.0 image versions and update the chartversion to 5.7.0-rc.0. Note that the GEM RC version doesn't exist yet and so hasn't been updated.


Part of https://github.com/grafana/mimir/issues/10917


