### PR TITLE
MQE: close inner operators of binary operations as early as possible

### DIFF
--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -93,8 +93,11 @@ type Engine struct {
 	estimatedPeakMemoryConsumption            prometheus.Histogram
 	queriesRejectedDueToPeakMemoryConsumption prometheus.Counter
 
-	// When operating in pedantic mode, we panic if memory consumption is > 0 after Query.Close()
-	// (indicating something was not returned to a pool).
+	// When operating in pedantic mode:
+	// - Query.Exec() will call Close() on the root operator a second time to ensure it behaves correctly if Close() is called multiple times.
+	// - Query.Close() will panic if memory consumption is > 0, which indicates something was not returned to a pool.
+	//
+	// Pedantic mode should only be enabled in tests. It is not intended to be used in production.
 	pedantic bool
 
 	useQueryPlanning bool

--- a/pkg/streamingpromql/operators/aggregations/quantile.go
+++ b/pkg/streamingpromql/operators/aggregations/quantile.go
@@ -88,10 +88,13 @@ func (q *QuantileAggregation) NextSeries(ctx context.Context) (types.InstantVect
 func (q *QuantileAggregation) Close() {
 	if q.Aggregation.ParamData.Samples != nil {
 		types.FPointSlicePool.Put(q.Aggregation.ParamData.Samples, q.MemoryConsumptionTracker)
+		q.Aggregation.ParamData.Samples = nil
 	}
+
 	if q.Param != nil {
 		q.Param.Close()
 	}
+
 	q.Aggregation.Close()
 }
 

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
@@ -286,7 +286,10 @@ func (t *InstantQuery) Close() {
 	t.Inner.Close()
 	t.Param.Close()
 
-	types.Float64SlicePool.Put(t.values, t.MemoryConsumptionTracker)
+	if t.values != nil {
+		types.Float64SlicePool.Put(t.values, t.MemoryConsumptionTracker)
+		t.values = nil
+	}
 }
 
 type instantQueryGroup struct {

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
@@ -407,7 +407,10 @@ func (t *RangeQuery) Close() {
 	t.Inner.Close()
 	t.Param.Close()
 
-	types.Int64SlicePool.Put(t.k, t.MemoryConsumptionTracker)
+	if t.k != nil {
+		types.Int64SlicePool.Put(t.k, t.MemoryConsumptionTracker)
+		t.k = nil
+	}
 }
 
 type rangeQueryGroup struct {

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
@@ -20,11 +20,14 @@ type AndUnlessBinaryOperation struct {
 	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
 	IsUnless                 bool // If true, this operator represents an 'unless', if false, this operator represents an 'and'
 
-	timeRange            types.QueryTimeRange
-	expressionPosition   posrange.PositionRange
-	leftSeriesGroups     []*andGroup
-	rightSeriesGroups    []*andGroup
-	nextRightSeriesIndex int
+	timeRange                  types.QueryTimeRange
+	expressionPosition         posrange.PositionRange
+	leftSeriesGroups           []*andGroup
+	rightSeriesGroups          []*andGroup
+	nextRightSeriesIndex       int
+	lastRightSeriesIndexToRead int
+	nextLeftSeriesIndex        int
+	lastLeftSeriesIndexToRead  int
 }
 
 var _ types.InstantVectorOperator = &AndUnlessBinaryOperation{}
@@ -46,10 +49,25 @@ func NewAndUnlessBinaryOperation(
 		IsUnless:                 isUnless,
 		timeRange:                timeRange,
 		expressionPosition:       expressionPosition,
+
+		lastLeftSeriesIndexToRead:  -1,
+		lastRightSeriesIndexToRead: -1,
 	}
 }
 
 func (a *AndUnlessBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
+	defer func() {
+		if a.lastLeftSeriesIndexToRead == -1 {
+			// We're not going to read anything from the left side, close it now.
+			a.Left.Close()
+		}
+
+		if a.lastRightSeriesIndexToRead == -1 {
+			// We're not going to read anything from the right side, close it now.
+			a.Right.Close()
+		}
+	}()
+
 	leftMetadata, err := a.Left.SeriesMetadata(ctx)
 	if err != nil {
 		return nil, err
@@ -101,17 +119,22 @@ func (a *AndUnlessBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.
 
 		if exists {
 			group.lastRightSeriesIndex = idx
+			a.lastRightSeriesIndexToRead = idx
 		}
 
 		// Even if there is no matching group, we want to store a nil value here so we know to throw the series away when we read it later.
 		a.rightSeriesGroups = append(a.rightSeriesGroups, group)
 	}
 
+	var metadata []types.SeriesMetadata
+
 	if a.IsUnless {
-		return a.computeUnlessSeriesMetadata(leftMetadata), nil
+		metadata = a.computeUnlessSeriesMetadata(leftMetadata)
+	} else {
+		metadata = a.computeAndSeriesMetadata(leftMetadata)
 	}
 
-	return a.computeAndSeriesMetadata(leftMetadata), nil
+	return metadata, nil
 }
 
 func (a *AndUnlessBinaryOperation) computeAndSeriesMetadata(leftMetadata []types.SeriesMetadata) []types.SeriesMetadata {
@@ -127,6 +150,7 @@ func (a *AndUnlessBinaryOperation) computeAndSeriesMetadata(leftMetadata []types
 		} else {
 			leftMetadata[nextOutputSeriesIndex] = leftMetadata[seriesIdx]
 			nextOutputSeriesIndex++
+			a.lastLeftSeriesIndexToRead = seriesIdx
 		}
 	}
 
@@ -142,10 +166,20 @@ func (a *AndUnlessBinaryOperation) computeUnlessSeriesMetadata(leftMetadata []ty
 		}
 	}
 
+	a.lastLeftSeriesIndexToRead = len(leftMetadata) - 1
+
 	return leftMetadata
 }
 
 func (a *AndUnlessBinaryOperation) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+	defer func() {
+		// If we're done reading the left side, close it so it can release any resources as early as possible.
+		// We do the same thing for the right side in readRightSideUntilGroupComplete.
+		if a.nextLeftSeriesIndex > a.lastLeftSeriesIndexToRead {
+			a.Left.Close()
+		}
+	}()
+
 	for {
 		if len(a.leftSeriesGroups) == 0 {
 			// No more series to return.
@@ -154,6 +188,7 @@ func (a *AndUnlessBinaryOperation) NextSeries(ctx context.Context) (types.Instan
 
 		thisSeriesGroup := a.leftSeriesGroups[0]
 		a.leftSeriesGroups = a.leftSeriesGroups[1:]
+		a.nextLeftSeriesIndex++
 
 		if thisSeriesGroup == nil {
 			// This series from the left side has no matching series on the right side.
@@ -219,6 +254,11 @@ func (a *AndUnlessBinaryOperation) readRightSideUntilGroupComplete(ctx context.C
 
 		types.PutInstantVectorSeriesData(data, a.MemoryConsumptionTracker)
 		a.nextRightSeriesIndex++
+	}
+
+	// If we're done reading the right side, close it so it can release any resources as early as possible.
+	if a.nextRightSeriesIndex > a.lastRightSeriesIndexToRead {
+		a.Right.Close()
 	}
 
 	return nil

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package binops
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/operators"
+	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
+	testCases := map[string]struct {
+		isUnless    bool
+		leftSeries  []labels.Labels
+		rightSeries []labels.Labels
+
+		expectedOutputSeries                        []labels.Labels
+		expectLeftSideClosedAfterOutputSeriesIndex  int
+		expectRightSideClosedAfterOutputSeriesIndex int
+	}{
+		"and: reach end of both sides at the same time": {
+			isUnless: false,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "2", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  2,
+			expectRightSideClosedAfterOutputSeriesIndex: 2,
+		},
+		"unless: reach end of both sides at the same time": {
+			isUnless: true,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "2", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  2,
+			expectRightSideClosedAfterOutputSeriesIndex: 2,
+		},
+		"and: no more matches with unmatched series still to read on both sides": {
+			isUnless: false,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"unless: no more matches with unmatched series still to read on both sides": {
+			isUnless: true,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  2,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"and: no more matches with unmatched series still to read on left side": {
+			isUnless: false,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"unless: no more matches with unmatched series still to read on left side": {
+			isUnless: true,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  2,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"and: no more matches with unmatched series still to read on right side": {
+			isUnless: false,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"unless: no more matches with unmatched series still to read on right side": {
+			isUnless: true,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"and: some series do not match anything on the right": {
+			isUnless: false,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+				labels.FromStrings("group", "1", "series", "left-3"),
+				labels.FromStrings("group", "3", "series", "left-4"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-3"),
+				labels.FromStrings("group", "3", "series", "left-4"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  2,
+			expectRightSideClosedAfterOutputSeriesIndex: 2,
+		},
+		"and: no series match": {
+			isUnless: false,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "3", "series", "right-1"),
+			},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"unless: no series match": {
+			isUnless: true,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "3", "series", "right-1"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"and: no series on left": {
+			isUnless:   false,
+			leftSeries: []labels.Labels{},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "2", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"unless: no series on left": {
+			isUnless:   true,
+			leftSeries: []labels.Labels{},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "2", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"and: no series on right": {
+			isUnless: false,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+				labels.FromStrings("group", "3", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"unless: no series on right": {
+			isUnless: true,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+				labels.FromStrings("group", "3", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+				labels.FromStrings("group", "3", "series", "left-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  2,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if testCase.expectLeftSideClosedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectLeftSideClosedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideClosedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			}
+
+			if testCase.expectRightSideClosedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectRightSideClosedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideClosedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			}
+
+			timeRange := types.NewInstantQueryTimeRange(time.Now())
+			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries))}
+			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries))}
+			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
+			o := NewAndUnlessBinaryOperation(left, right, vectorMatching, limiting.NewMemoryConsumptionTracker(0, nil), testCase.isUnless, timeRange, posrange.PositionRange{})
+
+			ctx := context.Background()
+			outputSeries, err := o.SeriesMetadata(ctx)
+			require.NoError(t, err)
+
+			if len(testCase.expectedOutputSeries) == 0 {
+				require.Empty(t, outputSeries)
+			} else {
+				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
+			}
+
+			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
+			} else {
+				require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
+			}
+
+			if testCase.expectRightSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, right.Closed, "right side should be closed after SeriesMetadata, but it is not")
+			} else {
+				require.False(t, right.Closed, "right side should not be closed after SeriesMetadata, but it is")
+			}
+
+			for outputSeriesIdx := range outputSeries {
+				_, err := o.NextSeries(ctx)
+				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
+
+				if outputSeriesIdx >= testCase.expectLeftSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, left.Closed, "left side should be closed after output series at index %v, but it is not", outputSeriesIdx)
+				} else {
+					require.Falsef(t, left.Closed, "left side should not be closed after output series at index %v, but it is", outputSeriesIdx)
+				}
+
+				if outputSeriesIdx >= testCase.expectRightSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, right.Closed, "right side should be closed after output series at index %v, but it is not", outputSeriesIdx)
+				} else {
+					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
+				}
+			}
+
+			_, err = o.NextSeries(ctx)
+			require.Equal(t, types.EOS, err)
+		})
+	}
+}

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -184,19 +184,25 @@ func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context)
 	if canProduceAnySeries, err := g.loadSeriesMetadata(ctx); err != nil {
 		return nil, err
 	} else if !canProduceAnySeries {
+		g.Close()
 		return nil, nil
 	}
 
-	allMetadata, allSeries, oneSideSeriesUsed, manySideSeriesUsed, err := g.computeOutputSeries()
+	allMetadata, allSeries, oneSideSeriesUsed, lastOneSideSeriesUsedIndex, manySideSeriesUsed, lastManySideSeriesUsedIndex, err := g.computeOutputSeries()
 	if err != nil {
 		return nil, err
+	}
+
+	if len(allMetadata) == 0 {
+		g.Close()
+		return nil, nil
 	}
 
 	g.sortSeries(allMetadata, allSeries)
 	g.remainingSeries = allSeries
 
-	g.oneSideBuffer = operators.NewInstantVectorOperatorBuffer(g.oneSide, oneSideSeriesUsed, g.MemoryConsumptionTracker)
-	g.manySideBuffer = operators.NewInstantVectorOperatorBuffer(g.manySide, manySideSeriesUsed, g.MemoryConsumptionTracker)
+	g.oneSideBuffer = operators.NewInstantVectorOperatorBuffer(g.oneSide, oneSideSeriesUsed, lastOneSideSeriesUsedIndex, g.MemoryConsumptionTracker)
+	g.manySideBuffer = operators.NewInstantVectorOperatorBuffer(g.manySide, manySideSeriesUsed, lastManySideSeriesUsedIndex, g.MemoryConsumptionTracker)
 
 	return allMetadata, nil
 }
@@ -239,8 +245,10 @@ func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Cont
 // - a list of all possible series this operator could return
 // - a corresponding list of the source series for each output series
 // - a list indicating which series from the "one" side are needed to compute the output
+// - the index of the last series from the "one" side that is needed to compute the output
 // - a list indicating which series from the "many" side are needed to compute the output
-func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.SeriesMetadata, []*groupedBinaryOperationOutputSeries, []bool, []bool, error) {
+// - the index of the last series from the "many" side that is needed to compute the output
+func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.SeriesMetadata, []*groupedBinaryOperationOutputSeries, []bool, int, []bool, int, error) {
 	groupKeyFunc := vectorMatchingGroupKeyFunc(g.VectorMatching)
 
 	// First, iterate through all the series on the "one" side and determine all the possible groups.
@@ -285,9 +293,11 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 
 	manySideSeriesUsed, err := types.BoolSlicePool.Get(len(g.manySideMetadata), g.MemoryConsumptionTracker)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, -1, nil, -1, err
 	}
+
 	manySideSeriesUsed = manySideSeriesUsed[:len(g.manySideMetadata)]
+	lastManySideSeriesUsedIndex := -1
 
 	for idx, s := range g.manySideMetadata {
 		groupKey := groupKeyFunc(s.Labels)
@@ -299,6 +309,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 		}
 
 		manySideSeriesUsed[idx] = true
+		lastManySideSeriesUsedIndex = idx
 		manySideGroupKey := manySideGroupKeyFunc(s.Labels)
 		thisManySide, exists := manySideMap[string(manySideGroupKey)] // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
 
@@ -339,10 +350,11 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 	// Next, go through all the "one" side groups again, and determine which of the "one" side series we'll actually need.
 	oneSideSeriesUsed, err := types.BoolSlicePool.Get(len(g.oneSideMetadata), g.MemoryConsumptionTracker)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, -1, nil, -1, err
 	}
 
 	oneSideSeriesUsed = oneSideSeriesUsed[:len(g.oneSideMetadata)]
