### PR TITLE
ingest: Clarify we expect ordering between samples

### DIFF
--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -338,6 +338,7 @@ type labelsHashFunc func(labels.Labels) uint64
 
 // parallelStorageShards is a collection of shards that are used to parallelize the writes to the storage by series.
 // Each series is hashed to a shard that contains its own batchingQueue.
+// Each series is consistently assigned to the same shard. This allows us to preserve the order of samples of the same series between multiple PushToStorage calls.
 type parallelStorageShards struct {
 	metrics      *storagePusherMetrics
 	errorHandler *pushErrorHandler

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -831,19 +831,19 @@ func TestParallelStorageShards_ShardWriteRequest(t *testing.T) {
 					mockPreallocTimeseriesWithSample("series_c", 1, 2),
 				}},
 				{Timeseries: []mimirpb.PreallocTimeseries{
-					mockPreallocTimeseriesWithSample("series_a", 2, 3),
 					mockPreallocTimeseriesWithSample("series_b", 2, 3),
+					mockPreallocTimeseriesWithSample("series_a", 2, 3),
 					mockPreallocTimeseriesWithSample("series_c", 2, 3),
 				}},
 				{Timeseries: []mimirpb.PreallocTimeseries{
-					mockPreallocTimeseriesWithSample("series_a", 3, 4),
 					mockPreallocTimeseriesWithSample("series_b", 3, 4),
 					mockPreallocTimeseriesWithSample("series_c", 3, 4),
+					mockPreallocTimeseriesWithSample("series_a", 3, 4),
 				}},
 				{Timeseries: []mimirpb.PreallocTimeseries{
-					mockPreallocTimeseriesWithSample("series_a", 4, 5),
-					mockPreallocTimeseriesWithSample("series_b", 4, 5),
 					mockPreallocTimeseriesWithSample("series_c", 4, 5),
+					mockPreallocTimeseriesWithSample("series_b", 4, 5),
+					mockPreallocTimeseriesWithSample("series_a", 4, 5),
 				}},
 			},
 			// We expect no errors during the push calls themselves as flushing happens on Close.

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -821,6 +821,60 @@ func TestParallelStorageShards_ShardWriteRequest(t *testing.T) {
 			upstreamPushErrs: []error{nil, nil},
 			expectedCloseErr: nil,
 		},
+		"preserving sample order between requests": {
+			shardCount: 4,
+			batchSize:  4, // Large enough to hold all samples for one series
+			requests: []*mimirpb.WriteRequest{
+				{Timeseries: []mimirpb.PreallocTimeseries{
+					mockPreallocTimeseriesWithSample("series_a", 1, 2),
+					mockPreallocTimeseriesWithSample("series_b", 1, 2),
+					mockPreallocTimeseriesWithSample("series_c", 1, 2),
+				}},
+				{Timeseries: []mimirpb.PreallocTimeseries{
+					mockPreallocTimeseriesWithSample("series_a", 2, 3),
+					mockPreallocTimeseriesWithSample("series_b", 2, 3),
+					mockPreallocTimeseriesWithSample("series_c", 2, 3),
+				}},
+				{Timeseries: []mimirpb.PreallocTimeseries{
+					mockPreallocTimeseriesWithSample("series_a", 3, 4),
+					mockPreallocTimeseriesWithSample("series_b", 3, 4),
+					mockPreallocTimeseriesWithSample("series_c", 3, 4),
+				}},
+				{Timeseries: []mimirpb.PreallocTimeseries{
+					mockPreallocTimeseriesWithSample("series_a", 4, 5),
+					mockPreallocTimeseriesWithSample("series_b", 4, 5),
+					mockPreallocTimeseriesWithSample("series_c", 4, 5),
+				}},
+			},
+			// We expect no errors during the push calls themselves as flushing happens on Close.
+			expectedErrs: []error{nil, nil, nil, nil},
+
+			// We expect 3 final pushes after Close(), one for each shard.
+			// The exact content depends on the hashing, so we can't predict the exact order or grouping easily.
+			// We'll verify the content manually in the test logic override below.
+			expectedUpstreamPushes: []*mimirpb.WriteRequest{
+				{Timeseries: []mimirpb.PreallocTimeseries{
+					mockPreallocTimeseriesWithSample("series_a", 1, 2),
+					mockPreallocTimeseriesWithSample("series_a", 2, 3),
+					mockPreallocTimeseriesWithSample("series_a", 3, 4),
+					mockPreallocTimeseriesWithSample("series_a", 4, 5),
+				}},
+				{Timeseries: []mimirpb.PreallocTimeseries{
+					mockPreallocTimeseriesWithSample("series_b", 1, 2),
+					mockPreallocTimeseriesWithSample("series_b", 2, 3),
+					mockPreallocTimeseriesWithSample("series_b", 3, 4),
+					mockPreallocTimeseriesWithSample("series_b", 4, 5),
+				}},
+				{Timeseries: []mimirpb.PreallocTimeseries{
+					mockPreallocTimeseriesWithSample("series_c", 1, 2),
+					mockPreallocTimeseriesWithSample("series_c", 2, 3),
+					mockPreallocTimeseriesWithSample("series_c", 3, 4),
+					mockPreallocTimeseriesWithSample("series_c", 4, 5),
+				}},
+			},
+			upstreamPushErrs: []error{nil, nil, nil},
+			expectedCloseErr: nil,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -1027,10 +1027,14 @@ func BenchmarkMarshalWriteRequestToRecords_NoSplitting(b *testing.B) {
 }
 
 func mockPreallocTimeseries(metricName string) mimirpb.PreallocTimeseries {
+	return mockPreallocTimeseriesWithSample(metricName, 1, 2)
+}
+
+func mockPreallocTimeseriesWithSample(metricName string, ts int64, val float64) mimirpb.PreallocTimeseries {
 	return mimirpb.PreallocTimeseries{
 		TimeSeries: &mimirpb.TimeSeries{
 			Labels:    []mimirpb.LabelAdapter{{Name: "__name__", Value: metricName}},
-			Samples:   []mimirpb.Sample{{TimestampMs: 1, Value: 2}},
+			Samples:   []mimirpb.Sample{{TimestampMs: ts, Value: val}},
 			Exemplars: []mimirpb.Exemplar{}, // Makes comparison with unmarshalled TimeSeries easy.
 		},
 	}


### PR DESCRIPTION
@bboreham had feedback that we don't note that there's expected ordering between samples to be preserved. This PR adds a comment and a test. 
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
