### PR TITLE
[chore]: `validation.NewOverides` doesn't return an error

### DIFF
--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -843,9 +843,7 @@ receivers:
 				flagext.DefaultValues(&limits)
 				limits.AlertmanagerReceiversBlockPrivateAddresses = firewallEnabled
 
-				overrides, err := validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
-
+				overrides := validation.NewOverrides(limits, nil)
 				features := featurecontrol.NoopFlags{}
 
 				// Start the alertmanager.

--- a/pkg/blockbuilder/config_test.go
+++ b/pkg/blockbuilder/config_test.go
@@ -104,8 +104,7 @@ func blockBuilderConfig(t *testing.T, addr string) (Config, *validation.Override
 	limits.OutOfOrderTimeWindow = 2 * model.Duration(time.Hour)
 	limits.OutOfOrderBlocksExternalLabelEnabled = true // Needed to reproduce a panic.
 	limits.NativeHistogramsIngestionEnabled = true
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 
 	return cfg, overrides
 }

--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -77,8 +77,7 @@ func TestTSDBBuilder(t *testing.T) {
 			NativeHistogramsIngestionEnabled: true,
 		},
 	}
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
 
 	// Hold samples for all cases and check for the correctness.
 	var expSamples []mimirpb.Sample
@@ -282,8 +281,7 @@ func TestTSDBBuilder(t *testing.T) {
 }
 
 func TestTSDBBuilder_CompactAndUpload_fail(t *testing.T) {
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	metrics := newTSDBBBuilderMetrics(prometheus.NewPedanticRegistry())
 	builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides, metrics, 0)
 	t.Cleanup(func() {
@@ -295,7 +293,7 @@ func TestTSDBBuilder_CompactAndUpload_fail(t *testing.T) {
 		partitionID: 0,
 		tenantID:    userID,
 	}
-	_, err = builder.getOrCreateTSDB(tenant)
+	_, err := builder.getOrCreateTSDB(tenant)
 	require.NoError(t, err)
 
 	errUploadFailed := fmt.Errorf("upload failed")
@@ -381,8 +379,7 @@ func TestProcessingEmptyRequest(t *testing.T) {
 	lastEnd := 2 * time.Hour.Milliseconds()
 	currEnd := lastEnd + time.Hour.Milliseconds()
 
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	metrics := newTSDBBBuilderMetrics(prometheus.NewPedanticRegistry())
 	builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides, metrics, 0)
 
@@ -435,8 +432,7 @@ func TestTSDBBuilderLimits(t *testing.T) {
 			NativeHistogramsIngestionEnabled: true,
 		},
 	}
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
 
 	metrics := newTSDBBBuilderMetrics(prometheus.NewPedanticRegistry())
 	builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides, metrics, applyGlobalSeriesLimitUnder)
@@ -504,8 +500,7 @@ func TestTSDBBuilderNativeHistogramEnabledError(t *testing.T) {
 			NativeHistogramsIngestionEnabled: false,
 		},
 	}
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
 
 	metrics := newTSDBBBuilderMetrics(prometheus.NewPedanticRegistry())
 	builder := NewTSDBBuilder(log.NewNopLogger(), t.TempDir(), mimir_tsdb.BlocksStorageConfig{}, overrides, metrics, 0)

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1187,8 +1187,7 @@ func TestMultitenantCompactor_ShouldCompactOnlyUsersOwnedByTheInstanceOnSharding
 		var limits validation.Limits
 		flagext.DefaultValues(&limits)
 		limits.CompactorTenantShardSize = 1
-		overrides, err := validation.NewOverrides(limits, nil)
-		require.NoError(t, err)
+		overrides := validation.NewOverrides(limits, nil)
 
 		c, _, tsdbPlanner, l, _ := prepareWithConfigProvider(t, cfg, bucketClient, overrides)
 		defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
