### PR TITLE
Grafana Alertmanager: Prevent invalid config and use correct template validation on Apply

### DIFF
--- a/pkg/alertmanager/api_grafana.go
+++ b/pkg/alertmanager/api_grafana.go
@@ -435,7 +435,7 @@ func (am *MultitenantAlertmanager) DeleteUserGrafanaConfig(w http.ResponseWriter
 func validateUserGrafanaConfig(logger log.Logger, cfg alertspb.GrafanaAlertConfigDesc, limits Limits, user string) error {
 	// We don't have a valid use case for empty configurations. If a tenant does not have a
 	// configuration set and issue a request to the Alertmanager, we'll a) upload an empty
-	// config and b) immediately start an Alertmanager instance for them if a fallback
+	// config and b) start an Alertmanager instance for them if a fallback
 	// configuration is provisioned.
 	if cfg.RawConfig == "" {
 		return fmt.Errorf("configuration provided is empty, if you'd like to remove your configuration please use the delete configuration endpoint")

--- a/pkg/alertmanager/api_grafana.go
+++ b/pkg/alertmanager/api_grafana.go
@@ -9,11 +9,16 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/alerting/definition"
+	alertingNotify "github.com/grafana/alerting/notify"
+	alertingReceivers "github.com/grafana/alerting/receivers"
+	alertingTemplates "github.com/grafana/alerting/templates"
 	"github.com/grafana/dskit/tenant"
 	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
+	"github.com/prometheus/alertmanager/notify"
 
 	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
 	"github.com/grafana/mimir/pkg/util"
@@ -386,6 +391,12 @@ func (am *MultitenantAlertmanager) SetUserGrafanaConfig(w http.ResponseWriter, r
 	}
 
 	cfgDesc := alertspb.ToGrafanaProto(string(rawCfg), userID, cfg.Hash, cfg.CreatedAt, cfg.Default, cfg.Promoted, cfg.ExternalURL, cfg.StaticHeaders)
+	if err := validateUserGrafanaConfig(logger, cfgDesc, am.limits, userID); err != nil {
+		level.Error(logger).Log("msg", errValidatingConfig, "err", err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		util.WriteJSONResponse(w, errorResult{Status: statusError, Error: fmt.Sprintf("%s: %s", errValidatingConfig, err.Error())})
+		return
+	}
 	err = am.store.SetGrafanaAlertConfig(r.Context(), cfgDesc)
 	if err != nil {
 		level.Error(logger).Log("msg", errStoringGrafanaConfig, "err", err.Error())
@@ -418,4 +429,63 @@ func (am *MultitenantAlertmanager) DeleteUserGrafanaConfig(w http.ResponseWriter
 
 	w.WriteHeader(http.StatusOK)
 	util.WriteJSONResponse(w, successResult{Status: statusSuccess})
+}
+
+// ValidateUserGrafanaConfig validates the Grafana Alertmanager configuration.
+func validateUserGrafanaConfig(logger log.Logger, cfg alertspb.GrafanaAlertConfigDesc, limits Limits, user string) error {
+	// We don't have a valid use case for empty configurations. If a tenant does not have a
+	// configuration set and issue a request to the Alertmanager, we'll a) upload an empty
+	// config and b) immediately start an Alertmanager instance for them if a fallback
+	// configuration is provisioned.
+	if cfg.RawConfig == "" {
+		return fmt.Errorf("configuration provided is empty, if you'd like to remove your configuration please use the delete configuration endpoint")
+	}
+
+	// Perform a similar flow of transformations that would happen in the Alertmanager on Sync & Apply.
+	grafanaConfig, err := createUsableGrafanaConfig(logger, cfg, "")
+	if err != nil {
+		return err
+	}
+
+	userAmConfig, err := definition.LoadCompat([]byte(grafanaConfig.RawConfig))
+	if err != nil {
+		return fmt.Errorf("error unmarshalling Grafana configuration: %w", err)
+	}
+
+	if l := limits.AlertmanagerMaxTemplatesCount(user); l > 0 && len(grafanaConfig.Templates) > l {
+		// Permissive limit to first verify impact on existing users.
+		// TODO: Make this strict.
+		level.Warn(logger).Log("msg", "too many templates in configuration", "user", user, "templates", len(grafanaConfig.Templates), "limit", l)
+	}
+
+	if maxSize := limits.AlertmanagerMaxTemplateSize(user); maxSize > 0 {
+		// Permissive limit to first verify impact on existing users.
+		// TODO: Make this strict.
+		for name, tmpl := range grafanaConfig.Templates {
+			if size := len(tmpl.Body); size > maxSize {
+				level.Warn(logger).Log("msg", "template too big", "user", user, "template", name, "size", size, "limit", maxSize)
+			}
+		}
+	}
+
+	// Validate template files.
+	tmpls := make([]string, 0, len(grafanaConfig.Templates))
+	for _, tmpl := range grafanaConfig.Templates {
+		tmpls = append(tmpls, tmpl.Body)
+	}
+
+	tmpl, err := alertingTemplates.FromContent(tmpls, WithCustomFunctions(user))
+	if err != nil {
+		return err
+	}
+
+	noopWrapper := func(integrationName string, notifier notify.Notifier) notify.Notifier { return notifier }
+	for _, rcv := range userAmConfig.Receivers {
+		_, err := buildGrafanaReceiverIntegrations(alertingReceivers.EmailSenderConfig{}, alertingNotify.PostableAPIReceiverToAPIReceiver(rcv), tmpl, logger, noopWrapper)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/alertmanager/api_grafana_test.go
+++ b/pkg/alertmanager/api_grafana_test.go
@@ -5,6 +5,7 @@ package alertmanager
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -305,9 +306,6 @@ func TestMultitenantAlertmanager_GetUserGrafanaState(t *testing.T) {
 }
 
 func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
-	storage := objstore.NewInMemBucket()
-	alertstore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, storage, nil, log.NewNopLogger())
-
 	cases := []struct {
 		name            string
 		maxConfigSize   int
@@ -386,10 +384,92 @@ func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 			expResponseBody: successJSON,
 			expStorageKey:   "grafana_alertmanager/test_user/grafana_config",
 		},
+		{
+			name: "invalid template",
+			body: `
+{
+  "configuration": {
+    "template_files": {
+      "broken": "{{define \"broken\" -}}{{ DOESNTEXIST \"param\" }} {{- end }}"
+    },
+    "alertmanager_config": {
+      "route": {
+        "receiver": "test_receiver",
+        "group_by": ["alertname"]
+      },
+      "receivers": [
+        {
+          "name": "test_receiver",
+          "grafana_managed_receiver_configs": []
+        }
+      ]
+    }
+  },
+  "configuration_hash": "ChEKBW5mbG9nEghzb21lZGF0YQ==",
+  "created": 12312414343,
+  "default": false,
+  "promoted": true,
+  "external_url": "http://test.grafana.com"
+}
+			`,
+			orgID:         "test_user",
+			expStatusCode: http.StatusBadRequest,
+			expResponseBody: `
+			{
+				"error": "error validating Alertmanager config: template: :1: function \"DOESNTEXIST\" not defined",
+				"status": "error"
+			}
+			`,
+		},
+		{
+			name: "invalid receiver",
+			body: `
+{
+  "configuration": {
+    "template_files": {},
+    "alertmanager_config": {
+      "route": {
+        "receiver": "invalid_receiver",
+        "group_by": ["alertname"]
+      },
+      "receivers": [
+        {
+          "name": "invalid_receiver",
+          "grafana_managed_receiver_configs": [{
+					"uid": "",
+					"name": "invalid_receiver",
+					"type": "webhook",
+					"disableResolveMessage": true,
+					"settings": {
+						"url": ""
+					}
+				}]
+        }
+      ]
+    }
+  },
+  "configuration_hash": "ChEKBW5mbG9nEghzb21lZGF0YQ==",
+  "created": 12312414343,
+  "default": false,
+  "promoted": true,
+  "external_url": "http://test.grafana.com"
+}
+			`,
+			orgID:         "test_user",
+			expStatusCode: http.StatusBadRequest,
+			expResponseBody: `
+			{
+				"error": "error validating Alertmanager config: failed to validate integration \"invalid_receiver\" (UID ) of type \"webhook\": required field 'url' is not specified",
+				"status": "error"
+			}
+			`,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			storage := objstore.NewInMemBucket()
+			alertstore := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, storage, nil, log.NewNopLogger())
 			am := &MultitenantAlertmanager{
 				store:  alertstore,
 				logger: test.NewTestingLogger(t),
@@ -410,21 +490,21 @@ func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 			).WithContext(ctx)
 
 			am.SetUserGrafanaConfig(rec, req)
-			require.Equal(t, tc.expStatusCode, rec.Code)
+			assert.Equal(t, tc.expStatusCode, rec.Code)
 
 			if tc.expResponseBody != "" {
 				body, err := io.ReadAll(rec.Body)
 				require.NoError(t, err)
 
-				require.JSONEq(t, tc.expResponseBody, string(body))
+				assert.JSONEq(t, tc.expResponseBody, string(body))
 			}
 
 			if tc.expStorageKey == "" {
-				require.Len(t, storage.Objects(), 0)
+				assert.Len(t, storage.Objects(), 0)
 			} else {
-				require.Len(t, storage.Objects(), 1)
+				assert.Len(t, storage.Objects(), 1)
 				_, ok := storage.Objects()[tc.expStorageKey]
-				require.True(t, ok)
+				assert.True(t, ok)
 			}
 		})
 	}

--- a/pkg/alertmanager/api_grafana_test.go
+++ b/pkg/alertmanager/api_grafana_test.go
@@ -5,7 +5,6 @@ package alertmanager
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +15,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 

--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/alerting/definition"
 
@@ -20,7 +21,7 @@ import (
 // createUsableGrafanaConfig creates an amConfig from a GrafanaAlertConfigDesc.
 // If provided, it assigns the global section from the Mimir config to the Grafana config.
 // The SMTP and HTTP settings in this section can be used to configure Grafana receivers.
-func (am *MultitenantAlertmanager) createUsableGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc, rawMimirConfig string) (amConfig, error) {
+func createUsableGrafanaConfig(logger log.Logger, gCfg alertspb.GrafanaAlertConfigDesc, rawMimirConfig string) (amConfig, error) {
 	externalURL, err := url.Parse(gCfg.ExternalUrl)
 	if err != nil {
 		return amConfig{}, err
@@ -53,7 +54,7 @@ func (am *MultitenantAlertmanager) createUsableGrafanaConfig(gCfg alertspb.Grafa
 			for _, integration := range rcv.GrafanaManagedReceivers {
 				itypes = append(itypes, integration.Type)
 			}
-			level.Debug(am.logger).Log("msg", "receiver with same name is defined multiple times. Only the last one will be used", "receiver_name", rcv.Name, "overwritten_integrations", strings.Join(itypes, ","))
+			level.Debug(logger).Log("msg", "receiver with same name is defined multiple times. Only the last one will be used", "receiver_name", rcv.Name, "overwritten_integrations", strings.Join(itypes, ","))
 			continue
 		}
 		rcvs = append(rcvs, rcv)

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -136,7 +136,7 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			am := MultitenantAlertmanager{logger: log.NewNopLogger()}
-			cfg, err := am.createUsableGrafanaConfig(test.grafanaConfig, test.mimirConfig)
+			cfg, err := createUsableGrafanaConfig(am.logger, test.grafanaConfig, test.mimirConfig)
 			if test.expErr != "" {
 				require.Error(t, err)
 				require.Equal(t, test.expErr, err.Error())
@@ -175,7 +175,7 @@ func TestCreateUsableGrafanaConfig(t *testing.T) {
 
 			// Ensure that configuration is deterministic. For example, ordering of receivers.
 			// This is important for change detection.
-			cfg2, err := am.createUsableGrafanaConfig(test.grafanaConfig, test.mimirConfig)
+			cfg2, err := createUsableGrafanaConfig(am.logger, test.grafanaConfig, test.mimirConfig)
 			require.NoError(t, err)
 
 			require.Equal(t, cfg.RawConfig, cfg2.RawConfig)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -745,7 +745,7 @@ func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs)
 	// If the Mimir configuration is either default or empty, use the Grafana configuration.
 	if cfgs.Mimir.RawConfig == am.fallbackConfig || cfgs.Mimir.RawConfig == "" {
 		level.Debug(am.logger).Log("msg", "using grafana config with the default globals", "user", cfgs.Mimir.User)
-		cfg, err := am.createUsableGrafanaConfig(cfgs.Grafana, am.fallbackConfig)
+		cfg, err := createUsableGrafanaConfig(am.logger, cfgs.Grafana, am.fallbackConfig)
 		return cfg, true, err
 	}
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -419,7 +419,7 @@ templates:
 	require.Len(t, am.alertmanagers, 4)
 
 	// The Mimir configuration was empty, so the Grafana configuration should be chosen for user 4.
-	amCfg, err := am.createUsableGrafanaConfig(userGrafanaCfg, am.fallbackConfig)
+	amCfg, err := createUsableGrafanaConfig(am.logger, userGrafanaCfg, am.fallbackConfig)
 	require.NoError(t, err)
 	grafanaAlertConfigDesc := amCfg.AlertConfigDesc
 	require.Equal(t, grafanaAlertConfigDesc, am.cfgs["user4"])


### PR DESCRIPTION
A combination of two issues was causing a bug when attempting to use the new template function introduced with [custom webhook payloads](https://github.com/grafana/mimir/pull/11195) in a Grafana AM tenant:
 - The `SetUserGrafanaConfig` API endpoint was not validating templates (or receivers).
 - `ApplyConfig` was validating against Cloud AM template functions for Grafana AM tenants (though it was correctly using Grafana AM template functions to create the integrations).

Together, these allowed a few ways to get invalid config persisted to the grafana config bucket. This invalid config would not successfully Apply so would cause the config to not sync until the invalid config was corrected.

Additionally, since `ApplyConfig` was using the wrong template validation, even valid config could cause the above sync issue if attempting to use template functions available in Grafana AM but not in Cloud AM (such as the new webhook payload functions).

This PR:
- Does some small refactoring to reduce redundant function params and email config creation.
- Adds validation to the `SetUserGrafanaConfig` endpoint (specifically template and receiver).
- Adds template count and size limits as warnings alongside `SetUserGrafanaConfig` validation.
- Ensures `ApplyConfig` uses the correct template loader for Grafana AM receivers/tenants.
- Adds regression tests for the described issues.
