### PR TITLE
general cleanup: move all identical prom sample impls to test util

### DIFF
--- a/integration/compactor_test.go
+++ b/integration/compactor_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
 	"github.com/oklog/ulid/v2"
-	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -29,7 +28,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/bucket/s3"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
-	"github.com/grafana/mimir/pkg/util/test"
+	util_test "github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
@@ -64,37 +63,37 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 
 	// Create a few blocks to compact and upload them to the bucket.
 	metas := make([]*block.Meta, 0, numBlocks)
-	expectedSeries := make([]series, numBlocks)
+	expectedSeries := make([]util_test.Series, numBlocks)
 
 	for i := 0; i < numBlocks; i++ {
 		spec := block.SeriesSpec{
 			Labels: labels.FromStrings("case", "native_histogram", "i", strconv.Itoa(i)),
 			Chunks: []chunks.Meta{
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					sample{10, 0, test.GenerateTestHistogram(1), nil},
-					sample{20, 0, test.GenerateTestHistogram(2), nil},
+					util_test.NewSample(10, 0, util_test.GenerateTestHistogram(1), nil),
+					util_test.NewSample(20, 0, util_test.GenerateTestHistogram(2), nil),
 				})),
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					sample{30, 0, test.GenerateTestHistogram(3), nil},
-					sample{40, 0, test.GenerateTestHistogram(4), nil},
+					util_test.NewSample(30, 0, util_test.GenerateTestHistogram(3), nil),
+					util_test.NewSample(40, 0, util_test.GenerateTestHistogram(4), nil),
 				})),
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					sample{50, 0, test.GenerateTestHistogram(5), nil},
-					sample{2*time.Hour.Milliseconds() - 1, 0, test.GenerateTestHistogram(6), nil},
+					util_test.NewSample(50, 0, util_test.GenerateTestHistogram(5), nil),
+					util_test.NewSample(2*time.Hour.Milliseconds()-1, 0, util_test.GenerateTestHistogram(6), nil),
 				})),
 			},
 		}
 
 		// Populate expectedSeries for comparison w/ compactedSeries later.
-		var samples []sample
+		var samples []util_test.Sample
 		for _, chk := range spec.Chunks {
 			it := chk.Chunk.Iterator(nil)
 			for it.Next() != chunkenc.ValNone {
 				ts, h := it.AtHistogram(nil)
-				samples = append(samples, sample{t: ts, h: h})
+				samples = append(samples, util_test.NewSample(ts, 0, h, nil))
 			}
 		}
-		expectedSeries[i] = series{lbls: spec.Labels, samples: samples}
+		expectedSeries[i] = util_test.NewSeries(spec.Labels, samples)
 
 		meta, err := block.GenerateBlockFromSpec(inDir, []*block.SeriesSpec{&spec})
 		require.NoError(t, err)
@@ -120,7 +119,7 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 		return nil
 	}))
 
-	var compactedSeries []series
+	var compactedSeries []util_test.Series
 
 	for _, blockID := range blocks {
 		require.NoError(t, block.Download(context.Background(), log.NewNopLogger(), bktClient, ulid.MustParseStrict(blockID), filepath.Join(outDir, blockID)))
@@ -144,7 +143,7 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 			var lbls labels.ScratchBuilder
 			var chks []chunks.Meta
 
-			var samples []sample
+			var samples []util_test.Sample
 
 			require.NoError(t, ixReader.Series(p.At(), &lbls, &chks))
 
@@ -162,20 +161,14 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 						break
 					} else if valType == chunkenc.ValHistogram {
 						ts, h := it.AtHistogram(nil)
-						samples = append(samples, sample{
-							t: ts,
-							h: h,
-						})
+						samples = append(samples, util_test.NewSample(ts, 0, h, nil))
 					} else {
 						t.Error("Unexpected chunkenc.ValueType (we're expecting only histograms): " + string(valType))
 					}
 				}
 			}
 
-			compactedSeries = append(compactedSeries, series{
-				lbls:    lbls.Labels(),
-				samples: samples,
-			})
+			compactedSeries = append(compactedSeries, util_test.NewSeries(lbls.Labels(), samples))
 		}
 
 		require.NoError(t, ixReader.Close())
@@ -202,45 +195,6 @@ func isMarkedForDeletionDueToCompaction(t *testing.T, blockPath string) bool {
 	require.NoError(t, json.Unmarshal(b, deletionMark))
 
 	return deletionMark.Details == "source of compacted block"
-}
-
-type series struct {
-	lbls    labels.Labels
-	samples []sample
-}
-
-type sample struct {
-	t  int64
-	v  float64
-	h  *histogram.Histogram
-	fh *histogram.FloatHistogram
-}
-
-func (s sample) T() int64                      { return s.t }
-func (s sample) F() float64                    { return s.v }
-func (s sample) H() *histogram.Histogram       { return s.h }
-func (s sample) FH() *histogram.FloatHistogram { return s.fh }
-
-func (s sample) Type() chunkenc.ValueType {
-	switch {
-	case s.h != nil:
-		return chunkenc.ValHistogram
-	case s.fh != nil:
-		return chunkenc.ValFloatHistogram
-	default:
-		return chunkenc.ValFloat
-	}
-}
-
-func (s sample) Copy() chunks.Sample {
-	c := sample{t: s.t, v: s.v}
-	if s.h != nil {
-		c.h = s.h.Copy()
-	}
-	if s.fh != nil {
-		c.fh = s.fh.Copy()
-	}
-	return c
 }
 
 func must[T any](v T, err error) T {

--- a/integration/compactor_test.go
+++ b/integration/compactor_test.go
@@ -70,16 +70,16 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 			Labels: labels.FromStrings("case", "native_histogram", "i", strconv.Itoa(i)),
 			Chunks: []chunks.Meta{
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					util_test.NewSample(10, 0, util_test.GenerateTestHistogram(1), nil),
-					util_test.NewSample(20, 0, util_test.GenerateTestHistogram(2), nil),
+					util_test.Sample{TS: 10, Hist: util_test.GenerateTestHistogram(1)},
+					util_test.Sample{TS: 20, Hist: util_test.GenerateTestHistogram(2)},
 				})),
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					util_test.NewSample(30, 0, util_test.GenerateTestHistogram(3), nil),
-					util_test.NewSample(40, 0, util_test.GenerateTestHistogram(4), nil),
+					util_test.Sample{TS: 30, Hist: util_test.GenerateTestHistogram(3)},
+					util_test.Sample{TS: 40, Hist: util_test.GenerateTestHistogram(4)},
 				})),
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					util_test.NewSample(50, 0, util_test.GenerateTestHistogram(5), nil),
-					util_test.NewSample(2*time.Hour.Milliseconds()-1, 0, util_test.GenerateTestHistogram(6), nil),
+					util_test.Sample{TS: 50, Hist: util_test.GenerateTestHistogram(5)},
+					util_test.Sample{TS: 2*time.Hour.Milliseconds() - 1, Hist: util_test.GenerateTestHistogram(6)},
 				})),
 			},
 		}
@@ -90,10 +90,10 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 			it := chk.Chunk.Iterator(nil)
 			for it.Next() != chunkenc.ValNone {
 				ts, h := it.AtHistogram(nil)
-				samples = append(samples, util_test.NewSample(ts, 0, h, nil))
+				samples = append(samples, util_test.Sample{TS: ts, Hist: h})
 			}
 		}
-		expectedSeries[i] = util_test.NewSeries(spec.Labels, samples)
+		expectedSeries[i] = util_test.Series{Labels: spec.Labels, Samples: samples}
 
 		meta, err := block.GenerateBlockFromSpec(inDir, []*block.SeriesSpec{&spec})
 		require.NoError(t, err)
@@ -161,14 +161,14 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 						break
 					} else if valType == chunkenc.ValHistogram {
 						ts, h := it.AtHistogram(nil)
-						samples = append(samples, util_test.NewSample(ts, 0, h, nil))
+						samples = append(samples, util_test.Sample{TS: ts, Hist: h})
 					} else {
 						t.Error("Unexpected chunkenc.ValueType (we're expecting only histograms): " + string(valType))
 					}
 				}
 			}
 
-			compactedSeries = append(compactedSeries, util_test.NewSeries(lbls.Labels(), samples))
+			compactedSeries = append(compactedSeries, util_test.Series{Labels: lbls.Labels(), Samples: samples})
 		}
 
 		require.NoError(t, ixReader.Close())

--- a/pkg/ingester/ingester_early_compaction_test.go
+++ b/pkg/ingester/ingester_early_compaction_test.go
@@ -474,7 +474,7 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldFailIngestingSamples
 		Samples: []util_test.Sample{{TS: startTime.Add(20 * time.Minute).UnixMilli(), Val: 2.0}},
 	}}))
 	assert.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-		Labels:  labels.FromStrings(labels.MetricName, "metric_2"),
+		Labels:  labels.FromStrings(labels.MetricName, "metric_1"),
 		Samples: []util_test.Sample{{TS: startTime.Add(30 * time.Minute).UnixMilli(), Val: 3.0}},
 	}}))
 }

--- a/pkg/ingester/ingester_early_compaction_test.go
+++ b/pkg/ingester/ingester_early_compaction_test.go
@@ -119,9 +119,10 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldTriggerCompactionOnl
 
 	// Push 10 series.
 	for seriesID := 0; seriesID < 10; seriesID++ {
-		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{
-			{labels.FromStrings(labels.MetricName, fmt.Sprintf("metric_%d", seriesID)), 0, sampleTimestamp},
-		}))
+		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+			labels.FromStrings(labels.MetricName, fmt.Sprintf("metric_%d", seriesID)),
+			[]util_test.Sample{{TS: sampleTimestamp, Val: 0}},
+		}}))
 	}
 
 	// TSDB head early compaction should not trigger because there are no inactive series yet.
