### PR TITLE
Fix TestConcurrentFetchers_fetchSingle flaky test

### DIFF
--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -986,7 +986,7 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 	})
 
 	t.Run("should return an empty non-error response if context is canceled", func(t *testing.T) {
-		fetchers, _, ctx, reg := setup(t)
+		fetchers, _, ctx, _ := setup(t)
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
 

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -1000,7 +1000,6 @@ func TestConcurrentFetchers_fetchSingle(t *testing.T) {
 
 		require.NoError(t, res.Err)
 		require.Len(t, res.Records, 0)
-		assertFetchMaxBytesMetric(t, reg, fw)
 	})
 
 	t.Run("should return an error response if the Fetch request fails", func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

In #11014 I've added the `assertFetchMaxBytesMetric()` assertion in some tests. This introduced some flakyness for `TestConcurrentFetchers_fetchSingle/should_return_an_empty_non-error_response_if_context_is_canceled` because the request may or may not issued based on when the cancel is captured (running in a different goroutine it's non-deterministic). We don't really need the assertion for that specific test case (we do for others), so we can simply remove it.

#### Which issue(s) this PR fixes or relates to

Fixes #11034

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
