### PR TITLE
Update PromQL test syntax to use new style

### DIFF
--- a/pkg/streamingpromql/testdata/ours-only/aggregators.test
+++ b/pkg/streamingpromql/testdata/ours-only/aggregators.test
@@ -21,5 +21,7 @@ load 6m
   series{env="prod", instance="3"} 0   0   8   _   _   _   _ _
   param                            0.5 0.1 0.9 0.1 0.2 0.3 _ Inf
 
-eval_warn range from 0 to 42m step 6m quantile(scalar(param), series)
+eval range from 0 to 42m step 6m quantile(scalar(param), series)
+  expect no_info
+  expect warn
   {} 1 0.6000000000000001 9.799999999999999 20 _ 1 _ _

--- a/pkg/streamingpromql/testdata/ours/aggregators.test
+++ b/pkg/streamingpromql/testdata/ours/aggregators.test
@@ -181,7 +181,9 @@ eval instant at 0m sum(single_histogram)
 eval instant at 0m avg(single_histogram)
   {} {{schema:0 sum:5.666666666666667 count:6 buckets:[1.6666666666666667 4 0.33333333333333337]}}
 
-eval_info instant at 0m quantile(0.5, single_histogram)
+eval instant at 0m quantile(0.5, single_histogram)
+  expect info
+  expect no_warn
 
 eval instant at 0m sum by (label) (single_histogram)
   {label="value"} {{schema:0 count:4 sum:2 buckets:[1 2 1]}}
@@ -252,7 +254,9 @@ eval range from 0 to 5m step 1m sum(single_histogram)
 eval range from 0 to 5m step 1m avg(single_histogram)
   {} 0 0.5 0.5 2.5 4 {{sum:2 count:4 buckets:[1 2 1]}}
 
-eval_info range from 0 to 5m step 1m quantile(0.5, single_histogram)
+eval range from 0 to 5m step 1m quantile(0.5, single_histogram)
+  expect info
+  expect no_warn
   {} 0 0.5 0.5 2.5 4
 
 clear
@@ -263,11 +267,17 @@ load 1m
   single_histogram{label="value2"}  {{sum:5 count:5 buckets:[1 3 1]}}
 
 # "If either operator has to aggregate a mix of histogram samples and float samples, the corresponding vector element is removed from the output vector entirely."
-eval_warn instant at 1m sum(single_histogram)
+eval instant at 1m sum(single_histogram)
+  expect no_info
+  expect warn
 
-eval_warn instant at 1m avg(single_histogram)
+eval instant at 1m avg(single_histogram)
+  expect no_info
+  expect warn
 
-eval_info instant at 1m quantile(0.5, single_histogram)
+eval instant at 1m quantile(0.5, single_histogram)
+  expect info
+  expect no_warn
   {} 3
 
 clear
@@ -278,11 +288,17 @@ load 1m
   single_histogram{label="value2"}  3
 
 # "If either operator has to aggregate a mix of histogram samples and float samples, the corresponding vector element is removed from the output vector entirely."
-eval_warn instant at 1m sum(single_histogram)
+eval instant at 1m sum(single_histogram)
+  expect no_info
+  expect warn
 
-eval_warn instant at 1m avg(single_histogram)
+eval instant at 1m avg(single_histogram)
+  expect no_info
+  expect warn
 
-eval_info instant at 1m quantile(0.5, single_histogram)
+eval instant at 1m quantile(0.5, single_histogram)
+  expect info
+  expect no_warn
   {} 3
 
 clear
@@ -295,11 +311,17 @@ load 1m
   single_histogram{label="value3"}  3
 
 # "If either operator has to aggregate a mix of histogram samples and float samples, the corresponding vector element is removed from the output vector entirely."
-eval_warn instant at 1m sum(single_histogram)
+eval instant at 1m sum(single_histogram)
+  expect no_info
+  expect warn
 
-eval_warn instant at 1m avg(single_histogram)
+eval instant at 1m avg(single_histogram)
+  expect no_info
+  expect warn
 
-eval_info instant at 1m quantile(0.5, single_histogram)
+eval instant at 1m quantile(0.5, single_histogram)
+  expect info
+  expect no_warn
   {} 2
 
 clear
@@ -311,15 +333,23 @@ load 1m
   series{label="value3"}  -20 -9  -9                                         {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
   histogram_only_series   {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}} {{schema:1 sum:5 count:5 buckets:[1 3 1]}}
 
-eval_info range from 0 to 5m step 1m max(series)
+eval range from 0 to 5m step 1m max(series)
+  expect info
+  expect no_warn
   {} 0 -9 -9 10 -10 _
 
-eval_info range from 0 to 5m step 1m min(series)
+eval range from 0 to 5m step 1m min(series)
+  expect info
+  expect no_warn
   {} -20 -10 -10 10 -10 _
 
-eval_info range from 0 to 2m step 1m max(histogram_only_series)
+eval range from 0 to 2m step 1m max(histogram_only_series)
+  expect info
+  expect no_warn
 
-eval_info range from 0 to 2m step 1m min(histogram_only_series)
+eval range from 0 to 2m step 1m min(histogram_only_series)
+  expect info
+  expect no_warn
 
 clear
 