@@ -138,9 +139,10 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldTriggerCompactionOnl
 
 	// Push 20 more series.
 	for seriesID := 10; seriesID < 30; seriesID++ {
-		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{
-			{labels.FromStrings(labels.MetricName, fmt.Sprintf("metric_%d", seriesID)), 0, sampleTimestamp},
-		}))
+		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+			labels.FromStrings(labels.MetricName, fmt.Sprintf("metric_%d", seriesID)),
+			[]util_test.Sample{{TS: sampleTimestamp, Val: 0}},
+		}}))
 	}
 
 	// The last 20 series are active so since only 33% of series are inactive we expect the early compaction to not trigger yet.
@@ -202,7 +204,10 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldCompactHeadUpUntilNo
 		// Push a series with a sample.
 		sampleTime := now
 		sampleTimes = append(sampleTimes, sampleTime)
-		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{{metricLabels, 1.0, sampleTime.UnixMilli()}}))
+		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+			metricLabels,
+			[]util_test.Sample{{TS: sampleTime.UnixMilli(), Val: 1.0}},
+		}}))
 
 		// Advance time and then check if TSDB head early compaction is triggered.
 		// We expect no block to be created because there's no sample before "now - active series idle timeout".
@@ -237,7 +242,10 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldCompactHeadUpUntilNo
 		// Advance time and push another sample to the same series.
 		sampleTime := now
 		sampleTimes = append(sampleTimes, sampleTime)
-		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{{metricLabels, 2.0, sampleTime.UnixMilli()}}))
+		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+			metricLabels,
+			[]util_test.Sample{{TS: sampleTime.UnixMilli(), Val: 2.0}},
+		}}))
 
 		// Advance time, trigger the TSDB head early compaction, and then check the compacted block.
 		now = now.Add(20 * time.Minute)
@@ -265,13 +273,19 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldCompactHeadUpUntilNo
 		// Push a sample with the timestamp BEFORE the next TSDB block range boundary.
 		firstSampleTime := now
 		sampleTimes = append(sampleTimes, firstSampleTime)
-		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{{metricLabels, 3.0, firstSampleTime.UnixMilli()}}))
+		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+			metricLabels,
+			[]util_test.Sample{{TS: firstSampleTime.UnixMilli(), Val: 3.0}},
+		}}))
 
 		// Push a sample with the timestamp AFTER the next TSDB block range boundary.
 		now = now.Add(4 * time.Hour)
 		secondSampleTime := now
 		sampleTimes = append(sampleTimes, secondSampleTime)
-		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{{metricLabels, 4.0, secondSampleTime.UnixMilli()}}))
+		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+			metricLabels,
+			[]util_test.Sample{{TS: secondSampleTime.UnixMilli(), Val: 4.0}},
+		}}))
 
 		// Trigger a normal TSDB head compaction.
 		ingester.compactBlocks(ctx, false, 0, nil)
@@ -353,7 +367,10 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldCompactBlocksHonorin
 	require.NoError(t, err)
 
 	for i := 0; i < 5; i++ {
-		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{{metricLabels, float64(i), startTime.Add(time.Duration(i) * time.Hour).UnixMilli()}}))
+		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+			metricLabels,
+			[]util_test.Sample{{TS: startTime.Add(time.Duration(i) * time.Hour).UnixMilli(), Val: float64(i)}},
+		}}))
 	}
 
 	// TSDB Head early compaction.
@@ -423,8 +440,14 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldFailIngestingSamples
 	startTime, err := time.Parse(time.RFC3339, "2023-06-24T00:00:00Z")
 	require.NoError(t, err)
 
-	require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{{labels.FromStrings(labels.MetricName, "metric_1"), 1.0, startTime.UnixMilli()}}))
-	require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{{labels.FromStrings(labels.MetricName, "metric_1"), 2.0, startTime.Add(20 * time.Minute).UnixMilli()}}))
+	require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+		labels.FromStrings(labels.MetricName, "metric_1"),
+		[]util_test.Sample{{TS: startTime.UnixMilli(), Val: 1.0}},
+	}}))
+	require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+		labels.FromStrings(labels.MetricName, "metric_1"),
+		[]util_test.Sample{{TS: startTime.Add(20 * time.Minute).UnixMilli(), Val: 2.0}},
+	}}))
 
 	// TSDB Head early compaction.
 	ingester.compactBlocksToReduceInMemorySeries(ctx, startTime.Add(30*time.Minute))
@@ -442,9 +465,18 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldFailIngestingSamples
 	}, readMetricSamplesFromBlockDir(t, filepath.Join(userBlocksDir, listBlocksInDir(t, userBlocksDir)[0].String()), "metric_1"))
 
 	// Should allow to push samples after "now - active series idle timeout", but not before that.
-	assert.ErrorContains(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{{labels.FromStrings(labels.MetricName, "metric_2"), 1.0, startTime.UnixMilli()}}), "the sample has been rejected because its timestamp is too old")
-	assert.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{{labels.FromStrings(labels.MetricName, "metric_2"), 2.0, startTime.Add(20 * time.Minute).UnixMilli()}}))
-	assert.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []series{{labels.FromStrings(labels.MetricName, "metric_1"), 3.0, startTime.Add(30 * time.Minute).UnixMilli()}}))
+	assert.ErrorContains(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+		labels.FromStrings(labels.MetricName, "metric_2"),
+		[]util_test.Sample{{TS: startTime.UnixMilli(), Val: 1.0}},
+	}}), "the sample has been rejected because its timestamp is too old")
+	assert.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+		labels.FromStrings(labels.MetricName, "metric_2"),
+		[]util_test.Sample{{TS: startTime.Add(20 * time.Minute).UnixMilli(), Val: 2.0}},
+	}}))
+	assert.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
+		labels.FromStrings(labels.MetricName, "metric_2"),
+		[]util_test.Sample{{TS: startTime.Add(30 * time.Minute).UnixMilli(), Val: 3.0}},
+	}}))
 }
 
 func TestIngester_compactBlocksToReduceInMemorySeries_Concurrency(t *testing.T) {
@@ -516,12 +548,11 @@ func TestIngester_compactBlocksToReduceInMemorySeries_Concurrency(t *testing.T) 
 						timestamp := startTime.Add(time.Duration(sampleIdx) * time.Millisecond).UnixMilli()
 
 						// Prepare the series to write.
-						seriesToWrite := make([]series, 0, toSeriesID-fromSeriesID+1)
+						seriesToWrite := make([]util_test.Series, 0, toSeriesID-fromSeriesID+1)
 						for seriesIdx := fromSeriesID; seriesIdx <= toSeriesID; seriesIdx++ {
-							seriesToWrite = append(seriesToWrite, series{
-								lbls:      labels.FromStrings(labels.MetricName, fmt.Sprintf("series_%05d", seriesIdx)),
-								value:     float64(sampleIdx),
-								timestamp: timestamp,
+							seriesToWrite = append(seriesToWrite, util_test.Series{
+								Labels:  labels.FromStrings(labels.MetricName, fmt.Sprintf("series_%05d", seriesIdx)),
+								Samples: []util_test.Sample{{TS: timestamp, Val: float64(sampleIdx)}},
 							})
 						}
 

--- a/pkg/ingester/ingester_early_compaction_test.go
+++ b/pkg/ingester/ingester_early_compaction_test.go
@@ -120,8 +120,8 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldTriggerCompactionOnl
 	// Push 10 series.
 	for seriesID := 0; seriesID < 10; seriesID++ {
 		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-			labels.FromStrings(labels.MetricName, fmt.Sprintf("metric_%d", seriesID)),
-			[]util_test.Sample{{TS: sampleTimestamp, Val: 0}},
+			Labels:  labels.FromStrings(labels.MetricName, fmt.Sprintf("metric_%d", seriesID)),
+			Samples: []util_test.Sample{{TS: sampleTimestamp, Val: 0}},
 		}}))
 	}
 
@@ -140,8 +140,8 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldTriggerCompactionOnl
 	// Push 20 more series.
 	for seriesID := 10; seriesID < 30; seriesID++ {
 		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-			labels.FromStrings(labels.MetricName, fmt.Sprintf("metric_%d", seriesID)),
-			[]util_test.Sample{{TS: sampleTimestamp, Val: 0}},
+			Labels:  labels.FromStrings(labels.MetricName, fmt.Sprintf("metric_%d", seriesID)),
+			Samples: []util_test.Sample{{TS: sampleTimestamp, Val: 0}},
 		}}))
 	}
 
@@ -205,8 +205,8 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldCompactHeadUpUntilNo
 		sampleTime := now
 		sampleTimes = append(sampleTimes, sampleTime)
 		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-			metricLabels,
-			[]util_test.Sample{{TS: sampleTime.UnixMilli(), Val: 1.0}},
+			Labels:  metricLabels,
+			Samples: []util_test.Sample{{TS: sampleTime.UnixMilli(), Val: 1.0}},
 		}}))
 
 		// Advance time and then check if TSDB head early compaction is triggered.
@@ -243,8 +243,8 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldCompactHeadUpUntilNo
 		sampleTime := now
 		sampleTimes = append(sampleTimes, sampleTime)
 		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-			metricLabels,
-			[]util_test.Sample{{TS: sampleTime.UnixMilli(), Val: 2.0}},
+			Labels:  metricLabels,
+			Samples: []util_test.Sample{{TS: sampleTime.UnixMilli(), Val: 2.0}},
 		}}))
 
 		// Advance time, trigger the TSDB head early compaction, and then check the compacted block.
@@ -274,8 +274,8 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldCompactHeadUpUntilNo
 		firstSampleTime := now
 		sampleTimes = append(sampleTimes, firstSampleTime)
 		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-			metricLabels,
-			[]util_test.Sample{{TS: firstSampleTime.UnixMilli(), Val: 3.0}},
+			Labels:  metricLabels,
+			Samples: []util_test.Sample{{TS: firstSampleTime.UnixMilli(), Val: 3.0}},
 		}}))
 
 		// Push a sample with the timestamp AFTER the next TSDB block range boundary.