+	lastOneSideSeriesUsedIndex := -1
 
 	for _, oneSideGroup := range oneSideMap {
 		var thisMatchGroup *matchGroup
@@ -362,6 +374,8 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 			for _, idx := range oneSide.seriesIndices {
 				oneSideSeriesUsed[idx] = true
 			}
+
+			lastOneSideSeriesUsedIndex = max(lastOneSideSeriesUsedIndex, oneSide.latestSeriesIndex())
 		}
 	}
 
@@ -374,7 +388,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 		outputSeries = append(outputSeries, o.outputSeries)
 	}
 
-	return outputMetadata, outputSeries, oneSideSeriesUsed, manySideSeriesUsed, nil
+	return outputMetadata, outputSeries, oneSideSeriesUsed, lastOneSideSeriesUsedIndex, manySideSeriesUsed, lastManySideSeriesUsedIndex, nil
 }
 
 // additionalLabelsKeyFunc returns a function that extracts a key representing the additional labels from a "one" side series that will
@@ -712,17 +726,21 @@ func (g *GroupedVectorVectorBinaryOperation) Close() {
 
 	if g.oneSideMetadata != nil {
 		types.PutSeriesMetadataSlice(g.oneSideMetadata)
+		g.oneSideMetadata = nil
 	}
 
 	if g.manySideMetadata != nil {
 		types.PutSeriesMetadataSlice(g.manySideMetadata)
+		g.manySideMetadata = nil
 	}
 
 	if g.oneSideBuffer != nil {
 		g.oneSideBuffer.Close()
+		g.oneSideBuffer = nil
 	}
 
 	if g.manySideBuffer != nil {
 		g.manySideBuffer.Close()
+		g.manySideBuffer = nil
 	}
 }

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -194,6 +194,9 @@ func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context)
 	}
 
 	if len(allMetadata) == 0 {
+		types.PutSeriesMetadataSlice(allMetadata)
+		types.BoolSlicePool.Put(oneSideSeriesUsed, g.MemoryConsumptionTracker)
+		types.BoolSlicePool.Put(manySideSeriesUsed, g.MemoryConsumptionTracker)
 		g.Close()
 		return nil, nil
 	}

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -5,10 +5,12 @@ package binops
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
@@ -313,6 +315,201 @@ func TestGroupedVectorVectorBinaryOperation_OutputSeriesSorting(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
+		})
+	}
+}
+
+func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
+	testCases := map[string]struct {
+		leftSeries  []labels.Labels
+		rightSeries []labels.Labels
+
+		expectedOutputSeries                        []labels.Labels
+		expectLeftSideClosedAfterOutputSeriesIndex  int
+		expectRightSideClosedAfterOutputSeriesIndex int
+	}{
+		"no series on left": {
+			leftSeries: []labels.Labels{},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+				labels.FromStrings("group", "3"),
+			},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"no series on right": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+				labels.FromStrings("group", "3"),
+			},
+			rightSeries: []labels.Labels{},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"reach end of both sides at the same time": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: 1,
+		},
+		"no more matches with unmatched series still to read on both sides": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  0,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"no more matches with unmatched series still to read on left side": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  0,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"no more matches with unmatched series still to read on right side": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  0,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"no matches": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "3"),
+				labels.FromStrings("group", "4"),
+				labels.FromStrings("group", "5"),
+			},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"left side exhausted before right": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "3"),
+				labels.FromStrings("group", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+				labels.FromStrings("group", "3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+				labels.FromStrings("group", "3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: 2,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if testCase.expectLeftSideClosedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectLeftSideClosedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideClosedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			}
+
+			if testCase.expectRightSideClosedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectRightSideClosedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideClosedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			}
+
+			timeRange := types.NewInstantQueryTimeRange(time.Now())
+			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries))}
+			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries))}
+			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}, Card: parser.CardOneToMany}
+			o, err := NewGroupedVectorVectorBinaryOperation(left, right, vectorMatching, parser.ADD, false, limiting.NewMemoryConsumptionTracker(0, nil), annotations.New(), posrange.PositionRange{}, timeRange)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			outputSeries, err := o.SeriesMetadata(ctx)
+			require.NoError(t, err)
+
+			if len(testCase.expectedOutputSeries) == 0 {
+				require.Empty(t, outputSeries)
+			} else {
+				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
+			}
+
+			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
+			} else {
+				require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
+			}
+
+			if testCase.expectRightSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, right.Closed, "right side should be closed after SeriesMetadata, but it is not")
+			} else {
+				require.False(t, right.Closed, "right side should not be closed after SeriesMetadata, but it is")
+			}
+
+			for outputSeriesIdx := range outputSeries {
+				_, err := o.NextSeries(ctx)
+				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
+
+				if outputSeriesIdx >= testCase.expectLeftSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, left.Closed, "left side should be closed after output series at index %v, but it is not", outputSeriesIdx)
+				} else {
+					require.Falsef(t, left.Closed, "left side should not be closed after output series at index %v, but it is", outputSeriesIdx)
+				}
+
+				if outputSeriesIdx >= testCase.expectRightSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, right.Closed, "right side should be closed after output series at index %v, but it is not", outputSeriesIdx)
+				} else {
+					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
+				}
+			}
+
+			_, err = o.NextSeries(ctx)
+			require.Equal(t, types.EOS, err)
 		})
 	}
 }

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -466,7 +466,8 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries))}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries))}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}, Card: parser.CardOneToMany}
-			o, err := NewGroupedVectorVectorBinaryOperation(left, right, vectorMatching, parser.ADD, false, limiting.NewMemoryConsumptionTracker(0, nil), annotations.New(), posrange.PositionRange{}, timeRange)
+			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+			o, err := NewGroupedVectorVectorBinaryOperation(left, right, vectorMatching, parser.ADD, false, memoryConsumptionTracker, annotations.New(), posrange.PositionRange{}, timeRange)
 			require.NoError(t, err)
 
 			ctx := context.Background()