@@ -332,12 +362,16 @@ load 1m
   mixed_series{type="histogram", label="value2"}  NaN
   mixed_series{type="onlyNaN"} NaN
 
-eval_info instant at 1m min by (type) (mixed_series)
+eval instant at 1m min by (type) (mixed_series)
+  expect info
+  expect no_warn
   {type="float"} -5
   {type="histogram"} NaN
   {type="onlyNaN"} NaN
 
-eval_info instant at 1m max by (type) (mixed_series)
+eval instant at 1m max by (type) (mixed_series)
+  expect info
+  expect no_warn
   {type="float"} 10
   {type="histogram"} NaN
   {type="onlyNaN"} NaN
@@ -690,11 +724,17 @@ load 6m
   series{idx="3"}   7 8 Inf NaN -Inf
 
 # Quantile value warning is emitted even when no series are returned
-eval_warn range from 0 to 12m step 6m quantile(20, noseries)
+eval range from 0 to 12m step 6m quantile(20, noseries)
+  expect no_info
+  expect warn
 
-eval_warn range from 0 to 12m step 6m quantile(Inf, noseries)
+eval range from 0 to 12m step 6m quantile(Inf, noseries)
+  expect no_info
+  expect warn
 
-eval_warn range from 0 to 12m step 6m quantile(-Inf, noseries)
+eval range from 0 to 12m step 6m quantile(-Inf, noseries)
+  expect no_info
+  expect warn
 
 eval range from 0 to 30m step 6m quantile(0.9, series)
   {} 6.4 7.4 +Inf 6.4 7.4 8.7

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -189,10 +189,14 @@ eval instant at 0 second_histogram - first_histogram
   {job="test"} {{schema:0 sum:5 count:2 buckets:[0 0 0]}}
 
 # Cannot multiply two histograms
-eval_info instant at 0 first_histogram * second_histogram
+eval instant at 0 first_histogram * second_histogram
+  expect info
+  expect no_warn
 
 # Cannot divide a histogram by a histogram
-eval_info instant at 0 first_histogram / second_histogram
+eval instant at 0 first_histogram / second_histogram
+  expect info
+  expect no_warn
 
 # Histogram multiplied by float
 eval instant at 0 first_histogram * metric
@@ -207,34 +211,54 @@ eval instant at 0 first_histogram / metric
   {job="test"} {{schema:0 count:2 sum:2.5 buckets:[0.5 1 0.5]}}
 
 # Cannot divide a float by a histogram
-eval_info instant at 0 metric / first_histogram
+eval instant at 0 metric / first_histogram
+  expect info
+  expect no_warn
 
 # Cannot add a float to a histogram
-eval_info instant at 0 first_histogram + metric
+eval instant at 0 first_histogram + metric
+  expect info
+  expect no_warn
 
 # Cannot subtract a float from a histogram
-eval_info instant at 0 first_histogram - metric
+eval instant at 0 first_histogram - metric
+  expect info
+  expect no_warn
 
 # Cannot perform atan2 on a histogram.
-eval_info instant at 0 first_histogram atan2 metric
+eval instant at 0 first_histogram atan2 metric
+  expect info
+  expect no_warn
 
 # Cannot apply ^ to a histogram.
-eval_info instant at 0 first_histogram ^ second_histogram
+eval instant at 0 first_histogram ^ second_histogram
+  expect info
+  expect no_warn
 
 # Cannot apply ^ to a histogram.
-eval_info instant at 0 first_histogram ^ metric
+eval instant at 0 first_histogram ^ metric
+  expect info
+  expect no_warn
 
 # Cannot apply ^ to a histogram.
-eval_info instant at 0 metric ^ first_histogram
+eval instant at 0 metric ^ first_histogram
+  expect info
+  expect no_warn
 
 # Cannot apply % to a histogram.
-eval_info instant at 0 first_histogram % second_histogram
+eval instant at 0 first_histogram % second_histogram
+  expect info
+  expect no_warn
 
 # Cannot apply % to a histogram.
-eval_info instant at 0 first_histogram % metric
+eval instant at 0 first_histogram % metric
+  expect info
+  expect no_warn
 
 # Cannot apply % to a histogram.
-eval_info instant at 0 metric % first_histogram
+eval instant at 0 metric % first_histogram
+  expect info
+  expect no_warn
 
 clear
 
@@ -276,16 +300,24 @@ load 1m
   another_mixed{job="test"} 10 {{schema:0 sum:12 count:6 buckets:[2 4 6]}}  {{schema:0 sum:12 count:6 buckets:[2 4 6]}}   4                                            5                                              {{schema:0 sum:12 count:6 buckets:[2 4 6]}}
 #                           @0 @5m                                          @10m                                          @15m                                         @20m                                           @25m
 
-eval_info range from 0 to 5m step 1m mixed_metric + another_mixed
+eval range from 0 to 5m step 1m mixed_metric + another_mixed
+  expect info
+  expect no_warn
   {job="test"}              20 11                                           12                                            7                                            _                                              {{schema:0 sum:24 count:12 buckets:[4 8 12]}}
 
