### PR TITLE
Maybe fix TestPartitionReader_ConsumeAtStartup race condition

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2612,7 +2612,7 @@ func TestPartitionCommitter_commit(t *testing.T) {
 func newKafkaProduceClient(t *testing.T, addrs string) *kgo.Client {
 	writeClient, err := kgo.NewClient(
 		kgo.SeedBrokers(addrs),
-		kgo.WithLogger(NewKafkaLogger(mimirtest.NewTestingLogger(t))),
+		kgo.WithLogger(NewKafkaLogger(testingLogger.WithT(t))),
 		// We will choose the partition of each record.
 		kgo.RecordPartitioner(kgo.ManualPartitioner()),
 	)


### PR DESCRIPTION
#### What this PR does

This PR is a follow up of #9428. Assuming the direction in that PR is the right one, then we need to use the synchronized and shared logger in `newKafkaProduceClient()` (which is used by `TestPartitionReader_ConsumeAtStartup`) and other tests. This change may fix the race condition described in https://github.com/grafana/mimir/issues/10686 (I haven't been able to reproduce it, so I'm not sure it's enough to fix it).

#### Which issue(s) this PR fixes or relates to

Maybe #10686

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