@@ -510,6 +511,10 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 
 			_, err = o.NextSeries(ctx)
 			require.Equal(t, types.EOS, err)
+
+			o.Close()
+			// Make sure we've returned everything to their pools.
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 		})
 	}
 }

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -97,6 +97,13 @@ func (g *oneToOneBinaryOperationRightSide) updatePresence(timestampIdx int64, se
 	return -1
 }
 
+// latestSeriesIndex returns the index of the last right series used in this side.
+//
+// It assumes that rightSeriesIndices is sorted in ascending order.
+func (g *oneToOneBinaryOperationRightSide) latestRightSeriesIndex() int {
+	return g.rightSeriesIndices[len(g.rightSeriesIndices)-1]
+}
+
 type oneToOneBinaryOperationOutputSeriesWithLabels struct {
 	labels labels.Labels
 	series *oneToOneBinaryOperationOutputSeries
@@ -158,19 +165,25 @@ func (b *OneToOneVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context
 	if canProduceAnySeries, err := b.loadSeriesMetadata(ctx); err != nil {
 		return nil, err
 	} else if !canProduceAnySeries {
+		b.Close()
 		return nil, nil
 	}
 
-	allMetadata, allSeries, leftSeriesUsed, rightSeriesUsed, err := b.computeOutputSeries()
+	allMetadata, allSeries, leftSeriesUsed, lastLeftSeriesUsedIndex, rightSeriesUsed, lastRightSeriesUsedIndex, err := b.computeOutputSeries()
 	if err != nil {
 		return nil, err
+	}
+
+	if len(allMetadata) == 0 {
+		b.Close()
+		return nil, nil
 	}
 
 	b.sortSeries(allMetadata, allSeries)
 	b.remainingSeries = allSeries
 
-	b.leftBuffer = operators.NewInstantVectorOperatorBuffer(b.Left, leftSeriesUsed, b.MemoryConsumptionTracker)
-	b.rightBuffer = operators.NewInstantVectorOperatorBuffer(b.Right, rightSeriesUsed, b.MemoryConsumptionTracker)
+	b.leftBuffer = operators.NewInstantVectorOperatorBuffer(b.Left, leftSeriesUsed, lastLeftSeriesUsedIndex, b.MemoryConsumptionTracker)
+	b.rightBuffer = operators.NewInstantVectorOperatorBuffer(b.Right, rightSeriesUsed, lastRightSeriesUsedIndex, b.MemoryConsumptionTracker)
 
 	return allMetadata, nil
 }
@@ -213,8 +226,10 @@ func (b *OneToOneVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Con
 // - a list of all possible series this operator could return
 // - a corresponding list of the source series for each output series
 // - a list indicating which series from the left side are needed to compute the output
+// - the index of the last series from the left side that is needed to compute the output
 // - a list indicating which series from the right side are needed to compute the output
-func (b *OneToOneVectorVectorBinaryOperation) computeOutputSeries() ([]types.SeriesMetadata, []*oneToOneBinaryOperationOutputSeries, []bool, []bool, error) {
+// - the index of the last series from the right side that is needed to compute the output
+func (b *OneToOneVectorVectorBinaryOperation) computeOutputSeries() ([]types.SeriesMetadata, []*oneToOneBinaryOperationOutputSeries, []bool, int, []bool, int, error) {
 	groupKeyFunc := vectorMatchingGroupKeyFunc(b.VectorMatching)
 
 	// If the left side is smaller than the right, build a map of the possible groups from the left side
@@ -234,16 +249,18 @@ func (b *OneToOneVectorVectorBinaryOperation) computeOutputSeries() ([]types.Ser
 
 	leftSeriesUsed, err := types.BoolSlicePool.Get(len(b.leftMetadata), b.MemoryConsumptionTracker)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, -1, nil, -1, err
 	}
 
 	rightSeriesUsed, err := types.BoolSlicePool.Get(len(b.rightMetadata), b.MemoryConsumptionTracker)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, -1, nil, -1, err
 	}
 
 	leftSeriesUsed = leftSeriesUsed[:len(b.leftMetadata)]
+	lastLeftSeriesUsedIndex := -1
 	rightSeriesUsed = rightSeriesUsed[:len(b.rightMetadata)]
+	lastRightSeriesUsedIndex := -1
 	labelsFunc := groupLabelsFunc(b.VectorMatching, b.Op, b.ReturnBool)
 	outputSeriesLabelsBytes := make([]byte, 0, 1024)
 
@@ -268,6 +285,8 @@ func (b *OneToOneVectorVectorBinaryOperation) computeOutputSeries() ([]types.Ser
 				for _, rightSeriesIndex := range rightSide.rightSeriesIndices {
 					rightSeriesUsed[rightSeriesIndex] = true
 				}
+
+				lastRightSeriesUsedIndex = max(lastRightSeriesUsedIndex, rightSide.latestRightSeriesIndex())
 			}
 
 			rightSide.outputSeriesCount++
@@ -282,6 +301,7 @@ func (b *OneToOneVectorVectorBinaryOperation) computeOutputSeries() ([]types.Ser
 
 		outputSeries.series.leftSeriesIndices = append(outputSeries.series.leftSeriesIndices, leftSeriesIndex)
 		leftSeriesUsed[leftSeriesIndex] = true
+		lastLeftSeriesUsedIndex = leftSeriesIndex
 	}
 
 	allMetadata := types.GetSeriesMetadataSlice(len(outputSeriesMap))
@@ -292,7 +312,7 @@ func (b *OneToOneVectorVectorBinaryOperation) computeOutputSeries() ([]types.Ser
 		allSeries = append(allSeries, outputSeries.series)
 	}
 
-	return allMetadata, allSeries, leftSeriesUsed, rightSeriesUsed, nil
+	return allMetadata, allSeries, leftSeriesUsed, lastLeftSeriesUsedIndex, rightSeriesUsed, lastRightSeriesUsedIndex, nil
 }
 
 func (b *OneToOneVectorVectorBinaryOperation) computeLeftSideGroups(groupKeyFunc func(labels.Labels) []byte) map[string]struct{} {
@@ -547,17 +567,21 @@ func (b *OneToOneVectorVectorBinaryOperation) Close() {
 
 	if b.leftMetadata != nil {
 		types.PutSeriesMetadataSlice(b.leftMetadata)
+		b.leftMetadata = nil
 	}
 
 	if b.rightMetadata != nil {
 		types.PutSeriesMetadataSlice(b.rightMetadata)
+		b.rightMetadata = nil
 	}
 
 	if b.leftBuffer != nil {
 		b.leftBuffer.Close()
+		b.leftBuffer = nil
 	}
 
 	if b.rightBuffer != nil {
 		b.rightBuffer.Close()
+		b.rightBuffer = nil
 	}
 }

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -175,6 +175,9 @@ func (b *OneToOneVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context
 	}
 
 	if len(allMetadata) == 0 {
+		types.PutSeriesMetadataSlice(allMetadata)
+		types.BoolSlicePool.Put(leftSeriesUsed, b.MemoryConsumptionTracker)
+		types.BoolSlicePool.Put(rightSeriesUsed, b.MemoryConsumptionTracker)
 		b.Close()
 		return nil, nil
 	}

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -3,18 +3,24 @@
 package binops
 
 import (
+	"context"
 	"slices"
 	"sort"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/operators"
+	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
@@ -437,6 +443,227 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 				sorter := newFavourRightSideSorter(metadata, series)
 				test(t, series, metadata, sorter, testCase.expectedOrderFavouringRightSide)
 			})
+		})
+	}
+}
+
+func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
+	testCases := map[string]struct {
+		leftSeries  []labels.Labels
+		rightSeries []labels.Labels
+
+		expectedOutputSeries                        []labels.Labels
+		expectLeftSideClosedAfterOutputSeriesIndex  int
+		expectRightSideClosedAfterOutputSeriesIndex int
+	}{
+		"no series on left": {
+			leftSeries: []labels.Labels{},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "2", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"no series on right": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+				labels.FromStrings("group", "3", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"reach end of both sides at the same time": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "2", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: 1,
+		},
+		"no more matches with unmatched series still to read on both sides": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  0,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"no more matches with unmatched series still to read on left side": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  0,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"no more matches with unmatched series still to read on right side": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  0,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"no matches": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "3", "series", "right-1"),
+				labels.FromStrings("group", "4", "series", "right-2"),
+				labels.FromStrings("group", "5", "series", "right-3"),
+			},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"right side exhausted before left": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "2", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"left side exhausted before right": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "3", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "2", "series", "right-1"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+				labels.FromStrings("group", "3", "series", "right-4"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1"),
+				labels.FromStrings("group", "2"),
+				labels.FromStrings("group", "3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: 2,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if testCase.expectLeftSideClosedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectLeftSideClosedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideClosedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			}
+
+			if testCase.expectRightSideClosedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectRightSideClosedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideClosedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			}
+
+			timeRange := types.NewInstantQueryTimeRange(time.Now())
+			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries))}
+			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries))}
+			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
+			o, err := NewOneToOneVectorVectorBinaryOperation(left, right, vectorMatching, parser.ADD, false, limiting.NewMemoryConsumptionTracker(0, nil), annotations.New(), posrange.PositionRange{}, timeRange)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			outputSeries, err := o.SeriesMetadata(ctx)
+			require.NoError(t, err)
+
+			if len(testCase.expectedOutputSeries) == 0 {
+				require.Empty(t, outputSeries)
+			} else {
+				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
+			}
+
+			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
+			} else {
+				require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
+			}
+
+			if testCase.expectRightSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, right.Closed, "right side should be closed after SeriesMetadata, but it is not")
+			} else {
+				require.False(t, right.Closed, "right side should not be closed after SeriesMetadata, but it is")
+			}
+
+			for outputSeriesIdx := range outputSeries {
+				_, err := o.NextSeries(ctx)
+				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
+
+				if outputSeriesIdx >= testCase.expectLeftSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, left.Closed, "left side should be closed after output series at index %v, but it is not", outputSeriesIdx)
+				} else {
+					require.Falsef(t, left.Closed, "left side should not be closed after output series at index %v, but it is", outputSeriesIdx)
+				}
+
+				if outputSeriesIdx >= testCase.expectRightSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, right.Closed, "right side should be closed after output series at index %v, but it is not", outputSeriesIdx)
+				} else {
+					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
+				}
+			}
+
+			_, err = o.NextSeries(ctx)
+			require.Equal(t, types.EOS, err)
 		})
 	}
 }

