### PR TITLE
querier: handle non-retriable errors in `Labels*` calls

### DIFF
--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -1030,12 +1030,11 @@ func (q *blocksStoreQuerier) fetchLabelNamesFromStore(
 
 			namesResp, err := c.LabelNames(gCtx, req)
 			if err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					return err
+				if shouldRetry(err) {
+					level.Warn(spanLog).Log("msg", "failed to fetch label names; error is retriable", "remote", c.RemoteAddress(), "err", err)
+					return nil
 				}
-
-				level.Warn(spanLog).Log("msg", "failed to fetch label names", "remote", c.RemoteAddress(), "err", err)
-				return nil
+				return fmt.Errorf("non-retriable error while fetching label names from store: %w", err)
 			}
 
 			myQueriedBlocks := []ulid.ULID(nil)
@@ -1110,11 +1109,11 @@ func (q *blocksStoreQuerier) fetchLabelValuesFromStore(
 
 			valuesResp, err := c.LabelValues(gCtx, req)
 			if err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					return err
+				if shouldRetry(err) {
+					level.Warn(spanLog).Log("msg", "failed to fetch label values; error is retriable", "remote", c.RemoteAddress(), "err", err)
+					return nil
 				}
-				level.Warn(spanLog).Log("msg", "failed to fetch label values", "remote", c.RemoteAddress(), "err", err)
-				return nil
+				return fmt.Errorf("non-retriable error while fetching label values from store: %w", err)
 			}
 
 			myQueriedBlocks := []ulid.ULID(nil)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does


I found this while investigating a different bug.

Changed error handling for LabelValues and LabelNames in `blocks_store_queryable.go` to distinguish retriable and non-retriable errors. This matches the logic for series calls

https://github.com/grafana/mimir/blob/0676ed782eb07d5383093b822683923cb33bdca9/pkg/querier/blocks_store_queryable.go#L781-L788


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
