### PR TITLE
Docs: Update OTel resource attribute promotion docs

### DIFF
--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -111,9 +111,13 @@ service:
 
 OpenTelemetry metrics use resource attributes to describe the set of characteristics associated with a given resource, or entity, producing telemetry data. For example, a host resource might have multiple attributes, including an ID, an image, and a type.
 
-To optimize the storage of and ability to query this data, you can configure Mimir to promote specified OTel resource attributes to labels at the time of ingestion, with periods (`.`) replaced by underscores (`_`).
+To optimize the storage of and ability to query this data, you can use the `promote_otel_resource_attributes` setting to configure Mimir to promote specified OTel resource attributes to labels at the time of ingestion.
 
-Grafana Cloud automatically promotes the following OTel resource attributes to labels:
+{{< admonition type="note" >}}
+The `promote_otel_resource_attributes` setting is an experimental feature in Grafana Mimir.
+{{< /admonition >}}
+
+Grafana Cloud automatically promotes the following OTel resource attributes to labels, with periods (`.`) replaced by underscores (`_`):
 
 - `service.instance.id`
 - `service.name`
@@ -141,6 +145,8 @@ To disable this setting or to update this list, contact Grafana Labs Support.
 Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.
 
 To learn more about OpenTelemetry resource attributes, refer to [Resources](https://opentelemetry.io/docs/languages/js/resources/) in the OpenTelemetry documentation.
+
+To learn more about ingesting OpenTelemetry data in Grafana Cloud, refer to [OTLP: OpenTelemetry Protocol format considerations](https://grafana.com/docs/grafana-cloud/send-data/otlp/otlp-format-considerations/).
 
 ## Format considerations
 


### PR DESCRIPTION
#### What this PR does

This PR makes the following updates to https://grafana.com/docs/mimir/next/configure/configure-otel-collector/#work-with-default-opentelemetry-labels:
- Notes the name of setting (`promote_otel_resource_attributes`)
- Notes the setting is experimental in Mimir.
- Cross-references https://grafana.com/docs/grafana-cloud/send-data/otlp/otlp-format-considerations/.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/2977

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
