### PR TITLE
listblocks: add json/yaml output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 ### Tools
 
 * [ENHANCEMENT] `kafkatool`: Add `offsets` command for querying various partition offsets. #11115
+* [ENHANCEMENT] `listblocks`: Output can now also be JSON or YAML for easier parsing. #11184
 
 ## 2.16.0
 

--- a/docs/sources/mimir/manage/tools/listblocks.md
+++ b/docs/sources/mimir/manage/tools/listblocks.md
@@ -33,6 +33,8 @@ Block ID                     Min Time               Max Time               Durat
 Listblocks has many options you can use to modify the output. The following list contains the most important listblocks options:
 
 ```
+  -format string
+    	The format of the output. Must be one of "tabbed", "json", or "yaml" (default "tabbed")
   -max-time value
     	If set, only blocks with MaxTime <= this value is printed
   -min-time value

--- a/tools/listblocks/README.md
+++ b/tools/listblocks/README.md
@@ -5,19 +5,19 @@ This program displays information about blocks in object storage.
 ## Flags
 
 - `--user` (required) The user (tenant) that owns the blocks to be listed
-- `--format` (defaults to `tabbed`) The format of the output. Must be one of `tabbed`, `json`, or `yaml`
-- `--show-deleted` (defaults to `false`) Show blocks marked for deletion
-- `--show-labels` (defaults to `false`) Show block labels
-- `--show-ulid-time` (defaults to `false`) Show time from ULID
-- `--show-sources` (defaults to `false`) Show compaction sources
-- `--show-parents` (defaults to `false`) Show parent blocks
-- `--show-compaction-level` (defaults to `false`) Show compaction level
-- `--show-block-size` (defaults to `false`) Show size of block based on details in meta.json, if available
-- `--show-stats` (defaults to `false`) Show block stats (number of series, chunks, samples)
-- `--split-count` (defaults to `0`) If not 0, shows split number that would be used for grouping blocks during split compaction
+- `--format` The format of the output. Must be one of `tabbed`, `json`, or `yaml` (default `tabbed`)
+- `--show-deleted` Show blocks marked for deletion (default `false`)
+- `--show-labels` Show block labels (default `false`)
+- `--show-ulid-time` Show time from ULID (default `false`)
+- `--show-sources` Show compaction sources (default `false`)
+- `--show-parents` Show parent blocks (default `false`)
+- `--show-compaction-level` Show compaction level (default `false`)
+- `--show-block-size` Show size of block based on details in meta.json, if available (default `false`)
+- `--show-stats` Show block stats (number of series, chunks, samples) (default `false`)
+- `--split-count` If not 0, shows split number that would be used for grouping blocks during split compaction (default `0`)
 - `--min-time` If set, only blocks with minTime >= this value are printed
 - `--max-time` If set, only blocks with maxTime <= this value are printed
-- `--use-ulid-time-for-min-time-check` (defaults to `false`) If true, meta.json files for blocks with ULID time before `--min-time` are not loaded. This may incorrectly skip blocks
+- `--use-ulid-time-for-min-time-check` If true, meta.json files for blocks with ULID time before `--min-time` are not loaded. This may incorrectly skip blocks (default `false`)
 
 Each supported object storage service also has an additional set of flags (see examples in [Running](##Running)).
 

--- a/tools/listblocks/README.md
+++ b/tools/listblocks/README.md
@@ -1,0 +1,118 @@
+# listblocks
+
+This program displays information about blocks in object storage.
+
+## Flags
+
+- `--user` (required) The user (tenant) that owns the blocks to be listed
+- `--format` (defaults to `tabbed`) The format of the output. Must be one of `tabbed`, `json`, or `yaml`
+- `--show-deleted` (defaults to `false`) Show blocks marked for deletion
+- `--show-labels` (defaults to `false`) Show block labels 
+- `--show-ulid-time` (defaults to `false`) Show time from ULID 
+- `--show-sources` (defaults to `false`) Show compaction sources 
+- `--show-parents` (defaults to `false`) Show parent blocks 
+- `--show-compaction-level` (defaults to `false`) Show compaction level 
+- `--show-block-size` (defaults to `false`) Show size of block based on details in meta.json, if available
+- `--show-stats` (defaults to `false`) Show block stats (number of series, chunks, samples)
+- `--split-count` (defaults to `0`) If not 0, shows split number that would be used for grouping blocks during split compaction
+- `--min-time` If set, only blocks with minTime >= this value are printed
+- `--max-time` If set, only blocks with maxTime <= this value are printed
+- `--use-ulid-time-for-min-time-check` (defaults to `false`) If true, meta.json files for blocks with ULID time before `--min-time` are not loaded. This may incorrectly skip blocks
+
+Each supported object storage service also has an additional set of flags (see examples in [Running](##Running)).
+
+## Output formats
+
+The default `tabbed` output format is suitable for human consumption without the use of other tools. The `json` and `yaml` formats are more easily parsed and can be used in combination with other tools like `jq` and `yq` respectively.
+
+`tabbed`
+```
+Block ID                     Min Time               Max Time               Duration        No Compact                                    Size
+01HRB9NDFKKYM8CKGPBEY0E8QX   2024-03-06T00:00:00Z   2024-03-07T00:00:00Z   24h0m0s         [Time: 2025-04-10T19:48:56Z Reason: manual]   687 MiB
+01HRDWWNZQCH1MWCWKK4VMW08R   2024-03-07T00:00:00Z   2024-03-08T00:00:00Z   24h0m0s                                                       688 MiB
+```
+
+`json` (Note: pretty-printed here for readability)
+```json
+[
+  {
+    "blockID": "01HRB9NDFKKYM8CKGPBEY0E8QX",
+    "duration": "24h0m0s",
+    "durationSeconds": 86400,
+    "maxTime": "2024-03-07T00:00:00Z",
+    "minTime": "2024-03-06T00:00:00Z",
+    "noCompact": {
+      "time": "2025-04-10T19:48:56Z",
+      "reason": "manual"
+    },
+    "size": "687 MiB",
+    "sizeBytes": 720756845
+  },
+  {
+    "blockID": "01HRDWWNZQCH1MWCWKK4VMW08R",
+    "duration": "24h0m0s",
+    "durationSeconds": 86400,
+    "maxTime": "2024-03-08T00:00:00Z",
+    "minTime": "2024-03-07T00:00:00Z",
+    "size": "688 MiB",
+    "sizeBytes": 721221809
+  }
+]
+```
+
+`yaml`
+```yaml
+- blockID: 01HRB9NDFKKYM8CKGPBEY0E8QX
+  duration: 24h0m0s
+  durationSeconds: 86400
+  maxTime: "2024-03-07T00:00:00Z"
+  minTime: "2024-03-06T00:00:00Z"
+  noCompact:
+    time: "2025-04-10T19:48:56Z"
+    reason: manual
+  size: 687 MiB
+  sizeBytes: 720756845
+- blockID: 01HRDWWNZQCH1MWCWKK4VMW08R
+  duration: 24h0m0s
+  durationSeconds: 86400
+  maxTime: "2024-03-08T00:00:00Z"
+  minTime: "2024-03-07T00:00:00Z"
+  size: 688 MiB
+  sizeBytes: 721221809
+```
+
+## Running
+
+Run `go build` in this directory to build the program. Then, use an example below as a guide.
+
+### Example for Google Cloud Storage
+
+```bash
+./listblocks \
+  --user <user> \
+  --backend gcs \
+  --gcs.bucket-name <bucket name> \
+```
+
+### Example for Azure Blob Storage
+
+```bash
+./listblocks \
+  --user <user> \
+  --backend azure \
+  --azure.container-name <container name> \
+  --azure.account-name <account name> \
+  --azure.account-key <account key> \
+```
+
+### Example for Amazon Simple Storage Service
+
+```bash
+./listblocks \
+  --user <user> \
+  --backend s3 \
+  --s3.bucket-name <bucket name> \
+  --s3.access-key-id <access key id> \
+  --s3.secret-access-key <secret access key> \
+  --s3.endpoint <endpoint> \
+```

--- a/tools/listblocks/README.md
+++ b/tools/listblocks/README.md
@@ -7,11 +7,11 @@ This program displays information about blocks in object storage.
 - `--user` (required) The user (tenant) that owns the blocks to be listed
 - `--format` (defaults to `tabbed`) The format of the output. Must be one of `tabbed`, `json`, or `yaml`
 - `--show-deleted` (defaults to `false`) Show blocks marked for deletion
-- `--show-labels` (defaults to `false`) Show block labels 
-- `--show-ulid-time` (defaults to `false`) Show time from ULID 
-- `--show-sources` (defaults to `false`) Show compaction sources 
-- `--show-parents` (defaults to `false`) Show parent blocks 
-- `--show-compaction-level` (defaults to `false`) Show compaction level 
+- `--show-labels` (defaults to `false`) Show block labels
+- `--show-ulid-time` (defaults to `false`) Show time from ULID
+- `--show-sources` (defaults to `false`) Show compaction sources
+- `--show-parents` (defaults to `false`) Show parent blocks
+- `--show-compaction-level` (defaults to `false`) Show compaction level
 - `--show-block-size` (defaults to `false`) Show size of block based on details in meta.json, if available
 - `--show-stats` (defaults to `false`) Show block stats (number of series, chunks, samples)
 - `--split-count` (defaults to `0`) If not 0, shows split number that would be used for grouping blocks during split compaction
@@ -26,6 +26,7 @@ Each supported object storage service also has an additional set of flags (see e
 The default `tabbed` output format is suitable for human consumption without the use of other tools. The `json` and `yaml` formats are more easily parsed and can be used in combination with other tools like `jq` and `yq` respectively.
 
 `tabbed`
+
 ```
 Block ID                     Min Time               Max Time               Duration        No Compact                                    Size
 01HRB9NDFKKYM8CKGPBEY0E8QX   2024-03-06T00:00:00Z   2024-03-07T00:00:00Z   24h0m0s         [Time: 2025-04-10T19:48:56Z Reason: manual]   687 MiB
