### PR TITLE
MQE: Add SeriesMetadata limiting_pool memory tracker

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1433,27 +1433,28 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			expr:          "some_metric",
 			shouldSucceed: true,
 
-			// Each series has five samples, which will be rounded up to 8 (the nearest power of two) by the bucketed pool, and we have five series.
-			rangeQueryExpectedPeak: 5 * 8 * types.FPointSize,
+			// Each series has five samples, which will be rounded up to 8 (the nearest power of two) by the bucketed pool,
+			// and we have five series and each of the series has SeriesMetadata.
+			rangeQueryExpectedPeak: 5*8*types.FPointSize + 8*types.SeriesMetadataSize,
 			rangeQueryLimit:        0,
 
 			// At peak, we'll hold all the output samples plus one series, which has one sample.
-			// The output contains five samples, which will be rounded up to 8 (the nearest power of two).
-			instantQueryExpectedPeak: types.FPointSize + 8*types.VectorSampleSize,
+			// The output contains five samples with SeriesMetadata, which will be rounded up to 8 (the nearest power of two).
+			instantQueryExpectedPeak: types.FPointSize + 8*(types.VectorSampleSize+types.SeriesMetadataSize),
 			instantQueryLimit:        0,
 		},
 		"limit enabled, but query does not exceed limit": {
 			expr:          "some_metric",
 			shouldSucceed: true,
 
-			// Each series has five samples, which will be rounded up to 8 (the nearest power of two) by the bucketed pool, and we have five series.
-			rangeQueryExpectedPeak: 5 * 8 * types.FPointSize,
-			rangeQueryLimit:        1000,
+			// Each series has five samples with SeriesMetadata, which will be rounded up to 8 (the nearest power of two) by the bucketed pool, and we have five series.
+			rangeQueryExpectedPeak: 5*8*types.FPointSize + 8*types.SeriesMetadataSize,
+			rangeQueryLimit:        5*8*types.FPointSize + 8*types.SeriesMetadataSize,
 
 			// At peak, we'll hold all the output samples plus one series, which has one sample.
-			// The output contains five samples, which will be rounded up to 8 (the nearest power of two).
-			instantQueryExpectedPeak: types.FPointSize + 8*types.VectorSampleSize,
-			instantQueryLimit:        1000,
+			// The output contains five samples with SeriesMetadata, which will be rounded up to 8 (the nearest power of two).
+			instantQueryExpectedPeak: types.FPointSize + 8*(types.VectorSampleSize+types.SeriesMetadataSize),
+			instantQueryLimit:        types.FPointSize + 8*(types.VectorSampleSize+types.SeriesMetadataSize),
 		},
 		"limit enabled, and query exceeds limit": {
 			expr:          "some_metric",
@@ -1474,17 +1475,14 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			// Each series has five samples, which will be rounded up to 8 (the nearest power of two) by the bucketed pool.
 			// At peak we'll hold in memory:
 			//  - the running total for the sum() (two floats (due to kahan) and a bool at each step, with the number of steps rounded to the nearest power of 2),
-			//  - and the next series from the selector.
-			rangeQueryExpectedPeak: 8*(2*types.Float64Size+types.BoolSize) + 8*types.FPointSize,
-			rangeQueryLimit:        8*(2*types.Float64Size+types.BoolSize) + 8*types.FPointSize,
+			//  - and the next series with SeriesMetadata from the selector.
+			rangeQueryExpectedPeak: 8*(2*types.Float64Size+types.BoolSize) + 8*types.FPointSize + types.SeriesMetadataSize,
+			rangeQueryLimit:        8*(2*types.Float64Size+types.BoolSize) + 8*types.FPointSize + types.SeriesMetadataSize,
 
 			// Each series has one sample, which is already a power of two.
-			// At peak we'll hold in memory:
-			//  - the running total for the sum() (two floats and a bool),
-			//  - the next series from the selector,
-			//  - and the output sample.
-			instantQueryExpectedPeak: 2*types.Float64Size + types.BoolSize + types.FPointSize + types.VectorSampleSize,
-			instantQueryLimit:        2*types.Float64Size + types.BoolSize + types.FPointSize + types.VectorSampleSize,
+			// At peak we'll hold in memory 9 SeriesMetadata.
+			instantQueryExpectedPeak: 9 * types.SeriesMetadataSize,
+			instantQueryLimit:        9 * types.SeriesMetadataSize,
 		},
 		"limit enabled, query selects more samples than limit but should not load all of them into memory at once, and peak consumption is over limit": {
 			expr:          "sum(some_metric)",
@@ -1493,19 +1491,15 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			// Each series has five samples, which will be rounded up to 8 (the nearest power of two) by the bucketed pool.
 			// At peak we'll hold in memory:
 			// - the running total for the sum() (two floats (due to kahan) and a bool at each step, with the number of steps rounded to the nearest power of 2),
-			// - and the next series from the selector.
+			// - and the next series with SeriesMetadata from the selector.
 			// The last thing to be allocated is the bool slice for the running total, so that won't contribute to the peak before the query is aborted.
-			rangeQueryExpectedPeak: 8*2*types.Float64Size + 8*types.FPointSize,
-			rangeQueryLimit:        8*(2*types.Float64Size+types.BoolSize) + 8*types.FPointSize - 1,
+			rangeQueryExpectedPeak: 8*(2*types.Float64Size+types.FPointSize) + types.SeriesMetadataSize,
+			rangeQueryLimit:        8*(2*types.Float64Size+types.FPointSize) + types.SeriesMetadataSize + types.BoolSize - 1,
 
-			// Each series has one sample, which is already a power of two.
-			// At peak we'll hold in memory:
-			// - the running total for the sum() (two floats and a bool),
-			// - the next series from the selector,
-			// - and the output sample.
-			// The last thing to be allocated is the bool slice for the running total, so that won't contribute to the peak before the query is aborted.
-			instantQueryExpectedPeak: 2*types.Float64Size + types.FPointSize + types.VectorSampleSize,
-			instantQueryLimit:        2*types.Float64Size + types.BoolSize + types.FPointSize + types.VectorSampleSize - 1,
+			// At peak we'll hold in memory 9 SeriesMetadata.
+			// To make the memory limit fail, we set limit at 8 SeriesMetadata, hence no any small allocation is possible.
+			instantQueryExpectedPeak: 8 * types.SeriesMetadataSize,
+			instantQueryLimit:        8 * types.SeriesMetadataSize,
 		},
 		"histogram: limit enabled, but query does not exceed limit": {
 			expr:          "sum(some_histogram)",
@@ -1515,15 +1509,15 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			// At peak we'll hold in memory:
 			//  - the running total for the sum() (a histogram pointer at each step, with the number of steps rounded to the nearest power of 2),
 			//  - and the next series from the selector.
-			rangeQueryExpectedPeak: 8*types.HistogramPointerSize + 8*types.HPointSize,
-			rangeQueryLimit:        8*types.HistogramPointerSize + 8*types.HPointSize,
+			rangeQueryExpectedPeak: 8*types.HistogramPointerSize + 8*types.HPointSize + types.SeriesMetadataSize,
+			rangeQueryLimit:        8*types.HistogramPointerSize + 8*types.HPointSize + types.SeriesMetadataSize,
 			// Each series has one sample, which is already a power of two.
 			// At peak we'll hold in memory:
 			//  - the running total for the sum() (a histogram pointer),
 			//  - the next series from the selector,
 			//  - and the output sample.
-			instantQueryExpectedPeak: types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize,
-			instantQueryLimit:        types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize,
+			instantQueryExpectedPeak: types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize + types.SeriesMetadataSize,
+			instantQueryLimit:        types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize + types.SeriesMetadataSize,
 		},
 		"histogram: limit enabled, and query exceeds limit": {
 			expr:          "sum(some_histogram)",
@@ -1534,16 +1528,16 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			//  - the running total for the sum() (a histogram pointer at each step, with the number of steps rounded to the nearest power of 2),
 			//  - and the next series from the selector.
 			// The last thing to be allocated is the HistogramPointerSize slice for the running total, so that won't contribute to the peak before the query is aborted.
-			rangeQueryExpectedPeak: 8 * types.HPointSize,
-			rangeQueryLimit:        8*types.HistogramPointerSize + 8*types.HPointSize - 1,
+			rangeQueryExpectedPeak: 8*types.HPointSize + types.SeriesMetadataSize,
+			rangeQueryLimit:        8*types.HPointSize + types.SeriesMetadataSize + 8*types.HistogramPointerSize - 1,
 			// Each series has one sample, which is already a power of two.
 			// At peak we'll hold in memory:
 			//  - the running total for the sum() (a histogram pointer),
 			//  - the next series from the selector,
 			//  - and the output sample.
 			// The last thing to be allocated is the HistogramPointerSize slice for the running total, so that won't contribute to the peak before the query is aborted.
-			instantQueryExpectedPeak: types.HPointSize + types.VectorSampleSize,
-			instantQueryLimit:        types.HistogramPointerSize + types.HPointSize + types.VectorSampleSize - 1,
+			instantQueryExpectedPeak: types.HPointSize + types.VectorSampleSize + types.SeriesMetadataSize,
+			instantQueryLimit:        types.HPointSize + types.VectorSampleSize + types.SeriesMetadataSize + types.HistogramPointerSize - 1,
 		},
 	}
 

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1475,7 +1475,8 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			// Each series has five samples, which will be rounded up to 8 (the nearest power of two) by the bucketed pool.
 			// At peak we'll hold in memory:
 			//  - the running total for the sum() (two floats (due to kahan) and a bool at each step, with the number of steps rounded to the nearest power of 2),