@@ -283,8 +283,8 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldCompactHeadUpUntilNo
 		secondSampleTime := now
 		sampleTimes = append(sampleTimes, secondSampleTime)
 		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-			metricLabels,
-			[]util_test.Sample{{TS: secondSampleTime.UnixMilli(), Val: 4.0}},
+			Labels:  metricLabels,
+			Samples: []util_test.Sample{{TS: secondSampleTime.UnixMilli(), Val: 4.0}},
 		}}))
 
 		// Trigger a normal TSDB head compaction.
@@ -368,8 +368,8 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldCompactBlocksHonorin
 
 	for i := 0; i < 5; i++ {
 		require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-			metricLabels,
-			[]util_test.Sample{{TS: startTime.Add(time.Duration(i) * time.Hour).UnixMilli(), Val: float64(i)}},
+			Labels:  metricLabels,
+			Samples: []util_test.Sample{{TS: startTime.Add(time.Duration(i) * time.Hour).UnixMilli(), Val: float64(i)}},
 		}}))
 	}
 
@@ -441,12 +441,12 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldFailIngestingSamples
 	require.NoError(t, err)
 
 	require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-		labels.FromStrings(labels.MetricName, "metric_1"),
-		[]util_test.Sample{{TS: startTime.UnixMilli(), Val: 1.0}},
+		Labels:  labels.FromStrings(labels.MetricName, "metric_1"),
+		Samples: []util_test.Sample{{TS: startTime.UnixMilli(), Val: 1.0}},
 	}}))
 	require.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-		labels.FromStrings(labels.MetricName, "metric_1"),
-		[]util_test.Sample{{TS: startTime.Add(20 * time.Minute).UnixMilli(), Val: 2.0}},
+		Labels:  labels.FromStrings(labels.MetricName, "metric_1"),
+		Samples: []util_test.Sample{{TS: startTime.Add(20 * time.Minute).UnixMilli(), Val: 2.0}},
 	}}))
 
 	// TSDB Head early compaction.
@@ -466,16 +466,16 @@ func TestIngester_compactBlocksToReduceInMemorySeries_ShouldFailIngestingSamples
 
 	// Should allow to push samples after "now - active series idle timeout", but not before that.
 	assert.ErrorContains(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-		labels.FromStrings(labels.MetricName, "metric_2"),
-		[]util_test.Sample{{TS: startTime.UnixMilli(), Val: 1.0}},
+		Labels:  labels.FromStrings(labels.MetricName, "metric_2"),
+		Samples: []util_test.Sample{{TS: startTime.UnixMilli(), Val: 1.0}},
 	}}), "the sample has been rejected because its timestamp is too old")
 	assert.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-		labels.FromStrings(labels.MetricName, "metric_2"),
