### PR TITLE
Activate and deactivate reactive limiter with ingest storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@
 * [BUGFIX] Query-frontend: Fix blocks retention period enforcement when a request has multiple tenants (tenant federation). #11069
 * [BUGFIX] Query-frontend: Fix `-query-frontend.query-sharding-max-sharded-queries` enforcement for instant queries with binary operators. #11086
 * [BUGFIX] Memberlist: Fix hash ring updates before the full-join has been completed, when `-memberlist.notify-interval` is configured. #11098
-  [BUGFIX] Query-frontend: Fix an issue where transient errors could be inadvertently cached. #11198
+* [BUGFIX] Query-frontend: Fix an issue where transient errors could be inadvertently cached. #11198
+* [BUGFIX] Ingester: read reactive limiters should activate and deactivate when the ingester changes state. #11234
 * [ENHANCEMENT] Query-frontend: Add `cortex_query_samples_processed_total` metric. #11110
 
 ### Mixin

--- a/pkg/ingester/reactivelimiter.go
+++ b/pkg/ingester/reactivelimiter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/util/reactivelimiter"
 )
@@ -29,15 +30,20 @@ type ingesterReactiveLimiter struct {
 
 	prioritizer *rejectionPrioritizer
 	push        reactivelimiter.BlockingLimiter
-	read        reactivelimiter.BlockingLimiter
+	read        *activatableLimiter
 }
 
 // Returns an ingesterReactiveLimiter that uses reactivelimiter.PriorityLimiters with a Prioritizer when push and read
 // limiting is enabled, else that uses reactivelimiter.BlockingLimiter if only one of these is enabled.
 func newIngesterReactiveLimiter(prioritizerConfig *reactivelimiter.RejectionPrioritizerConfig, pushConfig *reactivelimiter.Config, readConfig *reactivelimiter.Config, logger log.Logger, registerer prometheus.Registerer) *ingesterReactiveLimiter {
+	var prioritizer *rejectionPrioritizer
+	var pushLimiter reactivelimiter.BlockingLimiter
+	var blockingReadLimiter reactivelimiter.BlockingLimiter
+	var readLimiter *activatableLimiter
+
 	if pushConfig.Enabled && readConfig.Enabled {
 		// Create prioritizer to prioritize the rejection threshold between push and read limiters
-		prioritizer := &rejectionPrioritizer{
+		prioritizer = &rejectionPrioritizer{
 			cfg:         prioritizerConfig,
 			Prioritizer: reactivelimiter.NewPrioritizer(logger),
 		}
@@ -57,24 +63,53 @@ func newIngesterReactiveLimiter(prioritizerConfig *reactivelimiter.RejectionPrio
 		})
 
 		// Create limiters that use prioritizer
-		limiter := &ingesterReactiveLimiter{
-			prioritizer: prioritizer,
-			push:        newPriorityLimiter(pushConfig, prioritizer, reactivelimiter.PriorityHigh, "push", logger, registerer),
-			read:        newPriorityLimiter(readConfig, prioritizer, reactivelimiter.PriorityLow, "read", logger, registerer),
-		}
-		limiter.service = services.NewTimerService(prioritizerConfig.CalibrationInterval, nil, limiter.update, nil)
-		return limiter
+		pushLimiter = newPriorityLimiter(pushConfig, prioritizer, reactivelimiter.PriorityHigh, "push", logger, registerer)
+		blockingReadLimiter = newPriorityLimiter(readConfig, prioritizer, reactivelimiter.PriorityLow, "read", logger, registerer)
+	} else {
+		pushLimiter = newBlockingLimiter(pushConfig, "push", logger, registerer)
+		blockingReadLimiter = newBlockingLimiter(readConfig, "read", logger, registerer)
 	}
 
-	return &ingesterReactiveLimiter{
-		push: newBlockingLimiter(pushConfig, "push", logger, registerer),
-		read: newBlockingLimiter(readConfig, "read", logger, registerer),
+	if blockingReadLimiter != nil {
+		readLimiter = &activatableLimiter{
+			BlockingLimiter: blockingReadLimiter,
+		}
 	}
+
+	limiter := &ingesterReactiveLimiter{
+		prioritizer: prioritizer,
+		push:        pushLimiter,
+		read:        readLimiter,
+	}
+
+	if prioritizer != nil {
+		limiter.service = services.NewTimerService(prioritizerConfig.CalibrationInterval, nil, limiter.update, nil)
+	}
+
+	return limiter
+}
+
+func (l *ingesterReactiveLimiter) isReadLimiterActive() bool {
+	return l.read != nil && l.read.active.Load()
 }
 
 func (l *ingesterReactiveLimiter) update(_ context.Context) error {
 	l.prioritizer.Calibrate()
 	return nil
+}
+
+type activatableLimiter struct {
+	active atomic.Bool
+	reactivelimiter.BlockingLimiter
+}
+
+func (l *activatableLimiter) activate() {
+	l.active.Store(true)
+}
+
+func (l *activatableLimiter) deactivate() {
+	l.active.Store(false)
+	l.Reset()
 }
 
 func newBlockingLimiter(cfg *reactivelimiter.Config, requestType string, logger log.Logger, registerer prometheus.Registerer) reactivelimiter.BlockingLimiter {

--- a/pkg/ingester/reactivelimiter.go
+++ b/pkg/ingester/reactivelimiter.go
@@ -30,7 +30,8 @@ type ingesterReactiveLimiter struct {
 
 	prioritizer *rejectionPrioritizer
 	push        reactivelimiter.BlockingLimiter
-	read        *activatableLimiter
+	// The read limiter is activated and deactivated when ingesters become active or read only. When deactivated, the limit resets.
+	read *activatableLimiter
 }
 
 // Returns an ingesterReactiveLimiter that uses reactivelimiter.PriorityLimiters with a Prioritizer when push and read

--- a/pkg/util/math/ewma.go
+++ b/pkg/util/math/ewma.go
@@ -12,6 +12,9 @@ type Ewma interface {
 
 	// Value gets the current value of the moving average.
 	Value() float64
+
+	// Reset resets the value of the moving average and requires a new warmup if one was configured.
+	Reset()
 }
 
 // NewEwma creates a new exponentially weighted moving average for the windowSize and warmupSamples.
@@ -26,10 +29,12 @@ func NewEwma(windowSize uint, warmupSamples uint8) Ewma {
 
 type ewma struct {
 	warmupSamples   uint8
-	count           uint8
 	smoothingFactor float64
-	value           float64
-	sum             float64
+
+	// Mutable state
+	count uint8
+	value float64
+	sum   float64
 }
 
 // Add decays the Ewma value via (oldValue * (1 - smoothingFactor)) + (newValue * smoothingFactor)
@@ -47,6 +52,12 @@ func (e *ewma) Add(newValue float64) float64 {
 
 func (e *ewma) Value() float64 {
 	return e.value
+}
+
+func (e *ewma) Reset() {
+	e.count = 0
+	e.value = 0
+	e.sum = 0
 }
 
 // Smooth returns a value that is decreased by some portion of the oldValue, and increased by some portion of the

--- a/pkg/util/math/ewma_test.go
+++ b/pkg/util/math/ewma_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEWMA_AddAndValue(t *testing.T) {
@@ -49,4 +50,16 @@ func TestEWMA_AddAndValue(t *testing.T) {
 			assert.Equal(t, tc.expected, math.Round(ma.Value()))
 		})
 	}
+}
+
+func TestEWMA_Reset(t *testing.T) {
+	ma := NewEwma(10, 0)
+
+	require.Equal(t, 0.0, ma.Value())
+	ma.Add(10)
+	ma.Add(0)
+	require.NotEqual(t, 0.0, ma.Value())
+
+	ma.Reset()
+	require.Equal(t, 0.0, ma.Value())
 }

--- a/pkg/util/math/median.go
+++ b/pkg/util/math/median.go
@@ -45,3 +45,13 @@ func (f *MedianFilter) Median() float64 {
 	}
 	return f.sorted[len(f.sorted)/2]
 }
+
+// Reset resets the filter to its initial value.
+func (f *MedianFilter) Reset() {
+	for i := range f.values {
+		f.values[i] = 0
+		f.sorted[i] = 0
+	}
+	f.index = 0
+	f.size = 0
+}

--- a/pkg/util/math/median_test.go
+++ b/pkg/util/math/median_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMedianFilter(t *testing.T) {
@@ -42,4 +43,15 @@ func TestMedianFilter(t *testing.T) {
 		median := filter.Add(9.0)
 		assert.Equal(t, 5.0, median)
 	})
+}
+
+func TestMedianFilter_Reset(t *testing.T) {
+	filter := NewMedianFilter(3)
+	filter.Add(5.0)
+	filter.Add(2.0)
+	filter.Add(8.0)
+	require.NotEqual(t, 0.0, filter.Median())
+
+	filter.Reset()
+	require.Equal(t, 0.0, filter.Median())
 }

