### PR TITLE
MQE: avoid using statement in `Query` where possible

### DIFF
--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -885,7 +885,3 @@ func (q *Query) Cancel() {
 func (q *Query) String() string {
 	return q.qs
 }
-
-func timeMilliseconds(t time.Time) int64 {
-	return t.UnixNano() / int64(time.Millisecond/time.Nanosecond)
-}

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -37,6 +37,7 @@ import (
 var errQueryCancelled = cancellation.NewErrorf("query execution cancelled")
 var errQueryClosed = cancellation.NewErrorf("Query.Close() called")
 var errQueryFinished = cancellation.NewErrorf("query execution finished")
+var errStringForRangeQuery = errors.New("query expression produces a string, but expression for range queries must produce an instant vector or scalar")
 
 type Query struct {
 	queryable                storage.Queryable
@@ -48,6 +49,7 @@ type Query struct {
 	memoryConsumptionTracker *limiting.MemoryConsumptionTracker
 	annotations              *annotations.Annotations
 	stats                    *types.QueryStats
+	lookbackDelta            time.Duration
 
 	// Time range of the top-level query.
 	// Subqueries may use a different range.
@@ -85,6 +87,7 @@ func newQuery(ctx context.Context, queryable storage.Queryable, opts promql.Quer
 		memoryConsumptionTracker: limiting.NewMemoryConsumptionTracker(maxEstimatedMemoryConsumptionPerQuery, engine.queriesRejectedDueToPeakMemoryConsumption),
 		annotations:              annotations.New(),
 		stats:                    &types.QueryStats{},
+		lookbackDelta:            lookbackDelta,
 
 		statement: &parser.EvalStmt{
 			Expr:          expr,
@@ -95,7 +98,7 @@ func newQuery(ctx context.Context, queryable storage.Queryable, opts promql.Quer
 		},
 	}
 
-	if q.IsInstant() {
+	if start == end && interval == 0 {
 		q.topLevelQueryTimeRange = types.NewInstantQueryTimeRange(start)
 	} else {
 		q.topLevelQueryTimeRange = types.NewRangeQueryTimeRange(start, end, interval)
@@ -153,7 +156,7 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr, timeRange types
 
 	switch e := expr.(type) {
 	case *parser.VectorSelector:
-		lookbackDelta := q.statement.LookbackDelta
+		lookbackDelta := q.lookbackDelta
 
 		return &selectors.InstantVectorSelector{
 			MemoryConsumptionTracker: q.memoryConsumptionTracker,
@@ -544,10 +547,6 @@ func (q *Query) convertFunctionCallToScalarOperator(e *parser.Call, timeRange ty
 	return factory(args, q.memoryConsumptionTracker, q.annotations, e.PosRange, timeRange)
 }
 
-func (q *Query) IsInstant() bool {
-	return q.statement.Start == q.statement.End && q.statement.Interval == 0
-}
-
 func (q *Query) Exec(ctx context.Context) *promql.Result {
 	defer q.root.Close()
 
@@ -584,7 +583,7 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 			"expr", q.qs,
 		)
 
-		if q.IsInstant() {
+		if q.topLevelQueryTimeRange.IsInstant {
 			msg = append(msg,
 				"queryType", "instant",
 				"time", q.topLevelQueryTimeRange.StartT,
@@ -602,9 +601,8 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 		q.engine.estimatedPeakMemoryConsumption.Observe(float64(q.memoryConsumptionTracker.PeakEstimatedMemoryConsumptionBytes))
 	}()
 
-	switch q.statement.Expr.Type() {
-	case parser.ValueTypeMatrix:
-		root := q.root.(types.RangeVectorOperator)
+	switch root := q.root.(type) {
+	case types.RangeVectorOperator:
 		series, err := root.SeriesMetadata(ctx)
 		if err != nil {
 			return &promql.Result{Err: err}
@@ -617,15 +615,14 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 		}
 
 		q.result = &promql.Result{Value: v}
-	case parser.ValueTypeVector:
-		root := q.root.(types.InstantVectorOperator)
+	case types.InstantVectorOperator:
 		series, err := root.SeriesMetadata(ctx)
 		if err != nil {
 			return &promql.Result{Err: err}
 		}
 		defer types.PutSeriesMetadataSlice(series)
 
-		if q.IsInstant() {
+		if q.topLevelQueryTimeRange.IsInstant {
 			v, err := q.populateVectorFromInstantVectorOperator(ctx, root, series)
 			if err != nil {
 				return &promql.Result{Err: err}
@@ -640,30 +637,26 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 
 			q.result = &promql.Result{Value: v}
 		}
-	case parser.ValueTypeScalar:
-		root := q.root.(types.ScalarOperator)
+	case types.ScalarOperator:
 		d, err := root.GetValues(ctx)
 		if err != nil {
 			return &promql.Result{Err: err}
 		}
 
-		if q.IsInstant() {
+		if q.topLevelQueryTimeRange.IsInstant {
 			q.result = &promql.Result{Value: q.populateScalarFromScalarOperator(d)}
 		} else {
 			q.result = &promql.Result{Value: q.populateMatrixFromScalarOperator(d)}
 		}
-	case parser.ValueTypeString:
-		if q.IsInstant() {
-			root := q.root.(types.StringOperator)
-			str := root.GetValue()
-			q.result = &promql.Result{Value: q.populateStringFromStringOperator(str)}
+	case types.StringOperator:
+		if q.topLevelQueryTimeRange.IsInstant {
+			q.result = &promql.Result{Value: q.populateStringFromStringOperator(root)}
 		} else {
 			// This should be caught in newQuery above
-			return &promql.Result{Err: fmt.Errorf("query expression produces a %s, but expression for range queries must produce an instant vector or scalar", parser.DocumentedType(q.statement.Expr.Type()))}
+			return &promql.Result{Err: errStringForRangeQuery}
 		}
 	default:
-		// This should be caught in newQuery above.
-		return &promql.Result{Err: compat.NewNotSupportedError(fmt.Sprintf("unsupported result type %s", parser.DocumentedType(q.statement.Expr.Type())))}
+		return &promql.Result{Err: fmt.Errorf("operator %T produces unknown result type", root)}
 	}
 
 	// To make comparing to Prometheus' engine easier, only return the annotations if there are some, otherwise, return nil.
@@ -674,15 +667,15 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 	return q.result
 }
 
-func (q *Query) populateStringFromStringOperator(str string) promql.String {
+func (q *Query) populateStringFromStringOperator(o types.StringOperator) promql.String {
 	return promql.String{
-		T: timeMilliseconds(q.statement.Start),
-		V: str,
+		T: q.topLevelQueryTimeRange.StartT,
+		V: o.GetValue(),
 	}
 }
 
 func (q *Query) populateVectorFromInstantVectorOperator(ctx context.Context, o types.InstantVectorOperator, series []types.SeriesMetadata) (promql.Vector, error) {
-	ts := timeMilliseconds(q.statement.Start)
+	ts := q.topLevelQueryTimeRange.StartT
 	v, err := types.VectorPool.Get(len(series), q.memoryConsumptionTracker)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -37,7 +37,6 @@ import (
 var errQueryCancelled = cancellation.NewErrorf("query execution cancelled")
 var errQueryClosed = cancellation.NewErrorf("Query.Close() called")
 var errQueryFinished = cancellation.NewErrorf("query execution finished")
-var errStringForRangeQuery = errors.New("query expression produces a string, but expression for range queries must produce an instant vector or scalar")
 
 type Query struct {
 	queryable                storage.Queryable
@@ -649,12 +648,7 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 			q.result = &promql.Result{Value: q.populateMatrixFromScalarOperator(d)}
 		}
 	case types.StringOperator:
-		if q.topLevelQueryTimeRange.IsInstant {
-			q.result = &promql.Result{Value: q.populateStringFromStringOperator(root)}
-		} else {
-			// This should be caught in newQuery above
-			return &promql.Result{Err: errStringForRangeQuery}
-		}
+		q.result = &promql.Result{Value: q.populateStringFromStringOperator(root)}
 	default:
 		return &promql.Result{Err: fmt.Errorf("operator %T produces unknown result type", root)}
 	}

--- a/pkg/streamingpromql/types/data.go
+++ b/pkg/streamingpromql/types/data.go
@@ -156,6 +156,7 @@ type QueryTimeRange struct {
 	IntervalMilliseconds int64 // Range query interval, or 1 for instant queries. Note that this is deliberately different to parser.EvalStmt.Interval for instant queries (where it is 0) to simplify some loop conditions.
 
 	StepCount int // 1 for instant queries.
+	IsInstant bool
 }
 
 func NewInstantQueryTimeRange(t time.Time) QueryTimeRange {
@@ -166,6 +167,7 @@ func NewInstantQueryTimeRange(t time.Time) QueryTimeRange {
 		EndT:                 ts,
 		IntervalMilliseconds: 1,
 		StepCount:            1,
+		IsInstant:            true,
 	}
 }
 
@@ -179,6 +181,7 @@ func NewRangeQueryTimeRange(start time.Time, end time.Time, interval time.Durati
 		EndT:                 endT,
 		IntervalMilliseconds: IntervalMilliseconds,
 		StepCount:            int((endT-startT)/IntervalMilliseconds) + 1,
+		IsInstant:            false,
 	}
 }
 

--- a/pkg/streamingpromql/types/data_test.go
+++ b/pkg/streamingpromql/types/data_test.go
@@ -286,8 +286,10 @@ func TestQueryTimeRange(t *testing.T) {
 
 			if tc.interval == 0 {
 				qtr = NewInstantQueryTimeRange(tc.start)
+				require.True(t, qtr.IsInstant)
 			} else {
 				qtr = NewRangeQueryTimeRange(tc.start, tc.end, tc.interval)
+				require.False(t, qtr.IsInstant)
 			}
 
 			require.Equal(t, tc.expectedStart, qtr.StartT, "StartT matches")


### PR DESCRIPTION
#### What this PR does

This PR refactors the `Query` type to avoid using the `EvalStmt` where possible.

This will make it easier to introduce queries based on query plans, as query plans may not have an equivalent PromQL statement.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
