### PR TITLE
HTTP cluster validation: fixing wrong client name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@
   * `-server.cluster-validation.http.soft-validation`
   * `-server.cluster-validation.http.exclude-paths`
 * [ENHANCEMENT] Query-frontend: Add experimental support to include the cluster validation label in HTTP requests headers via `-query-frontend.client-cluster-validation.label` configuration option. When cluster validation is enabled on HTTP server side, the cluster validation label from HTTP requests is compared with the HTTP server's cluster validation label. #11010
-  * By setting `-<grpc-client-config-path>.cluster-validation.label`, you configure the cluster validation label of _a single_ gRPC client, whose `grpcclient.Config` object is configurable through `-<grpc-client-config-path>`.
-  * By setting `-common.client-cluster-validation.label`, you configure the cluster validation label of _all_ gRPC clients.
 * [ENHANCEMENT] Memberlist: Add `-memberlist.abort-if-fast-join-fails` support and retries on DNS resolution. #11067
 * [ENHANCEMENT] Querier: Allow configuring all gRPC options for store-gateway client, similar to other gRPC clients. #11074
 * [ENHANCEMENT] Ruler: Log the number of series returned for each query as `result_series_count` as part of `query stats` log lines. #11081

--- a/pkg/frontend/config.go
+++ b/pkg/frontend/config.go
@@ -107,7 +107,7 @@ func InitFrontend(
 }
 
 func invalidClusterValidationReporter(cfg CombinedFrontendConfig, reg prometheus.Registerer, logger log.Logger) middleware.InvalidClusterValidationReporter {
-	invalidClusterValidation := util.NewRequestInvalidClusterValidationLabelsTotalCounter(reg, "query-frontend", util.HTTPProtocol)
+	invalidClusterValidation := util.NewRequestInvalidClusterValidationLabelsTotalCounter(reg, "querier", util.HTTPProtocol)
 	return util.NewInvalidClusterValidationReporter(cfg.ClusterValidationConfig.Label, invalidClusterValidation, logger)
 }
 

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -152,7 +152,7 @@ func TestFrontend_ClusterValidationWhenDownstreamURLIsConfigured(t *testing.T) {
 			expectedMetrics: `
 				# HELP cortex_client_request_invalid_cluster_validation_labels_total Number of requests with invalid cluster validation label.
         	    # TYPE cortex_client_request_invalid_cluster_validation_labels_total counter
-        	    cortex_client_request_invalid_cluster_validation_labels_total{client="query-frontend",method="/api/v1/query_range",protocol="http"} 1
+        	    cortex_client_request_invalid_cluster_validation_labels_total{client="querier",method="/api/v1/query_range",protocol="http"} 1
 			`,
 		},
 		"if client has no cluster validation label and soft cluster validation is enabled no error is returned": {


### PR DESCRIPTION
#### What this PR does

In https://github.com/grafana/mimir/pull/11010 we added support for configuring cluster validation label for HTTP clients called by the query-frontend. These HTTP clients are queriers, hence in case of cluster validation errors, the `client` label of the `cortex_client_request_invalid_cluster_validation_labels_total` metrics should be `querier`, and not `query-frontend`, as https://github.com/grafana/mimir/pull/11010 reported. The present PR fixes this.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
