### PR TITLE
Query Frontend: Expose samples_processed in a metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [BUGFIX] Query-frontend: Fix blocks retention period enforcement when a request has multiple tenants (tenant federation). #11069
 * [BUGFIX] Query-frontend: Fix `-query-frontend.query-sharding-max-sharded-queries` enforcement for instant queries with binary operators. #11086
 * [BUGFIX] Memberlist: Fix hash ring updates before the full-join has been completed, when `-memberlist.notify-interval` is configured. #11098
+* [ENHANCEMENT] Query Fronted: Expose samples_processed in a metric. #11110
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 * [BUGFIX] Query-frontend: Fix blocks retention period enforcement when a request has multiple tenants (tenant federation). #11069
 * [BUGFIX] Query-frontend: Fix `-query-frontend.query-sharding-max-sharded-queries` enforcement for instant queries with binary operators. #11086
 * [BUGFIX] Memberlist: Fix hash ring updates before the full-join has been completed, when `-memberlist.notify-interval` is configured. #11098
-* [ENHANCEMENT] Query Frontend: Add `cortex_query_samples_processed_total` metric. #11110
+* [ENHANCEMENT] Query-frontend: Add `cortex_query_samples_processed_total` metric. #11110
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 * [BUGFIX] Query-frontend: Fix blocks retention period enforcement when a request has multiple tenants (tenant federation). #11069
 * [BUGFIX] Query-frontend: Fix `-query-frontend.query-sharding-max-sharded-queries` enforcement for instant queries with binary operators. #11086
 * [BUGFIX] Memberlist: Fix hash ring updates before the full-join has been completed, when `-memberlist.notify-interval` is configured. #11098
-* [ENHANCEMENT] Query Fronted: Add `cortex_query_samples_processed_total` metric. #11110
+* [ENHANCEMENT] Query Frontend: Add `cortex_query_samples_processed_total` metric. #11110
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 * [BUGFIX] Query-frontend: Fix blocks retention period enforcement when a request has multiple tenants (tenant federation). #11069
 * [BUGFIX] Query-frontend: Fix `-query-frontend.query-sharding-max-sharded-queries` enforcement for instant queries with binary operators. #11086
 * [BUGFIX] Memberlist: Fix hash ring updates before the full-join has been completed, when `-memberlist.notify-interval` is configured. #11098
