### PR TITLE
MQE: set correct lookback delta on statement

### DIFF
--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -40,7 +40,6 @@ var errQueryFinished = cancellation.NewErrorf("query execution finished")
 
 type Query struct {
 	queryable                storage.Queryable
-	opts                     promql.QueryOpts
 	statement                *parser.EvalStmt
 	root                     types.Operator
 	engine                   *Engine
@@ -81,7 +80,6 @@ func newQuery(ctx context.Context, queryable storage.Queryable, opts promql.Quer
 
 	q := &Query{
 		queryable:                queryable,
-		opts:                     opts,
 		engine:                   engine,
 		qs:                       qs,
 		memoryConsumptionTracker: limiting.NewMemoryConsumptionTracker(maxEstimatedMemoryConsumptionPerQuery, engine.queriesRejectedDueToPeakMemoryConsumption),

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -62,6 +62,11 @@ func newQuery(ctx context.Context, queryable storage.Queryable, opts promql.Quer
 		opts = promql.NewPrometheusQueryOpts(false, 0)
 	}
 
+	lookbackDelta := opts.LookbackDelta()
+	if lookbackDelta == 0 {
+		lookbackDelta = engine.lookbackDelta
+	}
+
 	maxEstimatedMemoryConsumptionPerQuery, err := engine.limitsProvider.GetMaxEstimatedMemoryConsumptionPerQuery(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get memory consumption limit for query: %w", err)
@@ -88,7 +93,7 @@ func newQuery(ctx context.Context, queryable storage.Queryable, opts promql.Quer
 			Start:         start,
 			End:           end,
 			Interval:      interval, // 0 for instant queries
-			LookbackDelta: opts.LookbackDelta(),
+			LookbackDelta: lookbackDelta,
 		},
 	}
 
@@ -150,10 +155,7 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr, timeRange types
 
 	switch e := expr.(type) {
 	case *parser.VectorSelector:
-		lookbackDelta := q.opts.LookbackDelta()
-		if lookbackDelta == 0 {
-			lookbackDelta = q.engine.lookbackDelta
-		}
+		lookbackDelta := q.statement.LookbackDelta
 
 		return &selectors.InstantVectorSelector{
 			MemoryConsumptionTracker: q.memoryConsumptionTracker,


### PR DESCRIPTION
#### What this PR does

This PR fixes the issue where the `parser.Statement` returned by a MQE `Query` does not have the correct lookback delta set if the engine default or global default is being used.

As far as I can see, nothing uses this information, so there was no impact to this, but wanted to tidy it up before it did cause a problem.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
