### PR TITLE
[mimir-distributed-release-5.7] Update mimir version to 2.16.0

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,7 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-## 5.7.0-rc.0
+## 5.7.0-rc.1
 
 * [CHANGE] Tokengen: Added k8s secret storage for the admin token. #5237
 * [CHANGE] Memcached: Update to Memcached 1.6.34. #10318

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 5.7.0-rc.0
-appVersion: 2.16.0-rc.0
+version: 5.7.0-rc.1
+appVersion: 2.16.0
 description: "Grafana Mimir"
 home: https://grafana.com/docs/helm-charts/mimir-distributed/latest/
 icon: https://grafana.com/static/img/logos/logo-mimir.svg

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/latest/)
 
 For the full documentation, visit [Grafana mimir-distributed Helm chart documentation](https://grafana.com/docs/helm-charts/mimir-distributed/latest/).
 
-> **Note:** The documentation version is derived from the Helm chart version which is 5.7.0-rc.0.
+> **Note:** The documentation version is derived from the Helm chart version which is 5.7.0-rc.1.
 
 When upgrading from Helm chart version 4.X, please see [Migrate the Helm chart from version 4.x to 5.0](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-helm-chart-4.x-to-5.0/).
 When upgrading from Helm chart version 3.x, please see [Migrate from single zone to zone-aware replication with Helm](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-from-single-zone-with-helm/).
@@ -14,7 +14,7 @@ When upgrading from Helm chart version 2.1, please see [Upgrade the Grafana Mimi
 
 # mimir-distributed
 
-![Version: 5.7.0-rc.0](https://img.shields.io/badge/Version-5.7.0--rc.0-informational?style=flat-square) ![AppVersion: 2.16.0-rc.0](https://img.shields.io/badge/AppVersion-2.16.0--rc.0-informational?style=flat-square)
+![Version: 5.7.0-rc.1](https://img.shields.io/badge/Version-5.7.0--rc.1-informational?style=flat-square) ![AppVersion: 2.16.0](https://img.shields.io/badge/AppVersion-2.16.0-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -34,7 +34,7 @@ image:
   # -- Grafana Mimir container image repository. Note: for Grafana Enterprise Metrics use the value 'enterprise.image.repository'
   repository: grafana/mimir
   # -- Grafana Mimir container image tag. Note: for Grafana Enterprise Metrics use the value 'enterprise.image.tag'
-  tag: 2.16.0-rc.0
+  tag: 2.16.0
   # -- Container pull policy - shared between Grafana Mimir and Grafana Enterprise Metrics
   pullPolicy: IfNotPresent
   # -- Optionally specify an array of imagePullSecrets - shared between Grafana Mimir and Grafana Enterprise Metrics
@@ -573,7 +573,7 @@ alertmanager:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   statefulSet:
     enabled: true
@@ -851,7 +851,7 @@ distributor:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   # Setting it to null will produce a deployment without replicas set, allowing you to use autoscaling with the deployment
   replicas: 1
@@ -971,7 +971,7 @@ ingester:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   # -- Total number of replicas for the ingester across all availability zones
   # If ingester.zoneAwareReplication.enabled=false, this number is taken as is.
@@ -1208,7 +1208,7 @@ overrides_exporter:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   replicas: 1
 
@@ -1305,7 +1305,7 @@ ruler:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   replicas: 1
 
@@ -1434,7 +1434,7 @@ ruler_querier:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   replicas: 2
 
@@ -1559,7 +1559,7 @@ ruler_query_frontend:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   # Setting it to null will produce a deployment without replicas set, allowing you to use autoscaling with the deployment
   replicas: 1
@@ -1676,7 +1676,7 @@ ruler_query_scheduler:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   replicas: 2
 
@@ -1772,7 +1772,7 @@ querier:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   replicas: 2
 
@@ -1910,7 +1910,7 @@ query_frontend:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   # Setting it to null will produce a deployment without replicas set, allowing you to use autoscaling with the deployment
   replicas: 1
@@ -2028,7 +2028,7 @@ query_scheduler:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   replicas: 2
 
@@ -2124,7 +2124,7 @@ store_gateway:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   # -- Total number of replicas for the store-gateway across all availability zones
   # If store_gateway.zoneAwareReplication.enabled=false, this number is taken as is.
@@ -2352,7 +2352,7 @@ compactor:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   replicas: 1
 
@@ -3400,7 +3400,7 @@ gateway:
   # Only applies to the GEM gateway. Use gateway.nginx.image for the nginx gateway.
   image:
     # repository: grafana/mimir-enterprise
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   # -- Number of replicas for the Deployment
   replicas: 1
@@ -4208,7 +4208,7 @@ admin_api:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/enterprise-metrics
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   replicas: 1
 
@@ -4696,7 +4696,7 @@ federation_frontend:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
 
   # -- Specifies whether other components should be deployed. This is an easy way to deploy the resources necessary for a standalone
   # federation-frontend without the rest of the GEM components.
@@ -4797,7 +4797,7 @@ smoke_test:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir
-    # tag: 2.15.0
+    # tag: 2.16.0
   # -- Controls the backoffLimit on the Kubernetes Job. The Job is marked as failed after that many retries.
   backoffLimit: 5
   # The image section has been removed as continuous test is now a module of the regular Mimir image.
@@ -4821,7 +4821,7 @@ continuous_test:
   # When set it takes precedence over what is defined in global "image" or "enterprise.image" sections.
   image:
     # repository: grafana/mimir-continuous-test
-    # tag: 2.15.0
+    # tag: 2.16.0
   # -- Number of replicas to start of continuous test
   replicas: 1
   # The image section has been removed as continuous test is now a module of the regular Mimir image.


### PR DESCRIPTION
Bump chart version to rc.1 and include Mimir 2.16.0 final.

Part of https://github.com/grafana/mimir/issues/10917
