### PR TITLE
Fixing a typo in the list of promoted labels

### DIFF
--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -120,7 +120,7 @@ Grafana Cloud automatically promotes the following OTel resource attributes to l
 - `service.namespace`
 - `service.version`
 - `cloud.availability_zone`
-- `cloud region`
+- `cloud.region`
 - `container.name`
 - `deployment.environment.name`
 - `k8s.cluster.name`


### PR DESCRIPTION
Should be `cloud.region` rather than `cloud region`.