### PR TITLE
Add readiness check and partition assignment tests to usage tracker

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -1044,6 +1044,13 @@ func (t *Mimir) readyHandler(sm *services.Manager, shutdownRequested *atomic.Boo
 			}
 		}
 
+		if t.UsageTracker != nil {
+			if err := t.UsageTracker.CheckReady(r.Context()); err != nil {
+				http.Error(w, "Usage Tracker not ready: "+err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+		}
+
 		util.WriteTextResponse(w, "ready")
 	}
 }

--- a/pkg/usagetracker/tracker_test.go
+++ b/pkg/usagetracker/tracker_test.go
@@ -37,7 +37,7 @@ func TestUsageTracker_PartitionAssignment(t *testing.T) {
 			"a0": newTestUsageTracker(t, 0, "zone-a", ikv, pkv, cluster),
 			"b0": newTestUsageTracker(t, 0, "zone-b", ikv, pkv, cluster),
 		}
-		waitUntilAllTrackersSeeAllInstnacesInTheirZones(t, trackers)
+		waitUntilAllTrackersSeeAllInstancesInTheirZones(t, trackers)
 
 		// First checks, we haven't done any kind of reconciliation yet, so no partitions should be active yet, no partitions have owners.
 		requireAllTrackersNotReady(t, trackers)
@@ -84,7 +84,7 @@ func TestUsageTracker_PartitionAssignment(t *testing.T) {
 			"a1": newTestUsageTracker(t, 1, "zone-a", ikv, pkv, cluster),
 			"b1": newTestUsageTracker(t, 1, "zone-b", ikv, pkv, cluster),
 		}
-		waitUntilAllTrackersSeeAllInstnacesInTheirZones(t, trackers)
+		waitUntilAllTrackersSeeAllInstancesInTheirZones(t, trackers)
 
 		// Usage-trackers have started now, we run reconciliations but nothing should happen yet
 		// because previous instances (-0) are not running yet.
@@ -126,7 +126,7 @@ func TestUsageTracker_PartitionAssignment(t *testing.T) {
 			"a0": a0,
 			"b0": b0,
 		}
-		waitUntilAllTrackersSeeAllInstnacesInTheirZones(t, trackers)
+		waitUntilAllTrackersSeeAllInstancesInTheirZones(t, trackers)
 
 		// Create trackers and check that they're ready.
 		reconcileAllTrackersPartitionCountTimes(t, trackers)
@@ -136,7 +136,7 @@ func TestUsageTracker_PartitionAssignment(t *testing.T) {
 		a1 := newTestUsageTracker(t, 1, "zone-a", ikv, pkv, cluster)
 		trackers["a1"] = a1
 
-		waitUntilAllTrackersSeeAllInstnacesInTheirZones(t, trackers)
+		waitUntilAllTrackersSeeAllInstancesInTheirZones(t, trackers)
 		// Reconcile again (no need to reconcile so many times, but it's a noop after the needed amount).
 		reconcileAllTrackersPartitionCountTimes(t, trackers)
 
@@ -204,7 +204,7 @@ func TestUsageTracker_PartitionAssignment(t *testing.T) {
 				cfg.MaxPartitionsToCreatePerReconcile = testPartitionsCount / expectedZoneBReconcilesToCreateAllPartitions
 			}),
 		}
-		waitUntilAllTrackersSeeAllInstnacesInTheirZones(t, trackers)
+		waitUntilAllTrackersSeeAllInstancesInTheirZones(t, trackers)
 
 		// Reconcile once:
 		for key, ut := range trackers {
@@ -244,7 +244,7 @@ func requireAllTrackersNotReady(t *testing.T, trackers map[string]*UsageTracker)
 		require.Error(t, ut.CheckReady(context.Background()), "Tracker %q should not be ready yet", key)
 	}
 }