-			//  - and the next series with SeriesMetadata from the selector.
+			//  - the next series from the selector
+			//  - the labels for the output series
 			rangeQueryExpectedPeak: 8*(2*types.Float64Size+types.BoolSize) + 8*types.FPointSize + types.SeriesMetadataSize,
 			rangeQueryLimit:        8*(2*types.Float64Size+types.BoolSize) + 8*types.FPointSize + types.SeriesMetadataSize,
 

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1648,7 +1648,7 @@ func TestMemoryConsumptionLimit_MultipleQueries(t *testing.T) {
 	opts := NewTestEngineOpts()
 	opts.CommonOpts.Reg = reg
 
-	limit := 3 * 8 * types.FPointSize // Allow up to three series with five points (which will be rounded up to 8, the nearest power of 2)
+	limit := 3*8*types.FPointSize + 8*types.SeriesMetadataSize // Allow up to three series and its SeriesMetadatawith five points (which will be rounded up to 8, the nearest power of 2)
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(limit), stats.NewQueryMetrics(reg), nil, log.NewNopLogger())
 	require.NoError(t, err)
 

--- a/pkg/streamingpromql/operators/aggregations/aggregation_test.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation_test.go
@@ -383,6 +383,7 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 			} else {
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedSeries), series)
 			}
+			types.SeriesMetadataSlicePool.Put(series, memoryConsumptionTracker)
 
 			// Read the first output series to force the creation of incomplete groups.
 			seriesData, err := o.NextSeries(ctx)
@@ -392,7 +393,6 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 
 			// Close the operator and confirm all memory has been released.
 			o.Close()
-			types.SeriesMetadataSlicePool.Put(series, memoryConsumptionTracker)
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 		})
 	}

--- a/pkg/streamingpromql/operators/aggregations/count_values.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values.go
@@ -91,7 +91,7 @@ func (c *CountValues) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadat
 		return nil, err
 	}
 
-	defer types.PutSeriesMetadataSlice(innerMetadata)
+	defer types.SeriesMetadataSlicePool.Put(innerMetadata, c.MemoryConsumptionTracker)
 
 	c.labelsBuilder = labels.NewBuilder(labels.EmptyLabels())
 	c.labelsBytesBuffer = make([]byte, 0, 1024) // Why 1024 bytes? It's what labels.Labels.String() uses as a buffer size, so we use that as a sensible starting point too.
