### PR TITLE
GitHub actions: restrict permissions for some workflows

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -2,6 +2,9 @@ name: compare-helm-with-jsonnet
 
 on: pull_request
 
+permissions:
+  contents: read
+
 concurrency:
   # Cancel any running workflow for the same branch when new commits are pushed.
   # We group both by ref_name (available when CI is triggered by a push to a branch/tag)

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -2,6 +2,9 @@ name: helm-ci
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   call-lint:
     uses: grafana/helm-charts/.github/workflows/linter.yml@main

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -6,9 +6,16 @@ on:
       - main
       - "mimir-distributed-release-[0-9]+.[0-9]+"
 
+# No default permissions.
+permissions: {}
+
 jobs:
   call-update-helm-repo:
     uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main
+    permissions:
+      # Give restricted read permissions to "update-helm-repo" action. The action
+      # requests higher permissions for the specific "release" job.
+      contents: read
     with:
       charts_dir: operations/helm/charts
       cr_configfile: operations/helm/cr.yaml


### PR DESCRIPTION
#### What this PR does

Default permissions (when not specified) may be broader than necessary. In this PR I'm restricting the permissions of some actions. I'm not sure changes in `helm-release` are correct (that means it has enough permissions) but it's something we can later fix if broken.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
