### PR TITLE
Update mimir-prom to v1.8.2-0.20250326171450-97c8191bd4dc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -311,7 +311,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250325130416-35fb1760f4fe
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250326171450-97c8191bd4dc
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -1288,8 +1288,8 @@ github.com/grafana/gomemcache v0.0.0-20250318131618-74242eea118d h1:oXRJlb9UjVsl
 github.com/grafana/gomemcache v0.0.0-20250318131618-74242eea118d/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/grafana/mimir-prometheus v0.0.0-20250325130416-35fb1760f4fe h1:8eVI7IxdZne420pA9k1OHlwYOyDQOQV1mpPNr5zXpgs=
-github.com/grafana/mimir-prometheus v0.0.0-20250325130416-35fb1760f4fe/go.mod h1:BAiuTb1VIMGkFkAxCupsKnPL2jBHiwtx5AlzVDLings=
+github.com/grafana/mimir-prometheus v1.8.2-0.20250326171450-97c8191bd4dc h1:FxJ3ekMSP6g/CHV3Qo7GMSLEmD3z45QrOY7CR1vl2ew=
+github.com/grafana/mimir-prometheus v1.8.2-0.20250326171450-97c8191bd4dc/go.mod h1:ZOdOGMVBSAzUasgE0jcUlXTFpmct3hWyfJy6L7uRwkE=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/prometheus-alertmanager v0.25.1-0.20250325133853-820cb26e127a h1:nqT3xW4njhELeaW8rv5F9TP4jDDnmaHJfcRC2ekfWgE=

--- a/vendor/github.com/prometheus/prometheus/storage/remote/client.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/client.go
@@ -145,8 +145,8 @@ type ReadClient interface {
 }
 
 // NewReadClient creates a new client for remote read.
-func NewReadClient(name string, conf *ClientConfig) (ReadClient, error) {
-	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client")
+func NewReadClient(name string, conf *ClientConfig, optFuncs ...config_util.HTTPClientOption) (ReadClient, error) {
+	httpClient, err := config_util.NewClientFromConfig(conf.HTTPClientConfig, "remote_storage_read_client", optFuncs...)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1099,7 +1099,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v0.0.0-20250325130416-35fb1760f4fe
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20250326171450-97c8191bd4dc
 ## explicit; go 1.23.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1806,7 +1806,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v0.0.0-20250325130416-35fb1760f4fe
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250326171450-97c8191bd4dc
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
#### What this PR does

This updates mimir-prom to https://github.com/grafana/mimir-prometheus/pull/859

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Very minor update.