-		[]util_test.Sample{{TS: startTime.Add(20 * time.Minute).UnixMilli(), Val: 2.0}},
+		Labels:  labels.FromStrings(labels.MetricName, "metric_2"),
+		Samples: []util_test.Sample{{TS: startTime.Add(20 * time.Minute).UnixMilli(), Val: 2.0}},
 	}}))
 	assert.NoError(t, pushSeriesToIngester(ctxWithUser, t, ingester, []util_test.Series{{
-		labels.FromStrings(labels.MetricName, "metric_2"),
-		[]util_test.Sample{{TS: startTime.Add(30 * time.Minute).UnixMilli(), Val: 3.0}},
+		Labels:  labels.FromStrings(labels.MetricName, "metric_2"),
+		Samples: []util_test.Sample{{TS: startTime.Add(30 * time.Minute).UnixMilli(), Val: 3.0}},
 	}}))
 }
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -4447,16 +4447,16 @@ func l2m(lbls labels.Labels) model.Metric {
 func Test_Ingester_Query(t *testing.T) {
 	series := []util_test.Series{
 		{
-			labels.FromStrings(labels.MetricName, "test_1", "status", "200", "route", "get_user"),
-			[]util_test.Sample{{TS: 100000, Val: 1}},
+			Labels:  labels.FromStrings(labels.MetricName, "test_1", "status", "200", "route", "get_user"),
+			Samples: []util_test.Sample{{TS: 100000, Val: 1}},
 		},
 		{
-			labels.FromStrings(labels.MetricName, "test_1", "status", "500", "route", "get_user"),
-			[]util_test.Sample{{TS: 110000, Val: 1}},
+			Labels:  labels.FromStrings(labels.MetricName, "test_1", "status", "500", "route", "get_user"),
+			Samples: []util_test.Sample{{TS: 110000, Val: 1}},
 		},
 		{
-			labels.FromStrings(labels.MetricName, "test_2", "status", "500", "route", "get_user"),
-			[]util_test.Sample{{TS: 200000, Val: 2}},
+			Labels:  labels.FromStrings(labels.MetricName, "test_2", "status", "500", "route", "get_user"),
+			Samples: []util_test.Sample{{TS: 200000, Val: 2}},
 		},
 	}
 
@@ -4590,20 +4590,20 @@ func Test_Ingester_Query(t *testing.T) {
 func TestIngester_LabelNamesAndValues(t *testing.T) {
 	series := []util_test.Series{
 		{
-			labels.FromStrings(labels.MetricName, "metric_0", "status", "500"),
-			[]util_test.Sample{{TS: 100000, Val: 1}},
+			Labels:  labels.FromStrings(labels.MetricName, "metric_0", "status", "500"),
+			Samples: []util_test.Sample{{TS: 100000, Val: 1}},
 		},
 		{
-			labels.FromStrings(labels.MetricName, "metric_0", "status", "200"),
-			[]util_test.Sample{{TS: 110000, Val: 1}},
+			Labels:  labels.FromStrings(labels.MetricName, "metric_0", "status", "200"),
+			Samples: []util_test.Sample{{TS: 110000, Val: 1}},
 		},
 		{
-			labels.FromStrings(labels.MetricName, "metric_1", "env", "prod"),
-			[]util_test.Sample{{TS: 200000, Val: 2}},
+			Labels:  labels.FromStrings(labels.MetricName, "metric_1", "env", "prod"),
+			Samples: []util_test.Sample{{TS: 200000, Val: 2}},
 		},
 		{
-			labels.FromStrings(labels.MetricName, "metric_1", "env", "prod", "status", "300"),
-			[]util_test.Sample{{TS: 200000, Val: 3}},
+			Labels:  labels.FromStrings(labels.MetricName, "metric_1", "env", "prod", "status", "300"),
+			Samples: []util_test.Sample{{TS: 200000, Val: 3}},
 		},
 	}
 
@@ -4654,20 +4654,20 @@ func TestIngester_LabelNamesAndValues(t *testing.T) {
 func TestIngester_LabelValuesCardinality(t *testing.T) {
 	series := []util_test.Series{
 		{
-			labels.FromStrings(labels.MetricName, "metric_0", "status", "500"),
-			[]util_test.Sample{{TS: 100000, Val: 1.5}},
+			Labels:  labels.FromStrings(labels.MetricName, "metric_0", "status", "500"),
+			Samples: []util_test.Sample{{TS: 100000, Val: 1.5}},
 		},
 		{
-			labels.FromStrings(labels.MetricName, "metric_0", "status", "200"),
-			[]util_test.Sample{{TS: 110030, Val: 1.5}},
+			Labels:  labels.FromStrings(labels.MetricName, "metric_0", "status", "200"),
+			Samples: []util_test.Sample{{TS: 110030, Val: 1.5}},
 		},
 		{
-			labels.FromStrings(labels.MetricName, "metric_1", "env", "prod"),
-			[]util_test.Sample{{TS: 100060, Val: 1.5}},
+			Labels:  labels.FromStrings(labels.MetricName, "metric_1", "env", "prod"),
+			Samples: []util_test.Sample{{TS: 100060, Val: 1.5}},
 		},
 		{
-			labels.FromStrings(labels.MetricName, "metric_1", "env", "prod", "status", "300"),
-			[]util_test.Sample{{TS: 100090, Val: 1.5}},
+			Labels:  labels.FromStrings(labels.MetricName, "metric_1", "env", "prod", "status", "300"),
+			Samples: []util_test.Sample{{TS: 100090, Val: 1.5}},
 		},
 	}
 	tests := map[string]struct {

--- a/pkg/ingester/owned_series_test.go
+++ b/pkg/ingester/owned_series_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/storage/ingest"
 	"github.com/grafana/mimir/pkg/util"
+	util_test "github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
@@ -37,7 +38,7 @@ const ownedServiceTestUserSeriesLimit = 10000
 const defaultHeartbeatPeriod = 100 * time.Millisecond
 
 type ownedSeriesTestContextBase struct {
-	seriesToWrite []series
+	seriesToWrite []util_test.Series
 
 	user        string
 	ownedSeries *ownedSeriesService
@@ -757,21 +758,20 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 	}
 }
 
-func generateSeriesWithTokens(testUser string) ([]series, []uint32) {
+func generateSeriesWithTokens(testUser string) ([]util_test.Series, []uint32) {
 	return generateSeriesWithTokensAt(testUser, time.Now())
 }
 
-func generateSeriesWithTokensAt(testUser string, startTime time.Time) ([]series, []uint32) {
-	var seriesToWrite []series
+func generateSeriesWithTokensAt(testUser string, startTime time.Time) ([]util_test.Series, []uint32) {
+	var seriesToWrite []util_test.Series
 	var seriesTokens []uint32
 	for seriesIdx := 0; seriesIdx < ownedServiceSeriesCount; seriesIdx++ {
-		s := series{
-			lbls:      labels.FromStrings(labels.MetricName, "test", fmt.Sprintf("lbl_%05d", seriesIdx), "value"),
-			value:     float64(0),
-			timestamp: startTime.Add(time.Duration(seriesIdx) * time.Millisecond).UnixMilli(),
+		s := util_test.Series{
+			Labels:  labels.FromStrings(labels.MetricName, "test", fmt.Sprintf("lbl_%05d", seriesIdx), "value"),
+			Samples: []util_test.Sample{{TS: startTime.Add(time.Duration(seriesIdx) * time.Millisecond).UnixMilli(), Val: float64(0)}},
 		}
 		seriesToWrite = append(seriesToWrite, s)
-		seriesTokens = append(seriesTokens, mimirpb.ShardByAllLabels(testUser, s.lbls))
+		seriesTokens = append(seriesTokens, mimirpb.ShardByAllLabels(testUser, s.Labels))
 	}
 	return seriesToWrite, seriesTokens
 }
@@ -793,7 +793,7 @@ func (c *ownedSeriesWithPartitionsRingTestContext) pushUserSeries(t *testing.T) 
 	})
 
 	for _, s := range c.seriesToWrite {
-		req, _, _, _ := mockWriteRequest(t, s.lbls, s.value, s.timestamp)
+		req, _, _, _ := mockWriteRequest(t, s.Labels, s.Samples[0].Val, s.Samples[0].TS)
 		require.NoError(t, writer.WriteSync(context.Background(), c.partitionID, c.user, req))
 	}
 

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -75,7 +75,7 @@ func TestPusherAppendable(t *testing.T) {
 			name: "tenant without delay, normal value",
 			series: []util_test.Series{
 				{
-					[]labels.Label{{"__name__", "foo_bar"}},
+					labels.Labels{{"__name__", "foo_bar"}},
 					[]util_test.Sample{{TS: 120_000, Val: 1.234}},
 				},
 			},
@@ -86,7 +86,7 @@ func TestPusherAppendable(t *testing.T) {
 			hasNanSample: true,
 			series: []util_test.Series{
 				{
-					[]labels.Label{{"__name__", "foo_bar"}},
+					labels.Labels{{"__name__", "foo_bar"}},
 					[]util_test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
 				},
 			},
@@ -95,7 +95,7 @@ func TestPusherAppendable(t *testing.T) {
 			name: "ALERTS, normal value",
 			series: []util_test.Series{
 				{
-					[]labels.Label{
+					labels.Labels{
 						{"__name__", "ALERT"},
 						{"alertname", "boop"},
 					},
@@ -108,7 +108,7 @@ func TestPusherAppendable(t *testing.T) {
 			hasNanSample: true,
 			series: []util_test.Series{
 				{
-					[]labels.Label{
+					labels.Labels{
 						{"__name__", "ALERT"},
 						{"alertname", "boop"},
 					},
@@ -120,7 +120,7 @@ func TestPusherAppendable(t *testing.T) {
 			name: "tenant without delay, histogram value",
 			series: []util_test.Series{
 				{
-					[]labels.Label{{"__name__", "foo_bar"}},
+					labels.Labels{{"__name__", "foo_bar"}},
 					[]util_test.Sample{{TS: 200_000, Hist: util_test.GenerateTestHistogram(10)}},
 				},
 			},
@@ -129,7 +129,7 @@ func TestPusherAppendable(t *testing.T) {
 			name: "tenant without delay, float histogram value",
 			series: []util_test.Series{
 				{
-					[]labels.Label{{"__name__", "foo_bar"}},
+					labels.Labels{{"__name__", "foo_bar"}},
 					[]util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(10)}},
 				},
 			},
@@ -138,19 +138,19 @@ func TestPusherAppendable(t *testing.T) {
 			name: "mix of float and float histogram",
 			series: []util_test.Series{
 				{
-					[]labels.Label{{"__name__", "foo_bar1"}},
+					labels.Labels{{"__name__", "foo_bar1"}},
 					[]util_test.Sample{{TS: 230_000, Val: 999}},
 				},
 				{
-					[]labels.Label{{"__name__", "foo_bar3"}},
+					labels.Labels{{"__name__", "foo_bar3"}},
 					[]util_test.Sample{{TS: 230_000, Val: 888}},
 				},
 				{
-					[]labels.Label{{"__name__", "foo_bar3"}},
+					labels.Labels{{"__name__", "foo_bar3"}},
 					[]util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(10)}},
 				},
 				{
-					[]labels.Label{{"__name__", "foo_bar4"}},
+					labels.Labels{{"__name__", "foo_bar4"}},
 					[]util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(99)}},
 				},
 			},

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/grafana/mimir/pkg/ruler/rulespb"
 	"github.com/grafana/mimir/pkg/storage/series"
 	util_log "github.com/grafana/mimir/pkg/util/log"
-	util_test "github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 type fakePusher struct {
@@ -69,14 +69,14 @@ func TestPusherAppendable(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		hasNanSample bool // If true, it will be a single float sample with NaN.
-		series       []util_test.Series
+		series       []test.Series
 	}{
 		{
 			name: "tenant without delay, normal value",
-			series: []util_test.Series{
+			series: []test.Series{
 				{
 					Labels:  labels.FromStrings(labels.MetricName, "foo_bar"),
-					Samples: []util_test.Sample{{TS: 120_000, Val: 1.234}},
+					Samples: []test.Sample{{TS: 120_000, Val: 1.234}},
 				},
 			},
 		},
@@ -84,68 +84,68 @@ func TestPusherAppendable(t *testing.T) {
 		{
 			name:         "tenant without delay, stale nan value",
 			hasNanSample: true,
-			series: []util_test.Series{
+			series: []test.Series{
 				{
 					Labels:  labels.FromStrings(labels.MetricName, "foo_bar"),
-					Samples: []util_test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
+					Samples: []test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
 				},
 			},
 		},
 		{
 			name: "ALERTS, normal value",
-			series: []util_test.Series{
+			series: []test.Series{
 				{
 					Labels:  labels.FromStrings(labels.MetricName, "ALERT", labels.AlertName, "boop"),
-					Samples: []util_test.Sample{{TS: 120_000, Val: 1.234}},
+					Samples: []test.Sample{{TS: 120_000, Val: 1.234}},
 				},
 			},
 		},
 		{
 			name:         "ALERTS, stale nan value",
 			hasNanSample: true,
-			series: []util_test.Series{
+			series: []test.Series{
 				{
 					Labels:  labels.FromStrings(labels.MetricName, "ALERT", labels.AlertName, "boop"),
-					Samples: []util_test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
+					Samples: []test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
 				},
 			},
 		},
 		{
 			name: "tenant without delay, histogram value",
-			series: []util_test.Series{
+			series: []test.Series{
 				{
 					Labels:  labels.FromStrings(labels.MetricName, "foo_bar"),
-					Samples: []util_test.Sample{{TS: 200_000, Hist: util_test.GenerateTestHistogram(10)}},
+					Samples: []test.Sample{{TS: 200_000, Hist: test.GenerateTestHistogram(10)}},
 				},
 			},
 		},
 		{
 			name: "tenant without delay, float histogram value",
-			series: []util_test.Series{
+			series: []test.Series{
 				{
 					Labels:  labels.FromStrings(labels.MetricName, "foo_bar"),
-					Samples: []util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(10)}},
+					Samples: []test.Sample{{TS: 230_000, FloatHist: test.GenerateTestFloatHistogram(10)}},
 				},
 			},
 		},
 		{
 			name: "mix of float and float histogram",
-			series: []util_test.Series{
+			series: []test.Series{
 				{
 					Labels:  labels.FromStrings(labels.MetricName, "foo_bar1"),
-					Samples: []util_test.Sample{{TS: 230_000, Val: 999}},
+					Samples: []test.Sample{{TS: 230_000, Val: 999}},
 				},
 				{
 					Labels:  labels.FromStrings(labels.MetricName, "foo_bar3"),
-					Samples: []util_test.Sample{{TS: 230_000, Val: 888}},
+					Samples: []test.Sample{{TS: 230_000, Val: 888}},
 				},
 				{
 					Labels:  labels.FromStrings(labels.MetricName, "foo_bar2"),
-					Samples: []util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(10)}},
+					Samples: []test.Sample{{TS: 230_000, FloatHist: test.GenerateTestFloatHistogram(10)}},
 				},
 				{
 					Labels:  labels.FromStrings(labels.MetricName, "foo_bar4"),
-					Samples: []util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(99)}},
+					Samples: []test.Sample{{TS: 230_000, FloatHist: test.GenerateTestFloatHistogram(99)}},
 				},
 			},
 		},
@@ -579,7 +579,7 @@ func TestDefaultManagerFactory_CorrectQueryableUsed(t *testing.T) {
 
 			// Ensure the result has been written.
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				pusher.AssertCalled(util_test.NewCollectWithLogf(collect), "Push", mock.Anything, mock.Anything)
+				pusher.AssertCalled(test.NewCollectWithLogf(collect), "Push", mock.Anything, mock.Anything)
 			}, 5*time.Second, 100*time.Millisecond)
 
 			manager.Stop()
@@ -643,7 +643,7 @@ func TestDefaultManagerFactory_ShouldNotWriteRecordingRuleResultsWhenDisabled(t 
 			if writeEnabled {
 				// Ensure the result has been written.
 				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					pusher.AssertCalled(util_test.NewCollectWithLogf(collect), "Push", mock.Anything, mock.Anything)
+					pusher.AssertCalled(test.NewCollectWithLogf(collect), "Push", mock.Anything, mock.Anything)
 				}, 5*time.Second, 100*time.Millisecond)
 			} else {
 				// Ensure no write occurred within a reasonable amount of time.

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -75,7 +75,7 @@ func TestPusherAppendable(t *testing.T) {
 			name: "tenant without delay, normal value",
 			series: []util_test.Series{
 				{
-					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar"}},
+					Labels:  labels.FromStrings(labels.MetricName, "foo_bar"),
 					Samples: []util_test.Sample{{TS: 120_000, Val: 1.234}},
 				},
 			},
@@ -86,7 +86,7 @@ func TestPusherAppendable(t *testing.T) {
 			hasNanSample: true,
 			series: []util_test.Series{
 				{
-					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar"}},
+					Labels:  labels.FromStrings(labels.MetricName, "foo_bar"),
 					Samples: []util_test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
 				},
 			},
@@ -95,10 +95,7 @@ func TestPusherAppendable(t *testing.T) {
 			name: "ALERTS, normal value",
 			series: []util_test.Series{
 				{
-					Labels: labels.Labels{
-						labels.Label{"__name__", "ALERT"},
-						labels.Label{Name: "alertname", Value: "boop"},
-					},
+					Labels:  labels.FromStrings(labels.MetricName, "ALERT", labels.AlertName, "boop"),
 					Samples: []util_test.Sample{{TS: 120_000, Val: 1.234}},
 				},
 			},
@@ -108,10 +105,7 @@ func TestPusherAppendable(t *testing.T) {
 			hasNanSample: true,
 			series: []util_test.Series{
 				{
-					Labels: labels.Labels{
-						labels.Label{Name: "__name__", Value: "ALERT"},
-						labels.Label{Name: "alertname", Value: "boop"},
-					},
+					Labels:  labels.FromStrings(labels.MetricName, "ALERT", labels.AlertName, "boop"),
 					Samples: []util_test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
 				},
 			},
@@ -120,7 +114,7 @@ func TestPusherAppendable(t *testing.T) {
 			name: "tenant without delay, histogram value",
 			series: []util_test.Series{
 				{
-					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar"}},
+					Labels:  labels.FromStrings(labels.MetricName, "foo_bar"),
 					Samples: []util_test.Sample{{TS: 200_000, Hist: util_test.GenerateTestHistogram(10)}},
 				},
 			},
@@ -129,7 +123,7 @@ func TestPusherAppendable(t *testing.T) {
 			name: "tenant without delay, float histogram value",
 			series: []util_test.Series{
 				{
-					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar"}},
+					Labels:  labels.FromStrings(labels.MetricName, "foo_bar"),
 					Samples: []util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(10)}},
 				},
 			},
@@ -138,19 +132,19 @@ func TestPusherAppendable(t *testing.T) {
 			name: "mix of float and float histogram",
 			series: []util_test.Series{
 				{
-					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar1"}},
+					Labels:  labels.FromStrings(labels.MetricName, "foo_bar1"),
 					Samples: []util_test.Sample{{TS: 230_000, Val: 999}},
 				},
 				{
-					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar3"}},
+					Labels:  labels.FromStrings(labels.MetricName, "foo_bar3"),
 					Samples: []util_test.Sample{{TS: 230_000, Val: 888}},
 				},
 				{
-					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar3"}},
+					Labels:  labels.FromStrings(labels.MetricName, "foo_bar2"),
 					Samples: []util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(10)}},
 				},
 				{
-					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar4"}},
+					Labels:  labels.FromStrings(labels.MetricName, "foo_bar4"),
 					Samples: []util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(99)}},
 				},
 			},

--- a/pkg/ruler/compat_test.go
+++ b/pkg/ruler/compat_test.go
@@ -75,8 +75,8 @@ func TestPusherAppendable(t *testing.T) {
 			name: "tenant without delay, normal value",
 			series: []util_test.Series{
 				{
-					labels.Labels{{"__name__", "foo_bar"}},
-					[]util_test.Sample{{TS: 120_000, Val: 1.234}},
+					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar"}},
+					Samples: []util_test.Sample{{TS: 120_000, Val: 1.234}},
 				},
 			},
 		},
@@ -86,8 +86,8 @@ func TestPusherAppendable(t *testing.T) {
 			hasNanSample: true,
 			series: []util_test.Series{
 				{
-					labels.Labels{{"__name__", "foo_bar"}},
-					[]util_test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
+					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar"}},
+					Samples: []util_test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
 				},
 			},
 		},
@@ -95,11 +95,11 @@ func TestPusherAppendable(t *testing.T) {
 			name: "ALERTS, normal value",
 			series: []util_test.Series{
 				{
-					labels.Labels{
-						{"__name__", "ALERT"},
-						{"alertname", "boop"},
+					Labels: labels.Labels{
+						labels.Label{"__name__", "ALERT"},
+						labels.Label{Name: "alertname", Value: "boop"},
 					},
-					[]util_test.Sample{{TS: 120_000, Val: 1.234}},
+					Samples: []util_test.Sample{{TS: 120_000, Val: 1.234}},
 				},
 			},
 		},
@@ -108,11 +108,11 @@ func TestPusherAppendable(t *testing.T) {
 			hasNanSample: true,
 			series: []util_test.Series{
 				{
-					labels.Labels{
-						{"__name__", "ALERT"},
-						{"alertname", "boop"},
+					Labels: labels.Labels{
+						labels.Label{Name: "__name__", Value: "ALERT"},
+						labels.Label{Name: "alertname", Value: "boop"},
 					},
-					[]util_test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
+					Samples: []util_test.Sample{{TS: 120_000, Val: math.Float64frombits(value.StaleNaN)}},
 				},
 			},
 		},
@@ -120,8 +120,8 @@ func TestPusherAppendable(t *testing.T) {
 			name: "tenant without delay, histogram value",
 			series: []util_test.Series{
 				{
-					labels.Labels{{"__name__", "foo_bar"}},
-					[]util_test.Sample{{TS: 200_000, Hist: util_test.GenerateTestHistogram(10)}},
+					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar"}},
+					Samples: []util_test.Sample{{TS: 200_000, Hist: util_test.GenerateTestHistogram(10)}},
 				},
 			},
 		},
@@ -129,8 +129,8 @@ func TestPusherAppendable(t *testing.T) {
 			name: "tenant without delay, float histogram value",
 			series: []util_test.Series{
 				{
-					labels.Labels{{"__name__", "foo_bar"}},
-					[]util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(10)}},
+					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar"}},
+					Samples: []util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(10)}},
 				},
 			},
 		},
@@ -138,20 +138,20 @@ func TestPusherAppendable(t *testing.T) {
 			name: "mix of float and float histogram",
 			series: []util_test.Series{
 				{
-					labels.Labels{{"__name__", "foo_bar1"}},
-					[]util_test.Sample{{TS: 230_000, Val: 999}},
+					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar1"}},
+					Samples: []util_test.Sample{{TS: 230_000, Val: 999}},
 				},
 				{
-					labels.Labels{{"__name__", "foo_bar3"}},
-					[]util_test.Sample{{TS: 230_000, Val: 888}},
+					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar3"}},
+					Samples: []util_test.Sample{{TS: 230_000, Val: 888}},
 				},
 				{
-					labels.Labels{{"__name__", "foo_bar3"}},
-					[]util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(10)}},
+					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar3"}},
+					Samples: []util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(10)}},
 				},
 				{
-					labels.Labels{{"__name__", "foo_bar4"}},
-					[]util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(99)}},
+					Labels:  labels.Labels{labels.Label{Name: "__name__", Value: "foo_bar4"}},
+					Samples: []util_test.Sample{{TS: 230_000, FloatHist: util_test.GenerateTestFloatHistogram(99)}},
 				},
 			},
 		},

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -517,16 +517,16 @@ func TestBucketStore_Series_ShouldQueryBlockWithOutOfOrderChunks(t *testing.T) {
 			{
 				Labels: seriesWithOutOfOrderChunks,
 				Chunks: []chunks.Meta{
-					must(chunks.ChunkFromSamples([]chunks.Sample{sample{t: 20, v: 20}, sample{t: 21, v: 21}})),
-					must(chunks.ChunkFromSamples([]chunks.Sample{sample{t: 10, v: 10}, sample{t: 11, v: 11}})),
+					must(chunks.ChunkFromSamples([]chunks.Sample{test.Sample{TS: 20, Val: 20}, test.Sample{TS: 21, Val: 21}})),
+					must(chunks.ChunkFromSamples([]chunks.Sample{test.Sample{TS: 10, Val: 10}, test.Sample{TS: 11, Val: 11}})),
 				},
 			},
 			// Series with out of order and overlapping chunks.
 			{
 				Labels: seriesWithOverlappingChunks,
 				Chunks: []chunks.Meta{
-					must(chunks.ChunkFromSamples([]chunks.Sample{sample{t: 20, v: 20}, sample{t: 21, v: 21}})),
-					must(chunks.ChunkFromSamples([]chunks.Sample{sample{t: 10, v: 10}, sample{t: 20, v: 20}})),
+					must(chunks.ChunkFromSamples([]chunks.Sample{test.Sample{TS: 20, Val: 20}, test.Sample{TS: 21, Val: 21}})),
+					must(chunks.ChunkFromSamples([]chunks.Sample{test.Sample{TS: 10, Val: 10}, test.Sample{TS: 20, Val: 20}})),
 				},
 			},
 		}
@@ -564,26 +564,26 @@ func TestBucketStore_Series_ShouldQueryBlockWithOutOfOrderChunks(t *testing.T) {
 	tests := map[string]struct {
 		minT                                int64
 		maxT                                int64
-		expectedSamplesForOutOfOrderChunks  []sample
-		expectedSamplesForOverlappingChunks []sample
+		expectedSamplesForOutOfOrderChunks  []test.Sample
+		expectedSamplesForOverlappingChunks []test.Sample
 	}{
 		"query all samples": {
 			minT:                                math.MinInt64,
 			maxT:                                math.MaxInt64,
-			expectedSamplesForOutOfOrderChunks:  []sample{{t: 20, v: 20}, {t: 21, v: 21}, {t: 10, v: 10}, {t: 11, v: 11}},
-			expectedSamplesForOverlappingChunks: []sample{{t: 20, v: 20}, {t: 21, v: 21}, {t: 10, v: 10}, {t: 20, v: 20}},
+			expectedSamplesForOutOfOrderChunks:  []test.Sample{{TS: 20, Val: 20}, {TS: 21, Val: 21}, {TS: 10, Val: 10}, {TS: 11, Val: 11}},
+			expectedSamplesForOverlappingChunks: []test.Sample{{TS: 20, Val: 20}, {TS: 21, Val: 21}, {TS: 10, Val: 10}, {TS: 20, Val: 20}},
 		},
 		"query samples from 1st chunk only": {
 			minT:                                21,
 			maxT:                                22, // Not included.
-			expectedSamplesForOutOfOrderChunks:  []sample{{t: 20, v: 20}, {t: 21, v: 21}},
-			expectedSamplesForOverlappingChunks: []sample{{t: 20, v: 20}, {t: 21, v: 21}},
+			expectedSamplesForOutOfOrderChunks:  []test.Sample{{TS: 20, Val: 20}, {TS: 21, Val: 21}},
+			expectedSamplesForOverlappingChunks: []test.Sample{{TS: 20, Val: 20}, {TS: 21, Val: 21}},
 		},
 		"query samples from 2nd (out of order) chunk only": {
 			minT:                                10,
 			maxT:                                11, // Not included.
-			expectedSamplesForOutOfOrderChunks:  []sample{{t: 10, v: 10}, {t: 11, v: 11}},
-			expectedSamplesForOverlappingChunks: []sample{{t: 10, v: 10}, {t: 20, v: 20}},
+			expectedSamplesForOutOfOrderChunks:  []test.Sample{{TS: 10, Val: 10}, {TS: 11, Val: 11}},
+			expectedSamplesForOverlappingChunks: []test.Sample{{TS: 10, Val: 10}, {TS: 20, Val: 20}},
 		},
 	}
 

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1075,7 +1075,7 @@ func TestStoreGateway_SeriesQueryingShouldRemoveExternalLabels(t *testing.T) {
 				assert.Equal(t, []mimirpb.LabelAdapter{{Name: "series_id", Value: strconv.Itoa(seriesID)}}, actual.Labels)
 
 				// Ensure samples have been correctly queried. The store-gateway doesn't deduplicate chunks,
-				// so the same test.Sample is returned twice because in this test we query two identical blocks.
+				// so the same sample is returned twice because in this test we query two identical blocks.
 				samples, err := readSamplesFromChunks(actual.Chunks)
 				require.NoError(t, err)
 				assert.Equal(t, []test.Sample{

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1509,7 +1509,7 @@ func mockStorageConfig(t *testing.T) mimir_tsdb.BlocksStorageConfig {
 }
 
 // mockTSDB create 1+ TSDB blocks storing numSeries of series, each series
-// with 1 test.Sample and its timestamp evenly distributed between minT and maxT.
+// with 1 sample and its timestamp evenly distributed between minT and maxT.
 // If numBlocks > 0, then it uses numSeries only to find the distribution of
 // samples.
 func mockTSDB(t *testing.T, dir string, numSeries, numBlocks int, minT, maxT int64) {

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1417,7 +1417,7 @@ func TestStoreGateway_SeriesQueryingShouldEnforceMaxChunksPerQueryLimit(t *testi
 
 	storageDir := t.TempDir()
 
-	// Generate 1 TSDB block with chunksQueried series. Since each mocked series contains only 1 test.Sample,
+	// Generate 1 TSDB block with chunksQueried series. Since each mocked series contains only 1 sample,
 	// it will also only have 1 chunk.
 	now := time.Now()
 	minT := now.Add(-1*time.Hour).Unix() * 1000

--- a/pkg/util/test/tsdb.go
+++ b/pkg/util/test/tsdb.go
@@ -14,6 +14,10 @@ type Series struct {
 	samples []Sample
 }
 
+func NewSeries(lbls labels.Labels, samples []Sample) Series {
+	return Series{lbls, samples}
+}
+
 type Sample struct {
 	t  int64
 	v  float64
@@ -21,7 +25,7 @@ type Sample struct {
 	fh *histogram.FloatHistogram
 }
 
-func NewSample(t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) chunks.Sample {
+func NewSample(t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) Sample {
 	return Sample{t, v, h, fh}
 }
 

--- a/pkg/util/test/tsdb.go
+++ b/pkg/util/test/tsdb.go
@@ -14,6 +14,10 @@ type Series struct {
 	Samples []Sample
 }
 
+// Sample is a test implementation of the prometheus chunks.Sample interface.
+// The possible sample value types are mutually exclusive -
+// a sample can only be a float, histogram, or float histogram.
+// This is not enforced in a constructor for convenience in test code.
 type Sample struct {
 	TS        int64
 	Val       float64

--- a/pkg/util/test/tsdb.go
+++ b/pkg/util/test/tsdb.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package test
+
+import (
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+type Series struct {
+	lbls    labels.Labels
+	samples []Sample
+}
+
+type Sample struct {
+	t  int64
+	v  float64
+	h  *histogram.Histogram
+	fh *histogram.FloatHistogram
+}
+
+func NewSample(t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) chunks.Sample {
+	return Sample{t, v, h, fh}
+}
+
+func (s Sample) T() int64                      { return s.t }
+func (s Sample) F() float64                    { return s.v }
+func (s Sample) H() *histogram.Histogram       { return s.h }
+func (s Sample) FH() *histogram.FloatHistogram { return s.fh }
+
+func (s Sample) Type() chunkenc.ValueType {
+	switch {
+	case s.h != nil:
+		return chunkenc.ValHistogram
+	case s.fh != nil:
+		return chunkenc.ValFloatHistogram
+	default:
+		return chunkenc.ValFloat
+	}
+}
+
+func (s Sample) Copy() chunks.Sample {
+	c := Sample{t: s.t, v: s.v}
+	if s.h != nil {
+		c.h = s.h.Copy()
+	}
+	if s.fh != nil {
+		c.fh = s.fh.Copy()
+	}
+	return c
+}

--- a/pkg/util/test/tsdb.go
+++ b/pkg/util/test/tsdb.go
@@ -10,43 +10,27 @@ import (
 )
 
 type Series struct {
-	lbls    labels.Labels
-	samples []Sample
-}
-
-func NewSeries(lbls labels.Labels, samples []Sample) Series {
-	return Series{lbls, samples}
-}
-
-func (s Series) Labels() labels.Labels {
-	return s.lbls
-}
-
-func (s Series) Samples() []Sample {
-	return s.samples
+	Labels  labels.Labels
+	Samples []Sample
 }
 
 type Sample struct {
-	t  int64
-	v  float64
-	h  *histogram.Histogram
-	fh *histogram.FloatHistogram
+	TS        int64
+	Val       float64
+	Hist      *histogram.Histogram
+	FloatHist *histogram.FloatHistogram
 }
 
-func NewSample(t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) Sample {
-	return Sample{t, v, h, fh}
-}
-
-func (s Sample) T() int64                      { return s.t }
-func (s Sample) F() float64                    { return s.v }
-func (s Sample) H() *histogram.Histogram       { return s.h }
-func (s Sample) FH() *histogram.FloatHistogram { return s.fh }
+func (s Sample) T() int64                      { return s.TS }
+func (s Sample) F() float64                    { return s.Val }
+func (s Sample) H() *histogram.Histogram       { return s.Hist }
+func (s Sample) FH() *histogram.FloatHistogram { return s.FloatHist }
 
 func (s Sample) Type() chunkenc.ValueType {
 	switch {
-	case s.h != nil:
+	case s.Hist != nil:
 		return chunkenc.ValHistogram
-	case s.fh != nil:
+	case s.FloatHist != nil:
 		return chunkenc.ValFloatHistogram
 	default:
 		return chunkenc.ValFloat
@@ -54,12 +38,12 @@ func (s Sample) Type() chunkenc.ValueType {
 }
 
 func (s Sample) Copy() chunks.Sample {
-	c := Sample{t: s.t, v: s.v}
-	if s.h != nil {
-		c.h = s.h.Copy()
+	c := Sample{TS: s.TS, Val: s.Val}
+	if s.Hist != nil {
+		c.Hist = s.Hist.Copy()
 	}
-	if s.fh != nil {
-		c.fh = s.fh.Copy()
+	if s.FloatHist != nil {
+		c.FloatHist = s.FloatHist.Copy()
 	}
 	return c
 }

--- a/pkg/util/test/tsdb.go
+++ b/pkg/util/test/tsdb.go
@@ -18,6 +18,14 @@ func NewSeries(lbls labels.Labels, samples []Sample) Series {
 	return Series{lbls, samples}
 }
 
+func (s Series) Labels() labels.Labels {
+	return s.lbls
+}
+
+func (s Series) Samples() []Sample {
+	return s.samples
+}
+
 type Sample struct {
 	t  int64
 	v  float64

--- a/tools/splitblocks/main_test.go
+++ b/tools/splitblocks/main_test.go
@@ -13,16 +13,15 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/runutil"
 	"github.com/prometheus/common/promslog"
-	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	util_test "github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestSplitBlocks(t *testing.T) {
@@ -155,13 +154,13 @@ func buildSeriesSpec(startOfDay time.Time) []*block.SeriesSpec {
 			Chunks: []chunks.Meta{
 				must(chunks.ChunkFromSamples([]chunks.Sample{
 					// Ends up in block 1
-					newSample(startOfDay.Add(10*time.Minute).UnixMilli(), 1, nil, nil),
-					newSample(startOfDay.Add(12*time.Hour).UnixMilli(), 2, nil, nil),
+					util_test.NewSample(startOfDay.Add(10*time.Minute).UnixMilli(), 1, nil, nil),
+					util_test.NewSample(startOfDay.Add(12*time.Hour).UnixMilli(), 2, nil, nil),
 					// Ends up in block 2
-					newSample(startOfDay.Add(24*time.Hour).UnixMilli(), 3, nil, nil),
-					newSample(startOfDay.Add(36*time.Hour).UnixMilli(), 4, nil, nil),
+					util_test.NewSample(startOfDay.Add(24*time.Hour).UnixMilli(), 3, nil, nil),
+					util_test.NewSample(startOfDay.Add(36*time.Hour).UnixMilli(), 4, nil, nil),
 					// Ends up in block 3
-					newSample(startOfDay.Add(48*time.Hour).UnixMilli(), 5, nil, nil),
+					util_test.NewSample(startOfDay.Add(48*time.Hour).UnixMilli(), 5, nil, nil),
 				})),
 			},
 		},
@@ -171,17 +170,17 @@ func buildSeriesSpec(startOfDay time.Time) []*block.SeriesSpec {
 			Chunks: []chunks.Meta{
 				// Ends up in block 1
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					newSample(startOfDay.UnixMilli(), 1, nil, nil),
-					newSample(startOfDay.Add(12*time.Hour).UnixMilli(), 2, nil, nil),
+					util_test.NewSample(startOfDay.UnixMilli(), 1, nil, nil),
+					util_test.NewSample(startOfDay.Add(12*time.Hour).UnixMilli(), 2, nil, nil),
 				})),
 				// Ends up in block 2
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					newSample(startOfDay.Add(24*time.Hour).UnixMilli(), 3, nil, nil),
-					newSample(startOfDay.Add(36*time.Hour).UnixMilli(), 4, nil, nil),
+					util_test.NewSample(startOfDay.Add(24*time.Hour).UnixMilli(), 3, nil, nil),
+					util_test.NewSample(startOfDay.Add(36*time.Hour).UnixMilli(), 4, nil, nil),
 				})),
 				// Ends up in block 3
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					newSample(startOfDay.Add(48*time.Hour).UnixMilli(), 5, nil, nil),
+					util_test.NewSample(startOfDay.Add(48*time.Hour).UnixMilli(), 5, nil, nil),
 				})),
 			},
 		},
@@ -191,9 +190,9 @@ func buildSeriesSpec(startOfDay time.Time) []*block.SeriesSpec {
 			Chunks: []chunks.Meta{
 				must(chunks.ChunkFromSamples([]chunks.Sample{
 					// Ends up in block 2
-					newSample(startOfDay.Add(24*time.Hour).UnixMilli(), 1, nil, nil),
-					newSample(startOfDay.Add(25*time.Hour).UnixMilli(), 2, nil, nil),
-					newSample(startOfDay.Add(26*time.Hour).UnixMilli(), 3, nil, nil),
+					util_test.NewSample(startOfDay.Add(24*time.Hour).UnixMilli(), 1, nil, nil),
+					util_test.NewSample(startOfDay.Add(25*time.Hour).UnixMilli(), 2, nil, nil),
+					util_test.NewSample(startOfDay.Add(26*time.Hour).UnixMilli(), 3, nil, nil),
 				})),
 			},
 		},
@@ -241,39 +240,4 @@ func must[T any](v T, err error) T {
 		panic(err)
 	}
 	return v
-}
-
-type sample struct {
-	t  int64
-	v  float64
-	h  *histogram.Histogram
-	fh *histogram.FloatHistogram
-}
-
-func newSample(t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram) chunks.Sample {
-	return sample{t, v, h, fh}
-}
-func (s sample) T() int64                      { return s.t }
-func (s sample) F() float64                    { return s.v }
-func (s sample) H() *histogram.Histogram       { return s.h }
-func (s sample) FH() *histogram.FloatHistogram { return s.fh }
-
-func (s sample) Type() chunkenc.ValueType {
-	switch {
-	case s.h != nil:
-		return chunkenc.ValHistogram
-	case s.fh != nil:
-		return chunkenc.ValFloatHistogram
-	default:
-		return chunkenc.ValFloat
-	}
-}
-
-func (s sample) Copy() chunks.Sample {
-	return sample{
-		s.t,
-		s.v,
-		s.h.Copy(),
-		s.fh.Copy(),
-	}
 }

--- a/tools/splitblocks/main_test.go
+++ b/tools/splitblocks/main_test.go
@@ -154,13 +154,13 @@ func buildSeriesSpec(startOfDay time.Time) []*block.SeriesSpec {
 			Chunks: []chunks.Meta{
 				must(chunks.ChunkFromSamples([]chunks.Sample{
 					// Ends up in block 1
-					util_test.NewSample(startOfDay.Add(10*time.Minute).UnixMilli(), 1, nil, nil),
-					util_test.NewSample(startOfDay.Add(12*time.Hour).UnixMilli(), 2, nil, nil),
+					util_test.Sample{TS: startOfDay.Add(10 * time.Minute).UnixMilli(), Val: 1},
+					util_test.Sample{TS: startOfDay.Add(12 * time.Hour).UnixMilli(), Val: 2},
 					// Ends up in block 2
-					util_test.NewSample(startOfDay.Add(24*time.Hour).UnixMilli(), 3, nil, nil),
-					util_test.NewSample(startOfDay.Add(36*time.Hour).UnixMilli(), 4, nil, nil),
+					util_test.Sample{TS: startOfDay.Add(24 * time.Hour).UnixMilli(), Val: 3},
+					util_test.Sample{TS: startOfDay.Add(36 * time.Hour).UnixMilli(), Val: 4},
 					// Ends up in block 3
-					util_test.NewSample(startOfDay.Add(48*time.Hour).UnixMilli(), 5, nil, nil),
+					util_test.Sample{TS: startOfDay.Add(48 * time.Hour).UnixMilli(), Val: 5},
 				})),
 			},
 		},
@@ -170,17 +170,17 @@ func buildSeriesSpec(startOfDay time.Time) []*block.SeriesSpec {
 			Chunks: []chunks.Meta{
 				// Ends up in block 1
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					util_test.NewSample(startOfDay.UnixMilli(), 1, nil, nil),
-					util_test.NewSample(startOfDay.Add(12*time.Hour).UnixMilli(), 2, nil, nil),
+					util_test.Sample{TS: startOfDay.UnixMilli(), Val: 1},
+					util_test.Sample{TS: startOfDay.Add(12 * time.Hour).UnixMilli(), Val: 2},
 				})),
 				// Ends up in block 2
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					util_test.NewSample(startOfDay.Add(24*time.Hour).UnixMilli(), 3, nil, nil),
-					util_test.NewSample(startOfDay.Add(36*time.Hour).UnixMilli(), 4, nil, nil),
+					util_test.Sample{TS: startOfDay.Add(24 * time.Hour).UnixMilli(), Val: 3},
+					util_test.Sample{TS: startOfDay.Add(36 * time.Hour).UnixMilli(), Val: 4},
 				})),
 				// Ends up in block 3
 				must(chunks.ChunkFromSamples([]chunks.Sample{
-					util_test.NewSample(startOfDay.Add(48*time.Hour).UnixMilli(), 5, nil, nil),
+					util_test.Sample{TS: startOfDay.Add(48 * time.Hour).UnixMilli(), Val: 5},
 				})),
 			},
 		},
@@ -190,9 +190,9 @@ func buildSeriesSpec(startOfDay time.Time) []*block.SeriesSpec {
 			Chunks: []chunks.Meta{
 				must(chunks.ChunkFromSamples([]chunks.Sample{
 					// Ends up in block 2
-					util_test.NewSample(startOfDay.Add(24*time.Hour).UnixMilli(), 1, nil, nil),
-					util_test.NewSample(startOfDay.Add(25*time.Hour).UnixMilli(), 2, nil, nil),
-					util_test.NewSample(startOfDay.Add(26*time.Hour).UnixMilli(), 3, nil, nil),
+					util_test.Sample{TS: startOfDay.Add(24 * time.Hour).UnixMilli(), Val: 1},
+					util_test.Sample{TS: startOfDay.Add(25 * time.Hour).UnixMilli(), Val: 2},
+					util_test.Sample{TS: startOfDay.Add(26 * time.Hour).UnixMilli(), Val: 3},
 				})),
 			},
 		},

--- a/tools/tsdb-chunks/main_test.go
+++ b/tools/tsdb-chunks/main_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
-	util_test "github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestTSDBChunks(t *testing.T) {
@@ -22,14 +22,14 @@ func TestTSDBChunks(t *testing.T) {
 		Labels: labels.FromStrings(labels.MetricName, "asdf"),
 		Chunks: []chunks.Meta{
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				util_test.Sample{TS: 10, Val: 11},
-				util_test.Sample{TS: 20, Val: 12},
-				util_test.Sample{TS: 30, Val: 13},
+				test.Sample{TS: 10, Val: 11},
+				test.Sample{TS: 20, Val: 12},
+				test.Sample{TS: 30, Val: 13},
 			})),
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				util_test.Sample{TS: 40, Hist: util_test.GenerateTestHistogram(1)},
-				util_test.Sample{TS: 50, Hist: util_test.GenerateTestHistogram(2)},
-				util_test.Sample{TS: 60, Hist: util_test.GenerateTestHistogram(3)},
+				test.Sample{TS: 40, Hist: test.GenerateTestHistogram(1)},
+				test.Sample{TS: 50, Hist: test.GenerateTestHistogram(2)},
+				test.Sample{TS: 60, Hist: test.GenerateTestHistogram(3)},
 			})),
 		},
 	}
@@ -37,7 +37,7 @@ func TestTSDBChunks(t *testing.T) {
 	meta, err := block.GenerateBlockFromSpec(tmpDir, []*block.SeriesSpec{&spec})
 	require.NoError(t, err)
 
-	co := util_test.CaptureOutput(t)
+	co := test.CaptureOutput(t)
 
 	chunkFilename := path.Join(tmpDir, meta.ULID.String(), "chunks", "000001")
 	require.NoError(t, printChunksFile(chunkFilename, true))

--- a/tools/tsdb-chunks/main_test.go
+++ b/tools/tsdb-chunks/main_test.go
@@ -7,14 +7,12 @@ import (
 	"path"
 	"testing"
 
-	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
-	"github.com/grafana/mimir/pkg/util/test"
+	util_test "github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestTSDBChunks(t *testing.T) {
@@ -24,14 +22,14 @@ func TestTSDBChunks(t *testing.T) {
 		Labels: labels.FromStrings(labels.MetricName, "asdf"),
 		Chunks: []chunks.Meta{
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				sample{10, 11, nil, nil},
-				sample{20, 12, nil, nil},
-				sample{30, 13, nil, nil},
+				util_test.Sample{TS: 10, Val: 11},
+				util_test.Sample{TS: 20, Val: 12},
+				util_test.Sample{TS: 30, Val: 13},
 			})),
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				sample{40, 0, test.GenerateTestHistogram(1), nil},
-				sample{50, 0, test.GenerateTestHistogram(2), nil},
-				sample{60, 0, test.GenerateTestHistogram(3), nil},
+				util_test.Sample{TS: 40, Hist: util_test.GenerateTestHistogram(1)},
+				util_test.Sample{TS: 50, Hist: util_test.GenerateTestHistogram(2)},
+				util_test.Sample{TS: 60, Hist: util_test.GenerateTestHistogram(3)},
 			})),
 		},
 	}
