### PR TITLE
Login to DockerHub using creds from Vault

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -319,12 +319,8 @@ jobs:
           name: Docker Images
       - name: Extract Docker Images from Archive
         run: tar xvf images.tar -C /
+      - name: Login to DockerHub
+        uses: grafana/shared-workflows/actions/dockerhub-login@13fb504e3bfe323c1188bf244970d94b2d336e86 # v1.0.1
       - name: Deploy
         run: |
-          if [ -n "$DOCKER_PASSWORD" ]; then
-            printenv DOCKER_PASSWORD | skopeo login -u "$DOCKER_USERNAME" --password-stdin docker.io
-          fi
           ./.github/workflows/scripts/push-images.sh /tmp/images grafana/ $(make image-tag)
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
#### What this PR does

This uses the shared workflow that reads DockerHub credentials from vault rather than from repo secrets, which were removed due to recent security incident.

#### Which issue(s) this PR fixes or relates to

Ref docs:
https://github.com/grafana/shared-workflows/tree/main/actions/dockerhub-login

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