--- a/pkg/streamingpromql/operators/binops/or_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation.go
@@ -159,10 +159,11 @@ func (o *OrBinaryOperation) computeSeriesOutputOrder(leftMetadata []types.Series
 	// state on both sides.
 
 	nextLeftSeriesToRead := 0
-	lastSeriesFromLeft := false
 	series := types.GetSeriesMetadataSlice(len(leftMetadata) + len(rightMetadata))
 
 	for nextRightSeriesToRead, rightGroup := range o.rightSeriesGroups {
+		lastSeriesFromLeft := false
+
 		// Check if we need to advance through some left series first.
 		if rightGroup != nil && rightGroup.lastLeftSeriesIndex >= nextLeftSeriesToRead {
 			seriesCount := rightGroup.lastLeftSeriesIndex - nextLeftSeriesToRead + 1
@@ -196,11 +197,7 @@ func (o *OrBinaryOperation) computeSeriesOutputOrder(leftMetadata []types.Series
 		seriesCount := len(leftMetadata) - nextLeftSeriesToRead
 		series = append(series, leftMetadata[nextLeftSeriesToRead:]...)
 
-		if lastSeriesFromLeft {
-			o.leftSeriesCount[len(o.leftSeriesCount)-1] += seriesCount
-		} else {
-			o.leftSeriesCount = append(o.leftSeriesCount, seriesCount)
-		}
+		o.leftSeriesCount = append(o.leftSeriesCount, seriesCount)
 	}
 
 	return series

--- a/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
@@ -5,6 +5,7 @@ package binops
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -307,6 +308,278 @@ func TestOrBinaryOperationSorting(t *testing.T) {
 
 			expectedSeriesMetadata := testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeriesOrder)
 			require.Equal(t, expectedSeriesMetadata, actualSeriesMetadata)
+		})
+	}
+}
+
+func TestOrBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
+	testCases := map[string]struct {
+		leftSeries  []labels.Labels
+		rightSeries []labels.Labels
+
+		expectedOutputSeries                        []labels.Labels
+		expectLeftSideClosedAfterOutputSeriesIndex  int
+		expectRightSideClosedAfterOutputSeriesIndex int
+	}{
+		"reach end of both sides at the same time": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "2", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+				labels.FromStrings("group", "2", "series", "right-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  4,
+			expectRightSideClosedAfterOutputSeriesIndex: 5,
+		},
+		"no more matches with unmatched series still to read on both sides": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  5,
+			expectRightSideClosedAfterOutputSeriesIndex: 4,
+		},
+		"no more matches with unmatched series still to read on left side": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  4,
+			expectRightSideClosedAfterOutputSeriesIndex: 3,
+		},
+		"no more matches with unmatched series still to read on right side": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  1,
+			expectRightSideClosedAfterOutputSeriesIndex: 4,
+		},
+		"some series do not match anything on the right": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+				labels.FromStrings("group", "1", "series", "left-3"),
+				labels.FromStrings("group", "3", "series", "left-4"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+				labels.FromStrings("group", "1", "series", "left-3"),
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "left-4"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  5,
+			expectRightSideClosedAfterOutputSeriesIndex: 6,
+		},
+		"some series do not match anything on the left": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "3", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "2", "series", "right-2"),
+				labels.FromStrings("group", "1", "series", "right-3"),
+				labels.FromStrings("group", "3", "series", "right-4"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "2", "series", "right-2"),
+				labels.FromStrings("group", "1", "series", "right-3"),
+				labels.FromStrings("group", "3", "series", "left-3"),
+				labels.FromStrings("group", "3", "series", "right-4"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  5,
+			expectRightSideClosedAfterOutputSeriesIndex: 6,
+		},
+		"no series match": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "3", "series", "right-1"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "3", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  2,
+			expectRightSideClosedAfterOutputSeriesIndex: 0,
+		},
+		"no series on left": {
+			leftSeries: []labels.Labels{},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "2", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "2", "series", "right-2"),
+				labels.FromStrings("group", "3", "series", "right-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: 2,
+		},
+		"no series on right": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+				labels.FromStrings("group", "3", "series", "left-3"),
+			},
+			rightSeries: []labels.Labels{},
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "2", "series", "left-2"),
+				labels.FromStrings("group", "3", "series", "left-3"),
+			},
+			expectLeftSideClosedAfterOutputSeriesIndex:  2,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+		"no series on either side": {
+			leftSeries:  []labels.Labels{},
+			rightSeries: []labels.Labels{},
+
+			expectedOutputSeries:                        []labels.Labels{},
+			expectLeftSideClosedAfterOutputSeriesIndex:  -1,
+			expectRightSideClosedAfterOutputSeriesIndex: -1,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if testCase.expectLeftSideClosedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectLeftSideClosedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideClosedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			}
+
+			if testCase.expectRightSideClosedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectRightSideClosedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideClosedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			}
+
+			timeRange := types.NewInstantQueryTimeRange(time.Now())
+			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries))}
+			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries))}
+			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
+			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+			o := NewOrBinaryOperation(left, right, vectorMatching, memoryConsumptionTracker, timeRange, posrange.PositionRange{})
+
+			ctx := context.Background()
+			outputSeries, err := o.SeriesMetadata(ctx)
+			require.NoError(t, err)
+
+			if len(testCase.expectedOutputSeries) == 0 {
+				require.Empty(t, outputSeries)
+			} else {
+				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
+			}
+
+			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
+			} else {
+				require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
+			}
+
+			if testCase.expectRightSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, right.Closed, "right side should be closed after SeriesMetadata, but it is not")
+			} else {
+				require.False(t, right.Closed, "right side should not be closed after SeriesMetadata, but it is")
+			}
+
+			for outputSeriesIdx := range outputSeries {
+				_, err := o.NextSeries(ctx)
+				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
+
+				if outputSeriesIdx >= testCase.expectLeftSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, left.Closed, "left side should be closed after output series at index %v, but it is not", outputSeriesIdx)
+				} else {
+					require.Falsef(t, left.Closed, "left side should not be closed after output series at index %v, but it is", outputSeriesIdx)
+				}
+
+				if outputSeriesIdx >= testCase.expectRightSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, right.Closed, "right side should be closed after output series at index %v, but it is not", outputSeriesIdx)
+				} else {
+					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
+				}
+			}
+
+			_, err = o.NextSeries(ctx)
+			require.Equal(t, types.EOS, err)
+
+			o.Close()
+			// Make sure we've returned everything to their pools.
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 		})
 	}
 }

