### PR TITLE
codeowners: kick grafanabot out

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,8 +27,8 @@
 CHANGELOG.md
 
 # Dependencies
-go.mod @stevesg @grafana/mimir-maintainers @grafanabot
-go.sum @stevesg @grafana/mimir-maintainers @grafanabot
-/vendor/ @stevesg @grafana/mimir-maintainers @grafanabot
-/vendor/github.com/prometheus/alertmanager @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers @grafanabot
-/vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers @grafanabot
+go.mod @stevesg @grafana/mimir-maintainers
+go.sum @stevesg @grafana/mimir-maintainers
+/vendor/ @stevesg @grafana/mimir-maintainers
+/vendor/github.com/prometheus/alertmanager @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers
+/vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers


### PR DESCRIPTION
#### What this PR does

`grafanabot` is no longer with us, as all automation was moved to GitHub apps. We can kick the bot out of the list of code owners.