@@ -125,7 +125,11 @@ func (c *CountValues) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadat
 		types.PutInstantVectorSeriesData(data, c.MemoryConsumptionTracker)
 	}
 
-	outputMetadata := types.GetSeriesMetadataSlice(len(accumulator))
+	outputMetadata, err := types.SeriesMetadataSlicePool.Get(len(accumulator), c.MemoryConsumptionTracker)
+	if err != nil {
+		return nil, err
+	}
+
 	c.series = make([][]promql.FPoint, 0, len(accumulator))
 
 	for _, s := range accumulator {

--- a/pkg/streamingpromql/operators/aggregations/count_values_test.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values_test.go
@@ -218,6 +218,7 @@ func TestCountValues_GroupLabelling(t *testing.T) {
 				Data: []types.InstantVectorSeriesData{
 					{Floats: floats},
 				},
+				MemoryConsumptionTracker: memoryConsumptionTracker,
 			}
 
 			labelName := operators.NewStringLiteral("value", posrange.PositionRange{})

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query_test.go
@@ -383,7 +383,7 @@ func TestTopKBottomKInstantQuery_GroupingAndSorting(t *testing.T) {
 			})
 
 			o := New(
-				&operators.TestOperator{Series: testCase.inputSeries, Data: data},
+				&operators.TestOperator{Series: testCase.inputSeries, Data: data, MemoryConsumptionTracker: memoryConsumptionTracker},
 				&scalars.ScalarConstant{Value: 2, TimeRange: timeRange, MemoryConsumptionTracker: memoryConsumptionTracker},
 				timeRange,
 				testCase.grouping,

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query_test.go
@@ -303,7 +303,7 @@ func TestTopKBottomKRangeQuery_GroupingAndSorting(t *testing.T) {
 			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 
 			o := New(
-				&operators.TestOperator{Series: testCase.inputSeries},
+				&operators.TestOperator{Series: testCase.inputSeries, MemoryConsumptionTracker: memoryConsumptionTracker},
 				&scalars.ScalarConstant{Value: 2, TimeRange: timeRange, MemoryConsumptionTracker: memoryConsumptionTracker},
 				timeRange,
 				testCase.grouping,

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
@@ -79,6 +79,7 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 								// Range queries will return all input series, but those with histograms will return no data from NextSeries() below.
 								require.ElementsMatch(t, testutils.LabelsToSeriesMetadata(inputSeries), series)
 							}
+							types.SeriesMetadataSlicePool.Put(series, memoryConsumptionTracker)
 
 							if readSeries {
 								seriesData, err := o.NextSeries(ctx)
@@ -93,7 +94,6 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 
 							// Close the operator and confirm all memory has been released.
 							o.Close()
-							types.SeriesMetadataSlicePool.Put(series, memoryConsumptionTracker)
 							require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 						})
 					}

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
@@ -62,6 +62,7 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 									createDummyData(t, true, timeRange, memoryConsumptionTracker),
 									createDummyData(t, false, timeRange, memoryConsumptionTracker),
 								},
+								MemoryConsumptionTracker: memoryConsumptionTracker,
 							}
 
 							param := scalars.NewScalarConstant(6, timeRange, memoryConsumptionTracker, posrange.PositionRange{})
@@ -92,6 +93,7 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 
 							// Close the operator and confirm all memory has been released.
 							o.Close()
+							types.SeriesMetadataSlicePool.Put(series, memoryConsumptionTracker)
 							require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 						})
 					}

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
@@ -75,7 +75,7 @@ func (a *AndUnlessBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.
 
 	if len(leftMetadata) == 0 {
 		// We can't produce any series, we are done.
-		types.PutSeriesMetadataSlice(leftMetadata)
+		types.SeriesMetadataSlicePool.Put(leftMetadata, a.MemoryConsumptionTracker)
 		return nil, nil
 	}
 
@@ -84,7 +84,7 @@ func (a *AndUnlessBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.
 		return nil, err
 	}
 
-	defer types.PutSeriesMetadataSlice(rightMetadata)
+	defer types.SeriesMetadataSlicePool.Put(rightMetadata, a.MemoryConsumptionTracker)
 
 	if len(rightMetadata) == 0 && !a.IsUnless {
 		// We can't produce any series, we are done.

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
@@ -88,6 +88,7 @@ func (a *AndUnlessBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.
 
 	if len(rightMetadata) == 0 && !a.IsUnless {
 		// We can't produce any series, we are done.
+		types.SeriesMetadataSlicePool.Put(leftMetadata, a.MemoryConsumptionTracker)
 		return nil, nil
 	}
 
@@ -126,15 +127,10 @@ func (a *AndUnlessBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.
 		a.rightSeriesGroups = append(a.rightSeriesGroups, group)
 	}
 
-	var metadata []types.SeriesMetadata
-
 	if a.IsUnless {
-		metadata = a.computeUnlessSeriesMetadata(leftMetadata)
-	} else {
-		metadata = a.computeAndSeriesMetadata(leftMetadata)
+		return a.computeUnlessSeriesMetadata(leftMetadata), nil
 	}
-
-	return metadata, nil
+	return a.computeAndSeriesMetadata(leftMetadata), nil
 }
 
 func (a *AndUnlessBinaryOperation) computeAndSeriesMetadata(leftMetadata []types.SeriesMetadata) []types.SeriesMetadata {

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -359,8 +359,8 @@ func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testin
 			require.Equal(t, types.EOS, err)
 
 			o.Close()
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 			// Make sure we've returned everything to their pools.
+			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 		})
 	}

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -325,6 +325,7 @@ func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testin
 			} else {
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
+			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
@@ -360,7 +361,6 @@ func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testin
 
 			o.Close()
 			// Make sure we've returned everything to their pools.
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 		})
 	}

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -583,8 +583,8 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 				rightData[i] = createTestData(float64(i))
 			}
 