-eval_info range from 0 to 5m step 1m mixed_metric - another_mixed
+eval range from 0 to 5m step 1m mixed_metric - another_mixed
+  expect info
+  expect no_warn
   {job="test"}              0  -9                                           -8                                            -1                                           _                                              {{schema:0 sum:0 count:0}}
 
-eval_info range from 0 to 5m step 1m mixed_metric * another_mixed
+eval range from 0 to 5m step 1m mixed_metric * another_mixed
+  expect info
+  expect no_warn
   {job="test"}              100 10                                          20                                            12                                           {{schema:0 sum:30 count:15 buckets:[5 10 15]}} _
 
-eval_info range from 0 to 5m step 1m mixed_metric / another_mixed
+eval range from 0 to 5m step 1m mixed_metric / another_mixed
+  expect info
+  expect no_warn
   {job="test"}              1  0.1                                          0.2                                           0.75                                         {{schema:0 sum:1.2 count:0.6 buckets:[0.2 0.4 0.6]}} _
 
 clear
@@ -295,7 +327,9 @@ load 1m
   left   {{schema:0 sum:1 count:1 buckets:[1]}}  {{schema:0 sum:1 count:1 buckets:[1]}}                           {{schema:-53 sum:1 count:3 custom_values:[2 3] buckets:[1 2]}}   {{schema:-53 sum:1 count:3 custom_values:[2 3] buckets:[1 2]}}
   right  {{schema:0 sum:3 count:4 buckets:[4]}}  {{schema:-53 sum:1 count:3 custom_values:[5 10] buckets:[1 2]}}  {{schema:-53 sum:1 count:3 custom_values:[5 10] buckets:[1 2]}}  {{schema:-53 sum:2 count:6 custom_values:[2 3] buckets:[5 2]}}
 
-eval_warn range from 0 to 3m step 1m left + right
+eval range from 0 to 3m step 1m left + right
+  expect no_info
+  expect warn
   {}     {{schema:0 sum:4 count:5 buckets:[5]}}  _                                                                _                                                                {{schema:-53 sum:3 count:9 custom_values:[2 3] buckets:[6 4]}}
 
 clear
@@ -317,18 +351,24 @@ eval range from 0m to 24m step 6m my_metric / 2
 
 # Scalar on left side
 # Note that positive scalar / histogram == nothing.
-eval_info range from 0m to 24m step 6m 2 / my_metric
+eval range from 0m to 24m step 6m 2 / my_metric
+  expect info
+  expect no_warn
   {histograms="both"} 0.4 0.2 _
   {job="foo"} 2 1 0.6666666666666667 0.5 0.4
   {job="bar"} 0.2 0.1 0.06666666666666667 _ 0.04
 
 # Test other arithmetic operations.
-eval_info range from 0m to 24m step 6m my_metric + 2
+eval range from 0m to 24m step 6m my_metric + 2
+  expect info
+  expect no_warn
   {histograms="both"} 7 12 _
   {job="foo"} 3 4 5 6 7
   {job="bar"} 12 22 32 _ 52
 
-eval_info range from 0m to 24m step 6m my_metric - 2
+eval range from 0m to 24m step 6m my_metric - 2
+  expect info
+  expect no_warn
   {histograms="both"} 3 8
   {job="foo"} -1 0 1 2 3
   {job="bar"} 8 18 28 _ 48
@@ -339,12 +379,16 @@ eval range from 0m to 24m step 6m my_metric * 2
   {job="foo"} 2 4 6 8 10
   {job="bar"} 20 40 60 _ 100
 
-eval_info range from 0m to 24m step 6m my_metric ^ 2
+eval range from 0m to 24m step 6m my_metric ^ 2
+  expect info
+  expect no_warn
   {histograms="both"} 25 100 _
   {job="foo"} 1 4 9 16 25
   {job="bar"} 100 400 900 _ 2500
 
-eval_info range from 0m to 24m step 6m my_metric % 2
+eval range from 0m to 24m step 6m my_metric % 2
+  expect info
+  expect no_warn
   {histograms="both"} 1 0 _
   {job="foo"} 1 0 1 0 1
   {job="bar"} 0 0 0 _ 0
@@ -413,10 +457,14 @@ eval range from 0 to 24m step 6m left_histograms == right_histograms
 eval range from 0 to 24m step 6m left_histograms == bool right_histograms
   {} 1 0 _ _ _
 
-eval_info range from 0 to 24m step 6m left_histograms == right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms == right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms == bool right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms == bool right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
 eval range from 0 to 60m step 6m left_floats != right_floats
@@ -431,10 +479,14 @@ eval range from 0 to 24m step 6m left_histograms != right_histograms
 eval range from 0 to 24m step 6m left_histograms != bool right_histograms
   {} 0 1 _ _ _
 
-eval_info range from 0 to 24m step 6m left_histograms != right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms != right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms != bool right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms != bool right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
 eval range from 0 to 60m step 6m left_floats > right_floats
