### PR TITLE
Fix flaky OTel histograms test

### DIFF
--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -368,8 +368,22 @@ func TestConvertOTelHistograms(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 0, dropped)
 		if convertHistogramsToNHCB {
-			require.Len(t, mimirTS, 2)
-			require.Len(t, mimirTS[0].Histograms, 1)
+			ts := make([]mimirpb.PreallocTimeseries, 0, len(mimirTS))
+			for i := range mimirTS {
+				var metricName string
+				for _, lbl := range mimirTS[i].Labels {
+					if lbl.Name == labels.MetricName {
+						metricName = lbl.Value
+						break
+					}
+				}
+				if metricName == "target_info" {
+					continue
+				}
+				ts = append(ts, mimirTS[i])
+			}
+			require.Len(t, ts, 1)
+			require.Len(t, ts[0].Histograms, 1)
 		} else {
 			require.Len(t, mimirTS, 6)
 			require.Len(t, mimirTS[0].Histograms, 0)

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -369,6 +369,7 @@ func TestConvertOTelHistograms(t *testing.T) {
 		require.Equal(t, 0, dropped)
 		if convertHistogramsToNHCB {
 			ts := make([]mimirpb.PreallocTimeseries, 0, len(mimirTS))
+			// Filter out target_info series
 			for i := range mimirTS {
 				var metricName string
 				for _, lbl := range mimirTS[i].Labels {
@@ -386,7 +387,9 @@ func TestConvertOTelHistograms(t *testing.T) {
 			require.Len(t, ts[0].Histograms, 1)
 		} else {
 			require.Len(t, mimirTS, 6)
-			require.Len(t, mimirTS[0].Histograms, 0)
+			for i := range mimirTS {
+				require.Len(t, mimirTS[i].Histograms, 0)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Fix for flaky OTel explicit histogram to native histogram with custom buckets test.

#### Which issue(s) this PR fixes or relates to

Fixes #11302

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
