### PR TITLE
move readTsdb to parquet storage sub-package; rename method & vars for clarity & testability

### DIFF
--- a/pkg/storage/parquet/cache.go
+++ b/pkg/storage/parquet/cache.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	lru "github.com/hashicorp/golang-lru/v2"

--- a/pkg/storage/parquet/enc.go
+++ b/pkg/storage/parquet/enc.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	"bytes"

--- a/pkg/storage/parquet/enc_test.go
+++ b/pkg/storage/parquet/enc_test.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	"fmt"

--- a/pkg/storage/parquet/prometheus_parquet_chunks_encoder.go
+++ b/pkg/storage/parquet/prometheus_parquet_chunks_encoder.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	"bytes"

--- a/pkg/storage/parquet/reader.go
+++ b/pkg/storage/parquet/reader.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	"context"

--- a/pkg/storage/parquet/reader_test.go
+++ b/pkg/storage/parquet/reader_test.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	"bytes"

--- a/pkg/storage/parquet/row.go
+++ b/pkg/storage/parquet/row.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 const (
 	ColHash                        = "s_hash"

--- a/pkg/storage/parquet/stats.go
+++ b/pkg/storage/parquet/stats.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	"sort"

--- a/pkg/storage/parquet/stats_test.go
+++ b/pkg/storage/parquet/stats_test.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	"os"

--- a/pkg/storage/parquet/tsdbcodec/reader.go
+++ b/pkg/storage/parquet/tsdbcodec/reader.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/26344c3ec7409713fcf52a9c41cd0dce537b3100/pkg/compactor/parquet_compactor.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
 package tsdbcodec
 
 import (

--- a/pkg/storage/parquet/tsdbcodec/reader.go
+++ b/pkg/storage/parquet/tsdbcodec/reader.go
@@ -1,0 +1,155 @@
+package tsdbcodec
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"runtime"
+	"slices"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/mimir/pkg/storage/parquet"
+	util_log "github.com/grafana/mimir/pkg/util/log"
+)
+
+func BlockToParquetRowsStream(
+	ctx context.Context,
+	path string,
+	maxParquetIndexSizeLimit int, // TODO what does this mean and how to set it?
+	rowsPerBatch int,
+	batchStreamBufferSize int,
+	logger log.Logger,
+) (chan []parquet.ParquetRow, []string, int, error) {
+	// TODO
+	b, err := tsdb.OpenBlock( /*logutil.GoKitLogToSlog(logger)*/ slog.New(slog.DiscardHandler), path, nil, tsdb.DefaultPostingsDecoderFactory)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	idx, err := b.Index()
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	cReader, err := b.Chunks()
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	metricNames, err := idx.LabelValues(ctx, labels.MetricName)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	k, v := index.AllPostingsKey()
+	all, err := idx.Postings(ctx, k, v)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	total := 0
+	for all.Next() {
+		total++
+	}
+
+	labelNames, err := idx.LabelNames(ctx)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	slices.SortFunc(metricNames, func(a, b string) int {
+		return bytes.Compare(
+			truncateByteArray([]byte(a), maxParquetIndexSizeLimit),
+			truncateByteArray([]byte(b), maxParquetIndexSizeLimit),
+		)
+	})
+	rc := make(chan []parquet.ParquetRow, batchStreamBufferSize)
+	chunksEncoder := parquet.NewPrometheusParquetChunksEncoder()
+
+	go func() {
+		defer close(rc)
+		batch := make([]parquet.ParquetRow, 0, rowsPerBatch)
+		batchMutex := &sync.Mutex{}
+		for _, metricName := range metricNames {
+			if ctx.Err() != nil {
+				return
+			}
+			p, err := idx.Postings(ctx, labels.MetricName, metricName)
+			if err != nil {
+				return
+			}
+			eg := &errgroup.Group{}
+			eg.SetLimit(runtime.GOMAXPROCS(0))
+
+			for p.Next() {
+				chks := []chunks.Meta{}
+				builder := labels.ScratchBuilder{}
+
+				at := p.At()
+				err = idx.Series(at, &builder, &chks)
+				if err != nil {
+					return
+				}
+				eg.Go(func() error {
+					for i := range chks {
+						chks[i].Chunk, _, err = cReader.ChunkOrIterable(chks[i])
+						if err != nil {
+							return err
+						}
+					}
+
+					data, err := chunksEncoder.Encode(chks)
+					if err != nil {
+						return err
+					}
+
+					promLbls := builder.Labels()
+					lbsls := make(map[string]string)
+
+					promLbls.Range(func(l labels.Label) {
+						lbsls[l.Name] = l.Value
+					})
+
+					row := parquet.ParquetRow{
+						Hash:    promLbls.Hash(),
+						Columns: lbsls,
+						Data:    data,
+					}
+
+					batchMutex.Lock()
+					batch = append(batch, row)
+					if len(batch) >= rowsPerBatch {
+						rc <- batch
+						batch = make([]parquet.ParquetRow, 0, rowsPerBatch)
+					}
+					batchMutex.Unlock()
+					return nil
+				})
+			}
+
+			err = eg.Wait()
+			if err != nil {
+				level.Error(util_log.Logger).Log("msg", "failed to process chunk", "err", err)
+				return
+			}
+		}
+		if len(batch) > 0 {
+			rc <- batch
+		}
+	}()
+
+	return rc, labelNames, total, nil
+}
+
+func truncateByteArray(value []byte, sizeLimit int) []byte {
+	if len(value) > sizeLimit {
+		value = value[:sizeLimit]
+	}
+	return value
+}

--- a/pkg/storage/parquet/util_test.go
+++ b/pkg/storage/parquet/util_test.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	"bytes"

--- a/pkg/storage/parquet/writer.go
+++ b/pkg/storage/parquet/writer.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	"errors"

--- a/pkg/storage/parquet/writer_test.go
+++ b/pkg/storage/parquet/writer_test.go
@@ -3,7 +3,7 @@
 // Provenance-includes-license: Apache-2.0
 // Provenance-includes-copyright: The Cortex Authors.
 
-package storage
+package parquet
 
 import (
 	"bytes"


### PR DESCRIPTION
We want to be able to isolate & unit test this stuff and reading a TSDB block to parquet rows should be general enough that it does not need to be specific to the compactor.

Also updated `pkg/storage/parquet` files to be the package name `pkg/storage/parquet` rather than just `pkg/storage`, to match other storage subpackages.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