--- a/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
@@ -255,7 +255,11 @@ func (v *VectorScalarBinaryOperation) ExpressionPosition() posrange.PositionRang
 func (v *VectorScalarBinaryOperation) Close() {
 	v.Scalar.Close()
 	v.Vector.Close()
-	types.FPointSlicePool.Put(v.scalarData.Samples, v.MemoryConsumptionTracker)
+
+	if v.scalarData.Samples != nil {
+		types.FPointSlicePool.Put(v.scalarData.Samples, v.MemoryConsumptionTracker)
+		v.scalarData.Samples = nil
+	}
 }
 
 func (v *VectorScalarBinaryOperation) emitAnnotation(generator types.AnnotationGenerator) {

--- a/pkg/streamingpromql/operators/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge.go
@@ -54,7 +54,7 @@ func (d *DeduplicateAndMerge) SeriesMetadata(ctx context.Context) ([]types.Serie
 	d.groups = groups
 	types.PutSeriesMetadataSlice(innerMetadata)
 
-	d.buffer = NewInstantVectorOperatorBuffer(d.Inner, nil, d.MemoryConsumptionTracker)
+	d.buffer = NewInstantVectorOperatorBuffer(d.Inner, nil, len(innerMetadata), d.MemoryConsumptionTracker)
 
 	return outputMetadata, nil
 }

--- a/pkg/streamingpromql/operators/functions/absent.go
+++ b/pkg/streamingpromql/operators/functions/absent.go
@@ -110,7 +110,11 @@ func (a *Absent) ExpressionPosition() posrange.PositionRange {
 
 func (a *Absent) Close() {
 	a.Inner.Close()
-	types.BoolSlicePool.Put(a.presence, a.MemoryConsumptionTracker)
+
+	if a.presence != nil {
+		types.BoolSlicePool.Put(a.presence, a.MemoryConsumptionTracker)
+		a.presence = nil
+	}
 }
 
 // CreateLabelsForAbsentFunction returns the labels that are uniquely and exactly matched

--- a/pkg/streamingpromql/operators/functions/absent_over_time.go
+++ b/pkg/streamingpromql/operators/functions/absent_over_time.go
@@ -116,5 +116,9 @@ func (a *AbsentOverTime) ExpressionPosition() posrange.PositionRange {
 
 func (a *AbsentOverTime) Close() {
 	a.Inner.Close()
-	types.BoolSlicePool.Put(a.presence, a.MemoryConsumptionTracker)
+
+	if a.presence != nil {
+		types.BoolSlicePool.Put(a.presence, a.MemoryConsumptionTracker)
+		a.presence = nil
+	}
 }

--- a/pkg/streamingpromql/operators/functions/function_over_instant_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_instant_vector.go
@@ -107,7 +107,10 @@ func (m *FunctionOverInstantVector) NextSeries(ctx context.Context) (types.Insta
 
 func (m *FunctionOverInstantVector) Close() {
 	m.Inner.Close()
+
 	for _, sd := range m.scalarArgsData {
 		types.FPointSlicePool.Put(sd.Samples, m.MemoryConsumptionTracker)
 	}
+
+	m.scalarArgsData = nil
 }

--- a/pkg/streamingpromql/operators/functions/function_over_range_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_range_vector.go
@@ -194,4 +194,6 @@ func (m *FunctionOverRangeVector) Close() {
 	for _, d := range m.scalarArgsData {
 		types.FPointSlicePool.Put(d.Samples, m.MemoryConsumptionTracker)
 	}
+
+	m.scalarArgsData = nil
 }

--- a/pkg/streamingpromql/operators/functions/histogram_quantile.go
+++ b/pkg/streamingpromql/operators/functions/histogram_quantile.go
@@ -438,7 +438,11 @@ func (h *HistogramQuantileFunction) computeOutputSeriesForGroup(g *bucketGroup) 
 func (h *HistogramQuantileFunction) Close() {
 	h.inner.Close()
 	h.phArg.Close()
-	types.FPointSlicePool.Put(h.phValues.Samples, h.memoryConsumptionTracker)
+
+	if h.phValues.Samples != nil {
+		types.FPointSlicePool.Put(h.phValues.Samples, h.memoryConsumptionTracker)
+		h.phValues.Samples = nil
+	}
 }
 
 type bucketGroupSorter struct {

--- a/pkg/streamingpromql/operators/functions/sort.go
+++ b/pkg/streamingpromql/operators/functions/sort.go
@@ -162,6 +162,8 @@ func (s *Sort) Close() {
 	s.Inner.Close()
 
 	// Return any remaining data to the pool.
+	// Any data in allData that was previously passed to the calling operator by NextSeries does not need to be returned to the pool,
+	// as the calling operator is responsible for returning it to the pool.
 	for s.seriesReturned < len(s.allData) {
 		types.PutInstantVectorSeriesData(s.allData[s.seriesReturned], s.MemoryConsumptionTracker)
 		s.seriesReturned++

--- a/pkg/streamingpromql/operators/functions/sort.go
+++ b/pkg/streamingpromql/operators/functions/sort.go
@@ -161,5 +161,9 @@ func (s *Sort) ExpressionPosition() posrange.PositionRange {
 func (s *Sort) Close() {
 	s.Inner.Close()
 
-	// We don't need to do anything with s.allData here: we passed ownership of the data to the calling operator when we returned it in NextSeries.
+	// Return any remaining data to the pool.
+	for s.seriesReturned < len(s.allData) {
+		types.PutInstantVectorSeriesData(s.allData[s.seriesReturned], s.MemoryConsumptionTracker)
+		s.seriesReturned++
+	}
 }

--- a/pkg/streamingpromql/operators/operator_buffer_test.go
+++ b/pkg/streamingpromql/operators/operator_buffer_test.go
@@ -46,7 +46,7 @@ func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) 
 	seriesUsed := []bool{true, false, true, true, true}
 	memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*6)) // We have 6 FPoints from the inner series.
-	buffer := NewInstantVectorOperatorBuffer(inner, seriesUsed, memoryConsumptionTracker)
+	buffer := NewInstantVectorOperatorBuffer(inner, seriesUsed, 4, memoryConsumptionTracker)
 	ctx := context.Background()
 
 	// Read first series.
@@ -54,29 +54,34 @@ func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) 
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series0Data}, series)
 	require.Empty(t, buffer.buffer) // Should not buffer series that was immediately returned.
+	require.False(t, inner.Closed)
 
 	// Read next desired series, skipping over series that won't be used.
 	series, err = buffer.GetSeries(ctx, []int{2})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series2Data}, series)
 	require.Empty(t, buffer.buffer) // Should not buffer series at index 1 that won't be used.
