### PR TITLE
Add ingester HPA trigger targeting max owned series per pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 * [CHANGE] Update rollout-operator version to 0.26.0. #11232
 * [CHANGE] Memcached: Set a timeout of `500ms` for the `ruler-storage` cache instead of the default `200ms`. #11231
 * [FEATURE] Make ingest storage ingester HPA behavior configurable through `_config.ingest_storage_ingester_hpa_behavior`. #11168
-* [FEATURE] Add an alternate ingest storage HPA trigger that targets max owned series per pod. #11356
+* [FEATURE] Add an alternate ingest storage HPA trigger that targets maximum owned series per pod. #11356
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * [CHANGE] Update rollout-operator version to 0.26.0. #11232
 * [CHANGE] Memcached: Set a timeout of `500ms` for the `ruler-storage` cache instead of the default `200ms`. #11231
 * [FEATURE] Make ingest storage ingester HPA behavior configurable through `_config.ingest_storage_ingester_hpa_behavior`. #11168
+* [FEATURE] Add an alternate ingest storage HPA trigger that targets max owned series per pod. #11356
 
 ### Mimirtool
 

--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -10,8 +10,16 @@
     ingest_storage_ingester_autoscaling_min_replicas_per_zone: error 'you must set ingest_storage_ingester_autoscaling_min_replicas_per_zone in the _config in namespace %s' % $._config.namespace,
     ingest_storage_ingester_autoscaling_max_replicas_per_zone: error 'you must set ingest_storage_ingester_autoscaling_max_replicas_per_zone in the _config in namespace %s' % $._config.namespace,
 
+    // Which triggers to use for autoscaling. It is possible to enable both triggers; the HPA will use the highest desired number of replicas across all triggers.
+    ingest_storage_ingester_autoscaling_use_average_active_series_trigger: true,
+    ingest_storage_ingester_autoscaling_use_max_owned_series_trigger: false,
+
     // The target number of active series per ingester.
     ingest_storage_ingester_autoscaling_active_series_threshold: 1500000,
+
+    // The target max of owned series across all ingesters.
+    // Our ideal max series per ingester is 2/3 of the instance limit, but we target 90% of that to account for scaling delays and the 10% HPA tolerance.
+    ingest_storage_ingester_autoscaling_max_owned_series_threshold: std.toString(0.9 * $._config.ingester_instance_limits.max_series * (2 / 3)),
 
     // How long to wait before terminating an ingester after it has been notified about the scale down.
     ingest_storage_ingester_downscale_delay: if 'querier.query-ingesters-within' in $.querier_args then
@@ -29,7 +37,7 @@
     ingest_storage_replica_template_label_selector: 'name=ingester-zone-a',
 
     // Make triggers configurable so that we can add more. Each object needs to have: query, threshold, metric_type.
-    ingest_storage_ingester_autoscaling_triggers: [
+    ingest_storage_ingester_autoscaling_triggers: [] + (if $._config.ingest_storage_ingester_autoscaling_use_average_active_series_trigger then [
       {
         // Target ingesters in primary zone, ignoring read-write mode ingesters.
         local sum_series_from_ready_pods = |||
@@ -57,7 +65,42 @@
         threshold: std.toString($._config.ingest_storage_ingester_autoscaling_active_series_threshold),
         metric_type: 'AverageValue',  // HPA will compute desired replicas as "<query result> / <threshold>".
       },
-    ],
+    ] else []) + (if $._config.ingest_storage_ingester_autoscaling_use_max_owned_series_trigger then [
+      {
+        // We want to target a maximum number of owned series per ingester pod.
+        // However, we can't use a `Value` metric because the HPA will also count pods assigned to read-only partitions when calculating the desired number of replicas.
+        // This means we need to use an `AverageValue` metric, which doesn't use the current replica count at all.
+        // To do this, we fake a "total owned series" value by multiplying the max owned series per pod by the number of active partitions.
+        // The HPA then calculates the desired replica count as this total value / threshold.
+
+        // Calculate the "total owned series" as the owned series on the worst pod multiplied by the number of active partitions.
+        local max_owned_series_x_active_partitions = |||
+          (
+              max(
+                  sum by (pod) (cortex_ingester_owned_series{cluster="%(cluster)s", namespace="%(namespace)s", job="%(namespace)s/%(primary_zone)s", container="ingester"})
+                  and
+                  sum by (pod) (kube_pod_status_ready{cluster="%(cluster)s", namespace="%(namespace)s", pod=~"%(primary_zone)s.*", condition="true"}) > 0
+              )
+              *
+              max(cortex_partition_ring_partitions{cluster="%(cluster)s", namespace="%(namespace)s", state="Active", container="distributor", name="ingester-partitions"})
+          )
+        |||,
+
+        // Our compaction cycles are 2h long, but the max stabilizationWindowSeconds is only 1h. This means that we'll react to a scale-down
+        // after compaction half-way through a cycle, when the series counts in ingesters are still growing, resulting in partitions being put into read-only
+        // mode only to be taken back out of it a short time later. To artificially increase our stabilization window to 3h, we use a `max_over_time`
+        // of 2h. However, because this query uses both the max-owned-series-per-pod and the partition count, and the max-owned-series-per-pod doesn't decrease
+        // until some time after the partition count increases, we see brief spikes in the artificial "total series" we calculate after a scale-up. To
+        // mitigate this, we first use a `min_over_time` of 5m.
+        query: ('max_over_time(min_over_time(' + max_owned_series_x_active_partitions + '[5m:])[2h:5m])') % {
+          cluster: $._config.cluster,
+          namespace: $._config.namespace,
+          primary_zone: $._config.ingest_storage_ingester_autoscaling_primary_zone,
+        },
+        threshold: $._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold,
+        metric_type: 'AverageValue',  // HPA will compute desired replicas as "<query result> / <threshold>".
+      },
+    ] else []),
 
     // When set to false, metrics used by scaling triggers are only indexed if there is more than 1 trigger.
     // When set to true, they are always indexed.
@@ -80,6 +123,7 @@
   assert !$._config.ingest_storage_ingester_autoscaling_ingester_annotations_enabled || !$._config.ingester_automated_downscale_enabled : 'partitions ingester autoscaling and ingester automated downscale config are mutually exclusive in namespace %s' % $._config.namespace,
   assert !$._config.ingest_storage_ingester_autoscaling_ingester_annotations_enabled || !$._config.ingester_automated_downscale_v2_enabled : 'partitions ingester autoscaling and ingester automated downscale v2 config are mutually exclusive in namespace %s' % $._config.namespace,
   assert !$._config.ingest_storage_ingester_autoscaling_enabled || $.rollout_operator_deployment != null : 'partitions ingester autoscaling requires rollout-operator in namespace %s' % $._config.namespace,
+  assert !$._config.ingest_storage_ingester_autoscaling_enabled || std.length($._config.ingest_storage_ingester_autoscaling_triggers) > 0 : 'partitions ingester autoscaling requires at least one trigger to be enabled in namespace %s' % $._config.namespace,
 
   // Create resource that will be targetted by ScaledObject.
   ingester_primary_zone_replica_template: if !$._config.ingest_storage_ingester_autoscaling_enabled then null else $.replicaTemplate($._config.ingest_storage_ingester_autoscaling_primary_zone, replicas=-1, label_selector=$._config.ingest_storage_replica_template_label_selector),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds a second ingest storage ingester HPA trigger that targets a max number of owned series per pod. This trigger can be enabled in addition to or in place of the existing one that targets average active series per pod.

As it is possible to disable each of the triggers separately, also adds a check to make sure the HPA has at least one trigger when the configs are rendered.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
