### PR TITLE
Add note about saturated nodes in `MimirDistributorGcUsesTooMuchCpu` runbook.

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -171,6 +171,9 @@ This is a symptom of setting GOMEMLIMIT too low, so GC is triggered too frequent
 How to **fix** it:
 
 1. Ensure that distributor horizontal pod auto-scaling works properly, so that distributors are scaled out horizontally in response to CPU pressure.
+1. Aggregate the alert query by pod to see if the alert is being triggered by outlier pods. As distrbutors are stateless, we expect each pod to have roughly
+    equal GC-related CPU usage. If there are pods using far more GC CPU than others, examine the nodes housing those pods, and if they're over-taxed, CPU-wise,
+    you can attempt to roll these pods to different nodes by deleting them.
 
 ### MimirDistributorReachingInflightPushRequestLimit
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -173,7 +173,7 @@ How to **fix** it:
 1. Ensure that distributor horizontal pod auto-scaling works properly, so that distributors are scaled out horizontally in response to CPU pressure.
 1. Aggregate the alert query by pod to see if the alert is being triggered by outlier pods. As distrbutors are stateless, we expect each pod to have roughly
    equal GC-related CPU usage. If there are pods using far more GC CPU than others, examine the nodes housing those pods, and if they're over-taxed, CPU-wise,
-   you can attempt to roll these pods to different nodes by deleting them.
+   you can attempt to move these pods to different nodes by deleting them.
 
 ### MimirDistributorReachingInflightPushRequestLimit
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -172,8 +172,8 @@ How to **fix** it:
 
 1. Ensure that distributor horizontal pod auto-scaling works properly, so that distributors are scaled out horizontally in response to CPU pressure.
 1. Aggregate the alert query by pod to see if the alert is being triggered by outlier pods. As distrbutors are stateless, we expect each pod to have roughly
-    equal GC-related CPU usage. If there are pods using far more GC CPU than others, examine the nodes housing those pods, and if they're over-taxed, CPU-wise,
-    you can attempt to roll these pods to different nodes by deleting them.
+   equal GC-related CPU usage. If there are pods using far more GC CPU than others, examine the nodes housing those pods, and if they're over-taxed, CPU-wise,
+   you can attempt to roll these pods to different nodes by deleting them.
 
 ### MimirDistributorReachingInflightPushRequestLimit
 


### PR DESCRIPTION
#### What this PR does

Note that we expect distributors to use uniform GC CPU, and to check the underlying compute resources if they are not.


#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
