### PR TITLE
Renames the ingester queued read requests panel title

### DIFF
--- a/operations/mimir-mixin/dashboards/reads.libsonnet
+++ b/operations/mimir-mixin/dashboards/reads.libsonnet
@@ -409,7 +409,7 @@ local filename = 'mimir-reads.json';
       $._config.show_reactive_limiter_panels,
       $.row('Instance Limits')
       .addPanel(
-        $.timeseriesPanel('Ingester per %s blocked requests' % $._config.per_instance_label) +
+        $.timeseriesPanel('Ingester per %s queued requests' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'sum by (%s) (cortex_ingester_reactive_limiter_blocked_requests{%s, request_type="read"})'
           % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ingester)], '',
@@ -425,7 +425,7 @@ local filename = 'mimir-reads.json';
         { fieldConfig+: { defaults+: { unit: 'req' } } }
       )
       .addPanel(
-        $.timeseriesPanel('Ingester %s pod inflight request limit' % $._config.per_instance_label) +
+        $.timeseriesPanel('Ingester per %s inflight request limit' % $._config.per_instance_label) +
         $.hiddenLegendQueryPanel(
           'sum by (%s) (cortex_ingester_reactive_limiter_inflight_limit{%s, request_type="read"})'
           % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ingester)], '',


### PR DESCRIPTION
Similar to #[11186](https://github.com/grafana/mimir/pull/11186), but for read requests.

- Renames the ingester queued requests panel title
- Fixes the inflight requests limits panel title

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