@@ -1767,8 +1766,7 @@ func prepareConfig(t *testing.T) Config {
 func prepare(t *testing.T, compactorCfg Config, bucketClient objstore.Bucket) (*MultitenantCompactor, *tsdbCompactorMock, *tsdbPlannerMock, *concurrency.SyncBuffer, prometheus.Gatherer) {
 	var limits validation.Limits
 	flagext.DefaultValues(&limits)
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 
 	return prepareWithConfigProvider(t, compactorCfg, bucketClient, overrides)
 }
@@ -1963,8 +1961,7 @@ func TestMultitenantCompactor_DeleteLocalSyncFiles(t *testing.T) {
 		var limits validation.Limits
 		flagext.DefaultValues(&limits)
 		limits.CompactorTenantShardSize = 1 // Each tenant will belong to single compactor only.
-		overrides, err := validation.NewOverrides(limits, nil)
-		require.NoError(t, err)
+		overrides := validation.NewOverrides(limits, nil)
 
 		c, _, tsdbPlanner, _, _ := prepareWithConfigProvider(t, cfg, inmem, overrides)
 		t.Cleanup(func() {

--- a/pkg/costattribution/manager_test.go
+++ b/pkg/costattribution/manager_test.go
@@ -19,7 +19,7 @@ import (
 
 func newTestManager() *Manager {
 	logger := log.NewNopLogger()
-	limits, _ := testutils.NewMockCostAttributionLimits(0)
+	limits := testutils.NewMockCostAttributionLimits(0)
 	reg := prometheus.NewRegistry()
 	manager, err := NewManager(5*time.Second, 10*time.Second, logger, limits, reg)
 	if err != nil {
@@ -152,9 +152,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 	})
 
 	t.Run("Disabling user cost attribution", func(t *testing.T) {
-		var err error
-		manager.limits, err = testutils.NewMockCostAttributionLimits(1)
-		assert.NoError(t, err)
+		manager.limits = testutils.NewMockCostAttributionLimits(1)
 		assert.NoError(t, manager.purgeInactiveAttributionsUntil(time.Unix(11, 0)))
 		assert.Equal(t, 1, len(manager.sampleTrackersByUserID))
 
@@ -167,9 +165,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 	})
 
 	t.Run("Updating user cardinality and labels", func(t *testing.T) {
-		var err error
-		manager.limits, err = testutils.NewMockCostAttributionLimits(2)
-		assert.NoError(t, err)
+		manager.limits = testutils.NewMockCostAttributionLimits(2)
 		assert.NoError(t, manager.purgeInactiveAttributionsUntil(time.Unix(12, 0)))
 		assert.Equal(t, 1, len(manager.sampleTrackersByUserID))
 		assert.True(t, manager.SampleTracker("user3").hasSameLabels([]string{"feature", "team"}))
@@ -219,7 +215,7 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 
 	t.Run("Purge after inactive timeout", func(t *testing.T) {
 		// disable cost attribution for user1 to test purging
-		manager.limits, _ = testutils.NewMockCostAttributionLimits(1)
+		manager.limits = testutils.NewMockCostAttributionLimits(1)
 		assert.NoError(t, manager.purgeInactiveAttributionsUntil(time.Unix(5, 0)))
 
 		// User3's tracker should remain since it's active, user1's tracker should be removed

--- a/pkg/costattribution/testutils/test_utils.go
+++ b/pkg/costattribution/testutils/test_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
-func NewMockCostAttributionLimits(idx int, lvs ...string) (*validation.Overrides, error) {
+func NewMockCostAttributionLimits(idx int, lvs ...string) *validation.Overrides {
 	baseLimits := map[string]*validation.Limits{
 		"user1": {MaxCostAttributionCardinalityPerUser: 5, CostAttributionLabels: []string{"team"}},
 		"user2": {MaxCostAttributionCardinalityPerUser: 2, CostAttributionLabels: []string{}},

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -262,8 +262,7 @@ func TestDistributor_Push_ShouldReturnErrorMappedTo4xxStatusCodeIfWriteRequestCo
 	limits := prepareDefaultLimits()
 	limits.MaxLabelValueLength = hugeLabelValueLength
 
-	overrides, err := validation.NewOverrides(*limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(*limits, nil)
 
 	testConfig := prepConfig{
 		numDistributors:         1,

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2379,8 +2379,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 					})
 
 					caCase.cfg(&limits)
-					overrides, err := validation.NewOverrides(limits, nil)
-					require.NoError(b, err)
+					overrides := validation.NewOverrides(limits, nil)
 
 					// Initialize the cost attribution manager
 					var cam *costattribution.Manager
@@ -5921,9 +5920,7 @@ func prepare(t testing.TB, cfg prepConfig) ([]*Distributor, []*mockIngester, []*
 			}
 		}
 
-		overrides, err := validation.NewOverrides(*cfg.limits, nil)
-		require.NoError(t, err)
-
+		overrides := validation.NewOverrides(*cfg.limits, nil)
 		reg := prometheus.NewPedanticRegistry()
 		d, err := New(distributorCfg, clientConfig, overrides, nil, nil, ingestersRing, partitionsRing, true, reg, log.NewNopLogger())
 		require.NoError(t, err)
@@ -8597,9 +8594,7 @@ func TestCheckStartedMiddleware(t *testing.T) {
 		return &noopIngester{}, nil
 	})
 
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
-
+	overrides := validation.NewOverrides(limits, nil)
 	distributor, err := New(distributorConfig, clientConfig, overrides, nil, nil, ingestersRing, nil, true, nil, log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -8677,8 +8672,7 @@ func Test_outerMaybeDelayMiddleware(t *testing.T) {
 					IngestionArtificialDelay: model.Duration(tc.delay),
 				},
 			})
-			overrides, err := validation.NewOverrides(*prepareDefaultLimits(), limits)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(*prepareDefaultLimits(), limits)
 
 			// Mock to capture sleep and advance time.
 			timeSource := &MockTimeSource{CurrentTime: time.Now()}
@@ -8701,7 +8695,7 @@ func Test_outerMaybeDelayMiddleware(t *testing.T) {
 				ctx = user.InjectOrgID(ctx, tc.userID)
 			}
 			wrappedPush := distributor.outerMaybeDelayMiddleware(p)
-			err = wrappedPush(ctx, NewParsedRequest(&mimirpb.WriteRequest{}))
+			err := wrappedPush(ctx, NewParsedRequest(&mimirpb.WriteRequest{}))
 			require.NoError(t, err)
 
 			// Due to the 10% jitter we need to take into account that the number will not be deterministic in tests.

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -351,11 +351,7 @@ func BenchmarkOTLPHandler(b *testing.B) {
 		pushReq.CleanUp()
 		return nil
 	}
-	limits, err := validation.NewOverrides(
-		validation.Limits{},
-		validation.NewMockTenantLimits(map[string]*validation.Limits{}),
-	)
-	require.NoError(b, err)
+	limits := validation.MockDefaultOverrides()
 	handler := OTLPHandler(100000, nil, nil, limits, nil, RetryConfig{}, false, pushFunc, nil, nil, log.NewNopLogger())
 
 	b.Run("protobuf", func(b *testing.B) {
@@ -798,13 +794,12 @@ func TestHandlerOTLPPush(t *testing.T) {
 			testLimits := &validation.Limits{
 				PromoteOTelResourceAttributes: tt.promoteResourceAttributes,
 			}
-			limits, err := validation.NewOverrides(
+			limits := validation.NewOverrides(
 				validation.Limits{},
 				validation.NewMockTenantLimits(map[string]*validation.Limits{
 					"test": testLimits,
 				}),
 			)
-			require.NoError(t, err)
 			pusher := func(_ context.Context, pushReq *Request) error {
 				t.Helper()
 				t.Cleanup(pushReq.CleanUp)
@@ -884,11 +879,10 @@ func TestHandler_otlpDroppedMetricsPanic(t *testing.T) {
 	metric2.SetName(name)
 	metric2.SetEmptyGauge()
 
-	limits, err := validation.NewOverrides(
+	limits := validation.NewOverrides(
 		validation.Limits{},
 		validation.NewMockTenantLimits(map[string]*validation.Limits{}),
 	)
-	require.NoError(t, err)
 
 	req := createOTLPProtoRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), "")
 	resp := httptest.NewRecorder()
@@ -930,11 +924,7 @@ func TestHandler_otlpDroppedMetricsPanic2(t *testing.T) {
 	metric2.SetName(name)
 	metric2.SetEmptyGauge()
 
-	limits, err := validation.NewOverrides(
-		validation.Limits{},
-		validation.NewMockTenantLimits(map[string]*validation.Limits{}),
-	)
-	require.NoError(t, err)
+	limits := validation.MockDefaultOverrides()
 
 	req := createOTLPProtoRequest(t, pmetricotlp.NewExportRequestFromMetrics(md), "")
 	resp := httptest.NewRecorder()

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -464,8 +464,7 @@ func TestHandler_SkipExemplarUnmarshalingBasedOnLimits(t *testing.T) {
 
 			defaults := validation.MockDefaultLimits()
 			defaults.MaxGlobalExemplarsPerUser = tc.maxGlobalExemplarsPerUser
-			limits, err := validation.NewOverrides(*defaults, nil)
-			require.NoError(t, err)
+			limits := validation.NewOverrides(*defaults, nil)
 
 			var gotReqEncoded *Request
 			handler := Handler(100000, nil, nil, true, false, limits, RetryConfig{}, func(_ context.Context, pushReq *Request) error {
@@ -1108,12 +1107,10 @@ func TestHandler_toHTTPStatus(t *testing.T) {
 					ServiceOverloadStatusCodeOnRateLimitEnabled: tc.serviceOverloadErrorEnabled,
 				},
 			}
-			limits, err := validation.NewOverrides(
+			limits := validation.NewOverrides(
 				validation.Limits{},
 				validation.NewMockTenantLimits(tenantLimits),
 			)
-			require.NoError(t, err)
-
 			status := toHTTPStatus(ctx, tc.err, limits)
 			assert.Equal(t, tc.expectedHTTPStatus, status)
 		})

--- a/pkg/distributor/rate_strategy_test.go
+++ b/pkg/distributor/rate_strategy_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -20,11 +19,10 @@ import (
 func TestIngestionRateStrategy(t *testing.T) {
 	t.Run("rate limiter should share the limit across the number of distributors", func(t *testing.T) {
 		// Init limits overrides
-		overrides, err := validation.NewOverrides(validation.Limits{
+		overrides := validation.NewOverrides(validation.Limits{
 			IngestionRate:      float64(1000),
 			IngestionBurstSize: 10000,
 		}, nil)
-		require.NoError(t, err)
 
 		mockRing := newReadLifecyclerMock()
 		mockRing.On("HealthyInstancesCount").Return(2)
@@ -42,11 +40,10 @@ func TestIngestionRateStrategy(t *testing.T) {
 	})
 	t.Run("Burst factor should be 3x the per distributor limit", func(t *testing.T) {
 		// Init limits overrides
-		overrides, err := validation.NewOverrides(validation.Limits{
+		overrides := validation.NewOverrides(validation.Limits{
 			IngestionRate:        float64(1000),
 			IngestionBurstFactor: 3,
 		}, nil)
-		require.NoError(t, err)
 
 		mockRing := newReadLifecyclerMock()
 		mockRing.On("HealthyInstancesCount").Return(2)
@@ -57,11 +54,10 @@ func TestIngestionRateStrategy(t *testing.T) {
 	})
 	t.Run("Burst factor should be set to to max int if limit is too large", func(t *testing.T) {
 		// Init limits overrides
-		overrides, err := validation.NewOverrides(validation.Limits{
+		overrides := validation.NewOverrides(validation.Limits{
 			IngestionRate:        float64(math.MaxInt),
 			IngestionBurstFactor: 3,
 		}, nil)
-		require.NoError(t, err)
 
 		mockRing := newReadLifecyclerMock()
 		mockRing.On("HealthyInstancesCount").Return(2)
@@ -72,11 +68,10 @@ func TestIngestionRateStrategy(t *testing.T) {
 	})
 	t.Run("Burst factor should be set to to max int if limit is rate.inf", func(t *testing.T) {
 		// Init limits overrides
-		overrides, err := validation.NewOverrides(validation.Limits{
+		overrides := validation.NewOverrides(validation.Limits{
 			IngestionRate:        math.MaxFloat64,
 			IngestionBurstFactor: 3,
 		}, nil)
-		require.NoError(t, err)
 
 		mockRing := newReadLifecyclerMock()
 		mockRing.On("HealthyInstancesCount").Return(2)

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -80,7 +80,7 @@ func TestValidateLabels(t *testing.T) {
 	cfg.maxLabelNameLength = 25
 	cfg.maxLabelNamesPerSeries = 3
 	cfg.maxLabelNamesPerInfoSeries = 4
-	limits, _ := catestutils.NewMockCostAttributionLimits(0, userID, "team")
+	limits := catestutils.NewMockCostAttributionLimits(0, userID, "team")
 	careg := prometheus.NewRegistry()
 	manager, err := costattribution.NewManager(5*time.Second, 10*time.Second, log.NewNopLogger(), limits, careg)
 	require.NoError(t, err)

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -347,8 +347,7 @@ func TestLimitsMiddleware_MaxQueryLookback_TenantFederation(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			limits, err := validation.NewOverrides(defaults, validation.NewMockTenantLimits(tenantLimits))
-			require.NoError(t, err)
+			limits := validation.NewOverrides(defaults, validation.NewMockTenantLimits(tenantLimits))
 
 			middleware := newLimitsMiddleware(limits, log.NewNopLogger())
 
@@ -364,7 +363,7 @@ func TestLimitsMiddleware_MaxQueryLookback_TenantFederation(t *testing.T) {
 				end:   util.TimeToMillis(testData.reqEndTime),
 			}
 
-			_, err = outer.Do(ctx, req)
+			_, err := outer.Do(ctx, req)
 			require.NoError(t, err)
 
 			// Assert on the time range of the request passed to the inner handler (5s delta).

--- a/pkg/frontend/querymiddleware/read_consistency_test.go
+++ b/pkg/frontend/querymiddleware/read_consistency_test.go
@@ -153,8 +153,7 @@ func TestGetDefaultReadConsistency(t *testing.T) {
 		"tenant-c": {IngestStorageReadConsistency: querierapi.ReadConsistencyStrong},
 	}
 
-	ov, err := validation.NewOverrides(defaults, validation.NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := validation.NewOverrides(defaults, validation.NewMockTenantLimits(tenantLimits))
 
 	tests := []struct {
 		tenantIDs []string

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -251,7 +251,7 @@ func (m *mockIndex) Series(ref storage.SeriesRef, builder *labels.ScratchBuilder
 }
 
 func TestActiveSeries_UpdateSeries_WithCostAttribution(t *testing.T) {
-	limits, _ := catestutils.NewMockCostAttributionLimits(0)
+	limits := catestutils.NewMockCostAttributionLimits(0)
 	reg := prometheus.NewRegistry()
 	manager, err := costattribution.NewManager(5*time.Second, 10*time.Second, log.NewNopLogger(), limits, reg)
 	require.NoError(t, err)

--- a/pkg/ingester/circuitbreaker_test.go
+++ b/pkg/ingester/circuitbreaker_test.go
@@ -613,8 +613,7 @@ func TestIngester_IngestStorage_PushToStorage_CircuitBreaker(t *testing.T) {
 					testModeEnabled:            true,
 				}
 
-				overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-				require.NoError(t, err)
+				overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 				i, _, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, registry)
 				require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
 				defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
@@ -633,7 +632,7 @@ func TestIngester_IngestStorage_PushToStorage_CircuitBreaker(t *testing.T) {
 					nil,
 					mimirpb.API,
 				)
-				err = i.PushToStorage(ctx, req)
+				err := i.PushToStorage(ctx, req)
 				require.NoError(t, err)
 
 				count := 0
@@ -661,7 +660,7 @@ func TestIngester_IngestStorage_PushToStorage_CircuitBreaker(t *testing.T) {
 						ctx := user.InjectOrgID(context.Background(), userID)
 						count++
 						i.circuitBreaker.push.testRequestDelay = testCase.pushRequestDelay
-						err = i.PushToStorage(ctx, req)
+						err := i.PushToStorage(ctx, req)
 						if initialDelayEnabled {
 							if testCase.expectedErrorWhenCircuitBreakerClosed != nil {
 								require.ErrorAs(t, err, &testCase.expectedErrorWhenCircuitBreakerClosed)

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -78,8 +78,7 @@ func TestIngester_Start(t *testing.T) {
 		cfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalJitterEnabled = false
 
 		// Create the ingester.
-		overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-		require.NoError(t, err)
+		overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 		ingester, kafkaCluster, watcher := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
 
 		// Mock the Kafka cluster to:
@@ -288,8 +287,7 @@ func TestIngester_QueryStream_IngestStorageReadConsistency(t *testing.T) {
 			limits.IngestStorageReadConsistency = testData.readConsistencyLevel
 
 			// Create the ingester.
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 			ingester, kafkaCluster, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
 
 			// Mock the Kafka cluster to fail the Fetch operation until we unblock it later in the test.
@@ -370,13 +368,11 @@ func TestIngester_PrepareShutdownHandler_IngestStorageSupport(t *testing.T) {
 	ctx := context.Background()
 
 	reg := prometheus.NewPedanticRegistry()
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 
 	// Start ingester.
 	cfg := defaultIngesterTestConfig(t)
 	ingester, _, watcher := createTestIngesterWithIngestStorage(t, &cfg, overrides, reg)
-	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, ingester))
 	t.Cleanup(func() {
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, ingester))
@@ -428,13 +424,10 @@ func TestIngester_PrepareShutdownHandler_IngestStorageSupport(t *testing.T) {
 func TestIngester_PreparePartitionDownscaleHandler(t *testing.T) {
 	ctx := context.Background()
 
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
-
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	setup := func(t *testing.T, cfg Config) (*Ingester, *ring.PartitionRingWatcher) {
 		// Start ingester.
 		ingester, _, watcher := createTestIngesterWithIngestStorage(t, &cfg, overrides, prometheus.NewPedanticRegistry())
-		require.NoError(t, err)
 		require.NoError(t, services.StartAndAwaitRunning(ctx, ingester))
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(ctx, ingester))
@@ -551,8 +544,7 @@ func TestIngester_PreparePartitionDownscaleHandler(t *testing.T) {
 func TestIngester_ShouldNotCreatePartitionIfThereIsShutdownMarker(t *testing.T) {
 	ctx := context.Background()
 
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 
 	cfg := defaultIngesterTestConfig(t)
 	ingester, _, watcher := createTestIngesterWithIngestStorage(t, &cfg, overrides, prometheus.NewPedanticRegistry())
@@ -562,7 +554,6 @@ func TestIngester_ShouldNotCreatePartitionIfThereIsShutdownMarker(t *testing.T) 
 	require.NoError(t, shutdownmarker.Create(shutdownmarker.GetPath(cfg.BlocksStorageConfig.TSDB.Dir)))
 
 	// Start ingester.
-	require.NoError(t, err)
 	require.NoError(t, ingester.StartAsync(ctx))
 	t.Cleanup(func() {
 		_ = services.StopAndAwaitTerminated(ctx, ingester)
@@ -579,8 +570,7 @@ func TestIngester_ShouldNotCreatePartitionIfThereIsShutdownMarker(t *testing.T) 
 
 func TestIngester_compactionServiceInterval(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	ingester, _, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, nil)
 
 	ingester.cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = time.Minute

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -3698,11 +3698,11 @@ func BenchmarkIngesterPush(b *testing.B) {
 					limitCfg := t.limitsCfg()
 					caCase.limitsCfg(&limitCfg)
 
-					overrides, err := validation.NewOverrides(limitCfg, nil)
-					require.NoError(b, err)
+					overrides := validation.NewOverrides(limitCfg, nil)
 
 					var cam *costattribution.Manager
 					if caCase.customRegistry != nil {
+						var err error
 						cam, err = costattribution.NewManager(5*time.Second, 10*time.Second, nil, overrides, caCase.customRegistry)
 						require.NoError(b, err)
 					}
@@ -5900,8 +5900,7 @@ func TestIngester_QueryStream_CounterResets(t *testing.T) {
 			NativeHistogramsIngestionEnabled: true,
 		},
 	}
-	override, err := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
-	require.NoError(t, err)
+	override := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
 
 	i, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, override, nil, "", "", nil)
 	require.NoError(t, err)
@@ -6358,10 +6357,7 @@ func prepareIngesterWithBlocksStorage(t testing.TB, ingesterCfg Config, ingester
 }
 
 func prepareIngesterWithBlocksStorageAndLimits(t testing.TB, ingesterCfg Config, limits validation.Limits, ingestersRing ring.ReadRing, dataDir string, registerer prometheus.Registerer) (*Ingester, error) {
-	overrides, err := validation.NewOverrides(limits, nil)
-	if err != nil {
-		return nil, err
-	}
+	overrides := validation.NewOverrides(limits, nil)
 	return prepareIngesterWithBlockStorageAndOverrides(t, ingesterCfg, overrides, ingestersRing, dataDir, "", registerer)
 }
 
@@ -6585,8 +6581,7 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			limits := defaultLimitsTestConfig()
 
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			// Create a temporary directory for TSDB
 			tempDir := t.TempDir()
@@ -7736,8 +7731,7 @@ func TestHeadCompactionOnStartup(t *testing.T) {
 
 	limits := defaultLimitsTestConfig()
 
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 
 	ingesterCfg := defaultIngesterTestConfig(t)
 	ingesterCfg.BlocksStorageConfig.TSDB.Dir = tempDir
@@ -8414,8 +8408,7 @@ func TestIngester_inflightPushRequests(t *testing.T) {
 	t.Run("with ingest storage enabled", func(t *testing.T) {
 		limits := InstanceLimits{MaxInflightPushRequests: 1}
 
-		overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-		require.NoError(t, err)
+		overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 
 		cfg := defaultIngesterTestConfig(t)
 		cfg.InstanceLimitsFn = func() *InstanceLimits { return &limits }
@@ -9531,8 +9524,7 @@ func TestIngesterActiveSeries(t *testing.T) {
 			limits := defaultLimitsTestConfig()
 			limits.ActiveSeriesBaseCustomTrackersConfig = activeSeriesDefaultConfig
 			limits.NativeHistogramsIngestionEnabled = true
-			overrides, err := validation.NewOverrides(limits, activeSeriesTenantOverride)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, activeSeriesTenantOverride)
 
 			ing, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, overrides, nil, "", "", registry)
 			require.NoError(t, err)
@@ -9666,8 +9658,7 @@ func TestIngesterActiveSeriesConfigChanges(t *testing.T) {
 				limits := defaultLimitsTestConfig()
 				limits.ActiveSeriesBaseCustomTrackersConfig = activeSeriesDefaultConfig
 				limits.NativeHistogramsIngestionEnabled = true
-				override, err := validation.NewOverrides(limits, activeSeriesTenantOverride)
-				require.NoError(t, err)
+				override := validation.NewOverrides(limits, activeSeriesTenantOverride)
 				ingester.limits = override
 				currentTime = time.Now()
 				// First update reloads the config
@@ -9797,8 +9788,7 @@ func TestIngesterActiveSeriesConfigChanges(t *testing.T) {
 				limits := defaultLimitsTestConfig()
 				limits.ActiveSeriesBaseCustomTrackersConfig = activeSeriesDefaultConfig
 				limits.NativeHistogramsIngestionEnabled = true
-				override, err := validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
+				override := validation.NewOverrides(limits, nil)
 				ingester.limits = override
 				ingester.updateActiveSeries(currentTime)
 				expectedMetrics = `
@@ -9921,8 +9911,7 @@ func TestIngesterActiveSeriesConfigChanges(t *testing.T) {
 				limits := defaultLimitsTestConfig()
 				limits.ActiveSeriesBaseCustomTrackersConfig = activeSeriesDefaultConfig
 				limits.NativeHistogramsIngestionEnabled = true
-				override, err := validation.NewOverrides(limits, activeSeriesTenantOverride)
-				require.NoError(t, err)
+				override := validation.NewOverrides(limits, activeSeriesTenantOverride)
 				ingester.limits = override
 				ingester.updateActiveSeries(currentTime)
 				expectedMetrics = `
@@ -10023,8 +10012,7 @@ func TestIngesterActiveSeriesConfigChanges(t *testing.T) {
 
 				// Remove all configs
 				limits := defaultLimitsTestConfig()
-				override, err := validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
+				override := validation.NewOverrides(limits, nil)
 				ingester.limits = override
 				ingester.updateActiveSeries(currentTime)
 				expectedMetrics = `
@@ -10054,14 +10042,11 @@ func TestIngesterActiveSeriesConfigChanges(t *testing.T) {
 			limits.ActiveSeriesBaseCustomTrackersConfig = testData.activeSeriesConfig
 			limits.NativeHistogramsIngestionEnabled = true
 			var overrides *validation.Overrides
-			var err error
 			// Without this, TenantLimitsMock(nil) != nil when using getOverridesForUser in limits.go
 			if testData.tenantLimits != nil {
-				overrides, err = validation.NewOverrides(limits, testData.tenantLimits)
-				require.NoError(t, err)
+				overrides = validation.NewOverrides(limits, testData.tenantLimits)
 			} else {
-				overrides, err = validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
+				overrides = validation.NewOverrides(limits, nil)
 			}
 
 			ing, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, overrides, nil, "", "", registry)
@@ -10121,8 +10106,7 @@ func testIngesterOutOfOrder(t *testing.T,
 	l.NativeHistogramsIngestionEnabled = true
 	tenantOverride := new(TenantLimitsMock)
 	tenantOverride.On("ByUserID", "test").Return(nil)
-	override, err := validation.NewOverrides(l, tenantOverride)
-	require.NoError(t, err)
+	override := validation.NewOverrides(l, tenantOverride)
 
 	setOOOTimeWindow := func(oooTW model.Duration) {
 		tenantOverride.ExpectedCalls = nil
@@ -10386,8 +10370,7 @@ func testIngesterOutOfOrderCompactHead(t *testing.T,
 			NativeHistogramsIngestionEnabled: true,
 		},
 	}
-	override, err := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
-	require.NoError(t, err)
+	override := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
 
 	i, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, override, nil, "", "", nil)
 	require.NoError(t, err)
@@ -10474,8 +10457,7 @@ func testIngesterOutOfOrderCompactHeadStillActive(t *testing.T,
 			NativeHistogramsIngestionEnabled: true,
 		},
 	}
-	override, err := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
-	require.NoError(t, err)
+	override := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(limits))
 
 	i, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, override, nil, "", "", nil)
 	require.NoError(t, err)
@@ -10551,8 +10533,7 @@ func Test_Ingester_ShipperLabelsOutOfOrderBlocksOnUpload(t *testing.T) {
 				},
 			}
 
-			override, err := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(tenantLimits))
-			require.NoError(t, err)
+			override := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(tenantLimits))
 
 			tmpDir := t.TempDir()
 			bucketDir := t.TempDir()
@@ -10661,8 +10642,7 @@ func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHis
 	userID := "1"
 	tenantOverride := new(TenantLimitsMock)
 	tenantOverride.On("ByUserID", userID).Return(nil)
-	override, err := validation.NewOverrides(limits, tenantOverride)
-	require.NoError(t, err)
+	override := validation.NewOverrides(limits, tenantOverride)
 
 	setNativeHistogramsIngestionEnabled := func(enabled bool) {
 		tenantOverride.ExpectedCalls = nil
@@ -10709,7 +10689,7 @@ func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHis
 
 	// Append only one series and one metadata first, expect no error.
 	ctx := user.InjectOrgID(context.Background(), userID)
-	_, err = ing.Push(ctx, mimirpb.NewWriteRequest([]*mimirpb.MetricMetadata{metadata1}, mimirpb.API).
+	_, err := ing.Push(ctx, mimirpb.NewWriteRequest([]*mimirpb.MetricMetadata{metadata1}, mimirpb.API).
 		AddFloatSeries([][]mimirpb.LabelAdapter{labels1}, []mimirpb.Sample{sample1}, nil).
 		AddHistogramSeries([][]mimirpb.LabelAdapter{labels1}, sampleHistograms, nil))
 	require.NoError(t, err)
@@ -10736,7 +10716,7 @@ func testIngesterCanEnableIngestAndQueryNativeHistograms(t *testing.T, sampleHis
 		}
 
 		s := stream{ctx: ctx}
-		err = ing.QueryStream(req, &s)
+		err := ing.QueryStream(req, &s)
 		require.NoError(t, err, msg)
 
 		res, err := client.StreamsToMatrix(model.Earliest, model.Latest, s.responses)
@@ -11538,8 +11518,7 @@ func TestIngester_lastUpdatedTimeIsNotInTheFuture(t *testing.T) {
 
 	l := defaultLimitsTestConfig()
 	l.CreationGracePeriod = model.Duration(time.Hour) * 24 * 365 * 15 // 15 years in the future
-	override, err := validation.NewOverrides(l, nil)
-	require.NoError(t, err)
+	override := validation.NewOverrides(l, nil)
 
 	// Create ingester
 	i, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, override, nil, "", "", nil)
@@ -11657,8 +11636,7 @@ func TestIngester_Starting(t *testing.T) {
 func TestIngester_PrepareUnregisterHandler(t *testing.T) {
 	ctx := context.Background()
 
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 
 	type testCase struct {
 		name                     string

--- a/pkg/ingester/limiter_test.go
+++ b/pkg/ingester/limiter_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/grafana/dskit/ring"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -360,8 +359,7 @@ func runLimiterMaxFunctionTest(
 			limits := validation.Limits{IngestionTenantShardSize: testData.shardSize}
 			applyLimits(&limits, testData.globalLimit)
 
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			strategy := newIngesterRingLimiterStrategy(ring, testData.ringReplicationFactor, testData.ringZoneAwarenessEnabled, "zone", overrides.IngestionTenantShardSize)
 			limiter := NewLimiter(overrides, strategy)
@@ -436,8 +434,7 @@ func runLimiterMaxFunctionTestWithPartitionsRing(
 			limits := validation.Limits{IngestionPartitionsTenantShardSize: testData.tenantPartitionsShardSize}
 			applyLimits(&limits, testData.globalLimit)
 
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			strategy := newPartitionRingLimiterStrategy(h, overrides.IngestionPartitionsTenantShardSize)
 			limiter := NewLimiter(overrides, strategy)
@@ -496,11 +493,9 @@ func TestLimiter_IsWithinMaxSeriesPerMetric(t *testing.T) {
 			ring := &ringCountMock{instancesCount: testData.ringIngesterCount, zonesCount: 1}
 
 			// Mock limits
-			limits, err := validation.NewOverrides(validation.Limits{
+			limits := validation.NewOverrides(validation.Limits{
 				MaxGlobalSeriesPerMetric: testData.maxGlobalSeriesPerMetric,
 			}, nil)
-			require.NoError(t, err)
-
 			strategy := newIngesterRingLimiterStrategy(ring, testData.ringReplicationFactor, false, "", limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxSeriesPerMetric("test", testData.series)
@@ -541,9 +536,7 @@ func TestLimiter_IsWithinMaxSeriesPerMetric_WithPartitionsRing(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			pr := buildPartitionRingFromPartitionStates(testData.partitionStates...)
 
-			limits, err := validation.NewOverrides(validation.Limits{MaxGlobalSeriesPerMetric: testData.maxGlobalSeriesPerMetric}, nil)
-			require.NoError(t, err)
-
+			limits := validation.NewOverrides(validation.Limits{MaxGlobalSeriesPerMetric: testData.maxGlobalSeriesPerMetric}, nil)
 			strategy := newPartitionRingLimiterStrategy(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxSeriesPerMetric("test", testData.series)
@@ -590,11 +583,9 @@ func TestLimiter_IsWithinMaxMetadataPerMetric(t *testing.T) {
 			ring := &ringCountMock{instancesCount: testData.ringIngesterCount, zonesCount: 1}
 
 			// Mock limits
-			limits, err := validation.NewOverrides(validation.Limits{
+			limits := validation.NewOverrides(validation.Limits{
 				MaxGlobalMetadataPerMetric: testData.maxGlobalMetadataPerMetric,
 			}, nil)
-			require.NoError(t, err)
-
 			strategy := newIngesterRingLimiterStrategy(ring, testData.ringReplicationFactor, false, "", limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxMetadataPerMetric("test", testData.metadata)
@@ -635,9 +626,7 @@ func TestLimiter_IsWithinMaxMetadataPerMetric_WithPartitionsRing(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			pr := buildPartitionRingFromPartitionStates(testData.partitionStates...)
 
-			limits, err := validation.NewOverrides(validation.Limits{MaxGlobalMetadataPerMetric: testData.maxGlobalMetadataPerMetric}, nil)
-			require.NoError(t, err)
-
+			limits := validation.NewOverrides(validation.Limits{MaxGlobalMetadataPerMetric: testData.maxGlobalMetadataPerMetric}, nil)
 			strategy := newPartitionRingLimiterStrategy(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxMetadataPerMetric("test", testData.metadata)
@@ -718,12 +707,10 @@ func TestLimiter_IsWithinMaxSeriesPerUser(t *testing.T) {
 			ring := &ringCountMock{instancesCount: testData.ringIngesterCount, zonesCount: 1}
 
 			// Mock limits
-			limits, err := validation.NewOverrides(validation.Limits{
+			limits := validation.NewOverrides(validation.Limits{
 				MaxGlobalSeriesPerUser:   testData.maxGlobalSeriesPerUser,
 				IngestionTenantShardSize: testData.tenantShardSize,
 			}, nil)
-			require.NoError(t, err)
-
 			strategy := newIngesterRingLimiterStrategy(ring, testData.ringReplicationFactor, false, "", limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxSeriesPerUser("test", testData.series, testData.minLocalLimit)
@@ -794,9 +781,7 @@ func TestLimiter_IsWithinMaxSeriesPerUser_WithPartitionsRing(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			pr := buildPartitionRingFromPartitionStates(testData.partitionStates...)
 
-			limits, err := validation.NewOverrides(validation.Limits{MaxGlobalSeriesPerUser: testData.maxGlobalSeriesPerUser, IngestionPartitionsTenantShardSize: testData.tenantShardSize}, nil)
-			require.NoError(t, err)
-
+			limits := validation.NewOverrides(validation.Limits{MaxGlobalSeriesPerUser: testData.maxGlobalSeriesPerUser, IngestionPartitionsTenantShardSize: testData.tenantShardSize}, nil)
 			strategy := newPartitionRingLimiterStrategy(&partitionRingHolder{pr: pr}, limits.IngestionPartitionsTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxSeriesPerUser("test", testData.series, testData.minLocalLimit)
@@ -843,11 +828,9 @@ func TestLimiter_IsWithinMaxMetricsWithMetadataPerUser(t *testing.T) {
 			ring := &ringCountMock{instancesCount: testData.ringIngesterCount, zonesCount: 1}
 
 			// Mock limits
-			limits, err := validation.NewOverrides(validation.Limits{
+			limits := validation.NewOverrides(validation.Limits{
 				MaxGlobalMetricsWithMetadataPerUser: testData.maxGlobalMetadataPerUser,
 			}, nil)
-			require.NoError(t, err)
-
 			strategy := newIngesterRingLimiterStrategy(ring, testData.ringReplicationFactor, false, "", limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxMetricsWithMetadataPerUser("test", testData.metadata)
@@ -888,9 +871,7 @@ func TestLimiter_IsWithinMaxMetricsWithMetadataPerUser_WithPartitionsRing(t *tes
 		t.Run(testName, func(t *testing.T) {
 			pr := buildPartitionRingFromPartitionStates(testData.partitionStates...)
 
-			limits, err := validation.NewOverrides(validation.Limits{MaxGlobalMetricsWithMetadataPerUser: testData.maxGlobalMetadataPerUser}, nil)
-			require.NoError(t, err)
-
+			limits := validation.NewOverrides(validation.Limits{MaxGlobalMetricsWithMetadataPerUser: testData.maxGlobalMetadataPerUser}, nil)
 			strategy := newPartitionRingLimiterStrategy(&partitionRingHolder{pr: pr}, limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
 			actual := limiter.IsWithinMaxMetricsWithMetadataPerUser("test", testData.metadata)

--- a/pkg/ingester/owned_series_test.go
+++ b/pkg/ingester/owned_series_test.go
@@ -736,9 +736,7 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 
 			c.registerTestedIngesterIntoRing(t, c.cfg.IngesterRing.InstanceID, c.cfg.IngesterRing.InstanceAddr, c.cfg.IngesterRing.InstanceZone)
 
-			var err error
-			c.overrides, err = validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(tc.limits))
-			require.NoError(t, err)
+			c.overrides = validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(tc.limits))
 
 			c.ing = setupIngesterWithOverrides(t, c.cfg, c.overrides, c.ingesterRing, "") // Pass ring so that limiter and oss see the same state
 
@@ -1450,10 +1448,7 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 			c.cfg.IngesterPartitionRing.KVStore.Mock = c.kvStore                               // Set ring with our in-memory KV, that we will use for watching.
 			c.cfg.BlocksStorageConfig.TSDB.Dir = ""                                            // Don't use default value, otherwise
 
-			var err error
-			c.overrides, err = validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(tc.limits))
-			require.NoError(t, err)
-
+			c.overrides = validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(tc.limits))
 			// createTestIngesterWithIngestStorage will register partition and ingester into the partition ring.
 			c.createIngesterAndPartitionRing(t)
 

--- a/pkg/ingester/shipper_test.go
+++ b/pkg/ingester/shipper_test.go
@@ -49,8 +49,7 @@ func TestShipper(t *testing.T) {
 
 	logs := &concurrency.SyncBuffer{}
 	logger := log.NewLogfmtLogger(logs)
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource)
 
 	t.Run("no shipper file yet", func(t *testing.T) {
@@ -191,8 +190,7 @@ func TestShipper_DeceivingUploadErrors(t *testing.T) {
 	bkt = deceivingUploadBucket{Bucket: bkt, objectBaseName: block.MetaFilename}
 
 	logger := log.NewLogfmtLogger(os.Stderr)
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource)
 
 	// Create and upload a block
@@ -257,8 +255,7 @@ func TestIterBlockMetas(t *testing.T) {
 			Version: 1,
 		},
 	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id3.String())))
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	shipper := newShipper(nil, overrides, "", newShipperMetrics(nil), dir, nil, block.TestSource)
 	metas, err := shipper.blockMetasFromOldest()
 	require.NoError(t, err)
@@ -271,8 +268,7 @@ func TestShipperAddsSegmentFiles(t *testing.T) {
 	dir := t.TempDir()
 
 	inmemory := objstore.NewInMemBucket()
-	overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	s := newShipper(nil, overrides, "", newShipperMetrics(nil), dir, inmemory, block.TestSource)
 
 	id := ulid.MustNew(1, nil)
@@ -415,8 +411,7 @@ func TestShipper_AddOOOLabel(t *testing.T) {
 					OutOfOrderBlocksExternalLabelEnabled: tc.addOOOLabel,
 				},
 			}
-			overrides, err := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(tenantLimits))
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(tenantLimits))
 			s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource)
 
 			createBlock(t, blocksDir, tc.meta.ULID, tc.meta)

--- a/pkg/ingester/user_metrics_metadata_test.go
+++ b/pkg/ingester/user_metrics_metadata_test.go
@@ -76,11 +76,10 @@ func TestUserMetricsMetadata(t *testing.T) {
 			// Mock the ring
 			ring := &ringCountMock{instancesCount: 1, zonesCount: 1}
 
-			limits, err := validation.NewOverrides(validation.Limits{
+			limits := validation.NewOverrides(validation.Limits{
 				MaxGlobalMetricsWithMetadataPerUser: testData.maxMetadataPerUser,
 				MaxGlobalMetadataPerMetric:          testData.maxMetadataPerMetric,
 			}, nil)
-			require.NoError(t, err)
 
 			strategy := newIngesterRingLimiterStrategy(ring, 1, false, "", limits.IngestionTenantShardSize)
 			limiter := NewLimiter(limits, strategy)
@@ -134,9 +133,7 @@ func TestUserMetricsMetadataRequest(t *testing.T) {
 	// Mock the ring
 	ring := &ringCountMock{instancesCount: 1, zonesCount: 1}
 
-	limits, err := validation.NewOverrides(validation.Limits{}, nil)
-	require.NoError(t, err)
-
+	limits := validation.NewOverrides(validation.Limits{}, nil)
 	strategy := newIngesterRingLimiterStrategy(ring, 1, false, "", limits.IngestionTenantShardSize)
 	limiter := NewLimiter(limits, strategy)
 

--- a/pkg/ingester/user_tsdb_test.go
+++ b/pkg/ingester/user_tsdb_test.go
@@ -238,9 +238,7 @@ func TestGetSeriesCountAndMinLocalLimit(t *testing.T) {
 
 func TestRecomputeOwnedSeries(t *testing.T) {
 	limits := validation.Limits{MaxGlobalSeriesPerUser: 0}
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
-
+	overrides := validation.NewOverrides(limits, nil)
 	limiter := NewLimiter(overrides, newIngesterRingLimiterStrategy(nil, 3, true, "zone", overrides.IngestionTenantShardSize))
 
 	t.Run("happy path", func(t *testing.T) {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -426,10 +426,10 @@ func (t *Mimir) initRuntimeConfig() (services.Service, error) {
 }
 
 func (t *Mimir) initOverrides() (serv services.Service, err error) {
-	t.Overrides, err = validation.NewOverrides(t.Cfg.LimitsConfig, t.TenantLimits)
+	t.Overrides = validation.NewOverrides(t.Cfg.LimitsConfig, t.TenantLimits)
 	// overrides don't have operational state, nor do they need to do anything more in starting/stopping phase,
 	// so there is no need to return any service.
-	return nil, err
+	return nil, nil
 }
 
 func (t *Mimir) initOverridesExporter() (services.Service, error) {

--- a/pkg/mimir/runtime_config_test.go
+++ b/pkg/mimir/runtime_config_test.go
@@ -238,8 +238,7 @@ overrides:
 		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), manager))
 	})
 
-	overrides, err := validation.NewOverrides(cfg.LimitsConfig, newTenantLimits(manager))
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(cfg.LimitsConfig, newTenantLimits(manager))
 
 	require.Equal(t, `additional:{foo="user_1_additional"};base:{foo="user_1_base"};common:{foo="user_1_additional"}`, overrides.ActiveSeriesCustomTrackersConfig("user-1").String())
 	require.Equal(t, `additional:{foo="user_1_additional"};base:{foo="user_1_base"};common:{foo="user_1_additional"}`, overrides.ActiveSeriesCustomTrackersConfig("user-2").String())

--- a/pkg/querier/cardinality_analysis_handler_test.go
+++ b/pkg/querier/cardinality_analysis_handler_test.go
@@ -211,8 +211,7 @@ func TestLabelNamesCardinalityHandler_DistributorError(t *testing.T) {
 			limits := validation.Limits{}
 			flagext.DefaultValues(&limits)
 			limits.CardinalityAnalysisEnabled = true
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 			handler := LabelNamesCardinalityHandler(distributor, overrides)
 			ctx := user.InjectOrgID(context.Background(), "test")
 
@@ -276,8 +275,7 @@ func TestLabelNamesCardinalityHandler_NegativeTests(t *testing.T) {
 			if !data.cardinalityAnalysisDisabled {
 				limits.CardinalityAnalysisEnabled = true
 			}
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 			handler := LabelNamesCardinalityHandler(mockDistributorLabelNamesAndValues([]*client.LabelValues{}, nil), overrides)
 
 			recorder := httptest.NewRecorder()
@@ -644,8 +642,7 @@ func TestLabelValuesCardinalityHandler_FeatureFlag(t *testing.T) {
 				nil)
 
 			limits := validation.Limits{CardinalityAnalysisEnabled: testData.cardinalityAnalysisEnabled}
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 			handler := LabelValuesCardinalityHandler(distributor, overrides)
 
 			recorder := httptest.NewRecorder()
@@ -1041,8 +1038,7 @@ func BenchmarkActiveNativeHistogramMetricsHandler_ServeHTTP(b *testing.B) {
 // createEnabledHandler creates a cardinalityHandler that can be either a LabelNamesCardinalityHandler or a LabelValuesCardinalityHandler
 func createEnabledHandler(t testing.TB, cardinalityHandler func(Distributor, *validation.Overrides) http.Handler, distributor *mockDistributor) http.Handler {
 	limits := validation.Limits{CardinalityAnalysisEnabled: true}
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 
 	handler := cardinalityHandler(distributor, overrides)
 	return handler

--- a/pkg/querier/filter_queryables_test.go
+++ b/pkg/querier/filter_queryables_test.go
@@ -33,8 +33,7 @@ func TestFilteringQueryablesViaHttpHeader(t *testing.T) {
 		logger := log.NewNopLogger()
 		reg := prometheus.NewPedanticRegistry()
 		metrics := stats.NewQueryMetrics(reg)
-		overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
-		require.NoError(t, err)
+		overrides := validation.NewOverrides(defaultLimitsConfig(), nil)
 
 		cfg := Config{}
 		flagext.DefaultValues(&cfg)

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -242,8 +242,7 @@ func TestQuerier(t *testing.T) {
 			distributor.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&client.QueryResponse{}, nil)
 			distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(client.CombinedQueryStreamResponse{}, nil)
 
-			overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(defaultLimitsConfig(), nil)
 
 			queryable, _, _, err := New(cfg, overrides, distributor, []TimeRangeQueryable{dbQueryable}, nil, log.NewNopLogger(), nil)
 			require.NoError(t, err)
@@ -314,8 +313,7 @@ func TestQuerier_QueryableReturnsChunksOutsideQueriedRange(t *testing.T) {
 
 	limits := defaultLimitsConfig()
 	limits.QueryIngestersWithin = 0 // Always query ingesters in this test.
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 
 	engine := promql.NewEngine(promql.EngineOpts{
 		Logger:     util_log.SlogFromGoKit(logger),
@@ -362,8 +360,7 @@ func TestBatchMergeChunks(t *testing.T) {
 
 	limits := defaultLimitsConfig()
 	limits.QueryIngestersWithin = 0 // Always query ingesters in this test.
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 
 	s1 := []mimirpb.Sample{}
 	s2 := []mimirpb.Sample{}
@@ -437,8 +434,7 @@ func BenchmarkQueryExecute(b *testing.B) {
 
 	limits := defaultLimitsConfig()
 	limits.QueryIngestersWithin = 0 // Always query ingesters in this test.
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(b, err)
+	overrides := validation.NewOverrides(limits, nil)
 
 	scenarios := []struct {
 		numChunks          int
@@ -636,8 +632,7 @@ func TestQuerier_QueryIngestersWithinConfig(t *testing.T) {
 
 			limits := defaultLimitsConfig()
 			limits.QueryIngestersWithin = model.Duration(c.queryIngestersWithin)
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			queryable, _, _, err := New(cfg, overrides, distributor, nil, nil, log.NewNopLogger(), nil)
 			require.NoError(t, err)
@@ -709,8 +704,7 @@ func TestQuerier_ValidateQueryTimeRange(t *testing.T) {
 			distributor.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Matrix{}, nil)
 			distributor.On("QueryStream", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(client.CombinedQueryStreamResponse{}, nil)
 
-			overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(defaultLimitsConfig(), nil)
 
 			queryable, _, _, err := New(cfg, overrides, distributor, nil, nil, log.NewNopLogger(), nil)
 			require.NoError(t, err)
@@ -777,8 +771,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 
 			limits := defaultLimitsConfig()
 			limits.MaxPartialQueryLength = model.Duration(maxQueryLength)
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			// We don't need to query any data for this test, so an empty distributor is fine.
 			distributor := &emptyDistributor{}
@@ -897,8 +890,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 			limits := defaultLimitsConfig()
 			limits.MaxQueryLookback = testData.maxQueryLookback
 			limits.QueryIngestersWithin = 0 // Always query ingesters in this test.
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			t.Run("query range", func(t *testing.T) {
 				distributor := &mockDistributor{}
@@ -1094,8 +1086,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxLabelsQueryRange(t *testing.T) {
 			limits.MaxPartialQueryLength = testData.maxLabelsQueryLength
 			limits.MaxTotalQueryLength = testData.maxLabelsQueryLength
 			limits.QueryIngestersWithin = 0 // Always query ingesters in this test.
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			distributor := &mockDistributor{}
 			distributor.On("MetricsForLabelMatchers", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]labels.Labels{}, nil)
@@ -1210,8 +1201,7 @@ func TestQuerier_ValidateQuery_MaxSeriesQueryLimit(t *testing.T) {
 			limits.MaxQueryLookback = model.Duration(thirtyDays * 2)
 			limits.MaxSeriesQueryLimit = testData.maxSeriesQueryLimit
 			limits.QueryIngestersWithin = 0 // Always query ingesters in this test.
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			distributor := &mockDistributor{}
 			distributor.On("MetricsForLabelMatchers", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]labels.Labels{}, nil)
@@ -1426,8 +1416,7 @@ func TestQuerier_QueryStoreAfterConfig(t *testing.T) {
 
 			limits := defaultLimitsConfig()
 			limits.QueryIngestersWithin = model.Duration(c.queryIngestersWithin)
-			overrides, err := validation.NewOverrides(limits, nil)
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(limits, nil)
 
 			// Mock the blocks storage to return an empty SeriesSet (we just need to check whether
 			// it was hit or not).
@@ -1707,8 +1696,7 @@ func TestTenantQueryLimitsProvider(t *testing.T) {
 		},
 	}
 
-	overrides, err := validation.NewOverrides(defaultLimitsConfig(), tenantLimits)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(defaultLimitsConfig(), tenantLimits)
 
 	provider := &tenantQueryLimitsProvider{
 		limits: overrides,

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -1252,9 +1252,7 @@ func TestRuler_NotifySyncRulesAsync_ShouldTriggerRulesSyncingAndCorrectlyHandleT
 		rulerCfg.Ring.Common.InstanceAddr = rulerAddr
 		rulerCfg.Ring.Common.KVStore = kv.Config{Mock: kvStore}
 
-		limits, err := validation.NewOverrides(*validation.MockDefaultLimits(), validation.NewMockTenantLimits(tenantLimits))
-		require.NoError(t, err)
-
+		limits := validation.NewOverrides(*validation.MockDefaultLimits(), validation.NewMockTenantLimits(tenantLimits))
 		regs[i] = prometheus.NewPedanticRegistry()
 		rulers[i] = prepareRuler(t, rulerCfg, store, withRulerAddrMap(rulerAddrMap), withRulerAddrAutomaticMapping(), withLimits(limits), withStart(), withPrometheusRegisterer(regs[i]))
 	}

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -385,8 +385,7 @@ func TestBucketStores_ChunksAndSeriesLimiterFactoriesInitializedByEnforcedLimits
 			bucket, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
 			require.NoError(t, err)
 
-			overrides, err := validation.NewOverrides(defaultLimits, validation.NewMockTenantLimits(testData.tenantLimits))
-			require.NoError(t, err)
+			overrides := validation.NewOverrides(defaultLimits, validation.NewMockTenantLimits(testData.tenantLimits))
 
 			var allowedTenants *util.AllowedTenants
 			reg := prometheus.NewPedanticRegistry()

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -326,9 +326,7 @@ func TestStoreGateway_InitialSyncWithWaitRingTokensStability(t *testing.T) {
 				gatewayCfg.ShardingRing.WaitStabilityMaxDuration = 30 * time.Second
 				limits.StoreGatewayTenantShardSize = testData.tenantShardSize
 
-				overrides, err := validation.NewOverrides(limits, nil)
-				require.NoError(t, err)
-
+				overrides := validation.NewOverrides(limits, nil)
 				reg := prometheus.NewPedanticRegistry()
 				g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, overrides, log.NewNopLogger(), reg, nil)
 				require.NoError(t, err)
@@ -418,9 +416,7 @@ func TestStoreGateway_BlocksSyncWithDefaultSharding_RingTopologyChangedAfterScal
 		gatewayCfg.ShardingRing.WaitStabilityMinDuration = waitStabilityMin
 		gatewayCfg.ShardingRing.WaitStabilityMaxDuration = 30 * time.Second
 
-		overrides, err := validation.NewOverrides(limits, nil)
-		require.NoError(t, err)
-
+		overrides := validation.NewOverrides(limits, nil)
 		reg := prometheus.NewPedanticRegistry()
 		g, err := newStoreGateway(gatewayCfg, storageCfg, bucketClient, ringStore, overrides, log.NewNopLogger(), reg, nil)
 		require.NoError(t, err)
@@ -1450,8 +1446,7 @@ func TestStoreGateway_SeriesQueryingShouldEnforceMaxChunksPerQueryLimit(t *testi
 					// Customise the limits.
 					limits := defaultLimitsConfig()
 					limits.MaxChunksPerQuery = testData.limit
-					overrides, err := validation.NewOverrides(limits, nil)
-					require.NoError(t, err)
+					overrides := validation.NewOverrides(limits, nil)
 
 					// Create a store-gateway used to query back the series from the blocks.
 					gatewayCfg := mockGatewayConfig()
@@ -1688,11 +1683,8 @@ func defaultLimitsConfig() validation.Limits {
 	return limits
 }
 
-func defaultLimitsOverrides(t *testing.T) *validation.Overrides {
-	overrides, err := validation.NewOverrides(defaultLimitsConfig(), nil)
-	require.NoError(t, err)
-
-	return overrides
+func defaultLimitsOverrides(_ *testing.T) *validation.Overrides {
+	return validation.NewOverrides(defaultLimitsConfig(), nil)
 }
 
 type mockShardingStrategy struct {

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -234,8 +234,7 @@ func createIngesterQueryable(t testing.TB, address string) storage.Queryable {
 	limits := defaultLimitsTestConfig()
 	limits.NativeHistogramsIngestionEnabled = true
 
-	overrides, err := validation.NewOverrides(limits, nil)
-	require.NoError(t, err)
+	overrides := validation.NewOverrides(limits, nil)
 
 	d, err := distributor.New(distributorCfg, clientCfg, overrides, nil, nil, ingestersRing, nil, false, nil, logger)
 	require.NoError(t, err)

--- a/pkg/streamingpromql/benchmarks/ingester.go
+++ b/pkg/streamingpromql/benchmarks/ingester.go
@@ -66,10 +66,7 @@ func startBenchmarkIngester(rootDataDir string) (*ingester.Ingester, string, fun
 	limits := defaultLimitsTestConfig()
 	limits.NativeHistogramsIngestionEnabled = true
 
-	overrides, err := validation.NewOverrides(limits, nil)
-	if err != nil {
-		return nil, "", nil, err
-	}
+	overrides := validation.NewOverrides(limits, nil)
 
 	ingesterCfg, closer := defaultIngesterTestConfig()
 	cleanupFuncs = append(cleanupFuncs, closer.Close)

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -558,11 +558,11 @@ type Overrides struct {
 }
 
 // NewOverrides makes a new Overrides.
-func NewOverrides(defaults Limits, tenantLimits TenantLimits) (*Overrides, error) {
+func NewOverrides(defaults Limits, tenantLimits TenantLimits) *Overrides {
 	return &Overrides{
 		tenantLimits:  tenantLimits,
 		defaultLimits: &defaults,
-	}, nil
+	}
 }
 
 // RequestRate returns the limit on request rate (requests per second).

--- a/pkg/util/validation/limits_mock.go
+++ b/pkg/util/validation/limits_mock.go
@@ -33,13 +33,7 @@ func MockOverrides(customize func(defaults *Limits, tenantLimits map[string]*Lim
 	tenantLimits := map[string]*Limits{}
 	customize(defaults, tenantLimits)
 
-	overrides, err := NewOverrides(*defaults, NewMockTenantLimits(tenantLimits))
-	if err != nil {
-		// This function is expected to be used only in tests, so we're not afraid of panicking.
-		panic(err)
-	}
-
-	return overrides
+	return NewOverrides(*defaults, NewMockTenantLimits(tenantLimits))
 }
 
 func MockDefaultLimits() *Limits {
@@ -49,12 +43,5 @@ func MockDefaultLimits() *Limits {
 }
 
 func MockDefaultOverrides() *Overrides {
-	defaults := MockDefaultLimits()
-	overrides, err := NewOverrides(*defaults, nil)
-	if err != nil {
-		// This function is expected to be used only in tests, so we're not afraid of panicking.
-		panic(err)
-	}
-
-	return overrides
+	return NewOverrides(*MockDefaultLimits(), nil)
 }

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -38,8 +38,7 @@ func TestOverridesManager_GetOverrides(t *testing.T) {
 	defaults := Limits{
 		MaxLabelNamesPerSeries: 100,
 	}
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 
 	require.Equal(t, 100, ov.MaxLabelNamesPerSeries("user1"))
 	require.Equal(t, 0, ov.MaxLabelValueLength("user1"))
@@ -184,8 +183,7 @@ func TestSmallestPositiveIntPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueryParallelism: 0,
 	}
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 
 	for _, tc := range []struct {
 		tenantIDs []string
@@ -216,8 +214,7 @@ func TestSmallestPositiveNonZeroIntPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxQueriersPerTenant: 0,
 	}
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 
 	for _, tc := range []struct {
 		tenantIDs []string
@@ -248,8 +245,7 @@ func TestSmallestPositiveNonZeroDurationPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxPartialQueryLength: 0,
 	}
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 
 	for _, tc := range []struct {
 		tenantIDs []string
@@ -280,8 +276,7 @@ func TestLargestPositiveNonZeroDurationPerTenant(t *testing.T) {
 	defaults := Limits{
 		MaxPartialQueryLength: 0,
 	}
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 
 	for _, tc := range []struct {
 		tenantIDs []string
@@ -307,8 +302,7 @@ func TestMinDurationPerTenant(t *testing.T) {
 		"tenant-c": {ResultsCacheTTLForCardinalityQuery: model.Duration(time.Hour)},
 	}
 
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 
 	for _, tc := range []struct {
 		tenantIDs []string
@@ -335,8 +329,7 @@ func TestMaxTotalQueryLengthWithoutDefault(t *testing.T) {
 	}
 	defaults := Limits{}
 
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 
 	for _, tc := range []struct {
 		tenantIDs []string
@@ -360,8 +353,7 @@ func TestMaxTotalQueryLengthWithDefault(t *testing.T) {
 		MaxTotalQueryLength: model.Duration(3 * time.Hour),
 	}
 
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 
 	for _, tc := range []struct {
 		tenantIDs []string
@@ -385,8 +377,7 @@ func TestMaxPartialQueryLengthWithDefault(t *testing.T) {
 		MaxPartialQueryLength: model.Duration(6 * time.Hour),
 	}
 
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 
 	assert.Equal(t, 6*time.Hour, ov.MaxPartialQueryLength(""))
 	assert.Equal(t, 1*time.Hour, ov.MaxPartialQueryLength("tenant-a"))
@@ -401,8 +392,7 @@ func TestMaxPartialQueryLengthWithoutDefault(t *testing.T) {
 	}
 	defaults := Limits{}
 
-	ov, err := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
-	require.NoError(t, err)
+	ov := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
 
 	assert.Equal(t, time.Duration(0), ov.MaxPartialQueryLength(""))
 	assert.Equal(t, 3*time.Hour, ov.MaxPartialQueryLength("tenant-a"))
@@ -465,8 +455,7 @@ alertmanager_notification_rate_limit_per_integration:
 			err := yaml.Unmarshal([]byte(tc.inputYAML), &limitsYAML)
 			require.NoError(t, err, "expected to be able to unmarshal from YAML")
 
-			ov, err := NewOverrides(limitsYAML, nil)
-			require.NoError(t, err)
+			ov := NewOverrides(limitsYAML, nil)
 
 			require.Equal(t, tc.expectedRateLimit, ov.NotificationRateLimit("user", "email"))
 			require.Equal(t, tc.expectedBurstSize, ov.NotificationBurstSize("user", "email"))
@@ -612,8 +601,7 @@ testuser:
 
 			tl := NewMockTenantLimits(overrides)
 
-			ov, err := NewOverrides(limitsYAML, tl)
-			require.NoError(t, err)
+			ov := NewOverrides(limitsYAML, tl)
 
 			require.Equal(t, tc.expectedRateLimit, ov.NotificationRateLimit("testuser", tc.testedIntegration))
 			require.Equal(t, tc.expectedBurstSize, ov.NotificationBurstSize("testuser", tc.testedIntegration))
@@ -661,8 +649,7 @@ ruler_max_rules_per_rule_group_by_namespace:
 			limitsYAML := Limits{}
 			require.NoError(t, yaml.Unmarshal([]byte(tt.inputYAML), &limitsYAML))
 
-			ov, err := NewOverrides(limitsYAML, nil)
-			require.NoError(t, err)
+			ov := NewOverrides(limitsYAML, nil)
 
 			require.Equal(t, tt.expectedLimit, ov.RulerMaxRulesPerRuleGroup("user", tt.expectedNamespace))
 		})
@@ -777,8 +764,7 @@ differentuser:
 			require.NoError(t, err)
 
 			tl := NewMockTenantLimits(overrides)
-			ov, err := NewOverrides(limitsYAML, tl)
-			require.NoError(t, err)
+			ov := NewOverrides(limitsYAML, tl)
 
 			require.Equal(t, tt.expectedLimit, ov.RulerMaxRulesPerRuleGroup("testuser", tt.inputNamespace))
 		})
@@ -825,8 +811,7 @@ ruler_max_rule_groups_per_tenant_by_namespace:
 			limitsYAML := Limits{}
 			require.NoError(t, yaml.Unmarshal([]byte(tt.inputYAML), &limitsYAML))
 
-			ov, err := NewOverrides(limitsYAML, nil)
-			require.NoError(t, err)
+			ov := NewOverrides(limitsYAML, nil)
 
 			require.Equal(t, tt.expectedLimit, ov.RulerMaxRuleGroupsPerTenant("user", tt.expectedNamespace))
 		})
@@ -940,8 +925,7 @@ differentuser:
 			require.NoError(t, err)
 
 			tl := NewMockTenantLimits(overrides)
-			ov, err := NewOverrides(limitsYAML, tl)
-			require.NoError(t, err)
+			ov := NewOverrides(limitsYAML, tl)
 
 			require.Equal(t, tt.expectedLimit, ov.RulerMaxRuleGroupsPerTenant("testuser", tt.inputNamespace))
 		})
@@ -995,8 +979,7 @@ user1:
 			require.NoError(t, err)
 
 			tl := NewMockTenantLimits(overrides)
-			ov, err := NewOverrides(LimitsYAML, tl)
-			require.NoError(t, err)
+			ov := NewOverrides(LimitsYAML, tl)
 
 			require.Equal(t, tt.expectedNamespaces, ov.RulerProtectedNamespaces("user1"))
 		})
@@ -1050,8 +1033,7 @@ user1:
 			require.NoError(t, err)
 
 			tl := NewMockTenantLimits(overrides)
-			ov, err := NewOverrides(LimitsYAML, tl)
-			require.NoError(t, err)
+			ov := NewOverrides(LimitsYAML, tl)
 
 			require.Equal(t, tt.expectedPerTenantConcurrency, ov.RulerMaxIndependentRuleEvaluationConcurrencyPerTenant("user1"))
 		})
@@ -1115,8 +1097,7 @@ active_series_additional_custom_trackers:
 					}
 					require.NoError(t, yaml.Unmarshal([]byte(testData.cfg), &limitsYAML))
 
-					overrides, err := NewOverrides(limitsYAML, nil)
-					require.NoError(t, err)
+					overrides := NewOverrides(limitsYAML, nil)
 
 					// We expect the pointer holder to be always initialised, either when initializing default values
 					// or by the unmarshalling.
@@ -1150,8 +1131,7 @@ active_series_additional_custom_trackers:
 		limitsYAML := Limits{}
 		require.NoError(t, yaml.Unmarshal([]byte(cfg), &limitsYAML))
 
-		overrides, err := NewOverrides(limitsYAML, nil)
-		require.NoError(t, err)
+		overrides := NewOverrides(limitsYAML, nil)
 
 		start := make(chan struct{})
 		wg := sync.WaitGroup{}
@@ -1534,8 +1514,7 @@ alertmanager_max_grafana_state_size_bytes: "0"
 			err := yaml.Unmarshal([]byte(tc.inputYAML), &limitsYAML)
 			require.NoError(t, err, "expected to be able to unmarshal from YAML")
 
-			ov, err := NewOverrides(limitsYAML, nil)
-			require.NoError(t, err)
+			ov := NewOverrides(limitsYAML, nil)
 
 			require.Equal(t, tc.expectedConfigSize, ov.AlertmanagerMaxGrafanaConfigSize("user"))
 			require.Equal(t, tc.expectedStateSize, ov.AlertmanagerMaxGrafanaStateSize("user"))
@@ -1564,8 +1543,7 @@ user1:
 	err := yaml.Unmarshal([]byte(inputYAML), &overrides)
 	require.NoError(t, err)
 	tl := NewMockTenantLimits(overrides)
-	ov, err := NewOverrides(getDefaultLimits(), tl)
-	require.NoError(t, err)
+	ov := NewOverrides(getDefaultLimits(), tl)
 
 	blockedRequests := ov.BlockedRequests("user1")
 	require.Len(t, blockedRequests, 2)


### PR DESCRIPTION
#### What this PR does

This method always returns a nil error, so all the error handling is unnecessary.

I've been looking for a moment to do this for a while now, I guess it's now time, because its usage just becomes wider and wider.

#### Which issue(s) this PR fixes or relates to

None.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
