### PR TITLE
docs: update s3 doc to indicate endpoint shouldn't include the bucket name prefix

### DIFF
--- a/docs/sources/mimir/configure/configure-object-storage-backend.md
+++ b/docs/sources/mimir/configure/configure-object-storage-backend.md
@@ -84,7 +84,7 @@ ruler_storage:
 ```
 
 {{< admonition type="note" >}}
-The endpoint value must not be prefixed with your bucket name (e.g., if your bucket is "my-storage-bucket", the endpoint cannot be "my-storage-bucket.s3.amazonaws.com").
+Don't prefix the endpoint value with your bucket name. For example, if your bucket is named "my-storage-bucket", you cannot name the endpoint "my-storage-bucket.s3.amazonaws.com".
 {{< /admonition >}}
 
 ### GCS

--- a/docs/sources/mimir/configure/configure-object-storage-backend.md
+++ b/docs/sources/mimir/configure/configure-object-storage-backend.md
@@ -83,6 +83,10 @@ ruler_storage:
     bucket_name: mimir-ruler
 ```
 
+{{< admonition type="note" >}}
+The endpoint value must not be prefixed with your bucket name (e.g., if your bucket is "my-storage-bucket", the endpoint cannot be "my-storage-bucket.s3.amazonaws.com").
+{{< /admonition >}}
+
 ### GCS
 
 ```yaml


### PR DESCRIPTION
… name prefix

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Document the s3 object storage endpoint must not prefixed with the bucket name.

#### Which issue(s) this PR fixes or relates to

Fixes #9177

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
