### PR TITLE
GitHub actions: set 'persist-credentials: false' for all actions/checkout jobs

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -29,6 +29,7 @@ jobs:
           # pin the version to before https://github.com/grafana/grafana-github-actions/pull/113 because
           # we don't want to have the same strict rules for PR labels
           ref: d284afd314ca3625c23595e9f62b52d215ead7ce
+          persist-credentials: false
 
       - name: Install Actions
         run: npm install --production --prefix ./actions

--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Get build image from Makefile
         id: build_image_step
         run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
@@ -28,6 +30,8 @@ jobs:
       image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Get Go Version
@@ -42,6 +46,8 @@ jobs:
     needs: goversion
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@v5
       with:
         go-version: ${{ needs.goversion.outputs.version }}

--- a/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
+++ b/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Get build image from Makefile
         id: build_image_step
         run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # Retrieve GitHub App Credentials from Vault
       - name: Retrieve GitHub App Credentials from Vault
@@ -62,6 +66,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.token.outputs.token }}
+          persist-credentials: false
 
       - name: Run Git Config
         run: |

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Get build image from Makefile
         id: build_image_step
         run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
@@ -37,6 +39,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Run Git Config
         run: git config --global --add safe.directory '*'

--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: imjasonh/setup-crane@v0.4
 
       - name: Update/regenerate files

--- a/.github/workflows/helm-weekly-release-reviewer.yml
+++ b/.github/workflows/helm-weekly-release-reviewer.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Approve and auto-merge
         id: auto-merge

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
           source_directory: docs/sources/mimir

--- a/.github/workflows/publish-technical-documentation-release-helm-charts.yml
+++ b/.github/workflows/publish-technical-documentation-release-helm-charts.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           # Full fetch depth is required to fetch tags. The publishing workflow uses tags to prevent publishing a release branch before it has been formally released, as determined by the presence of a matching tag for the release branch.
           fetch-depth: 0
+          persist-credentials: false
       - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v1
         with:
           release_tag_regexp: "^mimir-distributed-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"

--- a/.github/workflows/publish-technical-documentation-release-mimir.yml
+++ b/.github/workflows/publish-technical-documentation-release-mimir.yml
@@ -26,6 +26,7 @@ jobs:
           # Full fetch depth is required to fetch tags.
           # The publishing workflow uses tags to prevent publishing a release branch before it has been formally released, as determined by the presence of a matching tag for the release branch.
           fetch-depth: 0
+          persist-credentials: false
       - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2
         with:
           release_tag_regexp: "^mimir-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Checkout Pull Request Branch
         run: gh pr checkout ${{ github.event.pull_request.number }}

--- a/.github/workflows/sbom-report.yml
+++ b/.github/workflows/sbom-report.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
         
     - name: Anchore SBOM Action
       uses: anchore/sbom-action@v0.18.0

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Get build image from Makefile
         id: build_image_step
         run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
@@ -37,6 +39,8 @@ jobs:
       image: ${{ needs.prepare.outputs.build_image }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Get Go Version
@@ -54,6 +58,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
         # Commands in the Makefile are hardcoded with an assumed file structure of the CI container
@@ -114,6 +120,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
         # Commands in the Makefile are hardcoded with an assumed file structure of the CI container
@@ -144,6 +152,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
         # Commands in the Makefile are hardcoded with an assumed file structure of the CI container
@@ -175,6 +185,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Symlink Expected Path to Workspace
@@ -208,6 +220,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Install Docker Client
@@ -273,6 +287,8 @@ jobs:
           cache: false # We manage caching ourselves below to maintain consistency with the other jobs that don't use setup-go.
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Install Docker Client
@@ -339,6 +355,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Install Docker Client

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: "Check out code"
       uses: "actions/checkout@v4"
+      with:
+        persist-credentials: false
     - name: Run Git Config
       run: git config --global --add safe.directory '*'
     - name: Build website to test Mimir documentation
@@ -41,6 +43,7 @@ jobs:
       with:
         path: ${{ steps.mimir_branch.outputs.branch }}
         ref: ${{ steps.mimir_branch.outputs.branch }}
+        persist-credentials: false
     - name: Build website to test Helm chart documentation
       env:
         MIMIR_BRANCH: ${{ steps.mimir_branch.outputs.branch }}

--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: grafana/writers-toolkit/update-make-docs@update-make-docs/v1
         with:
           pr_options: >


### PR DESCRIPTION
#### What this PR does

As part of an effort to harden our GitHub actions workflows, in this PR I'm setting `persist-credentials: false` ([doc](https://github.com/actions/checkout)) for all actions/checkout jobs.

**How it works**:
By default, the auth token is persisted in the local git config. This behaviour enables our CI scripts to run authenticated git commands. The token is removed during post-job cleanup. Setting `persist-credentials: false` we opt-out.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
