### PR TITLE
MQE: don't hold reference to data in `sort`/`sort_desc` for any longer than necessary

### DIFF
--- a/pkg/streamingpromql/operators/functions/sort.go
+++ b/pkg/streamingpromql/operators/functions/sort.go
@@ -149,6 +149,7 @@ func (s *Sort) NextSeries(_ context.Context) (types.InstantVectorSeriesData, err
 	}
 
 	data := s.allData[s.seriesReturned]
+	s.allData[s.seriesReturned] = types.InstantVectorSeriesData{} // Clear our reference to the data, so it can be garbage collected.
 	s.seriesReturned++
 
 	return data, nil
@@ -168,4 +169,6 @@ func (s *Sort) Close() {
 		types.PutInstantVectorSeriesData(s.allData[s.seriesReturned], s.MemoryConsumptionTracker)
 		s.seriesReturned++
 	}
+
+	s.allData = nil
 }


### PR DESCRIPTION
#### What this PR does

This PR makes a minor improvement to the implementation of `sort` and `sort_desc` to allow series data to be garbage collected earlier.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
