### PR TITLE
Mixin: fix cluster_namespace_deployment:actual_replicas:count recording rule when there's a mix on single-zone and multi-zone deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * [ENHANCEMENT] Alerts: Improve `MimirIngesterFailsToProcessRecordsFromKafka` to not fire during forced TSDB head compaction. #11006
 * [ENHANCEMENT] Alerts: Add alerts for invalid cluster validation labels. #11255 #11282
 * [BUGFIX] Dashboards: fix "Mimir / Tenants" legends for non-Kubernetes deployments. #10891
+* [BUGFIX] Recording rules: fix `cluster_namespace_deployment:actual_replicas:count` recording rule when there's a mix on single-zone and multi-zone deployments. #11287
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/recording-rules.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/recording-rules.yaml
@@ -204,18 +204,28 @@ spec:
         rules:
           - expr: |
               # Convenience rule to get the number of replicas for both a deployment and a statefulset.
-              # Multi-zone deployments are grouped together removing the "zone-X" suffix.
+              #
+              # Notes:
+              # - Multi-zone deployments are grouped together removing the "zone-X" suffix.
+              # - To avoid "vector cannot contain metrics with the same labelset" errors we need to add an additional
+              #   label "deployment_without_zone" first, then run the aggregation, and finally rename "deployment_without_zone"
+              #   to "deployment".
               sum by (cluster, namespace, deployment) (
                 label_replace(
-                  kube_deployment_spec_replicas,
-                  # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
-                  # always matches everything and the (optional) zone is not removed.
-                  "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                  sum by (cluster, namespace, deployment_without_zone) (
+                    label_replace(
+                      kube_deployment_spec_replicas,
+                      # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                      # always matches everything and the (optional) zone is not removed.
+                      "deployment_without_zone", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                    )
+                  )
+                  or
+                  sum by (cluster, namespace, deployment_without_zone) (
+                    label_replace(kube_statefulset_replicas, "deployment_without_zone", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
+                  ),
+                  "deployment", "$1", "deployment_without_zone", "(.*)"
                 )
-              )
-              or
-              sum by (cluster, namespace, deployment) (
-                label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
               )
             record: cluster_namespace_deployment:actual_replicas:count
           - expr: |

--- a/operations/mimir-mixin-compiled-gem/rules.yaml
+++ b/operations/mimir-mixin-compiled-gem/rules.yaml
@@ -192,18 +192,28 @@ groups:
       rules:
         - expr: |
             # Convenience rule to get the number of replicas for both a deployment and a statefulset.
-            # Multi-zone deployments are grouped together removing the "zone-X" suffix.
+            #
+            # Notes:
+            # - Multi-zone deployments are grouped together removing the "zone-X" suffix.
+            # - To avoid "vector cannot contain metrics with the same labelset" errors we need to add an additional
+            #   label "deployment_without_zone" first, then run the aggregation, and finally rename "deployment_without_zone"
+            #   to "deployment".
             sum by (cluster, namespace, deployment) (
               label_replace(
-                kube_deployment_spec_replicas,
-                # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
-                # always matches everything and the (optional) zone is not removed.
-                "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                sum by (cluster, namespace, deployment_without_zone) (
+                  label_replace(
+                    kube_deployment_spec_replicas,
+                    # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                    # always matches everything and the (optional) zone is not removed.
+                    "deployment_without_zone", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                  )
+                )
+                or
+                sum by (cluster, namespace, deployment_without_zone) (
+                  label_replace(kube_statefulset_replicas, "deployment_without_zone", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
+                ),
+                "deployment", "$1", "deployment_without_zone", "(.*)"
               )
-            )
-            or
-            sum by (cluster, namespace, deployment) (
-              label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
             )
           record: cluster_namespace_deployment:actual_replicas:count
         - expr: |

--- a/operations/mimir-mixin-compiled/rules.yaml
+++ b/operations/mimir-mixin-compiled/rules.yaml
@@ -192,18 +192,28 @@ groups:
       rules:
         - expr: |
             # Convenience rule to get the number of replicas for both a deployment and a statefulset.
-            # Multi-zone deployments are grouped together removing the "zone-X" suffix.
+            #
+            # Notes:
+            # - Multi-zone deployments are grouped together removing the "zone-X" suffix.
+            # - To avoid "vector cannot contain metrics with the same labelset" errors we need to add an additional
+            #   label "deployment_without_zone" first, then run the aggregation, and finally rename "deployment_without_zone"
+            #   to "deployment".
             sum by (cluster, namespace, deployment) (
               label_replace(
-                kube_deployment_spec_replicas,
-                # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
-                # always matches everything and the (optional) zone is not removed.
-                "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                sum by (cluster, namespace, deployment_without_zone) (
+                  label_replace(
+                    kube_deployment_spec_replicas,
+                    # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
+                    # always matches everything and the (optional) zone is not removed.
+                    "deployment_without_zone", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
+                  )
+                )
+                or
+                sum by (cluster, namespace, deployment_without_zone) (
+                  label_replace(kube_statefulset_replicas, "deployment_without_zone", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
+                ),
+                "deployment", "$1", "deployment_without_zone", "(.*)"
               )
-            )
-            or
-            sum by (cluster, namespace, deployment) (
-              label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
             )
           record: cluster_namespace_deployment:actual_replicas:count
         - expr: |


### PR DESCRIPTION
#### What this PR does

Today we were migrating a Mimir cluster from single-AZ to multi-AZ deployment. During the migration the recording rule `cluster_namespace_deployment:actual_replicas:count` failed with the error `vector cannot contain metrics with the same labelset`. The problem is that if there's a Deployment with the name `xxx` and other Deployments with the name `xxx-zone-[abc]`, the query will fail after the `label_replace()` because of clashing series.

This PR fixes it.

#### Manual tests

I manually tested it.


Before:

```
sum by (cluster, namespace, deployment) (
  label_replace(
    kube_deployment_spec_replicas,
    # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
    # always matches everything and the (optional) zone is not removed.
    "deployment", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
  )
)
or
sum by (cluster, namespace, deployment) (
  label_replace(kube_statefulset_replicas, "deployment", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
)
```

After:

```
sum by (cluster, namespace, deployment) (
  label_replace(
    sum by (cluster, namespace, deployment_without_zone) (
      label_replace(
        kube_deployment_spec_replicas,
        # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
        # always matches everything and the (optional) zone is not removed.
        "deployment_without_zone", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
      )
    )
    or
    sum by (cluster, namespace, deployment_without_zone) (
      label_replace(kube_statefulset_replicas, "deployment_without_zone", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
    ),
    "deployment", "$1", "deployment_without_zone", "(.*)"
  )
)
```



#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
