### PR TITLE
Alertmanager: Propagate tenant to pre-notify hooks.

### DIFF
--- a/pkg/alertmanager/notify_hooks_notifier_test.go
+++ b/pkg/alertmanager/notify_hooks_notifier_test.go
@@ -60,6 +60,8 @@ func newTestHooksFixture(t *testing.T) *testHooksFixture {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/test/hook", r.URL.Path)
 
+		assert.Equal(t, "user", r.Header.Get("X-Scope-OrgID"))
+
 		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 


### PR DESCRIPTION
Extend the recently added experimental pre-notify hooks to include the tenant ID
in the X-Scope-OrgID header of the upstream request.
