### PR TITLE
MQE: make `nil` checks consistent in operator `Close` methods

### DIFF
--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
@@ -286,10 +286,8 @@ func (t *InstantQuery) Close() {
 	t.Inner.Close()
 	t.Param.Close()
 
-	if t.values != nil {
-		types.Float64SlicePool.Put(t.values, t.MemoryConsumptionTracker)
-		t.values = nil
-	}
+	types.Float64SlicePool.Put(t.values, t.MemoryConsumptionTracker)
+	t.values = nil
 }
 
 type instantQueryGroup struct {

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
@@ -416,10 +416,8 @@ func (t *RangeQuery) Close() {
 	t.Inner.Close()
 	t.Param.Close()
 
-	if t.k != nil {
-		types.Int64SlicePool.Put(t.k, t.MemoryConsumptionTracker)
-		t.k = nil
-	}
+	types.Int64SlicePool.Put(t.k, t.MemoryConsumptionTracker)
+	t.k = nil
 
 	if t.currentGroup != nil {
 		t.returnGroupAndSeriesToPool(t.currentGroup, t.seriesIndexInCurrentGroup)

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -727,15 +727,11 @@ func (g *GroupedVectorVectorBinaryOperation) Close() {
 	g.Right.Close()
 	// We don't need to close g.oneSide or g.manySide, as these are either g.Left or g.Right and so have been closed above.
 
-	if g.oneSideMetadata != nil {
-		types.PutSeriesMetadataSlice(g.oneSideMetadata)
-		g.oneSideMetadata = nil
-	}
+	types.PutSeriesMetadataSlice(g.oneSideMetadata)
+	g.oneSideMetadata = nil
 
-	if g.manySideMetadata != nil {
-		types.PutSeriesMetadataSlice(g.manySideMetadata)
-		g.manySideMetadata = nil
-	}
+	types.PutSeriesMetadataSlice(g.manySideMetadata)
+	g.manySideMetadata = nil
 
 	if g.oneSideBuffer != nil {
 		g.oneSideBuffer.Close()

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -568,15 +568,11 @@ func (b *OneToOneVectorVectorBinaryOperation) Close() {
 	b.Left.Close()
 	b.Right.Close()
 
-	if b.leftMetadata != nil {
-		types.PutSeriesMetadataSlice(b.leftMetadata)
-		b.leftMetadata = nil
-	}
+	types.PutSeriesMetadataSlice(b.leftMetadata)
+	b.leftMetadata = nil
 
-	if b.rightMetadata != nil {
-		types.PutSeriesMetadataSlice(b.rightMetadata)
-		b.rightMetadata = nil
-	}
+	types.PutSeriesMetadataSlice(b.rightMetadata)
+	b.rightMetadata = nil
 
 	if b.leftBuffer != nil {
 		b.leftBuffer.Close()

--- a/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
@@ -256,10 +256,8 @@ func (v *VectorScalarBinaryOperation) Close() {
 	v.Scalar.Close()
 	v.Vector.Close()
 
-	if v.scalarData.Samples != nil {
-		types.FPointSlicePool.Put(v.scalarData.Samples, v.MemoryConsumptionTracker)
-		v.scalarData.Samples = nil
-	}
+	types.FPointSlicePool.Put(v.scalarData.Samples, v.MemoryConsumptionTracker)
+	v.scalarData.Samples = nil
 }
 
 func (v *VectorScalarBinaryOperation) emitAnnotation(generator types.AnnotationGenerator) {

--- a/pkg/streamingpromql/operators/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge.go
@@ -139,5 +139,6 @@ func (d *DeduplicateAndMerge) Close() {
 
 	if d.buffer != nil {
 		d.buffer.Close()
+		d.buffer = nil
 	}
 }

--- a/pkg/streamingpromql/operators/functions/absent.go
+++ b/pkg/streamingpromql/operators/functions/absent.go
@@ -111,10 +111,8 @@ func (a *Absent) ExpressionPosition() posrange.PositionRange {
 func (a *Absent) Close() {
 	a.Inner.Close()
 
-	if a.presence != nil {
-		types.BoolSlicePool.Put(a.presence, a.MemoryConsumptionTracker)
-		a.presence = nil
-	}
+	types.BoolSlicePool.Put(a.presence, a.MemoryConsumptionTracker)
+	a.presence = nil
 }
 
 // CreateLabelsForAbsentFunction returns the labels that are uniquely and exactly matched

--- a/pkg/streamingpromql/operators/functions/absent_over_time.go
+++ b/pkg/streamingpromql/operators/functions/absent_over_time.go
@@ -117,8 +117,6 @@ func (a *AbsentOverTime) ExpressionPosition() posrange.PositionRange {
 func (a *AbsentOverTime) Close() {
 	a.Inner.Close()
 
-	if a.presence != nil {
-		types.BoolSlicePool.Put(a.presence, a.MemoryConsumptionTracker)
-		a.presence = nil
-	}
+	types.BoolSlicePool.Put(a.presence, a.MemoryConsumptionTracker)
+	a.presence = nil
 }

--- a/pkg/streamingpromql/operators/functions/histogram_quantile.go
+++ b/pkg/streamingpromql/operators/functions/histogram_quantile.go
@@ -439,10 +439,8 @@ func (h *HistogramQuantileFunction) Close() {
 	h.inner.Close()
 	h.phArg.Close()
 
-	if h.phValues.Samples != nil {
-		types.FPointSlicePool.Put(h.phValues.Samples, h.memoryConsumptionTracker)
-		h.phValues.Samples = nil
-	}
+	types.FPointSlicePool.Put(h.phValues.Samples, h.memoryConsumptionTracker)
+	h.phValues.Samples = nil
 }
 
 type bucketGroupSorter struct {

--- a/pkg/streamingpromql/operators/operator_buffer.go
+++ b/pkg/streamingpromql/operators/operator_buffer.go
@@ -108,8 +108,6 @@ func (b *InstantVectorOperatorBuffer) getSingleSeries(ctx context.Context, serie
 func (b *InstantVectorOperatorBuffer) Close() {
 	b.source.Close()
 
-	if b.seriesUsed != nil {
-		types.BoolSlicePool.Put(b.seriesUsed, b.memoryConsumptionTracker)
-		b.seriesUsed = nil
-	}
+	types.BoolSlicePool.Put(b.seriesUsed, b.memoryConsumptionTracker)
+	b.seriesUsed = nil
 }

--- a/pkg/streamingpromql/operators/operator_buffer.go
+++ b/pkg/streamingpromql/operators/operator_buffer.go
@@ -105,6 +105,9 @@ func (b *InstantVectorOperatorBuffer) getSingleSeries(ctx context.Context, serie
 	return d, nil
 }
 
+// Close frees all resources associated with this buffer.
+// Calling GetSeries after calling Close may result in unpredictable behaviour, corruption or crashes.
+// It is safe to call Close multiple times.
 func (b *InstantVectorOperatorBuffer) Close() {
 	b.source.Close()
 


### PR DESCRIPTION
#### What this PR does

It is safe to pass a `nil` slice to the `Put` method of a `BucketedPool` or `LimitingBucketedPool`, however some parts of MQE unnecessarily check if a slice is `nil` before calling `Put`. 

This PR makes all places consistent, removing the unnecessary checks.

#### Which issue(s) this PR fixes or relates to

Addresses https://github.com/grafana/mimir/pull/11162#discussion_r2035802201

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
