### PR TITLE
Fix double logging in querymiddleware caching

### DIFF
--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -31,9 +31,11 @@ import (
 )
 
 const (
-	notCachableReasonUnalignedTimeRange   = "unaligned-time-range"
-	notCachableReasonTooNew               = "too-new"
-	notCachableReasonModifiersNotCachable = "has-modifiers"
+	notCachableReasonUnalignedTimeRange                   = "unaligned-time-range"
+	notCachableReasonTooNew                               = "too-new"
+	notCachableReasonModifiersNotCachable                 = "has-modifiers"
+	notCachableReasonModifiersNotCachableFailedParse      = "has-modifiers-failed-parse"
+	notCachableReasonModifiersNotCachableFailedPreprocess = "has-modifiers-failed-preprocess"
 )
 
 var (


### PR DESCRIPTION
#### What this PR does

Remove double logging when `areEvaluationTimeModifiersCachable` evaluates to false due to an error in parsing or preprocessing the query expression.

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/grafana/mimir/pull/11292#discussion_r2058968044

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Minor change, should only affect logging and the reason recorded in a metric.