### PR TITLE
Improve MimirIngesterFailsToProcessRecordsFromKafka to not fire during forced TSDB head compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Store-gateway: Download sparse headers uploaded by compactors. Compactors have to be configured with `-compactor.upload-sparse-index-headers=true` option. #10879
 * [ENHANCEMENT] Compactor: Upload block index file and multiple segment files concurrently. Concurrency scales linearly with block size up to `-compactor.max-per-block-upload-concurrency`. #10947
 * [ENHANCEMENT] Ingester: Add per-user `cortex_ingester_tsdb_wal_replay_unknown_refs_total` and `cortex_ingester_tsdb_wbl_replay_unknown_refs_total` metrics to track unknown series references during WAL/WBL replay. #10981
+* [ENHANCEMENT] Ingester: Add `cortex_ingester_tsdb_forced_compactions_in_progress` metric reporting a value of 1 when there's a forced TSDB head compaction in progress. #11006
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952
@@ -22,6 +23,7 @@
 * [ENHANCEMENT] Dashboards: Include absolute number of notifications attempted to alertmanager in 'Mimir / Ruler'. #10918
 * [ENHANCEMENT] Alerts: Make `MimirRolloutStuck` a critical alert if it has been firing for 6h. #10890
 * [ENHANCEMENT] Dashboards: Add panels to the `Mimir / Tenants` and `Mimir / Top Tenants` dashboards showing the rate of gateway requests. #10978
+* [ENHANCEMENT] Alerts: Improve `MimirIngesterFailsToProcessRecordsFromKafka` to not fire during forced TSDB head compaction. #11006
 * [BUGFIX] Dashboards: fix "Mimir / Tenants" legends for non-Kubernetes deployments. #10891
 
 ### Jsonnet

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1187,12 +1187,18 @@ spec:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to consume write requests read from Kafka due to internal errors.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterfailstoprocessrecordsfromkafka
             expr: |
-              sum by (cluster, namespace, pod) (
-                  # This is the old metric name. We're keeping support for backward compatibility.
-                rate(cortex_ingest_storage_reader_records_failed_total{cause="server"}[1m])
-                or
-                rate(cortex_ingest_storage_reader_requests_failed_total{cause="server"}[1m])
-              ) > 0
+              (
+                sum by (cluster, namespace, pod) (
+                    # This is the old metric name. We're keeping support for backward compatibility.
+                  rate(cortex_ingest_storage_reader_records_failed_total{cause="server"}[1m])
+                  or
+                  rate(cortex_ingest_storage_reader_requests_failed_total{cause="server"}[1m])
+                ) > 0
+              )
+  
+              # Tolerate failures during the forced TSDB head compaction, because samples older than the
+              # new "head min time" will fail to be appended while the forced compaction is running.
+              unless (max by (cluster, namespace, pod) (cortex_ingester_tsdb_forced_compactions_in_progress) > 0)
             for: 5m
             labels:
               severity: critical

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1198,7 +1198,7 @@ spec:
   
               # Tolerate failures during the forced TSDB head compaction, because samples older than the
               # new "head min time" will fail to be appended while the forced compaction is running.
-              unless (max by (cluster, namespace, pod) (cortex_ingester_tsdb_forced_compactions_in_progress) > 0)
+              unless (max by (cluster, namespace, pod) (max_over_time(cortex_ingester_tsdb_forced_compactions_in_progress[1m])) > 0)
             for: 5m
             labels:
               severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1172,7 +1172,7 @@ groups:
 
             # Tolerate failures during the forced TSDB head compaction, because samples older than the
             # new "head min time" will fail to be appended while the forced compaction is running.
-            unless (max by (cluster, namespace, instance) (cortex_ingester_tsdb_forced_compactions_in_progress) > 0)
+            unless (max by (cluster, namespace, instance) (max_over_time(cortex_ingester_tsdb_forced_compactions_in_progress[1m])) > 0)
           for: 5m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1161,12 +1161,18 @@ groups:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to consume write requests read from Kafka due to internal errors.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterfailstoprocessrecordsfromkafka
           expr: |
