### PR TITLE
Block-builder-scheduler: offset tracking, job computation (take 2)

### DIFF
--- a/development/mimir-ingest-storage/config/grafana-agent.flow
+++ b/development/mimir-ingest-storage/config/grafana-agent.flow
@@ -101,6 +101,30 @@ prometheus.scrape "metrics_local_mimir_read_write_mode_mimir_backend" {
         scrape_classic_histograms = true
 }
 
+prometheus.scrape "metrics_local_mimir_block_builder" {
+        targets = concat(
+                [{
+                        __address__ = "mimir-block-builder-1:8080",
+                        cluster     = "docker-compose",
+                        container   = "mimir-block-builder",
+                        namespace   = "mimir-read-write-mode",
+                }],
+                [{
+                        __address__ = "mimir-block-builder-scheduler-1:8080",
+                        cluster     = "docker-compose",
+                        container   = "mimir-block-builder-scheduler",
+                        namespace   = "mimir-read-write-mode",
+                }],
+        )
+        forward_to      = [prometheus.remote_write.metrics_local.receiver]
+        job_name        = "mimir-read-write-mode/mimir-block-builder"
+        scrape_interval = "5s"
+        scrape_timeout  = "5s"
+
+        enable_protobuf_negotiation = true
+        scrape_classic_histograms = true
+}
+
 prometheus.remote_write "metrics_local" {
         endpoint {
                 name                   = "local"

--- a/development/mimir-ingest-storage/config/mimir.yaml
+++ b/development/mimir-ingest-storage/config/mimir.yaml
@@ -33,6 +33,11 @@ block_builder:
     update_interval: 5s
     max_update_age: 30m
 
+block_builder_scheduler:
+  scheduling_interval: 30s
+  job_size: 1m
+  startup_observe_time: 5s
+
 blocks_storage:
   s3:
     bucket_name:       mimir-blocks

--- a/pkg/blockbuilder/config.go
+++ b/pkg/blockbuilder/config.go
@@ -61,7 +61,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.DurationVar(&cfg.LookbackOnNoCommit, "block-builder.lookback-on-no-commit", 12*time.Hour, "How much of the historical records to look back when there is no kafka commit for a partition.")
 	f.IntVar(&cfg.ApplyMaxGlobalSeriesPerUserBelow, "block-builder.apply-max-global-series-per-user-below", 0, "Apply the global series limit per partition if the global series limit for the user is <= this given value. 0 means limits are disabled. If a user's limit is more than the given value, then the limits are not applied as well.")
 	f.BoolVar(&cfg.NoPartiallyConsumedRegion, "block-builder.no-partially-consumed-region", false, "Get rid of the 'last seen' logic and instead consume everything between two offsets to build the block.")
-	cfg.SchedulerConfig.GRPCClientConfig.RegisterFlags(f)
+	cfg.SchedulerConfig.RegisterFlags(f)
 }
 
 func (cfg *SchedulerConfig) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/blockbuilder/scheduler/config.go
+++ b/pkg/blockbuilder/scheduler/config.go
@@ -11,11 +11,14 @@ import (
 )
 
 type Config struct {
-	ConsumerGroup      string        `yaml:"consumer_group"`
-	SchedulingInterval time.Duration `yaml:"kafka_monitor_interval"`
-	ConsumeInterval    time.Duration `yaml:"consume_interval"`
-	StartupObserveTime time.Duration `yaml:"startup_observe_time"`
-	JobLeaseExpiry     time.Duration `yaml:"job_lease_expiry"`
+	ConsumerGroup       string        `yaml:"consumer_group"`
+	SchedulingInterval  time.Duration `yaml:"scheduling_interval"`
+	JobSize             time.Duration `yaml:"job_size"`
+	StartupObserveTime  time.Duration `yaml:"startup_observe_time"`
+	JobLeaseExpiry      time.Duration `yaml:"job_lease_expiry"`
+	LookbackOnNoCommit  time.Duration `yaml:"lookback_on_no_commit" category:"advanced"`
+	MaxScanAge          time.Duration `yaml:"max_scan_age" category:"advanced"`
+	MaxJobsPerPartition int           `yaml:"max_jobs_per_partition" category:"advanced"`
 
 	// Config parameters defined outside the block-builder-scheduler config and are injected dynamically.
 	Kafka ingest.KafkaConfig `yaml:"-"`
@@ -23,10 +26,13 @@ type Config struct {
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.ConsumerGroup, "block-builder-scheduler.consumer-group", "block-builder", "The Kafka consumer group used for getting/setting commmitted offsets.")
-	f.DurationVar(&cfg.SchedulingInterval, "block-builder-scheduler.scheduling-interval", 20*time.Second, "How frequently to recompute the schedule.")
-	f.DurationVar(&cfg.ConsumeInterval, "block-builder-scheduler.consume-interval", 1*time.Hour, "Interval between consumption cycles.")
-	f.DurationVar(&cfg.StartupObserveTime, "block-builder-scheduler.startup-observe-time", 25*time.Second, "How long to observe worker state before scheduling jobs.")
-	f.DurationVar(&cfg.JobLeaseExpiry, "block-builder-scheduler.job-lease-expiry", 2*time.Minute, "How long a job lease will live for before expiring.")
+	f.DurationVar(&cfg.SchedulingInterval, "block-builder-scheduler.scheduling-interval", 1*time.Minute, "How frequently to recompute the schedule.")
+	f.DurationVar(&cfg.JobSize, "block-builder-scheduler.job-size", 1*time.Hour, "How long jobs (and therefore blocks) should be.")
+	f.DurationVar(&cfg.StartupObserveTime, "block-builder-scheduler.startup-observe-time", 1*time.Minute, "How long to observe worker state before scheduling jobs.")
+	f.DurationVar(&cfg.JobLeaseExpiry, "block-builder-scheduler.job-lease-expiry", 2*time.Minute, "How long a job lease will live before expiring.")
+	f.DurationVar(&cfg.LookbackOnNoCommit, "block-builder-scheduler.lookback-on-no-commit", 6*time.Hour, "How much to look back if a commit is not found for a partition.")
+	f.DurationVar(&cfg.MaxScanAge, "block-builder-scheduler.max-scan-age", 12*time.Hour, "The oldest record age to consider when scanning for jobs.")
+	f.IntVar(&cfg.MaxJobsPerPartition, "block-builder-scheduler.max-jobs-per-partition", 1, "The maximum number of jobs that can be scheduled for a partition.")
 }
 
 func (cfg *Config) Validate() error {
@@ -39,14 +45,24 @@ func (cfg *Config) Validate() error {
 	if cfg.SchedulingInterval <= 0 {
 		return fmt.Errorf("scheduling interval (%d) must be positive", cfg.SchedulingInterval)
 	}
-	if cfg.ConsumeInterval <= 0 {
-		return fmt.Errorf("consume interval (%d) must be positive", cfg.ConsumeInterval)
+	if cfg.JobSize <= 0 {
+		return fmt.Errorf("job size (%d) must be positive", cfg.JobSize)
 	}
 	if cfg.StartupObserveTime <= 0 {
 		return fmt.Errorf("startup observe time (%d) must be positive", cfg.StartupObserveTime)
 	}
 	if cfg.JobLeaseExpiry <= 0 {
 		return fmt.Errorf("job lease expiry (%d) must be positive", cfg.JobLeaseExpiry)
+	}
+	if cfg.LookbackOnNoCommit <= 0 {
+		return fmt.Errorf("lookback on no commit (%d) must be positive", cfg.LookbackOnNoCommit)
+	}
+	if cfg.MaxScanAge <= 0 {
+		return fmt.Errorf("min scan age (%d) must be positive", cfg.MaxScanAge)
+	}
+	if cfg.MaxJobsPerPartition != 1 {
+		// TODO: revise once we've implemented safe bookkeeping under parallel region consumption.
+		return fmt.Errorf("max jobs per partition (%d) must be 1", cfg.MaxJobsPerPartition)
 	}
 	return nil
 }

--- a/pkg/blockbuilder/scheduler/jobs.go
+++ b/pkg/blockbuilder/scheduler/jobs.go
@@ -267,7 +267,7 @@ func (s *jobQueue[T]) count() int {
 	return len(s.jobs)
 }
 
-// count returns the number of assigned jobs in the jobQueue.
+// assigned returns the number of assigned jobs in the jobQueue.
 func (s *jobQueue[T]) assigned() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/blockbuilder/scheduler/jobs.go
+++ b/pkg/blockbuilder/scheduler/jobs.go
@@ -268,6 +268,20 @@ func (s *jobQueue[T]) count() int {
 	return len(s.jobs)
 }
 
+// count returns the number of assigned jobs in the jobQueue.
+func (s *jobQueue[T]) assigned() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	count := 0
+	for _, j := range s.jobs {
+		if j.assignee != "" {
+			count++
+		}
+	}
+	return count
+}
+
 type job[T any] struct {
 	key jobKey
 

--- a/pkg/blockbuilder/scheduler/jobs.go
+++ b/pkg/blockbuilder/scheduler/jobs.go
@@ -125,16 +125,7 @@ func (s *jobQueue[T]) addOrUpdate(id string, spec T) {
 		return
 	}
 
-	// Otherwise, we need to add a new job. See if the policy would allow it.
-
-	existingJobs := make([]*T, 0, len(s.jobs))
-	for _, j := range s.jobs {
-		existingJobs = append(existingJobs, &j.spec)
-	}
-	if !s.creationPolicy.canCreateJob(jobKey{id: id}, &spec, existingJobs) {
-		level.Debug(s.logger).Log("msg", "job creation policy disallowed job", "job_id", id)
-		return
-	}
+	// Otherwise, we need to add a new job.
 
 	j := &job[T]{
 		key: jobKey{

--- a/pkg/blockbuilder/scheduler/jobs.go
+++ b/pkg/blockbuilder/scheduler/jobs.go
@@ -129,7 +129,6 @@ func (s *jobQueue[T]) add(id string, spec T) error {
 		existingJobs = append(existingJobs, &j.spec)
 	}
 	if !s.creationPolicy.canCreateJob(jobKey{id: id}, &spec, existingJobs) {
-		level.Debug(s.logger).Log("msg", "job creation policy disallowed job", "job_id", id)
 		return errJobCreationDisallowed
 	}
 

--- a/pkg/blockbuilder/scheduler/jobs_test.go
+++ b/pkg/blockbuilder/scheduler/jobs_test.go
@@ -3,9 +3,6 @@
 package scheduler
 
 import (
-	"container/heap"
-	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -19,12 +16,8 @@ type testSpec struct {
 	commitRecTs time.Time
 }
 
-func testSpecLess(a, b testSpec) bool {
-	return a.commitRecTs.Before(b.commitRecTs)
-}
-
 func TestAssign(t *testing.T) {
-	s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), testSpecLess)
+	s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), noOpJobCreationPolicy[testSpec]{})
 
 	j0, j0spec, err := s.assign("w0")
 	require.Empty(t, j0.id)
@@ -52,7 +45,7 @@ func TestAssign(t *testing.T) {
 }
 
 func TestAssignComplete(t *testing.T) {
-	s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), testSpecLess)
+	s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), noOpJobCreationPolicy[testSpec]{})
 
 	{
 		err := s.completeJob(jobKey{"rando job", 965}, "w0")
@@ -96,7 +89,7 @@ func TestAssignComplete(t *testing.T) {
 }
 
 func TestLease(t *testing.T) {
-	s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), testSpecLess)
+	s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), noOpJobCreationPolicy[testSpec]{})
 	s.addOrUpdate("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
 	jk, jspec, err := s.assign("w0")
 	require.NotZero(t, jk.id)
@@ -137,7 +130,7 @@ func TestLease(t *testing.T) {
 // TestImportJob tests the importJob method - the method that is called to learn
 // about jobs in-flight from a previous scheduler instance.
 func TestImportJob(t *testing.T) {
-	s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), testSpecLess)
+	s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), noOpJobCreationPolicy[testSpec]{})
 	spec := testSpec{commitRecTs: time.Now().Add(-1 * time.Hour)}
 	require.NoError(t, s.importJob(jobKey{"job1", 122}, "w0", spec))
 	require.NoError(t, s.importJob(jobKey{"job1", 123}, "w2", spec))
