### PR TITLE
Fix -query-frontend.query-sharding-max-sharded-queries enforcement for instant queries with binary operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [BUGFIX] Ruler: don't count alerts towards `cortex_prometheus_notifications_dropped_total` if they are dropped due to alert relabelling. #10956
 * [BUGFIX] Querier: Fix issue where an entire store-gateway zone leaving caused high CPU usage trying to find active members of the leaving zone. #11028
 * [BUGFIX] Query-frontend: Fix blocks retention period enforcement when a request has multiple tenants (tenant federation). #11069
+* [BUGFIX] Query-frontend: Fix `-query-frontend.query-sharding-max-sharded-queries` enforcement for instant queries with binary operators. #11086
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1245,160 +1245,160 @@ func TestQuerySharding_ShouldOverrideShardingSizeViaOption(t *testing.T) {
 
 func TestQuerySharding_ShouldSupportMaxShardedQueries(t *testing.T) {
 	tests := map[string]struct {
-		query             string
-		hints             *Hints
-		totalShards       int
-		maxShardedQueries int
-		nativeHistograms  bool
-		expectedShards    int
-		compactorShards   int
+		query                         string
+		hints                         *Hints
+		totalShards                   int
+		maxShardedQueries             int
+		nativeHistograms              bool
+		expectedShardsPerPartialQuery int
+		compactorShards               int
 	}{
 		"query is not shardable": {
-			query:             "metric",
-			hints:             &Hints{TotalQueries: 1},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			expectedShards:    1,
+			query:                         "metric",
+			hints:                         &Hints{TotalQueries: 1},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			expectedShardsPerPartialQuery: 1,
 		},
 		"single splitted query, query has 1 shardable leg": {
-			query:             "sum(metric)",
-			hints:             &Hints{TotalQueries: 1},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			expectedShards:    16,
+			query:                         "sum(metric)",
+			hints:                         &Hints{TotalQueries: 1},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			expectedShardsPerPartialQuery: 16,
 		},
 		"single splitted query, query has many shardable legs": {
-			query:             "sum(metric_1) + sum(metric_2) + sum(metric_3) + sum(metric_4)",
-			hints:             &Hints{TotalQueries: 1},
-			totalShards:       16,
-			maxShardedQueries: 16,
-			expectedShards:    4,
+			query:                         "sum(metric_1) + sum(metric_2) + sum(metric_3) + sum(metric_4)",
+			hints:                         &Hints{TotalQueries: 1},
+			totalShards:                   16,
+			maxShardedQueries:             16,
+			expectedShardsPerPartialQuery: 4,
 		},
 		"multiple splitted queries, query has 1 shardable leg": {
-			query:             "sum(metric)",
-			hints:             &Hints{TotalQueries: 10},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			expectedShards:    6,
+			query:                         "sum(metric)",
+			hints:                         &Hints{TotalQueries: 10},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			expectedShardsPerPartialQuery: 6,
 		},
 		"multiple splitted queries, query has 2 shardable legs": {
-			query:             "sum(metric) / count(metric)",
-			hints:             &Hints{TotalQueries: 10},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			expectedShards:    3,
+			query:                         "sum(metric) / count(metric)",
+			hints:                         &Hints{TotalQueries: 10},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			expectedShardsPerPartialQuery: 3,
 		},
 		"multiple splitted queries, query has 2 shardable legs, no compactor shards": {
-			query:             "sum(metric) / count(metric)",
-			hints:             &Hints{TotalQueries: 3},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			compactorShards:   0,
-			expectedShards:    10,
+			query:                         "sum(metric) / count(metric)",
+			hints:                         &Hints{TotalQueries: 3},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			compactorShards:               0,
+			expectedShardsPerPartialQuery: 10,
 		},
 		"multiple splitted queries, query has 2 shardable legs, 3 compactor shards": {
-			query:             "sum(metric) / count(metric)",
-			hints:             &Hints{TotalQueries: 3},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			compactorShards:   3,
-			expectedShards:    9,
+			query:                         "sum(metric) / count(metric)",
+			hints:                         &Hints{TotalQueries: 3},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			compactorShards:               3,
+			expectedShardsPerPartialQuery: 9,
 		},
 		"multiple splitted queries, query has 2 shardable legs, 4 compactor shards": {
-			query:             "sum(metric) / count(metric)",
-			hints:             &Hints{TotalQueries: 3},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			compactorShards:   4,
-			expectedShards:    8,
+			query:                         "sum(metric) / count(metric)",
+			hints:                         &Hints{TotalQueries: 3},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			compactorShards:               4,
+			expectedShardsPerPartialQuery: 8,
 		},
 		"multiple splitted queries, query has 2 shardable legs, 10 compactor shards": {
-			query:             "sum(metric) / count(metric)",
-			hints:             &Hints{TotalQueries: 3},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			compactorShards:   10,
-			expectedShards:    10,
+			query:                         "sum(metric) / count(metric)",
+			hints:                         &Hints{TotalQueries: 3},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			compactorShards:               10,
+			expectedShardsPerPartialQuery: 10,
 		},
 		"multiple splitted queries, query has 2 shardable legs, 11 compactor shards": {
-			query:             "sum(metric) / count(metric)",
-			hints:             &Hints{TotalQueries: 3},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			compactorShards:   11,
-			expectedShards:    10, // cannot be adjusted to make 11 multiple or divisible, keep original.
+			query:                         "sum(metric) / count(metric)",
+			hints:                         &Hints{TotalQueries: 3},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			compactorShards:               11,
+			expectedShardsPerPartialQuery: 10, // cannot be adjusted to make 11 multiple or divisible, keep original.
 		},
 		"multiple splitted queries, query has 2 shardable legs, 14 compactor shards": {
-			query:             "sum(metric) / count(metric)",
-			hints:             &Hints{TotalQueries: 3},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			compactorShards:   14,
-			expectedShards:    7, // 7 divides 14
+			query:                         "sum(metric) / count(metric)",
+			hints:                         &Hints{TotalQueries: 3},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			compactorShards:               14,
+			expectedShardsPerPartialQuery: 7, // 7 divides 14
 		},
 		"query sharding is disabled": {
-			query:             "sum(metric)",
-			hints:             &Hints{TotalQueries: 1},
-			totalShards:       0, // Disabled.
-			maxShardedQueries: 64,
-			expectedShards:    1,
+			query:                         "sum(metric)",
+			hints:                         &Hints{TotalQueries: 1},
+			totalShards:                   0, // Disabled.
+			maxShardedQueries:             64,
+			expectedShardsPerPartialQuery: 1,
 		},
 		"native histograms accepted": {
-			query:             "sum(metric) / count(metric)",
-			hints:             &Hints{TotalQueries: 3},
-			totalShards:       16,
-			maxShardedQueries: 64,
-			nativeHistograms:  true,
-			compactorShards:   10,
-			expectedShards:    10,
+			query:                         "sum(metric) / count(metric)",
+			hints:                         &Hints{TotalQueries: 3},
+			totalShards:                   16,
+			maxShardedQueries:             64,
+			nativeHistograms:              true,
+			compactorShards:               10,
+			expectedShardsPerPartialQuery: 10,
 		},
 		"hints are missing, query has 1 shardable leg": {
-			query:             "count(metric)",
-			hints:             nil,
-			totalShards:       16,
-			maxShardedQueries: 32,
-			compactorShards:   8,
-			expectedShards:    16,
+			query:                         "count(metric)",
+			hints:                         nil,
+			totalShards:                   16,
+			maxShardedQueries:             32,
+			compactorShards:               8,
+			expectedShardsPerPartialQuery: 16,
 		},
 		"hints are missing, query has 2 shardable legs": {
-			query:             "count(metric_1) or count(metric_2)",
-			hints:             nil,
-			totalShards:       16,
-			maxShardedQueries: 32,
-			compactorShards:   8,
-			expectedShards:    16, // 2 legs * 16 shards per query = 32 max sharded queries
+			query:                         "count(metric_1) or count(metric_2)",
+			hints:                         nil,
+			totalShards:                   16,
+			maxShardedQueries:             32,
+			compactorShards:               8,
+			expectedShardsPerPartialQuery: 16, // 2 legs * 16 shards per query = 32 max sharded queries
 		},
 		"hints are missing, query has 4 shardable legs": {
-			query:             "count(metric_1) or count(metric_2) or count(metric_3) or count(metric_4)",
-			hints:             nil,
-			totalShards:       16,
-			maxShardedQueries: 32,
-			compactorShards:   8,
-			expectedShards:    8, // 4 legs * 8 shards per query = 32 max sharded queries
+			query:                         "count(metric_1) or count(metric_2) or count(metric_3) or count(metric_4)",
+			hints:                         nil,
+			totalShards:                   16,
+			maxShardedQueries:             32,
+			compactorShards:               8,
+			expectedShardsPerPartialQuery: 8, // 4 legs * 8 shards per query = 32 max sharded queries
 		},
 		"total queries number is missing in hints, query has 1 shardable leg": {
-			query:             "count(metric)",
-			hints:             &Hints{},
-			totalShards:       16,
-			maxShardedQueries: 32,
-			compactorShards:   8,
-			expectedShards:    16,
+			query:                         "count(metric)",
+			hints:                         &Hints{},
+			totalShards:                   16,
+			maxShardedQueries:             32,
+			compactorShards:               8,
+			expectedShardsPerPartialQuery: 16,
 		},
 		"total queries number is missing in hints, query has 2 shardable legs": {
-			query:             "count(metric_1) or count(metric_2)",
-			hints:             &Hints{},
-			totalShards:       16,
-			maxShardedQueries: 32,
-			compactorShards:   8,
-			expectedShards:    16, // 2 legs * 16 shards per query = 32 max sharded queries
+			query:                         "count(metric_1) or count(metric_2)",
+			hints:                         &Hints{},
+			totalShards:                   16,
+			maxShardedQueries:             32,
+			compactorShards:               8,
+			expectedShardsPerPartialQuery: 16, // 2 legs * 16 shards per query = 32 max sharded queries
 		},
 		"total queries number is missing in hints, query has 4 shardable legs": {
-			query:             "count(metric_1) or count(metric_2) or count(metric_3) or count(metric_4)",
-			hints:             &Hints{},
-			totalShards:       16,
-			maxShardedQueries: 32,
-			compactorShards:   8,
-			expectedShards:    8, // 4 legs * 8 shards per query = 32 max sharded queries
+			query:                         "count(metric_1) or count(metric_2) or count(metric_3) or count(metric_4)",
+			hints:                         &Hints{},
+			totalShards:                   16,
+			maxShardedQueries:             32,
+			compactorShards:               8,
+			expectedShardsPerPartialQuery: 8, // 4 legs * 8 shards per query = 32 max sharded queries
 		},
 	}
 
@@ -1442,7 +1442,7 @@ func TestQuerySharding_ShouldSupportMaxShardedQueries(t *testing.T) {
 			res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
 			require.NoError(t, err)
 			assert.Equal(t, statusSuccess, res.(*PrometheusResponse).GetStatus())
-			assert.Equal(t, testData.expectedShards, len(uniqueShards))
+			assert.Equal(t, testData.expectedShardsPerPartialQuery, len(uniqueShards))
 		})
 	}
 }

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1352,6 +1352,54 @@ func TestQuerySharding_ShouldSupportMaxShardedQueries(t *testing.T) {
 			compactorShards:   10,
 			expectedShards:    10,
 		},