+	require.False(t, inner.Closed)
 
 	// Read another desired series, skipping over a series that will be used later.
 	series, err = buffer.GetSeries(ctx, []int{4})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series4Data}, series)
 	require.Len(t, buffer.buffer, 1) // Should only have buffered a single series (index 3).
+	require.True(t, inner.Closed, "inner operator should be closed after reading last series that will be used")
 
 	// Read the series we just read past from the buffer.
 	series, err = buffer.GetSeries(ctx, []int{3})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series3Data}, series)
 	require.Empty(t, buffer.buffer) // Series that has been returned should be removed from buffer once it's returned.
+	require.True(t, inner.Closed)
 
 	// Read multiple series.
 	series, err = buffer.GetSeries(ctx, []int{5, 6})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series5Data, series6Data}, series)
+	require.True(t, inner.Closed)
 }
 
 func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
@@ -111,7 +116,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 
 	memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*6)) // We have 6 FPoints from the inner series.
-	buffer := NewInstantVectorOperatorBuffer(inner, nil, memoryConsumptionTracker)
+	buffer := NewInstantVectorOperatorBuffer(inner, nil, 6, memoryConsumptionTracker)
 	ctx := context.Background()
 
 	// Read first series.
@@ -119,33 +124,39 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series0Data}, series)
 	require.Empty(t, buffer.buffer) // Should not buffer series that was immediately returned.
