### PR TITLE
Don't log unavailable statistics in ruler query stats messages when using remote query-frontend

### DIFF
--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -255,7 +255,7 @@ func MetricsQueryFunc(qf rules.QueryFunc, userID string, queries, failedQueries 
 	}
 }
 
-func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime, zeroFetchedSeriesCount prometheus.Counter, logger log.Logger) rules.QueryFunc {
+func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime, zeroFetchedSeriesCount prometheus.Counter, remoteQuerier bool, logger log.Logger) rules.QueryFunc {
 	if queryTime == nil || zeroFetchedSeriesCount == nil {
 		return qf
 	}
@@ -294,12 +294,18 @@ func RecordAndReportRuleQueryMetrics(qf rules.QueryFunc, queryTime, zeroFetchedS
 			logMessage := []interface{}{
 				"msg", "query stats",
 				"component", "ruler",
-				"query_wall_time_seconds", wallTime.Seconds(),
-				"fetched_series_count", numSeries,
-				"fetched_chunk_bytes", numBytes,
-				"fetched_chunks_count", numChunks,
-				"sharded_queries", shardedQueries,
 				"query", qs,
+			}
+
+			if !remoteQuerier {
+				// These statistics will only be populated when using local rule evaluation (ie. not using a remote query-frontend).
+				logMessage = append(logMessage,
+					"query_wall_time_seconds", wallTime.Seconds(),
+					"fetched_series_count", numSeries,
+					"fetched_chunk_bytes", numBytes,
+					"fetched_chunks_count", numChunks,
+					"sharded_queries", shardedQueries,
+				)
 			}
 
 			if err == nil {
@@ -380,8 +386,9 @@ func DefaultTenantManagerFactory(
 
 		// Wrap the query function with our custom logic.
 		wrappedQueryFunc := WrapQueryFuncWithReadConsistency(queryFunc, logger)
-		wrappedQueryFunc = MetricsQueryFunc(wrappedQueryFunc, userID, totalQueries, failedQueries, cfg.QueryFrontend.Address != "")
-		wrappedQueryFunc = RecordAndReportRuleQueryMetrics(wrappedQueryFunc, queryTime, zeroFetchedSeriesCount, logger)
+		remoteQuerier := cfg.QueryFrontend.Address != ""
+		wrappedQueryFunc = MetricsQueryFunc(wrappedQueryFunc, userID, totalQueries, failedQueries, remoteQuerier)
+		wrappedQueryFunc = RecordAndReportRuleQueryMetrics(wrappedQueryFunc, queryTime, zeroFetchedSeriesCount, remoteQuerier, logger)
 
 		// Wrap the queryable with our custom logic.
 		wrappedQueryable := WrapQueryableWithReadConsistency(queryable, logger)


### PR DESCRIPTION
#### What this PR does

When the ruler is using a remote query-frontend, query stats such as the number of series fetched will not be available.

Prior to this PR, this would cause the `query stats` log line emitted by rulers to include these statistics with zeroes, for example:

```
query_wall_time_seconds=0 fetched_series_count=0 fetched_chunk_bytes=0 fetched_chunks_count=0 sharded_queries=0
```

This PR modifies the ruler to not log these fields at all when a remote query-frontend is in use.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
