### PR TITLE
fix(helm): fix indent for alertmanager-dep.yaml extraVolumes

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -33,6 +33,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Memcached: Use `dnssrvnoa+` address prefix instead of `dns+` which results in DNS `SRV` record lookups instead of `A` or `AAAA`. This results in fewer cache evictions when the members of the Memcached cluster change. #11041
 * [BUGFIX] Helm: Fix extra spaces in the extra-manifest helm chart.
 * [BUGFIX] Helm: Work around [Helm PR 12879](https://github.com/helm/helm/pull/12879) not clearing fields with `null`, instead setting them to `null`. #11140
+* [BUGFIX] Fix indentation in the templates that resolve `extraVolumes` values. #11202
 
 ## 5.7.0
 

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -147,10 +147,10 @@ spec:
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
         {{- if .Values.alertmanager.extraVolumes }}
-        {{ toYaml .Values.alertmanager.extraVolumes | indent 8}}
+        {{ toYaml .Values.alertmanager.extraVolumes | nindent 8}}
         {{- end }}
         {{- if .Values.global.extraVolumes }}
-        {{ toYaml .Values.global.extraVolumes | indent 8}}
+        {{ toYaml .Values.global.extraVolumes | nindent 8}}
         {{- end }}
         - name: storage
           emptyDir: {}

--- a/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-querier/graphite-querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-querier/graphite-querier-dep.yaml
@@ -135,10 +135,10 @@ spec:
           configMap:
             name: {{ template "mimir.fullname" . }}-graphite-schemas
         {{- if .Values.graphite.querier.extraVolumes }}
-        {{ toYaml .Values.graphite.querier.extraVolumes | indent 8}}
+        {{ toYaml .Values.graphite.querier.extraVolumes | nindent 8}}
         {{- end }}
         {{- if .Values.global.extraVolumes }}
-        {{ toYaml .Values.global.extraVolumes | indent 8}}
+        {{ toYaml .Values.global.extraVolumes | nindent 8}}
         {{- end }}
         - name: license
           secret:

--- a/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-write-proxy/graphite-write-proxy-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-write-proxy/graphite-write-proxy-dep.yaml
@@ -133,10 +133,10 @@ spec:
           configMap:
             name: {{ template "mimir.fullname" . }}-graphite-schemas
         {{- if .Values.graphite.write_proxy.extraVolumes }}
-        {{ toYaml .Values.graphite.write_proxy.extraVolumes | indent 8}}
+        {{ toYaml .Values.graphite.write_proxy.extraVolumes | nindent 8 }}
         {{- end }}
         {{- if .Values.global.extraVolumes }}
-        {{ toYaml .Values.global.extraVolumes | indent 8}}
+        {{ toYaml .Values.global.extraVolumes | nindent 8 }}
         {{- end }}
         - name: license
           secret:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR fixes a helm templating issues when running alertmanager as a deployment and extraVolumes are set either in global or alertmanager sections. 

#### Which issue(s) this PR fixes or relates to

Fixes #9775 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
