### PR TITLE
MQE: ensure binary operations release any intermediate state if they are closed before all series are read

### DIFF
--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
@@ -271,6 +271,19 @@ func (a *AndUnlessBinaryOperation) ExpressionPosition() posrange.PositionRange {
 func (a *AndUnlessBinaryOperation) Close() {
 	a.Left.Close()
 	a.Right.Close()
+
+	for _, group := range a.leftSeriesGroups {
+		if group == nil {
+			continue
+		}
+
+		group.Close(a.MemoryConsumptionTracker)
+	}
+
+	a.leftSeriesGroups = nil
+
+	// We don't need to explicitly close any groups in rightSeriesGroups, as they would have been closed above.
+	a.rightSeriesGroups = nil
 }
 
 type andGroup struct {
@@ -311,4 +324,5 @@ func (g *andGroup) FilterLeftSeries(leftData types.InstantVectorSeriesData, memo
 
 func (g *andGroup) Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) {
 	types.BoolSlicePool.Put(g.rightSamplePresence, memoryConsumptionTracker)
+	g.rightSamplePresence = nil
 }

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -364,3 +364,98 @@ func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testin
 		})
 	}
 }
+
+func TestAndUnlessBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *testing.T) {
+	testCases := map[string]struct {
+		leftSeries  []labels.Labels
+		rightSeries []labels.Labels
+
+		expectedAndOutputSeries    []labels.Labels
+		expectedUnlessOutputSeries []labels.Labels
+	}{
+		"closed after only reading series for current output group": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+				labels.FromStrings("group", "3", "series", "left-4"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "2", "series", "right-3"),
+			},
+
+			expectedAndOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"), // When we read this series, we'll have loaded presence for group="1", but nothing for group="2".
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			expectedUnlessOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"), // When we read this series, we'll have loaded presence for group="1", but nothing for group="2".
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+				labels.FromStrings("group", "3", "series", "left-4"),
+			},
+		},
+		"closed after reading series for multiple output groups": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"),
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+				labels.FromStrings("group", "3", "series", "left-4"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "2", "series", "right-1"),
+				labels.FromStrings("group", "1", "series", "right-2"),
+				labels.FromStrings("group", "1", "series", "right-3"),
+				labels.FromStrings("group", "2", "series", "right-4"),
+			},
+
+			expectedAndOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"), // When we read this series, we'll have loaded presence for group="1" and part of group="2".
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+			},
+			expectedUnlessOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "series", "left-1"), // When we read this series, we'll have loaded presence for group="1" and part of group="2".
+				labels.FromStrings("group", "1", "series", "left-2"),
+				labels.FromStrings("group", "2", "series", "left-3"),
+				labels.FromStrings("group", "3", "series", "left-4"),
+			},
+		},
+	}
+
+	for name, isUnless := range map[string]bool{"and": false, "unless": true} {
+		t.Run(name, func(t *testing.T) {
+			for name, testCase := range testCases {
+				t.Run(name, func(t *testing.T) {
+					timeRange := types.NewInstantQueryTimeRange(time.Now())
+					left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries))}
+					right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries))}
+					vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
+					memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+					o := NewAndUnlessBinaryOperation(left, right, vectorMatching, memoryConsumptionTracker, isUnless, timeRange, posrange.PositionRange{})
+
+					ctx := context.Background()
+					outputSeries, err := o.SeriesMetadata(ctx)
+					require.NoError(t, err)
+
+					if isUnless {
+						require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedUnlessOutputSeries), outputSeries)
+					} else {
+						require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedAndOutputSeries), outputSeries)
+					}
+
+					// Read the first output series to trigger the loading of some intermediate state for at least one of the output groups.
+					_, err = o.NextSeries(ctx)
+					require.NoError(t, err)
+
+					// Close the operator and confirm that we've returned everything to their pools.
+					o.Close()
+					require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+				})
+			}
+		})
+	}
+}

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -4,6 +4,7 @@ package binops
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"sort"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
@@ -668,6 +670,67 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 
 			o.Close()
 			// Make sure we've returned everything to their pools.
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+		})
+	}
+}
+
+func TestOneToOneVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *testing.T) {
+	for _, closeAfterFirstSeries := range []bool{true, false} {
+		t.Run(fmt.Sprintf("close after first series=%v", closeAfterFirstSeries), func(t *testing.T) {
+			leftSeries := []labels.Labels{
+				labels.FromStrings("group", "1", labels.MetricName, "left_1"),
+				labels.FromStrings("group", "1", labels.MetricName, "left_2"),
+			}
+
+			rightSeries := []labels.Labels{
+				labels.FromStrings("group", "1"),
+			}
+
+			step1 := timestamp.Time(0)
+			step2 := step1.Add(time.Minute)
+			timeRange := types.NewRangeQueryTimeRange(step1, step2, time.Minute)
+
+			var err error
+			memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+
+			left1Data := types.InstantVectorSeriesData{}
+			left1Data.Floats, err = types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+			require.NoError(t, err)
+			left1Data.Floats = append(left1Data.Floats, promql.FPoint{T: timestamp.FromTime(step1), F: 10})
+
+			left2Data := types.InstantVectorSeriesData{} // This series doesn't need any data.
+
+			rightData := types.InstantVectorSeriesData{}
+			rightData.Floats, err = types.FPointSlicePool.Get(2, memoryConsumptionTracker)
+			require.NoError(t, err)
+			rightData.Floats = append(rightData.Floats, promql.FPoint{T: timestamp.FromTime(step1), F: 5})
+			rightData.Floats = append(rightData.Floats, promql.FPoint{T: timestamp.FromTime(step2), F: 7})
+
+			left := &operators.TestOperator{Series: leftSeries, Data: []types.InstantVectorSeriesData{left1Data, left2Data}}
+			right := &operators.TestOperator{Series: rightSeries, Data: []types.InstantVectorSeriesData{rightData}}
+			vectorMatching := parser.VectorMatching{On: false}
+			o, err := NewOneToOneVectorVectorBinaryOperation(left, right, vectorMatching, parser.LTE, false, memoryConsumptionTracker, annotations.New(), posrange.PositionRange{}, timeRange)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			metadata, err := o.SeriesMetadata(ctx)
+			require.NoError(t, err)
+			require.Equal(t, testutils.LabelsToSeriesMetadata(leftSeries), metadata)
+
+			// Read the first series.
+			d, err := o.NextSeries(ctx)
+			require.NoError(t, err)
+			types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
+
+			if !closeAfterFirstSeries {
+				d, err = o.NextSeries(ctx)
+				require.NoError(t, err)
+				types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
+			}
+
+			// Close the operator and verify that the intermediate state is released.
+			o.Close()
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
 		})
 	}

--- a/pkg/streamingpromql/operators/binops/or_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation.go
@@ -317,6 +317,26 @@ func (o *OrBinaryOperation) ExpressionPosition() posrange.PositionRange {
 func (o *OrBinaryOperation) Close() {
 	o.Left.Close()
 	o.Right.Close()
+
+	for _, g := range o.leftSeriesGroups {
+		if g == nil {
+			continue
+		}
+
+		g.Close(o.MemoryConsumptionTracker)
+	}
+
+	o.leftSeriesGroups = nil
+
+	for _, g := range o.rightSeriesGroups {
+		if g == nil {
+			continue
+		}
+
+		g.Close(o.MemoryConsumptionTracker)
+	}
+
+	o.rightSeriesGroups = nil
 }
 
 type orGroup struct {
@@ -357,4 +377,5 @@ func (g *orGroup) FilterRightSeries(rightData types.InstantVectorSeriesData, mem
 
 func (g *orGroup) Close(memoryConsumptionTracker *limiting.MemoryConsumptionTracker) {
 	types.BoolSlicePool.Put(g.leftSamplePresence, memoryConsumptionTracker)
+	g.leftSamplePresence = nil
 }

--- a/pkg/streamingpromql/operators/operator_buffer_test.go
+++ b/pkg/streamingpromql/operators/operator_buffer_test.go
@@ -160,3 +160,42 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 	require.Equal(t, []types.InstantVectorSeriesData{series5Data, series6Data}, series)
 	require.True(t, inner.Closed)
 }
+
+func TestInstantVectorOperatorBuffer_ReleasesBufferWhenClosedEarly(t *testing.T) {
+	memoryConsumptionTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+
+	createTestData := func(val float64) types.InstantVectorSeriesData {
+		floats, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
+		require.NoError(t, err)
+		floats = append(floats, promql.FPoint{T: 0, F: val})
+		return types.InstantVectorSeriesData{Floats: floats}
+	}
+
+	series0Data := createTestData(0)
+	series1Data := createTestData(1)
+
+	inner := &TestOperator{
+		Series: []labels.Labels{
+			labels.FromStrings("series", "0"),
+			labels.FromStrings("series", "1"),
+		},
+		Data: []types.InstantVectorSeriesData{
+			series0Data,
+			series1Data,
+		},
+	}
+
+	buffer := NewInstantVectorOperatorBuffer(inner, nil, 1, memoryConsumptionTracker)
+	ctx := context.Background()
+
+	// Read the second series, causing the first to be buffered.
+	series, err := buffer.GetSeries(ctx, []int{1})
+	require.NoError(t, err)
+	require.Equal(t, []types.InstantVectorSeriesData{series1Data}, series)
+	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
+	require.Len(t, buffer.buffer, 1, "should have buffered first series")
+
+	// Close the buffer, which should release the buffered series.
+	buffer.Close()
+	require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+}


### PR DESCRIPTION
#### What this PR does

This PR is similar to #11171, but for binary operations.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