@@ -39,7 +37,7 @@ func TestTSDBChunks(t *testing.T) {
 	meta, err := block.GenerateBlockFromSpec(tmpDir, []*block.SeriesSpec{&spec})
 	require.NoError(t, err)
 
-	co := test.CaptureOutput(t)
+	co := util_test.CaptureOutput(t)
 
 	chunkFilename := path.Join(tmpDir, meta.ULID.String(), "chunks", "000001")
 	require.NoError(t, printChunksFile(chunkFilename, true))
@@ -61,40 +59,6 @@ Chunk #1: minTS=40 (1970-01-01T00:00:00.04Z), maxTS=60 (1970-01-01T00:00:00.06Z)
 	expected = fmt.Sprintf(expected, chunkFilename)
 
 	require.Equal(t, expected, sout)
-}
-
-type sample struct {
-	t  int64
-	v  float64
-	h  *histogram.Histogram
-	fh *histogram.FloatHistogram
-}
-
-func (s sample) T() int64                      { return s.t }
-func (s sample) F() float64                    { return s.v }
-func (s sample) H() *histogram.Histogram       { return s.h }
-func (s sample) FH() *histogram.FloatHistogram { return s.fh }
-
-func (s sample) Type() chunkenc.ValueType {
-	switch {
-	case s.h != nil:
-		return chunkenc.ValHistogram
-	case s.fh != nil:
-		return chunkenc.ValFloatHistogram
-	default:
-		return chunkenc.ValFloat
-	}
-}
-
-func (s sample) Copy() chunks.Sample {
-	c := sample{t: s.t, v: s.v}
-	if s.h != nil {
-		c.h = s.h.Copy()
-	}
-	if s.fh != nil {
-		c.fh = s.fh.Copy()
-	}
-	return c
 }
 
 func must[T any](v T, err error) T {

--- a/tools/tsdb-index-health/main_test.go
+++ b/tools/tsdb-index-health/main_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
-	util_test "github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestGatherIndexHealthStats(t *testing.T) {
@@ -23,9 +23,9 @@ func TestGatherIndexHealthStats(t *testing.T) {
 		Labels: labels.FromStrings(labels.MetricName, "asdf"),
 		Chunks: []chunks.Meta{
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				util_test.Sample{TS: 10, Val: 11},
-				util_test.Sample{TS: 20, Val: 12},
-				util_test.Sample{TS: 30, Val: 13},
+				test.Sample{TS: 10, Val: 11},
+				test.Sample{TS: 20, Val: 12},
+				test.Sample{TS: 30, Val: 13},
 			})),
 		},
 	}