-* [ENHANCEMENT] Query Fronted: Expose samples_processed in a metric. #11110
+* [ENHANCEMENT] Query Fronted: Add `cortex_query_samples_processed_total` metric. #11110
 
 ### Mixin
 

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -333,7 +333,7 @@ func (f *Handler) reportQueryStats(
 	numChunks := stats.LoadFetchedChunks()
 	numIndexBytes := stats.LoadFetchedIndexBytes()
 	sharded := strconv.FormatBool(stats.GetShardedQueries() > 0)
-	samplesProcessed := stats.GetSamplesProcessed()
+	samplesProcessed := stats.LoadSamplesProcessed()
 
 	if stats != nil {
 		// Track stats.

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -93,12 +93,13 @@ type Handler struct {
 	at           *activitytracker.ActivityTracker
 
 	// Metrics.
-	querySeconds    *prometheus.CounterVec
-	querySeries     *prometheus.CounterVec
-	queryChunkBytes *prometheus.CounterVec
-	queryChunks     *prometheus.CounterVec
-	queryIndexBytes *prometheus.CounterVec
-	activeUsers     *util.ActiveUsersCleanupService
+	querySeconds          *prometheus.CounterVec
+	querySeries           *prometheus.CounterVec
+	queryChunkBytes       *prometheus.CounterVec
+	queryChunks           *prometheus.CounterVec
+	queryIndexBytes       *prometheus.CounterVec
+	querySamplesProcessed *prometheus.CounterVec
+	activeUsers           *util.ActiveUsersCleanupService
 
 	mtx              sync.Mutex
 	inflightRequests int
@@ -143,6 +144,11 @@ func NewHandler(cfg HandlerConfig, roundTripper http.RoundTripper, log log.Logge
 			Help: "Number of TSDB index bytes fetched from store-gateway to execute a query.",
 		}, []string{"user"})
 
+		h.querySamplesProcessed = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_query_samples_processed_total",
+			Help: "Number of samples processed to execute a query.",
+		}, []string{"user"})
+
 		h.activeUsers = util.NewActiveUsersCleanupWithDefaultValues(func(user string) {
 			h.querySeconds.DeleteLabelValues(user, "true")
 			h.querySeconds.DeleteLabelValues(user, "false")
@@ -150,6 +156,7 @@ func NewHandler(cfg HandlerConfig, roundTripper http.RoundTripper, log log.Logge
 			h.queryChunkBytes.DeleteLabelValues(user)
 			h.queryChunks.DeleteLabelValues(user)
 			h.queryIndexBytes.DeleteLabelValues(user)
+			h.querySamplesProcessed.DeleteLabelValues(user)
 		})
 		// If cleaner stops or fail, we will simply not clean the metrics for inactive users.
 		_ = h.activeUsers.StartAsync(context.Background())
@@ -326,6 +333,7 @@ func (f *Handler) reportQueryStats(
 	numChunks := stats.LoadFetchedChunks()
 	numIndexBytes := stats.LoadFetchedIndexBytes()
 	sharded := strconv.FormatBool(stats.GetShardedQueries() > 0)
+	samplesProcessed := stats.GetSamplesProcessed()
 
 	if stats != nil {
 		// Track stats.
@@ -334,6 +342,7 @@ func (f *Handler) reportQueryStats(
 		f.queryChunkBytes.WithLabelValues(userID).Add(float64(numBytes))
 		f.queryChunks.WithLabelValues(userID).Add(float64(numChunks))
 		f.queryIndexBytes.WithLabelValues(userID).Add(float64(numIndexBytes))
+		f.querySamplesProcessed.WithLabelValues(userID).Add(float64(samplesProcessed))
 		f.activeUsers.UpdateUserTimestamp(userID, time.Now())
 	}
 
@@ -359,7 +368,7 @@ func (f *Handler) reportQueryStats(
 		estimatedSeriesCount, stats.GetEstimatedSeriesCount(),
 		queueTimeSeconds, stats.LoadQueueTime().Seconds(),
 		encodeTimeSeconds, stats.LoadEncodeTime().Seconds(),
-		"samples_processed", stats.LoadSamplesProcessed(),
+		"samples_processed", samplesProcessed,
 	}, formatQueryString(details, queryString)...)
 
 	if details != nil {

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -116,7 +116,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
-			expectedMetrics:         5,
+			expectedMetrics:         6,
 			expectedActivity:        "user:12345 UA:test-user-agent req:POST /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 		},
@@ -134,7 +134,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
-			expectedMetrics:         5,
+			expectedMetrics:         6,
 			expectedActivity:        "user:12345 UA:test-user-agent req:GET /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 		},
@@ -152,7 +152,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
-			expectedMetrics:         5,
+			expectedMetrics:         6,
 			expectedActivity:        "user:12345 UA:test-user-agent req:GET /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: api.ReadConsistencyStrong,
 		},
@@ -167,7 +167,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			downstreamResponse:      makeSuccessfulDownstreamResponse(),
 			expectedStatusCode:      200,
 			expectedParams:          url.Values{},
-			expectedMetrics:         5,
+			expectedMetrics:         6,
 			expectedActivity:        "user:12345 UA:test-user-agent req:GET /api/v1/query (no params)",
 			expectedReadConsistency: "",
 		},
@@ -226,7 +226,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			},
 			downstreamResponse: makeSuccessfulDownstreamResponse(),
 			expectedActivity:   "user:12345 UA:test-user-agent req:GET /api/v1/read end_0=42&end_1=20&hints_1=%7B%22step_ms%22%3A1000%7D&matchers_0=%7B__name__%3D%22some_metric%22%2Cfoo%3D~%22.%2Abar.%2A%22%7D&matchers_1=%7B__name__%3D%22up%22%7D&start_0=0&start_1=10",