-func waitUntilAllTrackersSeeAllInstnacesInTheirZones(t *testing.T, trackers map[string]*UsageTracker) {
+func waitUntilAllTrackersSeeAllInstancesInTheirZones(t *testing.T, trackers map[string]*UsageTracker) {
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		trackersPerZone := map[string]int{}
 		for _, ut := range trackers {

--- a/pkg/usagetracker/tracker_test.go
+++ b/pkg/usagetracker/tracker_test.go
@@ -3,14 +3,348 @@
 package usagetracker
 
 import (
+	"context"
+	"flag"
 	"fmt"
 	"math"
 	"slices"
 	"testing"
+	"time"
 
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/kv/consul"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+
+	"github.com/grafana/mimir/pkg/util/validation"
 )
+
+// testPartitionsCount is lower in test to make debugging easier.
+const testPartitionsCount = 16
+
+func TestUsageTracker_PartitionAssignment(t *testing.T) {
+	t.Run("happy-case initial assignment of all partitions", func(t *testing.T) {
+		t.Parallel()
+
+		ikv, pkv, cluster := prepareKVStoreAndKafkaMocks(t)
+		trackers := map[string]*UsageTracker{
+			"a0": newTestUsageTracker(t, 0, "zone-a", ikv, pkv, cluster),
+			"b0": newTestUsageTracker(t, 0, "zone-b", ikv, pkv, cluster),
+		}
+		waitUntilAllTrackersSeeAllInstnacesInTheirZones(t, trackers)
+
+		// First checks, we haven't done any kind of reconciliation yet, so no partitions should be active yet, no partitions have owners.
+		requireAllTrackersNotReady(t, trackers)
+
+		// Take partitionRing from one of the usage-trackers for convenience.
+		partitionRing := trackers["a0"].partitionRing
+		require.Empty(t, partitionRing.PartitionRing().ActivePartitionIDs(), "No partitions should be active yet.")
+		for partitionID := int32(0); partitionID < testPartitionsCount; partitionID++ {
+			require.Empty(t, partitionRing.PartitionRing().MultiPartitionOwnerIDs(partitionID, nil), "Partition %d should have no owners yet.")
+		}
+
+		// All usage-trackers have started now, run partition reconciliations.
+		reconcileAllTrackersPartitionCountTimes(t, trackers)
+
+		// Check that every partition has two owners.
+		ownedPartitions := map[string]int{}
+		for partitionID := int32(0); partitionID < testPartitionsCount; partitionID++ {
+			owners := partitionRing.PartitionRing().MultiPartitionOwnerIDs(0, nil)
+			require.Len(t, owners, 2, "Partition %d should have 2 owners", partitionID)
+			for _, o := range owners {
+				ownedPartitions[o]++
+			}
+		}
+
+		// Check that each owner ownds testParitionsCount / (len(trackers) / 2 zones) partitions.
+		for owner, partitions := range ownedPartitions {
+			require.Equal(t, testPartitionsCount/(len(trackers)/2), partitions, "Usage-Tracker %q should own exactly %d partitions.", owner, partitions)
+		}
+
+		// We should have all partitions active by this point.
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			require.Len(t, partitionRing.PartitionRing().ActivePartitionIDs(), testPartitionsCount)
+		}, 5*time.Second, 100*time.Millisecond)
+
+		// Usage-Trackers should be ready now.
+		requireAllTrackersReady(t, trackers)
+	})
+
+	t.Run("partitions are not instantiated if previous instances are not running", func(t *testing.T) {
+		t.Parallel()
+
+		ikv, pkv, cluster := prepareKVStoreAndKafkaMocks(t)
+		trackers := map[string]*UsageTracker{
+			"a1": newTestUsageTracker(t, 1, "zone-a", ikv, pkv, cluster),
+			"b1": newTestUsageTracker(t, 1, "zone-b", ikv, pkv, cluster),
+		}
+		waitUntilAllTrackersSeeAllInstnacesInTheirZones(t, trackers)
+
+		// Usage-trackers have started now, we run reconciliations but nothing should happen yet
+		// because previous instances (-0) are not running yet.
+		reconcileAllTrackersPartitionCountTimes(t, trackers)
+
+		// They should not be ready yet.
+		requireAllTrackersNotReady(t, trackers)
+
+		// start zone-a-0.
+		trackers["a0"] = newTestUsageTracker(t, 0, "zone-a", ikv, pkv, cluster)
+
+		// Reconcile them again.
+		for partitionID := int32(0); partitionID < testPartitionsCount; partitionID++ {
+			for key, ut := range trackers {
+				require.NoError(t, ut.reconcilePartitions(context.Background()), "Tracker %q could not reconcile", key)
+			}
+		}
+
+		// zone-a-0 and zone-a-1 should be ready now, but zone-b-1 is not ready yet because zone-b-0 didn't join the instance ring yet.
+		require.NoError(t, trackers["a0"].CheckReady(context.Background()), "Tracker a0 should be ready now")
+		require.NoError(t, trackers["a1"].CheckReady(context.Background()), "Tracker a1 should be ready now")
+		require.Error(t, trackers["b1"].CheckReady(context.Background()), "Tracker b1 should not be ready yet")
+	})
+
+	t.Run("new instance takes partitions, old instance gracefully shut downs them", func(t *testing.T) {
+		t.Parallel()
+
+		// lostPartitionsShutdownGracePeriod should be long enough for this test not to be flaky,
+		// but also short enough to keep the test fast
+		const lostPartitionsShutdownGracePeriod = time.Second
+		configureLostPartitionsShutdownGracePeriod := func(cfg *Config) {
+			cfg.LostPartitionsShutdownGracePeriod = lostPartitionsShutdownGracePeriod
+		}
+
+		ikv, pkv, cluster := prepareKVStoreAndKafkaMocks(t)
+		a0 := newTestUsageTracker(t, 0, "zone-a", ikv, pkv, cluster, configureLostPartitionsShutdownGracePeriod)
+		b0 := newTestUsageTracker(t, 0, "zone-b", ikv, pkv, cluster, configureLostPartitionsShutdownGracePeriod)
+		trackers := map[string]*UsageTracker{
+			"a0": a0,
+			"b0": b0,
+		}
+		waitUntilAllTrackersSeeAllInstnacesInTheirZones(t, trackers)
+
+		// Create trackers and check that they're ready.
+		reconcileAllTrackersPartitionCountTimes(t, trackers)
+		requireAllTrackersReady(t, trackers)
+
+		// Start zone-a-1.
+		a1 := newTestUsageTracker(t, 1, "zone-a", ikv, pkv, cluster)
+		trackers["a1"] = a1
+
+		waitUntilAllTrackersSeeAllInstnacesInTheirZones(t, trackers)
+		// Reconcile again (no need to reconcile so many times, but it's a noop after the needed amount).
+		reconcileAllTrackersPartitionCountTimes(t, trackers)
+
+		// All trackers should be ready.
+		requireAllTrackersReady(t, trackers)
+
+		// zone-a-0 should have 16 partitions, zone-a-1 should have 8, this is deterministic at this point.
+		a0.partitionsMtx.RLock()
+		require.Len(t, a0.partitions, 16)
+		a0.partitionsMtx.RUnlock()
+		a1.partitionsMtx.RLock()
+		require.Len(t, a1.partitions, 8)
+		a1.partitionsMtx.RUnlock()
+
+		// Check eventually because partitionRing update might be delayed.
+		partitionRing := a0.partitionRing
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			// First half still has 2 owners.
+			for partitionID := int32(0); partitionID < testPartitionsCount/2; partitionID++ {
+				require.Len(t, partitionRing.PartitionRing().MultiPartitionOwnerIDs(partitionID, nil), 2, "Partition %d should have 2 owners.", partitionID)
+			}
+			// Second half of partitions should have 3 owners now (zone-a-0, zone-a-1, zone-b-1)
+			for partitionID := int32(testPartitionsCount / 2); partitionID < testPartitionsCount; partitionID++ {
+				require.Len(t, partitionRing.PartitionRing().MultiPartitionOwnerIDs(partitionID, nil), 3, "Partition %d should have 2 owners.", partitionID)
+			}
+		}, time.Second, 100*time.Millisecond)
+
+		// Reconcile once more after ring is updated to make sure that zone-a-0 has tracked all the lost partitions with their times.
+		reconcileAllTrackersPartitionCountTimes(t, trackers)
+
+		// Wait until old partitions are lost.
+		time.Sleep(lostPartitionsShutdownGracePeriod)
+
+		reconcileAllTrackersPartitionCountTimes(t, trackers)
+
+		// zone-a-0 should have 8 partitions, zone-a-1 should have 8, this is deterministic at this point.
+		a0.partitionsMtx.RLock()
+		require.Len(t, a0.partitions, 8)
+		a0.partitionsMtx.RUnlock()
+		a1.partitionsMtx.RLock()
+		require.Len(t, a1.partitions, 8)
+		a1.partitionsMtx.RUnlock()
+
+		// Check eventually that owners are updated in the ring.
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			for partitionID := int32(0); partitionID < testPartitionsCount; partitionID++ {
+				require.Len(t, partitionRing.PartitionRing().MultiPartitionOwnerIDs(partitionID, nil), 2, "Partition %d should have 2 owners.", partitionID)
+			}
+		}, 5*lostPartitionsShutdownGracePeriod, 100*time.Millisecond)
+	})
+
+	t.Run("respects MaxPartitionsToCreatePerReconcile", func(t *testing.T) {
+		t.Parallel()
+
+		ikv, pkv, cluster := prepareKVStoreAndKafkaMocks(t)
+		const (
+			expectedZoneAReconcilesToCreateAllPartitions = 4
+			expectedZoneBReconcilesToCreateAllPartitions = 2
+		)
+		trackers := map[string]*UsageTracker{
+			"a0": newTestUsageTracker(t, 0, "zone-a", ikv, pkv, cluster, func(cfg *Config) {
+				cfg.MaxPartitionsToCreatePerReconcile = testPartitionsCount / expectedZoneAReconcilesToCreateAllPartitions
+			}),
+			"b0": newTestUsageTracker(t, 0, "zone-b", ikv, pkv, cluster, func(cfg *Config) {
+				cfg.MaxPartitionsToCreatePerReconcile = testPartitionsCount / expectedZoneBReconcilesToCreateAllPartitions
+			}),
+		}
+		waitUntilAllTrackersSeeAllInstnacesInTheirZones(t, trackers)
+
+		// Reconcile once:
+		for key, ut := range trackers {
+			require.NoError(t, ut.reconcilePartitions(context.Background()), "Tracker %q could not reconcile", key)
+			ut.partitionsMtx.RLock()
+			require.Equal(t, ut.cfg.MaxPartitionsToCreatePerReconcile, len(ut.partitions))
+			ut.partitionsMtx.RUnlock()
+		}
+
+		// Should not be ready yet:
+		requireAllTrackersNotReady(t, trackers)
+
+		// Reconcile rest expected times.
+		for reconcile := 1; reconcile < expectedZoneAReconcilesToCreateAllPartitions; reconcile++ {
+			require.NoError(t, trackers["a0"].reconcilePartitions(context.Background()), "Tracker a0 could not reconcile")
+		}
+		for reconcile := 1; reconcile < expectedZoneBReconcilesToCreateAllPartitions; reconcile++ {
+			require.NoError(t, trackers["b0"].reconcilePartitions(context.Background()), "Tracker b0 could not reconcile")
+		}
+
+		// Should be ready now.
+		for key, ut := range trackers {
+			require.NoError(t, ut.CheckReady(context.Background()), "Tracker %q should be ready now", key)
+		}
+	})
+}
+
+func requireAllTrackersReady(t *testing.T, trackers map[string]*UsageTracker) {
+	t.Helper()
+	for key, ut := range trackers {
+		require.NoError(t, ut.CheckReady(context.Background()), "Tracker %q should be ready now", key)
+	}
+}
+
+func requireAllTrackersNotReady(t *testing.T, trackers map[string]*UsageTracker) {
+	for key, ut := range trackers {
+		require.Error(t, ut.CheckReady(context.Background()), "Tracker %q should not be ready yet", key)
+	}
+}
+func waitUntilAllTrackersSeeAllInstnacesInTheirZones(t *testing.T, trackers map[string]*UsageTracker) {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		trackersPerZone := map[string]int{}
+		for _, ut := range trackers {
+			trackersPerZone[ut.cfg.InstanceRing.InstanceZone]++
+		}
+		for _, ut := range trackers {
+			require.Equal(t, trackersPerZone[ut.cfg.InstanceRing.InstanceZone], ut.instanceRing.WritableInstancesWithTokensInZoneCount(ut.cfg.InstanceRing.InstanceZone))
+		}
+	}, time.Second, 50*time.Millisecond)
+}
+
+// reconcileAllTrackersPartitionCountTimes calls reoncilePartition on each tracker testPartitionsCount times.
+// Since we only allow one partition creation per reconcile by default, this should allow for creation of all partitions.
+func reconcileAllTrackersPartitionCountTimes(t require.TestingT, trackers map[string]*UsageTracker) {
+	for partitionID := int32(0); partitionID < testPartitionsCount; partitionID++ {
+		for key, ut := range trackers {
+			require.NoError(t, ut.reconcilePartitions(context.Background()), "Tracker %q could not reconcile", key)
+		}
+	}
+}
+
+func prepareKVStoreAndKafkaMocks(t *testing.T) (*consul.Client, *consul.Client, *kfake.Cluster) {
+	ikv, instanceKVCloser := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, instanceKVCloser.Close()) })
+	pkv, partitionKVCloser := consul.NewInMemoryClient(ring.GetPartitionRingCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, partitionKVCloser.Close()) })
+	cluster := fakeKafkaCluster(t)
+	return ikv, pkv, cluster
+}
+
+func newTestUsageTracker(t *testing.T, index int, zone string, ikv, pkv kv.Client, cluster *kfake.Cluster, options ...func(cfg *Config)) *UsageTracker {
+	instanceID := fmt.Sprintf("usage-tracker-%s-%d", zone, index)
+	cfg := newTestUsageTrackerConfig(t, instanceID, zone, ikv, pkv, cluster)
+	for _, option := range options {
+		option(&cfg)
+	}
+	reg := prometheus.NewPedanticRegistry()
+	logger := log.NewNopLogger()
+	instanceRing, err := NewInstanceRingClient(cfg.InstanceRing, logger, reg)
+	require.NoError(t, err)
+	startServiceAndStopOnCleanup(t, instanceRing)
+
+	partitionRingWatcher := NewPartitionRingWatcher(pkv, logger, reg)
+	partitionRing := ring.NewMultiPartitionInstanceRing(partitionRingWatcher, instanceRing, cfg.InstanceRing.HeartbeatTimeout)
+	startServiceAndStopOnCleanup(t, partitionRingWatcher)
+
+	overrides, err := validation.NewOverrides(validation.Limits{}, nil)
+	require.NoError(t, err)
+
+	ut, err := NewUsageTracker(cfg, instanceRing, partitionRing, overrides, logger, reg)
+	require.NoError(t, err)
+
+	startServiceAndStopOnCleanup(t, ut)
+	return ut
+}
+
+func startServiceAndStopOnCleanup(t *testing.T, svc services.Service) {
+	t.Helper()
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), svc))
+	t.Cleanup(func() {
+		err := services.StopAndAwaitTerminated(context.Background(), svc)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("Unexpected error stopping service %T: %s", svc, err)
+		}
+	})
+}
+
+func newTestUsageTrackerConfig(t *testing.T, instanceID, zone string, ikv, pkv kv.Client, cluster *kfake.Cluster) Config {
+	var cfg Config
+	fs := flag.NewFlagSet("usage-tracker", flag.PanicOnError)
+	cfg.RegisterFlags(fs, log.NewNopLogger())
+	require.NoError(t, fs.Parse(nil))
+
+	cfg.Partitions = testPartitionsCount
+	cfg.InstanceRing.InstanceID = instanceID
+	cfg.InstanceRing.InstanceZone = zone
+	cfg.InstanceRing.InstanceAddr = "localhost"
+	// KVStore mocks.
+	cfg.InstanceRing.KVStore.Mock = ikv
+	cfg.PartitionRing.KVStore.Mock = pkv
+	// Test lower test-related configs to avoid long waiting times.
+	cfg.PartitionRing.waitOwnersDurationOnPending = 100 * time.Millisecond
+	cfg.PartitionRing.lifecyclerPollingInterval = 50 * time.Millisecond
+	// Fake kafka cluster address.
+	cfg.EventsStorage.Reader.Address = cluster.ListenAddrs()[0]
+	cfg.EventsStorage.Writer.Address = cluster.ListenAddrs()[0]
+
+	cfg.PartitionReconcileInterval = time.Hour // we do reconciliation manually
+
+	require.NoError(t, cfg.Validate())
+	return cfg
+}
+
+func fakeKafkaCluster(t *testing.T, topicsToSeed ...string) *kfake.Cluster {
+	t.Helper()
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(1, topicsToSeed...))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	return cluster
+}
 
 func TestInstancePartitions(t *testing.T) {
 	for partitions := int32(2); partitions <= 128; partitions *= 2 {

--- a/pkg/usagetracker/tracker_test.go
+++ b/pkg/usagetracker/tracker_test.go
@@ -165,7 +165,7 @@ func TestUsageTracker_PartitionAssignment(t *testing.T) {
 			}
 		}, time.Second, 100*time.Millisecond)
 
