### PR TITLE
ci: bump update-helm-repo workflow to retrieve app secrets from Vault

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -13,13 +13,14 @@ jobs:
   call-update-helm-repo:
     uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main
     permissions:
-      # Give restricted read permissions to "update-helm-repo" action. The action
-      # requests higher permissions for the specific "release" job.
-      contents: read
+      id-token: write
+      contents: write
+      packages: write
     with:
       charts_dir: operations/helm/charts
       cr_configfile: operations/helm/cr.yaml
       ct_configfile: operations/helm/ct.yaml
     secrets:
-      github_app_id: ${{ secrets.MIMIR_HELM_RELEASE_APP_ID }}
-      github_app_pem: ${{ secrets.MIMIR_HELM_RELEASE_APP_KEY_PEM }}
+      # "mimir-helm-release" is a GitHub app, that has permissions to push to grafana/helm-charts.
+      # The app's credentials seat in the mimir repo's vault (ref https://github.com/grafana/shared-workflows/tree/main/actions/get-vault-secrets).
+      vault_repo_secret_name: mimir-helm-release


### PR DESCRIPTION
#### What this PR does

This PR updates the `helm-release` workflow to use the credentials of the "mimir-helm-release" from Vault, rather than GitHub secrets.

The PR requires https://github.com/grafana/helm-charts/pull/3696