### PR TITLE
feat(otlp): Allow conversion of OTel explicit bucket histograms into NHCB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [ENHANCEMENT] Query-frontend: Add `cortex_query_samples_processed_cache_adjusted_total` metric. #11164
 * [ENHANCEMENT] Ingester/Distributor: Add `cortex_cost_attribution_*` metrics to observe the state of the cost-attribution trackers. #11112
 * [ENHANCEMENT] gRPC/HTTP servers: Add `cortex_server_invalid_cluster_validation_label_requests_total` metric, that is increased for every request with an invalid cluster validation label. #11241 #11277
+* [ENHANCEMENT] OTLP: Add support for converting OTel explicit bucket histograms to Prometheus native histograms with custom buckets using the `distributor.otel-convert-histograms-to-nhcb` flag. #11077
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5475,7 +5475,7 @@
           "kind": "field",
           "name": "otel_convert_histograms_to_nhcb",
           "required": false,
-          "desc": "Whether to convert OTel explicit bucket histograms to native histograms with custom buckets.",
+          "desc": "Whether to convert histograms to NHCB histograms.",
           "fieldValue": null,
           "fieldDefaultValue": false,
           "fieldFlag": "distributor.otel-convert-histograms-to-nhcb",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5475,7 +5475,7 @@
           "kind": "field",
           "name": "otel_convert_histograms_to_nhcb",
           "required": false,
