### PR TITLE
Grafana Alertmanager: Preserve order while removing duplicate receivers

### DIFF
--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -42,11 +42,11 @@ func (am *MultitenantAlertmanager) createUsableGrafanaConfig(gCfg alertspb.Grafa
 	// We want to:
 	// 1. Remove duplicate receivers and keep the last receiver occurrence if there are conflicts. This is based on the upstream implementation.
 	// 2. Maintain a consistent ordering and preferably original ordering. Otherwise, change detection will be impacted.
-	lastIndex := make(map[string]int)
+	lastIndex := make(map[string]int, len(amCfg.AlertmanagerConfig.Receivers))
 	for i, receiver := range amCfg.AlertmanagerConfig.Receivers {
 		lastIndex[receiver.Name] = i
 	}
-	rcvs := make([]*definition.PostableApiReceiver, 0, len(amCfg.AlertmanagerConfig.Receivers))
+	rcvs := make([]*definition.PostableApiReceiver, 0, len(lastIndex))
 	for i, rcv := range amCfg.AlertmanagerConfig.Receivers {
 		if i != lastIndex[rcv.Name] {
 			itypes := make([]string, 0, len(rcv.GrafanaManagedReceivers))

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -14,7 +14,57 @@ import (
 	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
 )
 
-const grafanaConfigWithDuplicateReceiverName = `{"template_files":{},"alertmanager_config":{"route":{"receiver":"test-receiver","group_by":["grafana_folder","alertname"]},"templates":null,"receivers":[{"name":"test-receiver","grafana_managed_receiver_configs":[{"uid":"dde6ntuob69dtf","name":"test-receiver","type":"webhook","disableResolveMessage":false,"settings":{"url":"http://localhost:8080","username":"test"},"secureSettings":{"password":"test"}}]},{"name":"test-receiver","grafana_managed_receiver_configs":[{"uid":"dde7ntuob69dtf","name":"test-receiver","type":"webhook","disableResolveMessage":false,"settings":{"url":"http://localhost:8080","username":"test"},"secureSettings":{"password":"test"}}]}]}}`
+const grafanaConfigWithDuplicateReceiverName = `{
+  "template_files": {},
+  "alertmanager_config": {
+    "route": {
+      "receiver": "test-receiver",
+      "group_by": [
+        "grafana_folder",
+        "alertname"
+      ]
+    },
+    "templates": null,
+    "receivers": [
+      {
+        "name": "test-receiver",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "dde6ntuob69dtf",
+            "name": "test-receiver",
+            "type": "webhook",
+            "disableResolveMessage": false,
+            "settings": {
+              "url": "http://localhost:8080",
+              "username": "test"
+            },
+            "secureSettings": {
+              "password": "test"
+            }
+          }
+        ]
+      },
+      {
+        "name": "test-receiver",
+        "grafana_managed_receiver_configs": [
+          {
+            "uid": "dde7ntuob69dtf",
+            "name": "test-receiver",
+            "type": "webhook",
+            "disableResolveMessage": false,
+            "settings": {
+              "url": "http://localhost:8080",
+              "username": "test"
+            },
+            "secureSettings": {
+              "password": "test"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}`
 
 func TestCreateUsableGrafanaConfig(t *testing.T) {
 	tests := []struct {

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -18,7 +18,7 @@ const grafanaConfigWithDuplicateReceiverName = `{
   "template_files": {},
   "alertmanager_config": {
     "route": {
-      "receiver": "test-receiver",
+      "receiver": "test-receiver8",
       "group_by": [
         "grafana_folder",
         "alertname"
@@ -26,8 +26,9 @@ const grafanaConfigWithDuplicateReceiverName = `{
     },
     "templates": null,
     "receivers": [
+      {"name": "test-receiver1","grafana_managed_receiver_configs": []},
       {
-        "name": "test-receiver",
+        "name": "test-receiver8",
         "grafana_managed_receiver_configs": [
           {
             "uid": "dde6ntuob69dtf",
@@ -44,8 +45,14 @@ const grafanaConfigWithDuplicateReceiverName = `{
           }
         ]
       },
+      {"name": "test-receiver2","grafana_managed_receiver_configs": []},
+      {"name": "test-receiver3","grafana_managed_receiver_configs": []},
+      {"name": "test-receiver4","grafana_managed_receiver_configs": []},
+      {"name": "test-receiver5","grafana_managed_receiver_configs": []},
+      {"name": "test-receiver6","grafana_managed_receiver_configs": []},
+      {"name": "test-receiver7","grafana_managed_receiver_configs": []},
       {
-        "name": "test-receiver",
+        "name": "test-receiver8",
         "grafana_managed_receiver_configs": [
           {
             "uid": "dde7ntuob69dtf",
@@ -61,7 +68,8 @@ const grafanaConfigWithDuplicateReceiverName = `{
             }
           }
         ]
-      }
+      },
+	  {"name": "test-receiver9","grafana_managed_receiver_configs": []}
     ]
   }
 }`
@@ -164,6 +172,13 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 				require.False(t, ok, fmt.Sprintf("duplicate receiver name %q found in final configuration", rcv.Name))
 				receiverNames[rcv.Name] = struct{}{}
 			}
+
+			// Ensure that configuration is deterministic. For example, ordering of receivers.
+			// This is important for change detection.
+			cfg2, err := am.createUsableGrafanaConfig(test.grafanaConfig, test.mimirConfig)
+			require.NoError(t, err)
+
+			require.Equal(t, cfg.RawConfig, cfg2.RawConfig)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

Previously, while removing duplicate receivers and intermediate map was used and original order was lost. Furthermore, the output order was undefined causing change detection on config syncs to continuously detect a spurious change.

#### Checklist

- [x] Tests updated.
