### PR TITLE
fix: Add support for mounting TLS certificates in provisioner

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,6 +28,7 @@ Entries should be ordered as follows:
 Entries should include a reference to the Pull Request that introduced the change.
 
 ## main / unreleased
+
 * [BUGFIX] Added extraVolumes to provisioner to support mounting TLS certificates. #11400
 * [CHANGE] KEDA Autoscaling: Changed toPromQLLabelSelector from object to list of strings, adding support for all PromQL operators. #10945
 * [CHANGE] Memcached: Set a timeout of `500ms` for the `ruler-storage` cache instead of the default `200ms`. #11231

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -28,7 +28,7 @@ Entries should be ordered as follows:
 Entries should include a reference to the Pull Request that introduced the change.
 
 ## main / unreleased
-
+* [BUGFIX] Added extraVolumes to provisioner to support mounting TLS certificates. #11400
 * [CHANGE] KEDA Autoscaling: Changed toPromQLLabelSelector from object to list of strings, adding support for all PromQL operators. #10945
 * [CHANGE] Memcached: Set a timeout of `500ms` for the `ruler-storage` cache instead of the default `200ms`. #11231
 * [BUGFIX] Memcached: Use `dnssrvnoa+` address prefix instead of `dns+` which results in DNS `SRV` record lookups instead of `A` or `AAAA`. This results in fewer cache evictions when the members of the Memcached cluster change. #11041

--- a/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
@@ -123,4 +123,4 @@ spec:
         {{- if .Values.global.extraVolumes }}
         {{- toYaml .Values.global.extraVolumes | nindent 8 }}
         {{- end }}
-{{- end -}} 
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
@@ -41,21 +41,24 @@ spec:
       {{- end }}
       {{- end }}
       initContainers:
-        {{- range $index, $tenant := .Values.provisioner.additionalTenants }}
-        - name: provisioner-{{ $tenant.name }}
+        - name: provisioner
           image: "{{ $.Values.provisioner.image.registry }}/{{ $.Values.provisioner.image.repository }}:{{ $.Values.provisioner.image.tag }}"
           imagePullPolicy: {{ $.Values.provisioner.image.pullPolicy }}
           command:
-            - /usr/bin/provisioner
-          args:
-            - -bootstrap-path=/bootstrap
-            - -cluster-name={{ include "mimir.clusterName" $ }}
-            - -api-url={{ tpl $.Values.provisioner.apiUrl $ }}
-            - -tenant={{ $tenant.name }}
-            - -access-policy=write-{{ $tenant.name }}:{{ $tenant.name }}:metrics:write
-            - -access-policy=read-{{ $tenant.name }}:{{ $tenant.name }}:metrics:read
-            - -token=write-{{ $tenant.name }}
-            - -token=read-{{ $tenant.name }}
+            - /bin/sh
+            - -euc
+            - |
+              {{- range $tenant := .Values.provisioner.additionalTenants }}
+              /usr/bin/provisioner \
+                -bootstrap-path=/bootstrap \
+                -cluster-name={{ include "mimir.clusterName" $ }} \
+                -api-url={{ tpl $.Values.provisioner.apiUrl $ }} \
+                -tenant={{ $tenant.name }} \
+                -access-policy=write-{{ $tenant.name }}:{{ $tenant.name }}:metrics:write \
+                -access-policy=read-{{ $tenant.name }}:{{ $tenant.name }}:metrics:read \
+                -token=write-{{ $tenant.name }} \
+                -token=read-{{ $tenant.name }}
+              {{- end }}
           volumeMounts:
             {{- if $.Values.provisioner.extraVolumeMounts }}
               {{ toYaml $.Values.provisioner.extraVolumeMounts | nindent 12 }}
@@ -72,7 +75,6 @@ spec:
           env:
             {{ toYaml . | nindent 12 }}
           {{- end }}
-        {{- end }}
       containers:
         - name: create-secret
           image: {{ include "mimir.kubectlImage" . }}
@@ -115,4 +117,10 @@ spec:
             secretName: {{ .Values.tokengenJob.adminTokenSecret }}
         - name: bootstrap
           emptyDir: {}
+        {{- if .Values.provisioner.extraVolumes }}
+        {{- toYaml .Values.provisioner.extraVolumes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.global.extraVolumes }}
+        {{- toYaml .Values.global.extraVolumes | nindent 8 }}
+        {{- end }}
 {{- end -}} 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4199,6 +4199,8 @@ provisioner:
     pullPolicy: IfNotPresent
   # -- Volume mounts to add to the provisioner pods
   extraVolumeMounts: []
+  # -- Volumes to add to the provisioner pods
+  extraVolumes: []
 
 # Settings for the admin_api service providing authentication and authorization service.
 # Can only be enabled if enterprise.enabled is true - requires license.

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/provisioner/provisioner-job.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/provisioner/provisioner-job.yaml
@@ -37,40 +37,31 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        - name: provisioner-team-a
+        - name: provisioner
           image: "us-docker.pkg.dev/grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner:latest"
           imagePullPolicy: IfNotPresent
           command:
-            - /usr/bin/provisioner
-          args:
-            - -bootstrap-path=/bootstrap
-            - -cluster-name=test-enterprise-values
-            - -api-url=http://test-enterprise-values-mimir-admin-api.citestns.svc:8080
-            - -tenant=team-a
-            - -access-policy=write-team-a:team-a:metrics:write
-            - -access-policy=read-team-a:team-a:metrics:read
-            - -token=write-team-a
-            - -token=read-team-a
-          volumeMounts:
-            - name: bootstrap
-              mountPath: /bootstrap
-            - name: admin-token
-              mountPath: /bootstrap/token
-              subPath: token
-        - name: provisioner-team-b
-          image: "us-docker.pkg.dev/grafanalabs-global/docker-enterprise-provisioner-prod/enterprise-provisioner:latest"
-          imagePullPolicy: IfNotPresent
-          command:
-            - /usr/bin/provisioner
-          args:
-            - -bootstrap-path=/bootstrap
-            - -cluster-name=test-enterprise-values
-            - -api-url=http://test-enterprise-values-mimir-admin-api.citestns.svc:8080
-            - -tenant=team-b
-            - -access-policy=write-team-b:team-b:metrics:write
-            - -access-policy=read-team-b:team-b:metrics:read
-            - -token=write-team-b
-            - -token=read-team-b
+            - /bin/sh
+            - -euc
+            - |
+              /usr/bin/provisioner \
+                -bootstrap-path=/bootstrap \
+                -cluster-name=test-enterprise-values \
+                -api-url=http://test-enterprise-values-mimir-admin-api.citestns.svc:8080 \
+                -tenant=team-a \
+                -access-policy=write-team-a:team-a:metrics:write \
+                -access-policy=read-team-a:team-a:metrics:read \
+                -token=write-team-a \
+                -token=read-team-a
+              /usr/bin/provisioner \
+                -bootstrap-path=/bootstrap \
+                -cluster-name=test-enterprise-values \
+                -api-url=http://test-enterprise-values-mimir-admin-api.citestns.svc:8080 \
+                -tenant=team-b \
+                -access-policy=write-team-b:team-b:metrics:write \
+                -access-policy=read-team-b:team-b:metrics:read \
+                -token=write-team-b \
+                -token=read-team-b
           volumeMounts:
             - name: bootstrap
               mountPath: /bootstrap


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds extraVolumes to the provisioner definition to ensure it can properly mount TLS certificates.  This PR also corrects the initContainer to use a single container with a call to /usr/bin/provisioner for each tenant, instead of an initContainer per tenant. 

#### Which issue(s) this PR fixes or relates to

Fixes #11400

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
