### PR TITLE
Add cortex_ingest_storage_reader_records_batch_fetch_max_bytes metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] Ingester: Add per-user `cortex_ingester_tsdb_wal_replay_unknown_refs_total` and `cortex_ingester_tsdb_wbl_replay_unknown_refs_total` metrics to track unknown series references during WAL/WBL replay. #10981
 * [ENHANCEMENT] Added `-ingest-storage.kafka.fetch-max-wait` configuration option to configure the maximum amount of time a Kafka broker waits for some records before a Fetch response is returned. #11012
 * [ENHANCEMENT] Ingester: Add `cortex_ingester_tsdb_forced_compactions_in_progress` metric reporting a value of 1 when there's a forced TSDB head compaction in progress. #11006
+* [ENHANCEMENT] Ingester: Add `cortex_ingest_storage_reader_records_batch_fetch_max_bytes` metric reporting the distribution of `MaxBytes` specified in the Fetch requests sent to Kafka. #11014
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -539,8 +539,11 @@ func (r *concurrentFetchers) fetchSingle(ctx context.Context, fw fetchWant) (fr 
 		return newErrorFetchResult(ctx, r.partitionID, errUnknownPartitionLeader)
 	}
 
-	// Build and send the Fetch request to the leader broker.
+	// Build the Fetch request.
 	req := r.buildFetchRequest(fw, leaderEpoch)
+	r.metrics.fetchMaxBytes.Observe(float64(req.MaxBytes))
+
+	// Send the Fetch request to the leader broker.
 	resp, err := req.RequestWith(ctx, r.client.Broker(int(leaderID)))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/concurrency"
+	"github.com/grafana/dskit/metrics"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/test"
 	"github.com/prometheus/client_golang/prometheus"
@@ -325,7 +326,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
 
 		// This should not block forever now
 		fetches, fetchCtx := fetchers.PollFetches(ctx)
@@ -349,7 +350,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 		}
 
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
 
 		fetches := longPollFetches(fetchers, 5, 2*time.Second)
 		assert.Equal(t, fetches.NumRecords(), 5)
@@ -367,7 +368,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
 
 		// Produce some records after starting the fetchers
 		for i := 0; i < 3; i++ {
@@ -388,7 +389,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
 
 		// Produce some records
 		for i := 0; i < 5; i++ {
@@ -439,7 +440,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
 
 		// Produce some records
 		for i := 0; i < 10; i++ {
@@ -470,7 +471,7 @@ func TestConcurrentFetchers(t *testing.T) {
 				_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 				client := newKafkaProduceClient(t, clusterAddr)
 
-				fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
+				fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
 
 				// Produce some records
 				for i := 0; i < 20; i++ {
@@ -506,7 +507,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		lastOffset := produceRecord(ctx, t, client, topicName, partitionID, []byte("last-initial-record"))
 
 		// Start fetchers from the offset after the initial records
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, lastOffset-1, concurrency, 0)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, lastOffset-1, concurrency, 0)
 
 		// Produce some more records
 		for i := 0; i < 3; i++ {
@@ -541,7 +542,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
 
 		for round := 0; round < 3; round++ {
 			t.Log("starting round", round)
@@ -586,7 +587,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
 
 		// Produce enough records to saturate each fetcher.
 		const initiallyProducedRecords = concurrency * 10
@@ -647,7 +648,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		fetchRequestCount := atomic.NewInt64(0)
 		maxRequestedOffset := atomic.NewInt64(-1)
 
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
 
 		// Produce initial records
 		var producedRecordsBytes [][]byte
@@ -769,7 +770,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0)
 
 		// Produce some records.
 		for i := 0; i < 10; i++ {
@@ -817,7 +818,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		}
 
 		// Create fetchers with tracking of uncompressed bytes
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, maxInflightBytes)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, maxInflightBytes)
 
 		// Wait for buffered records to stabilize, we expect that they stabilize because the limit is in effect.
 		waitForStableBufferedRecords(t, fetchers)
@@ -873,7 +874,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		client := newKafkaProduceClient(t, clusterAddr)
 
 		// Create fetchers early to ensure we don't miss any records
-		fetchers := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, maxInflightBytes)
+		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, maxInflightBytes)
 
 		// Produce large records
 		largeValue := bytes.Repeat([]byte{'a'}, largeRecordSize)
