### PR TITLE
Add optional reason to blocked queries for returning to requester

### DIFF
--- a/pkg/frontend/querymiddleware/errors.go
+++ b/pkg/frontend/querymiddleware/errors.go
@@ -25,8 +25,12 @@ func newMaxQueryExpressionSizeBytesError(actualSizeBytes, maxQuerySizeBytes int)
 	))
 }
 
-func newQueryBlockedError() error {
-	return apierror.New(apierror.TypeBadData, globalerror.QueryBlocked.Message("the request has been blocked by the cluster administrator"))
+func newQueryBlockedError(administratorReason string) error {
+	var reason string
+	if administratorReason != "" {
+		reason = fmt.Sprintf(" %s", administratorReason)
+	}
+	return apierror.New(apierror.TypeBadData, globalerror.QueryBlocked.Message(fmt.Sprintf("the request has been blocked by the cluster administrator%s", reason)))
 }
 
 func newQueryLimitedError(allowedFrequency time.Duration, tenantID string) error {

--- a/pkg/frontend/querymiddleware/errors_test.go
+++ b/pkg/frontend/querymiddleware/errors_test.go
@@ -23,8 +23,12 @@ func TestQueryMiddleware_Errors(t *testing.T) {
 			expectedErrorMsg: "the raw query size in bytes exceeds the limit (query size: 10, limit: 20) (err-mimir-max-query-expression-size-bytes). To adjust the related per-tenant limit, configure -query-frontend.max-query-expression-size-bytes, or contact your service administrator.",
 		},
 		"err-mimir-query-blocked has a correct message": {
-			err:              newQueryBlockedError(),
+			err:              newQueryBlockedError(""),
 			expectedErrorMsg: "the request has been blocked by the cluster administrator (err-mimir-query-blocked)",
+		},
+		"err-mimir-query-blocked has a correct message with reason": {
+			err:              newQueryBlockedError("because the query appears to be misconfigured"),
+			expectedErrorMsg: "the request has been blocked by the cluster administrator because the query appears to be misconfigured (err-mimir-query-blocked)",
 		},
 	}
 	for testName, testData := range tests {

--- a/pkg/util/validation/blocked_query.go
+++ b/pkg/util/validation/blocked_query.go
@@ -5,4 +5,5 @@ package validation
 type BlockedQuery struct {
 	Pattern string `yaml:"pattern"`
 	Regex   bool   `yaml:"regex"`
+	Reason  string `yaml:"reason"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
If `reason` is defined for a query in the `blocked_queries` list, the `reason` will be displayed with the `err-mimir-query-blocked` error message. An example error message would be:
```
the request has been blocked by the cluster administrator because the query appears to be misconfigured (err-mimir-query-blocked)
```

If the blocked query has no `reason`, errors will appear as they always have:
```
the request has been blocked by the cluster administrator (err-mimir-query-blocked)
```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
