### PR TITLE
Upgrade to dskit@main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [ENHANCEMENT] Ingester: Remove cost-attribution experimental `max_cost_attribution_labels_per_user` limit. #11090
 * [ENHANCEMENT] Update Go to 1.24.2. #11114
 * [ENHANCEMENT] Ingester/Distributor: Add `cortex_cost_attribution_*` metrics to observe the state of the cost-attribution trackers. #11112
+* [ENHANCEMENT] gRPC/HTTP servers: Add `cortex_server_invalid_cluster_validation_label_requests_total` metric, that is increased for every request with an invalid cluster validation label. #11241
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20250414072521-7b78bfe441ed
+	github.com/grafana/dskit v0.0.0-20250416180508-15fe9b42d47d
 	github.com/grafana/e2e v0.1.2-0.20250306030804-b80b212be908
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.7.11

--- a/go.sum
+++ b/go.sum
@@ -1276,8 +1276,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20250411135245-cad0d384d430 h1:qT0D7AIV0GRu8JUrSJYuyzj86kqLgksKQjwD++DqyOM=
 github.com/grafana/alerting v0.0.0-20250411135245-cad0d384d430/go.mod h1:3ER/8BhIEhvrddcztLQSc5ez1f1jNHIPdquc1F+DzOw=
-github.com/grafana/dskit v0.0.0-20250414072521-7b78bfe441ed h1:+D5CM2IictIjZTNhUaw/bLAdVZOwph85Cs+bUFKnXTU=
-github.com/grafana/dskit v0.0.0-20250414072521-7b78bfe441ed/go.mod h1:BoqjRhTdF0f3ssb1KjVh5B3Jv/HpSd1K27+qs5f8utE=
+github.com/grafana/dskit v0.0.0-20250416180508-15fe9b42d47d h1:QMljcOdL6tJh52y+ix6zDi4++19xrheaVFn2HPfwh8A=
+github.com/grafana/dskit v0.0.0-20250416180508-15fe9b42d47d/go.mod h1:BoqjRhTdF0f3ssb1KjVh5B3Jv/HpSd1K27+qs5f8utE=
 github.com/grafana/e2e v0.1.2-0.20250306030804-b80b212be908 h1:l3pFNUs4heAhiXnMo0thaJQrNWeE4SgLqUOEUmZtC6A=
 github.com/grafana/e2e v0.1.2-0.20250306030804-b80b212be908/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/franz-go v0.0.0-20241009100846-782ba1442937 h1:fwwnG/NcygoS6XbAaEyK2QzMXI/BZIEJvQ3CD+7XZm8=

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -3470,8 +3470,12 @@ func TestMultitenantAlertmanager_ClusterValidation(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			var grpcOptions []grpc.ServerOption
 			if testCase.serverClusterValidation.GRPC.Enabled {
+				reg := prometheus.NewPedanticRegistry()
 				grpcOptions = []grpc.ServerOption{
-					grpc.ChainUnaryInterceptor(middleware.ClusterUnaryServerInterceptor(testCase.serverClusterValidation.Label, testCase.serverClusterValidation.GRPC.SoftValidation, log.NewNopLogger())),
+					grpc.ChainUnaryInterceptor(middleware.ClusterUnaryServerInterceptor(
+						testCase.serverClusterValidation.Label, testCase.serverClusterValidation.GRPC.SoftValidation,
+						middleware.NewInvalidClusterRequests(reg), log.NewNopLogger(),
+					)),
 				}
 			}
 

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -184,7 +184,11 @@ func TestFrontend_ClusterValidationWhenDownstreamURLIsConfigured(t *testing.T) {
 			})
 			logger := log.NewNopLogger()
 			if testCase.enabled {
-				handler = middleware.ClusterValidationMiddleware(testCase.serverCluster, []string{}, testCase.softValidation, logger).Wrap(handler)
+				reg := prometheus.NewPedanticRegistry()
+				handler = middleware.ClusterValidationMiddleware(
+					testCase.serverCluster, []string{}, testCase.softValidation,
+					middleware.NewInvalidClusterRequests(reg), logger,
+				).Wrap(handler)
 			}
 			downstreamServer := http.Server{
 				Handler:      handler,

--- a/pkg/ruler/client_pool_test.go
+++ b/pkg/ruler/client_pool_test.go
@@ -160,8 +160,12 @@ func TestClientPool_ClusterValidation(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			var grpcOptions []grpc.ServerOption
 			if testCase.serverClusterValidation.GRPC.Enabled {
+				reg := prometheus.NewPedanticRegistry()
 				grpcOptions = []grpc.ServerOption{
-					grpc.ChainUnaryInterceptor(middleware.ClusterUnaryServerInterceptor(testCase.serverClusterValidation.Label, testCase.serverClusterValidation.GRPC.SoftValidation, log.NewNopLogger())),
+					grpc.ChainUnaryInterceptor(middleware.ClusterUnaryServerInterceptor(
+						testCase.serverClusterValidation.Label, testCase.serverClusterValidation.GRPC.SoftValidation,
+						middleware.NewInvalidClusterRequests(reg), log.NewNopLogger(),
+					)),
 				}
 			}
 

--- a/vendor/github.com/grafana/dskit/middleware/metrics.go
+++ b/vendor/github.com/grafana/dskit/middleware/metrics.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// NewInvalidClusterRequests registers and returns a new counter metric server_invalid_cluster_validation_label_requests_total.
+func NewInvalidClusterRequests(reg prometheus.Registerer) *prometheus.CounterVec {
+	return promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "server_invalid_cluster_validation_label_requests_total",
+		Help: "Number of requests received by server with invalid cluster validation label.",
+	}, []string{"protocol", "method", "cluster_validation_label", "request_cluster_validation_label"})
+}

