### PR TITLE
Don't log context cancellation as an error while streaming chunks

### DIFF
--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/gogo/status"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/prometheus/prometheus/model/labels"
+	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/limiter"
@@ -103,7 +105,7 @@ func (s *SeriesChunksStreamReader) StartBuffering() {
 
 		if err := s.readStream(log); err != nil {
 			s.errorChan <- err
-			if errors.Is(err, context.Canceled) {
+			if errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled {
 				return
 			}
 			level.Error(log).Log("msg", "received error while streaming chunks from ingester", "err", err)


### PR DESCRIPTION
#### What this PR does

This PR silences some log noise from ingester and store-gateway chunks streaming that occurs when a query request is cancelled or aborted.

Previously, messages like the following could be logged when a request was cancelled:

```
caller=streaming.go:109 method=SeriesChunksStreamReader.StartBuffering user=test level=error msg="received error while streaming chunks from ingester" err="rpc error: code = Canceled desc = context canceled"
```

These messages aren't helpful and can be a distraction when trying to understand what actually happened.

I don't believe this change is significant enough to warrant a changelog entry.

#### Which issue(s) this PR fixes or relates to

#10861

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
