### PR TITLE
MQE improve memory consumption estimate with Label information

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1519,7 +1519,7 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			// At peak, we'll hold all the output samples plus one series, which has one sample.
 			// The output contains five samples, which will be rounded up to 8 (the nearest power of two).
 			instantQueryExpectedPeak: types.FPointSize + 8*(types.VectorSampleSize+types.LabelPairEstimatedSize),
-			instantQueryLimit:        4944,
+			instantQueryLimit:        types.FPointSize + 8*(types.VectorSampleSize+types.LabelPairEstimatedSize),
 		},
 		"limit enabled, and query exceeds limit": {
 			expr:          "some_metric",

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1505,7 +1505,7 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 
 			// At peak, we'll hold all the output samples plus one series, which has one sample.
 			// The output contains five samples, which will be rounded up to 8 (the nearest power of two).
-			instantQueryExpectedPeak: types.FPointSize + 8*types.VectorSampleSize,
+			instantQueryExpectedPeak: types.FPointSize + 8*types.VectorSampleSize + 8*types.LabelPairEstimatedSize,
 			instantQueryLimit:        0,
 		},
 		"limit enabled, but query does not exceed limit": {
@@ -1518,8 +1518,8 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 
 			// At peak, we'll hold all the output samples plus one series, which has one sample.
 			// The output contains five samples, which will be rounded up to 8 (the nearest power of two).
-			instantQueryExpectedPeak: types.FPointSize + 8*types.VectorSampleSize,
-			instantQueryLimit:        1000,
+			instantQueryExpectedPeak: types.FPointSize + 8*types.VectorSampleSize + 8*types.LabelPairEstimatedSize,
+			instantQueryLimit:        4944,
 		},
 		"limit enabled, and query exceeds limit": {
 			expr:          "some_metric",
@@ -1548,9 +1548,10 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			// At peak we'll hold in memory:
 			//  - the running total for the sum() (two floats and a bool),
 			//  - the next series from the selector,
-			//  - and the output sample.
-			instantQueryExpectedPeak: 2*types.Float64Size + types.BoolSize + types.FPointSize + types.VectorSampleSize,
-			instantQueryLimit:        2*types.Float64Size + types.BoolSize + types.FPointSize + types.VectorSampleSize,
+			//  - the output sample,
+			//  - and the sample labels.
+			instantQueryExpectedPeak: 2*types.Float64Size + types.BoolSize + types.FPointSize + types.VectorSampleSize + types.LabelPairEstimatedSize,
+			instantQueryLimit:        2*types.Float64Size + types.BoolSize + types.FPointSize + types.VectorSampleSize + types.LabelPairEstimatedSize,
 		},
 		"limit enabled, query selects more samples than limit but should not load all of them into memory at once, and peak consumption is over limit": {
 			expr:          "sum(some_metric)",
@@ -1568,10 +1569,11 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			// At peak we'll hold in memory:
 			// - the running total for the sum() (two floats and a bool),
 			// - the next series from the selector,
-			// - and the output sample.
+			// - the output sample,
+			// - and the sample labels.
 			// The last thing to be allocated is the bool slice for the running total, so that won't contribute to the peak before the query is aborted.
-			instantQueryExpectedPeak: 2*types.Float64Size + types.FPointSize + types.VectorSampleSize,
-			instantQueryLimit:        2*types.Float64Size + types.BoolSize + types.FPointSize + types.VectorSampleSize - 1,
+			instantQueryExpectedPeak: 2*types.Float64Size + types.FPointSize + types.VectorSampleSize + types.LabelPairEstimatedSize,
+			instantQueryLimit:        2*types.Float64Size + types.BoolSize + types.FPointSize + types.VectorSampleSize + types.LabelPairEstimatedSize - 1,
 		},
 		"histogram: limit enabled, but query does not exceed limit": {
 			expr:          "sum(some_histogram)",
@@ -1587,9 +1589,10 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			// At peak we'll hold in memory:
 			//  - the running total for the sum() (a histogram pointer),
 			//  - the next series from the selector,
-			//  - and the output sample.
-			instantQueryExpectedPeak: types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize,
-			instantQueryLimit:        types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize,
+			//  - the output sample,
+			//  - and the sample labels.
+			instantQueryExpectedPeak: types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize + types.LabelPairEstimatedSize,
+			instantQueryLimit:        types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize + types.LabelPairEstimatedSize,
 		},
 		"histogram: limit enabled, and query exceeds limit": {
 			expr:          "sum(some_histogram)",
@@ -1606,10 +1609,11 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			// At peak we'll hold in memory:
 			//  - the running total for the sum() (a histogram pointer),
 			//  - the next series from the selector,
-			//  - and the output sample.
+			//  - the output sample,
+			//  - and the sample labels.
 			// The last thing to be allocated is the HistogramPointerSize slice for the running total, so that won't contribute to the peak before the query is aborted.
-			instantQueryExpectedPeak: types.HPointSize + types.VectorSampleSize,
-			instantQueryLimit:        types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize - 1,
+			instantQueryExpectedPeak: types.HPointSize + types.VectorSampleSize + types.LabelPairEstimatedSize,
+			instantQueryLimit:        types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize + types.LabelPairEstimatedSize - 1,
 		},
 	}
 

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1505,7 +1505,7 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 
 			// At peak, we'll hold all the output samples plus one series, which has one sample.
 			// The output contains five samples, which will be rounded up to 8 (the nearest power of two).
