### PR TITLE
Explicitly set required permissions with comments to explain them

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -11,6 +11,11 @@ on:
 
 jobs:
   deploy-pr-preview:
+    permissions:
+      contents: read # Clone repository.
+      id-token: write # Fetch Vault secrets.
+      pull-requests: write # Create or update pull request comments.
+      statuses: write # Update GitHub status check with deploy preview link.
     if: "!github.event.pull_request.head.repo.fork"
     uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:

--- a/docs/sources/mimir/get-started/_index.md
+++ b/docs/sources/mimir/get-started/_index.md
@@ -227,5 +227,4 @@ To add a data source, refer to [Add a data source](/docs/grafana/latest/administ
 
 ## Verify success
 
-After you have completed the tasks in this _Get started_ guide, you can query metrics in [Grafana Explore](/docs/grafana/latest/explore/)
-as well as create dashboard panels using your newly configured Grafana Mimir data source.
+After you have completed the tasks in this _Get started_ guide, you can query metrics in [Grafana Explore](/docs/grafana/latest/explore/) and create dashboard panels using your newly configured Grafana Mimir data source.


### PR DESCRIPTION
If `permissions` isn't set on the job, it uses the default permissions which may be too broad.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