@@ -153,42 +146,39 @@ func TestImportJob(t *testing.T) {
 	require.Equal(t, "w2", j.assignee)
 }
 
-func TestMinHeap(t *testing.T) {
-	n := 517
-	jobs := make([]*job[testSpec], n)
-	order := make([]int, n)
-	for i := 0; i < n; i++ {
-		jobs[i] = &job[testSpec]{
-			key: jobKey{
-				id:    fmt.Sprintf("job%d", i),
-				epoch: 0,
-			},
-			spec: testSpec{topic: "hello", commitRecTs: time.Unix(int64(i), 0)},
-		}
-		order[i] = i
-	}
+func TestJobCreationPolicies(t *testing.T) {
+	t.Run("noOpJobCreationPolicy", func(t *testing.T) {
+		s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), noOpJobCreationPolicy[testSpec]{})
 
-	// Push them in random order.
-	r := rand.New(rand.NewSource(9900))
-	r.Shuffle(len(order), func(i, j int) { order[i], order[j] = order[j], order[i] })
+		// noOp policy should always allow job creation
+		s.addOrUpdate("job1", testSpec{topic: "topic1"})
+		s.addOrUpdate("job2", testSpec{topic: "topic2"})
 
-	h := jobHeap[*job[testSpec]]{
-		less: func(a, b *job[testSpec]) bool {
-			return testSpecLess(a.spec, b.spec)
-		},
-	}
+		_, ok1 := s.jobs["job1"]
+		require.True(t, ok1, "job1 should be created")
+		_, ok2 := s.jobs["job2"]
+		require.True(t, ok2, "job2 should be created")
+	})
 
-	for _, j := range order {
-		heap.Push(&h, jobs[j])
-	}
+	t.Run("allowNone", func(t *testing.T) {
+		s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), allowNoneJobCreationPolicy[testSpec]{})
 
-	require.Equal(t, n, h.Len())
+		// allowNone policy should never allow job creation
+		s.addOrUpdate("job1", testSpec{topic: "topic1"})
+		s.addOrUpdate("job2", testSpec{topic: "topic2"})
 
-	for i := 0; i < len(jobs); i++ {
-		p := heap.Pop(&h).(*job[testSpec])
-		println(i)
-		require.Equal(t, jobs[i], p, "pop order should be in increasing commitRecTs")
-	}
-
-	require.Zero(t, h.Len())
+		_, ok1 := s.jobs["job1"]
+		require.False(t, ok1, "job1 should not be created")
+		_, ok2 := s.jobs["job2"]
+		require.False(t, ok2, "job2 should not be created")
+	})
 }
+
+// allowNoneJobCreationPolicy is a job creation policy that never allows job creation.
+type allowNoneJobCreationPolicy[T any] struct{}
+
+func (p allowNoneJobCreationPolicy[T]) canCreateJob(_ jobKey, _ *T, _ []*T) bool { // nolint:unused
+	return false
+}
+
+var _ jobCreationPolicy[any] = (*allowNoneJobCreationPolicy[any])(nil)

