### PR TITLE
MQE: add readme to benchmarks directory

### DIFF
--- a/pkg/streamingpromql/benchmarks/README.md
+++ b/pkg/streamingpromql/benchmarks/README.md
@@ -1,0 +1,4 @@
+This directory contains benchmarks used to evaluate the performance of MQE.
+
+While all benchmarks can be run with the standard `go test` command, using `tools/benchmark-query-engine` provides
+a number of benefits. See [its readme](../../../tools/benchmark-query-engine/README.md) for more details.


### PR DESCRIPTION
#### What this PR does

This PR adds a readme to the directory containing MQE's benchmarks, encouraging readers to use `tools/benchmark-query-engine` rather than using `go test` directly.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [x] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
