### PR TITLE
Report `artificialDelay` on `ServerTiming` header for push requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [CHANGE] Ingester/Distributor: renamed the experimental `max_cost_attribution_cardinality_per_user` config to `max_cost_attribution_cardinality`. #11092
 * [CHANGE] Frontend: The subquery spin-off feature is now enabled with `-query-frontend.subquery-spin-off-enabled=true` instead of `-query-frontend.instant-queries-with-subquery-spin-off=.*` #11153
 * [FEATURE] Distributor: experimental support for Prometheus Remote Write 2.0 protocol. Limitations: created timestamp is ignored, native histograms with custom buckets are rejected, per series metadata is merged on metric family level automatically, ingestion might fail if client sends ProtoBuf fields out of order. #11100 #11101
+* [ENHANCEMENT] Distributor: Report artificialDelay on ServerTiming header for push requests. #11178
 * [ENHANCEMENT] Ingester: Add support for exporting native histogram cost attribution metrics (`cortex_ingester_attributed_active_native_histogram_series` and `cortex_ingester_attributed_active_native_histogram_buckets`) with labels specified by customers to a custom Prometheus registry. #10892
 * [ENHANCEMENT] Store-gateway: Download sparse headers uploaded by compactors. Compactors have to be configured with `-compactor.upload-sparse-index-headers=true` option. #10879 #11072.
 * [ENHANCEMENT] Compactor: Upload block index file and multiple segment files concurrently. Concurrency scales linearly with block size up to `-compactor.max-per-block-upload-concurrency`. #10947

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 * [CHANGE] Ingester/Distributor: renamed the experimental `max_cost_attribution_cardinality_per_user` config to `max_cost_attribution_cardinality`. #11092
 * [CHANGE] Frontend: The subquery spin-off feature is now enabled with `-query-frontend.subquery-spin-off-enabled=true` instead of `-query-frontend.instant-queries-with-subquery-spin-off=.*` #11153
 * [FEATURE] Distributor: experimental support for Prometheus Remote Write 2.0 protocol. Limitations: created timestamp is ignored, native histograms with custom buckets are rejected, per series metadata is merged on metric family level automatically, ingestion might fail if client sends ProtoBuf fields out of order. #11100 #11101
-* [ENHANCEMENT] Distributor: Report artificialDelay on ServerTiming header for push requests. #11178
 * [ENHANCEMENT] Ingester: Add support for exporting native histogram cost attribution metrics (`cortex_ingester_attributed_active_native_histogram_series` and `cortex_ingester_attributed_active_native_histogram_buckets`) with labels specified by customers to a custom Prometheus registry. #10892
 * [ENHANCEMENT] Store-gateway: Download sparse headers uploaded by compactors. Compactors have to be configured with `-compactor.upload-sparse-index-headers=true` option. #10879 #11072.
 * [ENHANCEMENT] Compactor: Upload block index file and multiple segment files concurrently. Concurrency scales linearly with block size up to `-compactor.max-per-block-upload-concurrency`. #10947

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1370,7 +1370,9 @@ func (d *Distributor) outerMaybeDelayMiddleware(next PushFunc) PushFunc {
 			// Target delay - time spent processing the middleware chain including the push.
 			// If the request took longer than the target delay, we don't delay at all as sleep will return immediately for a negative value.
 			if delay := d.limits.DistributorIngestionArtificialDelay(userID) - d.now().Sub(start); delay > 0 {
-				d.sleep(util.DurationWithJitter(delay, 0.10))
+				delay = util.DurationWithJitter(delay, 0.10)
+				pushReq.artificialDelay = delay
+				d.sleep(delay)
 			}
 			return err
 		}

--- a/pkg/distributor/influx.go
+++ b/pkg/distributor/influx.go
@@ -142,7 +142,7 @@ func InfluxHandler(
 			} else {
 				level.Warn(logger).Log("msg", errorMsg, "response_code", httpCode, "err", err)
 			}
