### PR TITLE
Store-Gateway: Don't Increment thanos_objstore_bucket_operation_failures_total on failed Sparse Index Header GET 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [CHANGE] Ingester: Out-of-order native histograms are now enabled whenever both native histogram and out-of-order ingestion is enabled. The `-ingester.ooo-native-histograms-ingestion-enabled` CLI flag and corresponding `ooo_native_histograms_ingestion_enabled` runtime configuration option have been removed. #10956
 * [CHANGE] Distributor: removed the `cortex_distributor_label_values_with_newlines_total` metric. #10977
 * [ENHANCEMENT] Ingester: Add support for exporting native histogram cost attribution metrics (`cortex_ingester_attributed_active_native_histogram_series` and `cortex_ingester_attributed_active_native_histogram_buckets`) with labels specified by customers to a custom Prometheus registry. #10892
-* [ENHANCEMENT] Store-gateway: Download sparse headers uploaded by compactors. Compactors have to be configured with `-compactor.upload-sparse-index-headers=true` option. #10879
+* [ENHANCEMENT] Store-gateway: Download sparse headers uploaded by compactors. Compactors have to be configured with `-compactor.upload-sparse-index-headers=true` option. #10879 #11072.
 * [ENHANCEMENT] Compactor: Upload block index file and multiple segment files concurrently. Concurrency scales linearly with block size up to `-compactor.max-per-block-upload-concurrency`. #10947
 * [ENHANCEMENT] Ingester: Add per-user `cortex_ingester_tsdb_wal_replay_unknown_refs_total` and `cortex_ingester_tsdb_wbl_replay_unknown_refs_total` metrics to track unknown series references during WAL/WBL replay. #10981
 * [ENHANCEMENT] Added `-ingest-storage.kafka.fetch-max-wait` configuration option to configure the maximum amount of time a Kafka broker waits for some records before a Fetch response is returned. #11012

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -444,9 +444,12 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 			level.Warn(jobLogger).Log("msg", "failed to create filesystem bucket, skipping sparse header upload", "err", err)
 			break
 		}
