### PR TITLE
Cost attribution: remove `max_cost_attribution_labels_per_user` limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [ENHANCEMENT] Querier: Allow configuring all gRPC options for store-gateway client, similar to other gRPC clients. #11074
 * [ENHANCEMENT] Ruler: Log the number of series returned for each query as `result_series_count` as part of `query stats` log lines. #11081
 * [ENHANCEMENT] Ruler: Don't log statistics that are not available when using a remote query-frontend as part of `query stats` log lines. #11083
+* [ENHANCEMENT] Ingester: Remove cost-attribution experimental `max_cost_attribution_labels_per_user` limit. #11090
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4972,17 +4972,6 @@
         },
         {
           "kind": "field",
-          "name": "max_cost_attribution_labels_per_user",
-          "required": false,
-          "desc": "Maximum number of cost attribution labels allowed per user, the value is capped at 4.",
-          "fieldValue": null,
-          "fieldDefaultValue": 2,
-          "fieldFlag": "validation.max-cost-attribution-labels-per-user",
-          "fieldType": "int",
-          "fieldCategory": "experimental"
-        },
-        {
-          "kind": "field",
           "name": "max_cost_attribution_cardinality_per_user",
           "required": false,
           "desc": "Maximum cardinality of cost attribution labels allowed per user.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3465,8 +3465,6 @@ Usage of ./cmd/mimir/mimir:
     	Enforce every metadata has a metric name. (default true)
   -validation.max-cost-attribution-cardinality-per-user int
     	[experimental] Maximum cardinality of cost attribution labels allowed per user. (default 10000)
-  -validation.max-cost-attribution-labels-per-user int
-    	[experimental] Maximum number of cost attribution labels allowed per user, the value is capped at 4. (default 2)
   -validation.max-label-names-per-info-series int
     	Maximum number of label names per info series. Has no effect if less than the value of the maximum number of label names per series option (-validation.max-label-names-per-series) (default 80)
   -validation.max-label-names-per-series int

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -49,8 +49,7 @@ The following features are currently experimental:
 - Cost attribution
   - Configure labels for cost attribution
     - `-validation.cost-attribution-labels`
-  - Configure cost attribution limits, such as label cardinality and the maximum number of cost attribution labels
-    - `-validation.max-cost-attribution-labels-per-user`
+  - Configure cost attribution limits, such as cardinality:
     - `-validation.max-cost-attribution-cardinality-per-user`
   - Configure cooldown periods and eviction intervals for cost attribution
     - `-validation.cost-attribution-cooldown`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3724,11 +3724,6 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -validation.cost-attribution-labels
 [cost_attribution_labels: <string> | default = ""]
 
-# (experimental) Maximum number of cost attribution labels allowed per user, the
-# value is capped at 4.
-# CLI flag: -validation.max-cost-attribution-labels-per-user
-[max_cost_attribution_labels_per_user: <int> | default = 2]
-
 # (experimental) Maximum cardinality of cost attribution labels allowed per
 # user.
 # CLI flag: -validation.max-cost-attribution-cardinality-per-user

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -65,7 +65,6 @@ const (
 	AlertmanagerMaxGrafanaConfigSizeFlag      = "alertmanager.max-grafana-config-size-bytes"
 	AlertmanagerMaxGrafanaStateSizeFlag       = "alertmanager.max-grafana-state-size-bytes"
 	costAttributionLabelsFlag                 = "validation.cost-attribution-labels"
-	maxCostAttributionLabelsPerUserFlag       = "validation.max-cost-attribution-labels-per-user"
 
 	// MinCompactorPartialBlockDeletionDelay is the minimum partial blocks deletion delay that can be configured in Mimir.
 	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour
@@ -74,8 +73,6 @@ const (
 var (
 	errInvalidIngestStorageReadConsistency         = fmt.Errorf("invalid ingest storage read consistency (supported values: %s)", strings.Join(api.ReadConsistencies, ", "))
 	errInvalidMaxEstimatedChunksPerQueryMultiplier = errors.New("invalid value for -" + MaxEstimatedChunksPerQueryMultiplierFlag + ": must be 0 or greater than or equal to 1")
-	errCostAttributionLabelsLimitExceeded          = errors.New("invalid value for -" + costAttributionLabelsFlag + ": exceeds the limit defined by -" + maxCostAttributionLabelsPerUserFlag)
-	errInvalidMaxCostAttributionLabelsPerUser      = errors.New("invalid value for -" + maxCostAttributionLabelsPerUserFlag + ": must be less than or equal to 4")
 )
 
 // LimitError is a marker interface for the errors that do not comply with the specified limits.
@@ -201,7 +198,6 @@ type Limits struct {
 
 	// Cost attribution and limit.
 	CostAttributionLabels                flagext.StringSliceCSV `yaml:"cost_attribution_labels" json:"cost_attribution_labels" category:"experimental"`
-	MaxCostAttributionLabelsPerUser      int                    `yaml:"max_cost_attribution_labels_per_user" json:"max_cost_attribution_labels_per_user" category:"experimental"`
 	MaxCostAttributionCardinalityPerUser int                    `yaml:"max_cost_attribution_cardinality_per_user" json:"max_cost_attribution_cardinality_per_user" category:"experimental"`
 	CostAttributionCooldown              model.Duration         `yaml:"cost_attribution_cooldown" json:"cost_attribution_cooldown" category:"experimental"`
 
@@ -323,7 +319,6 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&l.SeparateMetricsGroupLabel, "validation.separate-metrics-group-label", "", "Label used to define the group label for metrics separation. For each write request, the group is obtained from the first non-empty group label from the first timeseries in the incoming list of timeseries. Specific distributor and ingester metrics will be further separated adding a 'group' label with group label's value. Currently applies to the following metrics: cortex_discarded_samples_total")
 
 	f.Var(&l.CostAttributionLabels, costAttributionLabelsFlag, "Defines labels for cost attribution. Applies to metrics like cortex_distributor_received_attributed_samples_total. To disable, set to an empty string. For example, 'team,service' produces metrics such as cortex_distributor_received_attributed_samples_total{team='frontend', service='api'}.")
-	f.IntVar(&l.MaxCostAttributionLabelsPerUser, maxCostAttributionLabelsPerUserFlag, 2, "Maximum number of cost attribution labels allowed per user, the value is capped at 4.")
 	f.IntVar(&l.MaxCostAttributionCardinalityPerUser, "validation.max-cost-attribution-cardinality-per-user", 10000, "Maximum cardinality of cost attribution labels allowed per user.")
 	f.Var(&l.CostAttributionCooldown, "validation.cost-attribution-cooldown", "Defines how long cost attribution stays in overflow before attempting a reset, with received/discarded samples extending the cooldown if overflow persists, while active series reset and restart tracking after the cooldown.")
 	f.IntVar(&l.MaxChunksPerQuery, MaxChunksPerQueryFlag, 2e6, "Maximum number of chunks that can be fetched in a single query from ingesters and store-gateways. This limit is enforced in the querier, ruler and store-gateway. 0 to disable.")
@@ -515,14 +510,6 @@ func (l *Limits) validate() error {
 
 	if !util.StringsContain(api.ReadConsistencies, l.IngestStorageReadConsistency) {
 		return errInvalidIngestStorageReadConsistency
-	}
-
-	if len(l.CostAttributionLabels) > l.MaxCostAttributionLabelsPerUser {
-		return errCostAttributionLabelsLimitExceeded
-	}
-
-	if l.MaxCostAttributionLabelsPerUser > 4 {
-		return errInvalidMaxCostAttributionLabelsPerUser
 	}
 
 	return nil
@@ -884,10 +871,6 @@ func (o *Overrides) SeparateMetricsGroupLabel(userID string) string {
 
 func (o *Overrides) CostAttributionLabels(userID string) []string {
 	return o.getOverridesForUser(userID).CostAttributionLabels
-}
-
-func (o *Overrides) MaxCostAttributionLabelsPerUser(userID string) int {
-	return o.getOverridesForUser(userID).MaxCostAttributionLabelsPerUser
 }
 
 func (o *Overrides) CostAttributionCooldown(userID string) time.Duration {

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -1188,18 +1188,6 @@ metric_relabel_configs:
 			cfg:         `ingest_storage_read_consistency: xyz`,
 			expectedErr: errInvalidIngestStorageReadConsistency.Error(),
 		},
-		"should fail when cost_attribution_labels exceed max_cost_attribution_labels_per_user": {
-			cfg: `
-cost_attribution_labels: label1, label2, label3,
-max_cost_attribution_labels_per_user: 2`,
-			expectedErr: errCostAttributionLabelsLimitExceeded.Error(),
-		},
-		"should fail when max_cost_attribution_labels_per_user is more than 4": {
-			cfg: `
-cost_attribution_labels: label1, label2,
-max_cost_attribution_labels_per_user: 5`,
-			expectedErr: errInvalidMaxCostAttributionLabelsPerUser.Error(),
-		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION
#### What this PR does

There were two limits for cost attribution labels:
- One configurable per tenant which we added because at some point tenants would self-serve this configuration (I insisted), but it doesn't really make sense to have it _here_, because it's too late in the pipeline. If there's a component rendering the runtime self-served configurations, it should enforce the labels amount there. Checking it here just makes the overrides loading fail.
- The other one, hard limit of 4 labels, was enforced by some technical detail we had in the first implementation (somewhere we had an array and we had to have an upper bound on it?), but it doesn't exist anymore, so we can remove it.

#### Which issue(s) this PR fixes or relates to

Follow up on https://github.com/grafana/mimir/pull/10269

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
