### PR TITLE
fix: Use dnssrvnoa to connect to memcached instances

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* BUGFIX Memcached: Use `dnssrvnoa+` address prefix instead of `dns+` which results in DNS `SRV` record lookups instead of `A` or `AAAA`. This results in fewer cache evictions when the members of the Memcached cluster change. #11041
+
 ## 5.7.0-rc.0
 
 * [CHANGE] KEDA Autoscaling: Changed toPromQLLabelSelector from object to list of strings, adding support for all PromQL operators. #10945

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -184,23 +184,23 @@ Alertmanager cluster bind address
 {{- end -}}
 
 {{- define "mimir.chunksCacheAddress" -}}
-dns+{{ template "mimir.fullname" . }}-chunks-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "chunks-cache").port }}
+dnssrvnoa+{{ template "mimir.fullname" . }}-chunks-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "chunks-cache").port }}
 {{- end -}}
 
 {{- define "mimir.indexCacheAddress" -}}
-dns+{{ template "mimir.fullname" . }}-index-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "index-cache").port }}
+dnssrvnoa+{{ template "mimir.fullname" . }}-index-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "index-cache").port }}
 {{- end -}}
 
 {{- define "mimir.metadataCacheAddress" -}}
-dns+{{ template "mimir.fullname" . }}-metadata-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "metadata-cache").port }}
+dnssrvnoa+{{ template "mimir.fullname" . }}-metadata-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "metadata-cache").port }}
 {{- end -}}
 
 {{- define "mimir.resultsCacheAddress" -}}
-dns+{{ template "mimir.fullname" . }}-results-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "results-cache").port }}
+dnssrvnoa+{{ template "mimir.fullname" . }}-results-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "results-cache").port }}
 {{- end -}}
 
 {{- define "mimir.adminCacheAddress" -}}
