### PR TITLE
block-builder: implement Is on errFirstRecordInFuture

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -487,6 +487,11 @@ func (e errFirstRecordInFuture) Error() string {
 	return fmt.Sprintf("first record in the partition has a timestamp greater than the section end time: %s", e.recordTs.UTC().String())
 }
 
+func (e errFirstRecordInFuture) Is(err error) bool {
+	_, ok := err.(*errFirstRecordInFuture)
+	return ok
+}
+
 func (b *BlockBuilder) consumePartitionSection(
 	ctx context.Context,
 	logger log.Logger,

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -39,6 +39,9 @@ func TestErrFirstRecordInFuture(t *testing.T) {
 	var err error
 	err = &errFirstRecordInFuture{recordTs: time.Now()}
 	assert.True(t, errors.Is(err, &errFirstRecordInFuture{}))
+
+	firstRecErr := &errFirstRecordInFuture{}
+	assert.True(t, errors.As(err, &firstRecErr))
 }
 
 func TestBlockBuilder_WipeOutDataDirOnStart(t *testing.T) {

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -36,8 +36,7 @@ import (
 )
 
 func TestErrFirstRecordInFuture(t *testing.T) {
-	var err error
-	err = &errFirstRecordInFuture{recordTs: time.Now()}
+	var err error = &errFirstRecordInFuture{recordTs: time.Now()}
 	assert.True(t, errors.Is(err, &errFirstRecordInFuture{}))
 
 	firstRecErr := &errFirstRecordInFuture{}

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -1074,11 +1074,11 @@ func TestFastCatchupOnIdlePartition(t *testing.T) {
 	require.NoError(t, err)
 
 	// The above cycle should try one consumption for the old commit point, then shortcut
-	// to the last 2h records. So we should not have more than 3-4 consumption attempts.
+	// to the last 2h records. So we should not have more than 4-5 consumption attempts.
 	// Without the shortcut in place, it will run consumption 48-49 times, one for each hour.
 	consumptionAttempts := getSampleCountFromHistogramVector(t, bb.blockBuilderMetrics.processPartitionDuration)
-	require.GreaterOrEqual(t, consumptionAttempts, 3)
-	require.LessOrEqual(t, consumptionAttempts, 4)
+	require.GreaterOrEqual(t, consumptionAttempts, 4)
+	require.LessOrEqual(t, consumptionAttempts, 5)
 
 	compareQueryWithDir(t,
 		path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, "1"),

--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -35,6 +35,12 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
+func TestErrFirstRecordInFuture(t *testing.T) {
+	var err error
+	err = &errFirstRecordInFuture{recordTs: time.Now()}
+	assert.True(t, errors.Is(err, &errFirstRecordInFuture{}))
+}
+
 func TestBlockBuilder_WipeOutDataDirOnStart(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
without this we were getting misleading error logs here

https://github.com/grafana/mimir/blob/961ad26da672ba89af27cd0d38190be9f807e73f/pkg/blockbuilder/blockbuilder.go#L520-L523

