### PR TITLE
chore(parquet): fix bucket client registerer component

### DIFF
--- a/pkg/querier/parquet_queryable.go
+++ b/pkg/querier/parquet_queryable.go
@@ -119,7 +119,7 @@ func NewParquetStoreQueryable(
 	logger log.Logger,
 	reg prometheus.Registerer,
 ) (*ParquetQueryable, error) {
-	bucketClient, err := bucket.NewClient(context.Background(), storageCfg.Bucket, ModuleName, logger, reg)
+	bucketClient, err := bucket.NewClient(context.Background(), storageCfg.Bucket, ModuleName, logger, prometheus.WrapRegistererWith(prometheus.Labels{"component": "querier-parquet"}, reg))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We forgot to set the right component label for the object storage access metrics