### PR TITLE
ci: Disable caching in workflows triggered by PR

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -7,6 +7,9 @@ on:
       - 'main' 
  workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   snyk-scan-ci:
     uses: 'grafana/security-github-actions/.github/workflows/snyk_monitor.yml@main'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,6 +5,11 @@ on:
     - cron: '30 1 * * *'
   workflow_dispatch: # Allows manual triggering
 
+permissions:
+  contents: read
+  issues: none
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -9,6 +9,9 @@ on:
       - mimir-[0-9]+.[0-9]+.[0-9]+**
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   # Cancel any running workflow for the same branch when new commits are pushed.
   # We group both by ref_name (available when CI is triggered by a push to a branch/tag)
@@ -68,32 +71,6 @@ jobs:
         run: |
           mkdir -p /go/src/github.com/grafana/mimir
           ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
-      - name: Get golangci-lint cache path
-        id: golangcilintcache
-        run: |
-          echo "path=$(golangci-lint cache status | grep 'Dir: ' | cut -d ' ' -f2)" >> "$GITHUB_OUTPUT"
-      - name: Cache golangci-lint cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          key: lint-golangci-lint-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum', '.golangci.yml', 'Makefile') }}
-          path: ${{ steps.golangcilintcache.outputs.path }}
-      - name: Get Go cache paths
-        id: goenv
-        run: |
-          echo "gocache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-          echo "gomodcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-      - name: Cache Go build cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          key: lint-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
-          path: ${{ steps.goenv.outputs.gocache }}
-      # Although we use vendoring, this linting job downloads all modules to verify that what is vendored is correct,
-      # so it'll use GOMODCACHE. Other jobs don't need this.
-      - name: Cache Go module cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          key: lint-go-mod-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
-          path: ${{ steps.goenv.outputs.gomodcache }}
       - name: Lint
         run: make BUILD_IN_CONTAINER=false lint
       - name: Check Vendor Directory
@@ -193,16 +170,6 @@ jobs:
         run: |
           mkdir -p /go/src/github.com/grafana/mimir
           ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
-      - name: Get Go build cache path
-        id: gocache
-        run: |
-          echo "path=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-      - name: Cache Go build cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          # Cache is shared between test groups.
-          key: test-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
-          path: ${{ steps.gocache.outputs.path }}
       - name: Run Tests
         run: |
           echo "Running unit tests (group ${{ matrix.test_group_id }} of ${{ matrix.test_group_total }}) with Go version: $(go version)"
@@ -235,15 +202,6 @@ jobs:
         run: |
           mkdir -p /go/src/github.com/grafana/mimir
           ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
-      - name: Get Go build cache path
-        id: gocache
-        run: |
-          echo "path=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-      - name: Cache Go build cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          key: build-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
-          path: ${{ steps.gocache.outputs.path }}
       - name: Build Multiarch Docker Images Locally
         # Ignore mimir-build-image and mimir-rules-action.
         run: |
@@ -297,16 +255,6 @@ jobs:
         run: |
           sudo mkdir -p /go/src/github.com/grafana/mimir
           sudo ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
-      - name: Get Go build cache path
-        id: gocache
-        run: |
-          echo "path=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-      - name: Cache Go build cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          # Cache is shared between test groups.
-          key: integration-go-build-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}
-          path: ${{ steps.gocache.outputs.path }}
       - name: Download Archive with Docker Images
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
#### What this PR does

Remove uses of `actions/cache` flagged by zizmor due to cache
poisoning issues. This change also sets default permissions for
snyk, stale, and test-build-deploy workflows to only what is
required.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
