### PR TITLE
MQE: ensure aggregations release any intermediate state if they are closed before all series are read

### DIFF
--- a/pkg/streamingpromql/operators/aggregations/aggregation.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation.go
@@ -236,6 +236,7 @@ func (a *Aggregation) NextSeries(ctx context.Context) (types.InstantVectorSeries
 		a.haveEmittedMixedFloatsAndHistogramsWarning = true
 	}
 
+	thisGroup.aggregation.Close(a.MemoryConsumptionTracker)
 	groupPool.Put(thisGroup)
 	return seriesData, nil
 }
@@ -272,6 +273,13 @@ func (a *Aggregation) Close() {
 	// The wrapping operator is responsible for returning any a.ParamData slice
 	// since it is responsible for setting them up.
 	a.Inner.Close()
+
+	for _, g := range a.remainingGroups {
+		g.aggregation.Close(a.MemoryConsumptionTracker)
+		groupPool.Put(g)
+	}
+
+	a.remainingGroups = nil
 }
 
 type groupSorter struct {

--- a/pkg/streamingpromql/operators/aggregations/aggregation_test.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation_test.go
@@ -5,14 +5,20 @@ package aggregations
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators"
+	"github.com/grafana/mimir/pkg/streamingpromql/operators/scalars"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
@@ -254,4 +260,161 @@ func TestAggregation_GroupLabelling(t *testing.T) {
 			require.Equal(t, expectedBytes, actualBytes)
 		})
 	}
