### PR TITLE
MQE: introduce `ResultType` method for query planner `Node`

### DIFF
--- a/pkg/streamingpromql/planning/core/aggregate_expression.go
+++ b/pkg/streamingpromql/planning/core/aggregate_expression.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/aggregations"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/aggregations/topkbottomk"
@@ -166,4 +167,8 @@ func (a *AggregateExpression) OperatorFactory(children []types.Operator, timeRan
 	}
 
 	return planning.NewSingleUseOperatorFactory(o), nil
+}
+
+func (a *AggregateExpression) ResultType() (parser.ValueType, error) {
+	return parser.ValueTypeVector, nil
 }

--- a/pkg/streamingpromql/planning/core/binary_expression.go
+++ b/pkg/streamingpromql/planning/core/binary_expression.go
@@ -202,6 +202,32 @@ func (b *BinaryExpression) createVectorVectorOperator(lhs, rhs types.InstantVect
 	}
 }
 
+func (b *BinaryExpression) ResultType() (parser.ValueType, error) {
+	lhs, err := b.LHS.ResultType()
+	if err != nil {
+		return parser.ValueTypeNone, err
+	}
+
+	rhs, err := b.RHS.ResultType()
+	if err != nil {
+		return parser.ValueTypeNone, err
+	}
+
+	if lhs == parser.ValueTypeScalar && rhs == parser.ValueTypeScalar {
+		return parser.ValueTypeScalar, nil
+	}
+
+	if lhs != parser.ValueTypeVector && lhs != parser.ValueTypeScalar {
+		return parser.ValueTypeNone, fmt.Errorf("left side of binary expression must be scalar or vector, got %v", lhs)
+	}
+
+	if rhs != parser.ValueTypeVector && rhs != parser.ValueTypeScalar {
+		return parser.ValueTypeNone, fmt.Errorf("right side of binary expression must be scalar or vector, got %v", rhs)
+	}
+
+	return parser.ValueTypeVector, nil
+}
+
 func (v *VectorMatching) Equals(other *VectorMatching) bool {
 	if v == nil && other == nil {
 		// Both are nil.

--- a/pkg/streamingpromql/planning/core/function_call.go
+++ b/pkg/streamingpromql/planning/core/function_call.go
@@ -131,6 +131,8 @@ func (f *FunctionCall) OperatorFactory(children []types.Operator, timeRange type
 }
 
 func (f *FunctionCall) ResultType() (parser.ValueType, error) {
+	// absent and absent_over_time are special cases that aren't present in InstantVectorFunctionOperatorFactories,
+	// so we have to handle them specifically.
 	if _, ok := functions.InstantVectorFunctionOperatorFactories[f.FunctionName]; ok || f.FunctionName == "absent" || f.FunctionName == "absent_over_time" {
 		return parser.ValueTypeVector, nil
 	}

--- a/pkg/streamingpromql/planning/core/function_call.go
+++ b/pkg/streamingpromql/planning/core/function_call.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
@@ -127,4 +128,16 @@ func (f *FunctionCall) OperatorFactory(children []types.Operator, timeRange type
 	default:
 		return nil, compat.NewNotSupportedError(fmt.Sprintf("'%v' function", f.FunctionName))
 	}
+}
+
+func (f *FunctionCall) ResultType() (parser.ValueType, error) {
+	if _, ok := functions.InstantVectorFunctionOperatorFactories[f.FunctionName]; ok || f.FunctionName == "absent" || f.FunctionName == "absent_over_time" {
+		return parser.ValueTypeVector, nil
+	}
+
+	if _, ok := functions.ScalarFunctionOperatorFactories[f.FunctionName]; ok {
+		return parser.ValueTypeScalar, nil
+	}
+
+	return parser.ValueTypeNone, compat.NewNotSupportedError(fmt.Sprintf("'%v' function", f.FunctionName))
 }

--- a/pkg/streamingpromql/planning/core/matrix_selector.go
+++ b/pkg/streamingpromql/planning/core/matrix_selector.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/selectors"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -74,4 +75,8 @@ func (m *MatrixSelector) OperatorFactory(_ []types.Operator, timeRange types.Que
 	o := selectors.NewRangeVectorSelector(selector, params.MemoryConsumptionTracker, params.Stats)
 
 	return planning.NewSingleUseOperatorFactory(o), nil
+}
+
+func (m *MatrixSelector) ResultType() (parser.ValueType, error) {
+	return parser.ValueTypeMatrix, nil
 }

--- a/pkg/streamingpromql/planning/core/number_literal.go
+++ b/pkg/streamingpromql/planning/core/number_literal.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/scalars"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -55,4 +56,8 @@ func (n *NumberLiteral) OperatorFactory(_ []types.Operator, timeRange types.Quer
 	o := scalars.NewScalarConstant(n.Value, timeRange, params.MemoryConsumptionTracker, n.ExpressionPosition.ToPrometheusType())
 
 	return planning.NewSingleUseOperatorFactory(o), nil
+}
+
+func (n *NumberLiteral) ResultType() (parser.ValueType, error) {
+	return parser.ValueTypeScalar, nil
 }

