### PR TITLE
MQE: Make memory consumption tracker concurrency safe

### DIFF
--- a/pkg/streamingpromql/limiting/memory_consumption.go
+++ b/pkg/streamingpromql/limiting/memory_consumption.go
@@ -3,6 +3,8 @@
 package limiting
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/mimir/pkg/util/limiter"
@@ -11,20 +13,23 @@ import (
 // MemoryConsumptionTracker tracks the current memory utilisation of a single query, and applies any max in-memory bytes limit.
 //
 // It also tracks the peak number of in-memory bytes for use in query statistics.
-//
-// It is not safe to use this type from multiple goroutines simultaneously.
 type MemoryConsumptionTracker struct {
-	MaxEstimatedMemoryConsumptionBytes     uint64
-	CurrentEstimatedMemoryConsumptionBytes uint64
-	PeakEstimatedMemoryConsumptionBytes    uint64
+	maxEstimatedMemoryConsumptionBytes     uint64
+	currentEstimatedMemoryConsumptionBytes uint64
+	peakEstimatedMemoryConsumptionBytes    uint64
 
 	rejectionCount        prometheus.Counter
 	haveRecordedRejection bool
+
+	// mtx protects all mutable state of the memory consumption tracker. We use a mutex
+	// rather than atomics because we only want to adjust the memory used after checking
+	// that it would not exceed the limit.
+	mtx sync.Mutex
 }
 
 func NewMemoryConsumptionTracker(maxEstimatedMemoryConsumptionBytes uint64, rejectionCount prometheus.Counter) *MemoryConsumptionTracker {
 	return &MemoryConsumptionTracker{
-		MaxEstimatedMemoryConsumptionBytes: maxEstimatedMemoryConsumptionBytes,
+		maxEstimatedMemoryConsumptionBytes: maxEstimatedMemoryConsumptionBytes,
 
 		rejectionCount: rejectionCount,
 	}
@@ -34,25 +39,47 @@ func NewMemoryConsumptionTracker(maxEstimatedMemoryConsumptionBytes uint64, reje
 //
 // It returns an error if the query would exceed the maximum memory consumption limit.
 func (l *MemoryConsumptionTracker) IncreaseMemoryConsumption(b uint64) error {
-	if l.MaxEstimatedMemoryConsumptionBytes > 0 && l.CurrentEstimatedMemoryConsumptionBytes+b > l.MaxEstimatedMemoryConsumptionBytes {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	if l.maxEstimatedMemoryConsumptionBytes > 0 && l.currentEstimatedMemoryConsumptionBytes+b > l.maxEstimatedMemoryConsumptionBytes {
 		if !l.haveRecordedRejection {
 			l.haveRecordedRejection = true
 			l.rejectionCount.Inc()
 		}
 
-		return limiter.NewMaxEstimatedMemoryConsumptionPerQueryLimitError(l.MaxEstimatedMemoryConsumptionBytes)
+		return limiter.NewMaxEstimatedMemoryConsumptionPerQueryLimitError(l.maxEstimatedMemoryConsumptionBytes)
 	}
 
-	l.CurrentEstimatedMemoryConsumptionBytes += b
-	l.PeakEstimatedMemoryConsumptionBytes = max(l.PeakEstimatedMemoryConsumptionBytes, l.CurrentEstimatedMemoryConsumptionBytes)
+	l.currentEstimatedMemoryConsumptionBytes += b
+	l.peakEstimatedMemoryConsumptionBytes = max(l.peakEstimatedMemoryConsumptionBytes, l.currentEstimatedMemoryConsumptionBytes)
 
 	return nil
 }
 
 // DecreaseMemoryConsumption decreases the current memory consumption by b bytes.
 func (l *MemoryConsumptionTracker) DecreaseMemoryConsumption(b uint64) {
-	if b > l.CurrentEstimatedMemoryConsumptionBytes {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	if b > l.currentEstimatedMemoryConsumptionBytes {
 		panic("Estimated memory consumption of this query is negative. This indicates something has been returned to a pool more than once, which is a bug.")
 	}
-	l.CurrentEstimatedMemoryConsumptionBytes -= b
+	l.currentEstimatedMemoryConsumptionBytes -= b
+}
+
+// PeakEstimatedMemoryConsumptionBytes returns the peak memory consumption in bytes.
+func (l *MemoryConsumptionTracker) PeakEstimatedMemoryConsumptionBytes() uint64 {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	return l.peakEstimatedMemoryConsumptionBytes
+}
+
+// CurrentEstimatedMemoryConsumptionBytes returns the current memory consumption in bytes.
+func (l *MemoryConsumptionTracker) CurrentEstimatedMemoryConsumptionBytes() uint64 {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	return l.currentEstimatedMemoryConsumptionBytes
 }

--- a/pkg/streamingpromql/limiting/memory_consumption_test.go
+++ b/pkg/streamingpromql/limiting/memory_consumption_test.go
@@ -5,12 +5,14 @@ package limiting
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 const rejectedQueriesMetricName = "rejected_queries"
@@ -20,28 +22,28 @@ func TestMemoryConsumptionTracker_Unlimited(t *testing.T) {
 	tracker := NewMemoryConsumptionTracker(0, metric)
 
 	require.NoError(t, tracker.IncreaseMemoryConsumption(128))
-	require.Equal(t, uint64(128), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(128), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(128), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(128), tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Add some more memory consumption. The current and peak stats should be updated.
 	require.NoError(t, tracker.IncreaseMemoryConsumption(2))
-	require.Equal(t, uint64(130), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(130), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(130), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(130), tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Reduce memory consumption. The current consumption should be updated, but the peak should be unchanged.
 	tracker.DecreaseMemoryConsumption(128)
-	require.Equal(t, uint64(2), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(130), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(2), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(130), tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Add some more memory consumption that doesn't take us over the previous peak.
 	require.NoError(t, tracker.IncreaseMemoryConsumption(8))
-	require.Equal(t, uint64(10), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(130), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(10), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(130), tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Add some more memory consumption that takes us over the previous peak.
 	require.NoError(t, tracker.IncreaseMemoryConsumption(121))
-	require.Equal(t, uint64(131), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(131), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(131), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(131), tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	assertRejectedQueriesCount(t, reg, 0)
 
@@ -55,46 +57,46 @@ func TestMemoryConsumptionTracker_Limited(t *testing.T) {
 
 	// Add some memory consumption beneath the limit.
 	require.NoError(t, tracker.IncreaseMemoryConsumption(8))
-	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(8), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(8), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 0)
 
 	// Add some more memory consumption beneath the limit.
 	require.NoError(t, tracker.IncreaseMemoryConsumption(1))
-	require.Equal(t, uint64(9), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(9), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 0)
 
 	// Reduce memory consumption.
 	tracker.DecreaseMemoryConsumption(1)
-	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 0)
 
 	// Try to add some more memory consumption where we would go over the limit.
 	const expectedError = "the query exceeded the maximum allowed estimated amount of memory consumed by a single query (limit: 11 bytes) (err-mimir-max-estimated-memory-consumption-per-query)"
 	require.ErrorContains(t, tracker.IncreaseMemoryConsumption(4), expectedError)
-	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 1)
 
 	// Make sure we don't increment the rejection count a second time for the same query.
 	require.ErrorContains(t, tracker.IncreaseMemoryConsumption(4), expectedError)
-	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 1)
 
 	// Keep adding more memory consumption up to the limit to make sure the failed increases weren't counted.
 	for i := 0; i < 3; i++ {
 		require.NoError(t, tracker.IncreaseMemoryConsumption(1))
-		require.Equal(t, uint64(9+i), tracker.CurrentEstimatedMemoryConsumptionBytes)
-		require.Equal(t, uint64(9+i), tracker.PeakEstimatedMemoryConsumptionBytes)
+		require.Equal(t, uint64(9+i), tracker.CurrentEstimatedMemoryConsumptionBytes())
+		require.Equal(t, uint64(9+i), tracker.PeakEstimatedMemoryConsumptionBytes())
 	}
 
 	// Try to add some more memory consumption when we're already at the limit.
 	require.ErrorContains(t, tracker.IncreaseMemoryConsumption(1), expectedError)
-	require.Equal(t, uint64(11), tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, uint64(11), tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(11), tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, uint64(11), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 1)
 
 	// Test reducing memory consumption to a negative panics
@@ -116,4 +118,82 @@ func createRejectedMetric() (*prometheus.Registry, prometheus.Counter) {
 	})
 
 	return reg, metric
+}
+
+func BenchmarkMemoryConsumptionTracker(b *testing.B) {
+	b.Run("no limits single threaded", func(b *testing.B) {
+		l := NewMemoryConsumptionTracker(0, nil)
+		for i := 0; i < b.N; i++ {
+			_ = l.IncreaseMemoryConsumption(uint64(b.N))
+			l.DecreaseMemoryConsumption(uint64(b.N))
+		}
+
+		require.Equal(b, uint64(0), l.CurrentEstimatedMemoryConsumptionBytes())
+	})
+
+	b.Run("with limits single threaded", func(b *testing.B) {
+		l := NewMemoryConsumptionTracker(1024*1024, nil)
+		for i := 0; i < b.N; i++ {
+			if err := l.IncreaseMemoryConsumption(uint64(b.N)); err == nil {
+				l.DecreaseMemoryConsumption(uint64(b.N))
+			}
+		}
+
+		require.Equal(b, uint64(0), l.CurrentEstimatedMemoryConsumptionBytes())
+	})
+
+	b.Run("no limits multiple threads", func(b *testing.B) {
+		l := NewMemoryConsumptionTracker(0, nil)
+		wg := sync.WaitGroup{}
+		run := atomic.NewBool(true)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for run.Load() {
+				_ = l.IncreaseMemoryConsumption(1024)
+				l.DecreaseMemoryConsumption(1024)
+			}
+		}()
+
+		for i := 0; i < b.N; i++ {
+			_ = l.IncreaseMemoryConsumption(uint64(b.N))
+			l.DecreaseMemoryConsumption(uint64(b.N))
+		}
+
+		run.Store(false)
+		wg.Wait()
+
+		require.Equal(b, uint64(0), l.CurrentEstimatedMemoryConsumptionBytes())
+	})
+
+	b.Run("with limits multiple threads", func(b *testing.B) {
+		l := NewMemoryConsumptionTracker(1024*1024, nil)
+		wg := sync.WaitGroup{}
+		run := atomic.NewBool(true)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for run.Load() {
+				if err := l.IncreaseMemoryConsumption(1024); err == nil {
+					l.DecreaseMemoryConsumption(1024)
+				}
+			}
+		}()
+
+		for i := 0; i < b.N; i++ {
+			if err := l.IncreaseMemoryConsumption(uint64(b.N)); err == nil {
+				l.DecreaseMemoryConsumption(uint64(b.N))
+			}
+		}
+
+		run.Store(false)
+		wg.Wait()
+
+		require.Equal(b, uint64(0), l.CurrentEstimatedMemoryConsumptionBytes())
+	})
+
 }

--- a/pkg/streamingpromql/limiting/memory_consumption_test.go
+++ b/pkg/streamingpromql/limiting/memory_consumption_test.go
@@ -138,7 +138,7 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 	})
 
 	b.Run("with limits single threaded", func(b *testing.B) {
-		counter := prometheus.NewCounter(prometheus.CounterOpts{
+		counter := promauto.With(nil).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_test_rejections_total",
 		})
 
@@ -181,7 +181,7 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 	})
 
 	b.Run("with limits multiple threads", func(b *testing.B) {
-		counter := prometheus.NewCounter(prometheus.CounterOpts{
+		counter := promauto.With(nil).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_test_rejections_total",
 		})
 

--- a/pkg/streamingpromql/operators/aggregations/aggregation_test.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation_test.go
@@ -393,7 +393,7 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 
 			// Close the operator and confirm all memory has been released.
 			o.Close()
-			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 		})
 	}
 }

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
@@ -94,7 +94,7 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 
 							// Close the operator and confirm all memory has been released.
 							o.Close()