+}
+
+func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
+	inputSeries := []labels.Labels{
+		// Order series so group 1 will be the first complete group, but part of group 2 will have been loaded first.
+		labels.FromStrings("group", "2", "idx", "1"),
+		labels.FromStrings("group", "2", "idx", "2"),
+		labels.FromStrings("group", "1", "idx", "3"),
+		labels.FromStrings("group", "2", "idx", "4"),
+		labels.FromStrings("group", "3", "idx", "5"),
+	}
+
+	expectedSimpleAggregationOutputSeries := []labels.Labels{
+		labels.FromStrings("group", "1"),
+		labels.FromStrings("group", "2"),
+		labels.FromStrings("group", "3"),
+	}
+
+	rangeQueryTimeRange := types.NewRangeQueryTimeRange(timestamp.Time(0), timestamp.Time(0).Add(5*time.Minute), time.Minute)
+	instantQueryTimeRange := types.NewInstantQueryTimeRange(timestamp.Time(0))
+
+	createSimpleAggregation := func(op parser.ItemType) func(types.InstantVectorOperator, types.QueryTimeRange, *limiting.MemoryConsumptionTracker) (types.InstantVectorOperator, error) {
+		return func(inner types.InstantVectorOperator, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiting.MemoryConsumptionTracker) (types.InstantVectorOperator, error) {
+			return NewAggregation(inner, timeRange, []string{"group"}, false, op, memoryConsumptionTracker, annotations.New(), posrange.PositionRange{})
+		}
+	}
+
+	testCases := map[string]struct {
+		createOperator                func(types.InstantVectorOperator, types.QueryTimeRange, *limiting.MemoryConsumptionTracker) (types.InstantVectorOperator, error)
+		instant                       bool
+		expectedSeries                []labels.Labels
+		allowExpectedSeriesInAnyOrder bool
+	}{
+		"avg": {
+			createOperator: createSimpleAggregation(parser.AVG),
+			expectedSeries: expectedSimpleAggregationOutputSeries,
+		},
+		"count": {
+			createOperator: createSimpleAggregation(parser.COUNT),
+			expectedSeries: expectedSimpleAggregationOutputSeries,
+		},
+		"group": {
+			createOperator: createSimpleAggregation(parser.GROUP),
+			expectedSeries: expectedSimpleAggregationOutputSeries,
+		},
+		"max": {
+			createOperator: createSimpleAggregation(parser.MAX),
+			expectedSeries: expectedSimpleAggregationOutputSeries,
+		},
+		"min": {
+			createOperator: createSimpleAggregation(parser.MIN),
+			expectedSeries: expectedSimpleAggregationOutputSeries,
+		},
+		"quantile": {
+			createOperator: func(inner types.InstantVectorOperator, queryTimeRange types.QueryTimeRange, memoryConsumptionTracker *limiting.MemoryConsumptionTracker) (types.InstantVectorOperator, error) {
+				param := scalars.NewScalarConstant(0.5, queryTimeRange, memoryConsumptionTracker, posrange.PositionRange{})
+				return NewQuantileAggregation(inner, param, queryTimeRange, []string{"group"}, false, memoryConsumptionTracker, annotations.New(), posrange.PositionRange{})
+			},
+			expectedSeries: expectedSimpleAggregationOutputSeries,
+		},
+		"stddev": {
+			createOperator: createSimpleAggregation(parser.STDDEV),
+			expectedSeries: expectedSimpleAggregationOutputSeries,
+		},
+		"stdvar": {
+			createOperator: createSimpleAggregation(parser.STDVAR),
+			expectedSeries: expectedSimpleAggregationOutputSeries,
+		},
+		"sum": {
+			createOperator: createSimpleAggregation(parser.SUM),
+			expectedSeries: expectedSimpleAggregationOutputSeries,
+		},
+		"count_values": {
+			createOperator: func(inner types.InstantVectorOperator, queryTimeRange types.QueryTimeRange, memoryConsumptionTracker *limiting.MemoryConsumptionTracker) (types.InstantVectorOperator, error) {
+				labelName := operators.NewStringLiteral("value", posrange.PositionRange{})
+				return NewCountValues(inner, labelName, queryTimeRange, []string{"group"}, false, memoryConsumptionTracker, posrange.PositionRange{}), nil
+			},
+			instant:                       true,
+			allowExpectedSeriesInAnyOrder: true,
+			expectedSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "value", "0"),
+				labels.FromStrings("group", "2", "value", "0"),
+				labels.FromStrings("group", "2", "value", "{count:0, sum:0}"),
+			},
+		},
+		// topk and bottomk are tested in the topkbottomk package.
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+			timeRange := rangeQueryTimeRange
+
+			if testCase.instant {
+				timeRange = instantQueryTimeRange
+			}
+
+			inner := &operators.TestOperator{
+				Series: inputSeries,
+				Data: []types.InstantVectorSeriesData{
+					createDummyData(t, false, timeRange, memoryConsumptionTracker),
+					createDummyData(t, true, timeRange, memoryConsumptionTracker),
+					createDummyData(t, false, timeRange, memoryConsumptionTracker),
+					{}, // The last two series won't be read, so don't bother creating series for them.
+					{},
+				},
+			}
+
+			o, err := testCase.createOperator(inner, timeRange, memoryConsumptionTracker)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			series, err := o.SeriesMetadata(ctx)
+			require.NoError(t, err)
+
+			if testCase.allowExpectedSeriesInAnyOrder {
+				require.ElementsMatch(t, testutils.LabelsToSeriesMetadata(testCase.expectedSeries), series)
+			} else {
+				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedSeries), series)
+			}
+
+			// Read the first output series to force the creation of incomplete groups.
+			seriesData, err := o.NextSeries(ctx)
+			require.NoError(t, err)
+
+			types.PutInstantVectorSeriesData(seriesData, memoryConsumptionTracker)
+
+			// Close the operator and confirm all memory has been released.
+			o.Close()
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+		})
+	}
+}
+
+func createDummyData(t *testing.T, histograms bool, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiting.MemoryConsumptionTracker) types.InstantVectorSeriesData {
+	d := types.InstantVectorSeriesData{}
+
+	if histograms {
+		var err error
+		d.Histograms, err = types.HPointSlicePool.Get(timeRange.StepCount, memoryConsumptionTracker)
+		require.NoError(t, err)
+
+		for i := range timeRange.StepCount {
+			d.Histograms = append(d.Histograms, promql.HPoint{T: timeRange.IndexTime(int64(i)), H: &histogram.FloatHistogram{Count: float64(i)}})
+		}
+
+	} else {
+		var err error
+		d.Floats, err = types.FPointSlicePool.Get(timeRange.StepCount, memoryConsumptionTracker)
+		require.NoError(t, err)
+
+		for i := range timeRange.StepCount {
+			d.Floats = append(d.Floats, promql.FPoint{T: timeRange.IndexTime(int64(i)), F: float64(i)})
+		}
+	}
+
+	return d
 }

