### PR TITLE
chore: Remove release-2.14 from automated updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,7 @@
     "extends": [
       "config:base"
     ],
-    "baseBranches": ["main", "release-2.16", "release-2.15", "release-2.14"],
+    "baseBranches": ["main", "release-2.16", "release-2.15"],
     "postUpdateOptions": [
       "gomodTidy",
       "gomodUpdateImportPaths"
@@ -11,7 +11,7 @@
     "schedule": ["before 9am on Monday"],
     "packageRules": [
       {
-        "matchBaseBranches": ["release-2.15", "release-2.14"],
+        "matchBaseBranches": ["release-2.16", "release-2.15"],
         "packagePatterns": ["*"],
         "enabled": false
       },


### PR DESCRIPTION
Mimir 2.16 is releases so 2.14 no longer gets automatic updates.

Part of https://github.com/grafana/mimir/issues/10917
