### PR TITLE
Log the number of series returned in ruler query stats messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   * By setting `-<grpc-client-config-path>.cluster-validation.label`, you configure the cluster validation label of _a single_ gRPC client, whose `grpcclient.Config` object is configurable through `-<grpc-client-config-path>`.
   * By setting `-common.client-cluster-validation.label`, you configure the cluster validation label of _all_ gRPC clients.
 * [ENHANCEMENT] Querier: Allow configuring all gRPC options for store-gateway client, similar to other gRPC clients. #11074
+* [ENHANCEMENT] Ruler: Log the number of series returned for each query as `result_series_count` as part of `query stats` log lines. #11081
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -267,6 +267,7 @@ func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime, zeroFetchedS
 		stats, ctx := querier_stats.ContextWithEmptyStats(ctx)
 		// If we've been passed a counter we want to record the wall time spent executing this request.
 		timer := prometheus.NewTimer(nil)
+		var result promql.Vector
 		var err error
 		defer func() {
 			// Update stats wall time based on the timer created above.
@@ -300,10 +301,15 @@ func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime, zeroFetchedS
 				"sharded_queries", shardedQueries,
 				"query", qs,
 			}
+
+			if err == nil {
+				logMessage = append(logMessage, "result_series_count", len(result))
+			}
+
 			level.Info(util_log.WithContext(ctx, logger)).Log(logMessage...)
 		}()
 
-		result, err := qf(ctx, qs, t)
+		result, err = qf(ctx, qs, t)
 		return result, err
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR modifies the ruler to log the number of returned series for each query as part of the existing `query stats` log message.

This is useful when trying to identify the source of an unexpectedly high number of alert notifications being sent by a ruler instance.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