--- a/pkg/streamingpromql/operators/aggregations/avg.go
+++ b/pkg/streamingpromql/operators/aggregations/avg.go
@@ -299,13 +299,15 @@ func (g *AvgAggregationGroup) ComputeOutputSeries(_ types.ScalarData, timeRange 
 		}
 	}
 
+	return types.InstantVectorSeriesData{Floats: floatPoints, Histograms: histogramPoints}, hasMixedData, nil
+}
+
+func (g *AvgAggregationGroup) Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) {
 	types.Float64SlicePool.Put(g.floats, memoryConsumptionTracker)
 	types.Float64SlicePool.Put(g.floatMeans, memoryConsumptionTracker)
 	types.Float64SlicePool.Put(g.floatCompensatingMeans, memoryConsumptionTracker)
+	types.BoolSlicePool.Put(g.incrementalMeans, memoryConsumptionTracker)
 	types.BoolSlicePool.Put(g.floatPresent, memoryConsumptionTracker)
 	types.HistogramSlicePool.Put(g.histograms, memoryConsumptionTracker)
-	types.BoolSlicePool.Put(g.incrementalMeans, memoryConsumptionTracker)
 	types.Float64SlicePool.Put(g.groupSeriesCounts, memoryConsumptionTracker)
-
-	return types.InstantVectorSeriesData{Floats: floatPoints, Histograms: histogramPoints}, hasMixedData, nil
 }

--- a/pkg/streamingpromql/operators/aggregations/common.go
+++ b/pkg/streamingpromql/operators/aggregations/common.go
@@ -3,8 +3,6 @@
 package aggregations
 
 import (
-	"strings"
-
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -40,30 +38,6 @@ var AggregationGroupFactories = map[parser.ItemType]AggregationGroupFactory{
 //
 // Invalid combinations include exponential and custom buckets, and histograms with incompatible custom buckets.
 var invalidCombinationOfHistograms = &histogram.FloatHistogram{}
-
-// The aggregation names are not exported, but their item types are. It's safe to assume the names will not change.
-// (ie, "avg" will be parser.AVG).
-var aggregationItemKey = map[string]parser.ItemType{
-	"avg":          parser.AVG,
-	"bottomk":      parser.BOTTOMK,
-	"count_values": parser.COUNT_VALUES,
-	"count":        parser.COUNT,
-	"group":        parser.GROUP,
-	"limit_ratio":  parser.LIMIT_RATIO,
-	"limitk":       parser.LIMITK,
-	"max":          parser.MAX,
-	"min":          parser.MIN,
-	"quantile":     parser.QUANTILE,
-	"stddev":       parser.STDDEV,
-	"stdvar":       parser.STDVAR,
-	"sum":          parser.SUM,
-	"topk":         parser.TOPK,
-}
-
-func GetAggregationItemType(aggregation string) (parser.ItemType, bool) {
-	item, ok := aggregationItemKey[strings.ToLower(aggregation)]
-	return item, ok
-}
 
 // SeriesToGroupLabelsBytesFunc is a function that computes a string-like representation of the output group labels for the given input series.
 //

--- a/pkg/streamingpromql/operators/aggregations/common.go
+++ b/pkg/streamingpromql/operators/aggregations/common.go
@@ -18,6 +18,9 @@ type AggregationGroup interface {
 	AccumulateSeries(data types.InstantVectorSeriesData, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, emitAnnotation types.EmitAnnotationFunc, remainingSeriesInGroup uint) error
 	// ComputeOutputSeries does any final calculations and returns the grouped series data
 	ComputeOutputSeries(param types.ScalarData, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiting.MemoryConsumptionTracker) (types.InstantVectorSeriesData, bool, error)
+	// Close releases any resources held by the group.
+	// Close is guaranteed to be called at most once per group.
+	Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker)
 }
 
 type AggregationGroupFactory func() AggregationGroup

--- a/pkg/streamingpromql/operators/aggregations/count.go
+++ b/pkg/streamingpromql/operators/aggregations/count.go
@@ -87,7 +87,9 @@ func (g *CountGroupAggregationGroup) ComputeOutputSeries(_ types.ScalarData, tim
 		}
 	}
 
