### PR TITLE
mixin: Add dashboard panels for per-tenant gateway metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * [ENHANCEMENT] Dashboards: Include absolute number of notifications attempted to alertmanager in 'Mimir / Ruler'. #10918
 * [ENHANCEMENT] Alerts: Make `MimirRolloutStuck` a critical alert if it has been firing for 6h. #10890
+* [ENHANCEMENT] Dashboards: Add panels to the `Mimir / Tenants` and `Mimir / Top Tenants` dashboards showing the rate of gateway requests. #10978
 * [BUGFIX] Dashboards: fix "Mimir / Tenants" legends for non-Kubernetes deployments. #10891
 
 ### Jsonnet

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -242,6 +242,7 @@
 
     // Whether mimir gateway is enabled. The gateway is usually enabled in GEM deployments.
     gateway_enabled: $._config.gem_enabled,
+    gateway_per_tenant_metrics_enabled: false,
 
     // Whether grafana cloud alertmanager instance-mapper is enabled
     alertmanager_im_enabled: false,

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -179,6 +179,20 @@ local filename = 'mimir-tenants.json';
       )
     )
 
+    .addRowIf(
+      $._config.gateway_per_tenant_metrics_enabled,
+      $.row('Tenant gateway requests').addPanel(
+        $.timeseriesPanel('Reads') +
+        $.qpsPanel('cortex_per_tenant_request_total{tenant=~"$user", route=~"%s"}' % $.queries.read_http_routes_regex)
+      ).addPanel(
+        $.timeseriesPanel('Writes') +
+        $.qpsPanel('cortex_per_tenant_request_total{tenant=~"$user", route=~"%s"}' % $.queries.write_http_routes_regex)
+      ).addPanel(
+        $.timeseriesPanel('Other') +
+        $.qpsPanel('cortex_per_tenant_request_total{tenant=~"$user", route!~"%s", route!~"%s"}' % [$.queries.read_http_routes_regex, $.queries.write_http_routes_regex]),
+      )
+    )
+
     .addRow(
       $.row('Exemplars and native histograms')
       .addPanel(

--- a/operations/mimir-mixin/dashboards/top-tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/top-tenants.libsonnet
@@ -144,6 +144,43 @@ local filename = 'mimir-top-tenants.json';
       ),
     )
 
+    .addRowIf(
+      $._config.gateway_per_tenant_metrics_enabled,
+      ($.row('By gateway read requests rate') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by gateway read requests rate in last 5m') +
+        { sort: { col: 2, desc: true } } +
+        $.tablePanel(
+          [
+            'topk($limit, sum by (tenant) (rate(cortex_per_tenant_request_total{route=~"%s", %s}[5m])))'
+            % [$.queries.read_http_routes_regex, $.namespaceMatcher()],
+          ], {
+            tenant: { alias: 'tenant', unit: 'string' },
+            Value: { alias: 'requests/s' },
+          }
+        )
+      ),
+    )
+
+    .addRowIf(
+      $._config.gateway_per_tenant_metrics_enabled,
+      ($.row('By gateway write requests rate') + { collapse: true })
+      .addPanel(
+        $.panel('Top $limit users by gateway write requests rate in last 5m') +
+        { sort: { col: 2, desc: true } } +
+        $.tablePanel(
+          [
+            'topk($limit, sum by (tenant) (rate(cortex_per_tenant_request_total{route=~"%s", %s}[5m])))'
+            % [$.queries.write_http_routes_regex, $.namespaceMatcher()],
+          ], {
+            tenant: { alias: 'tenant', unit: 'string' },
+            Value: { alias: 'requests/s' },
+          }
+        )
+      ),
+    )
+
+
     .addRow(
       ($.row('By discarded samples rate') + { collapse: true })
       .addPanel(


### PR DESCRIPTION
This allows us to see the amount of successful/failing requests for every tenant 
![image](https://github.com/user-attachments/assets/9ddae3c2-cce7-434b-a3f3-bf07b4979308)


Also, panels were added to the "Top Tenants" dashboard so we can see the biggest contributors of gateway load
![image](https://github.com/user-attachments/assets/5a09419e-a633-485a-91a3-1b94ac5adad3)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