@@ -443,16 +495,24 @@ eval range from 0 to 60m step 6m left_floats > right_floats
 eval range from 0 to 60m step 6m left_floats > bool right_floats
   {} 0 _ _ _ 0 _ 1 0 0 0 0
 
-eval_info range from 0 to 24m step 6m left_histograms > right_histograms
+eval range from 0 to 24m step 6m left_histograms > right_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms > bool right_histograms
+eval range from 0 to 24m step 6m left_histograms > bool right_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms > right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms > right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms > bool right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms > bool right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
 eval range from 0 to 60m step 6m left_floats >= right_floats
@@ -461,16 +521,24 @@ eval range from 0 to 60m step 6m left_floats >= right_floats
 eval range from 0 to 60m step 6m left_floats >= bool right_floats
   {} 0 _ _ _ 1 _ 1 0 0 1 1
 
-eval_info range from 0 to 24m step 6m left_histograms >= right_histograms
+eval range from 0 to 24m step 6m left_histograms >= right_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms >= bool right_histograms
+eval range from 0 to 24m step 6m left_histograms >= bool right_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms >= right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms >= right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms >= bool right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms >= bool right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
 eval range from 0 to 60m step 6m left_floats < right_floats
@@ -479,16 +547,24 @@ eval range from 0 to 60m step 6m left_floats < right_floats
 eval range from 0 to 60m step 6m left_floats < bool right_floats
   {} 1 _ _ _ 0 _ 0 1 0 0 0
 
-eval_info range from 0 to 24m step 6m left_histograms < right_histograms
+eval range from 0 to 24m step 6m left_histograms < right_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms < bool right_histograms
+eval range from 0 to 24m step 6m left_histograms < bool right_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms < right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms < right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms < bool right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms < bool right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
 eval range from 0 to 60m step 6m left_floats <= right_floats
@@ -497,16 +573,24 @@ eval range from 0 to 60m step 6m left_floats <= right_floats
 eval range from 0 to 60m step 6m left_floats <= bool right_floats
   {} 1 _ _ _ 1 _ 0 1 0 1 1
 
-eval_info range from 0 to 24m step 6m left_histograms <= right_histograms
+eval range from 0 to 24m step 6m left_histograms <= right_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms <= bool right_histograms
+eval range from 0 to 24m step 6m left_histograms <= bool right_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms <= right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms <= right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms <= bool right_floats_for_histograms
+eval range from 0 to 24m step 6m left_histograms <= bool right_floats_for_histograms
+  expect info
+  expect no_warn
   # No results.
 
 # Vector / scalar combinations with scalar on right side
@@ -543,76 +627,124 @@ eval range from 0 to 60m step 6m left_floats == NaN
 eval range from 0 to 60m step 6m left_floats == bool NaN
   {} 0 0 _ _ 0 _ 0 0 0 0 0
 
-eval_info range from 0 to 24m step 6m left_histograms == 3
+eval range from 0 to 24m step 6m left_histograms == 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms == 0
+eval range from 0 to 24m step 6m left_histograms == 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms != 3
+eval range from 0 to 24m step 6m left_histograms != 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms != 0
+eval range from 0 to 24m step 6m left_histograms != 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms > 3
+eval range from 0 to 24m step 6m left_histograms > 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms > 0
+eval range from 0 to 24m step 6m left_histograms > 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms >= 3
+eval range from 0 to 24m step 6m left_histograms >= 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms >= 0
+eval range from 0 to 24m step 6m left_histograms >= 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms < 3
+eval range from 0 to 24m step 6m left_histograms < 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms < 0
+eval range from 0 to 24m step 6m left_histograms < 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms <= 3
+eval range from 0 to 24m step 6m left_histograms <= 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms <= 0
+eval range from 0 to 24m step 6m left_histograms <= 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms == bool 3
+eval range from 0 to 24m step 6m left_histograms == bool 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms == bool 0
+eval range from 0 to 24m step 6m left_histograms == bool 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms != bool 3
+eval range from 0 to 24m step 6m left_histograms != bool 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms != bool 0
+eval range from 0 to 24m step 6m left_histograms != bool 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms > bool 3
+eval range from 0 to 24m step 6m left_histograms > bool 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms > bool 0
+eval range from 0 to 24m step 6m left_histograms > bool 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms >= bool 3
+eval range from 0 to 24m step 6m left_histograms >= bool 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms >= bool 0
+eval range from 0 to 24m step 6m left_histograms >= bool 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms < bool 3
+eval range from 0 to 24m step 6m left_histograms < bool 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms < bool 0
+eval range from 0 to 24m step 6m left_histograms < bool 0
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms <= bool 3
+eval range from 0 to 24m step 6m left_histograms <= bool 3
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m left_histograms <= bool 0
+eval range from 0 to 24m step 6m left_histograms <= bool 0
+  expect info
+  expect no_warn
   # No results.
 
 # Vector / scalar combinations with scalar on left side
@@ -649,40 +781,64 @@ eval range from 0 to 60m step 6m NaN == left_floats
 eval range from 0 to 60m step 6m NaN == bool left_floats
   {} 0 0 _ _ 0 _ 0 0 0 0 0
 
