### PR TITLE
Renovate: Exclude grpc dependency

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -16,6 +16,7 @@
         "enabled": false
       },
       {
+        // Don't update replace directives.
         "matchPackageNames": [
           "github.com/grafana/mimir-prometheus",
           "github.com/grafana/memberlist",
@@ -23,7 +24,8 @@
           "github.com/colega/go-yaml-yaml",
           "github.com/grafana/goautoneg",
           "github.com/grafana/opentracing-contrib-go-stdlib",
-          "github.com/charleskorn/go-grpc"
+          "github.com/charleskorn/go-grpc",
+          "google.golang.org/grpc",
         ],
         "enabled": false
       },


### PR DESCRIPTION
#### What this PR does

Configure Renovate to exclude the `google.golang.org/grpc` dependency, since we pin it through a `replace` directive.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
