### PR TITLE
Upgrade golangci-lint to v2.0.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,105 +1,98 @@
-output:
-  formats:
-    - format: line-number
-
-linters:
-  enable:
-    - errorlint
-    - forbidigo
-    - gci
-    - gocritic
-    - gofmt
-    - gosec
-    - loggercheck
-    - misspell
-    - revive
-
-linters-settings:
-  errcheck:
-    # path to a file containing a list of functions to exclude from checking
-    # see https://github.com/kisielk/errcheck#excluding-functions for details
-    exclude-functions:
-      - (*github.com/grafana/dskit/spanlogger.SpanLogger).Error
-      - (github.com/go-kit/kit/log.Logger).Log
-      - (github.com/go-kit/log.Logger).Log
-      - (github.com/mitchellh/colorstring).Println
-      - (github.com/opentracing/opentracing-go.Tracer).Inject
-      - io.Copy
-      - io/ioutil.ReadFile
-      - io/ioutil.WriteFile
-
-  gci:
-    # Section configuration to compare against.
-    # Section names are case-insensitive and may contain parameters in ().
-    # The default order of sections is `standard > default > custom > blank > dot`,
-    # If `custom-order` is `true`, it follows the order of `sections` option.
-    # Default: ["standard", "default"]
-    sections:
-      - standard
-      - default
-      - prefix(github.com/grafana/mimir)
-
-    # Skip generated files.
-    # Default: true
-    skip-generated: true
-    # Enable custom order of sections.
-    # If `true`, make the section order the same as the order of `sections`.
-    # Default: false
-    custom-order: true
-
-  errorlint:
-    # Check for plain error comparisons.
-    comparison: true
-
-    # Do not check for plain type assertions and type switches.
-    asserts: false
-
-    # Do not check whether fmt.Errorf uses the %w verb for formatting errors.
-    errorf: false
-
-  forbidigo:
-    forbid:
-      # We can't use faillint for a rule like this, because it does not support matching methods on structs or interfaces (see https://github.com/fatih/faillint/issues/18)
-      - p: ^.*\.CloseSend.*$
-        msg: Do not use CloseSend on a server-streaming gRPC stream. Use util.CloseAndExhaust instead. See the documentation on CloseAndExhaust for further explanation.
-
-  gosec:
-    includes:
-      - G103
-      - G104
-      - G108
-      - G109
-      - G112
-      - G114
-      - G302
-      - G401
-
-    excludes:
-      - G301 # Relies on system umask to restrict directory permissions, preserving operator flexibility
-      - G306 # Uses system umask to restrict file permissions instead of hardcoding values.
-
-  gocritic:
-    disable-all: true
-    enabled-checks:
-      # See https://golangci-lint.run/usage/linters/#gocritic for possible checks.
-      - dupImport
-
-  revive:
-    rules:
-      - name: redefines-builtin-id
-        disabled: true
-
+version: "2"
 run:
   timeout: 10m
-
   # List of build tags, all linters use it.
   build-tags:
     - netgo
     - stringlabels
     - requires_docker
     - requires_libpcap
-
-issues:
-  exclude-rules:
-    - linters: [ revive ]
-      text: "if-return"
+output:
+  formats:
+    text:
+      path: stdout
+      colors: false
+linters:
+  enable:
+    - errorlint
+    - forbidigo
+    - gocritic
+    - gosec
+    - loggercheck
+    - misspell
+    - revive
+  settings:
+    # path to a file containing a list of functions to exclude from checking
+    # see https://github.com/kisielk/errcheck#excluding-functions for details
+    errcheck:
+      exclude-functions:
+        - (*github.com/grafana/dskit/spanlogger.SpanLogger).Error
+        - (github.com/go-kit/kit/log.Logger).Log
+        - (github.com/go-kit/log.Logger).Log
+        - (github.com/mitchellh/colorstring).Println
+        - (github.com/opentracing/opentracing-go.Tracer).Inject
+        - io.Copy
+        - io/ioutil.ReadFile
+        - io/ioutil.WriteFile
+    errorlint:
+      # Do not check whether fmt.Errorf uses the %w verb for formatting errors.
+      errorf: false
+      # Do not check for plain type assertions and type switches.
+      asserts: false
+      # Check for plain error comparisons.
+      comparison: true
+    forbidigo:
+      # We can't use faillint for a rule like this, because it does not support matching methods on structs or interfaces (see https://github.com/fatih/faillint/issues/18)
+      forbid:
+        - pattern: ^.*\.CloseSend.*$
+          msg: Do not use CloseSend on a server-streaming gRPC stream. Use util.CloseAndExhaust instead. See the documentation on CloseAndExhaust for further explanation.
+    gocritic:
+      disable-all: true
+      enabled-checks:
+        # See https://golangci-lint.run/usage/linters/#gocritic for possible checks.
+        - dupImport
+    gosec:
+      includes:
+        - G103
+        - G104
+        - G108
+        - G109
+        - G112
+        - G114
+        - G302
+        - G401
+      excludes:
+        # Relies on system umask to restrict directory permissions, preserving operator flexibility
+        - G301
+        # Uses system umask to restrict file permissions instead of hardcoding values.
+        - G306
+    revive:
+      rules:
+        - name: redefines-builtin-id
+          disabled: true
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - revive
+        text: if-return
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      custom-order: true
+      # Section configuration to compare against.
+      # Section names are case-insensitive and may contain parameters in ().
+      # The default order of sections is `standard > default > custom > blank > dot`,
+      # If `custom-order` is `true`, it follows the order of `sections` option.
+      # Default: ["standard", "default"]
+      sections:
+        - standard
+        - default
+        - prefix(github.com/grafana/mimir)

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr11049-1a6c186ce8
+LATEST_BUILD_IMAGE_TAG ?= pr11104-c5d9f5a7de
 
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden

--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -321,7 +321,7 @@ func expandEnvironmentVariables(config []byte) []byte {
 		}
 
 		if strings.Contains(v, "\n") {
-			return strings.Replace(v, "\n", "", -1)
+			return strings.ReplaceAll(v, "\n", "")
 		}
 
 		return v

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -39,7 +39,7 @@ RUN GOARCH=$(go env GOARCH) && \
     curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
     chmod a+x /usr/bin/tk
 
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v1.64.8
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v2.0.2
 
 ENV SKOPEO_VERSION=v1.15.1
 RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \

--- a/pkg/alertmanager/alertstore/config.go
+++ b/pkg/alertmanager/alertstore/config.go
@@ -22,7 +22,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	prefix := "alertmanager-storage."
 
-	cfg.StorageBackendConfig.ExtraBackends = []string{local.Name}
+	cfg.ExtraBackends = []string{local.Name}
 	cfg.Local.RegisterFlagsWithPrefix(prefix, f)
 	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "alertmanager", f)
 }

--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -36,7 +36,7 @@ func (am *MultitenantAlertmanager) createUsableGrafanaConfig(gCfg alertspb.Grafa
 		if err != nil {
 			return amConfig{}, fmt.Errorf("failed to unmarshal Mimir Alertmanager configuration: %w", err)
 		}
-		amCfg.AlertmanagerConfig.Config.Global = cfg.Config.Global
+		amCfg.AlertmanagerConfig.Global = cfg.Global
 	}
 
 	// Check for duplicate receiver names.

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -98,7 +98,7 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 				var gCfg GrafanaAlertmanagerConfig
 				require.NoError(t, json.Unmarshal([]byte(test.grafanaConfig.RawConfig), &gCfg))
 
-				gCfg.AlertmanagerConfig.Global = mCfg.Config.Global
+				gCfg.AlertmanagerConfig.Global = mCfg.Global
 				b, err := json.Marshal(gCfg.AlertmanagerConfig)
 				require.NoError(t, err)
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -890,10 +890,8 @@ receivers:
 				// Ensure the server endpoint has not been called if firewall is enabled. Since the alert is delivered
 				// asynchronously, we should pool it for a short period.
 				deadline := time.Now().Add(3 * time.Second)