-eval_info range from 0 to 24m step 6m 3 == left_histograms
+eval range from 0 to 24m step 6m 3 == left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 0 == left_histograms
+eval range from 0 to 24m step 6m 0 == left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 3 != left_histograms
+eval range from 0 to 24m step 6m 3 != left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 0 != left_histograms
+eval range from 0 to 24m step 6m 0 != left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 3 < left_histograms
+eval range from 0 to 24m step 6m 3 < left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 0 < left_histograms
+eval range from 0 to 24m step 6m 0 < left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 3 < left_histograms
+eval range from 0 to 24m step 6m 3 < left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 0 < left_histograms
+eval range from 0 to 24m step 6m 0 < left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 3 > left_histograms
+eval range from 0 to 24m step 6m 3 > left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 0 > left_histograms
+eval range from 0 to 24m step 6m 0 > left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 3 >= left_histograms
+eval range from 0 to 24m step 6m 3 >= left_histograms
+  expect info
+  expect no_warn
   # No results.
 
-eval_info range from 0 to 24m step 6m 0 >= left_histograms
+eval range from 0 to 24m step 6m 0 >= left_histograms
+  expect info
+  expect no_warn
   # No results.
 
 # Scalar / scalar combinations
@@ -1372,10 +1528,14 @@ eval instant at 0 second_histogram - on(job) group_left first_histogram
   {job="test"} {{schema:0 sum:5 count:2 buckets:[0 0 0]}}
 
 # Cannot multiply two histograms
-eval_info instant at 0 first_histogram * on(job) group_left second_histogram
+eval instant at 0 first_histogram * on(job) group_left second_histogram
+  expect info
+  expect no_warn
 
 # Cannot divide a histogram by a histogram
-eval_info instant at 0 first_histogram / on(job) group_left second_histogram
+eval instant at 0 first_histogram / on(job) group_left second_histogram
+  expect info
+  expect no_warn
 
 # Histogram multiplied by float
 eval instant at 0 first_histogram * on(job) group_left metric

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -118,7 +118,9 @@ eval range from 0 to 7m step 1m present_over_time(some_metric_count[3m1s])
 eval range from 0 to 7m step 1m present_over_time(some_metric_count[6s])
   {foo="bar"} 1 1 1 1 _ _ 1 1
 
-eval_info range from 0 to 7m step 1m min_over_time(some_metric_count[3m1s])
+eval range from 0 to 7m step 1m min_over_time(some_metric_count[3m1s])
+  expect info
+  expect no_warn
   {foo="bar"} 0 0 0 0 1 2 3 _
 
 eval range from 0 to 7m step 1m min_over_time(some_metric_count[6s])
@@ -127,7 +129,9 @@ eval range from 0 to 7m step 1m min_over_time(some_metric_count[6s])
 eval range from 0 to 16m step 1m min_over_time(some_inf_and_nan_metric[3m1s])
   {foo="baz"} 0 0 0 0 1 2 3 Inf Inf Inf NaN 8 7 6 6 6 6
 
-eval_info range from 0 to 7m step 1m max_over_time(some_metric_count[3m1s])
+eval range from 0 to 7m step 1m max_over_time(some_metric_count[3m1s])
+  expect info
+  expect no_warn
   {foo="bar"} 0 1 2 3 3 3 3 _
 
 eval range from 0 to 7m step 1m max_over_time(some_metric_count[6s])
@@ -136,7 +140,9 @@ eval range from 0 to 7m step 1m max_over_time(some_metric_count[6s])
 eval range from 0 to 16m step 1m max_over_time(some_inf_and_nan_metric[3m1s])
   {foo="baz"} 0 1 2 3 Inf Inf Inf Inf Inf Inf NaN 8 8 8 8 7 6
 
-eval_warn range from 0 to 10m step 1m sum_over_time(some_metric_count[3m1s])
+eval range from 0 to 10m step 1m sum_over_time(some_metric_count[3m1s])
+  expect no_info
+  expect warn
   {foo="bar"} 0 1 3 6 6 5 _ {{schema:3 sum:9 count:7 buckets:[3 7 5]}} {{schema:3 sum:9 count:7 buckets:[3 7 5]}} {{schema:3 sum:9 count:7 buckets:[3 7 5]}} {{schema:3 sum:5 count:3 buckets:[2 5 4]}}
 
 eval range from 0 to 5m step 1m sum_over_time(some_metric_count[3m1s])
@@ -154,7 +160,9 @@ eval range from 0 to 2m step 1m sum_over_time(some_nhcb_metric[3m1s])
 eval range from 0 to 16m step 1m sum_over_time(some_inf_and_nan_metric[3m1s])
   {foo="baz"} 0 1 3 6 Inf Inf Inf NaN NaN NaN NaN NaN NaN NaN 21 13 6
 
