### PR TITLE
Subquery Spin-Off: Reuse results from identical downstream and spun-off queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [ENHANCEMENT] Ruler: Log the number of series returned for each query as `result_series_count` as part of `query stats` log lines. #11081
 * [ENHANCEMENT] Ruler: Don't log statistics that are not available when using a remote query-frontend as part of `query stats` log lines. #11083
 * [ENHANCEMENT] Ingester: Remove cost-attribution experimental `max_cost_attribution_labels_per_user` limit. #11090
+* [ENHANCEMENT] Frontend: Improve subquery spin-off performance in cases where the same subquery is run multiple times #11108
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/pkg/frontend/querymiddleware/sharded_queryable_test.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable_test.go
@@ -374,7 +374,7 @@ func TestNewSeriesSetFromEmbeddedQueriesResults(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			set := newSeriesSetFromEmbeddedQueriesResults([][]SampleStream{testData.input}, testData.hints)
+			set := newSeriesSetFromEmbeddedQueriesResults([][]SampleStream{testData.input}, testData.hints, false)
 			actual, err := seriesSetToSampleStreams(set)
 			require.NoError(t, err)
 			assertEqualSampleStream(t, testData.expected, actual)

--- a/pkg/storage/series/series_set.go
+++ b/pkg/storage/series/series_set.go
@@ -62,6 +62,12 @@ func (c *ConcreteSeriesSet) Warnings() annotations.Annotations {
 	return nil
 }
 
+// ShallowClone returns a new series set with the same series.
+// It shares the same series slice, but can be iterated independently.
+func (c *ConcreteSeriesSet) ShallowClone() storage.SeriesSet {
+	return NewConcreteSeriesSetFromSortedSeries(c.series)
+}
+
 // ConcreteSeries implements storage.Series.
 type ConcreteSeries struct {
 	labels     labels.Labels
@@ -76,6 +82,12 @@ func NewConcreteSeries(ls labels.Labels, samples []model.SamplePair, histograms 
 		samples:    samples,
 		histograms: histograms,
 	}
+}
+
+func (c *ConcreteSeries) Merge(other *ConcreteSeries) *ConcreteSeries {
+	c.samples = append(c.samples, other.samples...)
+	c.histograms = append(c.histograms, other.histograms...)
+	return c
 }
 
 // Labels implements storage.Series


### PR DESCRIPTION
We have a case where the same subquery query is run three times. In that case, we can run it once and reuse the result three times.

This commit adds a cache of results for identical queries.

Benchmark:

```
julienduchesne@triceratops mimir % benchstat benchmark_results1.txt benchmark_results2.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/frontend/querymiddleware
cpu: Apple M3 Pro
                                                                         │ benchmark_results1.txt │       benchmark_results2.txt        │
                                                                         │         sec/op         │   sec/op     vs base                │
SubquerySpinOff/single_downstream_mocked_downstream_false-11                         13.27m ±  4%   13.38m ± 4%        ~ (p=0.218 n=10)
SubquerySpinOff/single_downstream_mocked_downstream_true-11                          4.903µ ±  6%   4.965µ ± 1%        ~ (p=0.225 n=10)
SubquerySpinOff/single_spun_off_mocked_downstream_false-11                           250.3m ±  3%   248.9m ± 2%        ~ (p=0.971 n=10)
SubquerySpinOff/single_spun_off_mocked_downstream_true-11                            155.6µ ±  4%   152.3µ ± 3%        ~ (p=0.052 n=10)
SubquerySpinOff/two_spun_off_joined_mocked_downstream_false-11                       293.8m ±  5%   294.5m ± 4%        ~ (p=0.796 n=10)
SubquerySpinOff/two_spun_off_joined_mocked_downstream_true-11                        245.5µ ±  3%   236.1µ ± 1%   -3.81% (p=0.001 n=10)
SubquerySpinOff/three_spun_off_two_downstream_mocked_downstream_false-11             342.1m ± 12%   330.9m ± 2%   -3.27% (p=0.000 n=10)
SubquerySpinOff/three_spun_off_two_downstream_mocked_downstream_true-11              513.4µ ± 17%   461.7µ ± 2%  -10.08% (p=0.000 n=10)
geomean                                                                              3.659m         3.576m        -2.26%

                                                                         │ benchmark_results1.txt │         benchmark_results2.txt         │
                                                                         │          B/op          │     B/op      vs base                  │
SubquerySpinOff/single_downstream_mocked_downstream_false-11                         573.5Ki ± 0%   573.4Ki ± 0%        ~ (p=0.643 n=10)
SubquerySpinOff/single_downstream_mocked_downstream_true-11                          3.758Ki ± 0%   3.758Ki ± 0%        ~ (p=1.000 n=10) ¹
SubquerySpinOff/single_spun_off_mocked_downstream_false-11                           95.03Mi ± 0%   95.04Mi ± 0%        ~ (p=0.280 n=10)
SubquerySpinOff/single_spun_off_mocked_downstream_true-11                            411.8Ki ± 0%   412.6Ki ± 0%   +0.19% (p=0.000 n=10)
SubquerySpinOff/two_spun_off_joined_mocked_downstream_false-11                      191.72Mi ± 0%   97.11Mi ± 0%  -49.35% (p=0.000 n=10)
SubquerySpinOff/two_spun_off_joined_mocked_downstream_true-11                        823.5Ki ± 0%   573.4Ki ± 0%  -30.36% (p=0.000 n=10)
SubquerySpinOff/three_spun_off_two_downstream_mocked_downstream_false-11             293.7Mi ± 0%   103.9Mi ± 0%  -64.63% (p=0.000 n=10)
SubquerySpinOff/three_spun_off_two_downstream_mocked_downstream_true-11              2.008Mi ± 0%   1.274Mi ± 0%  -36.56% (p=0.000 n=10)
geomean                                                                              3.032Mi        2.209Mi       -27.15%
¹ all samples are equal

                                                                         │ benchmark_results1.txt │        benchmark_results2.txt         │
                                                                         │       allocs/op        │  allocs/op   vs base                  │
SubquerySpinOff/single_downstream_mocked_downstream_false-11                          7.279k ± 0%   7.279k ± 0%        ~ (p=1.000 n=10)
SubquerySpinOff/single_downstream_mocked_downstream_true-11                            109.0 ± 0%    109.0 ± 0%        ~ (p=1.000 n=10) ¹
SubquerySpinOff/single_spun_off_mocked_downstream_false-11                            11.66k ± 0%   11.66k ± 0%   +0.05% (p=0.020 n=10)
SubquerySpinOff/single_spun_off_mocked_downstream_true-11                             3.415k ± 0%   3.419k ± 0%   +0.12% (p=0.000 n=10)
SubquerySpinOff/two_spun_off_joined_mocked_downstream_false-11                        28.43k ± 0%   20.20k ± 0%  -28.96% (p=0.000 n=10)
SubquerySpinOff/two_spun_off_joined_mocked_downstream_true-11                         6.860k ± 0%   4.841k ± 0%  -29.42% (p=0.000 n=10)
SubquerySpinOff/three_spun_off_two_downstream_mocked_downstream_false-11              79.44k ± 0%   53.78k ± 0%  -32.30% (p=0.000 n=10)
SubquerySpinOff/three_spun_off_two_downstream_mocked_downstream_true-11               17.08k ± 0%   11.02k ± 0%  -35.50% (p=0.000 n=10)
geomean                                                                               7.332k        6.066k       -17.28%
```

#### Checklist

- [x] Tests updated.
- [N/A] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