--- a/pkg/blockbuilder/scheduler/jobs_test.go
+++ b/pkg/blockbuilder/scheduler/jobs_test.go
@@ -24,7 +24,8 @@ func TestAssign(t *testing.T) {
 	require.Zero(t, j0spec)
 	require.ErrorIs(t, err, errNoJobAvailable)
 
-	s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
+	e := s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
+	require.NoError(t, e)
 	j1, j1spec, err := s.assign("w0")
 	require.NotEmpty(t, j1.id)
 	require.NotZero(t, j1spec)
@@ -52,7 +53,8 @@ func TestAssignComplete(t *testing.T) {
 		require.ErrorIs(t, err, errJobNotFound)
 	}
 
-	s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
+	e := s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
+	require.NoError(t, e)
 	jk, jspec, err := s.assign("w0")
 	require.NotZero(t, jk)
 	require.NotZero(t, jspec)
@@ -90,7 +92,8 @@ func TestAssignComplete(t *testing.T) {
 
 func TestLease(t *testing.T) {
 	s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), noOpJobCreationPolicy[testSpec]{})
-	s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
+	e := s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
+	require.NoError(t, e)
 	jk, jspec, err := s.assign("w0")
 	require.NotZero(t, jk.id)
 	require.NotZero(t, jspec)

--- a/pkg/blockbuilder/scheduler/jobs_test.go
+++ b/pkg/blockbuilder/scheduler/jobs_test.go
@@ -24,7 +24,7 @@ func TestAssign(t *testing.T) {
 	require.Zero(t, j0spec)
 	require.ErrorIs(t, err, errNoJobAvailable)
 
-	s.addOrUpdate("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
+	s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
 	j1, j1spec, err := s.assign("w0")
 	require.NotEmpty(t, j1.id)
 	require.NotZero(t, j1spec)
@@ -36,7 +36,7 @@ func TestAssign(t *testing.T) {
 	require.Zero(t, j2spec)
 	require.ErrorIs(t, err, errNoJobAvailable)
 
-	s.addOrUpdate("job2", testSpec{topic: "hello2", commitRecTs: time.Now()})
+	s.add("job2", testSpec{topic: "hello2", commitRecTs: time.Now()})
 	j3, j3spec, err := s.assign("w0")
 	require.NotZero(t, j3.id)
 	require.NotZero(t, j3spec)
@@ -52,7 +52,7 @@ func TestAssignComplete(t *testing.T) {
 		require.ErrorIs(t, err, errJobNotFound)
 	}
 
-	s.addOrUpdate("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
+	s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
 	jk, jspec, err := s.assign("w0")
 	require.NotZero(t, jk)
 	require.NotZero(t, jspec)
@@ -90,7 +90,7 @@ func TestAssignComplete(t *testing.T) {
 
 func TestLease(t *testing.T) {
 	s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), noOpJobCreationPolicy[testSpec]{})
-	s.addOrUpdate("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
+	s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
 	jk, jspec, err := s.assign("w0")
 	require.NotZero(t, jk.id)
 	require.NotZero(t, jspec)
@@ -151,8 +151,8 @@ func TestJobCreationPolicies(t *testing.T) {
 		s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), noOpJobCreationPolicy[testSpec]{})
 
 		// noOp policy should always allow job creation
-		s.addOrUpdate("job1", testSpec{topic: "topic1"})
-		s.addOrUpdate("job2", testSpec{topic: "topic2"})
+		require.NoError(t, s.add("job1", testSpec{topic: "topic1"}))
+		require.NoError(t, s.add("job2", testSpec{topic: "topic2"}))
 
 		_, ok1 := s.jobs["job1"]
 		require.True(t, ok1, "job1 should be created")
@@ -164,8 +164,8 @@ func TestJobCreationPolicies(t *testing.T) {
 		s := newJobQueue(988*time.Hour, test.NewTestingLogger(t), allowNoneJobCreationPolicy[testSpec]{})
 
 		// allowNone policy should never allow job creation
-		s.addOrUpdate("job1", testSpec{topic: "topic1"})
-		s.addOrUpdate("job2", testSpec{topic: "topic2"})
+		require.ErrorIs(t, s.add("job1", testSpec{topic: "topic1"}), errJobCreationDisallowed)
+		require.ErrorIs(t, s.add("job2", testSpec{topic: "topic2"}), errJobCreationDisallowed)
 
 		_, ok1 := s.jobs["job1"]
 		require.False(t, ok1, "job1 should not be created")

--- a/pkg/blockbuilder/scheduler/jobs_test.go
+++ b/pkg/blockbuilder/scheduler/jobs_test.go
@@ -37,7 +37,8 @@ func TestAssign(t *testing.T) {
 	require.Zero(t, j2spec)
 	require.ErrorIs(t, err, errNoJobAvailable)
 
-	s.add("job2", testSpec{topic: "hello2", commitRecTs: time.Now()})
+	e = s.add("job2", testSpec{topic: "hello2", commitRecTs: time.Now()})
+	require.NoError(t, e)
 	j3, j3spec, err := s.assign("w0")
 	require.NotZero(t, j3.id)
 	require.NotZero(t, j3spec)

--- a/pkg/blockbuilder/scheduler/metrics.go
+++ b/pkg/blockbuilder/scheduler/metrics.go
@@ -14,6 +14,7 @@ type schedulerMetrics struct {
 	partitionEndOffset       *prometheus.GaugeVec
 	flushFailed              prometheus.Counter
 	outstandingJobs          prometheus.Gauge
+	pendingJobs              *prometheus.GaugeVec
 }
 
 func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
@@ -44,5 +45,9 @@ func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
 			Name: "cortex_blockbuilder_scheduler_outstanding_jobs",
 			Help: "The number of outstanding jobs.",
 		}),
+		pendingJobs: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_blockbuilder_scheduler_pending_jobs",
+			Help: "The number of jobs in the pending queues.",
+		}, []string{"partition"}),
 	}
 }

--- a/pkg/blockbuilder/scheduler/metrics.go
+++ b/pkg/blockbuilder/scheduler/metrics.go
@@ -13,6 +13,7 @@ type schedulerMetrics struct {
 	partitionCommittedOffset *prometheus.GaugeVec
 	partitionEndOffset       *prometheus.GaugeVec
 	flushFailed              prometheus.Counter
+	fetchOffsetsFailed       prometheus.Counter
 	outstandingJobs          prometheus.Gauge
 	assignedJobs             prometheus.Gauge
 	pendingJobs              *prometheus.GaugeVec
@@ -41,6 +42,10 @@ func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
 		flushFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_blockbuilder_scheduler_flush_failed_total",
 			Help: "The total number of Kafka flushes that failed.",
+		}),
+		fetchOffsetsFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_blockbuilder_scheduler_fetch_offsets_failed_total",
+			Help: "The number of times we've persistently failed to fetch committed offsets.",
 		}),
 		outstandingJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_blockbuilder_scheduler_outstanding_jobs",

--- a/pkg/blockbuilder/scheduler/metrics.go
+++ b/pkg/blockbuilder/scheduler/metrics.go
@@ -12,6 +12,8 @@ type schedulerMetrics struct {
 	partitionStartOffset     *prometheus.GaugeVec
 	partitionCommittedOffset *prometheus.GaugeVec
 	partitionEndOffset       *prometheus.GaugeVec
+	flushFailed              prometheus.Counter
+	outstandingJobs          prometheus.Gauge
 }
 
 func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
@@ -34,5 +36,13 @@ func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
 			Name: "cortex_blockbuilder_scheduler_partition_committed_offset",
 			Help: "The observed committed offset of each partition.",
 		}, []string{"partition"}),
+		flushFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_blockbuilder_scheduler_flush_failed_total",
+			Help: "The total number of Kafka flushes that failed.",
+		}),
+		outstandingJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_blockbuilder_scheduler_outstanding_jobs",
+			Help: "The number of outstanding jobs.",
+		}),
 	}
 }

--- a/pkg/blockbuilder/scheduler/metrics.go
+++ b/pkg/blockbuilder/scheduler/metrics.go
@@ -14,6 +14,7 @@ type schedulerMetrics struct {
 	partitionEndOffset       *prometheus.GaugeVec
 	flushFailed              prometheus.Counter
 	outstandingJobs          prometheus.Gauge
+	assignedJobs             prometheus.Gauge
 	pendingJobs              *prometheus.GaugeVec
 }
 
@@ -44,6 +45,10 @@ func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
 		outstandingJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_blockbuilder_scheduler_outstanding_jobs",
 			Help: "The number of outstanding jobs.",