+	require.False(t, inner.Closed)
 
 	// Read next desired series, skipping over a series that won't be read right now.
 	series, err = buffer.GetSeries(ctx, []int{2})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series2Data}, series)
 	require.Len(t, buffer.buffer, 1) // Should only have buffered a single series (index 1).
+	require.False(t, inner.Closed)
 
 	// Read another desired series, skipping over another series that will be read later.
 	series, err = buffer.GetSeries(ctx, []int{4})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series4Data}, series)
 	require.Len(t, buffer.buffer, 2) // Should only have buffered two series (indices 1 and 3).
+	require.False(t, inner.Closed)
 
 	// Read the series we just read past from the buffer.
 	series, err = buffer.GetSeries(ctx, []int{3})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series3Data}, series)
 	require.Len(t, buffer.buffer, 1) // Series that has been returned should be removed from buffer once it's returned.
+	require.False(t, inner.Closed)
 
 	// Read the series we buffered earlier.
 	series, err = buffer.GetSeries(ctx, []int{1})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series1Data}, series)
 	require.Empty(t, buffer.buffer)
+	require.False(t, inner.Closed)
 
 	// Read multiple series.
 	series, err = buffer.GetSeries(ctx, []int{5, 6})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series5Data, series6Data}, series)
+	require.True(t, inner.Closed)
 }