@@ -33,14 +33,14 @@ func TestGatherIndexHealthStats(t *testing.T) {
 		Labels: labels.FromStrings(labels.MetricName, "zxcv", "foo", "bar"),
 		Chunks: []chunks.Meta{
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				util_test.Sample{TS: 40, Hist: util_test.GenerateTestHistogram(1)},
-				util_test.Sample{TS: 50, Hist: util_test.GenerateTestHistogram(2)},
-				util_test.Sample{TS: 60, Hist: util_test.GenerateTestHistogram(3)},
+				test.Sample{TS: 40, Hist: test.GenerateTestHistogram(1)},
+				test.Sample{TS: 50, Hist: test.GenerateTestHistogram(2)},
+				test.Sample{TS: 60, Hist: test.GenerateTestHistogram(3)},
 			})),
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				util_test.Sample{TS: 70, Hist: util_test.GenerateTestHistogram(4)},
-				util_test.Sample{TS: 80, Hist: util_test.GenerateTestHistogram(5)},
-				util_test.Sample{TS: 90, Hist: util_test.GenerateTestHistogram(6)},
+				test.Sample{TS: 70, Hist: test.GenerateTestHistogram(4)},
+				test.Sample{TS: 80, Hist: test.GenerateTestHistogram(5)},
+				test.Sample{TS: 90, Hist: test.GenerateTestHistogram(6)},
 			})),
 		},
 	}