-							require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+							require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 						})
 					}
 				})

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -361,7 +361,7 @@ func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testin
 
 			o.Close()
 			// Make sure we've returned everything to their pools.
-			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 		})
 	}
 }
@@ -455,7 +455,7 @@ func TestAndUnlessBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *test
 
 					// Close the operator and confirm that we've returned everything to their pools.
 					o.Close()
-					require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+					require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 				})
 			}
 		})

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -518,7 +518,7 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 
 			o.Close()
 			// Make sure we've returned everything to their pools.
-			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 		})
 	}
 }
@@ -606,7 +606,7 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 
 			// Close the operator and verify that the intermediate state is released.
 			o.Close()
-			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 		})
 	}
 }

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -671,7 +671,7 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 
 			o.Close()
 			// Make sure we've returned everything to their pools.
-			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 		})
 	}
 }
@@ -733,7 +733,7 @@ func TestOneToOneVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEa
 
 			// Close the operator and verify that the intermediate state is released.
 			o.Close()
-			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 		})
 	}
 }

--- a/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
@@ -581,7 +581,7 @@ func TestOrBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
 
 			o.Close()
 			// Make sure we've returned everything to their pools.
-			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 		})
 	}
 }
@@ -694,7 +694,7 @@ func TestOrBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *testing.T) 
 
 			// Close the operator and confirm that we've returned everything to their pools.
 			o.Close()