+
+		// no-op...
+		fsInstrBkt := objstore.WithNoopInstr(fsbkt)
 		_ = concurrency.ForEachJob(ctx, uploadBlocksCount, c.blockSyncConcurrency, func(ctx context.Context, idx int) error {
 			blockToUpload := blocksToUpload[idx]
-			err := prepareSparseIndexHeader(ctx, jobLogger, fsbkt, subDir, blockToUpload.ulid, c.sparseIndexHeaderSamplingRate, c.sparseIndexHeaderconfig)
+			err := prepareSparseIndexHeader(ctx, jobLogger, fsInstrBkt, subDir, blockToUpload.ulid, c.sparseIndexHeaderSamplingRate, c.sparseIndexHeaderconfig)
 			if err != nil {
 				c.metrics.compactionBlocksBuildSparseHeadersFailed.Inc()
 				level.Warn(jobLogger).Log("msg", "failed to create sparse index headers", "block", blockToUpload.ulid.String(), "shard", blockToUpload.shardIndex, "err", err)
@@ -506,7 +509,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 	return true, compIDs, nil
 }
 
-func prepareSparseIndexHeader(ctx context.Context, logger log.Logger, bkt objstore.Bucket, dir string, id ulid.ULID, sampling int, cfg indexheader.Config) error {
+func prepareSparseIndexHeader(ctx context.Context, logger log.Logger, bkt objstore.InstrumentedBucketReader, dir string, id ulid.ULID, sampling int, cfg indexheader.Config) error {
 	// Calling NewStreamBinaryReader reads a block's index and writes a sparse-index-header to disk.
 	mets := indexheader.NewStreamBinaryReaderMetrics(nil)
 	br, err := indexheader.NewStreamBinaryReader(ctx, logger, bkt, dir, id, sampling, mets, cfg)

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -445,7 +445,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 			break
 		}
 
-		// no-op...
+		// instrument filesystem.Bucket to objstore.InstrumentedBucket
 		fsInstrBkt := objstore.WithNoopInstr(fsbkt)
 		_ = concurrency.ForEachJob(ctx, uploadBlocksCount, c.blockSyncConcurrency, func(ctx context.Context, idx int) error {
 			blockToUpload := blocksToUpload[idx]

--- a/pkg/storage/indexheader/header_test.go
+++ b/pkg/storage/indexheader/header_test.go
@@ -211,6 +211,11 @@ func Test_DownsampleSparseIndexHeader(t *testing.T) {
 
 			bkt := objstore.WithNoopInstr(ubkt)
 
+			defer func() {
+				require.NoError(t, ubkt.Close())
+				require.NoError(t, bkt.Close())
+			}()
+
 			ctx := context.Background()
 			noopMetrics := NewStreamBinaryReaderMetrics(nil)
 

--- a/pkg/storage/indexheader/header_test.go
+++ b/pkg/storage/indexheader/header_test.go
@@ -206,8 +206,10 @@ func Test_DownsampleSparseIndexHeader(t *testing.T) {
 			tmpDir := t.TempDir()
 			test.Copy(t, "./testdata/index_format_v2", filepath.Join(tmpDir, m.ULID.String()))
 
-			bkt, err := filesystem.NewBucket(tmpDir)
+			ubkt, err := filesystem.NewBucket(tmpDir)
 			require.NoError(t, err)
+
+			bkt := objstore.WithNoopInstr(ubkt)
 
 			ctx := context.Background()
 			noopMetrics := NewStreamBinaryReaderMetrics(nil)

--- a/pkg/storage/indexheader/header_test.go
+++ b/pkg/storage/indexheader/header_test.go
@@ -211,10 +211,10 @@ func Test_DownsampleSparseIndexHeader(t *testing.T) {
 
 			bkt := objstore.WithNoopInstr(ubkt)
 
-			defer func() {
+			t.Cleanup(func() {
 				require.NoError(t, ubkt.Close())
 				require.NoError(t, bkt.Close())
-			}()
+			})
 
 			ctx := context.Background()
 			noopMetrics := NewStreamBinaryReaderMetrics(nil)

--- a/pkg/storage/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storage/indexheader/lazy_binary_reader_test.go
@@ -43,7 +43,10 @@ func TestNewLazyBinaryReader_ShouldFailIfUnableToBuildIndexHeader(t *testing.T) 
 	bkt := objstore.WithNoopInstr(ubkt)
 
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, bkt.Close()) })
+	t.Cleanup(func() {
+		require.NoError(t, ubkt.Close())
+		require.NoError(t, bkt.Close())
+	})
 
 	testLazyBinaryReader(t, bkt, tmpDir, ulid.ULID{}, func(t *testing.T, _ *LazyBinaryReader, err error) {
 		require.Error(t, err)
@@ -186,7 +189,10 @@ func initBucketAndBlocksForTest(t testing.TB) (string, objstore.InstrumentedBuck
 	bkt := objstore.WithNoopInstr(ubkt)
 
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, bkt.Close()) })
+	t.Cleanup(func() {
+		require.NoError(t, ubkt.Close())
+		require.NoError(t, bkt.Close())
+	})
 
 	// Create block.
 	blockID, err := block.CreateBlock(ctx, tmpDir, []labels.Labels{

--- a/pkg/storage/indexheader/reader_pool.go
+++ b/pkg/storage/indexheader/reader_pool.go
@@ -80,7 +80,7 @@ func newReaderPool(logger log.Logger, indexHeaderConfig Config, lazyLoadingGate 
 // NewBinaryReader creates and returns a new binary reader. If the pool has been configured
 // with lazy reader enabled, this function will return a lazy reader. The returned lazy reader
 // is tracked by the pool and automatically closed once the idle timeout expires.
-func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, cfg Config) (Reader, error) {
+func (p *ReaderPool) NewBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.InstrumentedBucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, cfg Config) (Reader, error) {
 	var readerFactory func() (Reader, error)
 	var reader Reader
 	var err error

--- a/pkg/storage/indexheader/reader_pool_test.go
+++ b/pkg/storage/indexheader/reader_pool_test.go
@@ -152,6 +152,7 @@ func prepareReaderPool(t *testing.T) (context.Context, string, objstore.Instrume
 
 	require.NoError(t, err)
 	t.Cleanup(func() {
+		require.NoError(t, ubkt.Close())
 		require.NoError(t, bkt.Close())
 	})
 

--- a/pkg/storage/indexheader/reader_pool_test.go
+++ b/pkg/storage/indexheader/reader_pool_test.go
@@ -19,6 +19,7 @@ import (
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
 	"go.uber.org/atomic"
 
@@ -81,7 +82,6 @@ func TestReaderPool_ShouldCloseIdleLazyReaders(t *testing.T) {
 	const idleTimeout = time.Second
 	ctx, tmpDir, bkt, blockID, metrics := prepareReaderPool(t)
 	defer func() { require.NoError(t, os.RemoveAll(tmpDir)) }()
-	defer func() { require.NoError(t, bkt.Close()) }()
 
 	// Note that we are creating a ReaderPool that doesn't run a background cleanup task for idle
 	// Reader instances. We'll manually invoke the cleanup task when we need it as part of this test.
@@ -142,12 +142,14 @@ func TestReaderPool_LoadedBlocks(t *testing.T) {
 	require.Equal(t, []ulid.ULID{id}, loadedBlocks)
 }
 
-func prepareReaderPool(t *testing.T) (context.Context, string, *filesystem.Bucket, ulid.ULID, *ReaderPoolMetrics) {
+func prepareReaderPool(t *testing.T) (context.Context, string, objstore.InstrumentedBucketReader, ulid.ULID, *ReaderPoolMetrics) {
 	ctx := context.Background()
 
 	tmpDir := t.TempDir()
 
-	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	ubkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	bkt := objstore.WithNoopInstr(ubkt)
+
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, bkt.Close())

--- a/pkg/storage/indexheader/stream_binary_reader.go
+++ b/pkg/storage/indexheader/stream_binary_reader.go
@@ -70,7 +70,7 @@ type StreamBinaryReader struct {
 }
 
 // NewStreamBinaryReader loads or builds new index-header if not present on disk.
-func NewStreamBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, metrics *StreamBinaryReaderMetrics, cfg Config) (*StreamBinaryReader, error) {
+func NewStreamBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.InstrumentedBucketReader, dir string, id ulid.ULID, postingOffsetsInMemSampling int, metrics *StreamBinaryReaderMetrics, cfg Config) (*StreamBinaryReader, error) {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, logger, "indexheader.NewStreamBinaryReader")
 	defer spanLog.Finish()
 
@@ -95,7 +95,7 @@ func NewStreamBinaryReader(ctx context.Context, logger log.Logger, bkt objstore.
 }
 
 // newFileStreamBinaryReader loads sparse index-headers from disk, then from the bucket, or constructs it from the index-header if neither of the two available.
-func newFileStreamBinaryReader(ctx context.Context, binPath string, id ulid.ULID, sparseHeadersPath string, postingOffsetsInMemSampling int, logger log.Logger, bkt objstore.BucketReader, metrics *StreamBinaryReaderMetrics, cfg Config) (bw *StreamBinaryReader, err error) {
+func newFileStreamBinaryReader(ctx context.Context, binPath string, id ulid.ULID, sparseHeadersPath string, postingOffsetsInMemSampling int, logger log.Logger, bkt objstore.InstrumentedBucketReader, metrics *StreamBinaryReaderMetrics, cfg Config) (bw *StreamBinaryReader, err error) {
 	logger = log.With(logger, "id", id, "path", sparseHeadersPath, "inmem_sampling_rate", postingOffsetsInMemSampling)
 
 	r := &StreamBinaryReader{
@@ -168,7 +168,7 @@ func newFileStreamBinaryReader(ctx context.Context, binPath string, id ulid.ULID
 // It prioritizes: 1) Local file 2) Object store 3) Generating from the index-header
 // It returns an error if the sparse header cannot be loaded from any of the sources.
 // If the sparse header was not found on disk, it will try to write it after generating or downloading it. If writing fails, loadSparseHeader does not return an error.
-func (r *StreamBinaryReader) loadSparseHeader(ctx context.Context, logger log.Logger, cfg Config, indexLastPostingListEndBound uint64, postingOffsetsInMemSampling int, sparseHeadersPath string, bkt objstore.BucketReader, id ulid.ULID) error {
+func (r *StreamBinaryReader) loadSparseHeader(ctx context.Context, logger log.Logger, cfg Config, indexLastPostingListEndBound uint64, postingOffsetsInMemSampling int, sparseHeadersPath string, bkt objstore.InstrumentedBucketReader, id ulid.ULID) error {
 	// Only v2 indexes use sparse headers
 	if r.indexVersion != index.FormatV2 {
 		return r.loadFromIndexHeader(logger, cfg, indexLastPostingListEndBound, postingOffsetsInMemSampling)
@@ -215,13 +215,13 @@ func (r *StreamBinaryReader) loadSparseHeader(ctx context.Context, logger log.Lo
 
 // tryDownloadSparseHeader attempts to download the sparse header from the object store.
 // It returns the sparse header data if successful, nil + error otherwise.
-func tryDownloadSparseHeader(ctx context.Context, logger log.Logger, bkt objstore.BucketReader, id ulid.ULID) ([]byte, error) {
+func tryDownloadSparseHeader(ctx context.Context, logger log.Logger, bkt objstore.InstrumentedBucketReader, id ulid.ULID) ([]byte, error) {
 	if bkt == nil {
 		return nil, fmt.Errorf("bucket is nil")
 	}
 	sparseHeaderObjPath := filepath.Join(id.String(), block.SparseIndexHeaderFilename)
 
-	reader, err := bkt.Get(ctx, sparseHeaderObjPath)
+	reader, err := bkt.ReaderWithExpectedErrs(bkt.IsObjNotFoundErr).Get(ctx, sparseHeaderObjPath)
 	if err != nil {
 		return nil, fmt.Errorf("getting sparse index-header from bucket: %w", err)
 	}

--- a/pkg/storage/indexheader/stream_binary_reader_test.go
+++ b/pkg/storage/indexheader/stream_binary_reader_test.go
@@ -12,9 +12,12 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	promtestutil "github.com/prometheus/prometheus/util/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
@@ -30,9 +33,11 @@ func TestStreamBinaryReader_ShouldBuildSparseHeadersFromFileSimple(t *testing.T)
 	ctx := context.Background()
 
 	tmpDir := filepath.Join(t.TempDir(), "test-sparse index headers")
-	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+
+	ubkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, bkt.Close()) })
+	t.Cleanup(func() { require.NoError(t, ubkt.Close()) })
+	bkt := objstore.WithNoopInstr(ubkt)
 
 	// Create block.
 	blockID, err := block.CreateBlock(ctx, tmpDir, []labels.Labels{
@@ -71,9 +76,10 @@ func TestStreamBinaryReader_CheckSparseHeadersCorrectnessExtensive(t *testing.T)
 			t.Run(fmt.Sprintf("%vNames%vValues", nameCount, valueCount), func(t *testing.T) {
 				t.Parallel()
 				tmpDir := t.TempDir()
-				bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+				ubkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 				require.NoError(t, err)
-				t.Cleanup(func() { require.NoError(t, bkt.Close()) })
+				t.Cleanup(func() { require.NoError(t, ubkt.Close()) })
+				bkt := objstore.WithNoopInstr(ubkt)
 
 				blockID, err := block.CreateBlock(ctx, tmpDir, generateLabels(nameSymbols, valueSymbols), 100, 0, 1000, labels.FromStrings("ext1", "1"))
 				require.NoError(t, err)
@@ -104,9 +110,10 @@ func TestStreamBinaryReader_LabelValuesOffsetsHonorsContextCancel(t *testing.T) 
 	ctx := context.Background()
 
 	tmpDir := filepath.Join(t.TempDir(), "test-stream-binary-reader-cancel")
-	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	ubkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, bkt.Close()) })
+	t.Cleanup(func() { require.NoError(t, ubkt.Close()) })
+	bkt := objstore.WithNoopInstr(ubkt)
 
 	seriesCount := streamindex.CheckContextEveryNIterations * 10
 	// Create block.
@@ -131,6 +138,57 @@ func TestStreamBinaryReader_LabelValuesOffsetsHonorsContextCancel(t *testing.T) 
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestStreamBinaryReader_FailedSparseHeaderGetOpsAreNotTracked(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	tmpDir := filepath.Join(t.TempDir(), "test-sparse-headers-from-objstore")
+
+	blockID, err := block.CreateBlock(ctx, tmpDir, []labels.Labels{
+		labels.FromStrings("a", "1"),
+		labels.FromStrings("a", "2"),
+		labels.FromStrings("b", "3"),
+	}, 100, 0, 1000, labels.EmptyLabels())
+	require.NoError(t, err)
+
+	ubkt, err := filesystem.NewBucket(tmpDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ubkt.Close()) })
+
+	bkt := objstore.WrapWithMetrics(ubkt, prometheus.WrapRegistererWithPrefix("thanos_", reg), "")
+
+	// Create a new StreamBinaryReader - no sparse index header in object storage to use, will get 4XX on GET.
+	newReader, err := NewStreamBinaryReader(ctx, logger, bkt, tmpDir, blockID, 32, NewStreamBinaryReaderMetrics(nil), Config{})
+	require.NoError(t, err)
+	defer newReader.Close()
+
+	// Should not track the failure to get sparse index header
+	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP thanos_objstore_bucket_operation_failures_total Total number of operations against a bucket that failed, but were not expected to fail in certain way from caller perspective. Those errors have to be investigated.
+		# TYPE thanos_objstore_bucket_operation_failures_total counter
+		thanos_objstore_bucket_operation_failures_total{bucket="",operation="attributes"} 0
+		thanos_objstore_bucket_operation_failures_total{bucket="",operation="delete"} 0
+		thanos_objstore_bucket_operation_failures_total{bucket="",operation="exists"} 0
+		thanos_objstore_bucket_operation_failures_total{bucket="",operation="get"} 0
+		thanos_objstore_bucket_operation_failures_total{bucket="",operation="get_range"} 0
+		thanos_objstore_bucket_operation_failures_total{bucket="",operation="iter"} 0
+		thanos_objstore_bucket_operation_failures_total{bucket="",operation="upload"} 0
+		# HELP thanos_objstore_bucket_operations_total Total number of all attempted operations against a bucket.
+		# TYPE thanos_objstore_bucket_operations_total counter
+		thanos_objstore_bucket_operations_total{bucket="",operation="attributes"} 1
+		thanos_objstore_bucket_operations_total{bucket="",operation="delete"} 0
+		thanos_objstore_bucket_operations_total{bucket="",operation="exists"} 0
+		thanos_objstore_bucket_operations_total{bucket="",operation="get"} 1
+		thanos_objstore_bucket_operations_total{bucket="",operation="get_range"} 4
+		thanos_objstore_bucket_operations_total{bucket="",operation="iter"} 0
+		thanos_objstore_bucket_operations_total{bucket="",operation="upload"} 0
+	`),
+		"thanos_objstore_bucket_operations_total",
+		"thanos_objstore_bucket_operation_failures_total",
+	))
+}
+
 // TestStreamBinaryReader_UsesSparseHeaderFromObjectStore tests if StreamBinaryReader uses
 // a sparse index header that's already present in the object store instead of recreating it.
 func TestStreamBinaryReader_UsesSparseHeaderFromObjectStore(t *testing.T) {
@@ -139,9 +197,10 @@ func TestStreamBinaryReader_UsesSparseHeaderFromObjectStore(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	tmpDir := filepath.Join(t.TempDir(), "test-sparse-headers-from-objstore")
-	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	ubkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, bkt.Close()) })
+	t.Cleanup(func() { require.NoError(t, ubkt.Close()) })
+	bkt := objstore.WithNoopInstr(ubkt)
 
 	// Create block with sample data
 	blockID, err := block.CreateBlock(ctx, tmpDir, []labels.Labels{
@@ -180,8 +239,7 @@ func TestStreamBinaryReader_UsesSparseHeaderFromObjectStore(t *testing.T) {
 
 	// Create a bucket that can track downloads and verify content
 	trackedBkt := &trackedBucket{
-		BucketReader: bkt,
-		expectedPath: sparseHeaderObjPath,
+		InstrumentedBucketReader: bkt,
 	}
 
 	// Create a new StreamBinaryReader - it should use the sparse header from the object store
@@ -208,14 +266,17 @@ func TestStreamBinaryReader_UsesSparseHeaderFromObjectStore(t *testing.T) {
 
 // trackedBucket wraps a BucketReader and tracks details about downloaded files
 type trackedBucket struct {
-	objstore.BucketReader
-	expectedPath   string
+	objstore.InstrumentedBucketReader
 	getWasCalled   bool
 	downloadedPath string
+}
+
+func (b *trackedBucket) ReaderWithExpectedErrs(objstore.IsOpFailureExpectedFunc) objstore.BucketReader {
+	return b
 }
 
 func (b *trackedBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
 	b.getWasCalled = true
 	b.downloadedPath = name
-	return b.BucketReader.Get(ctx, name)
+	return b.InstrumentedBucketReader.Get(ctx, name)
 }

--- a/pkg/storage/indexheader/stream_binary_reader_test.go
+++ b/pkg/storage/indexheader/stream_binary_reader_test.go
@@ -82,11 +82,12 @@ func TestStreamBinaryReader_CheckSparseHeadersCorrectnessExtensive(t *testing.T)
 				tmpDir := t.TempDir()
 				ubkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 				require.NoError(t, err)
+				bkt := objstore.WithNoopInstr(ubkt)
+
 				t.Cleanup(func() {
 					require.NoError(t, bkt.Close())
 					require.NoError(t, ubkt.Close())
 				})
-				bkt := objstore.WithNoopInstr(ubkt)
 
 				blockID, err := block.CreateBlock(ctx, tmpDir, generateLabels(nameSymbols, valueSymbols), 100, 0, 1000, labels.FromStrings("ext1", "1"))
 				require.NoError(t, err)

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1047,8 +1047,10 @@ func prepareTestBlock(tb test.TB, dataSetup ...testBlockDataSetup) func() *bucke
 	tmpDir := tb.TempDir()
 	bucketDir := filepath.Join(tmpDir, "bkt")
 
-	bkt, err := filesystem.NewBucket(bucketDir)
+	ubkt, err := filesystem.NewBucket(bucketDir)
 	assert.NoError(tb, err)
+
+	bkt := objstore.WithNoopInstr(ubkt)
 
 	tb.Cleanup(func() {
 		assert.NoError(tb, bkt.Close())
@@ -1074,7 +1076,7 @@ func prepareTestBlock(tb test.TB, dataSetup ...testBlockDataSetup) func() *bucke
 			indexHeaderReader: r,
 			indexCache:        noopCache{},
 			chunkObjs:         chunkObjects,
-			bkt:               localBucket{Bucket: bkt, dir: bucketDir},
+			bkt:               localBucket{Bucket: ubkt, dir: bucketDir},
 			meta:              &block.Meta{BlockMeta: tsdb.BlockMeta{ULID: id, MinTime: minT, MaxTime: maxT}},
 			partitioners:      newGapBasedPartitioners(mimir_tsdb.DefaultPartitionerMaxGapSize, nil),
 		}
@@ -1732,9 +1734,11 @@ func TestBucketStore_Series_Concurrency(t *testing.T) {
 func TestBucketStore_Series_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	bkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
+	ubkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	assert.NoError(t, err)
-	defer func() { assert.NoError(t, bkt.Close()) }()
+	defer func() { assert.NoError(t, ubkt.Close()) }()
+	
+	bkt := objstore.WithNoopInstr(ubkt)
 
 	logger := log.NewNopLogger()
 	thanosMeta := block.ThanosMeta{

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1737,7 +1737,7 @@ func TestBucketStore_Series_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 	ubkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	assert.NoError(t, err)
 	defer func() { assert.NoError(t, ubkt.Close()) }()
-	
+
 	bkt := objstore.WithNoopInstr(ubkt)
 
 	logger := log.NewNopLogger()

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1739,10 +1739,10 @@ func TestBucketStore_Series_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 	assert.NoError(t, err)
 	bkt := objstore.WithNoopInstr(ubkt)
 
-	defer func() {
-		assert.NoError(t, ubkt.Close())
-		assert.NoError(t, bkt.Close())
-	}()
+	t.Cleanup(func() {
+		require.NoError(t, ubkt.Close())
+		require.NoError(t, bkt.Close())
+	})
 
 	logger := log.NewNopLogger()
 	thanosMeta := block.ThanosMeta{

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1053,6 +1053,7 @@ func prepareTestBlock(tb test.TB, dataSetup ...testBlockDataSetup) func() *bucke
 	bkt := objstore.WithNoopInstr(ubkt)
 
 	tb.Cleanup(func() {
+		assert.NoError(tb, ubkt.Close())
 		assert.NoError(tb, bkt.Close())
 	})
 
@@ -1736,9 +1737,12 @@ func TestBucketStore_Series_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 
 	ubkt, err := filesystem.NewBucket(filepath.Join(tmpDir, "bkt"))
 	assert.NoError(t, err)
-	defer func() { assert.NoError(t, ubkt.Close()) }()
-
 	bkt := objstore.WithNoopInstr(ubkt)
+
+	defer func() {
+		assert.NoError(t, ubkt.Close())
+		assert.NoError(t, bkt.Close())
+	}()
 
 	logger := log.NewNopLogger()
 	thanosMeta := block.ThanosMeta{


### PR DESCRIPTION
#### What this PR does

This fixes an issue where the `thanos_objstore_bucket_operation_failures_total` metric is incremented when trying to access a sparse-index-header that's not expected to exist. This issue could cause the `MimirStoreGatewayTooManyFailedOperations` alert to fire unexpectedly, and particularly if when `compactor.upload-sparse-index-headers` is not set.

This change replaces `objstore.BucketReader` with `objstore.InstrumentedBucketReader` in several locations in `pkg/storage/indexheader` so that we can use `ReaderWithExpectedErrs(IsOpFailureExpectedFunc)` (see: [IsOpFailureExpectedFunc](https://pkg.go.dev/github.com/thanos-io/objstore#IsOpFailureExpectedFunc)) to ignore certain errors.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