--- a/pkg/util/math/windows.go
+++ b/pkg/util/math/windows.go
@@ -70,14 +70,27 @@ func (r *RollingSum) CalculateCV() (cv, mean, variance float64) {
 	return cv, mean, variance
 }
 
+// Reset resets the sum to its initial state.
+func (r *RollingSum) Reset() {
+	for i := range r.samples {
+		r.samples[i] = 0
+	}
+	r.size = 0
+	r.index = 0
+	r.sumY = 0
+	r.sumSquares = 0
+}
+
 // CorrelationWindow can be used to compute correlation for sets of values over a rolling window.
 //
 // This type is not concurrency safe.
 type CorrelationWindow struct {
 	warmupSamples uint8
-	xSamples      *RollingSum
-	ySamples      *RollingSum
-	corrSumXY     float64
+
+	// Mutable state
+	xSamples  *RollingSum
+	ySamples  *RollingSum
+	corrSumXY float64
 }
 
 func NewCorrelationWindow(capacity uint, warmupSamples uint8) *CorrelationWindow {
@@ -129,4 +142,11 @@ func (w *CorrelationWindow) Add(x, y float64) (correlation, cvX, cvY float64) {
 	correlation = covariance / (math.Sqrt(varX) * math.Sqrt(varY))
 
 	return correlation, cvX, cvY
+}
+
+// Reset resets the window to its initial state.
+func (w *CorrelationWindow) Reset() {
+	w.xSamples.Reset()
+	w.ySamples.Reset()
+	w.corrSumXY = 0
 }

--- a/pkg/util/math/windows_test.go
+++ b/pkg/util/math/windows_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRollingSum(t *testing.T) {
@@ -152,6 +153,9 @@ func TestCorrelationWindow(t *testing.T) {
 
 			assert.InDelta(t, tc.expectedCorrelation, correlation, 0.0001)
 			assert.Equal(t, tc.expectedSize, w.xSamples.size)
+
+			w.Reset()
+			require.Equal(t, 0.0, w.corrSumXY)
 		})
 	}
 }