-eval_warn range from 0 to 10m step 1m avg_over_time(some_metric_count[3m1s])
+eval range from 0 to 10m step 1m avg_over_time(some_metric_count[3m1s])
+  expect no_info
+  expect warn
   {foo="bar"} 0 0.5 1 1.5 2 2.5 _ {{schema:3 sum:4.5 count:3.5 buckets:[1.5 3.5 2.5]}} {{schema:3 sum:4.5 count:3.5 buckets:[1.5 3.5 2.5]}} {{schema:3 sum:4.5 count:3.5 buckets:[1.5 3.5 2.5]}} {{schema:3 sum:5 count:3 buckets:[2 5 4]}}
 
 eval range from 0 to 5m step 1m avg_over_time(some_metric_count[3m1s])
@@ -618,7 +626,9 @@ load 1m
   metric{case="nhcb"} {{schema:-53 sum:1 count:5 custom_values:[5 10] buckets:[1 4]}} {{schema:-53 sum:15 count:2 custom_values:[5 10] buckets:[0 2]}} {{schema:-53 sum:3 count:15 custom_values:[5 10] buckets:[7 8]}} {{schema:-53 sum:3 count:15 custom_values:[5 10] buckets:[0 0]}}
   metric{case="floats, nh and nhcb"} 0 1 2 3 2 1 0 _ {{schema:3 sum:0 count:2 buckets:[1 2 1]}} {{schema:3 sum:0 count:1 buckets:[1 2 1]}} {{schema:3 sum:0 count:1 buckets:[1 0 1]}} {{schema:-53 sum:1 count:5 custom_values:[5 10] buckets:[1 4]}} {{schema:-53 sum:15 count:2 custom_values:[5 10] buckets:[0 2]}} {{schema:-53 sum:3 count:15 custom_values:[5 10] buckets:[7 8]}} {{schema:-53 sum:3 count:15 custom_values:[5 10] buckets:[0 0]}}
 
-eval_info range from 0 to 20m step 1m deriv(metric[3m1s])
+eval range from 0 to 20m step 1m deriv(metric[3m1s])
+  expect info
+  expect no_warn
   {case="all Inf"} _ NaN NaN NaN NaN NaN NaN NaN NaN NaN
   {case="all NaN"} _ NaN NaN NaN NaN NaN NaN NaN NaN NaN
   {case="all floats 1"} _ 0.016666666666666666 0.016666666666666666 0.016666666666666666 0.016666666666666666 0.016666666666666666 0.016666666666666666 0.016666666666666666 0.016666666666666666
@@ -656,7 +666,9 @@ load 1m
   metric{case="all nh"} {{schema:3 sum:0 count:0 buckets:[1 2 1]}} {{schema:3 sum:0 count:0 buckets:[1 2 1]}}
   metric{case="all nhcb"} {{schema:-53 sum:1 count:5 custom_values:[5 10] buckets:[1 4]}} {{schema:-53 sum:15 count:2 custom_values:[5 10] buckets:[0 2]}} {{schema:-53 sum:3 count:15 custom_values:[5 10] buckets:[7 8]}} {{schema:-53 sum:3 count:15 custom_values:[5 10] buckets:[0 0]}}
 
-eval_warn range from 0 to 8m step 1m idelta(metric[3m1s])
+eval range from 0 to 8m step 1m idelta(metric[3m1s])
+  expect no_info
+  expect warn
   {case="2 floats"} _ 4 4 4
   {case="2 floats and nh last sample"} _ 4
   {case="2 floats and nh middle sample"} _ _ 4 4
@@ -677,7 +689,9 @@ eval_warn range from 0 to 8m step 1m idelta(metric[3m1s])
   {case="all nh"} _ {{schema:3 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}} {{schema:3 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}} {{schema:3 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}}
   {case="all nhcb"} _ {{schema:-53 count:-3 sum:14 custom_values:[5 10] buckets:[-1 -2] counter_reset_hint:gauge}} {{schema:-53 count:13 sum:-12 custom_values:[5 10] buckets:[7 6] counter_reset_hint:gauge}} {{schema:-53 custom_values:[5 10] buckets:[-7 -8] counter_reset_hint:gauge}} {{schema:-53 custom_values:[5 10] buckets:[-7 -8] counter_reset_hint:gauge}} {{schema:-53 custom_values:[5 10] buckets:[-7 -8] counter_reset_hint:gauge}}
 
-eval_warn range from 0 to 8m step 1m irate(metric[3m1s])
+eval range from 0 to 8m step 1m irate(metric[3m1s])
+  expect no_info
+  expect warn
   {case="2 floats"} _ 0.06666666666666667 0.06666666666666667 0.06666666666666667
   {case="2 floats and nh last sample"} _ 0.06666666666666667
   {case="2 floats and nh middle sample"} _ _ 0.03333333333333333 0.03333333333333333
@@ -910,7 +924,9 @@ eval range from 0 to 2m step 1m timestamp(some_metric * 2)
   {case="histograms only"} 0 60 120
   {case="floats and histograms"} 0 60 120
 
-eval_info range from 0 to 2m step 1m timestamp(rate(some_metric{case=~".* only"}[2m]))
+eval range from 0 to 2m step 1m timestamp(rate(some_metric{case=~".* only"}[2m]))
+  expect info
+  expect no_warn
   {case="floats only"} _ 60 120
   {case="histograms only"} _ 60 120
 