-dns+{{ template "mimir.fullname" . }}-admin-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "admin-cache").port }}
+dnssrvnoa+{{ template "mimir.fullname" . }}-admin-cache.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ (index .Values "admin-cache").port }}
 {{- end -}}
 
 {{/*

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -57,21 +57,21 @@ data:
         chunks_cache:
           backend: memcached
           memcached:
-            addresses: dns+enterprise-https-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+enterprise-https-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
             timeout: 750ms
         index_cache:
           backend: memcached
           memcached:
-            addresses: dns+enterprise-https-values-mimir-index-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+enterprise-https-values-mimir-index-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 5242880
             timeout: 750ms
         metadata_cache:
           backend: memcached
           memcached:
-            addresses: dns+enterprise-https-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+enterprise-https-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
         sync_dir: /data/tsdb-sync
@@ -116,7 +116,7 @@ data:
       results_cache:
         backend: memcached
         memcached:
-          addresses: dns+enterprise-https-values-mimir-results-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+enterprise-https-values-mimir-results-cache.citestns.svc.cluster.local.:11211
           max_item_size: 5242880
           timeout: 500ms
           tls_cert_path: /certs/tls.crt
@@ -283,7 +283,7 @@ data:
       cache:
         backend: memcached
         memcached:
-          addresses: dns+enterprise-https-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+enterprise-https-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
           max_item_size: 1048576
       s3:
         bucket_name: ruler

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -25,21 +25,21 @@ data:
         chunks_cache:
           backend: memcached
           memcached:
-            addresses: dns+large-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+large-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
             timeout: 750ms
         index_cache:
           backend: memcached
           memcached:
-            addresses: dns+large-values-mimir-index-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+large-values-mimir-index-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 5242880
             timeout: 750ms
         metadata_cache:
           backend: memcached
           memcached:
-            addresses: dns+large-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+large-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
         sync_dir: /data/tsdb-sync
@@ -70,7 +70,7 @@ data:
       results_cache:
         backend: memcached
         memcached:
-          addresses: dns+large-values-mimir-results-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+large-values-mimir-results-cache.citestns.svc.cluster.local.:11211
           max_item_size: 5242880
           timeout: 500ms
       scheduler_address: large-values-mimir-query-scheduler-headless.citestns.svc:9095
@@ -112,7 +112,7 @@ data:
       cache:
         backend: memcached
         memcached:
-          addresses: dns+large-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+large-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
           max_item_size: 1048576
     runtime_config:
       file: /var/mimir/runtime.yaml

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -25,21 +25,21 @@ data:
         chunks_cache:
           backend: memcached
           memcached:
-            addresses: dns+small-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+small-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
             timeout: 750ms
         index_cache:
           backend: memcached
           memcached:
-            addresses: dns+small-values-mimir-index-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+small-values-mimir-index-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 5242880
             timeout: 750ms
         metadata_cache:
           backend: memcached
           memcached:
-            addresses: dns+small-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+small-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
         sync_dir: /data/tsdb-sync
@@ -70,7 +70,7 @@ data:
       results_cache:
         backend: memcached
         memcached:
-          addresses: dns+small-values-mimir-results-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+small-values-mimir-results-cache.citestns.svc.cluster.local.:11211
           max_item_size: 5242880
           timeout: 500ms
       scheduler_address: small-values-mimir-query-scheduler-headless.citestns.svc:9095
@@ -112,7 +112,7 @@ data:
       cache:
         backend: memcached
         memcached:
-          addresses: dns+small-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+small-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
           max_item_size: 1048576
     runtime_config:
       file: /var/mimir/runtime.yaml

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -25,7 +25,7 @@ data:
         cache:
           backend: memcached
           memcached:
-            addresses: dns+test-enterprise-configmap-values-mimir-admin-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+test-enterprise-configmap-values-mimir-admin-cache.citestns.svc.cluster.local.:11211
             max_item_size: 1048576
         s3:
           access_key_id: ${MINIO_ROOT_USER}
@@ -58,21 +58,21 @@ data:
         chunks_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-enterprise-configmap-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+test-enterprise-configmap-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
             timeout: 750ms
         index_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-enterprise-configmap-values-mimir-index-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+test-enterprise-configmap-values-mimir-index-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 5242880
             timeout: 750ms
         metadata_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-enterprise-configmap-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+test-enterprise-configmap-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
         sync_dir: /data/tsdb-sync
@@ -111,7 +111,7 @@ data:
       results_cache:
         backend: memcached
         memcached:
-          addresses: dns+test-enterprise-configmap-values-mimir-results-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+test-enterprise-configmap-values-mimir-results-cache.citestns.svc.cluster.local.:11211
           max_item_size: 5242880
           timeout: 500ms
       scheduler_address: test-enterprise-configmap-values-mimir-query-scheduler-headless.citestns.svc:9095
@@ -179,7 +179,7 @@ data:
       cache:
         backend: memcached
         memcached:
-          addresses: dns+test-enterprise-configmap-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+test-enterprise-configmap-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
           max_item_size: 1048576
       s3:
         access_key_id: ${MINIO_ROOT_USER}

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -33,21 +33,21 @@ data:
         chunks_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-oss-k8s-1.25-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+test-oss-k8s-1.25-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
             timeout: 750ms
         index_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-oss-k8s-1.25-values-mimir-index-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+test-oss-k8s-1.25-values-mimir-index-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 5242880
             timeout: 750ms
         metadata_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-oss-k8s-1.25-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+test-oss-k8s-1.25-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
         sync_dir: /data/tsdb-sync
@@ -84,7 +84,7 @@ data:
       results_cache:
         backend: memcached
         memcached:
-          addresses: dns+test-oss-k8s-1.25-values-mimir-results-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+test-oss-k8s-1.25-values-mimir-results-cache.citestns.svc.cluster.local.:11211
           max_item_size: 5242880
           timeout: 500ms
       scheduler_address: test-oss-k8s-1.25-values-mimir-query-scheduler-headless.citestns.svc:9095
@@ -127,7 +127,7 @@ data:
       cache:
         backend: memcached
         memcached:
-          addresses: dns+test-oss-k8s-1.25-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+test-oss-k8s-1.25-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
           max_item_size: 1048576
       s3:
         access_key_id: grafana-mimir

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -33,21 +33,21 @@ data:
         chunks_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-oss-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+test-oss-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
             timeout: 750ms
         index_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-oss-values-mimir-index-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+test-oss-values-mimir-index-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 5242880
             timeout: 750ms
         metadata_cache:
           backend: memcached
           memcached:
-            addresses: dns+test-oss-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+            addresses: dnssrvnoa+test-oss-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
             max_idle_connections: 150
             max_item_size: 1048576
         sync_dir: /data/tsdb-sync
@@ -84,7 +84,7 @@ data:
       results_cache:
         backend: memcached
         memcached:
-          addresses: dns+test-oss-values-mimir-results-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+test-oss-values-mimir-results-cache.citestns.svc.cluster.local.:11211
           max_item_size: 5242880
           timeout: 500ms
       scheduler_address: test-oss-values-mimir-query-scheduler-headless.citestns.svc:9095
@@ -126,7 +126,7 @@ data:
       cache:
         backend: memcached
         memcached:
-          addresses: dns+test-oss-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+          addresses: dnssrvnoa+test-oss-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
           max_item_size: 1048576
       s3:
         access_key_id: ${MINIO_ROOT_USER}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Fix the default memcached address to use `dnssrvnoa` instead of `dns` to avoid conflicts/rebalancing on the hashing algorithm when a memcached pod is restarted

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

This is the default in [Loki](https://github.com/grafana/loki/blob/b442d27fa6a0f9819d679c960ed5f396cbec199e/production/helm/loki/values.yaml#L210)

Thanks Gergely Madarász for raising this up on [Slack](https://grafana.slack.com/archives/C039863E8P7/p1742550271473749)