### PR TITLE
Remove experimental flag for native histograms

### DIFF
--- a/docs/sources/mimir/configure/configure-native-histograms-ingestion.md
+++ b/docs/sources/mimir/configure/configure-native-histograms-ingestion.md
@@ -7,10 +7,6 @@ weight: 160
 
 # Configure native histograms
 
-{{% admonition type="note" %}}
-Native histograms are an experimental feature of Grafana Mimir.
-{{% /admonition %}}
-
 You can configure native histograms ingestion via the Prometheus [remote write API](/docs/mimir/<MIMIR_VERSION>/references/http-api/#distributor) endpoint globally or per tenant.
 
 {{% admonition type="note" %}}

--- a/docs/sources/mimir/send/native-histograms/_index.md
+++ b/docs/sources/mimir/send/native-histograms/_index.md
@@ -15,10 +15,6 @@ weight: 100
 
 # Send native histograms to Mimir
 
-{{% admonition type="note" %}}
-Native histograms are an experimental feature of Grafana Mimir.
-{{% /admonition %}}
-
 Prometheus native histograms is a data type in the Prometheus ecosystem that makes it possible to produce, store, and query a high-resolution [histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) of observations.
 
 Native histograms are different from classic Prometheus histograms in a number of ways:

--- a/docs/sources/mimir/visualize/native-histograms/_index.md
+++ b/docs/sources/mimir/visualize/native-histograms/_index.md
@@ -17,10 +17,6 @@ weight: 100
 
 # Visualize native histograms
 
-{{% admonition type="note" %}}
-Native histograms are an experimental feature of Grafana Mimir.
-{{% /admonition %}}
-
 Prometheus native histograms are a data type in the Prometheus ecosystem that allow you to produce, store, and query a high-resolution [histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) of observations.
 To learn more about the native histograms data type and how to start sending native histograms to Grafana Mimir,
 refer to [Send native histograms to Mimir](../../send/native-histograms/).


### PR DESCRIPTION

#### What this PR does

This PR removes the note stating that native histograms are an experimental feature from the Mimir documentation. We already explain that it is a public preview, so the additional messaging is redundant and might serve to discourage Cloud customers..

See https://raintank-corp.slack.com/archives/C04AT2ANL90/p1745848572449149

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/2981

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