--- a/pkg/streamingpromql/planning/core/string_literal.go
+++ b/pkg/streamingpromql/planning/core/string_literal.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -55,4 +56,8 @@ func (s *StringLiteral) OperatorFactory(_ []types.Operator, _ types.QueryTimeRan
 	o := operators.NewStringLiteral(s.Value, s.ExpressionPosition.ToPrometheusType())
 
 	return planning.NewSingleUseOperatorFactory(o), nil
+}
+
+func (s *StringLiteral) ResultType() (parser.ValueType, error) {
+	return parser.ValueTypeString, nil
 }

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -138,4 +139,8 @@ func (s *Subquery) OperatorFactory(children []types.Operator, timeRange types.Qu
 	o := operators.NewSubquery(inner, timeRange, s.Timestamp.ToInt64(), s.Offset, s.Range, s.ExpressionPosition.ToPrometheusType(), params.MemoryConsumptionTracker)
 
 	return planning.NewSingleUseOperatorFactory(o), nil
+}
+
+func (s *Subquery) ResultType() (parser.ValueType, error) {
+	return parser.ValueTypeMatrix, nil
 }

--- a/pkg/streamingpromql/planning/core/unary_expression.go
+++ b/pkg/streamingpromql/planning/core/unary_expression.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
@@ -76,5 +77,8 @@ func (u *UnaryExpression) OperatorFactory(children []types.Operator, timeRange t
 	default:
 		return nil, fmt.Errorf("expected InstantVectorOperator or ScalarOperator as child of UnaryExpression, got %T", children[0])
 	}
+}
 
+func (u *UnaryExpression) ResultType() (parser.ValueType, error) {
+	return u.Inner.ResultType()
 }

--- a/pkg/streamingpromql/planning/core/vector_selector.go
+++ b/pkg/streamingpromql/planning/core/vector_selector.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/selectors"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -75,4 +76,8 @@ func (v *VectorSelector) OperatorFactory(_ []types.Operator, timeRange types.Que
 	}
 
 	return planning.NewSingleUseOperatorFactory(o), nil
+}
+
+func (v *VectorSelector) ResultType() (parser.ValueType, error) {
+	return parser.ValueTypeVector, nil
 }

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	prototypes "github.com/gogo/protobuf/types"
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
 
@@ -73,6 +74,11 @@ type Node interface {
 
 	// OperatorFactory returns a factory that produces operators for this node.
 	OperatorFactory(children []types.Operator, timeRange types.QueryTimeRange, params *OperatorParameters) (OperatorFactory, error)
+
+	// ResultType returns the kind of result this node produces.
+	//
+	// May return an error if the kind of result cannot be determined (eg. because the node references an unknown function).
+	ResultType() (parser.ValueType, error)
 
 	// FIXME: implementations for many of the above methods can be generated automatically
 }


### PR DESCRIPTION
#### What this PR does

This PR introduces a `ResultType` method for the query planner `Node` interface.

This will allow optimization passes to correctly handle nodes that produce different kinds of values. 

I'm raising this as a separate PR in the interests of keeping the upcoming common subexpression elimination PR smaller.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
