### PR TITLE
Fix blocks retention period enforcement in the query-frontend when a request has multiple tenants (tenant federation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [BUGFIX] Querier: return NaN from `irate()` if the second-last sample in the range is NaN and Prometheus' query engine is in use. #10956
 * [BUGFIX] Ruler: don't count alerts towards `cortex_prometheus_notifications_dropped_total` if they are dropped due to alert relabelling. #10956
 * [BUGFIX] Querier: Fix issue where an entire store-gateway zone leaving caused high CPU usage trying to find active members of the leaving zone. #11028
+* [BUGFIX] Query-frontend: Fix blocks retention period enforcement when a request has multiple tenants (tenant federation). #11069
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -150,7 +150,7 @@ func (l limitsMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Respon
 	}
 
 	// Clamp the time range based on the max query lookback and block retention period.
-	blocksRetentionPeriod := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, l.CompactorBlocksRetentionPeriod)
+	blocksRetentionPeriod := validation.LargestPositiveNonZeroDurationPerTenant(tenantIDs, l.CompactorBlocksRetentionPeriod)
 	maxQueryLookback := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, l.MaxQueryLookback)
 	maxLookback := smallestPositiveNonZeroDuration(blocksRetentionPeriod, maxQueryLookback)
 	if maxLookback > 0 {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -1335,6 +1335,24 @@ func SmallestPositiveNonZeroDurationPerTenant(tenantIDs []string, f func(string)
 	return *result
 }
 
+// LargestPositiveNonZeroDurationPerTenant is returning the maximum positive
+// and non-zero value of the supplied limit function for all given tenants. In
+// many limits a value of 0 means unlimited so the method will return 0 only if
+// all inputs have a limit of 0 or an empty tenant list is given.
+func LargestPositiveNonZeroDurationPerTenant(tenantIDs []string, f func(string) time.Duration) time.Duration {
+	var result *time.Duration
+	for _, tenantID := range tenantIDs {
+		v := f(tenantID)
+		if v > 0 && (result == nil || v > *result) {
+			result = &v
+		}
+	}
+	if result == nil {
+		return 0
+	}
+	return *result
+}
+
 // MinDurationPerTenant is returning the minimum duration per tenant. Without
 // tenants given it will return a time.Duration(0).
 func MinDurationPerTenant(tenantIDs []string, f func(string) time.Duration) time.Duration {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -1340,17 +1340,13 @@ func SmallestPositiveNonZeroDurationPerTenant(tenantIDs []string, f func(string)
 // many limits a value of 0 means unlimited so the method will return 0 only if
 // all inputs have a limit of 0 or an empty tenant list is given.
 func LargestPositiveNonZeroDurationPerTenant(tenantIDs []string, f func(string) time.Duration) time.Duration {
-	var result *time.Duration
+	result := time.Duration(0)
 	for _, tenantID := range tenantIDs {
-		v := f(tenantID)
-		if v > 0 && (result == nil || v > *result) {
-			result = &v
+		if v := f(tenantID); v > result {
+			result = v
 		}
 	}
-	if result == nil {
-		return 0
-	}
-	return *result
+	return result
 }
 
 // MinDurationPerTenant is returning the minimum duration per tenant. Without


### PR DESCRIPTION
#### What this PR does

When tenant federation is used and a query request has multiple tenants with different retention period, we should clamp the request time range based on the tenant with the largest retention and not the smallest retention. This PR fixes it.

For more details, see: https://github.com/grafana/mimir/issues/9727#issuecomment-2761898142

#### Which issue(s) this PR fixes or relates to

Fixes #9727

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
