### PR TITLE
[WIP] parquet-mimir fix tests and lints

### DIFF
--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -103,8 +103,8 @@ func testSingleBinaryEnv(t *testing.T, tlsEnabled bool, flags map[string]string)
 	require.NoError(t, mimir3.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))
 	require.NoError(t, mimir3.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))
 
-	// Tombstones should increase by four for each server that leaves (once for distributor, ingester, compactor and store-gateway ring)
-	tombstonesPerRemovedInstance := 4.0
+	// Tombstones should increase by five for each server that leaves (once for distributor, ingester, compactor, parquet-converter, and store-gateway ring)
+	tombstonesPerRemovedInstance := 5.0
 	require.NoError(t, s.Stop(mimir1))
 	require.NoError(t, mimir2.WaitSumMetrics(e2e.Equals(2*tokensPerInstance), "cortex_ring_tokens_total"))
 	require.NoError(t, mimir2.WaitSumMetrics(e2e.Equals(2), "memberlist_client_cluster_members_count"))
@@ -235,7 +235,7 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	// These values are multiplied by three to account for the fact that ingester
 	// distributor, compactor, store-gateway components use a ring.
 	expectedRingMembers := float64(minMimir) * 5 // One extra, because store-gateway-client uses ring too. But it's the same ring as store-gateway.