--- a/pkg/util/reactivelimiter/blockinglimiter.go
+++ b/pkg/util/reactivelimiter/blockinglimiter.go
@@ -21,6 +21,9 @@ type BlockingLimiter interface {
 	// CanAcquirePermit returns whether it's currently possible to acquire a permit, based on the number of requests
 	// inflight, the current queue size, and current rejection threshold.
 	CanAcquirePermit() bool
+
+	// Reset resets the limiter to its initial limit.
+	Reset()
 }
 
 // blockingLimiter wraps an adaptiveLimiter and blocks some portion of requests when the adaptiveLimiter is at its

--- a/pkg/util/reactivelimiter/prioritylimiter.go
+++ b/pkg/util/reactivelimiter/prioritylimiter.go
@@ -48,6 +48,9 @@ type PriorityLimiter interface {
 
 	// CanAcquirePermit returns whether it's currently possible to acquire a permit for the priority.
 	CanAcquirePermit(priority Priority) bool
+
+	// Reset resets the limiter to its initial limit.
+	Reset()
 }
 
 func NewPriorityLimiter(config *Config, prioritizer Prioritizer, logger log.Logger) PriorityLimiter {

--- a/pkg/util/reactivelimiter/reactivelimiter.go
+++ b/pkg/util/reactivelimiter/reactivelimiter.go
@@ -105,12 +105,12 @@ func newLimiter(config *Config, logger log.Logger) *reactiveLimiter {
 		semaphore:             mimirsync.NewDynamicSemaphore(int(config.InitialInflightLimit)),
 		limit:                 float64(config.InitialInflightLimit),
 		shortRTT:              &tDigestSample{TDigest: tdigest.NewWithCompression(100)},
+		medianFilter:          mimirmath.NewMedianFilter(smoothedSamples),
+		smoothedShortRTT:      mimirmath.NewEwma(smoothedSamples, warmupSamples),
 		longRTT:               mimirmath.NewEwma(config.LongWindow, warmupSamples),
 		nextUpdateTime:        time.Now(),
 		rttCorrelation:        mimirmath.NewCorrelationWindow(config.CorrelationWindow, warmupSamples),
 		throughputCorrelation: mimirmath.NewCorrelationWindow(config.CorrelationWindow, warmupSamples),
-		medianFilter:          mimirmath.NewMedianFilter(smoothedSamples),
-		smoothedShortRTT:      mimirmath.NewEwma(smoothedSamples, warmupSamples),
 	}
 }
 