--- a/tools/tsdb-index-health/main_test.go
+++ b/tools/tsdb-index-health/main_test.go
@@ -8,14 +8,12 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
-	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
-	"github.com/grafana/mimir/pkg/util/test"
+	util_test "github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestGatherIndexHealthStats(t *testing.T) {
@@ -25,9 +23,9 @@ func TestGatherIndexHealthStats(t *testing.T) {
 		Labels: labels.FromStrings(labels.MetricName, "asdf"),
 		Chunks: []chunks.Meta{
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				sample{10, 11, nil, nil},
-				sample{20, 12, nil, nil},
-				sample{30, 13, nil, nil},
+				util_test.Sample{TS: 10, Val: 11},
+				util_test.Sample{TS: 20, Val: 12},
+				util_test.Sample{TS: 30, Val: 13},
 			})),
 		},
 	}
@@ -35,14 +33,14 @@ func TestGatherIndexHealthStats(t *testing.T) {
 		Labels: labels.FromStrings(labels.MetricName, "zxcv", "foo", "bar"),
 		Chunks: []chunks.Meta{
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				sample{40, 0, test.GenerateTestHistogram(1), nil},
-				sample{50, 0, test.GenerateTestHistogram(2), nil},
-				sample{60, 0, test.GenerateTestHistogram(3), nil},
+				util_test.Sample{TS: 40, Hist: util_test.GenerateTestHistogram(1)},
+				util_test.Sample{TS: 50, Hist: util_test.GenerateTestHistogram(2)},
+				util_test.Sample{TS: 60, Hist: util_test.GenerateTestHistogram(3)},
 			})),
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				sample{70, 0, test.GenerateTestHistogram(4), nil},
-				sample{80, 0, test.GenerateTestHistogram(5), nil},
-				sample{90, 0, test.GenerateTestHistogram(6), nil},
+				util_test.Sample{TS: 70, Hist: util_test.GenerateTestHistogram(4)},
+				util_test.Sample{TS: 80, Hist: util_test.GenerateTestHistogram(5)},
+				util_test.Sample{TS: 90, Hist: util_test.GenerateTestHistogram(6)},
 			})),
 		},
 	}
