### PR TITLE
Add new function apierror.IsNonRetryableAPIErrorType

### DIFF
--- a/pkg/api/error/error.go
+++ b/pkg/api/error/error.go
@@ -136,12 +136,15 @@ func AddDetails(err error, details string) error {
 // IsNonRetryableAPIError returns true if err is an apiError which should be failed and not retried.
 func IsNonRetryableAPIError(err error) bool {
 	apiErr := &APIError{}
+	return errors.As(err, &apiErr) && IsNonRetryableAPIErrorType(apiErr.Type)
+}
+
+func IsNonRetryableAPIErrorType(typ Type) bool {
 	// Reasoning:
 	// TypeNone and TypeNotFound are not used anywhere in Mimir nor Prometheus;
 	// TypeTimeout, TypeTooManyRequests, TypeNotAcceptable, TypeUnavailable we presume a retry of the same request will fail in the same way.
 	// TypeCanceled means something wants us to stop.
 	// TypeExec, TypeBadData and TypeTooLargeEntry are caused by the input data.
 	// TypeInternal can be a 500 error e.g. from querier failing to contact store-gateway.
-
-	return errors.As(err, &apiErr) && apiErr.Type != TypeInternal
+	return typ != TypeInternal
 }


### PR DESCRIPTION
#### What this PR does

Add new function `apierror.IsNonRetryableAPIErrorType` so it can be used outside of Mimir.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Very minor, non-user-facing change.