-				for {
-					if time.Now().After(deadline) || serverInvoked.Load() {
-						break
-					}
+				for !time.Now().After(deadline) && !serverInvoked.Load() {
+
 					time.Sleep(100 * time.Millisecond)
 				}
 

--- a/pkg/alertmanager/state_persister_test.go
+++ b/pkg/alertmanager/state_persister_test.go
@@ -110,7 +110,7 @@ func TestStatePersister_Position0ShouldWrite(t *testing.T) {
 	{
 		time.Sleep(5 * time.Second)
 
-		assert.Equal(t, services.Starting, s.Service.State())
+		assert.Equal(t, services.Starting, s.State())
 		assert.Equal(t, 0, len(store.getWrites()))
 	}
 
@@ -144,13 +144,13 @@ func TestStatePersister_Position1ShouldNotWrite(t *testing.T) {
 
 	// Start the persister.
 	{
-		require.Equal(t, services.Starting, s.Service.State())
+		require.Equal(t, services.Starting, s.State())
 
 		state.getResult = makeTestFullState()
 		close(state.readyc)
 
 		require.NoError(t, s.AwaitRunning(context.Background()))
-		require.Equal(t, services.Running, s.Service.State())
+		require.Equal(t, services.Running, s.State())
 	}
 
 	// Should not have stored anything, having passed the interval multiple times.

--- a/pkg/alertmanager/state_replication.go
+++ b/pkg/alertmanager/state_replication.go
@@ -255,11 +255,11 @@ func (s *state) starting(ctx context.Context) error {
 
 // WaitReady is needed for the pipeline builder to know whenever we've settled and the state is up to date.
 func (s *state) WaitReady(ctx context.Context) error {
-	return s.Service.AwaitRunning(ctx)
+	return s.AwaitRunning(ctx)
 }
 
 func (s *state) Ready() bool {
-	return s.Service.State() == services.Running
+	return s.State() == services.Running
 }
 
 func (s *state) MergeGrafanaState(fs []*clusterpb.FullState) error {

--- a/pkg/api/error/error_test.go
+++ b/pkg/api/error/error_test.go
@@ -19,11 +19,12 @@ func TestAllPrometheusErrorTypeValues(t *testing.T) {
 		errorType := Type(prometheusErrorTypeString)
 		apiError := New(errorType, "")
 
-		if errorType == TypeUnavailable {
+		switch errorType {
+		case TypeUnavailable:
 			require.Equal(t, http.StatusServiceUnavailable, apiError.StatusCode())
-		} else if errorType == TypeInternal || errorType == TypeNone {
+		case TypeInternal, TypeNone:
 			require.Equal(t, http.StatusInternalServerError, apiError.StatusCode())
-		} else {
+		default:
 			// If this assertion fails, it probably means a new error type has been added to Prometheus' API.
 			require.NotEqual(t, http.StatusInternalServerError, apiError.StatusCode(), "unrecognised Prometheus error type constant '%s'", prometheusErrorTypeString)
 		}

--- a/pkg/blockbuilder/config_test.go
+++ b/pkg/blockbuilder/config_test.go
@@ -97,7 +97,7 @@ func blockBuilderConfig(t *testing.T, addr string) (Config, *validation.Override
 
 	// Block storage related options.
 	flagext.DefaultValues(&cfg.BlocksStorage)
-	cfg.BlocksStorage.Bucket.StorageBackendConfig.Backend = bucket.Filesystem
+	cfg.BlocksStorage.Bucket.Backend = bucket.Filesystem
 	cfg.BlocksStorage.Bucket.Filesystem.Directory = t.TempDir()
 
 	limits := defaultLimitsTestConfig()

--- a/pkg/compactor/job_sorting.go
+++ b/pkg/compactor/job_sorting.go
@@ -44,11 +44,8 @@ func sortJobsBySmallestRangeOldestBlocksFirst(jobs []*Job) []*Job {
 			return false
 		}
 
-		checkLength := true
+		checkLength := !(jobs[i].UseSplitting() && jobs[j].UseSplitting())
 		// Don't check length for splitting jobs. We want to the oldest split blocks to be first, no matter the length.
-		if jobs[i].UseSplitting() && jobs[j].UseSplitting() {
-			checkLength = false
-		}
 
 		if checkLength {
 			iLength := jobs[i].MaxTime() - jobs[i].MinTime()

--- a/pkg/compactor/job_sorting.go
+++ b/pkg/compactor/job_sorting.go
@@ -44,7 +44,7 @@ func sortJobsBySmallestRangeOldestBlocksFirst(jobs []*Job) []*Job {
 			return false
 		}
 
-		checkLength := !(jobs[i].UseSplitting() && jobs[j].UseSplitting())
+		checkLength := !jobs[i].UseSplitting() || !jobs[j].UseSplitting()
 		// Don't check length for splitting jobs. We want to the oldest split blocks to be first, no matter the length.
 
 		if checkLength {

--- a/pkg/compactor/split_merge_grouper.go
+++ b/pkg/compactor/split_merge_grouper.go
@@ -349,8 +349,8 @@ func getRangeStart(m *block.Meta, tr int64) int64 {
 
 func sortMetasByMinTime(metas []*block.Meta) []*block.Meta {
 	sort.Slice(metas, func(i, j int) bool {
-		if metas[i].BlockMeta.MinTime != metas[j].BlockMeta.MinTime {
-			return metas[i].BlockMeta.MinTime < metas[j].BlockMeta.MinTime
+		if metas[i].MinTime != metas[j].MinTime {
+			return metas[i].MinTime < metas[j].MinTime
 		}
 
 		// Compare labels in case of same MinTime to get stable results.

--- a/pkg/compactor/split_merge_job.go
+++ b/pkg/compactor/split_merge_job.go
@@ -56,12 +56,12 @@ func (j *job) conflicts(other *job) bool {
 	// are never merged together, so they can't conflict. Since all blocks within the same job are expected to have the same
 	// downsample resolution and external labels, we just check the 1st block of each job.
 	if len(j.blocks) > 0 && len(other.blocks) > 0 {
-		myLabels := labelsWithoutShard(j.blocksGroup.blocks[0].Thanos.Labels)
-		otherLabels := labelsWithoutShard(other.blocksGroup.blocks[0].Thanos.Labels)
+		myLabels := labelsWithoutShard(j.blocks[0].Thanos.Labels)
+		otherLabels := labelsWithoutShard(other.blocks[0].Thanos.Labels)
 		if !labels.Equal(myLabels, otherLabels) {
 			return false
 		}
-		if j.blocksGroup.blocks[0].Thanos.Downsample != other.blocksGroup.blocks[0].Thanos.Downsample {
+		if j.blocks[0].Thanos.Downsample != other.blocks[0].Thanos.Downsample {
 			return false
 		}
 	}

--- a/pkg/costattribution/sample_tracker.go
+++ b/pkg/costattribution/sample_tracker.go
@@ -145,7 +145,7 @@ func (st *SampleTracker) IncrementReceivedSamples(req *mimirpb.WriteRequest, now
 	defer bufferPool.Put(buf)
 	for _, ts := range req.Timeseries {
 		st.fillKeyFromLabelAdapters(ts.Labels, buf)
-		dict[string(buf.Bytes())] += len(ts.TimeSeries.Samples) + len(ts.TimeSeries.Histograms)
+		dict[string(buf.Bytes())] += len(ts.Samples) + len(ts.Histograms)
 	}
 
 	// Update the observations for each label set and update the state per request,

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1879,8 +1879,8 @@ func tokenForMetadata(userID string, metricName string) uint32 {
 func (d *Distributor) updateReceivedMetrics(req *mimirpb.WriteRequest, userID string) {
 	var receivedSamples, receivedExemplars, receivedMetadata int
 	for _, ts := range req.Timeseries {
-		receivedSamples += len(ts.TimeSeries.Samples) + len(ts.TimeSeries.Histograms)
-		receivedExemplars += len(ts.TimeSeries.Exemplars)
+		receivedSamples += len(ts.Samples) + len(ts.Histograms)
+		receivedExemplars += len(ts.Exemplars)
 	}
 	d.costAttributionMgr.SampleTracker(userID).IncrementReceivedSamples(req, mtime.Now())
 	receivedMetadata = len(req.Metadata)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -7780,14 +7780,15 @@ func TestDistributor_MetricsWithRequestModifications(t *testing.T) {
 		dist, reg := getDistributor(cfg)
 
 		metaDataGen := func(metricIdx int, metricName string) *mimirpb.MetricMetadata {
-			if metricIdx%3 == 0 {
+			switch metricIdx % 3 {
+			case 0:
 				return &mimirpb.MetricMetadata{
 					Type:             mimirpb.COUNTER,
 					MetricFamilyName: metricName,
 					Help:             strings.Repeat("a", metadataLengthLimit+1),
 					Unit:             "unknown",
 				}
-			} else if metricIdx%3 == 1 {
+			case 1:
 				return &mimirpb.MetricMetadata{
 					Type:             mimirpb.COUNTER,
 					MetricFamilyName: strings.Repeat("a", metadataLengthLimit+1),

--- a/pkg/distributor/influx.go
+++ b/pkg/distributor/influx.go
@@ -30,7 +30,7 @@ import (
 
 func influxRequestParser(ctx context.Context, r *http.Request, maxSize int, _ *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, logger log.Logger) (int, error) {
 	spanLogger, ctx := spanlogger.NewWithLogger(ctx, logger, "Distributor.InfluxHandler.decodeAndConvert")
-	defer spanLogger.Span.Finish()
+	defer spanLogger.Finish()
 
 	spanLogger.SetTag("content_type", r.Header.Get("Content-Type"))
 	spanLogger.SetTag("content_encoding", r.Header.Get("Content-Encoding"))

--- a/pkg/distributor/influxpush/parser.go
+++ b/pkg/distributor/influxpush/parser.go
@@ -157,6 +157,7 @@ func influxPointToTimeseries(pt models.Point, returnTs []mimirpb.PreallocTimeser
 // This function may modify the input slice.
 func replaceInvalidChars(bSlice []byte) []byte {
 	for bIndex, b := range bSlice {
+		//nolint:staticcheck
 		if !((b >= 'a' && b <= 'z') || // a-z
 			(b >= 'A' && b <= 'Z') || // A-Z
 			(b >= '0' && b <= '9') || // 0-9

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -249,7 +249,7 @@ func newOTLPParser(
 		}
 
 		spanLogger, ctx := spanlogger.NewWithLogger(ctx, logger, "Distributor.OTLPHandler.decodeAndConvert")
-		defer spanLogger.Span.Finish()
+		defer spanLogger.Finish()
 
 		spanLogger.SetTag("content_type", contentType)
 		spanLogger.SetTag("content_encoding", contentEncoding)

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -218,7 +218,7 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSets [
 	queryIngester := func(ctx context.Context, ing *ring.InstanceDesc, cancelContext context.CancelCauseFunc) (ingesterQueryResult, error) {
 		log, ctx := spanlogger.NewWithLogger(ctx, d.log, "Distributor.queryIngesterStream")
 		cleanup := func() {
-			log.Span.Finish()
+			log.Finish()
 			cancelContext(errStreamClosed)
 		}
 
@@ -236,8 +236,8 @@ func (d *Distributor) queryIngesterStream(ctx context.Context, replicationSets [
 			}
 		}()
 
-		log.Span.SetTag("ingester_address", ing.Addr)
-		log.Span.SetTag("ingester_zone", ing.Zone)
+		log.SetTag("ingester_address", ing.Addr)
+		log.SetTag("ingester_zone", ing.Zone)
 
 		client, err := d.ingesterPool.GetClientForInstance(*ing)
 		if err != nil {

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1097,18 +1097,18 @@ func testQueryShardingFunctionCorrectness(t *testing.T, queryable storage.Querya
 		if tpl == "" {
 			tpl = `(<fn>(bar1{}<args>))`
 		}
-		result := strings.Replace(tpl, "<fn>", fn, -1)
+		result := strings.ReplaceAll(tpl, "<fn>", fn)
 
 		if testMatrix {
 			// turn selectors into ranges
-			result = strings.Replace(result, "}", "}[1m]", -1)
+			result = strings.ReplaceAll(result, "}", "}[1m]")
 		}
 
 		if len(fArgs) > 0 {
 			args := "," + strings.Join(fArgs, ",")
-			result = strings.Replace(result, "<args>", args, -1)
+			result = strings.ReplaceAll(result, "<args>", args)
 		} else {
-			result = strings.Replace(result, "<args>", "", -1)
+			result = strings.ReplaceAll(result, "<args>", "")
 		}
 
 		return []string{

--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -284,9 +284,10 @@ func TestNewMockShardedQueryable(t *testing.T) {
 				samples := 0
 				histograms := 0
 				for valType := iter.Next(); valType != chunkenc.ValNone; valType = iter.Next() {
-					if valType == chunkenc.ValFloat {
+					switch valType {
+					case chunkenc.ValFloat:
 						samples++
-					} else if valType == chunkenc.ValHistogram || valType == chunkenc.ValFloatHistogram {
+					case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
 						histograms++
 					}
 				}

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -415,10 +415,10 @@ func mergeCacheExtentsWithAccumulator(extents []Extent, acc *accumulator) ([]Ext
 		return nil, err
 	}
 	return append(extents, Extent{
-		Start:            acc.Extent.Start,
-		End:              acc.Extent.End,
+		Start:            acc.Start,
+		End:              acc.End,
 		Response:         marshalled,
-		TraceId:          acc.Extent.TraceId,
+		TraceId:          acc.TraceId,
 		QueryTimestampMs: acc.QueryTimestampMs,
 	}), nil
 }

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -245,7 +245,7 @@ func newQueryTripperware(
 		if err != nil {
 			return nil, err
 		}
-		c = cache.NewCompression(cfg.ResultsCacheConfig.Compression, c, log)
+		c = cache.NewCompression(cfg.Compression, c, log)
 	}
 
 	cacheKeyGenerator := cfg.CacheKeyGenerator

--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -119,7 +119,7 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 	logger := log.With(s.logger, "query", req.GetQuery(), "query_timestamp", req.GetStart())
 
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, logger, "spinOffSubqueriesMiddleware.Do")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	// For now, the feature is completely opt-in
 	// So we check that the given query is allowed to be spun off

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -105,7 +105,7 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Metr
 	logger := log.With(s.logger, "query", req.GetQuery(), "query_timestamp", req.GetStart())
 
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, logger, "splitInstantQueryByIntervalMiddleware.Do")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/frontend/v2/frontend_scheduler_worker.go
+++ b/pkg/frontend/v2/frontend_scheduler_worker.go
@@ -404,8 +404,8 @@ func (w *frontendSchedulerWorker) schedulerLoop(loop schedulerpb.SchedulerForFro
 // enqueueRequest sends a request to this worker's scheduler, and returns an error if no further requests should be sent to the scheduler.
 func (w *frontendSchedulerWorker) enqueueRequest(loop schedulerpb.SchedulerForFrontend_FrontendLoopClient, req *frontendRequest) error {
 	spanLogger, _ := spanlogger.NewWithLogger(req.ctx, w.log, "frontendSchedulerWorker.enqueueRequest")
-	spanLogger.Span.SetTag("scheduler_address", w.conn.Target())
-	defer spanLogger.Span.Finish()
+	spanLogger.SetTag("scheduler_address", w.conn.Target())
+	defer spanLogger.Finish()
 
 	// Keep track of how long it takes to enqueue a request end-to-end.
 	durationTimer := prometheus.NewTimer(w.enqueueDuration)

--- a/pkg/ingester/client/buffering_client.go
+++ b/pkg/ingester/client/buffering_client.go
@@ -93,7 +93,7 @@ type wrappedRequest struct {
 }
 
 func (w *wrappedRequest) Marshal() ([]byte, error) {
-	size := w.WriteRequest.Size()
+	size := w.Size()
 	buf, slabID := w.slabPool.Get(size)
 
 	if w.slabID == 0 {
@@ -102,7 +102,7 @@ func (w *wrappedRequest) Marshal() ([]byte, error) {
 		w.moreSlabIDs = append(w.moreSlabIDs, slabID)
 	}
 
-	n, err := w.WriteRequest.MarshalToSizedBuffer(buf[:size])
+	n, err := w.MarshalToSizedBuffer(buf[:size])
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -3579,7 +3579,7 @@ func (i *Ingester) FlushHandler(w http.ResponseWriter, r *http.Request) {
 
 	allowedUsers := util.NewAllowedTenants(tenants, nil)
 	run := func() {
-		ingCtx := i.BasicService.ServiceContext()
+		ingCtx := i.ServiceContext()
 		if ingCtx == nil || ingCtx.Err() != nil {
 			level.Info(i.logger).Log("msg", "flushing TSDB blocks: ingester not running, ignoring flush request")
 			return

--- a/pkg/ingester/ingester_ring_test.go
+++ b/pkg/ingester/ingester_ring_test.go
@@ -234,15 +234,16 @@ func TestRingConfig_CustomTokenGenerator(t *testing.T) {
 		cfg.TokenGenerationStrategy = testData.tokenGenerationStrategy
 		cfg.SpreadMinimizingZones = testData.spreadMinimizingZones
 		lifecyclerConfig := cfg.ToLifecyclerConfig()
-		if testData.expectedResultStrategy == tokenGenerationRandom {
+		switch testData.expectedResultStrategy {
+		case tokenGenerationRandom:
 			tokenGenerator, ok := lifecyclerConfig.RingTokenGenerator.(*ring.RandomTokenGenerator)
 			assert.True(t, ok)
 			assert.NotNil(t, tokenGenerator)
-		} else if testData.expectedResultStrategy == tokenGenerationSpreadMinimizing {
+		case tokenGenerationSpreadMinimizing:
 			tokenGenerator, ok := lifecyclerConfig.RingTokenGenerator.(*ring.SpreadMinimizingTokenGenerator)
 			assert.True(t, ok)
 			assert.NotNil(t, tokenGenerator)
-		} else {
+		default:
 			assert.Nil(t, lifecyclerConfig.RingTokenGenerator)
 		}
 	}

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -11795,7 +11795,7 @@ func (i *failingIngester) startWaitAndCheck(ctx context.Context, t *testing.T) {
 func (i *failingIngester) shutDownWaitAndCheck(ctx context.Context, t *testing.T) {
 	// We properly shut down ingester, and ensure that it lifecycler is terminated.
 	require.NoError(t, services.StopAndAwaitTerminated(ctx, i))
-	require.Equal(t, services.Terminated, i.lifecycler.BasicService.State())
+	require.Equal(t, services.Terminated, i.lifecycler.State())
 }
 
 func (i *failingIngester) starting(parentCtx context.Context) error {

--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -235,7 +235,7 @@ func (s *shipper) blockMetasFromOldest() (metas []*block.Meta, _ error) {
 		metas = append(metas, m)
 	}
 	sort.Slice(metas, func(i, j int) bool {
-		return metas[i].BlockMeta.MinTime < metas[j].BlockMeta.MinTime
+		return metas[i].MinTime < metas[j].MinTime
 	})
 	return metas, nil
 }

--- a/pkg/ingester/shipper_test.go
+++ b/pkg/ingester/shipper_test.go
@@ -260,7 +260,7 @@ func TestIterBlockMetas(t *testing.T) {
 	metas, err := shipper.blockMetasFromOldest()
 	require.NoError(t, err)
 	require.Equal(t, sort.SliceIsSorted(metas, func(i, j int) bool {
-		return metas[i].BlockMeta.MinTime < metas[j].BlockMeta.MinTime
+		return metas[i].MinTime < metas[j].MinTime
 	}), true)
 }
 

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -543,8 +543,8 @@ func TestConfig_validateFilesystemPaths(t *testing.T) {
 			setup: func(cfg *Config) {
 				cfg.Target = flagext.StringSliceCSV{AlertManager}
 				cfg.Alertmanager.DataDir = "/path/to/alertmanager"
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager/"
+				cfg.AlertmanagerStorage.Backend = bucket.Filesystem
+				cfg.AlertmanagerStorage.Filesystem.Directory = "/path/to/alertmanager/"
 			},
 			expectedErr: `the configured alertmanager data directory "/path/to/alertmanager" cannot overlap with the configured alertmanager storage filesystem directory "/path/to/alertmanager/"`,
 		},
@@ -552,8 +552,8 @@ func TestConfig_validateFilesystemPaths(t *testing.T) {
 			setup: func(cfg *Config) {
 				cfg.Target = flagext.StringSliceCSV{AlertManager}
 				cfg.Alertmanager.DataDir = "/path/to/alertmanager"
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager/subdir"
+				cfg.AlertmanagerStorage.Backend = bucket.Filesystem
+				cfg.AlertmanagerStorage.Filesystem.Directory = "/path/to/alertmanager/subdir"
 			},
 			expectedErr: `the configured alertmanager data directory "/path/to/alertmanager" cannot overlap with the configured alertmanager storage filesystem directory "/path/to/alertmanager/subdir"`,
 		},
@@ -561,8 +561,8 @@ func TestConfig_validateFilesystemPaths(t *testing.T) {
 			setup: func(cfg *Config) {
 				cfg.Target = flagext.StringSliceCSV{AlertManager}
 				cfg.Alertmanager.DataDir = "/path/to/alertmanager/alerts"
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager"
+				cfg.AlertmanagerStorage.Backend = bucket.Filesystem
+				cfg.AlertmanagerStorage.Filesystem.Directory = "/path/to/alertmanager"
 			},
 			expectedErr: `the configured alertmanager data directory "/path/to/alertmanager/alerts" cannot overlap with the configured alertmanager storage filesystem directory "/path/to/alertmanager"`,
 		},
@@ -570,16 +570,16 @@ func TestConfig_validateFilesystemPaths(t *testing.T) {
 			setup: func(cfg *Config) {
 				cfg.Target = flagext.StringSliceCSV{AlertManager}
 				cfg.Alertmanager.DataDir = "/path/to/alertmanager/data"
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/alertmanager"
+				cfg.AlertmanagerStorage.Backend = bucket.Filesystem
+				cfg.AlertmanagerStorage.Filesystem.Directory = "/path/to/alertmanager"
 			},
 		},
 		"should fail if alertmanager data directory (relative) is a subdirectory of alertmanager filesystem backend directory (absolute), and matches with the prefix used to store alertmanager config": {
 			setup: func(cfg *Config) {
 				cfg.Target = flagext.StringSliceCSV{AlertManager}
 				cfg.Alertmanager.DataDir = "./data/alertmanager"
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.AlertmanagerStorage.Config.StorageBackendConfig.Filesystem.Directory = filepath.Join(cwd, "data")
+				cfg.AlertmanagerStorage.Backend = bucket.Filesystem
+				cfg.AlertmanagerStorage.Filesystem.Directory = filepath.Join(cwd, "data")
 			},
 			expectedErr: fmt.Sprintf(`the configured alertmanager data directory "./data/alertmanager" cannot overlap with the configured alertmanager storage filesystem directory "%s"`, filepath.Join(cwd, "data")),
 		},
@@ -587,8 +587,8 @@ func TestConfig_validateFilesystemPaths(t *testing.T) {
 			setup: func(cfg *Config) {
 				cfg.Target = flagext.StringSliceCSV{Ruler}
 				cfg.Ruler.RulePath = "/path/to/ruler"
-				cfg.RulerStorage.Config.StorageBackendConfig.Backend = bucket.Filesystem
-				cfg.RulerStorage.Config.StorageBackendConfig.Filesystem.Directory = "/path/to/ruler/"
+				cfg.RulerStorage.Backend = bucket.Filesystem
+				cfg.RulerStorage.Filesystem.Directory = "/path/to/ruler/"
 			},
 			expectedErr: `the configured ruler data directory "/path/to/ruler" cannot overlap with the configured ruler storage filesystem directory "/path/to/ruler/"`,
 		},

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -208,24 +208,24 @@ func (t *Mimir) initVault() (services.Service, error) {
 
 	// Update Configs - KVStore
 	// lint:sorted
-	t.Cfg.Alertmanager.ShardingRing.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.Compactor.ShardingRing.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.Distributor.DistributorRing.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.Distributor.HATrackerConfig.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.Ingester.IngesterPartitionRing.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.Ingester.IngesterRing.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
+	t.Cfg.Alertmanager.ShardingRing.Common.KVStore.Etcd.TLS.Reader = t.Vault
+	t.Cfg.Compactor.ShardingRing.Common.KVStore.Etcd.TLS.Reader = t.Vault
+	t.Cfg.Distributor.DistributorRing.Common.KVStore.Etcd.TLS.Reader = t.Vault
+	t.Cfg.Distributor.HATrackerConfig.KVStore.Etcd.TLS.Reader = t.Vault
+	t.Cfg.Ingester.IngesterPartitionRing.KVStore.Etcd.TLS.Reader = t.Vault
+	t.Cfg.Ingester.IngesterRing.KVStore.Etcd.TLS.Reader = t.Vault
 	t.Cfg.MemberlistKV.TCPTransport.TLS.Reader = t.Vault
-	t.Cfg.OverridesExporter.Ring.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.Ruler.Ring.Common.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
-	t.Cfg.StoreGateway.ShardingRing.KVStore.StoreConfig.Etcd.TLS.Reader = t.Vault
+	t.Cfg.OverridesExporter.Ring.Common.KVStore.Etcd.TLS.Reader = t.Vault
+	t.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.Etcd.TLS.Reader = t.Vault
+	t.Cfg.Ruler.Ring.Common.KVStore.Etcd.TLS.Reader = t.Vault
+	t.Cfg.StoreGateway.ShardingRing.KVStore.Etcd.TLS.Reader = t.Vault
 
 	// Update Configs - Redis Clients
 	// lint:sorted
-	t.Cfg.BlocksStorage.BucketStore.ChunksCache.BackendConfig.Redis.TLS.Reader = t.Vault
-	t.Cfg.BlocksStorage.BucketStore.IndexCache.BackendConfig.Redis.TLS.Reader = t.Vault
-	t.Cfg.BlocksStorage.BucketStore.MetadataCache.BackendConfig.Redis.TLS.Reader = t.Vault
-	t.Cfg.Frontend.QueryMiddleware.ResultsCacheConfig.BackendConfig.Redis.TLS.Reader = t.Vault
+	t.Cfg.BlocksStorage.BucketStore.ChunksCache.Redis.TLS.Reader = t.Vault
+	t.Cfg.BlocksStorage.BucketStore.IndexCache.Redis.TLS.Reader = t.Vault
+	t.Cfg.BlocksStorage.BucketStore.MetadataCache.Redis.TLS.Reader = t.Vault
+	t.Cfg.Frontend.QueryMiddleware.Redis.TLS.Reader = t.Vault
 
 	// Update Configs - GRPC Clients
 	// lint:sorted

--- a/pkg/mimir/modules_test.go
+++ b/pkg/mimir/modules_test.go
@@ -326,22 +326,22 @@ func TestInitVault(t *testing.T) {
 
 	// Check KVStore
 	require.NotNil(t, mimir.Cfg.MemberlistKV.TCPTransport.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.Distributor.HATrackerConfig.KVStore.StoreConfig.Etcd.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.Alertmanager.ShardingRing.Common.KVStore.StoreConfig.Etcd.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.Compactor.ShardingRing.Common.KVStore.StoreConfig.Etcd.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.Distributor.DistributorRing.Common.KVStore.StoreConfig.Etcd.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.Ingester.IngesterRing.KVStore.StoreConfig.Etcd.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.Ingester.IngesterPartitionRing.KVStore.StoreConfig.Etcd.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.Ruler.Ring.Common.KVStore.StoreConfig.Etcd.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.StoreGateway.ShardingRing.KVStore.StoreConfig.Etcd.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.StoreConfig.Etcd.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.OverridesExporter.Ring.Common.KVStore.StoreConfig.Etcd.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.Distributor.HATrackerConfig.KVStore.Etcd.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.Alertmanager.ShardingRing.Common.KVStore.Etcd.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.Compactor.ShardingRing.Common.KVStore.Etcd.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.Distributor.DistributorRing.Common.KVStore.Etcd.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.Ingester.IngesterRing.KVStore.Etcd.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.Ingester.IngesterPartitionRing.KVStore.Etcd.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.Ruler.Ring.Common.KVStore.Etcd.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.StoreGateway.ShardingRing.KVStore.Etcd.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.Etcd.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.OverridesExporter.Ring.Common.KVStore.Etcd.TLS.Reader)
 
 	// Check Redis Clients
-	require.NotNil(t, mimir.Cfg.BlocksStorage.BucketStore.IndexCache.BackendConfig.Redis.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.BlocksStorage.BucketStore.ChunksCache.BackendConfig.Redis.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.BlocksStorage.BucketStore.MetadataCache.BackendConfig.Redis.TLS.Reader)
-	require.NotNil(t, mimir.Cfg.Frontend.QueryMiddleware.ResultsCacheConfig.BackendConfig.Redis.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.BlocksStorage.BucketStore.IndexCache.Redis.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.BlocksStorage.BucketStore.ChunksCache.Redis.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.BlocksStorage.BucketStore.MetadataCache.Redis.TLS.Reader)
+	require.NotNil(t, mimir.Cfg.Frontend.QueryMiddleware.Redis.TLS.Reader)
 
 	// Check GRPC Clients
 	require.NotNil(t, mimir.Cfg.IngesterClient.GRPCClientConfig.TLS.Reader)

--- a/pkg/mimir/sanity_check_test.go
+++ b/pkg/mimir/sanity_check_test.go
@@ -72,8 +72,8 @@ func TestCheckObjectStoresConfig(t *testing.T) {
 				require.NoError(t, cfg.Target.Set("ruler"))
 
 				// Configure alertmanager storage to fail, but expect to succeed.
-				cfg.AlertmanagerStorage.Config.Backend = bucket.GCS
-				cfg.AlertmanagerStorage.Config.GCS.BucketName = "invalid"
+				cfg.AlertmanagerStorage.Backend = bucket.GCS
+				cfg.AlertmanagerStorage.GCS.BucketName = "invalid"
 			},
 			expected: "",
 		},

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -70,7 +70,7 @@ type PreallocWriteRequest struct {
 // gets copied into the PreallocTimeseries{} object which gets appended to Timeseries.
 func (p *PreallocWriteRequest) Unmarshal(dAtA []byte) error {
 	p.Timeseries = PreallocTimeseriesSliceFromPool()
-	p.WriteRequest.skipUnmarshalingExemplars = p.SkipUnmarshalingExemplars
+	p.skipUnmarshalingExemplars = p.SkipUnmarshalingExemplars
 	return p.WriteRequest.Unmarshal(dAtA)
 }
 
@@ -222,7 +222,7 @@ func (p *PreallocTimeseries) Unmarshal(dAtA []byte) error {
 		p.marshalledData = dAtA
 	}
 	p.TimeSeries = TimeseriesFromPool()
-	p.TimeSeries.SkipUnmarshalingExemplars = p.skipUnmarshalingExemplars
+	p.SkipUnmarshalingExemplars = p.skipUnmarshalingExemplars
 	return p.TimeSeries.Unmarshal(dAtA)
 }
 

--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -85,6 +85,7 @@ func New(cfg Config) (*MimirClient, error) {
 			"tls-cert": cfg.TLS.CertPath,
 			"tls-key":  cfg.TLS.KeyPath,
 		}).Errorf("error loading TLS files")
+		//nolint:staticcheck
 		return nil, fmt.Errorf("Mimir client initialization unsuccessful")
 	}
 

--- a/pkg/mimirtool/config/parameters.go
+++ b/pkg/mimirtool/config/parameters.go
@@ -32,15 +32,15 @@ func (i defaultValueInspectedEntry) Walk(f func(path string, value Value) error)
 }
 
 func (i defaultValueInspectedEntry) GetValue(path string) (Value, error) {
-	return i.InspectedEntry.GetDefaultValue(path)
+	return i.GetDefaultValue(path)
 }
 
 func (i defaultValueInspectedEntry) MustGetValue(path string) Value {
-	return i.InspectedEntry.MustGetDefaultValue(path)
+	return i.MustGetDefaultValue(path)
 }
 
 func (i defaultValueInspectedEntry) SetValue(path string, v Value) error {
-	return i.InspectedEntry.SetDefaultValue(path, v)
+	return i.SetDefaultValue(path, v)
 }
 
 func (i defaultValueInspectedEntry) walk(path string, errs *multierror.MultiError, f func(path string, value Value) error) {

--- a/pkg/mimirtool/rules/rules.go
+++ b/pkg/mimirtool/rules/rules.go
@@ -233,13 +233,13 @@ func (r RuleNamespace) Validate(groupNodes []rulefmt.RuleGroupNode) []error {
 
 	for i, g := range r.Groups {
 		if g.Name == "" {
-			errs = append(errs, fmt.Errorf("Groupname should not be empty"))
+			errs = append(errs, fmt.Errorf("group name should not be empty"))
 		}
 
 		if _, ok := set[g.Name]; ok {
 			errs = append(
 				errs,
-				fmt.Errorf("groupname: \"%s\" is repeated in the same namespace", g.Name),
+				fmt.Errorf("group name: %q is repeated in the same namespace", g.Name),
 			)
 		}
 

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -344,7 +344,7 @@ func (q *blocksStoreQuerier) Select(ctx context.Context, _ bool, sp *storage.Sel
 
 func (q *blocksStoreQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, q.logger, "blocksStoreQuerier.LabelNames")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {
@@ -389,7 +389,7 @@ func (q *blocksStoreQuerier) LabelNames(ctx context.Context, hints *storage.Labe
 
 func (q *blocksStoreQuerier) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, q.logger, "blocksStoreQuerier.LabelValues")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {
@@ -437,7 +437,7 @@ func (q *blocksStoreQuerier) Close() error {
 
 func (q *blocksStoreQuerier) selectSorted(ctx context.Context, sp *storage.SelectHints, tenantID string, matchers ...*labels.Matcher) storage.SeriesSet {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, q.logger, "blocksStoreQuerier.selectSorted")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	minT, maxT := sp.Start, sp.End
 
@@ -759,8 +759,8 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(ctx context.Context, sp *stor
 	for c, blockIDs := range clients {
 		g.Go(func() error {
 			log, reqCtx := spanlogger.NewWithLogger(reqCtx, spanLog, "blocksStoreQuerier.fetchSeriesFromStores")
-			defer log.Span.Finish()
-			log.Span.SetTag("store_gateway_address", c.RemoteAddress())
+			defer log.Finish()
+			log.SetTag("store_gateway_address", c.RemoteAddress())
 
 			// See: https://github.com/prometheus/prometheus/pull/8050
 			// TODO(goutham): we should ideally be passing the hints down to the storage layer

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -205,7 +205,7 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int
 
 func (q *distributorQuerier) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, q.logger, "distributorQuerier.LabelValues")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {
@@ -228,7 +228,7 @@ func (q *distributorQuerier) LabelValues(ctx context.Context, name string, hints
 
 func (q *distributorQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, q.logger, "distributorQuerier.LabelNames")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -202,7 +202,7 @@ type sampleAndChunkQueryable struct {
 }
 
 func (q *sampleAndChunkQueryable) ChunkQuerier(minT, maxT int64) (storage.ChunkQuerier, error) {
-	qr, err := q.Queryable.Querier(minT, maxT)
+	qr, err := q.Querier(minT, maxT)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ type multiQuerier struct {
 
 func (mq multiQuerier) getQueriers(ctx context.Context, matchers ...*labels.Matcher) (context.Context, []storage.Querier, error) {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, mq.logger, "multiQuerier.getQueriers")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	now := time.Now()
 
@@ -323,7 +323,7 @@ func (mq multiQuerier) getQueriers(ctx context.Context, matchers ...*labels.Matc
 // The bool passed is ignored because the series are always sorted.
 func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) (set storage.SeriesSet) {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, mq.logger, "querier.Select")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	ctx, queriers, err := mq.getQueriers(ctx, matchers...)
 	if errors.Is(err, errEmptyTimeRange) {

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -146,7 +146,7 @@ func (m *mockSeriesSet) Warnings() annotations.Annotations {
 // Select implements the storage.Querier interface.
 func (m mockTenantQuerier) Select(ctx context.Context, _ bool, _ *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	logger, _ := spanlogger.NewWithLogger(ctx, m.logger, "mockTenantQuerier.select")
-	defer logger.Span.Finish()
+	defer logger.Finish()
 	var matrix model.Matrix
 
 	tenantID, err := tenant.TenantID(ctx)
@@ -713,14 +713,14 @@ func TestMergeQueryable_LabelNames(t *testing.T) {
 		t.Run(scenario.mergeQueryableScenario.name, func(t *testing.T) {
 			t.Run(scenario.labelNamesTestCase.name, func(t *testing.T) {
 				ctx, reg, querier := scenario.init(t)
-				labelNames, warnings, err := querier.LabelNames(ctx, &storage.LabelHints{}, scenario.labelNamesTestCase.matchers...)
-				if scenario.labelNamesTestCase.expectedQueryErr != nil {
-					require.EqualError(t, err, scenario.labelNamesTestCase.expectedQueryErr.Error())
+				labelNames, warnings, err := querier.LabelNames(ctx, &storage.LabelHints{}, scenario.matchers...)
+				if scenario.expectedQueryErr != nil {
+					require.EqualError(t, err, scenario.expectedQueryErr.Error())
 				} else {
 					require.NoError(t, err)
-					assert.Equal(t, scenario.labelNamesTestCase.expectedLabelNames, labelNames)
-					assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(scenario.labelNamesTestCase.expectedMetrics), "cortex_querier_federation_tenants_queried"))
-					assertEqualWarnings(t, scenario.labelNamesTestCase.expectedWarnings, warnings)
+					assert.Equal(t, scenario.expectedLabelNames, labelNames)
+					assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(scenario.expectedMetrics), "cortex_querier_federation_tenants_queried"))
+					assertEqualWarnings(t, scenario.expectedWarnings, warnings)
 				}
 			})
 		})

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -207,7 +207,7 @@ func (r *DefaultMultiTenantManager) syncRulesToManager(user string, groups rules
 	}
 
 	// We need to update the manager only if it was just created or rules on disk have changed.
-	if !(created || update) {
+	if !created && !update {
 		level.Debug(r.logger).Log("msg", "rules have not changed, skipping rule manager update", "user", user)
 		return
 	}

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -167,7 +167,7 @@ func NewRemoteQuerier(
 // See: https://github.com/prometheus/prometheus/blob/28a830ed9f331e71549c24c2ac3b441033201e8f/storage/remote/client.go#L342
 func (q *RemoteQuerier) Read(ctx context.Context, query *prompb.Query, sortSeries bool) (storage.SeriesSet, error) {
 	log, ctx := spanlogger.NewWithLogger(ctx, q.logger, "ruler.RemoteQuerier.Read")
-	defer log.Span.Finish()
+	defer log.Finish()
 
 	rdReq := &prompb.ReadRequest{
 		Queries: []*prompb.Query{
@@ -246,7 +246,7 @@ func (q *RemoteQuerier) Read(ctx context.Context, query *prompb.Query, sortSerie
 // Query performs a query for the given time.
 func (q *RemoteQuerier) Query(ctx context.Context, qs string, t time.Time) (promql.Vector, error) {
 	logger, ctx := spanlogger.NewWithLogger(ctx, q.logger, "ruler.RemoteQuerier.Query")
-	defer logger.Span.Finish()
+	defer logger.Finish()
 
 	return q.query(ctx, qs, t, logger)
 }

--- a/pkg/ruler/rulestore/config.go
+++ b/pkg/ruler/rulestore/config.go
@@ -37,7 +37,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	prefix := "ruler-storage."
 
-	cfg.StorageBackendConfig.ExtraBackends = []string{BackendLocal}
+	cfg.ExtraBackends = []string{BackendLocal}
 	cfg.Local.RegisterFlagsWithPrefix(prefix, f)
 	cfg.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, "ruler", f)
 

--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
@@ -217,7 +217,7 @@ func mean(numbers []float64) float64 {
 func stddev(numbers []float64, mean float64) float64 {
 	sumOfSquares := 0.0
 	for _, number := range numbers {
-		sumOfSquares += math.Pow(number-mean, 2)
+		sumOfSquares += (number - mean) * (number - mean)
 	}
 	meanOfSquares := sumOfSquares / float64(len(numbers))
 	return math.Sqrt(meanOfSquares)

--- a/pkg/storage/indexheader/index/postings.go
+++ b/pkg/storage/indexheader/index/postings.go
@@ -64,9 +64,10 @@ type PostingOffsetTableV1 struct {
 }
 
 func NewPostingOffsetTable(factory *streamencoding.DecbufFactory, tableOffset int, indexVersion int, indexLastPostingListEndBound uint64, postingOffsetsInMemSampling int, doChecksum bool) (PostingOffsetTable, error) {
-	if indexVersion == index.FormatV1 {
+	switch indexVersion {
+	case index.FormatV1:
 		return newV1PostingOffsetTable(factory, tableOffset, indexLastPostingListEndBound)
-	} else if indexVersion == index.FormatV2 {
+	case index.FormatV2:
 		return newV2PostingOffsetTable(factory, tableOffset, indexLastPostingListEndBound, postingOffsetsInMemSampling, doChecksum)
 	}
 

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -100,7 +100,7 @@ func (c pusherConsumer) Consume(ctx context.Context, records []record) (returnEr
 			}
 
 			// We don't free the WriteRequest slices because they are being freed by a level below.
-			err := parsed.WriteRequest.Unmarshal(r.content)
+			err := parsed.Unmarshal(r.content)
 			if err != nil {
 				parsed.err = fmt.Errorf("parsing ingest consumer write request: %w", err)
 			}
@@ -447,7 +447,7 @@ func (p *parallelStorageShards) run(queue *batchingQueue) {
 	// By design of the queue, we must drain the queue, otherwise a deadlock could happen.
 	for wr := range queue.Channel() {
 		p.metrics.batchAge.Observe(time.Since(wr.startedAt).Seconds())
-		p.metrics.timeSeriesPerFlush.Observe(float64(len(wr.WriteRequest.Timeseries)))
+		p.metrics.timeSeriesPerFlush.Observe(float64(len(wr.Timeseries)))
 		processingStart := time.Now()
 
 		err := p.pusher.PushToStorage(wr.Context, wr.WriteRequest)

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -1311,10 +1311,10 @@ func TestBatchingQueue(t *testing.T) {
 
 		select {
 		case batch := <-queue.Channel():
-			require.Len(t, batch.WriteRequest.Timeseries, 3)
-			require.Equal(t, series1, batch.WriteRequest.Timeseries[0])
-			require.Equal(t, series2, batch.WriteRequest.Timeseries[1])
-			require.Equal(t, series3, batch.WriteRequest.Timeseries[2])
+			require.Len(t, batch.Timeseries, 3)
+			require.Equal(t, series1, batch.Timeseries[0])
+			require.Equal(t, series2, batch.Timeseries[1])
+			require.Equal(t, series3, batch.Timeseries[2])
 		case <-time.After(time.Second):
 			t.Fatal("expected batch to be flushed")
 		}
@@ -1346,9 +1346,9 @@ func TestBatchingQueue(t *testing.T) {
 		// Close the queue, and the items should be flushed.
 		require.NoError(t, queue.Close())
 
-		require.Len(t, batch.WriteRequest.Timeseries, 2)
-		require.Equal(t, series1, batch.WriteRequest.Timeseries[0])
-		require.Equal(t, series2, batch.WriteRequest.Timeseries[1])
+		require.Len(t, batch.Timeseries, 2)
+		require.Equal(t, series1, batch.Timeseries[0])
+		require.Equal(t, series2, batch.Timeseries[1])
 	})
 
 	t.Run("test queue capacity", func(t *testing.T) {
@@ -1370,7 +1370,7 @@ func TestBatchingQueue(t *testing.T) {
 
 		// Read one item to free up a queue space.
 		batch := <-queue.Channel()
-		require.Len(t, batch.WriteRequest.Timeseries, 3)
+		require.Len(t, batch.Timeseries, 3)
 
 		// Queue should have 4 items now and the currentBatch remains the same.
 		require.Len(t, queue.ch, 4)
@@ -1420,11 +1420,11 @@ func TestBatchingQueue(t *testing.T) {
 		select {
 		case batch, notExhausted := <-queue.Channel():
 			require.True(t, notExhausted)
-			require.Len(t, batch.WriteRequest.Timeseries, 1)
-			require.Len(t, batch.WriteRequest.Metadata, 1)
+			require.Len(t, batch.Timeseries, 1)
+			require.Len(t, batch.Metadata, 1)
 
 			// Check that the first series in the batch has the correct exemplars
-			require.Len(t, batch.WriteRequest.Timeseries[0].TimeSeries.Exemplars, 1)
+			require.Len(t, batch.Timeseries[0].Exemplars, 1)
 			require.Equal(t, 42.0, batch.WriteRequest.Timeseries[0].TimeSeries.Exemplars[0].Value)
 			require.Equal(t, int64(timestamp), batch.WriteRequest.Timeseries[0].TimeSeries.Exemplars[0].TimestampMs)
 			require.Equal(t, "trace_id", batch.WriteRequest.Timeseries[0].TimeSeries.Exemplars[0].Labels[0].Name)
@@ -1465,8 +1465,8 @@ func TestBatchingQueue_ErrorHandling(t *testing.T) {
 		// Also the batch was pushed.
 		select {
 		case batch := <-queue.Channel():
-			require.Equal(t, series2, batch.WriteRequest.Timeseries[0])
-			require.Equal(t, series2, batch.WriteRequest.Timeseries[1])
+			require.Equal(t, series2, batch.Timeseries[0])
+			require.Equal(t, series2, batch.Timeseries[1])
 		default:
 			t.Fatal("expected batch to be flushed")
 		}
@@ -1502,7 +1502,7 @@ func TestBatchingQueue_ErrorHandling(t *testing.T) {
 		// Batch is also pushed.
 		select {
 		case batch := <-queue.Channel():
-			require.Equal(t, series1, batch.WriteRequest.Timeseries[0])
+			require.Equal(t, series1, batch.Timeseries[0])
 		default:
 			t.Fatal("expected batch to be flushed")
 		}

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -769,7 +769,7 @@ func (r *PartitionReader) waitReadConsistency(ctx context.Context, withOffset bo
 
 		// Ensure the service is running. Some subservices used below are created when starting
 		// so they're not available before that.
-		if state := r.Service.State(); state != services.Running {
+		if state := r.State(); state != services.Running {
 			return struct{}{}, fmt.Errorf("partition reader service is not running (state: %s)", state.String())
 		}
 

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -161,7 +161,7 @@ func (c *KafkaProducer) updateMetricsLoop() {
 	for {
 		select {
 		case <-ticker.C:
-			c.bufferedProduceBytes.Observe(float64(c.Client.BufferedProduceBytes()))
+			c.bufferedProduceBytes.Observe(float64(c.BufferedProduceBytes()))
 
 		case <-c.closed:
 			return
@@ -220,7 +220,7 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 		// Produce() may theoretically block if the buffer is full, but we configure the Kafka client with
 		// unlimited buffer because we implement the buffer limit ourselves (see maxBufferedBytes). This means
 		// Produce() should never block for us in practice.
-		c.Client.Produce(context.WithoutCancel(ctx), record, onProduceDone)
+		c.Produce(context.WithoutCancel(ctx), record, onProduceDone)
 	}
 
 	// Wait for a response or until the context has done.

--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -420,7 +420,7 @@ func (s worstCaseFetchedDataStrategy) selectPostings(groups []postingGroup) (sel
 func numSeriesInSmallestIntersectingPostingGroup(groups []postingGroup) int64 {
 	var minGroupSize int64
 	for _, g := range groups {
-		if !g.isSubtract && !(len(g.keys) == 1 && g.keys[0] == allPostingsKey) {
+		if !g.isSubtract && (len(g.keys) != 1 || g.keys[0] != allPostingsKey) {
 			// The size of each posting list contains 4 bytes with the number of entries.
 			// We shouldn't count these as series.
 			groupSize := g.totalSize - int64(len(g.keys)*4)

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -328,7 +328,7 @@ func (u *BucketStores) syncUsersBlocks(ctx context.Context, includeUserIDs []str
 // Series implements the storegatewaypb.StoreGatewayServer interface, making a series request to the underlying user bucket store.
 func (u *BucketStores) Series(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer) error {
 	spanLog, spanCtx := spanlogger.NewWithLogger(srv.Context(), u.logger, "BucketStores.Series")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	userID := getUserIDFromGRPCContext(spanCtx)
 	if userID == "" {
@@ -349,7 +349,7 @@ func (u *BucketStores) Series(req *storepb.SeriesRequest, srv storegatewaypb.Sto
 // LabelNames implements the storegatewaypb.StoreGatewayServer interface.
 func (u *BucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
 	spanLog, spanCtx := spanlogger.NewWithLogger(ctx, u.logger, "BucketStores.LabelNames")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	userID := getUserIDFromGRPCContext(spanCtx)
 	if userID == "" {
@@ -367,7 +367,7 @@ func (u *BucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRe
 // LabelValues implements the storegatewaypb.StoreGatewayServer interface.
 func (u *BucketStores) LabelValues(ctx context.Context, req *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
 	spanLog, spanCtx := spanlogger.NewWithLogger(ctx, u.logger, "BucketStores.LabelValues")
-	defer spanLog.Span.Finish()
+	defer spanLog.Finish()
 
 	userID := getUserIDFromGRPCContext(spanCtx)
 	if userID == "" {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -862,8 +862,8 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 		postings, _, err := b.indexReader(selectAllStrategy{}).ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Empty(t, postings)
-		mockBucket.Mock.AssertNotCalled(t, "Get")
-		mockBucket.Mock.AssertNotCalled(t, "GetRange")
+		mockBucket.AssertNotCalled(t, "Get")
+		mockBucket.AssertNotCalled(t, "GetRange")
 	})
 
 	t.Run("requesting a label value (with regex) that doesn't exist doesn't reach the cache or the bucket", func(t *testing.T) {
@@ -880,8 +880,8 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 		postings, _, err := b.indexReader(selectAllStrategy{}).ExpandedPostings(context.Background(), matchers, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Empty(t, postings)
-		mockBucket.Mock.AssertNotCalled(t, "Get")
-		mockBucket.Mock.AssertNotCalled(t, "GetRange")
+		mockBucket.AssertNotCalled(t, "Get")
+		mockBucket.AssertNotCalled(t, "GetRange")
 	})
 
 	t.Run("postings selection strategy is respected", func(t *testing.T) {
@@ -1453,9 +1453,10 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 				expectedSamples = 1
 			}
 			seriesCut := int(p * float64(numOfBlocks*seriesPerBlock))
-			if seriesCut == 0 {
+			switch seriesCut {
+			case 0:
 				seriesCut = 1
-			} else if seriesCut == 1 {
+			case 1:
 				seriesCut = expectedSamples / samplesPerSeriesPerBlock
 			}
 

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -1300,7 +1300,7 @@ func encodeCachedSeriesForPostings(set seriesChunkRefsSet, diffEncodedPostings [
 		DiffEncodedPostings: diffEncodedPostings,
 	}
 	for i, s := range set.series {
-		entry.Series[i].Metric.Labels = mimirpb.FromLabelsToLabelAdapters(s.lset)
+		entry.Series[i].Labels = mimirpb.FromLabelsToLabelAdapters(s.lset)
 	}
 
 	uncompressed, err := entry.Marshal()

--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -33,11 +33,12 @@ type BenchCase struct {
 func (c BenchCase) Name() string {
 	name := c.Expr
 
-	if c.Steps == 0 {
+	switch c.Steps {
+	case 0:
 		name += ", instant query"
-	} else if c.Steps == 1 {
+	case 1:
 		name += fmt.Sprintf(", range query with %d step", c.Steps)
-	} else {
+	default:
 		name += fmt.Sprintf(", range query with %d steps", c.Steps)
 	}
 

--- a/pkg/streamingpromql/compat/fallback_engine_test.go
+++ b/pkg/streamingpromql/compat/fallback_engine_test.go
@@ -141,9 +141,10 @@ func newFakeEngineThatSupportsLimitedQueries() *fakeEngineThatSupportsLimitedQue
 }
 
 func (f *fakeEngineThatSupportsLimitedQueries) NewInstantQuery(_ context.Context, _ storage.Queryable, _ promql.QueryOpts, qs string, _ time.Time) (promql.Query, error) {
-	if qs == "a_supported_expression" {
+	switch qs {
+	case "a_supported_expression":
 		return f.query, nil
-	} else if qs == "an_invalid_expression" {
+	case "an_invalid_expression":
 		return nil, errors.New("the query is invalid")
 	}
 
@@ -151,9 +152,10 @@ func (f *fakeEngineThatSupportsLimitedQueries) NewInstantQuery(_ context.Context
 }
 
 func (f *fakeEngineThatSupportsLimitedQueries) NewRangeQuery(_ context.Context, _ storage.Queryable, _ promql.QueryOpts, qs string, _, _ time.Time, _ time.Duration) (promql.Query, error) {
-	if qs == "a_supported_expression" {
+	switch qs {
+	case "a_supported_expression":
 		return f.query, nil
-	} else if qs == "an_invalid_expression" {
+	case "an_invalid_expression":
 		return nil, errors.New("the query is invalid")
 	}
 

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1304,7 +1304,7 @@ type cancellationQueryable struct {
 
 func (w cancellationQueryable) Querier(_, _ int64) (storage.Querier, error) {
 	// nolint:gosimple
-	return cancellationQuerier{onQueried: w.onQueried}, nil
+	return cancellationQuerier(w), nil
 }
 
 type cancellationQuerier struct {

--- a/pkg/streamingpromql/operators/functions/histogram_quantile.go
+++ b/pkg/streamingpromql/operators/functions/histogram_quantile.go
@@ -334,7 +334,7 @@ func (h *HistogramQuantileFunction) saveNativeHistogramsToGroup(hPoints []promql
 
 	// We should only ever see one set of native histograms per group.
 	if g.nativeHistograms != nil {
-		return fmt.Errorf("We should never see more than one native histogram per group")
+		return fmt.Errorf("we should never see more than one native histogram per group")
 	}
 	g.nativeHistograms = hPoints
 	return nil

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -98,7 +98,7 @@ func newQuery(ctx context.Context, queryable storage.Queryable, opts promql.Quer
 		},
 	}
 
-	if start == end && interval == 0 {
+	if start.Equal(end) && interval == 0 {
 		q.topLevelQueryTimeRange = types.NewInstantQueryTimeRange(start)
 	} else {
 		q.topLevelQueryTimeRange = types.NewRangeQueryTimeRange(start, end, interval)

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -82,4 +82,4 @@ type StringOperator interface {
 	GetValue() string
 }
 
-var EOS = errors.New("operator stream exhausted") //nolint:revive
+var EOS = errors.New("operator stream exhausted") //nolint:revive,staticcheck

--- a/pkg/util/atomicfs/fsync.go
+++ b/pkg/util/atomicfs/fsync.go
@@ -52,18 +52,18 @@ func (a *File) Close() error {
 	cleanup := true
 	defer func() {
 		if cleanup {
-			_ = os.Remove(a.File.Name())
+			_ = os.Remove(a.Name())
 		}
 	}()
 
 	merr := multierror.New()
-	merr.Add(a.File.Sync())
+	merr.Add(a.Sync())
 	merr.Add(a.File.Close())
 	if err := merr.Err(); err != nil {
 		return err
 	}
 
-	if err := os.Rename(a.File.Name(), a.finalPath); err != nil {
+	if err := os.Rename(a.Name(), a.finalPath); err != nil {
 		return err
 	}
 

--- a/pkg/util/extract/extract.go
+++ b/pkg/util/extract/extract.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	errNoMetricNameLabel = fmt.Errorf("No metric name label")
+	errNoMetricNameLabel = fmt.Errorf("no metric name label")
 )
 
 // UnsafeMetricNameFromLabelAdapters extracts the metric name from a list of LabelPairs.

--- a/pkg/util/grpcencoding/s2/s2.go
+++ b/pkg/util/grpcencoding/s2/s2.go
@@ -55,7 +55,7 @@ func newCompressor() *compressor {
 
 func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {
 	s := c.poolCompressor.Get().(*writer)
-	s.Writer.Reset(w)
+	s.Reset(w)
 	return s, nil
 }
 

--- a/pkg/util/objtools/abs.go
+++ b/pkg/util/objtools/abs.go
@@ -192,7 +192,7 @@ func (bkt *azureBucket) ClientSideCopy(ctx context.Context, objectName string, d
 	if response.ContentLength == nil {
 		return errors.New("source object from Azure did not contain a content length")
 	}
-	body := response.DownloadResponse.Body
+	body := response.Body
 	if err := dstBucket.Upload(ctx, options.destinationObjectName(objectName), body, *response.ContentLength); err != nil {
 		_ = body.Close()
 		return errors.New("failed uploading source object from Azure to destination")

--- a/pkg/util/reactivelimiter/prioritylimiter.go
+++ b/pkg/util/reactivelimiter/prioritylimiter.go
@@ -82,7 +82,7 @@ func (l *priorityLimiter) CanAcquirePermit(priority Priority) bool {
 func (l *priorityLimiter) canAcquirePermit(granularPriority int) bool {
 	// Threshold against the limiter's max capacity
 	_, _, _, maxBlocked := l.queueStats()
-	if l.reactiveLimiter.Blocked() >= maxBlocked {
+	if l.Blocked() >= maxBlocked {
 		return false
 	}
 

--- a/pkg/util/validation/exporter/exporter.go
+++ b/pkg/util/validation/exporter/exporter.go
@@ -321,7 +321,7 @@ func (oe *OverridesExporter) isLeader() bool {
 		// If the ring is not enabled, export all metrics
 		return true
 	}
-	if oe.Service.State() != services.Running {
+	if oe.State() != services.Running {
 		// We haven't finished startup yet, likely waiting for ring stability.
 		return false
 	}

--- a/tools/doc-generator/write/writer.go
+++ b/tools/doc-generator/write/writer.go
@@ -76,9 +76,10 @@ func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 
 		// Specification
 		fieldDefault := e.FieldDefault
-		if e.FieldType == "string" {
+		switch e.FieldType {
+		case "string":
 			fieldDefault = strconv.Quote(fieldDefault)
-		} else if e.FieldType == "duration" {
+		case "duration":
 			fieldDefault = cleanupDuration(fieldDefault)
 		}
 

--- a/tools/kafkatool/consumer_group.go
+++ b/tools/kafkatool/consumer_group.go
@@ -57,7 +57,7 @@ func (c *ConsumerGroupCommand) listOffsets(_ *kingpin.ParseContext) error {
 
 	// Sort topic and partitions to get a stable output.
 	for _, entry := range offsets.Sorted() {
-		c.printer.PrintLine(fmt.Sprintf("Topic: %s \tPartition: %d \tOffset: %d", entry.Topic, entry.Partition, entry.Offset.At))
+		c.printer.PrintLine(fmt.Sprintf("Topic: %s \tPartition: %d \tOffset: %d", entry.Topic, entry.Partition, entry.At))
 	}
 
 	return nil

--- a/tools/query-step-alignment-analysis/main.go
+++ b/tools/query-step-alignment-analysis/main.go
@@ -44,7 +44,7 @@ func parseTime(str string) (time.Time, error) {
 func (qs *QueryStat) IsStepAligned() bool {
 	start := qs.Start.Truncate(qs.Step)
 	end := qs.End.Truncate(qs.Step)
-	return qs.Start == start && qs.End == end
+	return qs.Start.Equal(start) && qs.End.Equal(end)
 }
 
 // Queries which are involving only recent data are not cached

--- a/tools/querytee/proxy_endpoint.go
+++ b/tools/querytee/proxy_endpoint.go
@@ -262,14 +262,15 @@ func (p *ProxyEndpoint) executeBackendRequests(req *http.Request, backends []Pro
 		}
 
 		result, err := p.compareResponses(expectedResponse, actualResponse, evaluationTime)
-		if result == ComparisonFailed {
+		switch result {
+		case ComparisonFailed:
 			level.Error(logger).Log(
 				"msg", "response comparison failed",
 				"err", err,
 				"expected_response_duration", expectedResponse.elapsedTime,
 				"actual_response_duration", actualResponse.elapsedTime,
 			)
-		} else if result == ComparisonSkipped {
+		case ComparisonSkipped:
 			level.Warn(logger).Log(
 				"msg", "response comparison skipped",
 				"err", err,

--- a/tools/querytee/proxy_test.go
+++ b/tools/querytee/proxy_test.go
@@ -856,9 +856,10 @@ func mockQueryResponseWithExpectedBody(path string, expectedBody string, status 
 //   - http: HTTPListenAddr()
 //   - grpc: GRPCListenAddr()
 func getServerAddress(proto string, server *server.Server) string {
-	if proto == "http" {
+	switch proto {
+	case "http":
 		return "http://" + server.HTTPListenAddr().String()
-	} else if proto == "grpc" {
+	case "grpc":
 		return "dns:///" + server.GRPCListenAddr().String()
 	}
 

--- a/tools/trafficdump/main.go
+++ b/tools/trafficdump/main.go
@@ -95,7 +95,7 @@ func main() {
 	assemblers := make([]*tcpassembly.Assembler, *assemblersCount)
 	for ix := uint(0); ix < *assemblersCount; ix++ {
 		assemblers[ix] = tcpassembly.NewAssembler(streamPool)
-		assemblers[ix].AssemblerOptions.MaxBufferedPagesPerConnection = *assemblersMaxPagesPerConnection
+		assemblers[ix].MaxBufferedPagesPerConnection = *assemblersMaxPagesPerConnection
 	}
 
 	log.Println("Reading packets")

--- a/tools/trafficdump/parser.go
+++ b/tools/trafficdump/parser.go
@@ -188,11 +188,11 @@ func (rp *parser) decodePushRequest(req *http.Request, body []byte, matchers []*
 		}
 
 		if rp.includeSamples {
-			t.Samples = ts.TimeSeries.Samples
-			t.Exemplars = ts.TimeSeries.Exemplars
+			t.Samples = ts.Samples
+			t.Exemplars = ts.Exemplars
 		} else {
-			t.SamplesCount = len(ts.TimeSeries.Samples)
-			t.ExemplarsCount = len(ts.TimeSeries.Exemplars)
+			t.SamplesCount = len(ts.Samples)
+			t.ExemplarsCount = len(ts.Exemplars)
 		}
 
 		res.TimeSeries = append(res.TimeSeries, t)


### PR DESCRIPTION
#### What this PR does

Upgrade golangci-lint to v2.0.2, which requires migrating .golangci.yml.

Also fix issues raised by linters, mostly automatically (via `golangci-lint run --fix ./...`).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