--- a/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
@@ -179,4 +179,6 @@ func (v *InstantVectorSelector) NextSeries(ctx context.Context) (types.InstantVe
 
 func (v *InstantVectorSelector) Close() {
 	v.Selector.Close()
+	v.memoizedIterator = nil
+	v.chunkIterator = nil
 }

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -164,4 +164,5 @@ func (m *RangeVectorSelector) Close() {
 	m.Selector.Close()
 	m.floats.Close()
 	m.histograms.Close()
+	m.chunkIterator = nil
 }

--- a/pkg/streamingpromql/operators/test_operator.go
+++ b/pkg/streamingpromql/operators/test_operator.go
@@ -16,6 +16,7 @@ import (
 type TestOperator struct {
 	Series []labels.Labels
 	Data   []types.InstantVectorSeriesData
+	Closed bool
 }
 
 var _ types.InstantVectorOperator = &TestOperator{}
@@ -40,5 +41,5 @@ func (t *TestOperator) NextSeries(_ context.Context) (types.InstantVectorSeriesD
 }
 
 func (t *TestOperator) Close() {
-	panic("Close() not supported")
+	t.Closed = true
 }

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -554,6 +554,11 @@ func (q *Query) convertNodeToOperator(node planning.Node, timeRange types.QueryT
 func (q *Query) Exec(ctx context.Context) *promql.Result {
 	defer q.root.Close()
 
+	if q.engine.pedantic {
+		// Close the root operator a second time to ensure all operators behave correctly if Close is called multiple times.
+		defer q.root.Close()
+	}
+
 	ctx, cancel := context.WithCancelCause(ctx)
 	q.cancel = cancel
 

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -18,6 +18,7 @@ type Operator interface {
 	// Close frees all resources associated with this operator.
 	// Calling SeriesMetadata or NextSeries after calling Close may result in unpredictable behaviour, corruption or crashes.
 	// It must be safe to call Close at any time, including if SeriesMetadata or NextSeries have returned an error.
+	// It must be safe to call Close multiple times.
 	Close()
 }
 


### PR DESCRIPTION
#### What this PR does

This PR modifies MQE's behaviour when evaluating binary operations to close their inner operators as soon as they're no longer needed.

This allows those inner operators to then free resources that might otherwise remain until query evaluation has finished. This is particularly important for cases where only a subset of series from one side match the other side, and so some intermediate state might be unnecessarily held by inner operators until the query finishes.

This PR also clarifies that it is expected that calling `Close` on an operator multiple times should be safe, and extends pedantic mode to call `Close` on the query's root operator a second time to ensure this is true.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