-			addHeaders(w, err, r, httpCode, retryCfg)
+			addHeaders(w, err, r, httpCode, retryCfg, req.artificialDelay)
 			w.WriteHeader(httpCode)
 		} else {
 			w.WriteHeader(http.StatusNoContent) // Needed for Telegraf, otherwise it tries to marshal JSON and considers the write a failure.

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -152,7 +152,7 @@ func OTLPHandler(
 			}
 			level.Error(logger).Log(msgs...)
 		}
-		addHeaders(w, pushErr, r, httpCode, retryCfg)
+		addHeaders(w, pushErr, r, httpCode, retryCfg, req.artificialDelay)
 		writeErrorToHTTPResponseBody(r, w, httpCode, grpcCode, errorMsg, logger)
 	})
 }

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -934,7 +935,7 @@ func TestHandler_HandleRetryAfterHeader(t *testing.T) {
 				req.Header.Add("Retry-Attempt", tc.retryAttempt)
 			}
 
-			addHeaders(recorder, nil, req, tc.responseCode, tc.retryCfg)
+			addHeaders(recorder, nil, req, tc.responseCode, tc.retryCfg, 0)
 
 			retryAfter := recorder.Header().Get("Retry-After")
 			if !tc.expectRetry {
@@ -1113,6 +1114,72 @@ func TestHandler_toHTTPStatus(t *testing.T) {
 			)
 			status := toHTTPStatus(ctx, tc.err, limits)
 			assert.Equal(t, tc.expectedHTTPStatus, status)
+		})
+	}
+}
+
+func TestHandler_ServerTiming(t *testing.T) {
+	tests := []struct {
+		name   string
+		userID string
+		delay  time.Duration
+	}{
+		{
+			name:   "No delay configured",
+			userID: "user1",
+			delay:  0,
+		},
+		{
+			name:   "With delay configured",
+			userID: "user2",
+			delay:  500 * time.Millisecond,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			limits := validation.NewMockTenantLimits(map[string]*validation.Limits{
+				tc.userID: {
+					IngestionArtificialDelay: model.Duration(tc.delay),
+				},
+			})
+			overrides := validation.NewOverrides(*prepareDefaultLimits(), limits)
+
+			timeSource := &MockTimeSource{CurrentTime: time.Now()}
+			d := &Distributor{
+				log:    log.NewNopLogger(),
+				limits: overrides,
+				sleep:  timeSource.Sleep,
+				now:    timeSource.Now,
+			}
+
+			req := httptest.NewRequest("POST", "/api/v1/push", strings.NewReader("{}"))
+			req = req.WithContext(user.InjectOrgID(req.Context(), tc.userID))
+			w := httptest.NewRecorder()
+
+			handler := Handler(
+				1024*1024,
+				nil,
+				nil,
+				false,
+				false,
+				overrides,
+				RetryConfig{},
+				// Just outerMaybeDelayMiddleware and not wrapPushWithMiddlewares
+				d.outerMaybeDelayMiddleware(d.push),
+				nil,
+				log.NewNopLogger(),
+			)
+
+			handler.ServeHTTP(w, req)
+
+			serverTiming := w.Header().Get("Server-Timing")
+
+			if tc.delay > 0 {
+				require.True(t, strings.HasPrefix(serverTiming, "artificial_delay;dur="))
+			} else {
+				require.Empty(t, serverTiming)
+			}
 		})
 	}
 }

--- a/pkg/distributor/request.go
+++ b/pkg/distributor/request.go
@@ -4,6 +4,7 @@ package distributor
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
@@ -20,8 +21,9 @@ type Request struct {
 
 	getRequest supplierFunc
 
-	request *mimirpb.WriteRequest
-	err     error
+	request         *mimirpb.WriteRequest
+	err             error
+	artificialDelay time.Duration
 }
 
 func newRequest(p supplierFunc) *Request {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR reports added `artificialDelay` as part of the `ServerTiming` header on push requests.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