@@ -33,6 +34,7 @@ Block ID                     Min Time               Max Time               Durat
 ```
 
 `json` (Note: pretty-printed here for readability)
+
 ```json
 [
   {
@@ -61,6 +63,7 @@ Block ID                     Min Time               Max Time               Durat
 ```
 
 `yaml`
+
 ```yaml
 - blockID: 01HRB9NDFKKYM8CKGPBEY0E8QX
   duration: 24h0m0s

--- a/tools/listblocks/main.go
+++ b/tools/listblocks/main.go
@@ -56,7 +56,7 @@ func main() {
 	cfg := config{}
 	cfg.bucket.RegisterFlags(flag.CommandLine)
 	flag.StringVar(&cfg.userID, "user", "", "The user (tenant) that owns the blocks to be listed")
-	flag.StringVar(&cfg.format, "format", "tabbed", "The format of the output. Must be one of \"tabbed\" (the default), \"json\", or \"yaml\"")
+	flag.StringVar(&cfg.format, "format", "tabbed", "The format of the output. Must be one of \"tabbed\", \"json\", or \"yaml\"")
 	flag.BoolVar(&cfg.showDeleted, "show-deleted", false, "Show blocks marked for deletion")
 	flag.BoolVar(&cfg.showLabels, "show-labels", false, "Show block labels")
 	flag.BoolVar(&cfg.showUlidTime, "show-ulid-time", false, "Show time from ULID")

--- a/tools/listblocks/main.go
+++ b/tools/listblocks/main.go
@@ -103,7 +103,7 @@ func main() {
 
 	blocks := buildBlocksList(metas, deleteMarkerDetails, noCompactMarkerDetails, cfg)
 	if cfg.format == "tabbed" {
-		printMetas(blocks, cfg)
+		printTabbedOutput(blocks, cfg)
 		return
 	}
 
@@ -126,6 +126,8 @@ type noCompactSummary struct {
 	Reason string `json:"reason" yaml:"reason"`
 }
 
+// buildBlocksList constructs a map of fields for each block that will be later marshalled by printTabbedOutput or into JSON/YAML
+// printTabbedOutput uses key names created in this function directly so synchronize changes there (some keys aren't used by it)
 func buildBlocksList(metas map[ulid.ULID]*block.Meta, deleteMarkerDetails map[ulid.ULID]block.DeletionMark, noCompactMarkerDetails map[ulid.ULID]block.NoCompactMark, cfg config) []map[string]any {
 	blocks := make([]map[string]any, 0, len(metas))
 	for _, b := range listblocks.SortBlocks(metas) {
@@ -141,7 +143,7 @@ func buildBlocksList(metas map[ulid.ULID]*block.Meta, deleteMarkerDetails map[ul
 
 		m := make(map[string]any)
 
-		m["blockID"] = b.ULID.String()
+		m["blockID"] = b.ULID
 		if cfg.splitCount > 0 {
 			m["splitID"] = tsdb.HashBlockID(b.ULID) % uint32(cfg.splitCount)
 		}
@@ -206,7 +208,7 @@ func buildBlocksList(metas map[ulid.ULID]*block.Meta, deleteMarkerDetails map[ul
 // nolint:errcheck
 //
 //goland:noinspection GoUnhandledErrorResult
-func printMetas(blocks []map[string]any, cfg config) {
+func printTabbedOutput(blocks []map[string]any, cfg config) {
 
 	tabber := tabwriter.NewWriter(os.Stdout, 1, 4, 3, ' ', 0)
 	defer tabber.Flush()
@@ -294,8 +296,6 @@ func printMetas(blocks []map[string]any, cfg config) {
 
 		if cfg.showLabels {
 			fmt.Fprintf(tabber, "%s\t", b["labels"])
-		} else {
-			fmt.Fprintf(tabber, "\t")
 		}
 
 		if cfg.showSources {

--- a/tools/listblocks/main.go
+++ b/tools/listblocks/main.go
@@ -4,11 +4,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"os/signal"
+	"slices"
 	"syscall"
 	"text/tabwriter"
 	"time"
@@ -17,6 +20,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/prometheus/model/labels"
+	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/tsdb"
@@ -28,6 +32,7 @@ import (
 type config struct {
 	bucket              bucket.Config
 	userID              string
+	format              string
 	showDeleted         bool
 	showLabels          bool
 	showUlidTime        bool
@@ -50,19 +55,20 @@ func main() {
 	logger := gokitlog.NewNopLogger()
 	cfg := config{}
 	cfg.bucket.RegisterFlags(flag.CommandLine)
-	flag.StringVar(&cfg.userID, "user", "", "User (tenant)")
-	flag.BoolVar(&cfg.showDeleted, "show-deleted", false, "Show deleted blocks")
+	flag.StringVar(&cfg.userID, "user", "", "The user (tenant) that owns the blocks to be listed")
+	flag.StringVar(&cfg.format, "format", "tabbed", "The format of the output. Must be one of \"tabbed\" (the default), \"json\", or \"yaml\"")
+	flag.BoolVar(&cfg.showDeleted, "show-deleted", false, "Show blocks marked for deletion")
 	flag.BoolVar(&cfg.showLabels, "show-labels", false, "Show block labels")
 	flag.BoolVar(&cfg.showUlidTime, "show-ulid-time", false, "Show time from ULID")
 	flag.BoolVar(&cfg.showSources, "show-sources", false, "Show compaction sources")
 	flag.BoolVar(&cfg.showParents, "show-parents", false, "Show parent blocks")
 	flag.BoolVar(&cfg.showCompactionLevel, "show-compaction-level", false, "Show compaction level")
 	flag.BoolVar(&cfg.showBlockSize, "show-block-size", false, "Show size of block based on details in meta.json, if available")
+	flag.BoolVar(&cfg.showStats, "show-stats", false, "Show block stats (number of series, chunks, samples)")
 	flag.IntVar(&cfg.splitCount, "split-count", 0, "It not 0, shows split number that would be used for grouping blocks during split compaction")
 	flag.Var(&cfg.minTime, "min-time", "If set, only blocks with MinTime >= this value are printed")
 	flag.Var(&cfg.maxTime, "max-time", "If set, only blocks with MaxTime <= this value are printed")
 	flag.BoolVar(&cfg.useUlidTimeForMinTimeCheck, "use-ulid-time-for-min-time-check", false, "If true, meta.json files for blocks with ULID time before min-time are not loaded. This may incorrectly skip blocks that have data from the future (minT/maxT higher than ULID).")
-	flag.BoolVar(&cfg.showStats, "show-stats", false, "Show block stats (number of series, chunks, samples)")
 
 	// Parse CLI flags.
 	if err := flagext.ParseFlagsWithoutArguments(flag.CommandLine); err != nil {
@@ -71,6 +77,10 @@ func main() {
 
 	if cfg.userID == "" {
 		log.Fatalln("no user specified")
+	}
+
+	if !slices.Contains([]string{"tabbed", "json", "yaml"}, cfg.format) {
+		log.Fatalln("an invalid format was specified:", cfg.format)
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT)
@@ -91,14 +101,112 @@ func main() {
 		log.Fatalln("failed to read block metadata:", err)
 	}
 
-	printMetas(metas, deleteMarkerDetails, noCompactMarkerDetails, cfg)
+	blocks := buildBlocksList(metas, deleteMarkerDetails, noCompactMarkerDetails, cfg)
+	if cfg.format == "tabbed" {
+		printMetas(blocks, cfg)
+		return
+	}
+
+	var b []byte
+	if cfg.format == "yaml" {
+		b, err = yaml.Marshal(blocks)
+	} else {
+		b, err = json.Marshal(blocks)
+	}
+
+	if err != nil {
+		log.Fatalln("failed to marshal blocks list", err)
+	}
+
+	fmt.Println(string(b))
+}
+
+type noCompactSummary struct {
+	Time   string `json:"time" yaml:"time"`
+	Reason string `json:"reason" yaml:"reason"`
+}
+
+func buildBlocksList(metas map[ulid.ULID]*block.Meta, deleteMarkerDetails map[ulid.ULID]block.DeletionMark, noCompactMarkerDetails map[ulid.ULID]block.NoCompactMark, cfg config) []map[string]any {
+	blocks := make([]map[string]any, 0, len(metas))
+	for _, b := range listblocks.SortBlocks(metas) {
+		if !cfg.showDeleted && deleteMarkerDetails[b.ULID].DeletionTime != 0 {
+			continue
+		}
+		if !time.Time(cfg.minTime).IsZero() && util.TimeFromMillis(b.MinTime).Before(time.Time(cfg.minTime)) {
+			continue
+		}
+		if !time.Time(cfg.maxTime).IsZero() && util.TimeFromMillis(b.MaxTime).After(time.Time(cfg.maxTime)) {
+			continue
+		}
+
+		m := make(map[string]any)
+
+		m["blockID"] = b.ULID.String()
+		if cfg.splitCount > 0 {
+			m["splitID"] = tsdb.HashBlockID(b.ULID) % uint32(cfg.splitCount)
+		}
+		if cfg.showUlidTime {
+			m["ulidTime"] = util.TimeFromMillis(int64(b.ULID.Time())).UTC().Format(time.RFC3339)
+		}
+		m["minTime"] = util.TimeFromMillis(b.MinTime).UTC().Format(time.RFC3339)
+		m["maxTime"] = util.TimeFromMillis(b.MaxTime).UTC().Format(time.RFC3339)
+
+		duration := util.TimeFromMillis(b.MaxTime).Sub(util.TimeFromMillis(b.MinTime))
+		m["duration"] = duration.String()
+		m["durationSeconds"] = math.Floor(duration.Seconds())
+
+		if val, ok := noCompactMarkerDetails[b.ULID]; ok {
+			m["noCompact"] = noCompactSummary{
+				Time:   time.Unix(val.NoCompactTime, 0).UTC().Format(time.RFC3339),
+				Reason: string(val.Reason),
+			}
+		}
+
+		if cfg.showDeleted {
+			m["deletionTime"] = time.Unix(deleteMarkerDetails[b.ULID].DeletionTime, 0).UTC().Format(time.RFC3339)
+		}
+
+		if cfg.showCompactionLevel {
+			m["level"] = b.Compaction.Level
+		}
+
+		if cfg.showBlockSize {
+			m["size"] = listblocks.GetFormattedBlockSize(b)
+			m["sizeBytes"] = listblocks.GetBlockSizeBytes(b)
+		}
+
+		if cfg.showStats {
+			m["numSeries"] = b.Stats.NumSeries
+			m["numSamples"] = b.Stats.NumSamples
+			m["numChunks"] = b.Stats.NumChunks
+		}
+
+		if cfg.showLabels {
+			m["labels"] = labels.FromMap(b.Thanos.Labels)
+		}
+
+		if cfg.showSources {
+			m["sources"] = b.Compaction.Sources
+		}
+
+		if cfg.showParents {
+			var p []ulid.ULID
+			for _, pb := range b.Compaction.Parents {
+				p = append(p, pb.ULID)
+			}
+			m["parents"] = p
+		}
+
+		blocks = append(blocks, m)
+	}
+
+	return blocks
 }
 
 // nolint:errcheck
 //
 //goland:noinspection GoUnhandledErrorResult
-func printMetas(metas map[ulid.ULID]*block.Meta, deleteMarkerDetails map[ulid.ULID]block.DeletionMark, noCompactMarkerDetails map[ulid.ULID]block.NoCompactMark, cfg config) {
-	blocks := listblocks.SortBlocks(metas)
+func printMetas(blocks []map[string]any, cfg config) {
 
 	tabber := tabwriter.NewWriter(os.Stdout, 1, 4, 3, ' ', 0)
 	defer tabber.Flush()
@@ -141,78 +249,63 @@ func printMetas(metas map[ulid.ULID]*block.Meta, deleteMarkerDetails map[ulid.UL
 	fmt.Fprintln(tabber)
 
 	for _, b := range blocks {
-		if !cfg.showDeleted && deleteMarkerDetails[b.ULID].DeletionTime != 0 {
-			continue
-		}
-
-		if !time.Time(cfg.minTime).IsZero() && util.TimeFromMillis(b.MinTime).Before(time.Time(cfg.minTime)) {
-			continue
-		}
-		if !time.Time(cfg.maxTime).IsZero() && util.TimeFromMillis(b.MaxTime).After(time.Time(cfg.maxTime)) {
-			continue
-		}
-
-		fmt.Fprintf(tabber, "%v\t", b.ULID)
+		fmt.Fprintf(tabber, "%v\t", b["blockID"])
 		if cfg.splitCount > 0 {
-			fmt.Fprintf(tabber, "%d\t", tsdb.HashBlockID(b.ULID)%uint32(cfg.splitCount))
+			fmt.Fprintf(tabber, "%d\t", b["splitID"])
 		}
 		if cfg.showUlidTime {
-			fmt.Fprintf(tabber, "%v\t", util.TimeFromMillis(int64(b.ULID.Time())).UTC().Format(time.RFC3339))
+			fmt.Fprintf(tabber, "%v\t", b["ulidTime"])
 		}
-		fmt.Fprintf(tabber, "%v\t", util.TimeFromMillis(b.MinTime).UTC().Format(time.RFC3339))
-		fmt.Fprintf(tabber, "%v\t", util.TimeFromMillis(b.MaxTime).UTC().Format(time.RFC3339))
-		fmt.Fprintf(tabber, "%v\t", util.TimeFromMillis(b.MaxTime).Sub(util.TimeFromMillis(b.MinTime)))
+		fmt.Fprintf(tabber, "%v\t", b["minTime"])
+		fmt.Fprintf(tabber, "%v\t", b["maxTime"])
+		fmt.Fprintf(tabber, "%v\t", b["duration"])
 
-		if val, ok := noCompactMarkerDetails[b.ULID]; ok {
+		if val, ok := b["noCompact"]; ok {
+			val := val.(noCompactSummary)
 			fmt.Fprintf(tabber, "%v\t", []string{
-				fmt.Sprintf("Time: %s", time.Unix(val.NoCompactTime, 0).UTC().Format(time.RFC3339)),
-				fmt.Sprintf("Reason: %s", val.Reason)})
+				fmt.Sprintf("Time: %s", val.Time),
+				fmt.Sprintf("Reason: %s", val.Reason),
+			})
 		} else {
 			fmt.Fprintf(tabber, "\t")
 		}
 
 		if cfg.showDeleted {
-			if deleteMarkerDetails[b.ULID].DeletionTime == 0 {
-				fmt.Fprintf(tabber, "\t") // no deletion time.
+			if val, ok := b["deletionTime"]; ok {
+				fmt.Fprintf(tabber, "%v\t", val)
 			} else {
-				fmt.Fprintf(tabber, "%v\t", time.Unix(deleteMarkerDetails[b.ULID].DeletionTime, 0).UTC().Format(time.RFC3339))
+				fmt.Fprintf(tabber, "\t") // no deletion time.
 			}
 		}
 
 		if cfg.showCompactionLevel {
-			fmt.Fprintf(tabber, "%d\t", b.Compaction.Level)
+			fmt.Fprintf(tabber, "%d\t", b["level"])
 		}
 
 		if cfg.showBlockSize {
-			fmt.Fprintf(tabber, "%s\t", listblocks.GetFormattedBlockSize(b))
+			fmt.Fprintf(tabber, "%s\t", b["size"])
 		}
 
 		if cfg.showStats {
-			fmt.Fprintf(tabber, "%d\t", b.Stats.NumSeries)
-			fmt.Fprintf(tabber, "%d\t", b.Stats.NumSamples)
-			fmt.Fprintf(tabber, "%d\t", b.Stats.NumChunks)
+			fmt.Fprintf(tabber, "%d\t", b["numSeries"])
+			fmt.Fprintf(tabber, "%d\t", b["numSamples"])
+			fmt.Fprintf(tabber, "%d\t", b["numChunks"])
 		}
 
 		if cfg.showLabels {
-			if m := b.Thanos.Labels; m != nil {
-				fmt.Fprintf(tabber, "%s\t", labels.FromMap(b.Thanos.Labels))
-			} else {
-				fmt.Fprintf(tabber, "\t")
-			}
+			fmt.Fprintf(tabber, "%s\t", b["labels"])
+		} else {
+			fmt.Fprintf(tabber, "\t")
 		}
 
 		if cfg.showSources {
 			// No tab at the end.
-			fmt.Fprintf(tabber, "%v", b.Compaction.Sources)
+			fmt.Fprintf(tabber, "%v", b["sources"])
 		}
 
 		if cfg.showParents {
-			var p []ulid.ULID
-			for _, pb := range b.Compaction.Parents {
-				p = append(p, pb.ULID)
-			}
 			// No tab at the end.
-			fmt.Fprintf(tabber, "%v", p)
+			fmt.Fprintf(tabber, "%v", b["parents"])
 		}
 
 		fmt.Fprintln(tabber)


### PR DESCRIPTION
#### What this PR does

This adds a new `--format` flag for the `listblocks` tool which allows specifying an output format. The default `tabbed` format preserves the old behavior of the tool, while the new formats `json` and `yaml` allow for easier parsing.

The tricky part here was that `listblocks` supports a large number of flags that affect whether a field is in the output. In order to keep that the same between formats a `map[string]any` is first constructed for each block. If a field won't be in the output then it isn't in the map. The JSON/YAML marshal calls are then passed those maps directly and the more involved tabbed output generating function looks similar to before.

Overall this was motivated from my experience of trying to use `listblocks` to estimate the total size of blocks for a user. The current output format prints a block size like `12 KiB`. That's useful for human consumption, but it's inconvenient to ignore the column headers line, isolate each other line's size column, parse that format into bytes, and then sum it all in a script. The equivalent can now be done by specifying the `json` format and then piping into `jq 'map(.sizeBytes) | add'`. Trying to do more complex analysis should be significantly easier now.

I also added documentation in the tool's directory.

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
