### PR TITLE
MQE: remove flag to disable support for specific functions

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2248,27 +2248,6 @@
           "desc": "",
           "blockEntries": [
             {
-              "kind": "block",
-              "name": "features",
-              "required": false,
-              "desc": "",
-              "blockEntries": [
-                {
-                  "kind": "field",
-                  "name": "disabled_functions",
-                  "required": false,
-                  "desc": "Comma-separated list of function names to disable support for. Only applies if MQE is in use.",
-                  "fieldValue": null,
-                  "fieldDefaultValue": "",
-                  "fieldFlag": "querier.mimir-query-engine.disabled-functions",
-                  "fieldType": "string",
-                  "fieldCategory": "experimental"
-                }
-              ],
-              "fieldValue": null,
-              "fieldDefaultValue": null
-            },
-            {
               "kind": "field",
               "name": "use_query_planning",
               "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2193,8 +2193,6 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of samples a single query can load into memory. This config option should be set on query-frontend too when query sharding is enabled. (default 50000000)
   -querier.max-series-query-limit int
     	Maximum number of series, the series endpoint queries. This limit is enforced in the querier. If the requested limit is outside of the allowed value, the request doesn't fail, but is manipulated to only query data up to the allowed limit. Set to 0 to disable.
-  -querier.mimir-query-engine.disabled-functions comma-separated-list-of-strings
-    	[experimental] Comma-separated list of function names to disable support for. Only applies if MQE is in use.
   -querier.mimir-query-engine.use-query-planning
     	[experimental] Use query planner when evaluating queries.
   -querier.minimize-ingester-requests

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1623,12 +1623,6 @@ The `querier` block configures the querier.
 [lookback_delta: <duration> | default = 5m]
 
 mimir_query_engine:
-  features:
-    # (experimental) Comma-separated list of function names to disable support
-    # for. Only applies if MQE is in use.
-    # CLI flag: -querier.mimir-query-engine.disabled-functions
-    [disabled_functions: <string> | default = ""]
-
   # (experimental) Use query planner when evaluating queries.
   # CLI flag: -querier.mimir-query-engine.use-query-planning
   [use_query_planning: <boolean> | default = false]

--- a/pkg/streamingpromql/config.go
+++ b/pkg/streamingpromql/config.go
@@ -5,13 +5,11 @@ package streamingpromql
 import (
 	"flag"
 
-	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/prometheus/promql"
 )
 
 type EngineOpts struct {
 	CommonOpts promql.EngineOpts `yaml:"-"`
-	Features   Features
 
 	// When operating in pedantic mode, we panic if memory consumption is > 0 after Query.Close()
 	// (indicating something was not returned to a pool).
@@ -23,20 +21,4 @@ type EngineOpts struct {
 
 func (o *EngineOpts) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&o.UseQueryPlanning, "querier.mimir-query-engine.use-query-planning", false, "Use query planner when evaluating queries.")
-
-	o.Features.RegisterFlags(f)
-}
-
-type Features struct {
-	DisabledFunctions flagext.StringSliceCSV `yaml:"disabled_functions" category:"experimental"`
-}
-
-// EnableAllFeatures enables all features supported by MQE, including experimental or incomplete features.
-var EnableAllFeatures = Features{
-	// Note that we deliberately use a keyless literal here to force a compilation error if we don't keep this in sync with new fields added to FeatureToggles.
-	[]string{},
-}
-
-func (t *Features) RegisterFlags(f *flag.FlagSet) {
-	f.Var(&t.DisabledFunctions, "querier.mimir-query-engine.disabled-functions", "Comma-separated list of function names to disable support for. Only applies if MQE is in use.")
 }

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/go-kit/log"
@@ -51,9 +50,6 @@ func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *sta
 		return nil, errors.New("enabling delayed name removal not supported by Mimir query engine")
 	}
 
-	// We must sort DisabledFunctions as we use a binary search on it later.
-	slices.Sort(opts.Features.DisabledFunctions)
-
 	if opts.UseQueryPlanning && planner == nil {
 		return nil, errors.New("query planning enabled but no planner provided")
 	}
@@ -63,7 +59,6 @@ func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *sta
 		timeout:                  opts.CommonOpts.Timeout,
 		limitsProvider:           limitsProvider,
 		activeQueryTracker:       opts.CommonOpts.ActiveQueryTracker,
-		features:                 opts.Features,
 		noStepSubqueryIntervalFn: opts.CommonOpts.NoStepSubqueryIntervalFn,
 
 		logger: logger,
@@ -85,7 +80,6 @@ type Engine struct {
 	timeout            time.Duration
 	limitsProvider     QueryLimitsProvider
 	activeQueryTracker promql.QueryTracker
-	features           Features
 
 	noStepSubqueryIntervalFn func(rangeMillis int64) int64
 

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -50,8 +50,6 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 	parser.Functions["sort_by_label"].Experimental = false
 	parser.Functions["sort_by_label_desc"].Experimental = false
 
-	features := EnableAllFeatures
-
 	// The goal of this is not to list every conceivable expression that is unsupported, but to cover all the
 	// different cases and make sure we produce a reasonable error message when these cases are encountered.
 	unsupportedExpressions := map[string]string{
@@ -62,45 +60,33 @@ func TestUnsupportedPromQLFeatures(t *testing.T) {
 
 	for expression, expectedError := range unsupportedExpressions {
 		t.Run(expression, func(t *testing.T) {
-			requireQueryIsUnsupported(t, features, expression, expectedError)
+			requireQueryIsUnsupported(t, expression, expectedError)
 		})
 	}
 }
 
-func TestUnsupportedPromQLFeaturesWithFeatureToggles(t *testing.T) {
-	t.Run("function disabled by name", func(t *testing.T) {
-		features := EnableAllFeatures
-		features.DisabledFunctions = []string{"histogram_quantile", "ceil", "nonexistant"}
-
-		requireQueryIsSupported(t, features, "abs(metric{})")
-		requireQueryIsUnsupported(t, features, "ceil(metric{})", "'ceil' function")
-		requireQueryIsUnsupported(t, features, "histogram_quantile(0.9, h{})", "'histogram_quantile' function")
-	})
-}
-
-func requireQueryIsUnsupported(t *testing.T, features Features, expression string, expectedError string) {
+func requireQueryIsUnsupported(t *testing.T, expression string, expectedError string) {
 	t.Run("range query", func(t *testing.T) {
-		requireRangeQueryIsUnsupported(t, features, expression, expectedError)
+		requireRangeQueryIsUnsupported(t, expression, expectedError)
 	})
 
 	t.Run("instant query", func(t *testing.T) {
-		requireInstantQueryIsUnsupported(t, features, expression, expectedError)
+		requireInstantQueryIsUnsupported(t, expression, expectedError)
 	})
 }
 
-func requireQueryIsSupported(t *testing.T, features Features, expression string) {
+func requireQueryIsSupported(t *testing.T, expression string) {
 	t.Run("range query", func(t *testing.T) {
-		requireRangeQueryIsSupported(t, features, expression)
+		requireRangeQueryIsSupported(t, expression)
 	})
 
 	t.Run("instant query", func(t *testing.T) {
-		requireInstantQueryIsSupported(t, features, expression)
+		requireInstantQueryIsSupported(t, expression)
 	})
 }
 
-func requireRangeQueryIsUnsupported(t *testing.T, features Features, expression string, expectedError string) {
+func requireRangeQueryIsUnsupported(t *testing.T, expression string, expectedError string) {
 	opts := NewTestEngineOpts()
-	opts.Features = features
 
 	testWithAndWithoutQueryPlanner(t, opts, func(t *testing.T, engine *Engine) {
 		qry, err := engine.NewRangeQuery(context.Background(), nil, nil, expression, time.Now().Add(-time.Hour), time.Now(), time.Minute)
@@ -110,9 +96,8 @@ func requireRangeQueryIsUnsupported(t *testing.T, features Features, expression 
 	})
 }
 
-func requireInstantQueryIsUnsupported(t *testing.T, features Features, expression string, expectedError string) {
+func requireInstantQueryIsUnsupported(t *testing.T, expression string, expectedError string) {
 	opts := NewTestEngineOpts()
-	opts.Features = features
 
 	testWithAndWithoutQueryPlanner(t, opts, func(t *testing.T, engine *Engine) {
 		qry, err := engine.NewInstantQuery(context.Background(), nil, nil, expression, time.Now())
@@ -123,9 +108,8 @@ func requireInstantQueryIsUnsupported(t *testing.T, features Features, expressio
 	})
 }
 
-func requireRangeQueryIsSupported(t *testing.T, features Features, expression string) {
+func requireRangeQueryIsSupported(t *testing.T, expression string) {
 	opts := NewTestEngineOpts()
-	opts.Features = features
 
 	testWithAndWithoutQueryPlanner(t, opts, func(t *testing.T, engine *Engine) {
 		_, err := engine.NewRangeQuery(context.Background(), nil, nil, expression, time.Now().Add(-time.Hour), time.Now(), time.Minute)
@@ -133,9 +117,8 @@ func requireRangeQueryIsSupported(t *testing.T, features Features, expression st
 	})
 }
 
-func requireInstantQueryIsSupported(t *testing.T, features Features, expression string) {
+func requireInstantQueryIsSupported(t *testing.T, expression string) {
 	opts := NewTestEngineOpts()
-	opts.Features = features
 
 	testWithAndWithoutQueryPlanner(t, opts, func(t *testing.T, engine *Engine) {
 		_, err := engine.NewInstantQuery(context.Background(), nil, nil, expression, time.Now())

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -75,16 +75,6 @@ func requireQueryIsUnsupported(t *testing.T, expression string, expectedError st
 	})
 }
 
-func requireQueryIsSupported(t *testing.T, expression string) {
-	t.Run("range query", func(t *testing.T) {
-		requireRangeQueryIsSupported(t, expression)
-	})
-
-	t.Run("instant query", func(t *testing.T) {
-		requireInstantQueryIsSupported(t, expression)
-	})
-}
-
 func requireRangeQueryIsUnsupported(t *testing.T, expression string, expectedError string) {
 	opts := NewTestEngineOpts()
 
@@ -105,24 +95,6 @@ func requireInstantQueryIsUnsupported(t *testing.T, expression string, expectedE
 		require.ErrorIs(t, err, compat.NotSupportedError{})
 		require.EqualError(t, err, "not supported by streaming engine: "+expectedError)
 		require.Nil(t, qry)
-	})
-}
-
-func requireRangeQueryIsSupported(t *testing.T, expression string) {
-	opts := NewTestEngineOpts()
-
-	testWithAndWithoutQueryPlanner(t, opts, func(t *testing.T, engine *Engine) {
-		_, err := engine.NewRangeQuery(context.Background(), nil, nil, expression, time.Now().Add(-time.Hour), time.Now(), time.Minute)
-		require.NoError(t, err)
-	})
-}
-
-func requireInstantQueryIsSupported(t *testing.T, expression string) {
-	opts := NewTestEngineOpts()
-
-	testWithAndWithoutQueryPlanner(t, opts, func(t *testing.T, engine *Engine) {
-		_, err := engine.NewInstantQuery(context.Background(), nil, nil, expression, time.Now())
-		require.NoError(t, err)
 	})
 }
 

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -345,12 +345,6 @@ func (q *Query) convertToInstantVectorOperator(expr parser.Expr, timeRange types
 }
 
 func (q *Query) convertFunctionCallToInstantVectorOperator(e *parser.Call, timeRange types.QueryTimeRange) (types.InstantVectorOperator, error) {
-	// e.Func.Name is already validated and canonicalised by the parser. Meaning we don't need to check if the function name
-	// refers to a function that exists, nor normalise the casing etc. before checking if it is disabled.
-	if _, found := slices.BinarySearch(q.engine.features.DisabledFunctions, e.Func.Name); found {
-		return nil, compat.NewNotSupportedError(fmt.Sprintf("'%s' function", e.Func.Name))
-	}
-
 	switch e.Func.Name {
 	case "absent":
 		inner, err := q.convertToInstantVectorOperator(e.Args[0], timeRange)

--- a/pkg/streamingpromql/testing.go
+++ b/pkg/streamingpromql/testing.go
@@ -21,7 +21,6 @@ func NewTestEngineOpts() EngineOpts {
 			NoStepSubqueryIntervalFn: func(int64) int64 { return time.Minute.Milliseconds() },
 		},
 
-		Features: EnableAllFeatures,
 		Pedantic: true,
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR removes the last remaining feature toggle for individual functions MQE, as we're now satisfied with the stability of all functions.

#### Which issue(s) this PR fixes or relates to

#11002

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