--- a/vendor/github.com/grafana/dskit/server/metrics.go
+++ b/vendor/github.com/grafana/dskit/server/metrics.go
@@ -25,23 +25,25 @@ type Metrics struct {
 	SentMessageSize          *prometheus.HistogramVec
 	InflightRequests         *prometheus.GaugeVec
 	RequestThroughput        *prometheus.HistogramVec
+	InvalidClusterRequests   *prometheus.CounterVec
 }
 
 func NewServerMetrics(cfg Config) *Metrics {
-	reg := promauto.With(cfg.registererOrDefault())
+	reg := cfg.registererOrDefault()
+	factory := promauto.With(reg)
 
 	return &Metrics{
-		TCPConnections: reg.NewGaugeVec(prometheus.GaugeOpts{
+		TCPConnections: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "tcp_connections",
 			Help:      "Current number of accepted TCP connections.",
 		}, []string{"protocol"}),
-		TCPConnectionsLimit: reg.NewGaugeVec(prometheus.GaugeOpts{
+		TCPConnectionsLimit: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "tcp_connections_limit",
 			Help:      "The max number of TCP connections that can be accepted (0 means no limit).",
 		}, []string{"protocol"}),
-		RequestDuration: reg.NewHistogramVec(prometheus.HistogramOpts{
+		RequestDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
 			Name:                            "request_duration_seconds",
 			Help:                            "Time (in seconds) spent serving HTTP requests.",
@@ -50,7 +52,7 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"method", "route", "status_code", "ws"}),
-		PerTenantRequestDuration: reg.NewHistogramVec(prometheus.HistogramOpts{
+		PerTenantRequestDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
 			Name:                            "per_tenant_request_duration_seconds",
 			Help:                            "Time (in seconds) spent serving HTTP requests for a particular tenant.",
@@ -59,29 +61,29 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"method", "route", "status_code", "ws", "tenant"}),
-		PerTenantRequestTotal: reg.NewCounterVec(prometheus.CounterOpts{
+		PerTenantRequestTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "per_tenant_request_total",
 			Help:      "Total count of requests for a particular tenant.",
 		}, []string{"method", "route", "status_code", "ws", "tenant"}),
-		ReceivedMessageSize: reg.NewHistogramVec(prometheus.HistogramOpts{
+		ReceivedMessageSize: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "request_message_bytes",
 			Help:      "Size (in bytes) of messages received in the request.",
 			Buckets:   middleware.BodySizeBuckets,
 		}, []string{"method", "route"}),
-		SentMessageSize: reg.NewHistogramVec(prometheus.HistogramOpts{
+		SentMessageSize: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "response_message_bytes",
 			Help:      "Size (in bytes) of messages sent in response.",
 			Buckets:   middleware.BodySizeBuckets,
 		}, []string{"method", "route"}),
-		InflightRequests: reg.NewGaugeVec(prometheus.GaugeOpts{
+		InflightRequests: factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "inflight_requests",
 			Help:      "Current number of inflight requests.",
 		}, []string{"method", "route"}),
-		RequestThroughput: reg.NewHistogramVec(prometheus.HistogramOpts{
+		RequestThroughput: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
 			Name:                            "request_throughput_" + cfg.Throughput.Unit,
 			Help:                            "Server throughput of running requests.",
@@ -91,5 +93,6 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"method", "route"}),
+		InvalidClusterRequests: middleware.NewInvalidClusterRequests(reg),
 	}
 }