@@ -61,40 +59,6 @@ func TestGatherIndexHealthStats(t *testing.T) {
 	require.Equal(t, int64(3), stats.TotalChunks)
 	require.Equal(t, int64(2), stats.LabelNamesCount)
 	require.Equal(t, int64(2), stats.MetricLabelValuesCount)
-}
-
-type sample struct {
-	t  int64
-	v  float64
-	h  *histogram.Histogram
-	fh *histogram.FloatHistogram
-}
-
-func (s sample) T() int64                      { return s.t }
-func (s sample) F() float64                    { return s.v }
-func (s sample) H() *histogram.Histogram       { return s.h }
-func (s sample) FH() *histogram.FloatHistogram { return s.fh }
-
-func (s sample) Type() chunkenc.ValueType {
-	switch {
-	case s.h != nil:
-		return chunkenc.ValHistogram
-	case s.fh != nil:
-		return chunkenc.ValFloatHistogram
-	default:
-		return chunkenc.ValFloat
-	}
-}
-
-func (s sample) Copy() chunks.Sample {
-	c := sample{t: s.t, v: s.v}
-	if s.h != nil {
-		c.h = s.h.Copy()
-	}
-	if s.fh != nil {
-		c.fh = s.fh.Copy()
-	}
-	return c
 }
 
 func must[T any](v T, err error) T {

--- a/tools/tsdb-print-chunk/main_test.go
+++ b/tools/tsdb-print-chunk/main_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
-	util_test "github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestTSDBPrintChunk(t *testing.T) {
@@ -22,14 +22,14 @@ func TestTSDBPrintChunk(t *testing.T) {
 		Labels: labels.FromStrings(labels.MetricName, "asdf"),
 		Chunks: []chunks.Meta{
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				util_test.Sample{TS: 10, Val: 11},
-				util_test.Sample{TS: 20, Val: 12},
-				util_test.Sample{TS: 30, Val: 13},
+				test.Sample{TS: 10, Val: 11},
+				test.Sample{TS: 20, Val: 12},
+				test.Sample{TS: 30, Val: 13},
 			})),
 			must(chunks.ChunkFromSamples([]chunks.Sample{
-				util_test.Sample{TS: 40, Hist: util_test.GenerateTestHistogram(1)},
-				util_test.Sample{TS: 50, Hist: util_test.GenerateTestHistogram(2)},
-				util_test.Sample{TS: 60, Hist: util_test.GenerateTestHistogram(3)},
+				test.Sample{TS: 40, Hist: test.GenerateTestHistogram(1)},
+				test.Sample{TS: 50, Hist: test.GenerateTestHistogram(2)},
+				test.Sample{TS: 60, Hist: test.GenerateTestHistogram(3)},
 			})),
 		},
 	}
@@ -44,7 +44,7 @@ func TestTSDBPrintChunk(t *testing.T) {
 		chunkRefs = append(chunkRefs, strconv.Itoa(int(chkMeta.Ref)))
 	}
 
-	co := util_test.CaptureOutput(t)
+	co := test.CaptureOutput(t)
 	printChunks(blockDir, chunkRefs)
 	sout, _ := co.Done()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Lots of things in tests need a type that satisfies prometheus' `chunks.Sample` interface, and prometheus does not provide any public implementation.
We ended up with about 10 identical implementations, each private to a separate test file.

This makes them all one in our test utils package

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