--- a/pkg/streamingpromql/testdata/ours/histograms.test
+++ b/pkg/streamingpromql/testdata/ours/histograms.test
@@ -8,7 +8,9 @@ load 6m
   series{le="+Inf"} 8
   series{le="2000"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
 
-eval_info instant at 0m histogram_quantile(0.8, series)
+eval instant at 0m histogram_quantile(0.8, series)
+  expect info
+  expect no_warn
   {} 595
   {le="2000"} 2.29739670999407
 
@@ -29,7 +31,9 @@ eval instant at 0m histogram_quantile(0.8, series)
 load 6m
   series            0 10
 
-eval_warn instant at 0m histogram_quantile(0.8, series)
+eval instant at 0m histogram_quantile(0.8, series)
+  expect no_info
+  expect warn
   {} 4.800000000000001
 
 clear
@@ -57,7 +61,9 @@ load 6m
   series{le="+Inf"} 3 3 3 3 3
   ph                -0.5 NaN _ 9 0.9
 
-eval_warn range from 0m to 24m step 6m histogram_quantile(scalar(ph), series)
+eval range from 0m to 24m step 6m histogram_quantile(scalar(ph), series)
+  expect no_info
+  expect warn
   {} -Inf NaN NaN Inf 5.4
 
 clear
@@ -72,7 +78,9 @@ load 6m
   ph                0.5 NaN 0.9
 
 # Both engines output a warning even though there is no point where ph is also invalid.
-eval_warn range from 0m to 12m step 6m histogram_quantile(scalar(ph), series)
+eval range from 0m to 12m step 6m histogram_quantile(scalar(ph), series)
+  expect no_info
+  expect warn
   {} 3 _ 5.4
 
 clear
@@ -88,7 +96,9 @@ load 6m
   series{host="a"}     {{schema:0 sum:5 count:4 buckets:[9 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} _ _ _
   series{host="b"}     1 {{schema:0 sum:5 count:4 buckets:[0 3 1]}} {{schema:0 sum:5 count:4 buckets:[3 3 1]}} _
 
-eval_warn range from 0m to 24m step 6m histogram_quantile(0.8, series)
+eval range from 0m to 24m step 6m histogram_quantile(0.8, series)
+  expect no_info
+  expect warn
   {host="a"}      _ 2.29739670999407 820.0000000000007
   {host="a", le="0.1"} _ _ _ 3.0314331330207964
   {host="a", le="1"} _ _ _ 2.29739670999407
@@ -96,10 +106,14 @@ eval_warn range from 0m to 24m step 6m histogram_quantile(0.8, series)
   {host="a", le="100"} _ _ _ _ 3.2490095854249423
   {host="b"} _ 2.29739670999407 2.29739670999407
 
-eval_warn range from 0m to 12m step 6m histogram_quantile(0.8, series{host="a"})
+eval range from 0m to 12m step 6m histogram_quantile(0.8, series{host="a"})
+  expect no_info
+  expect warn
   {host="a"} _ 2.29739670999407 820.0000000000007
 
-eval_warn range from 0m to 24m step 6m histogram_quantile(0.8, series{host="b"})
+eval range from 0m to 24m step 6m histogram_quantile(0.8, series{host="b"})
+  expect no_info
+  expect warn
   {host="b"} _ 2.29739670999407 2.29739670999407
 
 clear
@@ -118,7 +132,9 @@ load 6m
   notEnoughObservations{le="1"} 0 1
   notEnoughObservations{le="+Inf"} 0 2
 
-eval_info range from 0m to 6m step 6m histogram_quantile(0.8, series)
+eval range from 0m to 6m step 6m histogram_quantile(0.8, series)
+  expect info
+  expect no_warn
   {} 4.800000000000001 NaN
 
 eval range from 0m to 6m step 6m histogram_quantile(0.8, noInfinity)
@@ -143,7 +159,9 @@ load 6m
   series{le="+Inf"} 3
   series{le="3"}    {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
 
-eval_warn instant at 0m histogram_quantile(0.8, series)
+eval instant at 0m histogram_quantile(0.8, series)
+  expect no_info
+  expect warn
   {} 4.800000000000001
   {le="3"} 2.29739670999407
 
@@ -160,7 +178,9 @@ load 6m
   series{le="+Inf"} 3
   series{le="3"}    {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
 
-eval_warn instant at 0m histogram_quantile(0.8, series)
+eval instant at 0m histogram_quantile(0.8, series)
+  expect no_info
+  expect warn
   {le="3"} 2.29739670999407
 
 clear

--- a/pkg/streamingpromql/testdata/ours/native_histograms.test
+++ b/pkg/streamingpromql/testdata/ours/native_histograms.test
@@ -188,10 +188,14 @@ load 1m
   incr_histogram	1 2 3 4 {{schema:5 sum:2 count:1 buckets:[1] offset:1}}
 
 # Each element in v that contains a mix of float and native histogram samples within the range, will be missing from the result vector.
-eval_warn instant at 5m rate(incr_histogram[5m])
+eval instant at 5m rate(incr_histogram[5m])
+  expect no_info
+  expect warn
   # We expect no results.
 
-eval_warn instant at 5m increase(incr_histogram[5m])
+eval instant at 5m increase(incr_histogram[5m])
+  expect no_info
+  expect warn
   # We expect no results.
 
 clear
@@ -204,10 +208,14 @@ load 1m
 # - The second value is a rate/increase from two floats
 # - The third value is a rate/increase across a float and histogram (so no value returned)
 # - The remaining values contain the rate/increase across two histograms in the vector
-eval_warn range from 0 to 4m step 1m rate(incr_histogram_sum[1m1s])
+eval range from 0 to 4m step 1m rate(incr_histogram_sum[1m1s])
+  expect no_info
+  expect warn
   {} _ 0.016666666666666666 _ {{schema:3 count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}} {{schema:3 count:0.016666666666666666 sum:0.03333333333333333 offset:1 buckets:[0.016666666666666666]}}
 
-eval_warn range from 0 to 4m step 1m increase(incr_histogram_sum[1m1s])
+eval range from 0 to 4m step 1m increase(incr_histogram_sum[1m1s])
+  expect no_info
+  expect warn
   {} _ 1.0166666666666666 _ {{schema:3 count:1.0166666666666666 sum:2.033333333333333 offset:1 buckets:[1.0166666666666666]}} {{schema:3 count:1.0166666666666666 sum:2.033333333333333 offset:1 buckets:[1.0166666666666666]}}
 
 clear
@@ -253,7 +261,9 @@ load 6m
 # T=12: mixed, should be ignored and emit a warning
 # T=18: only exponential
 # T=24: only custom
-eval_warn range from 0 to 24m step 6m sum(metric)
+eval range from 0 to 24m step 6m sum(metric)
+  expect no_info
+  expect warn
   {} {{sum:7 count:9 buckets:[2 5 2]}} {{schema:-53 sum:16 count:3 custom_values:[5 10] buckets:[1 2]}} _ {{sum:7 count:9 buckets:[2 5 2]}} {{schema:-53 sum:18 count:3 custom_values:[5 10] buckets:[1 2]}}
 
 clear
@@ -268,7 +278,9 @@ load 6m
 # T=6: compatible
 # T=12: incompatible followed by compatible, should be ignored and emit a warning
 # T=18: compatible
-eval_warn range from 0 to 18m step 6m sum(metric)
+eval range from 0 to 18m step 6m sum(metric)
+  expect no_info
+  expect warn
   {} _ {{schema:-53 sum:2 count:2 custom_values:[5 10] buckets:[2 4]}} _ {{schema:-53 sum:3.8 count:6 custom_values:[3] buckets:[6]}}
 
 clear

--- a/pkg/streamingpromql/testdata/ours/subqueries.test
+++ b/pkg/streamingpromql/testdata/ours/subqueries.test
@@ -102,12 +102,16 @@ eval range from 0 to 5m step 1m last_over_time(metric[1m1s:2m])
 # T=0m     T=1m     T=2m     T=3m     T=4m     T=5m
 # 0        4        3        6        -1       10
 
-eval_warn instant at 5m sum_over_time(last_over_time(metric[2m:1m])[5m:90s])
+eval instant at 5m sum_over_time(last_over_time(metric[2m:1m])[5m:90s])
+  expect no_info
+  expect warn
   {type="floats"} 9
   {type="histograms"} {{count:9}}
   # No results for {type="mixed"} due to mixture of floats and histograms
 
-eval_warn range from 0 to 5m step 1m sum_over_time(last_over_time(metric[2m:1m])[5m:90s])
+eval range from 0 to 5m step 1m sum_over_time(last_over_time(metric[2m:1m])[5m:90s])
+  expect no_info
+  expect warn
   {type="floats"} 0 0 4 10 10 9
   {type="histograms"} {{count:0}} {{count:0}} {{count:4}} {{count:10}} {{count:10}} {{count:9}}
   {type="mixed"} 0 0 4 10 10 _

--- a/tools/format-promql-test.sh
+++ b/tools/format-promql-test.sh
@@ -24,3 +24,7 @@ sed -E "${EDIT_IN_PLACE[@]}" 's/[[:space:]]+$//g' "$@"
 # Strip multiple consecutive blank lines
 # https://unix.stackexchange.com/a/216550/22142 explains the incantation below
 sed -E "${EDIT_IN_PLACE[@]}" '$!N;/^\n$/!P;D' "$@"
+
+# Prefer new syntax for annotation assertions introduced in https://github.com/prometheus/prometheus/pull/15995
+sed -E "${EDIT_IN_PLACE[@]}" 's/^eval_info (.*)/eval \1\n  expect info\n  expect no_warn/g' "$@"
+sed -E "${EDIT_IN_PLACE[@]}" 's/^eval_warn (.*)/eval \1\n  expect no_info\n  expect warn/g' "$@"


### PR DESCRIPTION
#### What this PR does

https://github.com/prometheus/prometheus/pull/15995 introduced a new syntax for annotation assertions in PromQL test files.

This PR updates our test cases to use the new syntax, and updates the formatting script to enforce that the old syntax is not used.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