--- a/vendor/github.com/grafana/dskit/server/server.go
+++ b/vendor/github.com/grafana/dskit/server/server.go
@@ -409,7 +409,10 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
 	if cfg.ClusterValidation.GRPC.Enabled {
-		grpcMiddleware = append(grpcMiddleware, middleware.ClusterUnaryServerInterceptor(cfg.ClusterValidation.Label, cfg.ClusterValidation.GRPC.SoftValidation, logger))
+		grpcMiddleware = append(grpcMiddleware, middleware.ClusterUnaryServerInterceptor(
+			cfg.ClusterValidation.Label, cfg.ClusterValidation.GRPC.SoftValidation,
+			metrics.InvalidClusterRequests, logger,
+		))
 	}
 
 	grpcStreamMiddleware := []grpc.StreamServerInterceptor{
@@ -570,7 +573,11 @@ func BuildHTTPMiddleware(cfg Config, router *mux.Router, metrics *Metrics, logge
 		httpMiddleware = append(defaultHTTPMiddleware, cfg.HTTPMiddleware...)
 	}
 	if cfg.ClusterValidation.HTTP.Enabled {
-		httpMiddleware = append(httpMiddleware, middleware.ClusterValidationMiddleware(cfg.ClusterValidation.Label, cfg.ClusterValidation.HTTP.ExcludedPaths, cfg.ClusterValidation.HTTP.SoftValidation, logger))
+		httpMiddleware = append(httpMiddleware, middleware.ClusterValidationMiddleware(
+			cfg.ClusterValidation.Label, cfg.ClusterValidation.HTTP.ExcludedPaths,
+			cfg.ClusterValidation.HTTP.SoftValidation,
+			metrics.InvalidClusterRequests, logger,
+		))
 	}
 
 	return httpMiddleware, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -650,7 +650,7 @@ github.com/grafana/alerting/receivers/webhook
 github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
 github.com/grafana/alerting/templates/gomplate
-# github.com/grafana/dskit v0.0.0-20250414072521-7b78bfe441ed
+# github.com/grafana/dskit v0.0.0-20250416180508-15fe9b42d47d
 ## explicit; go 1.22.0
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
#### What this PR does

Upgrade to dskit@main ([15fe9b42d47ddac4d4c947def386494a5a39cc60](https://github.com/grafana/dskit/commit/15fe9b42d47ddac4d4c947def386494a5a39cc60)), to get https://github.com/grafana/dskit/pull/680. This adds the `cortex_server_invalid_cluster_validation_label_requests_total` metric.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