-			left := &operators.TestOperator{Series: testCase.leftSeries, Data: leftData}
-			right := &operators.TestOperator{Series: testCase.rightSeries, Data: rightData}
+			left := &operators.TestOperator{Series: testCase.leftSeries, Data: leftData, MemoryConsumptionTracker: memoryConsumptionTracker}
+			right := &operators.TestOperator{Series: testCase.rightSeries, Data: rightData, MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}, Include: []string{"env"}, Card: parser.CardManyToOne}
 			o, err := NewGroupedVectorVectorBinaryOperation(left, right, vectorMatching, parser.LTE, false, memoryConsumptionTracker, annotations.New(), posrange.PositionRange{}, timeRange)
 			require.NoError(t, err)
@@ -593,6 +593,7 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 			outputSeries, err := o.SeriesMetadata(ctx)
 			require.NoError(t, err)
 			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
+			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 
 			// Read the first series.
 			d, err := o.NextSeries(ctx)

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -482,6 +482,7 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 			} else {
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
+			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
@@ -517,7 +518,6 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 
 			o.Close()
 			// Make sure we've returned everything to their pools.
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 		})
 	}

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -296,8 +296,9 @@ func TestGroupedVectorVectorBinaryOperation_OutputSeriesSorting(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			left := &operators.TestOperator{Series: testCase.leftSeries}
-			right := &operators.TestOperator{Series: testCase.rightSeries}
+			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+			left := &operators.TestOperator{Series: testCase.leftSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
+			right := &operators.TestOperator{Series: testCase.rightSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 
 			o, err := NewGroupedVectorVectorBinaryOperation(
 				left,
@@ -305,7 +306,7 @@ func TestGroupedVectorVectorBinaryOperation_OutputSeriesSorting(t *testing.T) {
 				testCase.matching,
 				testCase.op,
 				testCase.returnBool,
-				limiting.NewMemoryConsumptionTracker(0, nil),
+				memoryConsumptionTracker,
 				nil,
 				posrange.PositionRange{},
 				types.QueryTimeRange{},

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -708,8 +708,8 @@ func TestOneToOneVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEa
 			rightData.Floats = append(rightData.Floats, promql.FPoint{T: timestamp.FromTime(step1), F: 5})
 			rightData.Floats = append(rightData.Floats, promql.FPoint{T: timestamp.FromTime(step2), F: 7})
 
-			left := &operators.TestOperator{Series: leftSeries, Data: []types.InstantVectorSeriesData{left1Data, left2Data}}
-			right := &operators.TestOperator{Series: rightSeries, Data: []types.InstantVectorSeriesData{rightData}}
+			left := &operators.TestOperator{Series: leftSeries, Data: []types.InstantVectorSeriesData{left1Data, left2Data}, MemoryConsumptionTracker: memoryConsumptionTracker}
+			right := &operators.TestOperator{Series: rightSeries, Data: []types.InstantVectorSeriesData{rightData}, MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: false}
 			o, err := NewOneToOneVectorVectorBinaryOperation(left, right, vectorMatching, parser.LTE, false, memoryConsumptionTracker, annotations.New(), posrange.PositionRange{}, timeRange)
 			require.NoError(t, err)
@@ -718,6 +718,7 @@ func TestOneToOneVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEa
 			metadata, err := o.SeriesMetadata(ctx)
 			require.NoError(t, err)
 			require.Equal(t, testutils.LabelsToSeriesMetadata(leftSeries), metadata)
+			types.SeriesMetadataSlicePool.Put(metadata, memoryConsumptionTracker)
 
 			// Read the first series.
 			d, err := o.NextSeries(ctx)

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -619,10 +619,10 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 			}
 
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries))}
-			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries))}
-			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
 			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
+			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
+			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
 			o, err := NewOneToOneVectorVectorBinaryOperation(left, right, vectorMatching, parser.ADD, false, memoryConsumptionTracker, annotations.New(), posrange.PositionRange{}, timeRange)
 			require.NoError(t, err)
 

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -670,6 +670,7 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 
 			o.Close()
 			// Make sure we've returned everything to their pools.
+			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 		})
 	}

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -635,6 +635,7 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 			} else {
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
+			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
@@ -670,7 +671,6 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 
 			o.Close()
 			// Make sure we've returned everything to their pools.
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 		})
 	}

--- a/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
@@ -675,17 +675,17 @@ func TestOrBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *testing.T) 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries))}
-			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries))}
-			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
 			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
+			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
+			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
 			o := NewOrBinaryOperation(left, right, vectorMatching, memoryConsumptionTracker, timeRange, posrange.PositionRange{})
 
 			ctx := context.Background()
 			outputSeries, err := o.SeriesMetadata(ctx)
 			require.NoError(t, err)
 			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
-
+			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 			// Read the output series to trigger the loading of some intermediate state for at least one of the output groups.
 			for range testCase.closeAfterReadingIndex + 1 {
 				_, err := o.NextSeries(ctx)

--- a/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
@@ -545,6 +545,7 @@ func TestOrBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
 			} else {
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
+			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
@@ -580,7 +581,6 @@ func TestOrBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
 
 			o.Close()
 			// Make sure we've returned everything to their pools.
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 		})
 	}