-			instantQueryExpectedPeak: types.FPointSize + 8*types.VectorSampleSize + 8*types.LabelPairEstimatedSize,
+			instantQueryExpectedPeak: types.FPointSize + 8*(types.VectorSampleSize+types.LabelPairEstimatedSize),
 			instantQueryLimit:        0,
 		},
 		"limit enabled, but query does not exceed limit": {
@@ -1518,7 +1518,7 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 
 			// At peak, we'll hold all the output samples plus one series, which has one sample.
 			// The output contains five samples, which will be rounded up to 8 (the nearest power of two).
-			instantQueryExpectedPeak: types.FPointSize + 8*types.VectorSampleSize + 8*types.LabelPairEstimatedSize,
+			instantQueryExpectedPeak: types.FPointSize + 8*(types.VectorSampleSize+types.LabelPairEstimatedSize),
 			instantQueryLimit:        4944,
 		},
 		"limit enabled, and query exceeds limit": {

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -31,6 +31,7 @@ const (
 	// - Average name length (8 bytes)
 	// - Average value length (8 bytes)
 	// - Average total of labels per series (10)
+	// The last 3 averages value are taken based on guesstimate.
 	LabelPairEstimatedSize = (uint64(unsafe.Sizeof(labels.Label{})) + 8 + 8) * 10
 
 	FPointSize           = uint64(unsafe.Sizeof(promql.FPoint{}))

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -29,7 +29,8 @@ const (
 	// - Average name length (8 bytes)
 	// - Average value length (8 bytes)
 	// - Small overhead for the label struct itself (8 bytes)
-	LabelPairEstimatedSize = 56
+	// - 10 label pairs per series on average
+	LabelPairEstimatedSize = 56 * 10
 
 	FPointSize           = uint64(unsafe.Sizeof(promql.FPoint{}))
 	HPointSize           = uint64(unsafe.Sizeof(promql.HPoint{}) + nativeHistogramEstimatedSize)
@@ -185,7 +186,7 @@ func (p *LimitingBucketedPool[S, E]) Get(size int, tracker *limiting.MemoryConsu
 
 	// Series labels must be estimated only for VectorPool.
 	if _, isVector := any(s).(promql.Vector); isVector {
-		estimatedBytes += uint64(cap(s)) * LabelPairEstimatedSize * 10 // Assume 10 label pairs per series on average
+		estimatedBytes += uint64(cap(s)) * LabelPairEstimatedSize
 	}
 
 	if err := tracker.IncreaseMemoryConsumption(estimatedBytes); err != nil {
@@ -216,7 +217,7 @@ func (p *LimitingBucketedPool[S, E]) Put(s S, tracker *limiting.MemoryConsumptio
 
 	// Series labels must be estimated only for VectorPool.
 	if _, isVector := any(s).(promql.Vector); isVector {
-		estimatedBytes += uint64(cap(s)) * LabelPairEstimatedSize * 10 // Assume 10 label pairs per series on average
+		estimatedBytes += uint64(cap(s)) * LabelPairEstimatedSize
 	}
 
 	tracker.DecreaseMemoryConsumption(estimatedBytes)

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -28,9 +28,8 @@ const (
 	// - String headers (2 * unsafe.Sizeof(string) = 32 bytes on 64-bit systems)
 	// - Average name length (8 bytes)
 	// - Average value length (8 bytes)
-	// - Small overhead for the label struct itself (8 bytes)
 	// - 10 label pairs per series on average
-	LabelPairEstimatedSize = 56 * 10
+	LabelPairEstimatedSize = 48 * 10
 
 	FPointSize           = uint64(unsafe.Sizeof(promql.FPoint{}))
 	HPointSize           = uint64(unsafe.Sizeof(promql.HPoint{}) + nativeHistogramEstimatedSize)

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -6,6 +6,7 @@ import (
 	"unsafe"
 
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
@@ -24,12 +25,13 @@ const (
 	// (5 * 8 bytes). Some FloatHistograms will be bigger than this and some will be smaller.
 	nativeHistogramEstimatedSize = 288
 
-	// Estimated size of a label pair (name + value) in bytes. This is a conservative estimate that includes:
-	// - String headers (2 * unsafe.Sizeof(string) = 32 bytes on 64-bit systems)
+	// Estimated size of a label pair (name + value) in bytes.
+	// This is a conservative estimate that includes:
+	// - The size of Label struct
 	// - Average name length (8 bytes)
 	// - Average value length (8 bytes)
-	// - 10 label pairs per series on average
-	LabelPairEstimatedSize = 48 * 10
+	// - Average number of label pairs per series (10)
+	LabelPairEstimatedSize = (uint64(unsafe.Sizeof(labels.Label{})) + 8 + 8) * 10
 
 	FPointSize           = uint64(unsafe.Sizeof(promql.FPoint{}))
 	HPointSize           = uint64(unsafe.Sizeof(promql.HPoint{}) + nativeHistogramEstimatedSize)

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -30,7 +30,7 @@ const (
 	// - The size of Label struct
 	// - Average name length (8 bytes)
 	// - Average value length (8 bytes)
-	// - Average number of label pairs per series (10)
+	// - Average total of labels per series (10)
 	LabelPairEstimatedSize = (uint64(unsafe.Sizeof(labels.Label{})) + 8 + 8) * 10
 
 	FPointSize           = uint64(unsafe.Sizeof(promql.FPoint{}))

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -183,7 +183,7 @@ func (p *LimitingBucketedPool[S, E]) Get(size int, tracker *limiting.MemoryConsu
 	// - there's no guarantee the slice will have size 'size' when it's returned to us in putWithElementSize, so using 'size' would make the accounting below impossible
 	estimatedBytes := uint64(cap(s)) * p.elementSize
 
-	// Series labels must be estimated only for Vector pools.
+	// Series labels must be estimated only for VectorPool.
 	if _, isVector := any(s).(promql.Vector); isVector {
 		estimatedBytes += uint64(cap(s)) * LabelPairEstimatedSize * 10 // Assume 10 label pairs per series on average
 	}
@@ -214,7 +214,7 @@ func (p *LimitingBucketedPool[S, E]) Put(s S, tracker *limiting.MemoryConsumptio
 
 	estimatedBytes := uint64(cap(s)) * p.elementSize
 
-	// Series labels must be estimated only for Vector pools.
+	// Series labels must be estimated only for VectorPool.
 	if _, isVector := any(s).(promql.Vector); isVector {
 		estimatedBytes += uint64(cap(s)) * LabelPairEstimatedSize * 10 // Assume 10 label pairs per series on average
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Add memory consumption estimate with Label information. The estimation is based on the following:
- The size of `labels.Label` struct (32 bytes).
- Average length of string name of value of the label (8 bytes each).
- Average number of labels per series (guesstimating to 10).

I will try to figure out to improve the guesstimate of the two averages above by looking at the ops data.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
