### PR TITLE
Make ingest-storage ingester HPA behavior configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 ### Jsonnet
 
 * [CHANGE] Increase the allowed number of rule groups for small, medium_small, and extra_small user tiers by 20%. #11152
+* [FEATURE] Make ingest storage ingester HPA behavior configurable via `_config.ingest_storage_ingester_hpa_behavior`. #11168
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 ### Jsonnet
 
 * [CHANGE] Increase the allowed number of rule groups for small, medium_small, and extra_small user tiers by 20%. #11152
-* [FEATURE] Make ingest storage ingester HPA behavior configurable via `_config.ingest_storage_ingester_hpa_behavior`. #11168
+* [FEATURE] Make ingest storage ingester HPA behavior configurable through `_config.ingest_storage_ingester_hpa_behavior`. #11168
 
 ### Mimirtool
 

--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -69,6 +69,9 @@
     // https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#stabilization-window
     ingest_storage_ingester_autoscaling_scale_up_stabilization_window_seconds: $.util.parseDuration('30m'),
     ingest_storage_ingester_autoscaling_scale_down_stabilization_window_seconds: $.util.parseDuration('1h'),
+
+    // Optional overrides to the HPA behavior.
+    ingest_storage_ingester_hpa_behavior: {},
   },
 
   // Validate the configuration.
@@ -169,7 +172,7 @@
                 selectPolicy: 'Max',  // This would only have effect if there were multiple policies.
                 stabilizationWindowSeconds: $._config.ingest_storage_ingester_autoscaling_scale_down_stabilization_window_seconds,
               },
-            },
+            } + $._config.ingest_storage_ingester_hpa_behavior,
           },
         },
       },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds an optional jsonnet field that allows overriding of the HPA behavior fields in the ingest storage ingester scaledObject. This allows for more flexible configuration of the scale up/down policies.

#### Which issue(s) this PR fixes or relates to

Fixes #N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
