### PR TITLE
Use IngesterPartitionRingWatcher to reset reactive limiter

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -658,10 +658,6 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 		i.circuitBreaker.push.activate()
 	}
 
-	if i.reactiveLimiter.read != nil {
-		i.reactiveLimiter.read.activate()
-	}
-
 	return nil
 }
 
@@ -1725,7 +1721,7 @@ func (i *Ingester) StartReadRequest(ctx context.Context) (resultCtx context.Cont
 	if err := i.checkReadOverloaded(); err != nil {
 		return nil, err
 	}
-	if i.reactiveLimiter.isReadLimiterActive() && !i.reactiveLimiter.read.CanAcquirePermit() {
+	if i.reactiveLimiter.read != nil && !i.reactiveLimiter.read.CanAcquirePermit() {
 		i.metrics.rejected.WithLabelValues(reasonIngesterMaxInflightReadRequests).Inc()
 		return nil, newReactiveLimiterExceededError(reactivelimiter.ErrExceeded)
 	}
@@ -1750,7 +1746,7 @@ func (i *Ingester) PrepareReadRequest(ctx context.Context) (finishFn func(error)
 		cbFinish = st.requestFinish
 	}
 
-	if i.reactiveLimiter.isReadLimiterActive() {
+	if i.reactiveLimiter.read != nil {
 		// Acquire a permit, blocking if needed
 		permit, err := i.reactiveLimiter.read.AcquirePermit(ctx)
 		if err != nil {
@@ -3874,10 +3870,6 @@ func (i *Ingester) PreparePartitionDownscaleHandler(w http.ResponseWriter, r *ht
 			return
 		}
 
-		if i.reactiveLimiter.read != nil {
-			i.reactiveLimiter.read.deactivate()
-		}
-
 	case http.MethodDelete:
 		state, _, err := i.ingestPartitionLifecycler.GetPartitionState(r.Context())
 		if err != nil {
@@ -3898,10 +3890,6 @@ func (i *Ingester) PreparePartitionDownscaleHandler(w http.ResponseWriter, r *ht
 				level.Error(logger).Log("msg", "failed to change partition state to active", "err", err)
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
-			}
-
-			if i.reactiveLimiter.read != nil {
-				i.reactiveLimiter.read.activate()
 			}
 		}
 	}
@@ -3939,6 +3927,17 @@ func (i *Ingester) ShutdownHandler(w http.ResponseWriter, _ *http.Request) {
 	i.lifecycler.SetUnregisterOnShutdown(originalUnregister)
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// OnPartitionRingChanged resets the read reactive limiter when the ingester's partition transitions to active.
+func (i *Ingester) OnPartitionRingChanged(oldRing, newRing *ring.PartitionRingDesc) {
+	if i.reactiveLimiter.read != nil {
+		oldPartition, ok1 := oldRing.Partitions[i.ingestPartitionID]
+		newPartition, ok2 := newRing.Partitions[i.ingestPartitionID]
+		if ok1 && ok2 && oldPartition.State != newPartition.State && newPartition.State == ring.PartitionActive {
+			i.reactiveLimiter.read.Reset()
+		}
+	}
 }
 
 // checkAvailableForRead checks whether the ingester is available for read requests,

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -717,6 +717,9 @@ func (t *Mimir) initIngesterService() (serv services.Service, err error) {
 		return
 	}
 
+	if t.IngesterPartitionRingWatcher != nil {
+		t.IngesterPartitionRingWatcher = t.IngesterPartitionRingWatcher.WithDelegate(t.Ingester)
+	}
 	if t.ActiveGroupsCleanup != nil {
 		t.ActiveGroupsCleanup.Register(t.Ingester)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR:
- Uses the `IngesterPartitionRingWatcher` to reset the ingester's read reactive limiter when the ingester's partition changes to active state. 
- Removes the activatable limiter wrapper - so the limiter is now always active. This allows even an inactive ingester, which can still be processing read requests, to continue being limited if needed. Only when transitioning back to active will the limiter reset.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
