### PR TITLE
MQE: Include chunks loaded from store-gateway in memory estimate

### DIFF
--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/grafana/mimir/pkg/storegateway/hintspb"
 	"github.com/grafana/mimir/pkg/storegateway/storegatewaypb"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/globalerror"
 	"github.com/grafana/mimir/pkg/util/limiter"
@@ -1641,6 +1642,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 					ctx, cancel := context.WithCancel(context.Background())
 					t.Cleanup(cancel)
 					ctx = limiter.AddQueryLimiterToContext(ctx, testData.queryLimiter)
+					ctx = limiting.AddToContext(ctx, limiting.NewMemoryConsumptionTracker(0, nil))
 					st, ctx := stats.ContextWithEmptyStats(ctx)
 					const tenantID = "user-1"
 					ctx = user.InjectOrgID(ctx, tenantID)

--- a/pkg/querier/stats/stats.go
+++ b/pkg/querier/stats/stats.go
@@ -25,7 +25,8 @@ func ContextWithEmptyStats(ctx context.Context) (*Stats, context.Context) {
 }
 
 // FromContext gets the Stats out of the Context. Returns nil if stats have not
-// been initialised in the context.
+// been initialised in the context. Note that Stats methods are safe to call with
+// a nil receiver.
 func FromContext(ctx context.Context) *Stats {
 	o := ctx.Value(ctxKey)
 	if o == nil {

--- a/pkg/streamingpromql/operators/selectors/selector.go
+++ b/pkg/streamingpromql/operators/selectors/selector.go
@@ -85,6 +85,11 @@ func (s *Selector) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, 
 		return nil, err
 	}
 
+	// Add the memory consumption tracker to the context of this querier before performing the
+	// query so that we can keep track of memory used loading chunks. We use the context since
+	// we can't modify the Queryable/Querier interfaces and the limit is actually specific to
+	// this request (and hence a good fit for storing in the context).
+	ctx = limiting.AddToContext(ctx, s.MemoryConsumptionTracker)
 	ss := s.querier.Select(ctx, true, hints, s.Matchers...)
 	s.series = newSeriesList(s.MemoryConsumptionTracker)
 

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -858,8 +858,8 @@ func (q *Query) Close() {
 	}
 
 	if q.engine.pedantic && q.result.Err == nil {
-		if q.memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes() > 0 {
-			panic("Memory consumption tracker still estimates > 0 bytes used. This indicates something has not been returned to a pool.")
+		if bytesUsed := q.memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(); bytesUsed > 0 {
+			panic(fmt.Sprintf("Memory consumption tracker still estimates %d bytes used for %q. This indicates something has not been returned to a pool.", bytesUsed, q.originalExpression))
 		}
 	}
 }


### PR DESCRIPTION
#### What this PR does

This increases the tracked memory consumption when chunks streamed
from store-gateways are loaded into memory as part of series iterators.
Memory consumption is decreased when the iterators are exhausted.
This decrease is optimistic since there is no guarantee that iterators
are completely consumed during a query (but they _usually_ are unless
the query is canceled or aborted).

#### Which issue(s) this PR fixes or relates to

Related #11283

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