-			expectedMetrics:    5,
+			expectedMetrics:    6,
 			expectedStatusCode: 200,
 			expectedParams: url.Values{
 				"matchers_0": []string{"{__name__=\"some_metric\",foo=~\".*bar.*\"}"},
@@ -250,7 +250,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
-			expectedMetrics:         5,
+			expectedMetrics:         6,
 			expectedActivity:        "user:12345 UA: req:GET /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 		},
@@ -266,7 +266,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
-			expectedMetrics:         5,
+			expectedMetrics:         6,
 			expectedActivity:        "user:12345 UA: req:GET /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 		},
@@ -282,7 +282,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
-			expectedMetrics:         5,
+			expectedMetrics:         6,
 			expectedActivity:        "user:12345 UA: req:GET /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 		},
@@ -300,7 +300,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
-			expectedMetrics:         5,
+			expectedMetrics:         6,
 			expectedActivity:        "user:12345 UA: req:POST /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 			assertHeaders: func(t *testing.T, headers http.Header) {
@@ -325,7 +325,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"query": []string{"some_metric"},
 				"time":  []string{"42"},
 			},
-			expectedMetrics:         5,
+			expectedMetrics:         6,
 			expectedActivity:        "user:12345 UA: req:POST /api/v1/query query=some_metric&time=42",
 			expectedReadConsistency: "",
 			assertHeaders: func(t *testing.T, headers http.Header) {
@@ -427,6 +427,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				"cortex_query_fetched_chunk_bytes_total",
 				"cortex_query_fetched_chunks_total",
 				"cortex_query_fetched_index_bytes_total",
+				"cortex_query_samples_processed_total",
 			)
 
 			assert.NoError(t, err)
@@ -530,7 +531,7 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 				return nil, context.Canceled
 			},
 			expectedStatusCode:  StatusClientClosedRequest,
-			expectedMetrics:     5,
+			expectedMetrics:     6,
 			expectedStatusLog:   "canceled",
 			expectQueryParamLog: false,
 		},
@@ -545,7 +546,7 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 				}, nil
 			},
 			expectedStatusCode:  http.StatusInternalServerError,
-			expectedMetrics:     5,
+			expectedMetrics:     6,
 			expectedStatusLog:   "failed",
 			expectQueryParamLog: false,
 		},
@@ -571,6 +572,7 @@ func TestHandler_FailedRoundTrip(t *testing.T) {
 				"cortex_query_fetched_chunk_bytes_total",
 				"cortex_query_fetched_chunks_total",
 				"cortex_query_fetched_index_bytes_total",
+				"cortex_query_samples_processed_total",
 			)
 			require.NoError(t, err)
 

--- a/pkg/querier/stats/stats.pb.go
+++ b/pkg/querier/stats/stats.pb.go
@@ -50,7 +50,7 @@ type Stats struct {
 	QueueTime time.Duration `protobuf:"bytes,9,opt,name=queue_time,json=queueTime,proto3,stdduration" json:"queue_time"`
 	// The time spent at the frontend encoding the query's final results. Does not include time spent serializing results at the querier.
 	EncodeTime time.Duration `protobuf:"bytes,10,opt,name=encode_time,json=encodeTime,proto3,stdduration" json:"encode_time"`
-	// TotalSamples represents the total number of samples scanned while evaluating a query.
+	// SamplesProcessed represents the total number of samples scanned while evaluating a query.
 	SamplesProcessed uint64 `protobuf:"varint,11,opt,name=samples_processed,json=samplesProcessed,proto3" json:"samples_processed,omitempty"`
 	// The number of subqueries that were spun off as actual range queries in order to execute the full query
 	SpunOffSubqueries uint32 `protobuf:"varint,12,opt,name=spun_off_subqueries,json=spunOffSubqueries,proto3" json:"spun_off_subqueries,omitempty"`

--- a/pkg/querier/stats/stats.proto
+++ b/pkg/querier/stats/stats.proto
@@ -36,7 +36,7 @@ message Stats {
   google.protobuf.Duration queue_time = 9 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
   // The time spent at the frontend encoding the query's final results. Does not include time spent serializing results at the querier.
   google.protobuf.Duration encode_time = 10 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
-  // TotalSamples represents the total number of samples scanned while evaluating a query.
+  // SamplesProcessed represents the total number of samples scanned while evaluating a query.
   uint64 samples_processed = 11;
   // The number of subqueries that were spun off as actual range queries in order to execute the full query
   uint32 spun_off_subqueries = 12;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds cortex_query_samples_processed_total metric to keep track of actually processed samples per tenant.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
