### PR TITLE
Ruler: Fix Alertmanager URL tenant config mapping in deployments when runtime config is disabled

### DIFF
--- a/docs/internal/contributing/how-to-convert-config-to-per-tenant-limit.md
+++ b/docs/internal/contributing/how-to-convert-config-to-per-tenant-limit.md
@@ -171,6 +171,8 @@ Until deprecation is complete, we need to ensure that a user who is still settin
    }
    ```
 
+   Note this must be added prior to any checks for `t.Cfg.RuntimeConfig.LoadPath` or early exit paths within `initRuntimeConfig`. It's possible to configure Mimir with purely static config and disable runtime config; the mapping needs to happen in either case.
+
 ## Updating Mimir Docs
 
 1. Update the Mimir Config file docs.

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -415,12 +415,12 @@ func (t *Mimir) initRuntimeConfig() (services.Service, error) {
 		t.Cfg.LimitsConfig.RulerAlertmanagerClientConfig.NotifierConfig.TLS.Reader = t.Cfg.Ruler.DeprecatedNotifier.TLS.Reader
 	}
 
+	// End mappings for per-tenant config migrations.
+
 	if len(t.Cfg.RuntimeConfig.LoadPath) == 0 {
 		// no need to initialize module if load path is empty
 		return nil, nil
 	}
-
-	// End mappings for per-tenant config migrations.
 
 	serv, err := NewRuntimeManager(&t.Cfg, "mimir-runtime-config", prometheus.WrapRegistererWithPrefix("cortex_", t.Registerer), util_log.Logger)
 	if err == nil {

--- a/pkg/mimir/runtime_config.go
+++ b/pkg/mimir/runtime_config.go
@@ -231,20 +231,6 @@ func NewRuntimeManager(cfg *Config, name string, reg prometheus.Registerer, logg
 	loader := runtimeConfigLoader{validate: cfg.ValidateLimits}
 	cfg.RuntimeConfig.Loader = loader.load
 
-	// AlertmanagerURL and Notifier sub-options are moving from a global config to a per-tenant config.
-	// We need to preserve the option in the ruler yaml for at least two releases (that is, at least Mimir 3.0).
-	// If the ruler config is configured by the user, map it to its new place in the default limits.
-	if cfg.Ruler.DeprecatedAlertmanagerURL != "" {
-		cfg.LimitsConfig.RulerAlertmanagerClientConfig.AlertmanagerURL = cfg.Ruler.DeprecatedAlertmanagerURL
-	}
-	if !cfg.Ruler.DeprecatedNotifier.IsDefault() {
-		cfg.LimitsConfig.RulerAlertmanagerClientConfig.NotifierConfig = cfg.Ruler.DeprecatedNotifier
-	}
-	// Ensure the TLS settings reader is propagated.
-	if cfg.Ruler.DeprecatedNotifier.TLS.Reader != cfg.LimitsConfig.RulerAlertmanagerClientConfig.NotifierConfig.TLS.Reader {
-		cfg.LimitsConfig.RulerAlertmanagerClientConfig.NotifierConfig.TLS.Reader = cfg.Ruler.DeprecatedNotifier.TLS.Reader
-	}
-
 	// Make sure to set default limits before we start loading configuration into memory.
 	validation.SetDefaultLimitsForYAMLUnmarshalling(cfg.LimitsConfig)
 	ingester.SetDefaultInstanceLimitsForYAMLUnmarshalling(cfg.Ingester.DefaultLimits)


### PR DESCRIPTION
#### What this PR does

In the process of https://github.com/grafana/mimir/pull/10816, several ruler options are being migrated to per-tenant configs.

Normally, when yaml configuration containing the old values under `ruler:` is provided, we want to internally map it to the tenant default limits to preserve backward compatibility. This is typically done in `initRuntimeConfig()`.

This PR fixes a bug where this mapping fails on deployments with pure static config and no runtime config, and with the ruler alertmanager still configured via yaml in the old method. (i.e. Mimir deployments which use `-config.file` and not `-runtime-config.file`) In such deployments we never launch the runtime config service whatsoever, but we still need the mapping to happen as it might have been statically configured.

The fix is to simply move the mapping earlier in the process, it needs to happen before any shortcuts are taken.

I've noted this potential pitfall in the code and in the migration guide so that future changes others don't run into it.

This is covered already by GEM e2e tests, hence I didn't create a duplicate here. It's already under coverage. Mimir's integration test framework tends to set up Mimir via CLI options, which are not affected by the bug.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