--- a/pkg/streamingpromql/operators/deduplicate_and_merge_test.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge_test.go
@@ -157,8 +157,9 @@ func TestDeduplicateAndMerge(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			inner := &TestOperator{Series: testCase.inputSeries, Data: testCase.inputData}
-			o := NewDeduplicateAndMerge(inner, limiting.NewMemoryConsumptionTracker(0, nil))
+			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+			inner := &TestOperator{Series: testCase.inputSeries, Data: testCase.inputData, MemoryConsumptionTracker: memoryConsumptionTracker}
+			o := NewDeduplicateAndMerge(inner, memoryConsumptionTracker)
 
 			outputSeriesMetadata, err := o.SeriesMetadata(context.Background())
 			require.NoError(t, err)

--- a/pkg/streamingpromql/operators/functions/absent.go
+++ b/pkg/streamingpromql/operators/functions/absent.go
@@ -47,7 +47,7 @@ func (a *Absent) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, er
 	if err != nil {
 		return nil, err
 	}
-	defer types.PutSeriesMetadataSlice(innerMetadata)
+	defer types.SeriesMetadataSlicePool.Put(innerMetadata, a.MemoryConsumptionTracker)
 
 	a.presence, err = types.BoolSlicePool.Get(a.TimeRange.StepCount, a.MemoryConsumptionTracker)
 	if err != nil {
@@ -57,7 +57,11 @@ func (a *Absent) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, er
 	// Initialize presence slice
 	a.presence = a.presence[:a.TimeRange.StepCount]
 
-	metadata := types.GetSeriesMetadataSlice(1)
+	metadata, err := types.SeriesMetadataSlicePool.Get(1, a.MemoryConsumptionTracker)
+	if err != nil {
+		return nil, err
+	}
+
 	metadata = append(metadata, types.SeriesMetadata{
 		Labels: a.Labels,
 	})

--- a/pkg/streamingpromql/operators/functions/absent_over_time.go
+++ b/pkg/streamingpromql/operators/functions/absent_over_time.go
@@ -51,7 +51,7 @@ func (a *AbsentOverTime) SeriesMetadata(ctx context.Context) ([]types.SeriesMeta
 	if err != nil {
 		return nil, err
 	}
-	defer types.PutSeriesMetadataSlice(innerMetadata)
+	defer types.SeriesMetadataSlicePool.Put(innerMetadata, a.MemoryConsumptionTracker)
 
 	a.presence, err = types.BoolSlicePool.Get(a.TimeRange.StepCount, a.MemoryConsumptionTracker)
 	if err != nil {
@@ -61,7 +61,11 @@ func (a *AbsentOverTime) SeriesMetadata(ctx context.Context) ([]types.SeriesMeta
 	// Initialize presence slice
 	a.presence = a.presence[:a.TimeRange.StepCount]
 
-	metadata := types.GetSeriesMetadataSlice(1)
+	metadata, err := types.SeriesMetadataSlicePool.Get(1, a.MemoryConsumptionTracker)
+	if err != nil {
+		return nil, err
+	}
+
 	metadata = append(metadata, types.SeriesMetadata{
 		Labels: a.Labels,
 	})

--- a/pkg/streamingpromql/operators/functions/factories.go
+++ b/pkg/streamingpromql/operators/functions/factories.go
@@ -86,7 +86,7 @@ func TimeTransformationFunctionOperatorFactory(name string, seriesDataFunc Insta
 		var inner types.InstantVectorOperator
 		if len(args) == 0 {
 			// if the argument is not provided, it will default to vector(time())
-			inner = scalars.NewScalarToInstantVector(operators.NewTime(timeRange, memoryConsumptionTracker, expressionPosition), expressionPosition)
+			inner = scalars.NewScalarToInstantVector(operators.NewTime(timeRange, memoryConsumptionTracker, expressionPosition), expressionPosition, memoryConsumptionTracker)
 		} else if len(args) == 1 {
 			// if one argument is provided, it must be an instant vector
 			var ok bool
@@ -216,7 +216,7 @@ func QuantileOverTimeFactory(args []types.Operator, memoryConsumptionTracker *li
 	return o, nil
 }
 
-func scalarToInstantVectorOperatorFactory(args []types.Operator, _ *limiting.MemoryConsumptionTracker, _ *annotations.Annotations, expressionPosition posrange.PositionRange, _ types.QueryTimeRange) (types.InstantVectorOperator, error) {
+func scalarToInstantVectorOperatorFactory(args []types.Operator, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, _ *annotations.Annotations, expressionPosition posrange.PositionRange, _ types.QueryTimeRange) (types.InstantVectorOperator, error) {
 	if len(args) != 1 {
 		// Should be caught by the PromQL parser, but we check here for safety.
 		return nil, fmt.Errorf("expected exactly 1 argument for vector, got %v", len(args))
@@ -228,7 +228,7 @@ func scalarToInstantVectorOperatorFactory(args []types.Operator, _ *limiting.Mem
 		return nil, fmt.Errorf("expected a scalar argument for vector, got %T", args[0])
 	}
 
-	return scalars.NewScalarToInstantVector(inner, expressionPosition), nil
+	return scalars.NewScalarToInstantVector(inner, expressionPosition, memoryConsumptionTracker), nil
 }
 
 func LabelJoinFunctionOperatorFactory(args []types.Operator, memoryConsumptionTracker *limiting.MemoryConsumptionTracker, _ *annotations.Annotations, expressionPosition posrange.PositionRange, timeRange types.QueryTimeRange) (types.InstantVectorOperator, error) {

--- a/pkg/streamingpromql/operators/functions/function_over_instant_vector_test.go
+++ b/pkg/streamingpromql/operators/functions/function_over_instant_vector_test.go
@@ -29,6 +29,7 @@ func TestFunctionOverInstantVector(t *testing.T) {
 			{Floats: []promql.FPoint{{T: 0, F: 1}}},
 			{Floats: []promql.FPoint{{T: 0, F: 2}}},
 		},
+		MemoryConsumptionTracker: limiting.NewMemoryConsumptionTracker(0, nil),
 	}
 
 	metadataFuncCalled := false
@@ -74,6 +75,7 @@ func TestFunctionOverInstantVectorWithScalarArgs(t *testing.T) {
 			{Floats: []promql.FPoint{{T: 0, F: 1}}},
 			{Floats: []promql.FPoint{{T: 0, F: 2}}},
 		},
+		MemoryConsumptionTracker: limiting.NewMemoryConsumptionTracker(0, nil),
 	}
 
 	scalarOperator1 := &testScalarOperator{

--- a/pkg/streamingpromql/operators/functions/histogram_quantile_test.go
+++ b/pkg/streamingpromql/operators/functions/histogram_quantile_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 )
@@ -112,10 +113,12 @@ func TestHistogramQuantileFunction_ReturnsGroupsFinishedFirstEarliest(t *testing
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
+			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 			hOp := &HistogramQuantileFunction{
-				phArg:                  &testScalarOperator{},
-				inner:                  &operators.TestOperator{Series: testCase.inputSeries},
-				innerSeriesMetricNames: &operators.MetricNames{},
+				phArg:                    &testScalarOperator{},
+				inner:                    &operators.TestOperator{Series: testCase.inputSeries, MemoryConsumptionTracker: memoryConsumptionTracker},
+				innerSeriesMetricNames:   &operators.MetricNames{},
+				memoryConsumptionTracker: memoryConsumptionTracker,
 			}
 
 			outputSeries, err := hOp.SeriesMetadata(context.Background())

--- a/pkg/streamingpromql/operators/scalars/instant_vector_to_scalar.go
+++ b/pkg/streamingpromql/operators/scalars/instant_vector_to_scalar.go
@@ -96,7 +96,7 @@ func (i *InstantVectorToScalar) getInnerSeriesCount(ctx context.Context) (int, e
 		return 0, err
 	}
 
-	defer types.PutSeriesMetadataSlice(metadata)
+	defer types.SeriesMetadataSlicePool.Put(metadata, i.MemoryConsumptionTracker)
 
 	seriesCount := len(metadata)
 

--- a/pkg/streamingpromql/operators/scalars/scalar_to_instant_vector.go
+++ b/pkg/streamingpromql/operators/scalars/scalar_to_instant_vector.go
@@ -14,11 +14,11 @@ import (
 
 // ScalarToInstantVector is an operator that implements the vector() function.
 type ScalarToInstantVector struct {
-	Scalar types.ScalarOperator
-
-	expressionPosition       posrange.PositionRange
-	consumed                 bool
+	Scalar                   types.ScalarOperator
 	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
+
+	expressionPosition posrange.PositionRange
+	consumed           bool
 }
 
 var _ types.InstantVectorOperator = &ScalarToInstantVector{}

--- a/pkg/streamingpromql/operators/selectors/instant_vector_selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/instant_vector_selector_test.go
@@ -186,6 +186,7 @@ func TestInstantVectorSelector_NativeHistogramPointerHandling(t *testing.T) {
 			startTime := time.Unix(0, 0)
 			endTime := startTime.Add(time.Duration(testCase.stepCount-1) * time.Minute)
 
+			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 			selector := &InstantVectorSelector{
 				Selector: &Selector{
 					Queryable: storage,
@@ -193,9 +194,10 @@ func TestInstantVectorSelector_NativeHistogramPointerHandling(t *testing.T) {
 					Matchers: []*labels.Matcher{
 						labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "my_metric"),
 					},
-					LookbackDelta: 5 * time.Minute,
+					LookbackDelta:            5 * time.Minute,
+					MemoryConsumptionTracker: memoryConsumptionTracker,
 				},
-				MemoryConsumptionTracker: limiting.NewMemoryConsumptionTracker(0, nil),
+				MemoryConsumptionTracker: memoryConsumptionTracker,
 				Stats:                    &types.QueryStats{},
 			}
 
@@ -230,6 +232,7 @@ func TestInstantVectorSelector_SliceSizing(t *testing.T) {
 			startTime := timeZero.Add(time.Duration(startT) * time.Minute)
 			endTime := timeZero.Add(7 * time.Minute)
 
+			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 			selector := &InstantVectorSelector{
 				Selector: &Selector{
 					Queryable: storage,
@@ -237,9 +240,10 @@ func TestInstantVectorSelector_SliceSizing(t *testing.T) {
 					Matchers: []*labels.Matcher{
 						labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "metric"),
 					},
-					LookbackDelta: 5 * time.Minute,
+					LookbackDelta:            5 * time.Minute,
+					MemoryConsumptionTracker: memoryConsumptionTracker,
 				},
-				MemoryConsumptionTracker: limiting.NewMemoryConsumptionTracker(0, nil),
+				MemoryConsumptionTracker: memoryConsumptionTracker,
 				Stats:                    &types.QueryStats{},
 			}
 

--- a/pkg/streamingpromql/operators/selectors/selector.go
+++ b/pkg/streamingpromql/operators/selectors/selector.go
@@ -85,7 +85,7 @@ func (s *Selector) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, 
 	}
 
 	ss := s.querier.Select(ctx, true, hints, s.Matchers...)
-	s.series = newSeriesList()
+	s.series = newSeriesList(s.MemoryConsumptionTracker)
 
 	for ss.Next() {
 		s.series.Add(ss.At())
@@ -141,12 +141,13 @@ type seriesList struct {
 	memoryConsumptionTracker *limiting.MemoryConsumptionTracker
 }
 
-func newSeriesList() *seriesList {
+func newSeriesList(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) *seriesList {
 	firstBatch := getSeriesBatch()
 
 	return &seriesList{
-		currentSeriesBatch: firstBatch,
-		lastSeriesBatch:    firstBatch,
+		currentSeriesBatch:       firstBatch,
+		lastSeriesBatch:          firstBatch,
+		memoryConsumptionTracker: memoryConsumptionTracker,
 	}
 }
 

--- a/pkg/streamingpromql/operators/selectors/selector.go
+++ b/pkg/streamingpromql/operators/selectors/selector.go
@@ -32,11 +32,12 @@ type Selector struct {
 	// Set for range vector selectors, otherwise 0.
 	Range time.Duration
 
+	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
+
 	querier storage.Querier
 	series  *seriesList
 
-	seriesIdx                int
-	MemoryConsumptionTracker *limiting.MemoryConsumptionTracker
+	seriesIdx int
 }
 
 func (s *Selector) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {

--- a/pkg/streamingpromql/operators/selectors/selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/selector_test.go
@@ -16,11 +16,12 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 func TestSeriesList_BasicListOperations(t *testing.T) {
-	list := newSeriesList()
+	list := newSeriesList(&limiting.MemoryConsumptionTracker{})
 	require.Equal(t, 0, list.Len())
 
 	series1 := mockSeries{labels.FromStrings("series", "1")}
@@ -56,7 +57,7 @@ func TestSeriesList_OperationsNearBatchBoundaries(t *testing.T) {
 
 	for _, seriesCount := range cases {
 		t.Run(fmt.Sprintf("N=%v", seriesCount), func(t *testing.T) {
-			list := newSeriesList()
+			list := newSeriesList(&limiting.MemoryConsumptionTracker{})
 
 			seriesAdded := make([]storage.Series, 0, seriesCount)
 

--- a/pkg/streamingpromql/operators/selectors/selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/selector_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestSeriesList_BasicListOperations(t *testing.T) {
-	list := newSeriesList(&limiting.MemoryConsumptionTracker{})
+	list := newSeriesList(limiting.NewMemoryConsumptionTracker(0, nil))
 	require.Equal(t, 0, list.Len())
 
 	series1 := mockSeries{labels.FromStrings("series", "1")}
@@ -57,7 +57,7 @@ func TestSeriesList_OperationsNearBatchBoundaries(t *testing.T) {
 
 	for _, seriesCount := range cases {
 		t.Run(fmt.Sprintf("N=%v", seriesCount), func(t *testing.T) {
-			list := newSeriesList(&limiting.MemoryConsumptionTracker{})
+			list := newSeriesList(limiting.NewMemoryConsumptionTracker(0, nil))
 
 			seriesAdded := make([]storage.Series, 0, seriesCount)
 

--- a/pkg/streamingpromql/operators/selectors/selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/selector_test.go
@@ -87,7 +87,10 @@ func requireSeriesListContents(t *testing.T, list *seriesList, series ...storage
 		expectedMetadata = append(expectedMetadata, types.SeriesMetadata{Labels: s.Labels()})
 	}
 
-	require.Equal(t, expectedMetadata, list.ToSeriesMetadata())
+	metadata, err := list.ToSeriesMetadata()
+	require.NoError(t, err)
+
+	require.Equal(t, expectedMetadata, metadata)
 }
 
 type mockSeries struct {

--- a/pkg/streamingpromql/operators/selectors/selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/selector_test.go
@@ -115,9 +115,10 @@ func TestSelector_QueryRanges(t *testing.T) {
 		queryable := &mockQueryable{}
 		lookbackDelta := 5 * time.Minute
 		s := &Selector{
-			Queryable:     queryable,
-			TimeRange:     timeRange,
-			LookbackDelta: lookbackDelta,
+			Queryable:                queryable,
+			TimeRange:                timeRange,
+			LookbackDelta:            lookbackDelta,
+			MemoryConsumptionTracker: limiting.NewMemoryConsumptionTracker(0, nil),
 		}
 
 		_, err := s.SeriesMetadata(context.Background())
@@ -135,9 +136,10 @@ func TestSelector_QueryRanges(t *testing.T) {
 		queryable := &mockQueryable{}
 		selectorRange := 15 * time.Minute
 		s := &Selector{
-			Queryable: queryable,
-			TimeRange: timeRange,
-			Range:     selectorRange,
+			Queryable:                queryable,
+			TimeRange:                timeRange,
+			Range:                    selectorRange,
+			MemoryConsumptionTracker: limiting.NewMemoryConsumptionTracker(0, nil),
 		}
 
 		_, err := s.SeriesMetadata(context.Background())

--- a/pkg/streamingpromql/operators/test_operator.go
+++ b/pkg/streamingpromql/operators/test_operator.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
-	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
@@ -28,14 +27,19 @@ func (t *TestOperator) ExpressionPosition() posrange.PositionRange {
 }
 
 func (t *TestOperator) SeriesMetadata(_ context.Context) ([]types.SeriesMetadata, error) {
-	series := testutils.LabelsToSeriesMetadata(t.Series)
-	seriesPool, err := types.SeriesMetadataSlicePool.Get(len(series), t.MemoryConsumptionTracker)
+	if len(t.Series) == 0 {
+		return nil, nil
+	}
+
+	seriesPool, err := types.SeriesMetadataSlicePool.Get(len(t.Series), t.MemoryConsumptionTracker)
 	if err != nil {
 		return nil, err
 	}
 
-	seriesPool = seriesPool[:len(series)]
-	copy(seriesPool, series)
+	seriesPool = seriesPool[:len(t.Series)]
+	for i, l := range t.Series {
+		seriesPool[i].Labels = l
+	}
 	return seriesPool, nil
 }
 

--- a/pkg/streamingpromql/planning/core/matrix_selector.go
+++ b/pkg/streamingpromql/planning/core/matrix_selector.go
@@ -63,13 +63,14 @@ func (m *MatrixSelector) OperatorFactory(_ []types.Operator, timeRange types.Que
 	}
 
 	selector := &selectors.Selector{
-		Queryable:          params.Queryable,
-		TimeRange:          timeRange,
-		Timestamp:          TimestampFromTime(m.Timestamp),
-		Offset:             m.Offset.Milliseconds(),
-		Range:              m.Range,
-		Matchers:           matchers,
-		ExpressionPosition: m.ExpressionPosition.ToPrometheusType(),
+		Queryable:                params.Queryable,
+		TimeRange:                timeRange,
+		Timestamp:                TimestampFromTime(m.Timestamp),
+		Offset:                   m.Offset.Milliseconds(),
+		Range:                    m.Range,
+		Matchers:                 matchers,
+		ExpressionPosition:       m.ExpressionPosition.ToPrometheusType(),
+		MemoryConsumptionTracker: params.MemoryConsumptionTracker,
 	}
 
 	o := selectors.NewRangeVectorSelector(selector, params.MemoryConsumptionTracker, params.Stats)

--- a/pkg/streamingpromql/planning/core/vector_selector.go
+++ b/pkg/streamingpromql/planning/core/vector_selector.go
@@ -64,13 +64,14 @@ func (v *VectorSelector) OperatorFactory(_ []types.Operator, timeRange types.Que
 	o := &selectors.InstantVectorSelector{
 		MemoryConsumptionTracker: params.MemoryConsumptionTracker,
 		Selector: &selectors.Selector{
-			Queryable:          params.Queryable,
-			TimeRange:          timeRange,
-			Timestamp:          TimestampFromTime(v.Timestamp),
-			Offset:             v.Offset.Milliseconds(),
-			LookbackDelta:      params.LookbackDelta,
-			Matchers:           matchers,
-			ExpressionPosition: v.ExpressionPosition.ToPrometheusType(),
+			Queryable:                params.Queryable,
+			TimeRange:                timeRange,
+			Timestamp:                TimestampFromTime(v.Timestamp),
+			Offset:                   v.Offset.Milliseconds(),
+			LookbackDelta:            params.LookbackDelta,
+			Matchers:                 matchers,
+			ExpressionPosition:       v.ExpressionPosition.ToPrometheusType(),
+			MemoryConsumptionTracker: params.MemoryConsumptionTracker,
 		},
 		Stats: params.Stats,
 	}

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -190,7 +190,8 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr, timeRange types
 				LookbackDelta: lookbackDelta,
 				Matchers:      e.LabelMatchers,
 
-				ExpressionPosition: e.PositionRange(),
+				ExpressionPosition:       e.PositionRange(),
+				MemoryConsumptionTracker: q.memoryConsumptionTracker,
 			},
 			Stats: q.stats,
 		}, nil
@@ -404,7 +405,8 @@ func (q *Query) convertToRangeVectorOperator(expr parser.Expr, timeRange types.Q
 			Range:     e.Range,
 			Matchers:  vectorSelector.LabelMatchers,
 
-			ExpressionPosition: e.PositionRange(),
+			ExpressionPosition:       e.PositionRange(),
+			MemoryConsumptionTracker: q.memoryConsumptionTracker,
 		}
 
 		return selectors.NewRangeVectorSelector(selector, q.memoryConsumptionTracker, q.stats), nil

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -611,7 +611,7 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 		if err != nil {
 			return &promql.Result{Err: err}
 		}
-		defer types.PutSeriesMetadataSlice(series)
+		defer types.SeriesMetadataSlicePool.Put(series, q.memoryConsumptionTracker)
 
 		v, err := q.populateMatrixFromRangeVectorOperator(ctx, root, series)
 		if err != nil {
@@ -624,7 +624,7 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 		if err != nil {
 			return &promql.Result{Err: err}
 		}
-		defer types.PutSeriesMetadataSlice(series)
+		defer types.SeriesMetadataSlicePool.Put(series, q.memoryConsumptionTracker)
 
 		if q.topLevelQueryTimeRange.IsInstant {
 			v, err := q.populateVectorFromInstantVectorOperator(ctx, root, series)

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -187,9 +187,11 @@ func (p *LimitingBucketedPool[S, E]) Get(size int, tracker *limiting.MemoryConsu
 	// - there's no guarantee the slice will have size 'size' when it's returned to us in putWithElementSize, so using 'size' would make the accounting below impossible
 	estimatedBytes := uint64(cap(s)) * p.elementSize
 
-	if sm, isSeriesMetadata := any(s).(SeriesMetadata); isSeriesMetadata {
-		for _, l := range sm.Labels {
-			estimatedBytes += uint64(len(l.Name)+len(l.Value)) * StringSize
+	if series, isSeriesMetadata := any(s).([]SeriesMetadata); isSeriesMetadata {
+		for _, sm := range series {
+			for _, l := range sm.Labels {
+				estimatedBytes += uint64(len(l.Name)+len(l.Value)) * StringSize
+			}
 		}
 	}
 

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -31,7 +31,6 @@ const (
 	IntSize              = uint64(unsafe.Sizeof(int(0)))
 	Int64Size            = uint64(unsafe.Sizeof(int64(0)))
 	BoolSize             = uint64(unsafe.Sizeof(false))
-	StringSize           = uint64(unsafe.Sizeof(string("")))
 	HistogramPointerSize = uint64(unsafe.Sizeof((*histogram.FloatHistogram)(nil)))
 	SeriesMetadataSize   = uint64(unsafe.Sizeof(SeriesMetadata{}))
 )

--- a/pkg/streamingpromql/types/pool.go
+++ b/pkg/streamingpromql/types/pool.go
@@ -18,10 +18,6 @@ var (
 	matrixPool = pool.NewBucketedPool(MaxExpectedSeriesPerResult, func(size int) promql.Matrix {
 		return make(promql.Matrix, 0, size)
 	})
-
-	seriesMetadataSlicePool = pool.NewBucketedPool(MaxExpectedSeriesPerResult, func(size int) []SeriesMetadata {
-		return make([]SeriesMetadata, 0, size)
-	})
 )
 
 func GetMatrix(size int) promql.Matrix {
@@ -30,12 +26,4 @@ func GetMatrix(size int) promql.Matrix {
 
 func PutMatrix(m promql.Matrix) {
 	matrixPool.Put(m)
-}
-
-func GetSeriesMetadataSlice(size int) []SeriesMetadata {
-	return seriesMetadataSlicePool.Get(size)
-}
-
-func PutSeriesMetadataSlice(s []SeriesMetadata) {
-	seriesMetadataSlicePool.Put(s)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

- Move SeriesMetadata into limiting_pool as `SeriesMetadataSlicePool` so that it will be part of memory limit and estimate tracker in MQE
- Updated `TestOperator` to update MemoryConsumptionTracker in SeriesMetadata method call so that all tests behave correctly.
- Update the use of old SeriesMetadata pool in all operators into the new `SeriesMetadataSlicePool`
- Update and fix all tests.
- Notable tests to check are `TestMemoryConsumptionLimit_SingleQueries` and `TestMemoryConsumptionLimit_MultipleQueries`.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
