### PR TITLE
Upgrade golangci-lint to v1.64.8

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,6 +84,11 @@ linters-settings:
       # See https://golangci-lint.run/usage/linters/#gocritic for possible checks.
       - dupImport
 
+  revive:
+    rules:
+      - name: redefines-builtin-id
+        disabled: true
+
 run:
   timeout: 10m
 

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr10881-da6fc3a5fc
+LATEST_BUILD_IMAGE_TAG ?= pr11049-1a6c186ce8
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -39,7 +39,7 @@ RUN GOARCH=$(go env GOARCH) && \
     curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
     chmod a+x /usr/bin/tk
 
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.60.2
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.64.8
 
 ENV SKOPEO_VERSION=v1.15.1
 RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \
@@ -51,7 +51,7 @@ RUN GO111MODULE=on \
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 && \
 	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.2 && \
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
-	go install github.com/fatih/faillint@v1.12.0 && \
+	go install github.com/fatih/faillint@v1.15.0 && \
 	go install github.com/campoy/embedmd@v1.0.0 && \
 	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.4.0 && \
 	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@b97ae11 && \

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -230,8 +230,9 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeError(w, apierror.New(apierror.TypeInternal, err.Error()))
 			return
 		}
-		ctx, _ := context.WithDeadlineCause(r.Context(), deadline,
+		ctx, cancel := context.WithDeadlineCause(r.Context(), deadline,
 			cancellation.NewErrorf("write deadline exceeded (timeout: %v)", f.cfg.ActiveSeriesWriteTimeout))
+		defer cancel()
 		r = r.WithContext(ctx)
 	}
 
@@ -283,7 +284,6 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if f.cfg.QueryStatsEnabled {
 		f.reportQueryStats(r, params, startTime, queryResponseTime, queryResponseSize, queryDetails, resp.StatusCode, nil)
 	}
-
 }
 
 // reportSlowQuery reports slow queries.

--- a/pkg/ruler/notifier.go
+++ b/pkg/ruler/notifier.go
@@ -84,11 +84,12 @@ type rulerNotifier struct {
 }
 
 func newRulerNotifier(o *notifier.Options, l gklog.Logger) (*rulerNotifier, error) {
-	sdCtx, sdCancel := context.WithCancelCause(context.Background())
 	sdMetrics, err := discovery.CreateAndRegisterSDMetrics(o.Registerer)
 	if err != nil {
 		return nil, err
 	}
+
+	sdCtx, sdCancel := context.WithCancelCause(context.Background())
 	sl := util_log.SlogFromGoKit(l)
 	return &rulerNotifier{
 		notifier:  notifier.NewManager(o, sl),


### PR DESCRIPTION
#### What this PR does

Upgrade golangci-lint to v1.64.8 and faillint to v1.15.0. Fixing issues found by linters.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
