### PR TITLE
github: use mimir-github-bot to auto-merge weekly helm releases

### DIFF
--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -6,14 +6,15 @@ on:
 
   workflow_dispatch: # for manual testing
 
-# These permissions are needed to assume roles from Github's OIDC.
-permissions:
-  contents: read
-  id-token: write
+permissions: {}
 
 jobs:
   weekly-release-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,13 +24,16 @@ jobs:
         id: update
         run: bash .github/workflows/scripts/helm-weekly-release.sh
 
+      # This job uses "mimir-vendoring bot" instead of "github-actions bot" (secrets.GITHUB_TOKEN)
+      # because any events triggered by the later don't spawn GitHub actions.
+      # Refer to https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
       - name: Retrieve GitHub App Credentials from Vault
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # v1.1.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # get-vault-secrets-v1.2.0
         with:
           repo_secrets: |
-            APP_ID=mimir-github-bot:app_id
-            PRIVATE_KEY=mimir-github-bot:private_key
+            APP_ID=mimir-vendoring:app-id
+            PRIVATE_KEY=mimir-vendoring:app-pem-key
 
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/helm-weekly-release-reviewer.yml
+++ b/.github/workflows/helm-weekly-release-reviewer.yml
@@ -8,22 +8,38 @@ on:
     paths:
       - operations/helm/charts/**
 
-permissions:
-  pull-requests: write
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
   auto-reviewer:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
-    if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.user.login == 'mimir-github-bot[bot]' }}
+    if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.user.login == 'mimir-vendoring[bot]' }}
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Retrieve GitHub App Credentials from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # get-vault-secrets-v1.2.0
+        with:
+          repo_secrets: |
+            APP_ID=mimir-github-bot:app_id
+            PRIVATE_KEY=mimir-github-bot:private_key
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Approve and auto-merge
         id: auto-merge
@@ -34,7 +50,7 @@ jobs:
           --approve -b "**I'm approving** this pull request, since it is a helm release."
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Manual review is required
         if: steps.auto-merge.conclusion != 'success'


### PR DESCRIPTION
#### What this PR does

This is another follow-up to #10986

~~Here, I update the Helm weekly auto-review so the "mimir-github-bot" merged the PR, approved by the "github-actions" bot. The theory is that this should allow the CI to bypass the codeowners review (see https://github.com/grafana/mimir/pull/11008).~~

I've updated the PR to

- open weekly Helm release PRs from `mimir-vendoring-bot`
- use `mimir-github-bot` to auto-review the PR

This should resolve the problems, where we couldn't use `github-actions-bot` to open a PR, because these PRs don't trigger further automations on GitHub. And we cannot use `github-actions-bot` to auto-review the PRs, because cannot be the code owner.