### PR TITLE
deps: Use a non-retracted version of github.com/twmb/franz-go/pkg/kmsg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/twmb/franz-go v1.18.2-0.20250416232150-07cc0584a381
 	github.com/twmb/franz-go/pkg/kadm v1.14.0
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20250416232150-07cc0584a381
-	github.com/twmb/franz-go/pkg/kmsg v1.11.0
+	github.com/twmb/franz-go/pkg/kmsg v1.11.2
 	github.com/twmb/franz-go/plugin/kotel v1.5.0
 	github.com/twmb/franz-go/plugin/kprom v1.1.0
 	github.com/xlab/treeprint v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1768,8 +1768,8 @@ github.com/twmb/franz-go/pkg/kadm v1.14.0 h1:nAn1co1lXzJQocpzyIyOFOjUBf4WHWs5/fT
 github.com/twmb/franz-go/pkg/kadm v1.14.0/go.mod h1:XjOPz6ZaXXjrW2jVCfLuucP8H1w2TvD6y3PT2M+aAM4=
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20250416232150-07cc0584a381 h1:3DUojSNwAfW3kPK/om71YTXxjAZbY5Jd70pfm2k0/sU=
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20250416232150-07cc0584a381/go.mod h1:zCgWGv7Rg9B70WV6T+tUbifRJnx60gGTFU/U4xZpyUA=
-github.com/twmb/franz-go/pkg/kmsg v1.11.0 h1:zUY4I4xgNhQh3M0tPPWkJbfGBvsW9fM1XyIkAaB7AZ0=
-github.com/twmb/franz-go/pkg/kmsg v1.11.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
+github.com/twmb/franz-go/pkg/kmsg v1.11.2 h1:hIw75FpwcAjgeyfIGFqivAvwC5uNIOWRGvQgZhH4mhg=
+github.com/twmb/franz-go/pkg/kmsg v1.11.2/go.mod h1:CFfkkLysDNmukPYhGzuUcDtf46gQSqCZHMW1T4Z+wDE=
 github.com/twmb/franz-go/plugin/kotel v1.5.0 h1:TiPfGUbQK384OO7ZYGdo7JuPCbJn+/8njQ/D9Je9CDE=
 github.com/twmb/franz-go/plugin/kotel v1.5.0/go.mod h1:wRXzRo76x1myOUMaVHAyraXoGBdEcvlLChGTVv5+DWU=
 github.com/twmb/franz-go/plugin/kprom v1.1.0 h1:grGeIJbm4llUBF8jkDjTb/b8rKllWSXjMwIqeCCcNYQ=