-	types.Float64SlicePool.Put(g.values, memoryConsumptionTracker)
-
 	return types.InstantVectorSeriesData{Floats: floatPoints}, false, nil
+}
+
+func (g *CountGroupAggregationGroup) Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) {
+	types.Float64SlicePool.Put(g.values, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/aggregations/count_values.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values.go
@@ -245,4 +245,10 @@ func (c *CountValues) ExpressionPosition() posrange.PositionRange {
 func (c *CountValues) Close() {
 	c.Inner.Close()
 	c.LabelName.Close()
+
+	for _, d := range c.series {
+		types.FPointSlicePool.Put(d, c.MemoryConsumptionTracker)
+	}
+
+	c.series = nil
 }

--- a/pkg/streamingpromql/operators/aggregations/min_max.go
+++ b/pkg/streamingpromql/operators/aggregations/min_max.go
@@ -114,8 +114,10 @@ func (g *MinMaxAggregationGroup) ComputeOutputSeries(_ types.ScalarData, timeRan
 		}
 	}
 
+	return types.InstantVectorSeriesData{Floats: floatPoints}, false, nil
+}
+
+func (g *MinMaxAggregationGroup) Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) {
 	types.Float64SlicePool.Put(g.floatValues, memoryConsumptionTracker)
 	types.BoolSlicePool.Put(g.floatPresent, memoryConsumptionTracker)
-
-	return types.InstantVectorSeriesData{Floats: floatPoints}, false, nil
 }

--- a/pkg/streamingpromql/operators/aggregations/quantile.go
+++ b/pkg/streamingpromql/operators/aggregations/quantile.go
@@ -171,10 +171,16 @@ func (q *QuantileAggregationGroup) ComputeOutputSeries(param types.ScalarData, t
 		t := timeRange.StartT + int64(i)*timeRange.IntervalMilliseconds
 		f := floats.Quantile(p, qGroup.points)
 		quantilePoints = append(quantilePoints, promql.FPoint{T: t, F: f})
+	}
+
+	return types.InstantVectorSeriesData{Floats: quantilePoints}, false, nil
+}
+
+func (q *QuantileAggregationGroup) Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) {
+	for i, qGroup := range q.qGroups {
 		types.Float64SlicePool.Put(qGroup.points, memoryConsumptionTracker)
 		q.qGroups[i].points = nil
 	}
 
 	qGroupPool.Put(q.qGroups, memoryConsumptionTracker)
-	return types.InstantVectorSeriesData{Floats: quantilePoints}, false, nil
 }

--- a/pkg/streamingpromql/operators/aggregations/stddev_stdvar.go
+++ b/pkg/streamingpromql/operators/aggregations/stddev_stdvar.go
@@ -115,9 +115,11 @@ func (g *StddevStdvarAggregationGroup) ComputeOutputSeries(_ types.ScalarData, t
 		}
 	}
 
+	return types.InstantVectorSeriesData{Floats: floatPoints}, false, nil
+}
+
+func (g *StddevStdvarAggregationGroup) Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) {
 	types.Float64SlicePool.Put(g.floats, memoryConsumptionTracker)
 	types.Float64SlicePool.Put(g.floatMeans, memoryConsumptionTracker)
 	types.Float64SlicePool.Put(g.groupSeriesCounts, memoryConsumptionTracker)
-
-	return types.InstantVectorSeriesData{Floats: floatPoints}, false, nil
 }

--- a/pkg/streamingpromql/operators/aggregations/sum.go
+++ b/pkg/streamingpromql/operators/aggregations/sum.go
@@ -201,10 +201,12 @@ func (g *SumAggregationGroup) ComputeOutputSeries(_ types.ScalarData, timeRange 
 		}
 	}
 