+		}),
+		assignedJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_blockbuilder_scheduler_assigned_jobs",
+			Help: "The number of jobs assigned to workers.",
 		}),
 		pendingJobs: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_blockbuilder_scheduler_pending_jobs",

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -301,7 +301,6 @@ func (s *BlockBuilderScheduler) enqueuePendingJobsWorker(ctx context.Context) {
 
 // enqueuePendingJobs moves per-partition pending jobs to the active job queue
 // for assignment to workers, subject to the job creation policy.
-// Assumes the scheduler mutex is held.
 func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 	// For each partition, attempt to enqueue jobs until we run into a rejection
 	// from the job creation policy. Pending jobs are created in order of their

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -104,6 +104,7 @@ func (s *BlockBuilderScheduler) running(ctx context.Context) error {
 
 	s.metrics.outstandingJobs.Set(float64(s.jobs.count()))
 	s.metrics.assignedJobs.Set(float64(s.jobs.assigned()))
+
 	updateTick := time.NewTicker(s.cfg.SchedulingInterval)
 	defer updateTick.Stop()
 	for {

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -103,7 +103,7 @@ func (s *BlockBuilderScheduler) running(ctx context.Context) error {
 	level.Info(s.logger).Log("msg", "entering normal operation")
 
 	s.metrics.outstandingJobs.Set(float64(s.jobs.count()))
-
+	s.metrics.assignedJobs.Set(float64(s.jobs.assigned()))
 	updateTick := time.NewTicker(s.cfg.SchedulingInterval)
 	defer updateTick.Stop()
 	for {
@@ -220,6 +220,7 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 	})
 
 	s.metrics.outstandingJobs.Set(float64(s.jobs.count()))
+	s.metrics.assignedJobs.Set(float64(s.jobs.assigned()))
 }
 
 type partitionState struct {

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -591,7 +591,7 @@ func (o *offsetFinder) offsetAfterTime(ctx context.Context, topic string, partit
 
 var _ offsetStore = (*offsetFinder)(nil)
 
-// fetchCommittedOffsets fetches the committed offsets for the given consumer group.
+// fetchCommittedOffsets fetches the committed offsets for the scheduler's consumer group.
 // It returns empty offsets if the consumer group is not found.
 func (s *BlockBuilderScheduler) fetchCommittedOffsets(ctx context.Context) (kadm.Offsets, error) {
 	boff := backoff.New(ctx, backoff.Config{

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -865,6 +865,7 @@ type limitPerPartitionJobCreationPolicy struct {
 }
 
 // canCreateJob allows at most $partitionLimit jobs per partition.
+// TODO(davidgrant): add an error return to explain the reason for rejection.
 func (p limitPerPartitionJobCreationPolicy) canCreateJob(_ jobKey, spec *schedulerpb.JobSpec, existingJobs []*schedulerpb.JobSpec) bool {
 	remaining := p.partitionLimit - 1 // -1: we're about to add one.
 

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -581,7 +581,7 @@ func (s *BlockBuilderScheduler) fetchCommittedOffsets(ctx context.Context) (kadm
 	boff := backoff.New(ctx, backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
 		MaxBackoff: 5 * time.Second,
-		MaxRetries: 0, // Keep trying indefinitely.
+		MaxRetries: 20,
 	})
 	var lastErr error
 

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -253,7 +253,7 @@ func (s *partitionState) updateEndOffset(end int64, ts time.Time, jobSize time.D
 		return nil, nil
 	}
 
-	switch c := newJobBucket.Compare(s.jobBucket); c {
+	switch newJobBucket.Compare(s.jobBucket) {
 	case bucketBefore:
 		// New bucket is before our current one. This should only happen if our
 		// Kafka's end offsets aren't monotonically increasing.

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -425,6 +425,8 @@ func probeInitialJobOffsets(ctx context.Context, offs offsetStore, topic string,
 	}
 
 	sentinels := []*offsetTime{}
+
+	// Pick a more high-resolution interval to scan for the sentinel offsets.
 	scanStep := jobSize / 4
 
 	// Iterate backwards from the boundary time by job size, stopping when we've

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -524,16 +524,16 @@ func TestPartitionState(t *testing.T) {
 
 	var job *schedulerpb.JobSpec
 
-	job = pt.observeOffset(100, time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC))
+	job = pt.observeEndOffset(100, time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC))
 	require.Nil(t, job)
-	job = pt.observeOffset(200, time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC))
+	job = pt.observeEndOffset(200, time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC))
 	require.Equal(t, &schedulerpb.JobSpec{StartOffset: 100, EndOffset: 200}, job)
 
-	require.Nil(t, pt.observeOffset(201, time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC)))
-	require.Nil(t, pt.observeOffset(202, time.Date(2025, 3, 1, 11, 2, 10, 0, time.UTC)))
-	require.Nil(t, pt.observeOffset(203, time.Date(2025, 3, 1, 11, 3, 10, 0, time.UTC)))
+	require.Nil(t, pt.observeEndOffset(201, time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC)))
+	require.Nil(t, pt.observeEndOffset(202, time.Date(2025, 3, 1, 11, 2, 10, 0, time.UTC)))
+	require.Nil(t, pt.observeEndOffset(203, time.Date(2025, 3, 1, 11, 3, 10, 0, time.UTC)))
 
-	job = pt.observeOffset(300, z.Add(2*time.Hour))
+	job = pt.observeEndOffset(300, z.Add(2*time.Hour))
 	require.Equal(t, &schedulerpb.JobSpec{StartOffset: 200, EndOffset: 300}, job)
 }
 
@@ -546,7 +546,7 @@ func TestPartitionState_TerminallyDormantPartition(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		z = z.Add(7 * time.Minute)
-		j := pt.observeOffset(0, z)
+		j := pt.observeEndOffset(0, z)
 		assert.Nil(t, j)
 	}
 }
@@ -558,27 +558,27 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 
 	// A bunch of data observed:
 	var j *schedulerpb.JobSpec
-	j = pt.observeOffset(10, time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC))
+	j = pt.observeEndOffset(10, time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC))
 	assert.Nil(t, j)
-	j = pt.observeOffset(11, time.Date(2025, 3, 1, 10, 1, 11, 0, time.UTC))
+	j = pt.observeEndOffset(11, time.Date(2025, 3, 1, 10, 1, 11, 0, time.UTC))
 	assert.Nil(t, j)
-	j = pt.observeOffset(12, time.Date(2025, 3, 1, 10, 1, 12, 0, time.UTC))
+	j = pt.observeEndOffset(12, time.Date(2025, 3, 1, 10, 1, 12, 0, time.UTC))
 	assert.Nil(t, j)
 	// data ceases. continue to get observations in the same bucket.
-	j = pt.observeOffset(12, time.Date(2025, 3, 1, 10, 1, 13, 0, time.UTC))
+	j = pt.observeEndOffset(12, time.Date(2025, 3, 1, 10, 1, 13, 0, time.UTC))
 	assert.Nil(t, j)
 
 	// as we cross into the next bucket, there's still no new data.
-	j = pt.observeOffset(12, time.Date(2025, 3, 1, 11, 1, 0, 0, time.UTC))
+	j = pt.observeEndOffset(12, time.Date(2025, 3, 1, 11, 1, 0, 0, time.UTC))
 	assert.Equal(t, &schedulerpb.JobSpec{StartOffset: 10, EndOffset: 12}, j)
 
 	// and we keep getting the same offset.
-	j = pt.observeOffset(12, time.Date(2025, 3, 1, 11, 2, 0, 0, time.UTC))
+	j = pt.observeEndOffset(12, time.Date(2025, 3, 1, 11, 2, 0, 0, time.UTC))
 	assert.Nil(t, j)
-	j = pt.observeOffset(12, time.Date(2025, 3, 1, 11, 3, 0, 0, time.UTC))
+	j = pt.observeEndOffset(12, time.Date(2025, 3, 1, 11, 3, 0, 0, time.UTC))
 	assert.Nil(t, j)
 
 	// And in the next job bucket, still no new data.
-	j = pt.observeOffset(12, time.Date(2025, 3, 1, 12, 1, 0, 0, time.UTC))
+	j = pt.observeEndOffset(12, time.Date(2025, 3, 1, 12, 1, 0, 0, time.UTC))
 	assert.Nil(t, j)
 }

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -893,7 +893,8 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs(t *testing.T) {
 	sched.enqueuePendingJobs()
 	assert.Equal(t, 2, pt.pendingJobs.Len(), "enqueue should be a no-op until the assigned job is completed")
 
-	sched.jobs.completeJob(j, "worker1")
+	e := sched.jobs.completeJob(j, "worker1")
+	require.NoError(t, e)
 
 	sched.enqueuePendingJobs()
 	assert.Equal(t, 1, pt.pendingJobs.Len(), "enqueue should have succeeded after completing the job")

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -41,8 +41,10 @@ func mustSchedulerWithKafkaAddr(t *testing.T, addr string) (*BlockBuilderSchedul
 		Kafka: ingest.KafkaConfig{
 			Topic: "ingest",
 		},
-		ConsumerGroup:      "test-builder",
-		SchedulingInterval: 1000000 * time.Hour,
+		ConsumerGroup:       "test-builder",
+		SchedulingInterval:  1000000 * time.Hour,
+		JobSize:             1 * time.Hour,
+		MaxJobsPerPartition: 1,
 	}
 	reg := prometheus.NewPedanticRegistry()
 	sched, err := New(cfg, test.NewTestingLogger(t), reg)
@@ -65,8 +67,6 @@ func TestStartup(t *testing.T) {
 		require.ErrorContains(t, err, "observation period not complete")
 	}
 
-	now := time.Now()
-
 	// Some jobs that ostensibly exist, but scheduler doesn't know about.
 	j1 := job[schedulerpb.JobSpec]{
 		key: jobKey{
@@ -77,7 +77,6 @@ func TestStartup(t *testing.T) {
 			Topic:       "ingest",
 			Partition:   64,
 			StartOffset: 1000,
-			CommitRecTs: now.Add(-1 * time.Hour),
 		},
 	}
 	j2 := job[schedulerpb.JobSpec]{
@@ -89,7 +88,6 @@ func TestStartup(t *testing.T) {
 			Topic:       "ingest",
 			Partition:   65,
 			StartOffset: 256,
-			CommitRecTs: now.Add(-2 * time.Hour),
 		},
 	}
 	j3 := job[schedulerpb.JobSpec]{
@@ -101,7 +99,6 @@ func TestStartup(t *testing.T) {
 			Topic:       "ingest",
 			Partition:   66,
 			StartOffset: 57,
-			CommitRecTs: now.Add(-3 * time.Hour),
 		},
 	}
 
@@ -147,13 +144,64 @@ func TestStartup(t *testing.T) {
 		Partition:   65,
 		StartOffset: 256,
 		EndOffset:   9111,
-		CommitRecTs: now.Add(-1 * time.Hour),
 	})
 
 	a1key, a1spec, err := sched.assignJob("w0")
 	require.NoError(t, err)
 	require.NotZero(t, a1spec)
 	require.Equal(t, "ingest/65/256", a1key.id)
+}
+
+// Verify that we skip jobs that are before the committed offset due to extraneous bug situations.
+func TestAssignJobSkipsObsoleteOffsets(t *testing.T) {
+	sched, _ := mustScheduler(t)
+	sched.cfg.MaxJobsPerPartition = 0
+	sched.completeObservationMode()
+	// Add some jobs, then move the committed offsets past some of them.
+	s1 := &schedulerpb.JobSpec{
+		Topic:       "ingest",
+		Partition:   1,
+		StartOffset: 256,
+		EndOffset:   9111,
+	}
+	s2 := &schedulerpb.JobSpec{
+		Topic:       "ingest",
+		Partition:   2,
+		StartOffset: 50,
+		EndOffset:   128,
+	}
+	s3 := &schedulerpb.JobSpec{
+		Topic:       "ingest",
+		Partition:   2,
+		StartOffset: 700,
+		EndOffset:   900,
+	}
+
+	sched.addOrUpdateJobs(s1, s2, s3)
+
+	require.Equal(t, 3, sched.jobs.count())
+
+	sched.advanceCommittedOffset("ingest", 1, 256)
+	sched.advanceCommittedOffset("ingest", 2, 500)
+
+	// Advancing offsets doesn't actually remove any jobs.
+	require.Equal(t, 3, sched.jobs.count())
+
+	var assignedJobs []*schedulerpb.JobSpec
+
+	for {
+		_, s, err := sched.assignJob("big-time-worker-64")
+		if errors.Is(err, errNoJobAvailable) {
+			break
+		}
+		require.NoError(t, err)
+		assignedJobs = append(assignedJobs, &s)
+	}
+
+	require.ElementsMatch(t,
+		[]*schedulerpb.JobSpec{s1, s3}, assignedJobs,
+		"s2 should be skipped because its start offset is behind p2's committed offset",
+	)
 }
 
 func TestObservations(t *testing.T) {
@@ -191,7 +239,7 @@ func TestObservations(t *testing.T) {
 	}
 
 	{
-		nq := newJobQueue(988*time.Hour, test.NewTestingLogger(t), specLessThan)
+		nq := newJobQueue(988*time.Hour, test.NewTestingLogger(t), noOpJobCreationPolicy[schedulerpb.JobSpec]{})
 		sched.jobs = nq
 		sched.finalizeObservations()
 		require.Len(t, nq.jobs, 0, "No observations, no jobs")
@@ -214,10 +262,9 @@ func TestObservations(t *testing.T) {
 		clientData = append(clientData, observation{
 			key: jobKey{id: id, epoch: epoch},
 			spec: schedulerpb.JobSpec{
-				Topic:       "ingest",
-				Partition:   partition,
-				CommitRecTs: commitRecTs,
-				EndOffset:   endOffset,
+				Topic:     "ingest",
+				Partition: partition,
+				EndOffset: endOffset,
 			},
 			workerID:  worker,
 			complete:  isComplete,
@@ -302,7 +349,83 @@ func requireOffset(t *testing.T, offs kadm.Offsets, topic string, partition int3
 	require.Equal(t, expected, o.At, msgAndArgs...)
 }
 
-func TestMonitor(t *testing.T) {
+func TestOffsetMovement(t *testing.T) {
+	sched, _ := mustScheduler(t)
+
+	sched.committed = kadm.Offsets{
+		"ingest": {
+			1: kadm.Offset{
+				Topic:     "ingest",
+				Partition: 1,
+				At:        5000,
+			},
+		},
+	}
+	sched.completeObservationMode()
+
+	spec := schedulerpb.JobSpec{
+		Topic:       "ingest",
+		Partition:   1,
+		StartOffset: 5000,
+		EndOffset:   6000,
+	}
+
+	sched.jobs.addOrUpdate("ingest/1/5524", spec)
+	key, _, err := sched.jobs.assign("w0")
+	require.NoError(t, err)
+
+	require.NoError(t, sched.updateJob(key, "w0", false, spec))
+	requireOffset(t, sched.committed, "ingest", 1, 5000, "ingest/1 is in progress, so we should not move the offset")
+	require.NoError(t, sched.updateJob(key, "w0", true, spec))
+	requireOffset(t, sched.committed, "ingest", 1, 6000, "ingest/1 is complete, so offset should be advanced")
+	require.NoError(t, sched.updateJob(key, "w0", true, spec))
+	requireOffset(t, sched.committed, "ingest", 1, 6000, "ingest/1 is complete, so offset should be advanced")
+	sched.advanceCommittedOffset("ingest", 1, 2000)
+	requireOffset(t, sched.committed, "ingest", 1, 6000, "committed offsets cannot rewind")
+
+	sched.advanceCommittedOffset("ingest", 2, 6222)
+	requireOffset(t, sched.committed, "ingest", 2, 6222, "should create knowledge of partition 2")
+}
+
+func TestKafkaFlush(t *testing.T) {
+	sched, _ := mustScheduler(t)
+	ctx := context.Background()
+	var err error
+	sched.committed, err = sched.fetchCommittedOffsets(ctx)
+	require.NoError(t, err)
+
+	sched.completeObservationMode()
+
+	flushAndRequireOffsets := func(topic string, offsets map[int32]int64, args ...interface{}) {
+		require.NoError(t, sched.flushOffsetsToKafka(ctx))
+		offs, err := sched.fetchCommittedOffsets(ctx)
+		require.NoError(t, err)
+		for partition, expected := range offsets {
+			requireOffset(t, offs, topic, partition, expected, args...)
+		}
+	}
+
+	flushAndRequireOffsets("ingest", map[int32]int64{}, "no group found -> no offsets")
+
+	sched.advanceCommittedOffset("ingest", 1, 2000)
+	flushAndRequireOffsets("ingest", map[int32]int64{
+		1: 2000,
+	})
+
+	sched.advanceCommittedOffset("ingest", 4, 65535)
+	flushAndRequireOffsets("ingest", map[int32]int64{
+		1: 2000,
+		4: 65535,
+	})
+
+	sched.advanceCommittedOffset("ingest", 1, 4000)
+	flushAndRequireOffsets("ingest", map[int32]int64{
+		1: 4000,
+		4: 65535,
+	}, "should be able to advance an existing offset")
+}
+
+func TestUpdateSchedule(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
 
@@ -345,10 +468,458 @@ func TestMonitor(t *testing.T) {
 	`), "cortex_blockbuilder_scheduler_partition_end_offset"))
 }
 
-func TestLessThan(t *testing.T) {
-	now := time.Now()
-	oneHourAgo := now.Add(-1 * time.Hour)
-	assert.True(t, specLessThan(schedulerpb.JobSpec{CommitRecTs: oneHourAgo}, schedulerpb.JobSpec{CommitRecTs: now}))
-	assert.False(t, specLessThan(schedulerpb.JobSpec{CommitRecTs: now}, schedulerpb.JobSpec{CommitRecTs: oneHourAgo}))
-	assert.False(t, specLessThan(schedulerpb.JobSpec{CommitRecTs: now}, schedulerpb.JobSpec{CommitRecTs: now}))
+func TestFilterJobsBeforeCommittedOffsets(t *testing.T) {
+	committed := kadm.Offsets{}
+	committed.AddOffset("ingest", 0, 5, 0)
+	committed.AddOffset("ingest", 1, 10, 0)
+
+	jobs := []*schedulerpb.JobSpec{
+		{
+			Topic:       "ingest",
+			Partition:   0,
+			StartOffset: 4,
+		},
+		{
+			Topic:       "ingest",
+			Partition:   0,
+			StartOffset: 5,
+		},
+		{
+			Topic:       "ingest",
+			Partition:   1,
+			StartOffset: 8,
+		},
+		{
+			Topic:       "ingest",
+			Partition:   2,
+			StartOffset: 9,
+		},
+	}
+
+	filtered := filterJobsBeforeCommittedOffsets(jobs, committed)
+
+	require.EqualValues(t, []*schedulerpb.JobSpec{
+		{
+			Topic:       "ingest",
+			Partition:   0,
+			StartOffset: 5,
+		},
+		{
+			Topic:       "ingest",
+			Partition:   2,
+			StartOffset: 9,
+		},
+	}, filtered)
+
+	filtered2 := filterJobsBeforeCommittedOffsets([]*schedulerpb.JobSpec{}, committed)
+	require.Empty(t, filtered2)
+}
+
+type timeOffset struct {
+	time   time.Time
+	offset int64
+}
+
+func TestConsumptionRanges(t *testing.T) {
+	ctx := context.Background()
+
+	type offsetRange struct {
+		start, end int64
+	}
+
+	tests := map[string]struct {
+		offsets        []timeOffset
+		start          int64
+		resume         int64
+		end            int64
+		jobSize        time.Duration
+		boundary       time.Time
+		expectedRanges []offsetRange
+		minScanTime    time.Time
+		msg            string
+	}{
+		"basic hour-based consumption ranges": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC), 1000},
+				{time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC), 2000},
+				{time.Date(2025, 3, 1, 12, 0, 0, 0, time.UTC), 3000},
+				{time.Date(2025, 3, 1, 13, 0, 0, 0, time.UTC), 4000},
+				{time.Date(2025, 3, 1, 14, 0, 0, 0, time.UTC), 5000},
+				{time.Date(2025, 3, 1, 14, 30, 0, 0, time.UTC), 5500},
+				{time.Date(2025, 3, 1, 15, 0, 0, 0, time.UTC), 6000},
+				{time.Date(2025, 3, 1, 16, 0, 0, 0, time.UTC), 7000},
+			},
+			resume:      2000,
+			end:         10001,
+			jobSize:     1 * time.Hour,
+			boundary:    time.Date(2025, 3, 1, 15, 0, 0, 0, time.UTC),
+			minScanTime: time.Date(2025, 2, 20, 10, 0, 0, 0, time.UTC),
+			expectedRanges: []offsetRange{
+				{start: 2000, end: 3000},
+				{start: 3000, end: 4000},
+				{start: 4000, end: 5000},
+				{start: 5000, end: 6000},
+			},
+			msg: "consumption should exclude the offset on the boundary, but otherwise cover (commit, boundary]",
+		},
+		"no new data": {
+			// End offset is the one that was consumed last time.
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 100*1000000, time.UTC), 1000},
+				{time.Date(2025, 3, 1, 10, 0, 0, 101*1000000, time.UTC), 1001},
+				{time.Date(2025, 3, 1, 10, 0, 0, 199*1000000, time.UTC), 1999},
+			},
+			resume:         2000,
+			end:            2000,
+			jobSize:        200 * time.Millisecond,
+			boundary:       time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
+			minScanTime:    time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
+			expectedRanges: []offsetRange{},
+		},
+		"old data with single unconsumed record": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 199*1000000, time.UTC), 1999},
+				{time.Date(2025, 3, 1, 10, 0, 0, 200*1000000, time.UTC), 2000},
+			},
+			resume:      2000,
+			end:         2001,
+			jobSize:     200 * time.Millisecond,
+			boundary:    time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
+			minScanTime: time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
+			expectedRanges: []offsetRange{
+				{start: 2000, end: 2001},
+			},
+		},
+		"one record: no new data": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 199*1000000, time.UTC), 1999},
+			},
+			resume:         2000,
+			end:            2000,
+			jobSize:        200 * time.Millisecond,
+			boundary:       time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
+			minScanTime:    time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
+			expectedRanges: []offsetRange{},
+		},
+		"boundary before data -> no ranges": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 1000*1000000, time.UTC), 1000},
+				{time.Date(2025, 3, 1, 10, 0, 0, 1001*1000000, time.UTC), 1001},
+				{time.Date(2025, 3, 1, 10, 0, 0, 1002*1000000, time.UTC), 1002},
+			},
+			resume:         1000,
+			end:            1003,
+			jobSize:        200 * time.Millisecond,
+			boundary:       time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
+			minScanTime:    time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
+			expectedRanges: []offsetRange{},
+		},
+		"boundary at start of data": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 3000*1000000, time.UTC), 3000},
+				{time.Date(2025, 3, 1, 10, 0, 0, 4000*1000000, time.UTC), 4000},
+			},
+			resume:         3000,
+			end:            4001,
+			jobSize:        200 * time.Millisecond,
+			boundary:       time.Date(2025, 3, 1, 10, 0, 0, 3000*1000000, time.UTC),
+			minScanTime:    time.Date(2025, 2, 20, 10, 0, 0, 3000*1000000, time.UTC),
+			expectedRanges: []offsetRange{},
+			msg:            "all data is >= boundary -> no eligible jobs",
+		},
+		"boundary at end of data": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 3000*1000000, time.UTC), 3000},
+			},
+			resume:         3000,
+			end:            3001,
+			jobSize:        200 * time.Millisecond,
+			boundary:       time.Date(2025, 3, 1, 10, 0, 0, 3000*1000000, time.UTC),
+			minScanTime:    time.Date(2025, 2, 20, 10, 0, 0, 3000*1000000, time.UTC),
+			expectedRanges: []offsetRange{},
+		},
+		"empty partition: no data": {
+			offsets:        []timeOffset{},
+			resume:         0,
+			end:            0,
+			jobSize:        200 * time.Millisecond,
+			boundary:       time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
+			minScanTime:    time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
+			expectedRanges: []offsetRange{},
+		},
+		"data gaps wider than range width": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 99*1000000, time.UTC), 999},
+				{time.Date(2025, 3, 1, 10, 0, 0, 100*1000000, time.UTC), 1000},
+				{time.Date(2025, 3, 1, 10, 0, 0, 101*1000000, time.UTC), 1001},
+				{time.Date(2025, 3, 1, 10, 0, 0, 102*1000000, time.UTC), 1002},
+				{time.Date(2025, 3, 1, 10, 0, 0, 103*1000000, time.UTC), 1003},
+				{time.Date(2025, 3, 1, 10, 0, 0, 104*1000000, time.UTC), 1004},
+				{time.Date(2025, 3, 1, 10, 0, 0, 105*1000000, time.UTC), 1005},
+				{time.Date(2025, 3, 1, 10, 0, 0, 106*1000000, time.UTC), 1006},
+				{time.Date(2025, 3, 1, 10, 0, 0, 107*1000000, time.UTC), 1007},
+				{time.Date(2025, 3, 1, 10, 0, 0, 108*1000000, time.UTC), 1008},
+				{time.Date(2025, 3, 1, 10, 0, 0, 109*1000000, time.UTC), 1009},
+				{time.Date(2025, 3, 1, 10, 0, 0, 110*1000000, time.UTC), 1010},
+				{time.Date(2025, 3, 1, 10, 0, 0, 111*1000000, time.UTC), 1011},
+				{time.Date(2025, 3, 1, 10, 0, 0, 112*1000000, time.UTC), 1012},
+				// (large gap that would produce duplicate jobs in a naive implementation)
+				{time.Date(2025, 3, 1, 10, 0, 0, 500*1000000, time.UTC), 1013},
+				{time.Date(2025, 3, 1, 10, 0, 0, 501*1000000, time.UTC), 1014},
+				{time.Date(2025, 3, 1, 10, 0, 0, 502*1000000, time.UTC), 1015},
+				{time.Date(2025, 3, 1, 10, 0, 0, 503*1000000, time.UTC), 1016},
+				{time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC), 1017},
+			},
+			resume:      1000,
+			end:         10001,
+			jobSize:     100 * time.Millisecond,
+			boundary:    time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
+			minScanTime: time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
+			expectedRanges: []offsetRange{
+				{start: 1000, end: 1013},
+				{start: 1013, end: 1017},
+			},
+		},
+		"records with duplicate timestamps": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 100*1000000, time.UTC), 1000},
+				{time.Date(2025, 3, 1, 10, 0, 0, 101*1000000, time.UTC), 1001},
+				{time.Date(2025, 3, 1, 10, 0, 0, 102*1000000, time.UTC), 1002},
+				{time.Date(2025, 3, 1, 10, 0, 0, 102*1000000, time.UTC), 1003},
+				{time.Date(2025, 3, 1, 10, 0, 0, 102*1000000, time.UTC), 1004},
+				{time.Date(2025, 3, 1, 10, 0, 0, 102*1000000, time.UTC), 1005},
+				{time.Date(2025, 3, 1, 10, 0, 0, 102*1000000, time.UTC), 1006},
+				{time.Date(2025, 3, 1, 10, 0, 0, 102*1000000, time.UTC), 1007},
+				{time.Date(2025, 3, 1, 10, 0, 0, 102*1000000, time.UTC), 1008},
+			},
+			resume:      1000,
+			end:         1009,
+			jobSize:     100 * time.Millisecond,
+			boundary:    time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
+			minScanTime: time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
+			expectedRanges: []offsetRange{
+				{start: 1000, end: 1009},
+			},
+		},
+		"no data between resume and time boundary": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 100*1000000, time.UTC), 1000},
+				{time.Date(2025, 3, 1, 10, 0, 0, 200*1000000, time.UTC), 1001},
+				{time.Date(2025, 3, 1, 10, 0, 0, 300*1000000, time.UTC), 1002},
+				{time.Date(2025, 3, 1, 10, 0, 0, 400*1000000, time.UTC), 1003},
+				{time.Date(2025, 3, 1, 10, 0, 0, 500*1000000, time.UTC), 1004},
+			},
+			resume:      1000,
+			end:         1005,
+			jobSize:     100 * time.Millisecond,
+			boundary:    time.Date(2025, 3, 1, 10, 0, 0, 200*1000000, time.UTC),
+			minScanTime: time.Date(2025, 2, 20, 10, 0, 0, 200*1000000, time.UTC),
+			expectedRanges: []offsetRange{
+				{start: 1000, end: 1001},
+			},
+		},
+		"resumption offset is before min scan time": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 100*1000000, time.UTC), 1001},
+				{time.Date(2025, 3, 1, 10, 0, 0, 200*1000000, time.UTC), 1002},
+				{time.Date(2025, 3, 1, 10, 0, 0, 300*1000000, time.UTC), 1003},
+				{time.Date(2025, 3, 1, 10, 0, 0, 400*1000000, time.UTC), 1004},
+			},
+			resume:      1001,
+			end:         1004,
+			jobSize:     100 * time.Millisecond,
+			boundary:    time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
+			minScanTime: time.Date(2025, 3, 1, 10, 0, 0, 150*1000000, time.UTC),
+			expectedRanges: []offsetRange{
+				{start: 1002, end: 1003},
+				{start: 1003, end: 1004},
+			},
+		},
+		"min scan time later than any data": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 0, 0, 100*1000000, time.UTC), 1001},
+				{time.Date(2025, 3, 1, 10, 0, 0, 200*1000000, time.UTC), 1002},
+				{time.Date(2025, 3, 1, 10, 0, 0, 300*1000000, time.UTC), 1003},
+				{time.Date(2025, 3, 1, 10, 0, 0, 400*1000000, time.UTC), 1004},
+			},
+			resume:         1001,
+			end:            1004,
+			jobSize:        100 * time.Millisecond,
+			boundary:       time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
+			minScanTime:    time.Date(2025, 3, 1, 10, 0, 0, 900*1000000, time.UTC),
+			expectedRanges: []offsetRange{},
+		},
+		"boundary scan skips end and resumption offset in one iteration": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 1, 0, 0, time.UTC), 1001},
+				{time.Date(2025, 3, 1, 10, 2, 58, 0, time.UTC), 1002},
+				{time.Date(2025, 3, 1, 10, 3, 0, 0, time.UTC), 1003},
+				{time.Date(2025, 3, 1, 10, 3, 30, 0, time.UTC), 1004},
+			},
+			resume:      1003,
+			end:         1004,
+			jobSize:     1 * time.Minute,
+			boundary:    time.Date(2025, 3, 1, 10, 3, 40, 0, time.UTC),
+			minScanTime: time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC),
+			expectedRanges: []offsetRange{
+				{start: 1003, end: 1004},
+			},
+		},
+		"resume < start and start == end": {
+			offsets:        []timeOffset{},
+			start:          1004,
+			resume:         1000,
+			end:            1004,
+			jobSize:        1 * time.Minute,
+			boundary:       time.Date(2025, 3, 1, 10, 3, 40, 0, time.UTC),
+			minScanTime:    time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC),
+			expectedRanges: []offsetRange{},
+		},
+		"resume < start < end": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 10, 3, 0, 0, time.UTC), 1003},
+			},
+			start:       1003,
+			resume:      1000,
+			end:         1004,
+			jobSize:     1 * time.Minute,
+			boundary:    time.Date(2025, 3, 1, 10, 3, 40, 0, time.UTC),
+			minScanTime: time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC),
+			expectedRanges: []offsetRange{
+				{start: 1003, end: 1004},
+			},
+		},
+		"resume == start == end": {
+			offsets:        []timeOffset{},
+			start:          1003,
+			resume:         1003,
+			end:            1003,
+			jobSize:        1 * time.Minute,
+			boundary:       time.Date(2025, 3, 1, 10, 3, 40, 0, time.UTC),
+			minScanTime:    time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC),
+			expectedRanges: []offsetRange{},
+		},
+		"hour-based ranges when resume < start": {
+			offsets: []timeOffset{
+				{time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC), 2000},
+				{time.Date(2025, 3, 1, 12, 0, 0, 0, time.UTC), 3000},
+				{time.Date(2025, 3, 1, 13, 0, 0, 0, time.UTC), 4000},
+				{time.Date(2025, 3, 1, 14, 0, 0, 0, time.UTC), 5000},
+				{time.Date(2025, 3, 1, 14, 30, 0, 0, time.UTC), 5500},
+				{time.Date(2025, 3, 1, 15, 0, 0, 0, time.UTC), 6000},
+				{time.Date(2025, 3, 1, 16, 0, 0, 0, time.UTC), 7000},
+			},
+			start:       2000,
+			resume:      100,
+			end:         10001,
+			jobSize:     1 * time.Hour,
+			boundary:    time.Date(2025, 3, 1, 15, 0, 0, 0, time.UTC),
+			minScanTime: time.Date(2025, 1, 20, 10, 0, 0, 0, time.UTC),
+			expectedRanges: []offsetRange{
+				{start: 2000, end: 3000},
+				{start: 3000, end: 4000},
+				{start: 4000, end: 5000},
+				{start: 5000, end: 6000},
+			},
+			msg: "if resumption offset has fallen off the retention window, we should produce jobs beginning at start",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := &mockOffsetFinder{offsets: tt.offsets, end: tt.end}
+			j, err := computePartitionJobs(ctx, f, "topic", 0, tt.start, tt.resume, tt.end, tt.boundary, tt.jobSize, tt.minScanTime, test.NewTestingLogger(t))
+			assert.NoError(t, err)
+
+			for _, err := range validateJobs(j, tt.start, tt.resume, tt.end) {
+				assert.NoError(t, err)
+			}
+
+			// Convert offsetRange to JobSpec.
+			expectedJobs := make([]*schedulerpb.JobSpec, len(tt.expectedRanges))
+			for i, r := range tt.expectedRanges {
+				expectedJobs[i] = &schedulerpb.JobSpec{
+					Topic:       "topic",
+					Partition:   0,
+					StartOffset: r.start,
+					EndOffset:   r.end,
+				}
+			}
+			assert.Equal(t, expectedJobs, j, tt.msg)
+		})
+	}
+}
+
+// Create an offset finder that we can prepopulate with offset scenarios.
+type mockOffsetFinder struct {
+	offsets []timeOffset
+	end     int64
+}
+
+func (o *mockOffsetFinder) offsetAfterTime(_ context.Context, _ string, _ int32, t time.Time) (int64, error) {
+	// scan the offsets slice and return the lowest offset whose time is after t.
+	mint := time.Time{}
+	off := int64(-1)
+	for _, pair := range o.offsets {
+		if pair.time.After(t) {
+			if mint.IsZero() || mint.After(pair.time) {
+				mint = pair.time
+				off = pair.offset
+			}
+		}
+	}
+	if off == -1 {
+		// Like ListOffsetsAfterMilli, we return the end offset if we don't find any new data.
+		return o.end, nil
+	}
+	return off, nil
+}
+
+var _ offsetStore = (*mockOffsetFinder)(nil)
+
+func TestLimitNPolicy(t *testing.T) {
+	allow1 := limitPerPartitionJobCreationPolicy{partitionLimit: 1}
+
+	ok := allow1.canCreateJob(jobKey{id: "job1"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 0}, []*schedulerpb.JobSpec{})
+	require.True(t, ok)
+
+	ok = allow1.canCreateJob(jobKey{id: "job4"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 0}, []*schedulerpb.JobSpec{
+		{Topic: "topic", Partition: 1},
+	})
+	require.True(t, ok)
+
+	ok = allow1.canCreateJob(jobKey{id: "job5"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
+		{Topic: "topic", Partition: 1},
+	})
+	require.False(t, ok)
+
+	ok = allow1.canCreateJob(jobKey{id: "job5"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
+		{Topic: "topic", Partition: 2},
+		{Topic: "topic", Partition: 3},
+		{Topic: "topic", Partition: 3},
+	})
+	require.True(t, ok)
+
+	allow2 := limitPerPartitionJobCreationPolicy{partitionLimit: 2}
+	ok = allow2.canCreateJob(jobKey{id: "job6"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
+		{Topic: "topic", Partition: 2},
+		{Topic: "topic", Partition: 3},
+	})
+	require.True(t, ok)
+	ok = allow2.canCreateJob(jobKey{id: "job6"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
+		{Topic: "topic", Partition: 1},
+		{Topic: "topic", Partition: 2},
+	})
+	require.True(t, ok)
+	ok = allow2.canCreateJob(jobKey{id: "job6"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
+		{Topic: "topic", Partition: 1},
+		{Topic: "topic", Partition: 1},
+	})
+	require.False(t, ok)
+	ok = allow2.canCreateJob(jobKey{id: "job6"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
+		{Topic: "topic", Partition: 1},
+		{Topic: "topic", Partition: 1},
+		{Topic: "topic", Partition: 1},
+	})
+	require.False(t, ok)
 }

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -914,3 +914,21 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_Unlimited(t *testing.T) {
 	sched.enqueuePendingJobs()
 	assert.Equal(t, 0, pt.pendingJobs.Len(), "a single enqueue call should have drained all pending jobs")
 }
+
+func TestBlockBuilderScheduler_EnqueuePendingJobs_CommitRace(t *testing.T) {
+	sched, _ := mustScheduler(t)
+	sched.cfg.MaxJobsPerPartition = 0
+	sched.completeObservationMode(context.Background())
+
+	part := int32(1)
+	pt := sched.getPartitionState(part)
+	pt.addPendingJob(&offsetRange{start: 10, end: 20})
+
+	sched.advanceCommittedOffset("ingest", part, 20)
+
+	assert.Equal(t, 1, pt.pendingJobs.Len())
+	assert.Equal(t, 0, sched.jobs.count())
+	sched.enqueuePendingJobs()
+	assert.Equal(t, 0, pt.pendingJobs.Len())
+	assert.Equal(t, 0, sched.jobs.count(), "the job should have been ignored because it's behind the committed offset")
+}

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -139,13 +139,13 @@ func TestStartup(t *testing.T) {
 	}
 
 	// And we can resume normal operation:
-	sched.jobs.add("ingest/65/256", schedulerpb.JobSpec{
+	e := sched.jobs.add("ingest/65/256", schedulerpb.JobSpec{
 		Topic:       "ingest",
 		Partition:   65,
 		StartOffset: 256,
 		EndOffset:   9111,
 	})
-
+	require.NoError(t, e)
 	a1key, a1spec, err := sched.assignJob("w0")
 	require.NoError(t, err)
 	require.NotZero(t, a1spec)
@@ -177,9 +177,9 @@ func TestAssignJobSkipsObsoleteOffsets(t *testing.T) {
 		EndOffset:   900,
 	}
 
-	sched.jobs.add("ingest/1/256", s1)
-	sched.jobs.add("ingest/2/50", s2)
-	sched.jobs.add("ingest/2/700", s3)
+	require.NoError(t, sched.jobs.add("ingest/1/256", s1))
+	require.NoError(t, sched.jobs.add("ingest/2/50", s2))
+	require.NoError(t, sched.jobs.add("ingest/2/700", s3))
 
 	require.Equal(t, 3, sched.jobs.count())
 
@@ -372,7 +372,8 @@ func TestOffsetMovement(t *testing.T) {
 		EndOffset:   6000,
 	}
 
-	sched.jobs.add("ingest/1/5524", spec)
+	e := sched.jobs.add("ingest/1/5524", spec)
+	require.NoError(t, e)
 	key, _, err := sched.jobs.assign("w0")
 	require.NoError(t, err)
 

--- a/pkg/blockbuilder/schedulerpb/client.go
+++ b/pkg/blockbuilder/schedulerpb/client.go
@@ -174,7 +174,7 @@ func (s *schedulerClient) GetJob(ctx context.Context) (JobKey, JobSpec, error) {
 		// If we get here, we have a newly assigned job. Track it and return it.
 		key := *response.GetKey()
 		spec := *response.GetSpec()
-		level.Info(s.logger).Log("msg", "assigned job", "job_id", key.Id, "epoch", key.Epoch)
+		level.Info(s.logger).Log("msg", "assigned job", "job_id", key.Id, "epoch", key.Epoch, "spec", spec)
 
 		s.mu.Lock()
 		if _, ok := s.jobs[key]; ok {

--- a/pkg/blockbuilder/schedulerpb/client.go
+++ b/pkg/blockbuilder/schedulerpb/client.go
@@ -174,7 +174,7 @@ func (s *schedulerClient) GetJob(ctx context.Context) (JobKey, JobSpec, error) {
 		// If we get here, we have a newly assigned job. Track it and return it.
 		key := *response.GetKey()
 		spec := *response.GetSpec()
-		level.Info(s.logger).Log("msg", "assigned job", "job_id", key.Id, "epoch", key.Epoch, "spec", spec)
+		level.Info(s.logger).Log("msg", "assigned job", "job_id", key.Id, "epoch", key.Epoch, "spec", spec.String())
 
 		s.mu.Lock()
 		if _, ok := s.jobs[key]; ok {


### PR DESCRIPTION
#### What this PR does

This PR implements Kafka offset maintenance and job computation.

This is a replacement for #10105. Much of it is the same, but it pivots to a fairly different job detection strategy where we do not assume the results from `kadm.ListOffsetsAfterMilli` are stable over time. It is different in these ways:
1. During normal operation, this strategy asks Kafka for every partition's end offsets frequently, then uses those observations to detect when we can emit a job.
2. At startup time, there will be a potential multi-job backlog, so we do a one-time startup scan through [commit, end] and do a kind-of fast-forwarded observation scan, creating jobs in the same way.
3. As we only compute jobs once and we aren't yet ready to enqueue multiple jobs per partition, I needed a place to store these jobs. So I added another queue in `partitionState` that a new worker goroutine attempts to feed into the jobQueue every 2 seconds. (I _did_ sketch just implementing parallel consumption, but found a few sketchy edge cases needing more thought.)

---

This PR:

* [x] Updates the local notion of the current offsets as workers complete jobs.
* [x] Periodically flushes these offsets back to Kafka, and upon shutdown.
* [x] Detects a backlog and carves it into one or more jobs.
   * [x] (but for now, only assign one active job per partition)
   * [x] job computation uses the local notion of committed offsets rather than fetching it from Kafka.
* [x] Exposes some new job queue metrics:
   * `cortex_blockbuilder_scheduler_outstanding_jobs` a gauge which records the number of jobs that are in the jobQueue -- that is, either assigned or eligible to be assigned. This will be part of the autoscaling formula.
   * `cortex_blockbuilder_scheduler_assigned_jobs` a gauge which just shows assigned jobs
   * `cortex_blockbuilder_scheduler_pending_jobs` a gauge which shows jobs (per partition) that are waiting to be admitted to the jobQueue. (but cannot be due to job creation policy.)

It also:
* [x] Tracks unassigned jobs with a FIFO queue rather than a heap. (With this new scheme of consumption we don't have a great ordering function. This might change later.)

And fixes some bugs encountered while testing the scheduler:
* [x] StartupObserve period was insufficient for default scheduler client update interval - we want it to be at least enough time for two rounds of updates per worker.
* [x] Move observation period to inside the Mimir service `running` handler, so that we are healthy and able to receive k8s service RPCs to learn the state of the world.
* [x] block-builder command line parameter registration had a bug where the scheduler-related flags weren't actually being registered.
* [x] In-flight jobs that are behind the committed offset for a partition (for whatever reason) could become permanently stuck in the job queue as we were ignoring their updates. (Their assignment would expire and we'd reassign the job to another worker and repeat...)


#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
