### PR TITLE
undelete-blocks: avoid copies by removing S3 delete markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 * [ENHANCEMENT] `kafkatool`: Add `offsets` command for querying various partition offsets. #11115
 * [ENHANCEMENT] `listblocks`: Output can now also be JSON or YAML for easier parsing. #11184
 * [ENHANCEMENT] `mark-blocks`: Allow specifying blocks from multiple tenants. #11343
+* [ENHANCEMENT] `undelete-blocks`: Support removing S3 delete markers to avoid copying data when recovering blocks. #11256
 
 ## 2.16.0
 

--- a/pkg/util/objtools/bucket.go
+++ b/pkg/util/objtools/bucket.go
@@ -165,6 +165,10 @@ func (c *BucketConfig) ToBucket(ctx context.Context) (Bucket, error) {
 	}
 }
 
+func (c *BucketConfig) Backend() string {
+	return c.backend
+}
+
 type CopyBucketConfig struct {
 	clientSideCopy bool
 	source         BucketConfig

--- a/tools/undelete-blocks/README.md
+++ b/tools/undelete-blocks/README.md
@@ -16,6 +16,7 @@ The currently supported services are Amazon Simple Storage Service (S3 and S3-co
 - `--input-file` (optional) The file path to read when `--blocks-from` is `json` or `lines`, otherwise ignored. The default (`"-"`) assumes reading from standard input.
 - `--include-tenants` (optional) A comma separated list of what tenants to target.
 - `--exclude-tenants` (optional) A comma separated list of what tenants to ignore. Has precedence over `--include-tenants`.
+- `--allow-version-delete` (optional) Allow using version deletion. This is used to remove delete marker versions instead of copying data when possible (S3 backends only). The default is `true`.
 - `--dry-run` (optional) When set the changes that would be made to object storage are only logged rather than performed.
 
 Each supported object storage service also has an additional set of flags (see examples in [Running](##Running)).

--- a/tools/undelete-blocks/README.md
+++ b/tools/undelete-blocks/README.md
@@ -1,6 +1,6 @@
 # undelete-blocks
 
-This program is a disaster recovery tool that can restore deleted Mimir blocks in object storage.
+This program is a disaster recovery tool that can restore deleted Mimir blocks in object storage. If a partial failure is encountered when running this tool it is safe to rerun.
 
 The currently supported services are Amazon Simple Storage Service (S3 and S3-compatible), Azure Blob Storage (ABS), and Google Cloud Storage (GCS).
 

--- a/tools/undelete-blocks/main.go
+++ b/tools/undelete-blocks/main.go
@@ -20,17 +20,19 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
 
+	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/util/objtools"
 )
 
 type config struct {
-	bucketConfig   objtools.BucketConfig
-	blocksFrom     string
-	inputFile      string
-	includeTenants flagext.StringSliceCSV
-	excludeTenants flagext.StringSliceCSV
-	dryRun         bool
+	bucketConfig       objtools.BucketConfig
+	blocksFrom         string
+	inputFile          string
+	includeTenants     flagext.StringSliceCSV
+	excludeTenants     flagext.StringSliceCSV
+	allowVersionDelete bool
+	dryRun             bool
 }
 
 func (c *config) registerFlags(f *flag.FlagSet) {
@@ -39,6 +41,7 @@ func (c *config) registerFlags(f *flag.FlagSet) {
 	f.StringVar(&c.inputFile, "input-file", "-", "The file path to read when --blocks-from is json or lines, otherwise ignored. The default (\"-\") assumes reading from standard input.")
 	f.Var(&c.includeTenants, "include-tenants", "A comma separated list of what tenants to target.")
 	f.Var(&c.excludeTenants, "exclude-tenants", "A comma separated list of what tenants to ignore. Has precedence over included tenants.")
+	f.BoolVar(&c.allowVersionDelete, "allow-version-delete", true, "Allow using version deletion. This is used to remove delete marker versions instead of copying data when possible (S3 backends only).")
 	f.BoolVar(&c.dryRun, "dry-run", false, "When set the changes that would be made to object storage are only logged rather than performed.")
 }
 
@@ -56,6 +59,9 @@ func main() {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
+
+	// Version deletion is used for removing delete marker versions which only applies to S3
+	cfg.allowVersionDelete = cfg.allowVersionDelete && cfg.bucketConfig.Backend() == bucket.S3
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -78,7 +84,7 @@ func run(ctx context.Context, cfg config) error {
 		return errors.Wrap(err, "failed to get blocks")
 	}
 
-	undeleteBlocks(ctx, bucket, blocks, cfg.dryRun)
+	undeleteBlocks(ctx, bucket, blocks, cfg.allowVersionDelete, cfg.dryRun)
 	return nil
 }
 
@@ -300,7 +306,7 @@ func listGlobalMarkers(ctx context.Context, bucket objtools.Bucket, tenantID str
 	return m, nil
 }
 
-func undeleteBlocks(ctx context.Context, bucket objtools.Bucket, blocks map[string][]ulid.ULID, dryRun bool) {
+func undeleteBlocks(ctx context.Context, bucket objtools.Bucket, blocks map[string][]ulid.ULID, allowVersionDelete, dryRun bool) {
 	succeeded, notNeeded, failed := 0, 0, 0
 	defer func() {
 		slog.Info("undelete operations summary", "succeeded", succeeded, "notNeeded", notNeeded, "failed", failed, "dryRun", dryRun)
@@ -323,7 +329,7 @@ func undeleteBlocks(ctx context.Context, bucket objtools.Bucket, blocks map[stri
 				return
 			}
 
-			undeleted, err := undeleteBlock(ctx, bucket, tenantID, blockID, globalMarkerState[blockID], logger, dryRun)
+			undeleted, err := undeleteBlock(ctx, bucket, tenantID, blockID, globalMarkerState[blockID], logger, allowVersionDelete, dryRun)
 			if err != nil {
 				failed++
 				logger.Error("failed to undelete block", "err", err)
@@ -347,7 +353,13 @@ type version struct {
 	info         objtools.VersionInfo
 }
 
-func undeleteBlock(ctx context.Context, bkt objtools.Bucket, tenantID string, blockID ulid.ULID, globalState globalMarkerState, logger *slog.Logger, dryRun bool) (bool, error) {
+// restoreInfo contains the information necessary to perform a restore on an object
+type restoreInfo struct {
+	shadowingDeleteMarkers []version
+	target                 version
+}
+
+func undeleteBlock(ctx context.Context, bkt objtools.Bucket, tenantID string, blockID ulid.ULID, globalState globalMarkerState, logger *slog.Logger, allowVersionDelete bool, dryRun bool) (bool, error) {
 	/*
 	 Lifecycle of a block:
 	 1. Files without meta.json added
@@ -358,7 +370,7 @@ func undeleteBlock(ctx context.Context, bkt objtools.Bucket, tenantID string, bl
 	 6. Delete the delete markers, local then global
 
 	 To undelete a block we are going to:
-	 1. Ensure all files within an existing or restorable meta.json are exiting or restorable with a matching size
+	 1. Ensure all files within an existing or restorable meta.json are existing or restorable with a matching size
 	 2. Restore objects as needed (if restoring the meta.json it goes last)
 	 3. Delete the delete markers (local then global) as needed
 	 4. Restore the no-compact markers (local then global) as needed
@@ -393,24 +405,19 @@ func undeleteBlock(ctx context.Context, bkt objtools.Bucket, tenantID string, bl
 		return false, errors.Wrap(err, "failed reading the block meta file")
 	}
 
-	restoreTargets, err := targetsToRestore(m, objVersions, blockPrefix)
+	restoreInfos, err := targetsToRestore(m, objVersions, blockPrefix, allowVersionDelete)
 	if err != nil {
 		return false, errors.Wrap(err, "failed getting target versions to restore")
 	}
 	// Restore the meta last if it's needed
 	if metaVersion != nil {
-		restoreTargets = append(restoreTargets, *metaVersion)
+		restoreInfos = append(restoreInfos, buildRestore(objVersions[metaName], *metaVersion, allowVersionDelete))
 	}
 
-	for _, target := range restoreTargets {
-		if dryRun {
-			logger.Info("dry run: would restore", "object", target.objectName, "version", target.info.VersionID)
-			continue
+	for _, restoreInfo := range restoreInfos {
+		if err = restore(ctx, bkt, restoreInfo, logger, dryRun); err != nil {
+			return false, err
 		}
-		if err := bkt.RestoreVersion(ctx, target.objectName, target.info); err != nil {
-			return false, errors.Wrapf(err, "failed to restore object %s with version %s", target.objectName, target.info.VersionID)
-		}
-		logger.Info("restored an object version", "object", target.objectName, "version", target.info.VersionID)
 	}
 
 	markersModified, err := handleMarkers(ctx, bkt, tenantID, blockID, globalState, objVersions, dryRun, logger)
@@ -418,7 +425,7 @@ func undeleteBlock(ctx context.Context, bkt objtools.Bucket, tenantID string, bl
 		return false, err
 	}
 
-	return len(restoreTargets) != 0 || markersModified, nil
+	return len(restoreInfos) != 0 || markersModified, nil
 }
 
 func getMeta(ctx context.Context, bkt objtools.Bucket, path string, versions []version) (*block.Meta, *version, error) {
@@ -449,8 +456,8 @@ func getMeta(ctx context.Context, bkt objtools.Bucket, path string, versions []v
 	return m, metaVersion, nil
 }
 
-func targetsToRestore(m *block.Meta, objVersions map[string][]version, blockPrefix string) ([]version, error) {
-	targetVersions := make([]version, 0, len(m.Thanos.Files))
+func targetsToRestore(m *block.Meta, objVersions map[string][]version, blockPrefix string, allowVersionDelete bool) ([]restoreInfo, error) {
+	restores := make([]restoreInfo, 0, len(m.Thanos.Files))
 
 	// Verify that every expected file is present in the block and restorable
 	for _, file := range m.Thanos.Files {
@@ -468,11 +475,11 @@ func targetsToRestore(m *block.Meta, objVersions map[string][]version, blockPref
 			return nil, fmt.Errorf("block %s contained versions for %s, but none were restorable", blockPrefix, file.RelPath)
 		}
 		if restoreVersion != nil { // nil indicates the object has an existing current version
-			targetVersions = append(targetVersions, *restoreVersion)
+			restores = append(restores, buildRestore(versions, *restoreVersion, allowVersionDelete))
 		}
 	}
 
-	return targetVersions, nil
+	return restores, nil
 }
 
 func versionToRestore(versions []version, targetSize *int64) (v *version, ok bool) {
@@ -491,6 +498,75 @@ func versionToRestore(versions []version, targetSize *int64) (v *version, ok boo
 	}
 
 	return target, target != nil
+}
+
+// buildRestore builds restoration information
+func buildRestore(versions []version, target version, allowVersionDelete bool) restoreInfo {
+	var shadowingDeleteMarkers []version
+	if allowVersionDelete {
+		// If delete markers can be removed then copying data may be avoidable
+		shadowingDeleteMarkers = deleteMarkersShadowingTarget(versions, target)
+	}
+
+	return restoreInfo{
+		shadowingDeleteMarkers: shadowingDeleteMarkers,
+		target:                 target,
+	}
+}
+
+// deleteMarkersShadowingTarget identifies the case where there are versions (excluding the target) with a
+// last modified time >= the target version's last modified time and all such versions are delete markers.
+// If that is the case, a non-empty list of those versions are returned
+func deleteMarkersShadowingTarget(versions []version, target version) []version {
+	shadowing := make([]version, 0, len(versions))
+	for _, version := range versions {
+		if version.lastModified.Before(target.lastModified) || version.info.VersionID == target.info.VersionID {
+			continue
+		} else if !version.info.IsDeleteMarker {
+			// A non-delete marker is shadowing. Deleting it could cause unrecoverable data loss.
+			// It would be unexpected to ever encounter this case in Mimir, but out of caution refuse to delete it.
+			return nil
+		} else {
+			shadowing = append(shadowing, version)
+		}
+	}
+
+	return shadowing
+}
+
+func restore(ctx context.Context, bkt objtools.Bucket, restoreInfo restoreInfo, logger *slog.Logger, dryRun bool) error {
+	target := restoreInfo.target
+
+	if len(restoreInfo.shadowingDeleteMarkers) == 0 {
+		if dryRun {
+			logger.Info("dry run: would restore", "object", target.objectName, "version", target.info.VersionID)
+			return nil
+		}
+
+		if err := bkt.RestoreVersion(ctx, target.objectName, target.info); err != nil {
+			return errors.Wrapf(err, "failed to restore object %s with version %s", target.objectName, target.info.VersionID)
+		}
+
+		logger.Info("restored an object version", "object", target.objectName, "version", target.info.VersionID)
+		return nil
+	}
+
+	for _, deleteMarker := range restoreInfo.shadowingDeleteMarkers {
+		if dryRun {
+			logger.Info("dry run: would remove delete marker", "object", deleteMarker.objectName, "version", deleteMarker.info.VersionID)
+			continue
+		}
+
+		err := bkt.Delete(ctx, deleteMarker.objectName, objtools.DeleteOptions{
+			VersionID: deleteMarker.info.VersionID,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to remove a delete marker from object %s with version %s", deleteMarker.objectName, deleteMarker.info.VersionID)
+		}
+		logger.Info("removed delete marker", "object", deleteMarker.objectName, "version", deleteMarker.info.VersionID)
+	}
+
+	return nil
 }
 
 func handleMarkers(ctx context.Context, bkt objtools.Bucket, tenantID string, blockID ulid.ULID, globalState globalMarkerState,

--- a/tools/undelete-blocks/main.go
+++ b/tools/undelete-blocks/main.go
@@ -553,7 +553,7 @@ func restore(ctx context.Context, bkt objtools.Bucket, restoreInfo restoreInfo, 
 
 	for _, deleteMarker := range restoreInfo.shadowingDeleteMarkers {
 		if dryRun {
-			logger.Info("dry run: would remove delete marker", "object", deleteMarker.objectName, "version", deleteMarker.info.VersionID)
+			logger.Info("dry run: would remove S3 delete marker", "object", deleteMarker.objectName, "version", deleteMarker.info.VersionID)
 			continue
 		}
 
@@ -561,9 +561,9 @@ func restore(ctx context.Context, bkt objtools.Bucket, restoreInfo restoreInfo, 
 			VersionID: deleteMarker.info.VersionID,
 		})
 		if err != nil {
-			return errors.Wrapf(err, "failed to remove a delete marker from object %s with version %s", deleteMarker.objectName, deleteMarker.info.VersionID)
+			return errors.Wrapf(err, "failed to remove an S3 delete marker from object %s with version %s", deleteMarker.objectName, deleteMarker.info.VersionID)
 		}
-		logger.Info("removed delete marker", "object", deleteMarker.objectName, "version", deleteMarker.info.VersionID)
+		logger.Info("removed S3 delete marker", "object", deleteMarker.objectName, "version", deleteMarker.info.VersionID)
 	}
 
 	return nil

--- a/tools/undelete-blocks/main_test.go
+++ b/tools/undelete-blocks/main_test.go
@@ -511,9 +511,9 @@ func TestRestoreDryRun(t *testing.T) {
 	}
 
 	// Passing a nil bucket as a trap. A dry run should not touch it
-	restore(context.Background(), nil, r, nopSlog(), true)
+	require.NoError(t, restore(context.Background(), nil, r, nopSlog(), true))
 	r.shadowingDeleteMarkers = nil
-	restore(context.Background(), nil, r, nopSlog(), true)
+	require.NoError(t, restore(context.Background(), nil, r, nopSlog(), true))
 }
 
 func nopSlog() *slog.Logger {

--- a/tools/undelete-blocks/main_test.go
+++ b/tools/undelete-blocks/main_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -421,7 +422,101 @@ func TestHandleNoCompactMarker(t *testing.T) {
 	}
 }
 
+func v(t int, isDeleteMarker bool) version {
+	return version{
+		lastModified: time.Unix(int64(t), 0),
+		info: objtools.VersionInfo{
+			VersionID:      strconv.FormatInt(int64(t), 10),
+			IsDeleteMarker: isDeleteMarker,
+		},
+	}
+}
+
+func TestShadowingDeleteMarkers(t *testing.T) {
+	targetTime := 5
+	target := v(targetTime, false)
+
+	testCases := map[string]struct {
+		versions    []version
+		expectStart int
+		expectEnd   int
+	}{
+		"empty": {
+			versions: nil,
+		},
+		"single delete": {
+			versions:    []version{target, v(targetTime+1, true)},
+			expectStart: 1,
+			expectEnd:   2,
+		},
+		"surrounding delete": {
+			versions:    []version{v(targetTime-1, true), target, v(targetTime+1, true)},
+			expectStart: 2,
+			expectEnd:   3,
+		},
+		"multiple delete": {
+			versions:    []version{target, v(targetTime+1, true), v(targetTime+2, true)},
+			expectStart: 1,
+			expectEnd:   3,
+		},
+		"single delete unordered": {
+			versions:    []version{v(targetTime+1, true), target},
+			expectStart: 0,
+			expectEnd:   1,
+		},
+		"non-delete marker shadow": {
+			versions: []version{target, v(targetTime+1, false)},
+		},
+		"mixed shadow": {
+			versions: []version{target, v(targetTime+1, true), v(targetTime+2, false)},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := deleteMarkersShadowingTarget(tc.versions, target)
+			if tc.expectStart != tc.expectEnd {
+				require.Equal(t, tc.versions[tc.expectStart:tc.expectEnd], actual)
+			} else {
+				require.Empty(t, actual)
+			}
+		})
+	}
+}
+
+func TestBuildRestore(t *testing.T) {
+	targetTime := 5
+	target := v(targetTime, false)
+	versions := []version{target, v(targetTime+1, true)}
+
+	for _, allowVersionDelete := range []bool{false, true} {
+		restoreInfo := buildRestore(
+			versions,
+			target,
+			allowVersionDelete,
+		)
+		require.Equal(t, restoreInfo.target, target)
+		if allowVersionDelete {
+			require.Equal(t, versions[1:2], restoreInfo.shadowingDeleteMarkers)
+		} else {
+			require.Empty(t, restoreInfo.shadowingDeleteMarkers)
+		}
+	}
+}
+
+func TestRestoreDryRun(t *testing.T) {
+	r := restoreInfo{
+		shadowingDeleteMarkers: []version{v(0, true)},
+		target:                 v(0, false),
+	}
+
+	// Passing a nil bucket as a trap. A dry run should not touch it
+	restore(context.Background(), nil, r, nopSlog(), true)
+	r.shadowingDeleteMarkers = nil
+	restore(context.Background(), nil, r, nopSlog(), true)
+}
+
 func nopSlog() *slog.Logger {
-	// there's a proposal to make this more direct: https://github.com/golang/go/issues/62005
+	// slog.DiscardHandler can be used in go 1.24: https://github.com/golang/go/issues/62005
 	return slog.New(slog.NewJSONHandler(io.Discard, nil))
 }


### PR DESCRIPTION
Currently `undelete-blocks` is written in a generic way that relies on copying a noncurrent version's data to restore an object. 

#### What this PR does

When using S3-compatible object storage, copying data can be avoided by removing S3 delete markers instead (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManagingDelMarkers.html#RemDelMarker). This PR adds support for this  in `undelete-blocks`. This is a significant optimization when large amounts of data are involved.

It is important to note that deleting versions does introduce risk since it is irreversible. I made a choice to restrict the version deletion to only delete markers (which have no data). If an object is overwritten with a non-delete marker then data is copied like before. This felt like a good compromise to make since differing overwrites for an object within a block is unexpected in Mimir.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir-squad/issues/1805 (this is a private issue, but in summary it's listing potential follow-up improvements related to this tool).

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
