### PR TITLE
Alerts: Fix alerts for invalid cluster validation labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 * [ENHANCEMENT] Alerts: Make `MimirRolloutStuck` a critical alert if it has been firing for 6h. #10890
 * [ENHANCEMENT] Dashboards: Add panels to the `Mimir / Tenants` and `Mimir / Top Tenants` dashboards showing the rate of gateway requests. #10978
 * [ENHANCEMENT] Alerts: Improve `MimirIngesterFailsToProcessRecordsFromKafka` to not fire during forced TSDB head compaction. #11006
-* [ENHANCEMENT] Alerts: Add alerts for invalid cluster validation labels. #11255
+* [ENHANCEMENT] Alerts: Add alerts for invalid cluster validation labels. #11255 #11282
 * [BUGFIX] Dashboards: fix "Mimir / Tenants" legends for non-Kubernetes deployments. #10891
 
 ### Jsonnet

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -247,7 +247,7 @@ spec:
               message: Mimir servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclustervalidationlabelrequests
             expr: |
-              (sum by (cluster, namespace, pod) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+              (sum by (cluster, namespace) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
               # Alert only for namespaces with Mimir clusters.
               and (count by (cluster, namespace) (mimir_build_info) > 0)
             labels:
@@ -257,7 +257,7 @@ spec:
               message: Mimir clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclustervalidationlabelrequests
             expr: |
-              (sum by (cluster, namespace, pod) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+              (sum by (cluster, namespace) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
               # Alert only for namespaces with Mimir clusters.
               and (count by (cluster, namespace) (mimir_build_info) > 0)
             labels:

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -235,7 +235,7 @@ groups:
             message: Mimir servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace, instance) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
             and (count by (cluster, namespace) (mimir_build_info) > 0)
           labels:
@@ -245,7 +245,7 @@ groups:
             message: Mimir clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace, instance) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
             and (count by (cluster, namespace) (mimir_build_info) > 0)
           labels:

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -235,7 +235,7 @@ groups:
             message: GEM servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace, pod) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
             and (count by (cluster, namespace) (mimir_build_info) > 0)
           labels:
@@ -245,7 +245,7 @@ groups:
             message: GEM clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace, pod) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
             and (count by (cluster, namespace) (mimir_build_info) > 0)
           labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -235,7 +235,7 @@ groups:
             message: Mimir servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace, pod) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
             and (count by (cluster, namespace) (mimir_build_info) > 0)
           labels:
@@ -245,7 +245,7 @@ groups:
             message: Mimir clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace, pod) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
             and (count by (cluster, namespace) (mimir_build_info) > 0)
           labels:

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -397,7 +397,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           // Alert if servers are receiving requests with invalid cluster validation labels (i.e. meant for other clusters).
           alert: $.alertName('ServerInvalidClusterValidationLabelRequests'),
           expr: |||
-            (sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[%(range_interval)s]))) > 0
+            (sum by (%(alert_aggregation_labels)s) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[%(range_interval)s]))) > 0
             # Alert only for namespaces with Mimir clusters.
             and (count by (%(alert_aggregation_labels)s) (mimir_build_info) > 0)
           ||| % $._config {
@@ -414,7 +414,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           // Alert if clients' requests are rejected due to invalid cluster validation labels (i.e. there's a mismatch between clients' and servers' cluster validation labels).
           alert: $.alertName('ClientInvalidClusterValidationLabelRequests'),
           expr: |||
-            (sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[%(range_interval)s]))) > 0
+            (sum by (%(alert_aggregation_labels)s) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[%(range_interval)s]))) > 0
             # Alert only for namespaces with Mimir clusters.
             and (count by (%(alert_aggregation_labels)s) (mimir_build_info) > 0)
           ||| % $._config {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Fix alerts for invalid cluster validation labels, so that the two components to the query both aggregate on `cluster` and `namespace` labels.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
