### PR TITLE
Renovate: Disable dependency dashboard

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -57,5 +57,6 @@
       "enabled": true,
       "labels": ["security-update"]
     },
-    "osvVulnerabilityAlerts": true
+    "osvVulnerabilityAlerts": true,
+    "dependencyDashboard": false
 }


### PR DESCRIPTION
#### What this PR does

Disable Renovate's dependency dashboard, as otherwise we have to manually approve for it to open PRs to make major version updates. We just want the PRs.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