@@ -158,13 +158,12 @@ type reactiveLimiter struct {
 	mu        sync.RWMutex
 
 	// Guarded by mu
-	limit            float64        // The current concurrency limit
-	shortRTT         *tDigestSample // Short term execution times
-	medianFilter     *mimirmath.MedianFilter
-	smoothedShortRTT mimirmath.Ewma
-	longRTT          mimirmath.Ewma // Tracks long term average execution time
-	nextUpdateTime   time.Time      // Tracks when the limit can next be updated
-
+	limit                 float64        // The current concurrency limit
+	shortRTT              *tDigestSample // Short term execution times
+	medianFilter          *mimirmath.MedianFilter
+	smoothedShortRTT      mimirmath.Ewma
+	longRTT               mimirmath.Ewma               // Tracks long term average execution time
+	nextUpdateTime        time.Time                    // Tracks when the limit can next be updated
 	throughputCorrelation *mimirmath.CorrelationWindow // Tracks the correlation between concurrency and throughput
 	rttCorrelation        *mimirmath.CorrelationWindow // Tracks the correlation between concurrency and round trip times (RTT)
 }
@@ -204,6 +203,20 @@ func (l *reactiveLimiter) Blocked() int {
 
 func (l *reactiveLimiter) RejectionRate() float64 {
 	return 0
+}
+
+func (l *reactiveLimiter) Reset() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.semaphore.SetSize(int(l.config.InitialInflightLimit))
+	l.limit = float64(l.config.InitialInflightLimit)
+	l.shortRTT.Reset()
+	l.medianFilter.Reset()
+	l.smoothedShortRTT.Reset()
+	l.longRTT.Reset()
+	l.nextUpdateTime = time.Now()
+	l.rttCorrelation.Reset()
+	l.throughputCorrelation.Reset()
 }
 
 // Records the duration of a completed execution, updating the concurrency limit if the short shortRTT window is full.

--- a/pkg/util/sync/semaphore.go
+++ b/pkg/util/sync/semaphore.go
@@ -9,6 +9,8 @@ import (
 )
 
 // DynamicSemaphore is a semaphore that can be dynamically resized and allows FIFO blocking when full.
+//
+// This type is concurrency safe.
 type DynamicSemaphore struct {
 	mu      sync.Mutex
 	size    int       // Guarded by mu


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Since ingesters using ingest storage can become inactive when they switch to read only, and then active again, it makes sense to reset reactive limiters to their initial limit when transitioning back to active.

This PR improves the adaptive limiter implementation to support resetting back to the initial limit. It also updates ingesters using ingest storage and a read reactive limiter to activate or deactivate when the ingester changes state to read only mode or back to active. When deactivating, the limiter resets back to its initial value, which it will use if/when reactivated.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
