### PR TITLE
query-frontend: Move user middlewares before the caching middleware

### DIFF
--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -404,6 +404,17 @@ func newQueryMiddlewares(
 		prom2CompatMiddleware,
 	)
 
+	// Inject the extra middlewares provided by the user before the caching, query pruning, and
+	// query sharding middlewares.
+	// This is important because these extra middlewares can potentially mutate the incoming
+	// query.
+	if len(cfg.ExtraInstantQueryMiddlewares) > 0 {
+		queryInstantMiddleware = append(queryInstantMiddleware, cfg.ExtraInstantQueryMiddlewares...)
+	}
+	if len(cfg.ExtraRangeQueryMiddlewares) > 0 {
+		queryRangeMiddleware = append(queryRangeMiddleware, cfg.ExtraRangeQueryMiddlewares...)
+	}
+
 	if cfg.CacheResults && cfg.CacheErrors {
 		errorCachingMiddleware := newErrorCachingMiddleware(cacheClient, limits, resultsCacheEnabledByOption, cacheKeyGenerator, log, registerer)
 
@@ -417,17 +428,6 @@ func newQueryMiddlewares(
 			newInstrumentMiddleware("error_caching", metrics),
 			errorCachingMiddleware,
 		)
-	}
-
-	// Inject the extra middlewares provided by the user before the caching, query pruning, and
-	// query sharding middlewares.
-	// This is important because these extra middlewares can potentially mutate the incoming
-	// query.
-	if len(cfg.ExtraInstantQueryMiddlewares) > 0 {
-		queryInstantMiddleware = append(queryInstantMiddleware, cfg.ExtraInstantQueryMiddlewares...)
-	}
-	if len(cfg.ExtraRangeQueryMiddlewares) > 0 {
-		queryRangeMiddleware = append(queryRangeMiddleware, cfg.ExtraRangeQueryMiddlewares...)
 	}
 
 	// Create split and cache middleware if either splitting or caching is enabled


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR moves user-provided extra middleware for the query-frontend before the split and cache middleware. This is important because it's possible for user-provided middleware to mutate the query depending things that are not captured by the cache key (like headers).

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