-	expectedTombstones := float64(maxMimir-minMimir) * 4
+	expectedTombstones := float64(maxMimir-minMimir) * 5
 
 	require.Eventually(t, func() bool {
 		ok := true

--- a/pkg/parquetconverter/compation_marker.go
+++ b/pkg/parquetconverter/compation_marker.go
@@ -27,7 +27,8 @@ type CompactionMark struct {
 	Version int `json:"version"`
 }
 
-func (m *CompactionMark) markerFilename() string { return ParquetCompactionMakerFileName }
+// TODO this function sets off the linter as it is not used yet
+//func (m *CompactionMark) markerFilename() string { return ParquetCompactionMakerFileName }
 
 func ReadCompactMark(ctx context.Context, id ulid.ULID, userBkt objstore.InstrumentedBucket, logger log.Logger) (*CompactionMark, error) {
 	markerPath := path.Join(id.String(), ParquetCompactionMakerFileName)

--- a/pkg/parquetconverter/parquet_converter.go
+++ b/pkg/parquetconverter/parquet_converter.go
@@ -47,8 +47,12 @@ const (
 	batchSize                = 50000
 	batchStreamBufferSize    = 10
 	parquetFileName          = "block.parquet"
-	compactorRingKey         = "parquet-converter"
+	ringKey                  = "parquet-converter"
 	maxParquetIndexSizeLimit = 100
+)
+
+var (
+	RingOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 )
 
 type Config struct {
@@ -80,10 +84,13 @@ type ParquetConverter struct {
 	ring                   *ring.Ring
 	ringSubservices        *services.Manager
 	ringSubservicesWatcher *services.FailureWatcher
+
+	//Subservices manager.
+	subservices        *services.Manager
+	subservicesWatcher *services.FailureWatcher
 }
 
 func NewParquetConverter(cfg Config, compactorCfg compactor.Config, storageCfg mimir_tsdb.BlocksStorageConfig, logger log.Logger, registerer prometheus.Registerer, limits *validation.Overrides) (*ParquetConverter, error) {
-	registerer = prometheus.WrapRegistererWithPrefix("parquet_", registerer)
 	bucketClient, err := bucket.NewClient(context.Background(), storageCfg.Bucket, "parquet-converter", logger, registerer)
 	cfg.allowedTenants = util.NewAllowList(cfg.EnabledTenants, cfg.DisabledTenants)
 
@@ -91,6 +98,7 @@ func NewParquetConverter(cfg Config, compactorCfg compactor.Config, storageCfg m
 		return nil, err
 	}
 	indexLoaderConfig := bucketindex.LoaderConfig{
+		ExtraMetricsPrefix:    "parquet_",
 		CheckInterval:         time.Minute,
 		UpdateOnStaleInterval: storageCfg.BucketStore.SyncInterval,
 		UpdateOnErrorInterval: storageCfg.BucketStore.BucketIndex.UpdateOnErrorInterval,
@@ -98,6 +106,11 @@ func NewParquetConverter(cfg Config, compactorCfg compactor.Config, storageCfg m
 	}
 
 	loader := bucketindex.NewLoader(indexLoaderConfig, bucketClient, limits, util_log.Logger, registerer)
+
+	manager, err := services.NewManager(loader)
+	if err != nil {
+		return nil, errors.Wrap(err, "register parquet-converter subservices")
+	}
 
 	c := &ParquetConverter{
 		Cfg:          cfg,
@@ -108,104 +121,136 @@ func NewParquetConverter(cfg Config, compactorCfg compactor.Config, storageCfg m
 		registerer:   registerer,
 		blockRanges:  compactorCfg.BlockRanges.ToMilliseconds(),
 		limits:       limits,
+
+		subservices:        manager,
+		subservicesWatcher: services.NewFailureWatcher(),
 	}
 
-	c.Service = services.NewBasicService(c.starting, c.run, c.stopping)
+	c.Service = services.NewBasicService(c.starting, c.running, c.stopping).WithName("parquet-converter")
 	return c, nil
 }
 
-func (c *ParquetConverter) stopping(err error) error {
-	return nil
-}
-
 func (c *ParquetConverter) starting(ctx context.Context) error {
-	if true /*c.Cfg.ShardingEnabled*/ { // TODO
-		kvStore, err := kv.NewClient(c.CompactorCfg.ShardingRing.Common.KVStore, ring.GetCodec(), kv.RegistererWithKVName(c.registerer, "parquet-converter-lifecycler"), c.logger)
-		if err != nil {
-			return errors.Wrap(err, "failed to initialize parquet-converter' KV store")
-		}
-		lifecyclerCfg, err := c.CompactorCfg.ShardingRing.ToBasicLifecyclerConfig(c.logger)
-		if err != nil {
-			return errors.Wrap(err, "unable to create parquet-converter ring lifecycler config")
-		}
-		var delegate ring.BasicLifecyclerDelegate
-		delegate = ring.NewInstanceRegisterDelegate(ring.ACTIVE, lifecyclerCfg.NumTokens)
-		delegate = ring.NewLeaveOnStoppingDelegate(delegate, c.logger)
-		delegate = ring.NewAutoForgetDelegate(compactor.RingAutoForgetUnhealthyPeriods*lifecyclerCfg.HeartbeatTimeout, delegate, c.logger)
+	var err error
 
-		c.ringLifecycler, err = ring.NewBasicLifecycler(lifecyclerCfg,
-			"parquet-converter", compactorRingKey, kvStore, delegate, c.logger, prometheus.WrapRegistererWithPrefix("cortex_", c.registerer))
-		if err != nil {
-			return errors.Wrap(err, "unable to initialize parquet-converter ring lifecycler")
-		}
-
-		c.ring, err = ring.New(c.CompactorCfg.ShardingRing.ToRingConfig(), "parquet-converter", compactorRingKey, c.logger, prometheus.WrapRegistererWithPrefix("cortex_", c.registerer))
-		if err != nil {
-			return errors.Wrap(err, "unable to initialize parquet-converter ring")
-		}
-
-		c.ringSubservices, err = services.NewManager(c.ringLifecycler, c.ring)
-		if err == nil {
-			c.ringSubservicesWatcher = services.NewFailureWatcher()
-			c.ringSubservicesWatcher.WatchManager(c.ringSubservices)
-
-			if err := services.StartManagerAndAwaitHealthy(context.Background(), c.ringSubservices); err != nil {
-				return errors.Wrap(err, "unable to start parquet-converter subservices")
-			}
-		}
-	}
-
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, c.CompactorCfg.ShardingRing.WaitActiveInstanceTimeout)
-	defer cancel()
-	if err := ring.WaitInstanceState(ctxWithTimeout, c.ring, c.ringLifecycler.GetInstanceID(), ring.ACTIVE); err != nil {
-		level.Error(c.logger).Log("msg", "parquet-converter failed to become ACTIVE in the ring", "err", err)
+	// Initialize the parquet-converters ring if sharding is enabled.
+	c.ring, c.ringLifecycler, err = newRingAndLifecycler(c.CompactorCfg.ShardingRing, c.logger, c.registerer)
+	if err != nil {
 		return err
 	}
-	level.Info(c.logger).Log("msg", "parquet-converter is ACTIVE in the ring")
-	if err := c.loader.StartAsync(context.Background()); err != nil {
-		return errors.Wrap(err, "failed to start loader")
+
+	c.ringSubservices, err = services.NewManager(c.ringLifecycler, c.ring)
+	if err != nil {
+		return errors.Wrap(err, "unable to create parquet-converter ring dependencies")
 	}
 
-	if err := c.loader.AwaitRunning(ctx); err != nil {
-		return errors.Wrap(err, "failed to start loader")
+	c.ringSubservicesWatcher = services.NewFailureWatcher()
+	c.ringSubservicesWatcher.WatchManager(c.ringSubservices)
+	if err = c.ringSubservices.StartAsync(ctx); err != nil {
+		return errors.Wrap(err, "unable to start parquet-converter ring dependencies")
 	}
+
+	ctxTimeout, cancel := context.WithTimeout(ctx, c.CompactorCfg.ShardingRing.WaitActiveInstanceTimeout)
+	defer cancel()
+	if err = c.ringSubservices.AwaitHealthy(ctxTimeout); err != nil {
+		return errors.Wrap(err, "unable to start parquet-converter ring dependencies")
+	}
+
+	// If sharding is enabled we should wait until this instance is ACTIVE within the ring. This
+	// MUST be done before starting any other component depending on the users scanner, because
+	// the users scanner depends on the ring (to check whether a user belongs to this shard or not).
+	level.Info(c.logger).Log("msg", "waiting until parquet-converter is ACTIVE in the ring")
+	if err = ring.WaitInstanceState(ctxTimeout, c.ring, c.ringLifecycler.GetInstanceID(), ring.ACTIVE); err != nil {
+		return errors.Wrap(err, "parquet-converter failed to become ACTIVE in the ring")
+	}
+
+	level.Info(c.logger).Log("msg", "parquet-converter is ACTIVE in the ring")
+
+	// In the event of a cluster cold start or scale up of 2+ parquet-converter instances at the same
+	// time, we may end up in a situation where each new parquet-converter instance starts at a slightly
+	// different time and thus each one starts with a different state of the ring. It's better
+	// to just wait a short time for ring stability.
+	if c.CompactorCfg.ShardingRing.WaitStabilityMinDuration > 0 {
+		minWaiting := c.CompactorCfg.ShardingRing.WaitStabilityMinDuration
+		maxWaiting := c.CompactorCfg.ShardingRing.WaitStabilityMaxDuration
+
+		level.Info(c.logger).Log("msg", "waiting until parquet-converter ring topology is stable", "min_waiting", minWaiting.String(), "max_waiting", maxWaiting.String())
+		if err := ring.WaitRingStability(ctx, c.ring, RingOp, minWaiting, maxWaiting); err != nil {
+			level.Warn(c.logger).Log("msg", "parquet-converter ring topology is not stable after the max waiting time, proceeding anyway")
+		} else {
+			level.Info(c.logger).Log("msg", "parquet-converter ring topology is stable")
+		}
+	}
+
+	c.subservicesWatcher.WatchManager(c.subservices)
+
+	if err := services.StartManagerAndAwaitHealthy(context.Background(), c.subservices); err != nil {
+		return errors.Wrap(err, "unable to start parquet-converter subservices")
+	}
+
 	return nil
 }
 
-func (c *ParquetConverter) run(ctx context.Context) error {
+func newRingAndLifecycler(cfg compactor.RingConfig, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, *ring.BasicLifecycler, error) {
+	reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
+	kvStore, err := kv.NewClient(cfg.Common.KVStore, ring.GetCodec(), kv.RegistererWithKVName(reg, "parquet-converter-lifecycler"), logger)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to initialize parquet-converters' KV store")
+	}
 
-	go func() {
-		updateIndexTicker := time.NewTicker(time.Second * 60)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-updateIndexTicker.C:
-				users, err := c.discoverUsers(ctx)
-				if err != nil {
-					level.Error(util_log.Logger).Log("msg", "Error scanning users", "err", err)
-					break
-				}
-				for _, u := range users {
-					if c.Cfg.allowedTenants.IsAllowed(u) {
-						if ok, _ := c.ownBlock(u); ok {
-							err := c.updateParquetIndex(ctx, u)
-							if err != nil {
-								level.Error(util_log.Logger).Log("msg", "Error updating index", "err", err)
-							}
+	lifecyclerCfg, err := cfg.ToBasicLifecyclerConfig(logger)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to build parquet-converters' lifecycler config")
+	}
+
+	var delegate ring.BasicLifecyclerDelegate
+	delegate = ring.NewInstanceRegisterDelegate(ring.ACTIVE, lifecyclerCfg.NumTokens)
+	delegate = ring.NewLeaveOnStoppingDelegate(delegate, logger)
+	delegate = ring.NewAutoForgetDelegate(compactor.RingAutoForgetUnhealthyPeriods*lifecyclerCfg.HeartbeatTimeout, delegate, logger)
+
+	parquetConvertersLifecycler, err := ring.NewBasicLifecycler(lifecyclerCfg, "parquet-converter", ringKey, kvStore, delegate, logger, reg)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to initialize parquet-converter' lifecycler")
+	}
+
+	parquetConvertersRing, err := ring.New(cfg.ToRingConfig(), "parquet-converter", ringKey, logger, reg)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to initialize parquet-converter' parquetConvertersRing client")
+	}
+
+	return parquetConvertersRing, parquetConvertersLifecycler, nil
+}
+
+func (c *ParquetConverter) running(ctx context.Context) error {
+	updateIndexTicker := time.NewTicker(time.Second * 60)
+	convertBlocksTicker := time.NewTicker(time.Second * 10)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-c.ringSubservicesWatcher.Chan():
+			return errors.Wrap(err, "parquet-converter ring subservice failed")
+		case err := <-c.subservicesWatcher.Chan():
+			return errors.Wrap(err, "parquet-converter subservice failed")
+
+		case <-updateIndexTicker.C:
+			users, err := c.discoverUsers(ctx)
+			if err != nil {
+				level.Error(util_log.Logger).Log("msg", "Error scanning users", "err", err)
+				break
+			}
+			for _, u := range users {
+				if c.Cfg.allowedTenants.IsAllowed(u) {
+					if ok, _ := c.ownBlock(u); ok {
+						err := c.updateParquetIndex(ctx, u)
+						if err != nil {
+							level.Error(util_log.Logger).Log("msg", "Error updating index", "err", err)
 						}
 					}
 				}
 			}
-		}
-	}()
 
-	t := time.NewTicker(time.Second * 10)
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-t.C:
+		case <-convertBlocksTicker.C:
 			u, err := c.discoverUsers(ctx)
 			if err != nil {
 				level.Error(util_log.Logger).Log("msg", "Error scanning users", "err", err)
@@ -268,6 +313,16 @@ func (c *ParquetConverter) run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func (c *ParquetConverter) stopping(_ error) error {
+	ctx := context.Background()
+
+	services.StopAndAwaitTerminated(ctx, c.loader) //nolint:errcheck
+	if c.ringSubservices != nil {
+		return services.StopManagerAndAwaitStopped(ctx, c.ringSubservices)
+	}
+	return nil
 }
 
 func (c *ParquetConverter) updateParquetIndex(ctx context.Context, u string) error {
@@ -435,7 +490,7 @@ func (c *ParquetConverter) ownBlock(userID string) (bool, error) {
 	_, _ = hasher.Write([]byte(userID))
 	userHash := hasher.Sum32()
 
-	rs, err := c.ring.Get(userHash, compactor.RingOp, nil, nil, nil)
+	rs, err := c.ring.Get(userHash, RingOp, nil, nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/parquetconverter/parquet_converter.go
+++ b/pkg/parquetconverter/parquet_converter.go
@@ -149,7 +149,9 @@ func (c *ParquetConverter) starting(ctx context.Context) error {
 			c.ringSubservicesWatcher = services.NewFailureWatcher()
 			c.ringSubservicesWatcher.WatchManager(c.ringSubservices)
 
-			err = services.StartManagerAndAwaitHealthy(ctx, c.ringSubservices)
+			if err := services.StartManagerAndAwaitHealthy(context.Background(), c.ringSubservices); err != nil {
+				return errors.Wrap(err, "unable to start parquet-converter subservices")
+			}
 		}
 	}
 
@@ -343,19 +345,20 @@ func (c *ParquetConverter) removeDeletedBlocks(idx *bucketindex.Index, pIdx *buc
 	}
 }
 
-func (c *ParquetConverter) removeOutdatedBlocks(ctx context.Context, uBucket objstore.InstrumentedBucket, pIdx *bucketindex.ParquetIndex) {
-	for _, b := range pIdx.Blocks {
-		marker, err := ReadCompactMark(ctx, b.ID, uBucket, c.logger)
-		if err != nil {
-			level.Error(util_log.Logger).Log("msg", "failed to check if file exists", "err", err)
-			continue
-		}
-
-		if marker.Version < CurrentVersion {
-			delete(pIdx.Blocks, b.ID)
-		}
-	}
-}
+// TODO this function sets off the linter as it is not used yet
+//func (c *ParquetConverter) removeOutdatedBlocks(ctx context.Context, uBucket objstore.InstrumentedBucket, pIdx *bucketindex.ParquetIndex) {
+//	for _, b := range pIdx.Blocks {
+//		marker, err := ReadCompactMark(ctx, b.ID, uBucket, c.logger)
+//		if err != nil {
+//			level.Error(util_log.Logger).Log("msg", "failed to check if file exists", "err", err)
+//			continue
+//		}
+//
+//		if marker.Version < CurrentVersion {
+//			delete(pIdx.Blocks, b.ID)
+//		}
+//	}
+//}
 
 func (c *ParquetConverter) findNextBlockToCompact(ctx context.Context, uBucket objstore.InstrumentedBucket, idx *bucketindex.Index, pIdx *bucketindex.ParquetIndex) ([]*bucketindex.Block, int) {
 	deleted := map[ulid.ULID]struct{}{}
@@ -503,7 +506,10 @@ func TSDBBlockToParquet(ctx context.Context, id ulid.ULID, uploader Uploader, bD
 			err = ctx.Err()
 		}
 		fmt.Printf("Writing Metrics [%v] [%v]\n", 100*(float64(total)/float64(totalMetrics)), rows[0].Columns[labels.MetricName])
-		writer.WriteRows(rows)
+		err := writer.WriteRows(rows)
+		if err != nil {
+			return err
+		}
 		total += len(rows)
 	}
 

--- a/pkg/querier/parquet_blocks_finder_bucket_index.go
+++ b/pkg/querier/parquet_blocks_finder_bucket_index.go
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/26344c3ec7409713fcf52a9c41cd0dce537b3100/pkg/querier/parquet_blocks_finder_bucket_index.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+
 package querier
 
 import (

--- a/pkg/querier/parquet_blocks_finder_bucket_index.go
+++ b/pkg/querier/parquet_blocks_finder_bucket_index.go
@@ -4,17 +4,14 @@ import (
 	"context"
 	"time"
 
-	"github.com/grafana/dskit/services"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/thanos-io/objstore"
-
-	"github.com/cespare/xxhash/v2"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
@@ -128,8 +125,9 @@ func (f *ParquetBucketIndexBlocksFinder) GetBlocks(ctx context.Context, userID s
 	return blocks, matchingDeletionMarks, nil
 }
 
-func hash(s string) uint64 {
-	h := xxhash.New()
-	_, _ = h.Write([]byte(s))
-	return h.Sum64()
-}
+// TODO this function sets off the linter as it is not used yet
+//func hash(s string) uint64 {
+//	h := xxhash.New()
+//	_, _ = h.Write([]byte(s))
+//	return h.Sum64()
+//}

--- a/pkg/storage/parquet/prometheus_parquet_chunks_encoder.go
+++ b/pkg/storage/parquet/prometheus_parquet_chunks_encoder.go
@@ -128,6 +128,9 @@ func (e *PrometheusParquetChunksDecoder) Decode(data [][]byte, mint, maxt int64)
 		}
 		cData := b.Bytes()[:size]
 		chk, err := e.Pool.Get(chunkenc.Encoding(chkEnc), cData)
+		if err != nil {
+			return nil, err
+		}
 		c.Chunk = chk
 		if int64(minTime) > maxt {
 			continue

--- a/pkg/storage/parquet/stats.go
+++ b/pkg/storage/parquet/stats.go
@@ -6,6 +6,7 @@
 package parquet
 
 import (
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,7 +45,7 @@ func setToStrings(m map[string]struct{}) string {
 	for k := range m {
 		res = append(res, k)
 	}
-	sort.Strings(res)
+	slices.Sort(res)
 	return strings.Join(res, ",")
 }
 

--- a/pkg/storage/parquet/tsdbcodec/reader.go
+++ b/pkg/storage/parquet/tsdbcodec/reader.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/mimir/pkg/storage/parquet"
-	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
 func BlockToParquetRowsStream(
@@ -143,7 +142,7 @@ func BlockToParquetRowsStream(
 
 			err = eg.Wait()
 			if err != nil {
-				level.Error(util_log.Logger).Log("msg", "failed to process chunk", "err", err)
+				level.Error(logger).Log("msg", "failed to process chunk", "err", err)
 				return
 			}
 		}

--- a/pkg/storage/parquet/writer.go
+++ b/pkg/storage/parquet/writer.go
@@ -47,7 +47,6 @@ func NewParquetWriter(w io.Writer, rowsPerRowGroup int64, indexSizeLimit, numDat
 		skipPageBounds = append(skipPageBounds, c)
 		schemaGroup[c] = parquet.Compressed(parquet.Encoded(parquet.Leaf(parquet.ByteArrayType), &parquet.DeltaByteArray), &parquet.Zstd)
 	}
-	skipPageBounds = append(skipPageBounds)
 
 	for _, n := range columns {
 		if _, ok := schemaGroup[n]; !ok {

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -7,6 +7,7 @@ package bucketindex
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 )
 
 type LoaderConfig struct {
+	ExtraMetricsPrefix    string
 	CheckInterval         time.Duration
 	UpdateOnStaleInterval time.Duration
 	UpdateOnErrorInterval time.Duration
@@ -61,22 +63,22 @@ func NewLoader(cfg LoaderConfig, bucketClient objstore.Bucket, cfgProvider bucke
 		indexes:     map[string]*cachedIndex{},
 
 		loadAttempts: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_bucket_index_loads_total",
+			Name: fmt.Sprintf("cortex_%sbucket_index_loads_total", cfg.ExtraMetricsPrefix),
 			Help: "Total number of bucket index loading attempts.",
 		}),
 		loadFailures: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_bucket_index_load_failures_total",
+			Name: fmt.Sprintf("cortex_%sbucket_index_load_failures_total", cfg.ExtraMetricsPrefix),
 			Help: "Total number of bucket index loading failures.",
 		}),
 		loadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "cortex_bucket_index_load_duration_seconds",
+			Name:    fmt.Sprintf("cortex_%sbucket_index_load_duration_seconds", cfg.ExtraMetricsPrefix),
 			Help:    "Duration of the a single bucket index loading operation in seconds.",
 			Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 1, 10},
 		}),
 	}
 
 	l.loaded = promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "cortex_bucket_index_loaded",
+		Name: fmt.Sprintf("cortex_%sbucket_index_loaded", cfg.ExtraMetricsPrefix),
 		Help: "Number of bucket indexes currently loaded in-memory.",
 	}, l.countLoadedIndexesMetric)
 

--- a/pkg/storage/tsdb/bucketindex/parquet_loader.go
+++ b/pkg/storage/tsdb/bucketindex/parquet_loader.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/services"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/thanos-io/objstore"
 	"go.uber.org/atomic"
 
-	"github.com/grafana/dskit/services"
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/util"
 	util_log "github.com/grafana/mimir/pkg/util/log"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

* some minor lint fixes
* what looks like big changes in parquet-converter `starting`, `running`, and `stopping` funcs, but they are mostly just rearranged to mirror those in the compactor so that it's less weird to debug 
* some tweaks to the expected values for some ring member metrics in integration tests.
  * there is still a bunch of expected ring member metric values to fix in integration tests because with the current configuration we are:
  * still starting the store-gateways with its 512 ring tokens
  * _not_  initializing the the store-gateway queryable, which would normally also see the 512 ring tokens for the store-gateway sharding ring and contribute a tombstone on shutdown
  * now starting the parquet-converter, with _its_ 512 tokens and a tombstone on shutdown

There is a bunch to figure out there for making those integration tests make sense, obviously the most correct answer is to have a config option & test cases to handle this correctly in integration tests (when parquet is on, we would not start the store-gateways, etc.) but I think this is fine for this PR.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