+		"hints are missing, query has 1 shardable leg": {
+			query:             "count(metric)",
+			hints:             nil,
+			totalShards:       16,
+			maxShardedQueries: 32,
+			compactorShards:   8,
+			expectedShards:    16,
+		},
+		"hints are missing, query has 2 shardable legs": {
+			query:             "count(metric_1) or count(metric_2)",
+			hints:             nil,
+			totalShards:       16,
+			maxShardedQueries: 32,
+			compactorShards:   8,
+			expectedShards:    16, // 2 legs * 8 shards per query = 16 max sharded queries
+		},
+		"hints are missing, query has 4 shardable legs": {
+			query:             "count(metric_1) or count(metric_2) or count(metric_3) or count(metric_4)",
+			hints:             nil,
+			totalShards:       16,
+			maxShardedQueries: 32,
+			compactorShards:   8,
+			expectedShards:    8, // 4 legs * 8 shards per query = 32 max sharded queries
+		},
+		"total queries number is missing in hints, query has 1 shardable leg": {
+			query:             "count(metric)",
+			hints:             &Hints{},
+			totalShards:       16,
+			maxShardedQueries: 32,
+			compactorShards:   8,
+			expectedShards:    16,
+		},
+		"total queries number is missing in hints, query has 2 shardable legs": {
+			query:             "count(metric_1) or count(metric_2)",
+			hints:             &Hints{},
+			totalShards:       16,
+			maxShardedQueries: 32,
+			compactorShards:   8,
+			expectedShards:    16, // 2 legs * 8 shards per query = 16 max sharded queries
+		},
+		"total queries number is missing in hints, query has 4 shardable legs": {
+			query:             "count(metric_1) or count(metric_2) or count(metric_3) or count(metric_4)",
+			hints:             &Hints{},
+			totalShards:       16,
+			maxShardedQueries: 32,
+			compactorShards:   8,
+			expectedShards:    8, // 4 legs * 8 shards per query = 32 max sharded queries
+		},
 	}
 
 	for testName, testData := range tests {

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1366,7 +1366,7 @@ func TestQuerySharding_ShouldSupportMaxShardedQueries(t *testing.T) {
 			totalShards:       16,
 			maxShardedQueries: 32,
 			compactorShards:   8,
-			expectedShards:    16, // 2 legs * 8 shards per query = 16 max sharded queries
+			expectedShards:    16, // 2 legs * 16 shards per query = 32 max sharded queries
 		},
 		"hints are missing, query has 4 shardable legs": {
 			query:             "count(metric_1) or count(metric_2) or count(metric_3) or count(metric_4)",
@@ -1390,7 +1390,7 @@ func TestQuerySharding_ShouldSupportMaxShardedQueries(t *testing.T) {
 			totalShards:       16,
 			maxShardedQueries: 32,
 			compactorShards:   8,
-			expectedShards:    16, // 2 legs * 8 shards per query = 16 max sharded queries
+			expectedShards:    16, // 2 legs * 16 shards per query = 32 max sharded queries
 		},
 		"total queries number is missing in hints, query has 4 shardable legs": {
 			query:             "count(metric_1) or count(metric_2) or count(metric_3) or count(metric_4)",


### PR DESCRIPTION
#### What this PR does

Instant queries don't set `Hints.TotalQueries` because they're not split by time (only range queries do). This means that we never enforce `-query-frontend.query-sharding-max-sharded-queries` when the query has 1+ binary operators. This PR fixes it, assuming that if `TotalQueries` is unknown then it's just 1.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