-          "desc": "Whether to convert histograms to NHCB histograms.",
+          "desc": "Whether to convert OTel explicit histograms into native histograms with custom buckets.",
           "fieldValue": null,
           "fieldDefaultValue": false,
           "fieldFlag": "distributor.otel-convert-histograms-to-nhcb",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5473,6 +5473,17 @@
         },
         {
           "kind": "field",
+          "name": "otel_convert_histograms_to_nhcb",
+          "required": false,
+          "desc": "Whether to convert OTel explicit bucket histograms to native histograms with custom buckets.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "distributor.otel-convert-histograms-to-nhcb",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "ingest_storage_read_consistency",
           "required": false,
           "desc": "The default consistency level to enforce for queries when using the ingest storage. Supports values: strong, eventual.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1414,7 +1414,7 @@ Usage of ./cmd/mimir/mimir:
   -distributor.metric-relabeling-enabled
     	[experimental] Enable metric relabeling for the tenant. This configuration option can be used to forcefully disable metric relabeling on a per-tenant basis. (default true)
   -distributor.otel-convert-histograms-to-nhcb
-    	[experimental] Whether to convert histograms to NHCB histograms.
+    	[experimental] Whether to convert OTel explicit histograms into native histograms with custom buckets.
   -distributor.otel-created-timestamp-zero-ingestion-enabled
     	[experimental] Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.
   -distributor.otel-keep-identifying-resource-attributes

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1413,6 +1413,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Max size of the pooled buffers used for marshaling write requests. If 0, no max size is enforced.
   -distributor.metric-relabeling-enabled
     	[experimental] Enable metric relabeling for the tenant. This configuration option can be used to forcefully disable metric relabeling on a per-tenant basis. (default true)
+  -distributor.otel-convert-histograms-to-nhcb
+    	[experimental] Whether to convert histograms to NHCB histograms.
   -distributor.otel-created-timestamp-zero-ingestion-enabled
     	[experimental] Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.
   -distributor.otel-keep-identifying-resource-attributes
@@ -1421,8 +1423,6 @@ Usage of ./cmd/mimir/mimir:
     	Whether to enable automatic suffixes to names of metrics ingested through OTLP.
   -distributor.otel-promote-resource-attributes comma-separated-list-of-strings
     	[experimental] Optionally specify OTel resource attributes to promote to labels.
-  -distributor.otel-convert-histograms-to-nhcb
-    	[experimental] Optionally translate OTel explicit bucket histograms to native histograms with custom buckets.
   -distributor.remote-timeout duration
     	Timeout for downstream ingesters. (default 2s)
   -distributor.request-burst-size int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1421,6 +1421,8 @@ Usage of ./cmd/mimir/mimir:
     	Whether to enable automatic suffixes to names of metrics ingested through OTLP.
   -distributor.otel-promote-resource-attributes comma-separated-list-of-strings
     	[experimental] Optionally specify OTel resource attributes to promote to labels.
+  -distributor.otel-convert-histograms-to-nhcb
+    	[experimental] Optionally translate OTel explicit bucket histograms to native histograms with custom buckets.
   -distributor.remote-timeout duration
     	Timeout for downstream ingesters. (default 2s)
   -distributor.request-burst-size int

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -110,6 +110,8 @@ The following features are currently experimental:
     - `-distributor.ha-tracker.kvstore.store`
   - Allow keeping OpenTelemetry `service.instance.id`, `service.name` and `service.namespace` resource attributes in `target_info` on top of converting them to the `instance` and `job` labels.
     - `-distributor.otel-keep-identifying-resource-attributes`
+  - Enable conversion of OTel explicit bucket histograms into native histograms with custom buckets.
+    - `-distributor.otel-convert-histograms-to-nhcb`
 - Hash ring
   - Disabling ring heartbeat timeouts
     - `-distributor.ring.heartbeat-timeout=0`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4001,6 +4001,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -distributor.otel-keep-identifying-resource-attributes
 [otel_keep_identifying_resource_attributes: <boolean> | default = false]
 
+# (experimental) Whether to convert histograms to NHCB histograms.
+# CLI flag: -distributor.otel-convert-histograms-to-nhcb
+[otel_convert_histograms_to_nhcb: <boolean> | default = false]
+
 # (experimental) The default consistency level to enforce for queries when using
 # the ingest storage. Supports values: strong, eventual.
 # CLI flag: -ingest-storage.read-consistency

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4001,7 +4001,8 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -distributor.otel-keep-identifying-resource-attributes
 [otel_keep_identifying_resource_attributes: <boolean> | default = false]
 
-# (experimental) Whether to convert histograms to NHCB histograms.
+# (experimental) Whether to convert OTel explicit histograms into native
+# histograms with custom buckets.
 # CLI flag: -distributor.otel-convert-histograms-to-nhcb
 [otel_convert_histograms_to_nhcb: <boolean> | default = false]
 

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -275,12 +275,16 @@ func (c *Client) PushOTLP(timeseries []prompb.TimeSeries, metadata []mimirpb.Met
 		return nil, err
 	}
 
+	return c.PushOTLPPayload(data, "application/x-protobuf")
+}
+
+func (c *Client) PushOTLPPayload(payload []byte, contentType string) (*http.Response, error) {
 	// Create HTTP request
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://%s/otlp/v1/metrics", c.distributorAddress), bytes.NewReader(data))
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://%s/otlp/v1/metrics", c.distributorAddress), bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/x-protobuf")
+	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("X-Scope-OrgID", c.orgID)
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 	"testing"
 	"time"
@@ -185,4 +186,167 @@ func testOTLPIngestion(t *testing.T, enableSuffixes bool) {
 	metadataResponseBody, err = io.ReadAll(metadataResult.Body)
 	require.NoError(t, err)
 	require.JSONEq(t, expectedJSON, string(metadataResponseBody))
+}
+
+func TestOTLPHistogramIngestion(t *testing.T) {
+	t.Run("enabling conversion to NHCB", func(t *testing.T) {
+		testOTLPHistogramIngestion(t, true)
+	})
+
+	t.Run("disabling conversion to NHCB", func(t *testing.T) {
+		testOTLPHistogramIngestion(t, false)
+	})
+}
+
+func testOTLPHistogramIngestion(t *testing.T, enableExplicitHistogramToNHCB bool) {
+	t.Helper()
+
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Start dependencies.
+	minio := e2edb.NewMinio(9000, blocksBucketName)
+	require.NoError(t, s.StartAndWaitReady(minio))
+
+	// Start Mimir components.
+	require.NoError(t, copyFileToSharedDir(s, "docs/configurations/single-process-config-blocks.yaml", mimirConfigFile))
+
+	// Start Mimir in single binary mode, reading the config from file and overwriting
+	// the backend config to make it work with Minio.
+	flags := mergeFlags(
+		DefaultSingleBinaryFlags(),
+		BlocksStorageFlags(),
+		BlocksStorageS3Flags(),
+		map[string]string{
+			"-distributor.otel-convert-histograms-to-nhcb": strconv.FormatBool(enableExplicitHistogramToNHCB),
+		},
+	)
+
+	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
+	require.NoError(t, s.StartAndWaitReady(mimir))
+
+	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
+	require.NoError(t, err)
+
+	now := time.Now()
+	nowUnix := uint64(now.UnixNano())
+
+	jsonPayload := []byte(fmt.Sprintf(`{
+		"resourceMetrics": [
+			{
+				"resource": {
+					"attributes": [
+						{ "key": "resource.attr", "value": { "stringValue": "value" } }
+					]
+				},
+				"scopeMetrics": [
+					{
+						"metrics": [
+							{
+								"name": "explicit_bucket_histogram_series",
+								"description": "Explicit bucket histogram series",
+								"unit": "s",
+								"histogram": {
+									"aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+									"dataPoints": [
+										{
+											"attributes": [
+												{ "key": "metric-attr", "value": { "stringValue": "metric value" } }
+											],
+											"bucketCounts": [0, 4, 3, 0, 3],
+											"explicitBounds": [0, 5, 10, 15],
+											"count": 10,
+											"sum": 20,
+											"timeUnixNano": "%d"
+										}
+									]
+								}
+							},
+							{
+								"name": "exponential_histogram_series",
+								"description": "Exponential histogram series",
+								"unit": "s",
+								"exponentialHistogram": {
+									"aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+									"dataPoints": [
+										{
+											"attributes": [
+												{ "key": "metric-attr", "value": { "stringValue": "metric value" } }
+											],
+											"scale": 0,
+											"count": 15,
+											"sum": 25,
+											"zeroCount": 1,
+											"positive": {
+												"offset": 1,
+												"bucketCounts": [1, 0, 3, 2, 0, 3]
+											},
+											"negative": {
+												"offset": 0,
+												"bucketCounts": [4, 0, 0, 1]
+											},
+											"timeUnixNano": "%d"
+										}
+									]
+								}
+							}
+						]
+					}
+				]
+			}
+		]
+	}`, nowUnix, nowUnix))
+
+	res, err := c.PushOTLPPayload(jsonPayload, "application/json")
+
+	require.Equal(t, 200, res.StatusCode)
+
+	// Check metric to track OTLP requests
+	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_distributor_otlp_requests_total"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "user", "user-1"))))
+
+	// Query the histogram series
+	if enableExplicitHistogramToNHCB {
+		// Verify that when flag is disabled, OTel explicit bucket histograms are converted to native histograms with custom buckets
+		result, err := c.Query("explicit_bucket_histogram_series", now)
+		require.NoError(t, err)
+		require.Equal(t, result.(model.Vector)[0].Histogram.Count, model.FloatString(10))
+		require.Equal(t, result.(model.Vector)[0].Histogram.Sum, model.FloatString(20))
+		require.Equal(t, result.(model.Vector)[0].Histogram.Buckets[0].Upper, model.FloatString(5))
+		require.Equal(t, result.(model.Vector)[0].Histogram.Buckets[0].Count, model.FloatString(4))
+		require.Equal(t, result.(model.Vector)[0].Histogram.Buckets[1].Upper, model.FloatString(10))
+		require.Equal(t, result.(model.Vector)[0].Histogram.Buckets[1].Count, model.FloatString(3))
+		require.Equal(t, result.(model.Vector)[0].Histogram.Buckets[2].Upper, model.FloatString(math.Inf(1)))
+		require.Equal(t, result.(model.Vector)[0].Histogram.Buckets[2].Count, model.FloatString(3))
+	} else {
+		// Verify that when flag is enabled, OTel explicit bucket histograms are converted to classic histograms
+		result, err := c.Query("explicit_bucket_histogram_series_count", now)
+		require.NoError(t, err)
+		require.Equal(t, result.(model.Vector)[0].Value, model.SampleValue(10))
+		result, err = c.Query("explicit_bucket_histogram_series_sum", now)
+		require.NoError(t, err)
+		require.Equal(t, result.(model.Vector)[0].Value, model.SampleValue(20))
+		result, err = c.Query(`explicit_bucket_histogram_series_bucket{le="0"}`, now)
+		require.NoError(t, err)
+		require.Equal(t, result.(model.Vector)[0].Value, model.SampleValue(0))
+		result, err = c.Query(`explicit_bucket_histogram_series_bucket{le="5"}`, now)
+		require.NoError(t, err)
+		require.Equal(t, result.(model.Vector)[0].Value, model.SampleValue(4))
+		result, err = c.Query(`explicit_bucket_histogram_series_bucket{le="10"}`, now)
+		require.NoError(t, err)
+		require.Equal(t, result.(model.Vector)[0].Value, model.SampleValue(7))
+		result, err = c.Query(`explicit_bucket_histogram_series_bucket{le="15"}`, now)
+		require.NoError(t, err)
+		require.Equal(t, result.(model.Vector)[0].Value, model.SampleValue(7))
+		result, err = c.Query(`explicit_bucket_histogram_series_bucket{le="+Inf"}`, now)
+		require.NoError(t, err)
+		require.Equal(t, result.(model.Vector)[0].Value, model.SampleValue(10))
+	}
+
+	// Verify that OTel exponential histograms are converted to native histograms
+	result, err := c.Query("exponential_histogram_series", now)
+	require.NoError(t, err)
+	require.Equal(t, result.(model.Vector)[0].Histogram.Count, model.FloatString(15))
+	require.Equal(t, result.(model.Vector)[0].Histogram.Sum, model.FloatString(25))
 }

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -299,7 +299,7 @@ func testOTLPHistogramIngestion(t *testing.T, enableExplicitHistogramToNHCB bool
 	}`, nowUnix, nowUnix))
 
 	res, err := c.PushOTLPPayload(jsonPayload, "application/json")
-
+	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
 	// Check metric to track OTLP requests

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -320,6 +320,13 @@ func TestConvertOTelHistograms(t *testing.T) {
 		"service.name":        "service name",
 		"service.namespace":   "service namespace",
 		"service.instance.id": "service ID",
+		"existent-attr":       "resource value",
+		// This one is for testing conflict with metric attribute.
+		"metric-attr": "resource value",
+		// This one is for testing conflict with auto-generated job attribute.
+		"job": "resource value",
+		// This one is for testing conflict with auto-generated instance attribute.
+		"instance": "resource value",
 	}
 
 	md := pmetric.NewMetrics()
@@ -344,7 +351,7 @@ func TestConvertOTelHistograms(t *testing.T) {
 		dp.Attributes().PutStr("metric-attr", "metric value")
 	}
 
-	for _, convertHistogramsToNHCB := range []bool{true} {
+	for _, convertHistogramsToNHCB := range []bool{false, true} {
 		converter := newOTLPMimirConverter()
 		mimirTS, dropped, err := otelMetricsToTimeseries(
 			context.Background(),

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -1539,6 +1539,8 @@ func (o otlpLimitsMock) OTelKeepIdentifyingResourceAttributes(string) bool {
 	return false
 }
 
+func (o otlpLimitsMock) OTelConvertHistogramsToNHCB(string) bool { return false }
+
 func promToMimirHistogram(h *prompb.Histogram) mimirpb.Histogram {
 	pSpans := make([]mimirpb.BucketSpan, 0, len(h.PositiveSpans))
 	for _, span := range h.PositiveSpans {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -310,7 +310,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.OTelCreatedTimestampZeroIngestionEnabled, "distributor.otel-created-timestamp-zero-ingestion-enabled", false, "Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.")
 	f.Var(&l.PromoteOTelResourceAttributes, "distributor.otel-promote-resource-attributes", "Optionally specify OTel resource attributes to promote to labels.")
 	f.BoolVar(&l.OTelKeepIdentifyingResourceAttributes, "distributor.otel-keep-identifying-resource-attributes", false, "Whether to keep identifying OTel resource attributes in the target_info metric on top of converting to job and instance labels.")
-	f.BoolVar(&l.OTelConvertHistogramsToNHCB, "distributor.otel-convert-histograms-to-nhcb", false, "Whether to convert histograms to NHCB histograms.")
+	f.BoolVar(&l.OTelConvertHistogramsToNHCB, "distributor.otel-convert-histograms-to-nhcb", false, "Whether to convert OTel explicit histograms into native histograms with custom buckets.")
 
 	f.Var(&l.IngestionArtificialDelay, "distributor.ingestion-artificial-delay", "Target ingestion delay to apply to all tenants. If set to a non-zero value, the distributor will artificially delay ingestion time-frame by the specified duration by computing the difference between actual ingestion and the target. There is no delay on actual ingestion of samples, it is only the response back to the client.")
 	f.IntVar(&l.IngestionArtificialDelayConditionForTenantsWithLessThanMaxSeries, "distributor.ingestion-artificial-delay-condition-for-tenants-with-less-than-max-series", 0, "Condition to select tenants for which -distributor.ingestion-artificial-delay-duration-for-tenants-with-less-than-max-series should be applied.")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -270,6 +270,7 @@ type Limits struct {
 	OTelCreatedTimestampZeroIngestionEnabled bool                   `yaml:"otel_created_timestamp_zero_ingestion_enabled" json:"otel_created_timestamp_zero_ingestion_enabled" category:"experimental"`
 	PromoteOTelResourceAttributes            flagext.StringSliceCSV `yaml:"promote_otel_resource_attributes" json:"promote_otel_resource_attributes" category:"experimental"`
 	OTelKeepIdentifyingResourceAttributes    bool                   `yaml:"otel_keep_identifying_resource_attributes" json:"otel_keep_identifying_resource_attributes" category:"experimental"`
+	OTelConvertHistogramsToNHCB              bool                   `yaml:"otel_convert_histograms_to_nhcb" json:"otel_convert_histograms_to_nhcb" category:"experimental"`
 
 	// Ingest storage.
 	IngestStorageReadConsistency       string `yaml:"ingest_storage_read_consistency" json:"ingest_storage_read_consistency" category:"experimental"`
@@ -309,6 +310,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.OTelCreatedTimestampZeroIngestionEnabled, "distributor.otel-created-timestamp-zero-ingestion-enabled", false, "Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.")
 	f.Var(&l.PromoteOTelResourceAttributes, "distributor.otel-promote-resource-attributes", "Optionally specify OTel resource attributes to promote to labels.")
 	f.BoolVar(&l.OTelKeepIdentifyingResourceAttributes, "distributor.otel-keep-identifying-resource-attributes", false, "Whether to keep identifying OTel resource attributes in the target_info metric on top of converting to job and instance labels.")
+	f.BoolVar(&l.OTelConvertHistogramsToNHCB, "distributor.otel-convert-histograms-to-nhcb", false, "Whether to convert histograms to NHCB histograms.")
 
 	f.Var(&l.IngestionArtificialDelay, "distributor.ingestion-artificial-delay", "Target ingestion delay to apply to all tenants. If set to a non-zero value, the distributor will artificially delay ingestion time-frame by the specified duration by computing the difference between actual ingestion and the target. There is no delay on actual ingestion of samples, it is only the response back to the client.")
 	f.IntVar(&l.IngestionArtificialDelayConditionForTenantsWithLessThanMaxSeries, "distributor.ingestion-artificial-delay-condition-for-tenants-with-less-than-max-series", 0, "Condition to select tenants for which -distributor.ingestion-artificial-delay-duration-for-tenants-with-less-than-max-series should be applied.")
@@ -1234,6 +1236,10 @@ func (o *Overrides) PromoteOTelResourceAttributes(tenantID string) []string {
 
 func (o *Overrides) OTelKeepIdentifyingResourceAttributes(tenantID string) bool {
 	return o.getOverridesForUser(tenantID).OTelKeepIdentifyingResourceAttributes
+}
+
+func (o *Overrides) OTelConvertHistogramsToNHCB(tenantID string) bool {
+	return o.getOverridesForUser(tenantID).OTelConvertHistogramsToNHCB
 }
 
 // DistributorIngestionArtificialDelay returns the artificial ingestion latency for a given user.


### PR DESCRIPTION
#### What this PR does

This PR adds the ability to optionally translation OTel explicit bucket histograms into native histograms with custom buckets, using the flag added in https://github.com/prometheus/prometheus/pull/15850. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>
Related to https://github.com/prometheus/prometheus/issues/13485. 

#### Checklist

- [X] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [X] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
