### PR TITLE
Expose cost attribution operational insights

### DIFF
--- a/pkg/costattribution/active_tracker.go
+++ b/pkg/costattribution/active_tracker.go
@@ -286,3 +286,9 @@ func (at *ActiveSeriesTracker) fillKeyFromLabels(lbls labels.Labels, buf *bytes.
 		}
 	}
 }
+
+func (st *ActiveSeriesTracker) cardinality() (cardinality int, overflown bool) {
+	st.observedMtx.RLock()
+	defer st.observedMtx.RUnlock()
+	return len(st.observed), !st.overflowSince.IsZero()
+}

--- a/pkg/costattribution/active_tracker_test.go
+++ b/pkg/costattribution/active_tracker_test.go
@@ -14,12 +14,14 @@ import (
 )
 
 func TestActiveTracker_hasSameLabels(t *testing.T) {
-	ast := newTestManager().ActiveSeriesTracker("user1")
+	manager, _, _ := newTestManager()
+	ast := manager.ActiveSeriesTracker("user1")
 	assert.True(t, ast.hasSameLabels([]string{"team"}), "Expected cost attribution labels mismatch")
 }
 
 func TestActiveTracker_IncrementDecrement(t *testing.T) {
-	ast := newTestManager().ActiveSeriesTracker("user3")
+	manager, _, _ := newTestManager()
+	ast := manager.ActiveSeriesTracker("user3")
 	lbls1 := labels.FromStrings("department", "foo", "service", "bar")
 	lbls2 := labels.FromStrings("department", "bar", "service", "baz")
 	lbls3 := labels.FromStrings("department", "baz", "service", "foo")
@@ -47,7 +49,7 @@ func TestActiveTracker_IncrementDecrement(t *testing.T) {
 }
 
 func TestActiveTracker_Concurrency(t *testing.T) {
-	m := newTestManager()
+	m, _, costAttributionReg := newTestManager()
 	ast := m.ActiveSeriesTracker("user1")
 
 	var wg sync.WaitGroup
@@ -78,7 +80,7 @@ func TestActiveTracker_Concurrency(t *testing.T) {
     # TYPE cortex_ingester_attributed_active_series gauge
 	cortex_ingester_attributed_active_series{team="__overflow__",tenant="user1",tracker="cost-attribution"} 100
 `
-	assert.NoError(t, testutil.GatherAndCompare(m.costAttributionReg,
+	assert.NoError(t, testutil.GatherAndCompare(costAttributionReg,
 		strings.NewReader(expectedMetrics),
 		"cortex_ingester_attributed_active_series",
 		"cortex_ingester_attributed_active_native_histogram_series",

--- a/pkg/costattribution/active_tracker_test.go
+++ b/pkg/costattribution/active_tracker_test.go
@@ -78,7 +78,7 @@ func TestActiveTracker_Concurrency(t *testing.T) {
     # TYPE cortex_ingester_attributed_active_series gauge
 	cortex_ingester_attributed_active_series{team="__overflow__",tenant="user1",tracker="cost-attribution"} 100
 `
-	assert.NoError(t, testutil.GatherAndCompare(m.reg,
+	assert.NoError(t, testutil.GatherAndCompare(m.costAttributionReg,
 		strings.NewReader(expectedMetrics),
 		"cortex_ingester_attributed_active_series",
 		"cortex_ingester_attributed_active_native_histogram_series",

--- a/pkg/costattribution/manager_test.go
+++ b/pkg/costattribution/manager_test.go
@@ -77,7 +77,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
         # TYPE cortex_ingester_attributed_active_series gauge
         cortex_ingester_attributed_active_series{team="bar",tenant="user1",tracker="cost-attribution"} 3
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.reg,
+		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg,
 			strings.NewReader(expectedMetrics),
 			"cortex_discarded_attributed_samples_total",
 			"cortex_distributor_received_attributed_samples_total",
@@ -105,7 +105,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
         # TYPE cortex_ingester_attributed_active_series gauge
         cortex_ingester_attributed_active_series{team="bar",tenant="user1",tracker="cost-attribution"} 2
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.reg,
+		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg,
 			strings.NewReader(expectedMetrics),
 			"cortex_discarded_attributed_samples_total",
 			"cortex_distributor_received_attributed_samples_total",
@@ -127,7 +127,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 		# TYPE cortex_ingester_attributed_active_series gauge
 		cortex_ingester_attributed_active_series{team="bar",tenant="user1",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.reg,
+		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg,
 			strings.NewReader(expectedMetrics),
 			"cortex_discarded_attributed_samples_total",
 			"cortex_distributor_received_attributed_samples_total",
@@ -148,7 +148,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
         # TYPE cortex_ingester_attributed_active_series gauge
         cortex_ingester_attributed_active_series{team="bar",tenant="user1",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.reg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total", "cortex_ingester_attributed_active_series"))
+		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total", "cortex_ingester_attributed_active_series"))
 	})
 
 	t.Run("Disabling user cost attribution", func(t *testing.T) {
@@ -161,7 +161,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 		# TYPE cortex_distributor_received_attributed_samples_total counter
 		cortex_distributor_received_attributed_samples_total{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.reg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total", "cortex_distributor_received_attributed_samples_total", "cortex_ingester_attributed_active_series"))
+		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total", "cortex_distributor_received_attributed_samples_total", "cortex_ingester_attributed_active_series"))
 	})
 
 	t.Run("Updating user cardinality and labels", func(t *testing.T) {
@@ -177,7 +177,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 		# TYPE cortex_discarded_attributed_samples_total counter
 		cortex_discarded_attributed_samples_total{feature="__missing__",reason="invalid-metrics-name",team="foo",tenant="user3",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.reg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
 	})
 
 	t.Run("Overflow metrics on cardinality limit", func(t *testing.T) {
@@ -189,7 +189,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 		# TYPE cortex_distributor_received_attributed_samples_total counter
 		cortex_distributor_received_attributed_samples_total{feature="__overflow__",team="__overflow__",tenant="user3",tracker="cost-attribution"} 2
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.reg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
 	})
 }
 
@@ -210,7 +210,7 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 		cortex_discarded_attributed_samples_total{reason="invalid-metrics-name",team="foo",tenant="user1",tracker="cost-attribution"} 1
 		cortex_discarded_attributed_samples_total{department="foo",reason="out-of-window",service="bar",tenant="user3",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.reg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
 	})
 
 	t.Run("Purge after inactive timeout", func(t *testing.T) {
@@ -228,7 +228,7 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 		# TYPE cortex_discarded_attributed_samples_total counter
 		cortex_discarded_attributed_samples_total{department="foo",reason="out-of-window",service="bar",tenant="user3",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.reg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
 	})
 
 	t.Run("Purge all trackers", func(t *testing.T) {
@@ -239,6 +239,6 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 		assert.Equal(t, 1, len(manager.sampleTrackersByUserID), "Expected one active tracker after full purge")
 
 		// No metrics should remain after all purged
-		assert.NoError(t, testutil.GatherAndCompare(manager.reg, strings.NewReader(""), "cortex_discarded_attributed_samples_total", "cortex_distributor_received_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(""), "cortex_discarded_attributed_samples_total", "cortex_distributor_received_attributed_samples_total"))
 	})
 }

--- a/pkg/costattribution/manager_test.go
+++ b/pkg/costattribution/manager_test.go
@@ -17,26 +17,27 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
-func newTestManager() *Manager {
+func newTestManager() (manager *Manager, reg, costAttributionReg *prometheus.Registry) {
 	logger := log.NewNopLogger()
 	limits := testutils.NewMockCostAttributionLimits(0)
-	reg := prometheus.NewRegistry()
-	manager, err := NewManager(5*time.Second, 10*time.Second, logger, limits, reg)
+	reg = prometheus.NewRegistry()
+	costAttributionReg = prometheus.NewRegistry()
+	manager, err := NewManager(5*time.Second, 10*time.Second, logger, limits, reg, costAttributionReg)
 	if err != nil {
 		panic(err)
 	}
-	return manager
+	return manager, reg, costAttributionReg
 }
 
 func TestManager_New(t *testing.T) {
-	manager := newTestManager()
+	manager, _, _ := newTestManager()
 	assert.NotNil(t, manager)
 	assert.NotNil(t, manager.sampleTrackersByUserID)
 	assert.Equal(t, 10*time.Second, manager.inactiveTimeout)
 }
 
 func TestManager_CreateDeleteTracker(t *testing.T) {
-	manager := newTestManager()
+	manager, reg, costAttributionReg := newTestManager()
 
 	t.Run("Tracker existence and attributes", func(t *testing.T) {
 		user1SampleTracker := manager.SampleTracker("user1")
@@ -77,7 +78,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
         # TYPE cortex_ingester_attributed_active_series gauge
         cortex_ingester_attributed_active_series{team="bar",tenant="user1",tracker="cost-attribution"} 3
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg,
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg,
 			strings.NewReader(expectedMetrics),
 			"cortex_discarded_attributed_samples_total",
 			"cortex_distributor_received_attributed_samples_total",
@@ -105,7 +106,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
         # TYPE cortex_ingester_attributed_active_series gauge
         cortex_ingester_attributed_active_series{team="bar",tenant="user1",tracker="cost-attribution"} 2
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg,
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg,
 			strings.NewReader(expectedMetrics),
 			"cortex_discarded_attributed_samples_total",
 			"cortex_distributor_received_attributed_samples_total",
@@ -127,13 +128,31 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 		# TYPE cortex_ingester_attributed_active_series gauge
 		cortex_ingester_attributed_active_series{team="bar",tenant="user1",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg,
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg,
 			strings.NewReader(expectedMetrics),
 			"cortex_discarded_attributed_samples_total",
 			"cortex_distributor_received_attributed_samples_total",
 			"cortex_ingester_attributed_active_series",
 			"cortex_ingester_attributed_active_native_histogram_series",
 			"cortex_ingester_attributed_active_native_histogram_buckets",
+		))
+
+		expectedMetrics = `
+		# HELP cortex_cost_attribution_active_series_tracker_cardinality The cardinality of a cost attribution active series tracker for each user.
+		# TYPE cortex_cost_attribution_active_series_tracker_cardinality gauge
+		cortex_cost_attribution_active_series_tracker_cardinality{tracker="cost-attribution",user="user1"} 1
+		cortex_cost_attribution_active_series_tracker_cardinality{tracker="cost-attribution",user="user3"} 0
+		# HELP cortex_cost_attribution_sample_tracker_cardinality The cardinality of a cost attribution sample tracker for each user.
+		# TYPE cortex_cost_attribution_sample_tracker_cardinality gauge
+		cortex_cost_attribution_sample_tracker_cardinality{tracker="cost-attribution",user="user1"} 2
+		cortex_cost_attribution_sample_tracker_cardinality{tracker="cost-attribution",user="user3"} 1
+		`
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics),
+			"cortex_cost_attribution_sample_tracker_cardinality",
+			"cortex_cost_attribution_sample_tracker_overflown",
+			"cortex_cost_attribution_active_series_tracker_cardinality",
+			"cortex_cost_attribution_active_series_tracker_overflown",
 		))
 	})
 
@@ -148,7 +167,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
         # TYPE cortex_ingester_attributed_active_series gauge
         cortex_ingester_attributed_active_series{team="bar",tenant="user1",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total", "cortex_ingester_attributed_active_series"))
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total", "cortex_ingester_attributed_active_series"))
 	})
 
 	t.Run("Disabling user cost attribution", func(t *testing.T) {
@@ -161,7 +180,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 		# TYPE cortex_distributor_received_attributed_samples_total counter
 		cortex_distributor_received_attributed_samples_total{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total", "cortex_distributor_received_attributed_samples_total", "cortex_ingester_attributed_active_series"))
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total", "cortex_distributor_received_attributed_samples_total", "cortex_ingester_attributed_active_series"))
 	})
 
 	t.Run("Updating user cardinality and labels", func(t *testing.T) {
@@ -177,7 +196,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 		# TYPE cortex_discarded_attributed_samples_total counter
 		cortex_discarded_attributed_samples_total{feature="__missing__",reason="invalid-metrics-name",team="foo",tenant="user3",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
 	})
 
 	t.Run("Overflow metrics on cardinality limit", func(t *testing.T) {
@@ -189,12 +208,31 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 		# TYPE cortex_distributor_received_attributed_samples_total counter
 		cortex_distributor_received_attributed_samples_total{feature="__overflow__",team="__overflow__",tenant="user3",tracker="cost-attribution"} 2
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
+
+		expectedMetrics = `
+		# HELP cortex_cost_attribution_active_series_tracker_cardinality The cardinality of a cost attribution active series tracker for each user.
+		# TYPE cortex_cost_attribution_active_series_tracker_cardinality gauge
+		cortex_cost_attribution_active_series_tracker_cardinality{tracker="cost-attribution",user="user3"} 0
+		# HELP cortex_cost_attribution_sample_tracker_cardinality The cardinality of a cost attribution sample tracker for each user.
+		# TYPE cortex_cost_attribution_sample_tracker_cardinality gauge
+		cortex_cost_attribution_sample_tracker_cardinality{tracker="cost-attribution",user="user3"} 2
+		# HELP cortex_cost_attribution_sample_tracker_overflown This metric is exported with value 1 when a sample tracker for a user is overflown. It's not exported otherwise.
+		# TYPE cortex_cost_attribution_sample_tracker_overflown gauge
+		cortex_cost_attribution_sample_tracker_overflown{tracker="cost-attribution",user="user3"} 1
+		`
+
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics),
+			"cortex_cost_attribution_sample_tracker_cardinality",
+			"cortex_cost_attribution_sample_tracker_overflown",
+			"cortex_cost_attribution_active_series_tracker_cardinality",
+			"cortex_cost_attribution_active_series_tracker_overflown",
+		))
 	})
 }
 
 func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
-	manager := newTestManager()
+	manager, _, costAttributionReg := newTestManager()
 
 	manager.SampleTracker("user1").IncrementReceivedSamples(testutils.CreateRequest([]testutils.Series{{LabelValues: []string{"team", "foo"}, SamplesCount: 1}}), time.Unix(1, 0))
 	manager.SampleTracker("user1").IncrementDiscardedSamples([]mimirpb.LabelAdapter{{Name: "team", Value: "foo"}}, 1, "invalid-metrics-name", time.Unix(1, 0))
@@ -210,7 +248,7 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 		cortex_discarded_attributed_samples_total{reason="invalid-metrics-name",team="foo",tenant="user1",tracker="cost-attribution"} 1
 		cortex_discarded_attributed_samples_total{department="foo",reason="out-of-window",service="bar",tenant="user3",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
 	})
 
 	t.Run("Purge after inactive timeout", func(t *testing.T) {
@@ -228,7 +266,7 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 		# TYPE cortex_discarded_attributed_samples_total counter
 		cortex_discarded_attributed_samples_total{department="foo",reason="out-of-window",service="bar",tenant="user3",tracker="cost-attribution"} 1
 		`
-		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_discarded_attributed_samples_total"))
 	})
 
 	t.Run("Purge all trackers", func(t *testing.T) {
@@ -239,6 +277,6 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 		assert.Equal(t, 1, len(manager.sampleTrackersByUserID), "Expected one active tracker after full purge")
 
 		// No metrics should remain after all purged
-		assert.NoError(t, testutil.GatherAndCompare(manager.costAttributionReg, strings.NewReader(""), "cortex_discarded_attributed_samples_total", "cortex_distributor_received_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(""), "cortex_discarded_attributed_samples_total", "cortex_distributor_received_attributed_samples_total"))
 	})
 }

--- a/pkg/costattribution/sample_tracker.go
+++ b/pkg/costattribution/sample_tracker.go
@@ -318,3 +318,9 @@ func (st *SampleTracker) cleanupInactiveObservations(deadline time.Time) {
 	}
 	st.observedMtx.Unlock()
 }
+
+func (st *SampleTracker) cardinality() (cardinality int, overflown bool) {
+	st.observedMtx.RLock()
+	defer st.observedMtx.RUnlock()
+	return len(st.observed), !st.overflowSince.IsZero()
+}

--- a/pkg/costattribution/sample_tracker.go
+++ b/pkg/costattribution/sample_tracker.go
@@ -90,7 +90,7 @@ var bufferPool = sync.Pool{
 	},
 }
 
-func (st *SampleTracker) Collect(out chan<- prometheus.Metric) {
+func (st *SampleTracker) collectCostAttribution(out chan<- prometheus.Metric) {
 	// We don't know the performance of out receiver, so we don't want to hold the lock for too long
 	var prometheusMetrics []prometheus.Metric
 	st.observedMtx.RLock()

--- a/pkg/costattribution/sample_tracker_test.go
+++ b/pkg/costattribution/sample_tracker_test.go
@@ -17,13 +17,14 @@ import (
 )
 
 func TestSampleTracker_hasSameLabels(t *testing.T) {
-	st := newTestManager().SampleTracker("user1")
+	manager, _, _ := newTestManager()
+	st := manager.SampleTracker("user1")
 	assert.True(t, st.hasSameLabels([]string{"team"}), "Expected cost attribution labels mismatch")
 }
 
 func TestSampleTracker_IncrementReceviedSamples(t *testing.T) {
-	tManager := newTestManager()
-	st := tManager.SampleTracker("user4")
+	manager, _, costAttributionReg := newTestManager()
+	st := manager.SampleTracker("user4")
 	t.Run("One Single Series in Request", func(t *testing.T) {
 		st.IncrementReceivedSamples(testutils.CreateRequest([]testutils.Series{{LabelValues: []string{"platform", "foo", "service", "dodo"}, SamplesCount: 3}}), time.Unix(10, 0))
 
@@ -32,7 +33,7 @@ func TestSampleTracker_IncrementReceviedSamples(t *testing.T) {
 	# TYPE cortex_distributor_received_attributed_samples_total counter
 	cortex_distributor_received_attributed_samples_total{platform="foo",tenant="user4",tracker="cost-attribution"} 3
 	`
-		assert.NoError(t, testutil.GatherAndCompare(tManager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
 	})
 	t.Run("Multiple Different Series in Request", func(t *testing.T) {
 		st.IncrementReceivedSamples(testutils.CreateRequest([]testutils.Series{
@@ -46,7 +47,7 @@ func TestSampleTracker_IncrementReceviedSamples(t *testing.T) {
 	cortex_distributor_received_attributed_samples_total{platform="foo",tenant="user4",tracker="cost-attribution"} 6
 	cortex_distributor_received_attributed_samples_total{platform="bar",tenant="user4",tracker="cost-attribution"} 5
 	`
-		assert.NoError(t, testutil.GatherAndCompare(tManager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
 	})
 
 	t.Run("Multiple Series in Request with Same Labels", func(t *testing.T) {
@@ -61,12 +62,13 @@ func TestSampleTracker_IncrementReceviedSamples(t *testing.T) {
 	cortex_distributor_received_attributed_samples_total{platform="foo",tenant="user4",tracker="cost-attribution"} 14
 	cortex_distributor_received_attributed_samples_total{platform="bar",tenant="user4",tracker="cost-attribution"} 5
 	`
-		assert.NoError(t, testutil.GatherAndCompare(tManager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
 	})
 }
 
 func TestSampleTracker_IncrementDiscardedSamples(t *testing.T) {
-	st := newTestManager().SampleTracker("user3")
+	manager, _, _ := newTestManager()
+	st := manager.SampleTracker("user3")
 	lbls1 := []mimirpb.LabelAdapter{{Name: "department", Value: "foo"}, {Name: "service", Value: "bar"}}
 	lbls2 := []mimirpb.LabelAdapter{{Name: "department", Value: "bar"}, {Name: "service", Value: "baz"}}
 	lbls3 := []mimirpb.LabelAdapter{{Name: "department", Value: "baz"}, {Name: "service", Value: "foo"}}
@@ -90,7 +92,8 @@ func TestSampleTracker_IncrementDiscardedSamples(t *testing.T) {
 
 func TestSampleTracker_inactiveObservations(t *testing.T) {
 	// Setup the test environment: create a st for user1 with a "team" label and max cardinality of 5.
-	st := newTestManager().SampleTracker("user1")
+	manager, _, _ := newTestManager()
+	st := manager.SampleTracker("user1")
 
 	// Create two observations with different last update timestamps.
 	observations := [][]mimirpb.LabelAdapter{
@@ -125,7 +128,7 @@ func TestSampleTracker_Concurrency(t *testing.T) {
 	// Disabled due to spurious failures. See https://github.com/grafana/mimir/issues/10482
 	t.Skip()
 
-	m := newTestManager()
+	m, _, costAttributionReg := newTestManager()
 	st := m.SampleTracker("user1")
 
 	var wg sync.WaitGroup
@@ -154,5 +157,5 @@ func TestSampleTracker_Concurrency(t *testing.T) {
 	cortex_distributor_received_attributed_samples_total{team="__overflow__",tenant="user1",tracker="cost-attribution"} 95
 
 `
-	assert.NoError(t, testutil.GatherAndCompare(m.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total", "cortex_discarded_attributed_samples_total"))
+	assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total", "cortex_discarded_attributed_samples_total"))
 }

--- a/pkg/costattribution/sample_tracker_test.go
+++ b/pkg/costattribution/sample_tracker_test.go
@@ -32,7 +32,7 @@ func TestSampleTracker_IncrementReceviedSamples(t *testing.T) {
 	# TYPE cortex_distributor_received_attributed_samples_total counter
 	cortex_distributor_received_attributed_samples_total{platform="foo",tenant="user4",tracker="cost-attribution"} 3
 	`
-		assert.NoError(t, testutil.GatherAndCompare(tManager.reg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(tManager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
 	})
 	t.Run("Multiple Different Series in Request", func(t *testing.T) {
 		st.IncrementReceivedSamples(testutils.CreateRequest([]testutils.Series{
@@ -46,7 +46,7 @@ func TestSampleTracker_IncrementReceviedSamples(t *testing.T) {
 	cortex_distributor_received_attributed_samples_total{platform="foo",tenant="user4",tracker="cost-attribution"} 6
 	cortex_distributor_received_attributed_samples_total{platform="bar",tenant="user4",tracker="cost-attribution"} 5
 	`
-		assert.NoError(t, testutil.GatherAndCompare(tManager.reg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(tManager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
 	})
 
 	t.Run("Multiple Series in Request with Same Labels", func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestSampleTracker_IncrementReceviedSamples(t *testing.T) {
 	cortex_distributor_received_attributed_samples_total{platform="foo",tenant="user4",tracker="cost-attribution"} 14
 	cortex_distributor_received_attributed_samples_total{platform="bar",tenant="user4",tracker="cost-attribution"} 5
 	`
-		assert.NoError(t, testutil.GatherAndCompare(tManager.reg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
+		assert.NoError(t, testutil.GatherAndCompare(tManager.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total"))
 	})
 }
 
@@ -154,5 +154,5 @@ func TestSampleTracker_Concurrency(t *testing.T) {
 	cortex_distributor_received_attributed_samples_total{team="__overflow__",tenant="user1",tracker="cost-attribution"} 95
 
 `
-	assert.NoError(t, testutil.GatherAndCompare(m.reg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total", "cortex_discarded_attributed_samples_total"))
+	assert.NoError(t, testutil.GatherAndCompare(m.costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total", "cortex_discarded_attributed_samples_total"))
 }

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -664,10 +664,10 @@ func (t *Mimir) initActiveGroupsCleanupService() (services.Service, error) {
 func (t *Mimir) initCostAttributionService() (services.Service, error) {
 	// The cost attribution service is only initilized if the custom registry path is provided.
 	if t.Cfg.CostAttributionRegistryPath != "" {
-		reg := prometheus.NewRegistry()
+		costAttributionReg := prometheus.NewRegistry()
 		var err error
-		t.CostAttributionManager, err = costattribution.NewManager(t.Cfg.CostAttributionCleanupInterval, t.Cfg.CostAttributionEvictionInterval, util_log.Logger, t.Overrides, reg)
-		t.API.RegisterCostAttribution(t.Cfg.CostAttributionRegistryPath, reg)
+		t.CostAttributionManager, err = costattribution.NewManager(t.Cfg.CostAttributionCleanupInterval, t.Cfg.CostAttributionEvictionInterval, util_log.Logger, t.Overrides, t.Registerer, costAttributionReg)
+		t.API.RegisterCostAttribution(t.Cfg.CostAttributionRegistryPath, costAttributionReg)
 		return t.CostAttributionManager, err
 	}
 	return nil, nil


### PR DESCRIPTION
#### What this PR does

Adds metrics that observe the cardinality and the overflow state of each one of the cost-attribution trackers.

These metrics are exposed per user and tracker. The "overflown" metric is only exposed when tracker is actually overflown.

#### Which issue(s) this PR fixes or relates to

Fixes an internal need.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
