### PR TITLE
Fix deadlock in TestPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhenDone

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1870,6 +1870,10 @@ func TestPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhenDone(t *testi
 				if blocked.Load() {
 					blockedTicker := time.NewTicker(100 * time.Millisecond)
 					defer blockedTicker.Stop()
+
+					timeoutTimer := time.NewTimer(3 * time.Second)
+					defer timeoutTimer.Stop()
+
 				outer:
 					for {
 						select {
@@ -1877,7 +1881,7 @@ func TestPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhenDone(t *testi
 							if !blocked.Load() {
 								break outer
 							}
-						case <-time.After(3 * time.Second):
+						case <-timeoutTimer.C:
 							// This is basically a test failure as we never finish the test in time.
 							t.Log("failed to finish unblocking the consumer in time")
 							return nil


### PR DESCRIPTION
#### What this PR does

I looked at https://github.com/grafana/mimir/issues/11180. I found the root cause of the deadlock, the deadlock is caused by a failure in metrics assertion, for which I have no clue yet (I would need to see the actual assertion failing, instead of the test timeout panic). This PR fixes the test timeout panic, which is a first step.

**What's the change in this PR?**

The `time.After(3 * time.Second)` was impossible to reach, because `blockedTicker` was always triggering earlier (100ms). This means that if an assertion failed, we didn't interrupt the consumer after 3s, but it was looping forever.

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/11180

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
