### PR TITLE
Mimirtool: Add flag for enabling experimental PromQL function parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 ### Mimirtool
 
+* [FEATURE] Add `--enable-experimental-functions` flag to commands that parse PromQL to allow parsing experimental functions such as `sort()`.
+
 ### Mimir Continuous Test
 
 ### Query-tee

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Mimirtool
 
-* [FEATURE] Add `--enable-experimental-functions` flag to commands that parse PromQL to allow parsing experimental functions such as `sort()`.
+* [FEATURE] Add `--enable-experimental-functions` flag to commands that parse PromQL to allow parsing experimental functions such as `sort_by_label()`.
 
 ### Mimir Continuous Test
 

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -806,9 +806,9 @@ mimirtool analyze rule-file <file>
 
 ##### Configuration
 
-| Environment variable | Flag                              | Description                                                             |
-| -------------------- | --------------------------------- | ----------------------------------------------------------------------- |
-| -                    | `--output`                        | Sets the output file path, which by default is `metrics-in-ruler.json`. |
+| Environment variable | Flag       | Description                                                             |
+| -------------------- | ---------- | ----------------------------------------------------------------------- |
+| -                    | `--output` | Sets the output file path, which by default is `metrics-in-ruler.json`. |
 
 #### Prometheus
 

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -310,9 +310,10 @@ For more information, refer to the [documentation of Mimirtool Github Action](ht
 
 Configuration options relevant to rules commands:
 
-| Flag           | Description                                        |
-| -------------- | -------------------------------------------------- |
-| `--auth-token` | Authentication token for bearer token or JWT auth. |
+| Flag                              | Description                                                  |
+| --------------------------------- | ------------------------------------------------------------ |
+| `--auth-token`                    | Authentication token for bearer token or JWT auth.           |
+| `--enable-experimental-functions` | Enable parsing experimental PromQL functions (e.g. `sort()`) |
 
 #### List rules
 
@@ -683,6 +684,12 @@ X-Prom-Label-Policy: 1234:%7Bnamespace=%22A%22%7D
 
 You can analyze your Grafana or Hosted Grafana instance to determine which metrics are used and exported. You can also extract metrics from dashboard JSON files and rules YAML files.
 
+Configuration options relevant to analyze commands:
+
+| Environment variable | Flag                              | Description                                                       |
+| -------------------- | --------------------------------- | ----------------------------------------------------------------- |
+| -                    | `--enable-experimental-functions` | Enables parsing PromQL queries containing experimental functions. |
+
 #### Grafana
 
 The following command runs against your Grafana instance, downloads its dashboards, and extracts the Prometheus
@@ -799,9 +806,9 @@ mimirtool analyze rule-file <file>
 
 ##### Configuration
 
-| Environment variable | Flag       | Description                                                             |
-| -------------------- | ---------- | ----------------------------------------------------------------------- |
-| -                    | `--output` | Sets the output file path, which by default is `metrics-in-ruler.json`. |
+| Environment variable | Flag                              | Description                                                             |
+| -------------------- | --------------------------------- | ----------------------------------------------------------------------- |
+| -                    | `--output`                        | Sets the output file path, which by default is `metrics-in-ruler.json`. |
 
 #### Prometheus
 

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -310,10 +310,10 @@ For more information, refer to the [documentation of Mimirtool Github Action](ht
 
 Configuration options relevant to rules commands:
 
-| Flag                              | Description                                                  |
-| --------------------------------- | ------------------------------------------------------------ |
-| `--auth-token`                    | Authentication token for bearer token or JWT auth.           |
-| `--enable-experimental-functions` | Enable parsing experimental PromQL functions (e.g. `sort()`) |
+| Flag                              | Description                                                 |
+| --------------------------------- | ----------------------------------------------------------- |
+| `--auth-token`                    | Authentication token for bearer token or JWT authentication.|
+| `--enable-experimental-functions` | If set, enables parsing experimental PromQL functions.      |
 
 #### List rules
 

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -310,10 +310,10 @@ For more information, refer to the [documentation of Mimirtool Github Action](ht
 
 Configuration options relevant to rules commands:
 
-| Flag                              | Description                                                 |
-| --------------------------------- | ----------------------------------------------------------- |
-| `--auth-token`                    | Authentication token for bearer token or JWT authentication.|
-| `--enable-experimental-functions` | If set, enables parsing experimental PromQL functions.      |
+| Flag                              | Description                                                  |
+| --------------------------------- | ------------------------------------------------------------ |
+| `--auth-token`                    | Authentication token for bearer token or JWT authentication. |
+| `--enable-experimental-functions` | If set, enables parsing experimental PromQL functions.       |
 
 #### List rules
 

--- a/pkg/mimirtool/commands/analyse.go
+++ b/pkg/mimirtool/commands/analyse.go
@@ -18,7 +18,7 @@ type AnalyzeCommand struct{}
 
 func (cmd *AnalyzeCommand) Register(app *kingpin.Application, envVars EnvVarNames) {
 	analyzeCmd := app.Command("analyze", "Run analysis against your Prometheus, Grafana, and Grafana Mimir to see which metrics are being used and exported.")
-	analyzeCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions.").Action(func(*kingpin.ParseContext) error { parser.EnableExperimentalFunctions = true; return nil })
+	analyzeCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions.").BoolVar(&parser.EnableExperimentalFunctions)
 
 	paCmd := &PrometheusAnalyzeCommand{}
 	prometheusAnalyzeCmd := analyzeCmd.Command("prometheus", "Take the metrics being used in Grafana and get the cardinality from a Prometheus.").Action(paCmd.run)

--- a/pkg/mimirtool/commands/analyse.go
+++ b/pkg/mimirtool/commands/analyse.go
@@ -11,12 +11,14 @@ import (
 	"strconv"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/prometheus/prometheus/promql/parser"
 )
 
 type AnalyzeCommand struct{}
 
 func (cmd *AnalyzeCommand) Register(app *kingpin.Application, envVars EnvVarNames) {
 	analyzeCmd := app.Command("analyze", "Run analysis against your Prometheus, Grafana, and Grafana Mimir to see which metrics are being used and exported.")
+	analyzeCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions.").Action(func(*kingpin.ParseContext) error { parser.EnableExperimentalFunctions = true; return nil })
 
 	paCmd := &PrometheusAnalyzeCommand{}
 	prometheusAnalyzeCmd := analyzeCmd.Command("prometheus", "Take the metrics being used in Grafana and get the cardinality from a Prometheus.").Action(paCmd.run)

--- a/pkg/mimirtool/commands/promql.go
+++ b/pkg/mimirtool/commands/promql.go
@@ -17,7 +17,7 @@ type PromQLCommand struct {
 
 func (c *PromQLCommand) Register(app *kingpin.Application, _ EnvVarNames) {
 	promqlCmd := app.Command("promql", "PromQL formatting and editing for Grafana Mimir.")
-	promqlCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions.").Action(func(*kingpin.ParseContext) error { parser.EnableExperimentalFunctions = true; return nil })
+	promqlCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions.").BoolVar(&parser.EnableExperimentalFunctions)
 
 	// PromQL Format Query Command
 	promqlFormatCmd := promqlCmd.Command("format", "Format PromQL query with Prometheus' string formatter; wrap query in quotes for CLI parsing.").Action(c.formatQuery)

--- a/pkg/mimirtool/commands/promql.go
+++ b/pkg/mimirtool/commands/promql.go
@@ -17,6 +17,7 @@ type PromQLCommand struct {
 
 func (c *PromQLCommand) Register(app *kingpin.Application, _ EnvVarNames) {
 	promqlCmd := app.Command("promql", "PromQL formatting and editing for Grafana Mimir.")
+	promqlCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions").Action(func(*kingpin.ParseContext) error { parser.EnableExperimentalFunctions = true; return nil })
 
 	// PromQL Format Query Command
 	promqlFormatCmd := promqlCmd.Command("format", "Format PromQL query with Prometheus' string formatter; wrap query in quotes for CLI parsing.").Action(c.formatQuery)

--- a/pkg/mimirtool/commands/promql.go
+++ b/pkg/mimirtool/commands/promql.go
@@ -17,7 +17,7 @@ type PromQLCommand struct {
 
 func (c *PromQLCommand) Register(app *kingpin.Application, _ EnvVarNames) {
 	promqlCmd := app.Command("promql", "PromQL formatting and editing for Grafana Mimir.")
-	promqlCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions").Action(func(*kingpin.ParseContext) error { parser.EnableExperimentalFunctions = true; return nil })
+	promqlCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions.").Action(func(*kingpin.ParseContext) error { parser.EnableExperimentalFunctions = true; return nil })
 
 	// PromQL Format Query Command
 	promqlFormatCmd := promqlCmd.Command("format", "Format PromQL query with Prometheus' string formatter; wrap query in quotes for CLI parsing.").Action(c.formatQuery)

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -126,7 +126,7 @@ func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames, re
 	rulesCmd.Flag("key", "Basic auth password to use when contacting Grafana Mimir; alternatively, set "+envVars.APIKey+".").Default("").Envar(envVars.APIKey).StringVar(&r.ClientConfig.Key)
 	rulesCmd.Flag("backend", "Backend type to interact with (deprecated)").Default(rules.MimirBackend).EnumVar(&r.Backend, backends...)
 	rulesCmd.Flag("auth-token", "Authentication token for bearer token or JWT auth, alternatively set "+envVars.AuthToken+".").Default("").Envar(envVars.AuthToken).StringVar(&r.ClientConfig.AuthToken)
-	rulesCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions").Action(func(*kingpin.ParseContext) error { parser.EnableExperimentalFunctions = true; return nil })
+	rulesCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions.").Action(func(*kingpin.ParseContext) error { parser.EnableExperimentalFunctions = true; return nil })
 	r.ClientConfig.ExtraHeaders = map[string]string{}
 	rulesCmd.Flag("extra-headers", "Extra headers to add to the requests in header=value format, alternatively set newline separated "+envVars.ExtraHeaders+".").Envar(envVars.ExtraHeaders).StringMapVar(&r.ClientConfig.ExtraHeaders)
 

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -126,7 +126,7 @@ func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames, re
 	rulesCmd.Flag("key", "Basic auth password to use when contacting Grafana Mimir; alternatively, set "+envVars.APIKey+".").Default("").Envar(envVars.APIKey).StringVar(&r.ClientConfig.Key)
 	rulesCmd.Flag("backend", "Backend type to interact with (deprecated)").Default(rules.MimirBackend).EnumVar(&r.Backend, backends...)
 	rulesCmd.Flag("auth-token", "Authentication token for bearer token or JWT auth, alternatively set "+envVars.AuthToken+".").Default("").Envar(envVars.AuthToken).StringVar(&r.ClientConfig.AuthToken)
-	rulesCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions.").Action(func(*kingpin.ParseContext) error { parser.EnableExperimentalFunctions = true; return nil })
+	rulesCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions.").BoolVar(&parser.EnableExperimentalFunctions)
 	r.ClientConfig.ExtraHeaders = map[string]string{}
 	rulesCmd.Flag("extra-headers", "Extra headers to add to the requests in header=value format, alternatively set newline separated "+envVars.ExtraHeaders+".").Envar(envVars.ExtraHeaders).StringMapVar(&r.ClientConfig.ExtraHeaders)
 

--- a/pkg/mimirtool/commands/rules.go
+++ b/pkg/mimirtool/commands/rules.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/prometheus/prometheus/promql/parser"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/term"
 	yamlv3 "gopkg.in/yaml.v3"
@@ -125,6 +126,7 @@ func (r *RuleCommand) Register(app *kingpin.Application, envVars EnvVarNames, re
 	rulesCmd.Flag("key", "Basic auth password to use when contacting Grafana Mimir; alternatively, set "+envVars.APIKey+".").Default("").Envar(envVars.APIKey).StringVar(&r.ClientConfig.Key)
 	rulesCmd.Flag("backend", "Backend type to interact with (deprecated)").Default(rules.MimirBackend).EnumVar(&r.Backend, backends...)
 	rulesCmd.Flag("auth-token", "Authentication token for bearer token or JWT auth, alternatively set "+envVars.AuthToken+".").Default("").Envar(envVars.AuthToken).StringVar(&r.ClientConfig.AuthToken)
+	rulesCmd.Flag("enable-experimental-functions", "If set, enables parsing experimental PromQL functions").Action(func(*kingpin.ParseContext) error { parser.EnableExperimentalFunctions = true; return nil })
 	r.ClientConfig.ExtraHeaders = map[string]string{}
 	rulesCmd.Flag("extra-headers", "Extra headers to add to the requests in header=value format, alternatively set newline separated "+envVars.ExtraHeaders+".").Envar(envVars.ExtraHeaders).StringMapVar(&r.ClientConfig.ExtraHeaders)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Adds a flag to Mimirtool commands that parse PromQL expressions to enable the parsing of experimental PromQL expressions.

#### Which issue(s) this PR fixes or relates to

Fixes #10980.

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [X] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