@@ -937,12 +938,12 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 		partitionID = 1
 	)
 
-	setup := func(t *testing.T) (*concurrentFetchers, *kfake.Cluster, context.Context) {
+	setup := func(t *testing.T) (*concurrentFetchers, *kfake.Cluster, context.Context, prometheus.Gatherer) {
 		var (
 			ctx                  = context.Background()
 			cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topic)
 			client               = newKafkaProduceClient(t, clusterAddr)
-			fetchers             = createConcurrentFetchers(ctx, t, client, topic, partitionID, 0, 1, 0)
+			fetchers, reg        = createConcurrentFetchers(ctx, t, client, topic, partitionID, 0, 1, 0)
 		)
 		t.Cleanup(cluster.Close)
 
@@ -950,60 +951,80 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 		produceRecord(ctx, t, client, topic, partitionID, []byte("record-1"))
 		produceRecord(ctx, t, client, topic, partitionID, []byte("record-2"))
 		produceRecord(ctx, t, client, topic, partitionID, []byte("record-3"))
-		return fetchers, cluster, ctx
+		return fetchers, cluster, ctx, reg
+	}
+
+	assertFetchMaxBytesMetric := func(t *testing.T, reg prometheus.Gatherer, fw fetchWant) {
+		t.Helper()
+
+		metricFamilies, err := metrics.NewMetricFamilyMapFromGatherer(reg)
+		require.NoError(t, err)
+
+		maxBytesHistogram, err := metrics.FindHistogramWithNameAndLabels(metricFamilies, "cortex_ingest_storage_reader_records_batch_fetch_max_bytes")
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(1), maxBytesHistogram.GetSampleCount())
+		require.Equal(t, float64(fw.MaxBytes()), maxBytesHistogram.GetSampleSum())
 	}
 
 	t.Run("should fetch records honoring the start offset", func(t *testing.T) {
-		fetchers, _, ctx := setup(t)
-		res := fetchers.fetchSingle(ctx, fetchWant{
+		fetchers, _, ctx, reg := setup(t)
+
+		fw := fetchWant{
 			startOffset:             1,
 			endOffset:               5,
 			estimatedBytesPerRecord: 100,
 			targetMaxBytes:          1000000,
-		})
+		}
+		res := fetchers.fetchSingle(ctx, fw)
 
 		require.NoError(t, res.Err)
 		require.Len(t, res.Records, 2)
 		require.Equal(t, "record-2", string(res.Records[0].Value))
 		require.Equal(t, "record-3", string(res.Records[1].Value))
+		assertFetchMaxBytesMetric(t, reg, fw)
 	})
 
 	t.Run("should return an empty non-error response if context is canceled", func(t *testing.T) {
-		fetchers, _, ctx := setup(t)
+		fetchers, _, ctx, reg := setup(t)
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		res := fetchers.fetchSingle(ctx, fetchWant{
+		fw := fetchWant{
 			startOffset:             1,
 			endOffset:               5,
 			estimatedBytesPerRecord: 100,
 			targetMaxBytes:          1000000,
-		})
+		}
+		res := fetchers.fetchSingle(ctx, fw)
 
 		require.NoError(t, res.Err)
 		require.Len(t, res.Records, 0)
+		assertFetchMaxBytesMetric(t, reg, fw)
 	})
 
 	t.Run("should return an error response if the Fetch request fails", func(t *testing.T) {
-		fetchers, cluster, ctx := setup(t)
+		fetchers, cluster, ctx, reg := setup(t)
 		cluster.ControlKey(kmsg.Fetch.Int16(), func(_ kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			return nil, errors.New("failed request"), true
 		})
 
-		res := fetchers.fetchSingle(ctx, fetchWant{
+		fw := fetchWant{
 			startOffset:             1,
 			endOffset:               5,
 			estimatedBytesPerRecord: 100,
 			targetMaxBytes:          1000000,
-		})
+		}
+		res := fetchers.fetchSingle(ctx, fw)
 
 		require.Error(t, res.Err)
 		require.Len(t, res.Records, 0)
+		assertFetchMaxBytesMetric(t, reg, fw)
 	})
 
 	t.Run("should return an error response if the Fetch request contains an error", func(t *testing.T) {
-		fetchers, cluster, ctx := setup(t)
+		fetchers, cluster, ctx, reg := setup(t)
 		cluster.ControlKey(kmsg.Fetch.Int16(), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 			req := kreq.(*kmsg.FetchRequest)
@@ -1021,16 +1042,18 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 			}, nil, true
 		})
 
