### PR TITLE
block-builder: Fix a panic for out-of-order samples

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -863,6 +863,9 @@ func (b *BlockBuilder) uploadBlocks(ctx context.Context, tenantID, dbDir string,
 
 		if meta.Compaction.FromOutOfOrder() && b.limits.OutOfOrderBlocksExternalLabelEnabled(tenantID) {
 			// At this point the OOO data was already ingested and compacted, so there's no point in checking for the OOO feature flag
+			if meta.Thanos.Labels == nil {
+				meta.Thanos.Labels = map[string]string{}
+			}
 			meta.Thanos.Labels[mimir_tsdb.OutOfOrderExternalLabel] = mimir_tsdb.OutOfOrderExternalLabelValue
 		}
 

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -470,6 +470,53 @@ func TestBlockBuilder_WithMultipleTenants(t *testing.T) {
 	}
 }
 
+func TestBlockBuilder_OutOfOrder(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	kafkaCluster, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
+	kafkaClient := mustKafkaClient(t, kafkaAddr)
+	cfg, overrides := blockBuilderConfig(t, kafkaAddr)
+
+	cycleEndStartup := cycleEndBefore(time.Now(), cfg.ConsumeInterval, cfg.ConsumeIntervalBuffer)
+
+	var producedSamples []mimirpb.Sample
+	kafkaRecTime := cycleEndStartup.Truncate(cfg.ConsumeInterval).Add(-1 * time.Hour).Add(29 * time.Minute)
+	samples := produceSamples(ctx, t, kafkaClient, 0, kafkaRecTime, "1", kafkaRecTime.Add(-time.Minute))
+	producedSamples = append(producedSamples, samples...)
+	// Out of order sample.
+	kafkaRecTime = kafkaRecTime.Add(-time.Minute)
+	samples = produceSamples(ctx, t, kafkaClient, 0, kafkaRecTime, "1", kafkaRecTime.Add(-time.Minute))
+	producedSamples = append(producedSamples, samples...)
+
+	// Set up a hook to track commits from block-builder to kafka. Those indicate the end of a cycle.
+	kafkaCommits := atomic.NewInt32(0)
+	kafkaCluster.ControlKey(kmsg.OffsetCommit.Int16(), func(kmsg.Request) (kmsg.Response, error, bool) {
+		kafkaCommits.Add(1)
+		return nil, nil, false
+	})
+
+	reg := prometheus.NewPedanticRegistry()
+
+	bb, err := New(cfg, test.NewTestingLogger(t), reg, overrides)
+	require.NoError(t, err)
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
+	})
+
+	require.Eventually(t, func() bool { return kafkaCommits.Load() > 0 }, 20*time.Second, 100*time.Millisecond, "expected kafka commits")
+
+	compareQueryWithDir(t,
+		path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, "1"),
+		producedSamples, nil,
+		labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
+	)
+}
+
 func TestBlockBuilder_WithNonMonotonicRecordTimestamps(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/blockbuilder/config_test.go
+++ b/pkg/blockbuilder/config_test.go
@@ -102,6 +102,7 @@ func blockBuilderConfig(t *testing.T, addr string) (Config, *validation.Override
 
 	limits := defaultLimitsTestConfig()
 	limits.OutOfOrderTimeWindow = 2 * model.Duration(time.Hour)
+	limits.OutOfOrderBlocksExternalLabelEnabled = true // Needed to reproduce a panic.
 	limits.NativeHistogramsIngestionEnabled = true
 	overrides, err := validation.NewOverrides(limits, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
#### What this PR does

Fixes a panic when `OutOfOrderBlocksExternalLabelEnabled` is set for a tenant.


#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
