### PR TITLE
MQE: emit query planning latency metrics

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1766,20 +1766,25 @@ func rejectedMetrics(rejectedDueToMemoryConsumption int) string {
 	`, rejectedDueToMemoryConsumption)
 }
 
-func getHistogram(t *testing.T, reg *prometheus.Registry, name string) *dto.Histogram {
+func getMetrics(t *testing.T, reg *prometheus.Registry, name string) []*dto.Metric {
 	metrics, err := reg.Gather()
 	require.NoError(t, err)
 
 	for _, m := range metrics {
 		if m.GetName() == name {
-			require.Len(t, m.Metric, 1)
-
-			return m.Metric[0].Histogram
+			return m.Metric
 		}
 	}
 
 	require.Fail(t, "expected to find a metric with name "+name)
 	return nil
+}
+
+func getHistogram(t *testing.T, reg *prometheus.Registry, name string) *dto.Histogram {
+	m := getMetrics(t, reg, name)
+	require.Len(t, m, 1)
+
+	return m[0].Histogram
 }
 
 func TestActiveQueryTracker(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

This PR builds on the query planner introduced in https://github.com/grafana/mimir/pull/11004 and introduces latency metrics for each of the query planning stages.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/11004

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