-		res := fetchers.fetchSingle(ctx, fetchWant{
+		fw := fetchWant{
 			startOffset:             1,
 			endOffset:               5,
 			estimatedBytesPerRecord: 100,
 			targetMaxBytes:          1000000,
-		})
+		}
+		res := fetchers.fetchSingle(ctx, fw)
 
 		require.Error(t, res.Err)
 		require.ErrorContains(t, res.Err, kerr.UnknownServerError.Error())
 		require.Len(t, res.Records, 0)
+		assertFetchMaxBytesMetric(t, reg, fw)
 	})
 }
 
@@ -1044,7 +1067,7 @@ func TestConcurrentFetchers_parseFetchResponse(t *testing.T) {
 		ctx            = context.Background()
 		_, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topic)
 		client         = newKafkaProduceClient(t, clusterAddr)
-		fetchers       = createConcurrentFetchers(ctx, t, client, topic, partitionID, 0, 1, 0)
+		fetchers, _    = createConcurrentFetchers(ctx, t, client, topic, partitionID, 0, 1, 0)
 	)
 
 	t.Run("should return error if the response does not contain any topic", func(t *testing.T) {
@@ -1156,7 +1179,7 @@ func TestFetchResult_Merge(t *testing.T) {
 	})
 }
 
-func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Client, topic string, partition int32, startOffset int64, concurrency int, maxInflightBytes int32) *concurrentFetchers {
+func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Client, topic string, partition int32, startOffset int64, concurrency int, maxInflightBytes int32) (*concurrentFetchers, prometheus.Gatherer) {
 	logger := testingLogger.WithT(t)
 
 	reg := prometheus.NewPedanticRegistry()
@@ -1191,7 +1214,7 @@ func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Cli
 	require.NoError(t, err)
 	t.Cleanup(f.Stop)
 
-	return f
+	return f, reg
 }
 
 // longPollFetches polls fetches until the timeout is reached or the number of records is at least minRecords.

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -949,6 +949,7 @@ type readerMetrics struct {
 	fetchesErrors                    prometheus.Counter
 	fetchesTotal                     prometheus.Counter
 	fetchWaitDuration                prometheus.Histogram
+	fetchMaxBytes                    prometheus.Histogram
 	fetchedDiscardedRecordBytes      prometheus.Counter
 	strongConsistencyInstrumentation *StrongReadConsistencyInstrumentation[struct{}]
 	lastConsumedOffset               prometheus.Gauge
@@ -1017,6 +1018,11 @@ func newReaderMetrics(partitionID int32, reg prometheus.Registerer, metricsSourc
 		fetchWaitDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:                        "cortex_ingest_storage_reader_records_batch_wait_duration_seconds",
 			Help:                        "How long a consumer spent waiting for a batch of records from the Kafka client. If fetching is faster than processing, then this will be close to 0.",
+			NativeHistogramBucketFactor: 1.1,
+		}),
+		fetchMaxBytes: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:                        "cortex_ingest_storage_reader_records_batch_fetch_max_bytes",
+			Help:                        "The distribution of MaxBytes specified in the Fetch requests sent to Kafka.",
 			NativeHistogramBucketFactor: 1.1,
 		}),
 		fetchedDiscardedRecordBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
#### What this PR does

I'm trying to better understand what's the actual `MaxBytes` we specify in Fetch requests, but there's no metric tracking its distribution. In this PR I'm proposing to add the `cortex_ingest_storage_reader_records_batch_fetch_max_bytes` metric reporting the distribution of `MaxBytes` specified in the Fetch requests sent to Kafka.

Example from local dev env:

![Screenshot 2025-03-26 at 15 41 36](https://github.com/user-attachments/assets/3e76c44e-d646-4dff-a6cc-392418bbf527)


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
