### PR TITLE
ingest-storage: Add consumer support for a new record version 2, based on Remote Write 2.0

### DIFF
--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -94,7 +94,7 @@ func (b *TSDBBuilder) Process(ctx context.Context, rec *kgo.Record, lastBlockMax
 	}
 
 	// TODO(codesome): see if we can skip parsing exemplars. They are not persisted in the block so we can save some parsing here.
-	err = req.Unmarshal(rec.Value)
+	err = ingest.DeserializeRecordContent(rec.Value, &req, version)
 	if err != nil {
 		return false, fmt.Errorf("unmarshal record key %s: %w", rec.Key, err)
 	}

--- a/pkg/mimirpb/compat_rw2.go
+++ b/pkg/mimirpb/compat_rw2.go
@@ -32,8 +32,9 @@ const rw2SymbolPageSize = 16
 // mechanism, we would have to allocate a large amount of memory
 // or do reallocation. This is a compromise between the two.
 type rw2PagedSymbols struct {
-	count uint32
-	pages []*[]string
+	count  uint32
+	pages  []*[]string
+	offset uint32
 }
 
 func (ps *rw2PagedSymbols) append(symbol string) {
@@ -55,6 +56,7 @@ func (ps *rw2PagedSymbols) releasePages() {
 }
 
 func (ps *rw2PagedSymbols) get(ref uint32) (string, error) {
+	ref = ref - ps.offset
 	if ref < ps.count {
 		page := ps.pages[ref>>rw2SymbolPageSize]
 		return (*page)[ref&((1<<rw2SymbolPageSize)-1)], nil

--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -192,7 +192,7 @@ func TestRW2Unmarshal(t *testing.T) {
 		require.Equal(t, expected, &received)
 	})
 
-	t.Run("offset too high fails to unmarshal", func(t *testing.T) {
+	t.Run("wrong offset fails to unmarshal", func(t *testing.T) {
 		syms := test.NewSymbolTableBuilderWithOffset(nil, 256)
 		// Create a new WriteRequest with some sample data.
 		writeRequest := makeTestRW2WriteRequest(syms)
@@ -205,20 +205,10 @@ func TestRW2Unmarshal(t *testing.T) {
 		received.UnmarshalFromRW2 = true
 		received.RW2SymbolOffset = 257
 		err = received.Unmarshal(data)
-
 		require.ErrorContains(t, err, "invalid")
-	})
-
-	t.Run("offset too low fails to unmarshal", func(t *testing.T) {
-		syms := test.NewSymbolTableBuilderWithOffset(nil, 256)
-		// Create a new WriteRequest with some sample data.
-		writeRequest := makeTestRW2WriteRequest(syms)
-		writeRequest.Symbols = syms.GetSymbols()
-		data, err := writeRequest.Marshal()
-		require.NoError(t, err)
 
 		// Unmarshal the data back into Mimir's WriteRequest.
-		received := PreallocWriteRequest{}
+		received = PreallocWriteRequest{}
 		received.UnmarshalFromRW2 = true
 		received.RW2SymbolOffset = 255
 		err = received.Unmarshal(data)

--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -51,7 +51,6 @@ func TestRW2Unmarshal(t *testing.T) {
 		syms := test.NewSymbolTableBuilder(nil)
 		// Create a new WriteRequest with some sample data.
 		writeRequest := makeTestRW2WriteRequest(syms)
-		writeRequest.Symbols = syms.GetSymbols()
 		data, err := writeRequest.Marshal()
 		require.NoError(t, err)
 
@@ -122,7 +121,6 @@ func TestRW2Unmarshal(t *testing.T) {
 		syms := test.NewSymbolTableBuilderWithOffset(nil, 256)
 		// Create a new WriteRequest with some sample data.
 		writeRequest := makeTestRW2WriteRequest(syms)
-		writeRequest.Symbols = syms.GetSymbols()
 		data, err := writeRequest.Marshal()
 		require.NoError(t, err)
 
@@ -196,7 +194,6 @@ func TestRW2Unmarshal(t *testing.T) {
 		syms := test.NewSymbolTableBuilderWithOffset(nil, 256)
 		// Create a new WriteRequest with some sample data.
 		writeRequest := makeTestRW2WriteRequest(syms)
-		writeRequest.Symbols = syms.GetSymbols()
 		data, err := writeRequest.Marshal()
 		require.NoError(t, err)
 
@@ -218,7 +215,7 @@ func TestRW2Unmarshal(t *testing.T) {
 }
 
 func makeTestRW2WriteRequest(syms *test.SymbolTableBuilder) *rw2.Request {
-	return &rw2.Request{
+	req := &rw2.Request{
 		Timeseries: []rw2.TimeSeries{
 			{
 				LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_total"), syms.GetSymbol("job"), syms.GetSymbol("test_job")},
@@ -243,4 +240,6 @@ func makeTestRW2WriteRequest(syms *test.SymbolTableBuilder) *rw2.Request {
 			},
 		},
 	}
+	req.Symbols = syms.GetSymbols()
+	return req
 }

--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -47,10 +47,188 @@ func TestRW2TypesCompatible(t *testing.T) {
 }
 
 func TestRW2Unmarshal(t *testing.T) {
-	syms := test.NewSymbolTableBuilder(nil)
+	t.Run("rw2 compatible produces expected WriteRequest", func(t *testing.T) {
+		syms := test.NewSymbolTableBuilder(nil)
+		// Create a new WriteRequest with some sample data.
+		writeRequest := makeTestRW2WriteRequest(syms)
+		writeRequest.Symbols = syms.GetSymbols()
+		data, err := writeRequest.Marshal()
+		require.NoError(t, err)
 
-	// Create a new WriteRequest with some sample data.
-	writeRequest := &rw2.Request{
+		// Unmarshal the data back into Mimir's WriteRequest.
+		received := PreallocWriteRequest{}
+		received.UnmarshalFromRW2 = true
+		err = received.Unmarshal(data)
+		require.NoError(t, err)
+
+		expected := &PreallocWriteRequest{
+			WriteRequest: WriteRequest{
+				Timeseries: []PreallocTimeseries{
+					{
+						TimeSeries: &TimeSeries{
+							Labels: []LabelAdapter{
+								{
+									Name:  "__name__",
+									Value: "test_metric_total",
+								},
+								{
+									Name:  "job",
+									Value: "test_job",
+								},
+							},
+							Samples: []Sample{
+								{
+									Value:       123.456,
+									TimestampMs: 1234567890,
+								},
+							},
+							Exemplars: []Exemplar{
+								{
+									Value:       123.456,
+									TimestampMs: 1234567890,
+									Labels: []LabelAdapter{
+										{
+											Name:  "__name__",
+											Value: "test_metric_total",
+										},
+										{
+											Name:  "traceID",
+											Value: "1234567890abcdef",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Metadata: []*MetricMetadata{
+					{
+						MetricFamilyName: "test_metric_total",
+						Type:             COUNTER,
+						Help:             "test_metric_help",
+						Unit:             "test_metric_unit",
+					},
+				},
+				unmarshalFromRW2: true,
+			},
+			UnmarshalFromRW2: true,
+		}
+
+		// Check that the unmarshalled data matches the original data.
+		require.Equal(t, expected, &received)
+	})
+
+	t.Run("rw2 with offset produces expected WriteRequest", func(t *testing.T) {
+		syms := test.NewSymbolTableBuilderWithOffset(nil, 256)
+		// Create a new WriteRequest with some sample data.
+		writeRequest := makeTestRW2WriteRequest(syms)
+		writeRequest.Symbols = syms.GetSymbols()
+		data, err := writeRequest.Marshal()
+		require.NoError(t, err)
+
+		// Unmarshal the data back into Mimir's WriteRequest.
+		received := PreallocWriteRequest{}
+		received.UnmarshalFromRW2 = true
+		received.RW2SymbolOffset = 256
+		err = received.Unmarshal(data)
+		require.NoError(t, err)
+
+		expected := &PreallocWriteRequest{
+			WriteRequest: WriteRequest{
+				Timeseries: []PreallocTimeseries{
+					{
+						TimeSeries: &TimeSeries{
+							Labels: []LabelAdapter{
+								{
+									Name:  "__name__",
+									Value: "test_metric_total",
+								},
+								{
+									Name:  "job",
+									Value: "test_job",
+								},
+							},
+							Samples: []Sample{
+								{
+									Value:       123.456,
+									TimestampMs: 1234567890,
+								},
+							},
+							Exemplars: []Exemplar{
+								{
+									Value:       123.456,
+									TimestampMs: 1234567890,
+									Labels: []LabelAdapter{
+										{
+											Name:  "__name__",
+											Value: "test_metric_total",
+										},
+										{
+											Name:  "traceID",
+											Value: "1234567890abcdef",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Metadata: []*MetricMetadata{
+					{
+						MetricFamilyName: "test_metric_total",
+						Type:             COUNTER,
+						Help:             "test_metric_help",
+						Unit:             "test_metric_unit",
+					},
+				},
+				unmarshalFromRW2: true,
+				rw2symbols:       rw2PagedSymbols{offset: 256},
+			},
+			UnmarshalFromRW2: true,
+			RW2SymbolOffset:  256,
+		}
+
+		// Check that the unmarshalled data matches the original data.
+		require.Equal(t, expected, &received)
+	})
+
+	t.Run("offset too high fails to unmarshal", func(t *testing.T) {
+		syms := test.NewSymbolTableBuilderWithOffset(nil, 256)
+		// Create a new WriteRequest with some sample data.
+		writeRequest := makeTestRW2WriteRequest(syms)
+		writeRequest.Symbols = syms.GetSymbols()
+		data, err := writeRequest.Marshal()
+		require.NoError(t, err)
+
+		// Unmarshal the data back into Mimir's WriteRequest.
+		received := PreallocWriteRequest{}
+		received.UnmarshalFromRW2 = true
+		received.RW2SymbolOffset = 257
+		err = received.Unmarshal(data)
+
+		require.ErrorContains(t, err, "invalid")
+	})
+
+	t.Run("offset too low fails to unmarshal", func(t *testing.T) {
+		syms := test.NewSymbolTableBuilderWithOffset(nil, 256)
+		// Create a new WriteRequest with some sample data.
+		writeRequest := makeTestRW2WriteRequest(syms)
+		writeRequest.Symbols = syms.GetSymbols()
+		data, err := writeRequest.Marshal()
+		require.NoError(t, err)
+
+		// Unmarshal the data back into Mimir's WriteRequest.
+		received := PreallocWriteRequest{}
+		received.UnmarshalFromRW2 = true
+		received.RW2SymbolOffset = 255
+		err = received.Unmarshal(data)
+
+		require.ErrorContains(t, err, "invalid")
+	})
+}
+
+func makeTestRW2WriteRequest(syms *test.SymbolTableBuilder) *rw2.Request {
+	return &rw2.Request{
 		Timeseries: []rw2.TimeSeries{
 			{
 				LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_total"), syms.GetSymbol("job"), syms.GetSymbol("test_job")},
@@ -75,73 +253,4 @@ func TestRW2Unmarshal(t *testing.T) {
 			},
 		},
 	}
-	writeRequest.Symbols = syms.GetSymbols()
-	data, err := writeRequest.Marshal()
-	require.NoError(t, err)
-
-	// Unmarshal the data back into Mimir's WriteRequest.
-	received := PreallocWriteRequest{}
-	received.UnmarshalFromRW2 = true
-	err = received.Unmarshal(data)
-	require.NoError(t, err)
-
-	expected := &PreallocWriteRequest{
-		WriteRequest: WriteRequest{
-			Timeseries: []PreallocTimeseries{
-				{
-					TimeSeries: &TimeSeries{
-						Labels: []LabelAdapter{
-							{
-								Name:  "__name__",
-								Value: "test_metric_total",
-							},
-							{
-								Name:  "job",
-								Value: "test_job",
-							},
-						},
-						Samples: []Sample{
-							{
-								Value:       123.456,
-								TimestampMs: 1234567890,
-							},
-						},
-						Exemplars: []Exemplar{
-							{
-								Value:       123.456,
-								TimestampMs: 1234567890,
-								Labels: []LabelAdapter{
-									{
-										Name:  "__name__",
-										Value: "test_metric_total",
-									},
-									{
-										Name:  "traceID",
-										Value: "1234567890abcdef",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Metadata: []*MetricMetadata{
-				{
-					MetricFamilyName: "test_metric_total",
-					Type:             COUNTER,
-					Help:             "test_metric_help",
-					Unit:             "test_metric_unit",
-				},
-			},
-			unmarshalFromRW2: true,
-		},
-		UnmarshalFromRW2: true,
-	}
-
-	// Check that the unmarshalled data matches the original data.
-	require.Equal(t, expected, &received)
-}
-
-func TestRW2UnmarshalWithOffset(t *testing.T) {
-
 }

--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -141,3 +141,7 @@ func TestRW2Unmarshal(t *testing.T) {
 	// Check that the unmarshalled data matches the original data.
 	require.Equal(t, expected, &received)
 }
+
+func TestRW2UnmarshalWithOffset(t *testing.T) {
+
+}

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -66,6 +66,10 @@ type PreallocWriteRequest struct {
 
 	// UnmarshalRW2 is set to true if the Unmarshal method should unmarshal the data as a remote write 2.0 message.
 	UnmarshalFromRW2 bool
+
+	// RW2SymbolOffset is an optimization used for RW2-adjacent applications where typical symbol refs are shifted by an offset.
+	// This allows certain symbols to be reserved without being present in the symbols list.
+	RW2SymbolOffset uint32
 }
 
 // Unmarshal implements proto.Message.
@@ -75,6 +79,7 @@ func (p *PreallocWriteRequest) Unmarshal(dAtA []byte) error {
 	p.Timeseries = PreallocTimeseriesSliceFromPool()
 	p.skipUnmarshalingExemplars = p.SkipUnmarshalingExemplars
 	p.unmarshalFromRW2 = p.UnmarshalFromRW2
+	p.rw2symbols.offset = p.RW2SymbolOffset
 	return p.WriteRequest.Unmarshal(dAtA)
 }
 

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -104,7 +104,7 @@ func (c pusherConsumer) Consume(ctx context.Context, records []record) (returnEr
 			}
 
 			// We don't free the WriteRequest slices because they are being freed by a level below.
-			err := DeserializeRecordContent(r.content, parsed.WriteRequest, r.version)
+			err := DeserializeRecordContent(r.content, parsed.PreallocWriteRequest, r.version)
 			if err != nil {
 				parsed.err = fmt.Errorf("parsing ingest consumer write request: %w", err)
 			}

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -104,7 +104,7 @@ func (c pusherConsumer) Consume(ctx context.Context, records []record) (returnEr
 			}
 
 			// We don't free the WriteRequest slices because they are being freed by a level below.
-			err := parsed.Unmarshal(r.content)
+			err := DeserializeRecordContent(r.content, parsed.WriteRequest, r.version)
 			if err != nil {
 				parsed.err = fmt.Errorf("parsing ingest consumer write request: %w", err)
 			}

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -140,7 +140,7 @@ func TestPusherConsumer(t *testing.T) {
 			expectedWRs: writeReqs[0:2],
 			expErr:      "",
 			expectedLogLines: []string{
-				"level=error msg=\"failed to parse write request; skipping\" err=\"received a record with an unsupported version: 101, max supported version: 1\"",
+				"level=error msg=\"failed to parse write request; skipping\" err=\"parsing ingest consumer write request: received a record with an unsupported version: 101, max supported version: 1\"",
 			},
 		},
 		"failed processing of record": {

--- a/pkg/storage/ingest/pusher_test.go
+++ b/pkg/storage/ingest/pusher_test.go
@@ -140,7 +140,7 @@ func TestPusherConsumer(t *testing.T) {
 			expectedWRs: writeReqs[0:2],
 			expErr:      "",
 			expectedLogLines: []string{
-				"level=error msg=\"failed to parse write request; skipping\" err=\"parsing ingest consumer write request: received a record with an unsupported version: 101, max supported version: 1\"",
+				"level=error msg=\"failed to parse write request; skipping\" err=\"parsing ingest consumer write request: received a record with an unsupported version: 101, max supported version: 2\"",
 			},
 		},
 		"failed processing of record": {

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -14,6 +14,7 @@ import (
 const (
 	RecordVersionHeaderKey = "Version"
 	LatestRecordVersion    = 2
+	V2RecordSymbolOffset   = 64
 )
 
 func ValidateRecordVersion(version int) error {
@@ -105,5 +106,6 @@ func deserializeRecordContentV1(content []byte, wr *mimirpb.PreallocWriteRequest
 
 func deserializeRecordContentV2(content []byte, wr *mimirpb.PreallocWriteRequest) error {
 	wr.UnmarshalFromRW2 = true
+	wr.RW2SymbolOffset = V2RecordSymbolOffset
 	return wr.Unmarshal(content)
 }

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -85,7 +85,7 @@ func (v versionOneRecordSerializer) ToRecords(partitionID int32, tenantID string
 	return records, nil
 }
 
-func DeserializeRecordContent(content []byte, wr *mimirpb.WriteRequest, version int) error {
+func DeserializeRecordContent(content []byte, wr *mimirpb.PreallocWriteRequest, version int) error {
 	switch version {
 	case 0:
 		// V0 is body-comptaible with V1.
@@ -97,6 +97,6 @@ func DeserializeRecordContent(content []byte, wr *mimirpb.WriteRequest, version 
 	}
 }
 
-func deserializeRecordContentV1(content []byte, wr *mimirpb.WriteRequest) error {
+func deserializeRecordContentV1(content []byte, wr *mimirpb.PreallocWriteRequest) error {
 	return wr.Unmarshal(content)
 }

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -89,7 +89,7 @@ func (v versionOneRecordSerializer) ToRecords(partitionID int32, tenantID string
 func DeserializeRecordContent(content []byte, wr *mimirpb.PreallocWriteRequest, version int) error {
 	switch version {
 	case 0:
-		// V0 is body-comptaible with V1.
+		// V0 is body-compatible with V1.
 		fallthrough
 	case 1:
 		return deserializeRecordContentV1(content, wr)

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	RecordVersionHeaderKey = "Version"
-	LatestRecordVersion    = 1
+	LatestRecordVersion    = 2
 )
 
 func ValidateRecordVersion(version int) error {
@@ -92,11 +92,18 @@ func DeserializeRecordContent(content []byte, wr *mimirpb.PreallocWriteRequest, 
 		fallthrough
 	case 1:
 		return deserializeRecordContentV1(content, wr)
+	case 2:
+		return deserializeRecordContentV2(content, wr)
 	default:
 		return fmt.Errorf("received a record with an unsupported version: %d, max supported version: %d", version, LatestRecordVersion)
 	}
 }
 
 func deserializeRecordContentV1(content []byte, wr *mimirpb.PreallocWriteRequest) error {
+	return wr.Unmarshal(content)
+}
+
+func deserializeRecordContentV2(content []byte, wr *mimirpb.PreallocWriteRequest) error {
+	wr.UnmarshalFromRW2 = true
 	return wr.Unmarshal(content)
 }

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -84,3 +84,19 @@ func (v versionOneRecordSerializer) ToRecords(partitionID int32, tenantID string
 	}
 	return records, nil
 }
+
+func DeserializeRecordContent(content []byte, wr *mimirpb.WriteRequest, version int) error {
+	switch version {
+	case 0:
+		// V0 is body-comptaible with V1.
+		fallthrough
+	case 1:
+		return deserializeRecordContentV1(content, wr)
+	default:
+		return fmt.Errorf("received a record with an unsupported version: %d, max supported version: %d", version, LatestRecordVersion)
+	}
+}
+
+func deserializeRecordContentV1(content []byte, wr *mimirpb.WriteRequest) error {
+	return wr.Unmarshal(content)
+}

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/mimir/pkg/mimirpb"
-	"github.com/grafana/mimir/pkg/util/test"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/util/test"
 )
 
 func TestRecordVersionHeader(t *testing.T) {
@@ -225,7 +226,7 @@ func BenchmarkDeserializeRecordContent(b *testing.B) {
 	require.NoError(b, err)
 
 	b.Run("deserialize v1", func(b *testing.B) {
-		for b.Loop() {
+		for range b.N {
 			wr := &mimirpb.PreallocWriteRequest{}
 			err := DeserializeRecordContent(v1bytes, wr, 1)
 			if err != nil {
@@ -236,7 +237,7 @@ func BenchmarkDeserializeRecordContent(b *testing.B) {
 	})
 
 	b.Run("deserialize v2", func(b *testing.B) {
-		for b.Loop() {
+		for range b.N {
 			wr := &mimirpb.PreallocWriteRequest{}
 			err := DeserializeRecordContent(v2bytes, wr, 2)
 			if err != nil {

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
@@ -43,4 +44,59 @@ func TestRecordVersionHeader(t *testing.T) {
 			require.Equal(t, tt.version, parsed)
 		})
 	}
+}
+
+func BenchmarkDeserializeRecordContent(b *testing.B) {
+	// Generate a write request in each version
+	reqv1 := &mimirpb.PreallocWriteRequest{
+		WriteRequest: mimirpb.WriteRequest{
+			Timeseries: make([]mimirpb.PreallocTimeseries, 10000),
+		},
+	}
+	for i := range reqv1.Timeseries {
+		reqv1.Timeseries[i] = mockPreallocTimeseries(fmt.Sprintf("series_%d", i))
+	}
+	v1bytes, err := reqv1.Marshal()
+	require.NoError(b, err)
+
+	reqv2 := &mimirpb.PreallocWriteRequest{
+		WriteRequest: mimirpb.WriteRequest{
+			TimeseriesRW2: make([]mimirpb.TimeSeriesRW2, 10000),
+			SymbolsRW2:    make([]string, 0, 1+1+10000),
+		},
+	}
+	reqv2.SymbolsRW2 = append(reqv2.SymbolsRW2, "")
+	reqv2.SymbolsRW2 = append(reqv2.SymbolsRW2, "__name__")
+	for i := range reqv2.TimeseriesRW2 {
+		reqv2.TimeseriesRW2[i] = mimirpb.TimeSeriesRW2{
+			LabelsRefs: []uint32{1, uint32(i) + 2},
+			Samples:    []mimirpb.Sample{{TimestampMs: 1, Value: 2}},
+			Exemplars:  []mimirpb.ExemplarRW2{},
+		}
+		reqv2.SymbolsRW2 = append(reqv2.SymbolsRW2, fmt.Sprintf("series_%d", i))
+	}
+	v2bytes, err := reqv2.Marshal()
+	require.NoError(b, err)
+
+	b.Run("deserialize v1", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			wr := &mimirpb.PreallocWriteRequest{}
+			err := DeserializeRecordContent(v1bytes, wr, 1)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer mimirpb.ReuseSlice(wr.Timeseries)
+		}
+	})
+
+	b.Run("deserialize v2", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			wr := &mimirpb.PreallocWriteRequest{}
+			err := DeserializeRecordContent(v2bytes, wr, 2)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer mimirpb.ReuseSlice(wr.Timeseries)
+		}
+	})
 }

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -119,6 +119,19 @@ func TestDeserializeRecordContent(t *testing.T) {
 						LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_total"), syms.GetSymbol("traceID"), syms.GetSymbol("1234567890abcdef")},
 					},
 				},
+				Histograms: []mimirpb.Histogram{
+					{
+						Timestamp:      1234567890,
+						Count:          &mimirpb.Histogram_CountInt{CountInt: 10},
+						Sum:            100,
+						Schema:         3,
+						ZeroCount:      &mimirpb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+						PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+						PositiveDeltas: []int64{1},
+						NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+						NegativeDeltas: []int64{1},
+					},
+				},
 			}},
 		}
 		reqv2.Symbols = syms.GetSymbols()
@@ -140,6 +153,20 @@ func TestDeserializeRecordContent(t *testing.T) {
 				Labels:      []mimirpb.LabelAdapter{{Name: "__name__", Value: "test_metric_total"}, {Name: "traceID", Value: "1234567890abcdef"}}},
 		}
 		require.Equal(t, expExemplars, wr.Timeseries[0].Exemplars)
+		expHistograms := []mimirpb.Histogram{
+			{
+				Timestamp:      1234567890,
+				Count:          &mimirpb.Histogram_CountInt{CountInt: 10},
+				Sum:            100,
+				Schema:         3,
+				ZeroCount:      &mimirpb.Histogram_ZeroCountInt{ZeroCountInt: 0},
+				PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+				PositiveDeltas: []int64{1},
+				NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+				NegativeDeltas: []int64{1},
+			},
+		}
+		require.Equal(t, expHistograms, wr.Timeseries[0].Histograms)
 	})
 }
 

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -66,6 +66,11 @@ func TestDeserializeRecordContent(t *testing.T) {
 					mockPreallocTimeseriesWithAll("series_2"),
 				},
 				Source: mimirpb.API,
+				Metadata: []*mimirpb.MetricMetadata{
+					mockMetricMetadata("series_0"),
+					mockMetricMetadata("series_1"),
+					mockMetricMetadata("series_2"),
+				},
 			},
 		}
 		v0bytes, err := reqv0.Marshal()
@@ -88,6 +93,11 @@ func TestDeserializeRecordContent(t *testing.T) {
 					mockPreallocTimeseriesWithAll("series_2"),
 				},
 				Source: mimirpb.API,
+				Metadata: []*mimirpb.MetricMetadata{
+					mockMetricMetadata("series_0"),
+					mockMetricMetadata("series_1"),
+					mockMetricMetadata("series_2"),
+				},
 			},
 		}
 		v1bytes, err := reqv1.Marshal()
@@ -132,6 +142,11 @@ func TestDeserializeRecordContent(t *testing.T) {
 						NegativeDeltas: []int64{1},
 					},
 				},
+				Metadata: mimirpb.MetadataRW2{
+					Type:    mimirpb.METRIC_TYPE_COUNTER,
+					HelpRef: syms.GetSymbol("Help for test_metric_total"),
+					UnitRef: syms.GetSymbol("seconds"),
+				},
 			}},
 		}
 		reqv2.Symbols = syms.GetSymbols()
@@ -167,6 +182,13 @@ func TestDeserializeRecordContent(t *testing.T) {
 			},
 		}
 		require.Equal(t, expHistograms, wr.Timeseries[0].Histograms)
+		expMetadata := []*mimirpb.MetricMetadata{{
+			Type:             mimirpb.COUNTER,
+			MetricFamilyName: "test_metric_total",
+			Help:             "Help for test_metric_total",
+			Unit:             "seconds",
+		}}
+		require.Equal(t, expMetadata, wr.Metadata)
 	})
 }
 

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -79,7 +79,7 @@ func BenchmarkDeserializeRecordContent(b *testing.B) {
 	require.NoError(b, err)
 
 	b.Run("deserialize v1", func(b *testing.B) {
-		for n := 0; n < b.N; n++ {
+		for b.Loop() {
 			wr := &mimirpb.PreallocWriteRequest{}
 			err := DeserializeRecordContent(v1bytes, wr, 1)
 			if err != nil {
@@ -90,7 +90,7 @@ func BenchmarkDeserializeRecordContent(b *testing.B) {
 	})
 
 	b.Run("deserialize v2", func(b *testing.B) {
-		for n := 0; n < b.N; n++ {
+		for b.Loop() {
 			wr := &mimirpb.PreallocWriteRequest{}
 			err := DeserializeRecordContent(v2bytes, wr, 2)
 			if err != nil {

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -232,7 +232,7 @@ func BenchmarkDeserializeRecordContent(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			defer mimirpb.ReuseSlice(wr.Timeseries)
+			mimirpb.ReuseSlice(wr.Timeseries)
 		}
 	})
 
@@ -243,7 +243,7 @@ func BenchmarkDeserializeRecordContent(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			defer mimirpb.ReuseSlice(wr.Timeseries)
+			mimirpb.ReuseSlice(wr.Timeseries)
 		}
 	})
 }

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -1095,6 +1095,15 @@ func mockPreallocTimeseriesWithAll(metricName string) mimirpb.PreallocTimeseries
 	}
 }
 
+func mockMetricMetadata(name string) *mimirpb.MetricMetadata {
+	return &mimirpb.MetricMetadata{
+		Type:             mimirpb.COUNTER,
+		MetricFamilyName: name,
+		Help:             fmt.Sprintf("Help for %s", name),
+		Unit:             "seconds",
+	}
+}
+
 func getProduceRequestRecordsCount(req *kmsg.ProduceRequest) (int, error) {
 	count := 0
 

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -1061,6 +1061,40 @@ func mockPreallocTimeseriesWithExemplar(metricName string) mimirpb.PreallocTimes
 	}
 }
 
+func mockPreallocTimeseriesWithAll(metricName string) mimirpb.PreallocTimeseries {
+	return mimirpb.PreallocTimeseries{
+		TimeSeries: &mimirpb.TimeSeries{
+			Labels: []mimirpb.LabelAdapter{
+				{Name: "__name__", Value: metricName},
+			},
+			Samples: []mimirpb.Sample{{
+				TimestampMs: 1,
+				Value:       2,
+			}},
+			Exemplars: []mimirpb.Exemplar{{
+				TimestampMs: 2,
+				Value:       14,
+				Labels: []mimirpb.LabelAdapter{
+					{Name: "trace_id", Value: metricName + "_trace"},
+				},
+			}},
+			Histograms: []mimirpb.Histogram{{
+				Count:          &mimirpb.Histogram_CountFloat{CountFloat: 2},
+				Sum:            10,
+				Schema:         1,
+				ZeroThreshold:  0.001,
+				ZeroCount:      &mimirpb.Histogram_ZeroCountFloat{ZeroCountFloat: 0},
+				NegativeSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+				NegativeCounts: []float64{1},
+				PositiveSpans:  []mimirpb.BucketSpan{{Offset: 0, Length: 1}},
+				PositiveCounts: []float64{1},
+				ResetHint:      mimirpb.Histogram_UNKNOWN,
+				Timestamp:      0,
+			}},
+		},
+	}
+}
+
 func getProduceRequestRecordsCount(req *kmsg.ProduceRequest) (int, error) {
 	count := 0
 

--- a/pkg/util/test/rw2.go
+++ b/pkg/util/test/rw2.go
@@ -130,7 +130,7 @@ func (symbols *SymbolTableBuilder) GetSymbol(sym string) uint32 {
 func (symbols *SymbolTableBuilder) GetSymbols() []string {
 	res := make([]string, len(symbols.symbols))
 	for sym, i := range symbols.symbols {
-		res[i] = sym
+		res[i-symbols.offset] = sym
 	}
 	return res
 }

--- a/pkg/util/test/rw2.go
+++ b/pkg/util/test/rw2.go
@@ -99,16 +99,22 @@ func AddHistogramSeries(
 type SymbolTableBuilder struct {
 	count   uint32
 	symbols map[string]uint32
+	offset  uint32
 }
 
 func NewSymbolTableBuilder(symbols []string) *SymbolTableBuilder {
+	return NewSymbolTableBuilderWithOffset(symbols, 0)
+}
+
+func NewSymbolTableBuilderWithOffset(symbols []string, offset uint32) *SymbolTableBuilder {
 	symbolsMap := make(map[string]uint32)
 	for i, sym := range symbols {
-		symbolsMap[sym] = uint32(i)
+		symbolsMap[sym] = uint32(i) + offset
 	}
 	return &SymbolTableBuilder{
 		count:   uint32(len(symbols)),
 		symbols: symbolsMap,
+		offset:  offset,
 	}
 }
 
@@ -116,9 +122,9 @@ func (symbols *SymbolTableBuilder) GetSymbol(sym string) uint32 {
 	if i, ok := symbols.symbols[sym]; ok {
 		return i
 	}
-	symbols.symbols[sym] = symbols.count
+	symbols.symbols[sym] = symbols.offset + symbols.count
 	symbols.count++
-	return symbols.count - 1
+	return symbols.offset + symbols.count - 1
 }
 
 func (symbols *SymbolTableBuilder) GetSymbols() []string {


### PR DESCRIPTION
#### What this PR does

Introduces a new record version `V2`, and implements consumer-side support for it.

It's inspired by Prometheus Remote Write 2.0, but not strictly compatible with it. A notable difference is that the symbol refs are shifted up by 64. This reserves space for a future common symbols table, allowing us to completely avoid sending certain commonly used symbols through Kafka.

The format is internal to Mimir, it doesn't need to exactly match any external standard. Aside from within test code, there is currently no way to produce records of the V2 format. Therefore, we're still able to iterate on the format in the future and make breaking changes. I'm not adding this to the changelog for that reason; when we decide to "lock down" the format, the changelog will be updated at that time.

The implementation heavily leverages @krajorama's work in https://github.com/grafana/mimir/pull/11100 and inherits several optimizations from it.

#### Which issue(s) this PR fixes or relates to

Rel https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