-		// Reconcile zone-a-0 once more after ring is updated to make sure that all the lost partitions with their times.
+		// Reconcile zone-a-0 once more after ring is updated to make sure that it notes all the lost partitions with their times.
 		require.NoError(t, a0.reconcilePartitions(context.Background()))
 
 		// Wait until old partitions are lost.

--- a/pkg/usagetracker/tracker_test.go
+++ b/pkg/usagetracker/tracker_test.go
@@ -62,7 +62,7 @@ func TestUsageTracker_PartitionAssignment(t *testing.T) {
 			}
 		}
 
-		// Check that each owner ownds testParitionsCount / (len(trackers) / 2 zones) partitions.
+		// Check that each owner owns testParitionsCount / (len(trackers) / 2 zones) partitions.
 		for owner, partitions := range ownedPartitions {
 			require.Equal(t, testPartitionsCount/(len(trackers)/2), partitions, "Usage-Tracker %q should own exactly %d partitions.", owner, partitions)
 		}


### PR DESCRIPTION
#### What this PR does

Adds the readiness check endpoint to usage-tracker.

Also adds tests for usage-tracker partition assignment logic in order to keep this new code tested (as well as testing previously untested partition reconciliation).

I tried to make sure that they're not flaky:

```
~/w/github.com/grafana/mimir on  usage-tracker-partition-assignment-tests 11:19:43
$ go test -count=10 -run=TestUsageTracker_PartitionAssignment ./pkg/usagetracker
ok  	github.com/grafana/mimir/pkg/usagetracker	17.751s

~/w/github.com/grafana/mimir on  usage-tracker-partition-assignment-tests 11:20:37
$ go test -count=100 -run=TestUsageTracker_PartitionAssignment ./pkg/usagetracker
ok  	github.com/grafana/mimir/pkg/usagetracker	179.885s
```

Please note that this is going to be merged to `usage-tracker` branch, not `main`.