-			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 		})
 	}
 }

--- a/pkg/streamingpromql/operators/functions/common_test.go
+++ b/pkg/streamingpromql/operators/functions/common_test.go
@@ -60,7 +60,7 @@ func TestFloatTransformationFunc(t *testing.T) {
 	modifiedSeriesData, err := transformFunc(seriesData, nil, types.QueryTimeRange{}, memoryConsumptionTracker)
 	require.NoError(t, err)
 	require.Equal(t, expected, modifiedSeriesData)
-	require.Equal(t, types.FPointSize*2+types.HPointSize*1, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+	require.Equal(t, types.FPointSize*2+types.HPointSize*1, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 }
 
 func TestFloatTransformationDropHistogramsFunc(t *testing.T) {
@@ -92,5 +92,5 @@ func TestFloatTransformationDropHistogramsFunc(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, modifiedSeriesData)
 	// We expect the dropped histogram to be returned to the pool
-	require.Equal(t, types.FPointSize*2, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+	require.Equal(t, types.FPointSize*2, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 }

--- a/pkg/streamingpromql/operators/operator_buffer_test.go
+++ b/pkg/streamingpromql/operators/operator_buffer_test.go
@@ -197,5 +197,5 @@ func TestInstantVectorOperatorBuffer_ReleasesBufferWhenClosedEarly(t *testing.T)
 
 	// Close the buffer, which should release the buffered series.
 	buffer.Close()
-	require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes)
+	require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 }

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -585,7 +585,7 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 
 		msg = append(msg,
 			"msg", "query stats",
-			"estimatedPeakMemoryConsumption", q.memoryConsumptionTracker.PeakEstimatedMemoryConsumptionBytes,
+			"estimatedPeakMemoryConsumption", q.memoryConsumptionTracker.PeakEstimatedMemoryConsumptionBytes(),
 			"expr", q.originalExpression,
 		)
 
@@ -604,7 +604,7 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 		}
 
 		level.Info(logger).Log(msg...)
-		q.engine.estimatedPeakMemoryConsumption.Observe(float64(q.memoryConsumptionTracker.PeakEstimatedMemoryConsumptionBytes))
+		q.engine.estimatedPeakMemoryConsumption.Observe(float64(q.memoryConsumptionTracker.PeakEstimatedMemoryConsumptionBytes()))
 	}()
 
 	switch root := q.root.(type) {
@@ -858,7 +858,7 @@ func (q *Query) Close() {
 	}
 
 	if q.engine.pedantic && q.result.Err == nil {
-		if q.memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes > 0 {
+		if q.memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes() > 0 {
 			panic("Memory consumption tracker still estimates > 0 bytes used. This indicates something has not been returned to a pool.")
 		}
 	}

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -35,39 +35,39 @@ func TestLimitingBucketedPool_Unlimited(t *testing.T) {
 	s100, err := p.Get(100, tracker)
 	require.NoError(t, err)
 	require.Equal(t, 128, cap(s100))
-	require.Equal(t, 128*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 128*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 128*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 128*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Get another slice from the pool, the current and peak stats should be updated.
 	s2, err := p.Get(2, tracker)
 	require.NoError(t, err)
 	require.Equal(t, 2, cap(s2))
-	require.Equal(t, 130*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 130*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 130*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 130*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Put a slice back into the pool, the current stat should be updated but peak should be unchanged.
 	p.Put(s100, tracker)
-	require.Equal(t, 2*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 130*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 2*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 130*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Get another slice from the pool that doesn't take us over the previous peak.
 	s5, err := p.Get(5, tracker)
 	require.NoError(t, err)
 	require.Equal(t, 8, cap(s5))
-	require.Equal(t, 10*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 130*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 10*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 130*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Get another slice from the pool that does take us over the previous peak.
 	s200, err := p.Get(200, tracker)
 	require.NoError(t, err)
 	require.Equal(t, 256, cap(s200))
-	require.Equal(t, 266*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 266*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 266*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 266*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Ensure we handle nil slices safely.
 	p.Put(nil, tracker)
-	require.Equal(t, 266*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 266*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 266*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 266*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	assertRejectedQueryCount(t, reg, 0)
 }
@@ -88,38 +88,38 @@ func TestLimitingPool_Limited(t *testing.T) {
 	s7, err := p.Get(7, tracker)
 	require.NoError(t, err)
 	require.Equal(t, 8, cap(s7))
-	require.Equal(t, 8*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 8*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 8*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 8*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueryCount(t, reg, 0)
 
 	// Get another slice from the pool beneath the limit.
 	s1, err := p.Get(1, tracker)
 	require.NoError(t, err)
 	require.Equal(t, 1, cap(s1))
-	require.Equal(t, 9*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 9*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 9*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 9*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueryCount(t, reg, 0)
 
 	// Return a slice to the pool.
 	p.Put(s1, tracker)
-	require.Equal(t, 8*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 9*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 8*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 9*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueryCount(t, reg, 0)
 
 	// Try to get a slice where the requested size would push us over the limit.
 	_, err = p.Get(4, tracker)
 	expectedError := fmt.Sprintf("the query exceeded the maximum allowed estimated amount of memory consumed by a single query (limit: %d bytes) (err-mimir-max-estimated-memory-consumption-per-query)", limit)
 	require.ErrorContains(t, err, expectedError)
-	require.Equal(t, 8*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 9*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 8*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 9*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueryCount(t, reg, 1)
 
 	// Try to get a slice where the requested size is under the limit, but the capacity of the slice returned by the pool is over the limit.
 	// (We expect the pool to be configured with a factor of 2, so a slice of size 3 will be rounded up to 4 elements.)
 	_, err = p.Get(3, tracker)
 	require.ErrorContains(t, err, expectedError)
-	require.Equal(t, 8*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 9*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 8*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 9*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Make sure we don't increment the rejection count a second time for the same query.
 	assertRejectedQueryCount(t, reg, 1)
@@ -129,15 +129,15 @@ func TestLimitingPool_Limited(t *testing.T) {
 		s1, err = p.Get(1, tracker)
 		require.NoError(t, err)
 		require.Equal(t, 1, cap(s1))
-		require.Equal(t, uint64(9+i)*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-		require.Equal(t, uint64(9+i)*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+		require.Equal(t, uint64(9+i)*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+		require.Equal(t, uint64(9+i)*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 	}
 
 	// Try to get another slice while we're already at the limit.
 	_, err = p.Get(1, tracker)
 	require.ErrorContains(t, err, expectedError)
-	require.Equal(t, 11*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes)
-	require.Equal(t, 11*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes)
+	require.Equal(t, 11*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
+	require.Equal(t, 11*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueryCount(t, reg, 1)
 }
 


### PR DESCRIPTION
#### What this PR does

This change makes it safe to use `MemoryConsumptionTracker` from multiple goroutines. This is a prerequisite to tracking memory used by chunks loaded from store-gateways and distributors which is done in multiple goroutines in parallel.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