--- a/vendor/github.com/twmb/franz-go/pkg/kmsg/generated.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kmsg/generated.go
@@ -4329,12 +4329,21 @@ func (v *FetchRequest) AppendTo(dst []byte) []byte {
 						dst = kbin.AppendInt32(dst, v)
 					}
 					if isFlexible {
-						dst = kbin.AppendUvarint(dst, 1+uint32(v.UnknownTags.Len()))
-						{
-							v := v.ReplicaDirectoryID
-							dst = kbin.AppendUvarint(dst, 0)
-							dst = kbin.AppendUvarint(dst, 16)
-							dst = kbin.AppendUuid(dst, v)
+						var toEncode []uint32
+						if v.ReplicaDirectoryID != [16]byte{} {
+							toEncode = append(toEncode, 0)
+						}
+						dst = kbin.AppendUvarint(dst, uint32(len(toEncode)+v.UnknownTags.Len()))
+						for _, tag := range toEncode {
+							switch tag {
+							case 0:
+								{
+									v := v.ReplicaDirectoryID
+									dst = kbin.AppendUvarint(dst, 0)
+									dst = kbin.AppendUvarint(dst, 16)
+									dst = kbin.AppendUuid(dst, v)
+								}
+							}
 						}
 						dst = v.UnknownTags.AppendEach(dst)
 					}
@@ -15707,7 +15716,7 @@ type DescribeGroupsResponseGroup struct {
 	ErrorCode int16
 
 	// ErrorMessage is an optional message with more detail for the error code.
-	ErrorMessage *string
+	ErrorMessage *string // v6+
 
 	// Group is the id of this group.
 	Group string
@@ -15802,7 +15811,7 @@ func (v *DescribeGroupsResponse) AppendTo(dst []byte) []byte {
 				v := v.ErrorCode
 				dst = kbin.AppendInt16(dst, v)
 			}
-			{
+			if version >= 6 {
 				v := v.ErrorMessage
 				if isFlexible {
 					dst = kbin.AppendCompactNullableString(dst, v)
@@ -15966,7 +15975,7 @@ func (v *DescribeGroupsResponse) readFrom(src []byte, unsafe bool) error {
 				v := b.Int16()
 				s.ErrorCode = v
 			}
-			{
+			if version >= 6 {
 				var v *string
 				if isFlexible {
 					if unsafe {
@@ -42175,12 +42184,21 @@ func (v *FetchSnapshotRequest) AppendTo(dst []byte) []byte {
 						dst = kbin.AppendInt64(dst, v)
 					}
 					if isFlexible {
-						dst = kbin.AppendUvarint(dst, 1+uint32(v.UnknownTags.Len()))
-						{
-							v := v.ReplicaDirectoryID
-							dst = kbin.AppendUvarint(dst, 0)
-							dst = kbin.AppendUvarint(dst, 16)
-							dst = kbin.AppendUuid(dst, v)
+						var toEncode []uint32
+						if v.ReplicaDirectoryID != [16]byte{} {
+							toEncode = append(toEncode, 0)
+						}
+						dst = kbin.AppendUvarint(dst, uint32(len(toEncode)+v.UnknownTags.Len()))
+						for _, tag := range toEncode {
+							switch tag {
+							case 0:
+								{
+									v := v.ReplicaDirectoryID
+									dst = kbin.AppendUvarint(dst, 0)
+									dst = kbin.AppendUvarint(dst, 16)
+									dst = kbin.AppendUuid(dst, v)
+								}
+							}
 						}
 						dst = v.UnknownTags.AppendEach(dst)
 					}
@@ -46663,11 +46681,12 @@ type ConsumerGroupHeartbeatRequest struct {
 	UnknownTags Tags
 }
 
-func (*ConsumerGroupHeartbeatRequest) Key() int16                 { return 68 }
-func (*ConsumerGroupHeartbeatRequest) MaxVersion() int16          { return 1 }
-func (v *ConsumerGroupHeartbeatRequest) SetVersion(version int16) { v.Version = version }
-func (v *ConsumerGroupHeartbeatRequest) GetVersion() int16        { return v.Version }
-func (v *ConsumerGroupHeartbeatRequest) IsFlexible() bool         { return v.Version >= 0 }
+func (*ConsumerGroupHeartbeatRequest) Key() int16                   { return 68 }
+func (*ConsumerGroupHeartbeatRequest) MaxVersion() int16            { return 1 }
+func (v *ConsumerGroupHeartbeatRequest) SetVersion(version int16)   { v.Version = version }
+func (v *ConsumerGroupHeartbeatRequest) GetVersion() int16          { return v.Version }
+func (v *ConsumerGroupHeartbeatRequest) IsFlexible() bool           { return v.Version >= 0 }
+func (v *ConsumerGroupHeartbeatRequest) IsGroupCoordinatorRequest() {}
 func (v *ConsumerGroupHeartbeatRequest) ResponseKind() Response {
 	r := &ConsumerGroupHeartbeatResponse{Version: v.Version}
 	r.Default()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1266,7 +1266,7 @@ github.com/twmb/franz-go/pkg/kadm
 # github.com/twmb/franz-go/pkg/kfake v0.0.0-20250416232150-07cc0584a381
 ## explicit; go 1.21
 github.com/twmb/franz-go/pkg/kfake
-# github.com/twmb/franz-go/pkg/kmsg v1.11.0
+# github.com/twmb/franz-go/pkg/kmsg v1.11.2
 ## explicit; go 1.21
 github.com/twmb/franz-go/pkg/kmsg
 github.com/twmb/franz-go/pkg/kmsg/internal/kbin


### PR DESCRIPTION
#### What this PR does

github.com/twmb/franz-go/pkg/kmsg v1.11.0 is marked as [retracted](https://pkg.go.dev/github.com/twmb/franz-go/pkg/kmsg@v1.11.0)
This caused issues with vendoring when I tried to do it locally (and might be broken). Bump to a non-retracted version.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