-            sum by (cluster, namespace, instance) (
-                # This is the old metric name. We're keeping support for backward compatibility.
-              rate(cortex_ingest_storage_reader_records_failed_total{cause="server"}[1m])
-              or
-              rate(cortex_ingest_storage_reader_requests_failed_total{cause="server"}[1m])
-            ) > 0
+            (
+              sum by (cluster, namespace, instance) (
+                  # This is the old metric name. We're keeping support for backward compatibility.
+                rate(cortex_ingest_storage_reader_records_failed_total{cause="server"}[1m])
+                or
+                rate(cortex_ingest_storage_reader_requests_failed_total{cause="server"}[1m])
+              ) > 0
+            )
+
+            # Tolerate failures during the forced TSDB head compaction, because samples older than the
+            # new "head min time" will fail to be appended while the forced compaction is running.
+            unless (max by (cluster, namespace, instance) (cortex_ingester_tsdb_forced_compactions_in_progress) > 0)
           for: 5m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -1175,12 +1175,18 @@ groups:
             message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to consume write requests read from Kafka due to internal errors.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterfailstoprocessrecordsfromkafka
           expr: |
-            sum by (cluster, namespace, pod) (
-                # This is the old metric name. We're keeping support for backward compatibility.
-              rate(cortex_ingest_storage_reader_records_failed_total{cause="server"}[1m])
-              or
-              rate(cortex_ingest_storage_reader_requests_failed_total{cause="server"}[1m])
-            ) > 0
+            (
+              sum by (cluster, namespace, pod) (
+                  # This is the old metric name. We're keeping support for backward compatibility.
+                rate(cortex_ingest_storage_reader_records_failed_total{cause="server"}[1m])
+                or
+                rate(cortex_ingest_storage_reader_requests_failed_total{cause="server"}[1m])
+              ) > 0
+            )
+
+            # Tolerate failures during the forced TSDB head compaction, because samples older than the
+            # new "head min time" will fail to be appended while the forced compaction is running.
+            unless (max by (cluster, namespace, pod) (cortex_ingester_tsdb_forced_compactions_in_progress) > 0)
           for: 5m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -1186,7 +1186,7 @@ groups:
 
             # Tolerate failures during the forced TSDB head compaction, because samples older than the
             # new "head min time" will fail to be appended while the forced compaction is running.
-            unless (max by (cluster, namespace, pod) (cortex_ingester_tsdb_forced_compactions_in_progress) > 0)
+            unless (max by (cluster, namespace, pod) (max_over_time(cortex_ingester_tsdb_forced_compactions_in_progress[1m])) > 0)
           for: 5m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1175,12 +1175,18 @@ groups:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to consume write requests read from Kafka due to internal errors.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterfailstoprocessrecordsfromkafka
           expr: |
-            sum by (cluster, namespace, pod) (
-                # This is the old metric name. We're keeping support for backward compatibility.
-              rate(cortex_ingest_storage_reader_records_failed_total{cause="server"}[1m])
-              or
-              rate(cortex_ingest_storage_reader_requests_failed_total{cause="server"}[1m])
-            ) > 0
+            (
+              sum by (cluster, namespace, pod) (
+                  # This is the old metric name. We're keeping support for backward compatibility.
+                rate(cortex_ingest_storage_reader_records_failed_total{cause="server"}[1m])
+                or
+                rate(cortex_ingest_storage_reader_requests_failed_total{cause="server"}[1m])
+              ) > 0
+            )
+
+            # Tolerate failures during the forced TSDB head compaction, because samples older than the
+            # new "head min time" will fail to be appended while the forced compaction is running.
+            unless (max by (cluster, namespace, pod) (cortex_ingester_tsdb_forced_compactions_in_progress) > 0)
           for: 5m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1186,7 +1186,7 @@ groups:
 
             # Tolerate failures during the forced TSDB head compaction, because samples older than the
             # new "head min time" will fail to be appended while the forced compaction is running.