+	return types.InstantVectorSeriesData{Floats: floatPoints, Histograms: histogramPoints}, hasMixedData, nil
+}
+
+func (g *SumAggregationGroup) Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) {
 	types.Float64SlicePool.Put(g.floatSums, memoryConsumptionTracker)
 	types.Float64SlicePool.Put(g.floatCompensatingValues, memoryConsumptionTracker)
 	types.BoolSlicePool.Put(g.floatPresent, memoryConsumptionTracker)
 	types.HistogramSlicePool.Put(g.histogramSums, memoryConsumptionTracker)
-
-	return types.InstantVectorSeriesData{Floats: floatPoints, Histograms: histogramPoints}, hasMixedData, nil
 }

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
@@ -399,6 +399,15 @@ func (t *RangeQuery) returnSeriesToPool(series rangeQuerySeries) {
 	types.Float64SlicePool.Put(series.values, t.MemoryConsumptionTracker)
 }
 
+func (t *RangeQuery) returnGroupAndSeriesToPool(g *rangeQueryGroup, firstSeriesIdxToReturn int) {
+	for _, s := range g.series[firstSeriesIdxToReturn:] {
+		t.returnSeriesToPool(s)
+	}
+
+	t.returnGroupToPool(g)
+
+}
+
 func (t *RangeQuery) ExpressionPosition() posrange.PositionRange {
 	return t.expressionPosition
 }
@@ -408,6 +417,18 @@ func (t *RangeQuery) Close() {
 	t.Param.Close()
 
 	types.Int64SlicePool.Put(t.k, t.MemoryConsumptionTracker)
+	t.k = nil
+
+	if t.currentGroup != nil {
+		t.returnGroupAndSeriesToPool(t.currentGroup, t.seriesIndexInCurrentGroup)
+		t.currentGroup = nil
+	}
+
+	for _, g := range t.remainingGroups {
+		t.returnGroupAndSeriesToPool(g, 0)
+	}
+
+	t.remainingGroups = nil
 }
 
 type rangeQueryGroup struct {

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package topkbottomk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/prometheus/prometheus/util/annotations"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
+	"github.com/grafana/mimir/pkg/streamingpromql/operators"
+	"github.com/grafana/mimir/pkg/streamingpromql/operators/scalars"
+	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
+	inputSeries := []labels.Labels{
+		labels.FromStrings("idx", "1"),
+		labels.FromStrings("idx", "2"),
+		labels.FromStrings("idx", "3"),
+		labels.FromStrings("idx", "4"),
+		labels.FromStrings("idx", "5"),
+		labels.FromStrings("idx", "6"),
+	}
+
+	expectedOutputSeriesForInstantQuery := []labels.Labels{
+		labels.FromStrings("idx", "1"),
+		// idx="2" contains histograms and so will be ignored.
+		labels.FromStrings("idx", "3"),
+		labels.FromStrings("idx", "4"),
+		// idx="5" contains histograms and so will be ignored.
+		labels.FromStrings("idx", "6"),
+	}
+
+	rangeQueryTimeRange := types.NewRangeQueryTimeRange(timestamp.Time(0), timestamp.Time(0).Add(5*time.Minute), time.Minute)
+	instantQueryTimeRange := types.NewInstantQueryTimeRange(timestamp.Time(0))
+
+	for name, isTopK := range map[string]bool{"topk": true, "bottomk": false} {
+		t.Run(name, func(t *testing.T) {
+			for name, timeRange := range map[string]types.QueryTimeRange{"range query": rangeQueryTimeRange, "instant query": instantQueryTimeRange} {
+				t.Run(name, func(t *testing.T) {
+					for name, readSeries := range map[string]bool{"read one series": true, "read no series": false} {
+						t.Run(name, func(t *testing.T) {
+							memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+
+							inner := &operators.TestOperator{
+								Series: inputSeries,
+								Data: []types.InstantVectorSeriesData{
+									createDummyData(t, false, timeRange, memoryConsumptionTracker),
+									createDummyData(t, true, timeRange, memoryConsumptionTracker),
+									createDummyData(t, false, timeRange, memoryConsumptionTracker),
+									createDummyData(t, false, timeRange, memoryConsumptionTracker),
+									createDummyData(t, true, timeRange, memoryConsumptionTracker),
+									createDummyData(t, false, timeRange, memoryConsumptionTracker),
+								},
+							}
+
+							param := scalars.NewScalarConstant(6, timeRange, memoryConsumptionTracker, posrange.PositionRange{})
+							o := New(inner, param, timeRange, nil, false, isTopK, memoryConsumptionTracker, annotations.New(), posrange.PositionRange{})
+
+							ctx := context.Background()
+							series, err := o.SeriesMetadata(ctx)
+							require.NoError(t, err)
+
+							if timeRange.IsInstant {
+								// Instant queries will not return series with only histograms.
+								require.ElementsMatch(t, testutils.LabelsToSeriesMetadata(expectedOutputSeriesForInstantQuery), series)
+							} else {
+								// Range queries will return all input series, but those with histograms will return no data from NextSeries() below.
+								require.ElementsMatch(t, testutils.LabelsToSeriesMetadata(inputSeries), series)
+							}
+
+							if readSeries {
+								seriesData, err := o.NextSeries(ctx)
+								require.NoError(t, err)
+								types.PutInstantVectorSeriesData(seriesData, memoryConsumptionTracker)
+							}
+
+							// TestOperator does not release any unread data on Close(), so do that now.
+							for _, d := range inner.Data {
+								types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
+							}
+
+							// Close the operator and confirm all memory has been released.
+							o.Close()
+							require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func createDummyData(t *testing.T, histograms bool, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiting.MemoryConsumptionTracker) types.InstantVectorSeriesData {
+	d := types.InstantVectorSeriesData{}
+
+	if histograms {
+		var err error
+		d.Histograms, err = types.HPointSlicePool.Get(timeRange.StepCount, memoryConsumptionTracker)
+		require.NoError(t, err)
+
+		for i := range timeRange.StepCount {
+			d.Histograms = append(d.Histograms, promql.HPoint{T: timeRange.IndexTime(int64(i)), H: &histogram.FloatHistogram{Count: float64(i)}})
+		}
+
+	} else {
+		var err error
+		d.Floats, err = types.FPointSlicePool.Get(timeRange.StepCount, memoryConsumptionTracker)
+		require.NoError(t, err)
+
+		for i := range timeRange.StepCount {
+			d.Floats = append(d.Floats, promql.FPoint{T: timeRange.IndexTime(int64(i)), F: float64(i)})
+		}
+	}
+
+	return d
+}

--- a/pkg/streamingpromql/operators/test_operator.go
+++ b/pkg/streamingpromql/operators/test_operator.go
@@ -16,6 +16,7 @@ import (
 type TestOperator struct {
 	Series []labels.Labels
 	Data   []types.InstantVectorSeriesData
+	Closed bool
 }
 
 var _ types.InstantVectorOperator = &TestOperator{}
@@ -40,5 +41,5 @@ func (t *TestOperator) NextSeries(_ context.Context) (types.InstantVectorSeriesD
 }
 
 func (t *TestOperator) Close() {
-	panic("Close() not supported")
+	t.Closed = true
 }

--- a/pkg/streamingpromql/operators/test_operator.go
+++ b/pkg/streamingpromql/operators/test_operator.go
@@ -41,5 +41,7 @@ func (t *TestOperator) NextSeries(_ context.Context) (types.InstantVectorSeriesD
 }
 
 func (t *TestOperator) Close() {
+	// Note that we do not return any unused series data here: this is the responsibility of the test, if needed.
+
 	t.Closed = true
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where aggregations could not return some slices to their respective pools if the operator is closed before all series have been read. This reduces the effectiveness of memory pooling, but does not cause any other negative consequences.

This could happen if a binary operation is consuming the output of the aggregation and not all series are needed for that binary operation, for example.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