-            unless (max by (cluster, namespace, pod) (cortex_ingester_tsdb_forced_compactions_in_progress) > 0)
+            unless (max by (cluster, namespace, pod) (max_over_time(cortex_ingester_tsdb_forced_compactions_in_progress[1m])) > 0)
           for: 5m
           labels:
             severity: critical

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -123,12 +123,18 @@
           alert: $.alertName('IngesterFailsToProcessRecordsFromKafka'),
           'for': '5m',
           expr: |||
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (
-                # This is the old metric name. We're keeping support for backward compatibility.
-              rate(cortex_ingest_storage_reader_records_failed_total{cause="server"}[1m])
-              or
-              rate(cortex_ingest_storage_reader_requests_failed_total{cause="server"}[1m])
-            ) > 0
+            (
+              sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (
+                  # This is the old metric name. We're keeping support for backward compatibility.
+                rate(cortex_ingest_storage_reader_records_failed_total{cause="server"}[1m])
+                or
+                rate(cortex_ingest_storage_reader_requests_failed_total{cause="server"}[1m])
+              ) > 0
+            )
+
+            # Tolerate failures during the forced TSDB head compaction, because samples older than the
+            # new "head min time" will fail to be appended while the forced compaction is running.
+            unless (max by (%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_tsdb_forced_compactions_in_progress) > 0)
           ||| % $._config,
           labels: {
             severity: 'critical',

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -134,7 +134,7 @@
 
             # Tolerate failures during the forced TSDB head compaction, because samples older than the
             # new "head min time" will fail to be appended while the forced compaction is running.
-            unless (max by (%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_tsdb_forced_compactions_in_progress) > 0)
+            unless (max by (%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(cortex_ingester_tsdb_forced_compactions_in_progress[1m])) > 0)
           ||| % $._config,
           labels: {
             severity: 'critical',

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -65,11 +65,12 @@ type ingesterMetrics struct {
 	maxLocalSeriesPerUser *prometheus.GaugeVec
 
 	// Head compactions metrics.
-	compactionsTriggered   prometheus.Counter
-	compactionsFailed      prometheus.Counter
-	appenderAddDuration    prometheus.Histogram
-	appenderCommitDuration prometheus.Histogram
-	idleTsdbChecks         *prometheus.CounterVec
+	compactionsTriggered       prometheus.Counter
+	compactionsFailed          prometheus.Counter
+	forcedCompactionInProgress prometheus.Gauge
+	appenderAddDuration        prometheus.Histogram
+	appenderCommitDuration     prometheus.Histogram
+	idleTsdbChecks             *prometheus.CounterVec
 
 	// Open all existing TSDBs metrics
 	openExistingTSDB prometheus.Counter
@@ -345,11 +346,15 @@ func newIngesterMetrics(
 			Name: "cortex_ingester_tsdb_compactions_triggered_total",
 			Help: "Total number of triggered compactions.",
 		}),
-
 		compactionsFailed: promauto.With(r).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_ingester_tsdb_compactions_failed_total",
 			Help: "Total number of compactions that failed.",
 		}),
+		forcedCompactionInProgress: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_ingester_tsdb_forced_compactions_in_progress",
+			Help: "Reports 1 if there's a forced TSDB head compaction in progress, 0 otherwise.",
+		}),
+
 		appenderAddDuration: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingester_tsdb_appender_add_duration_seconds",
 			Help:    "The total time it takes for a push request to add samples to the TSDB appender.",


### PR DESCRIPTION
#### What this PR does

The `MimirIngesterFailsToProcessRecordsFromKafka` alert currently fires each time there a forced TSDB head compaction in progress, because samples older than the new "head min time" will fail to be ingested (will be retried over and over, until the head compaction completes).

I would like to have the alert not firing during forced head compaction, given it's not actionable, but we miss a metric to know when there's a forced head compaction in progress. In this PR I'm adding a metric and using it in the alert. The alert query has been changed so that it keep working even if the new metric has not been deployed it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
