### PR TITLE
MQE: fix issue where slice is used after being returned to pool

### DIFF
--- a/pkg/streamingpromql/operators/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge.go
@@ -56,9 +56,8 @@ func (d *DeduplicateAndMerge) SeriesMetadata(ctx context.Context) ([]types.Serie
 	}
 
 	d.groups = groups
-	types.SeriesMetadataSlicePool.Put(innerMetadata, d.MemoryConsumptionTracker)
-
 	d.buffer = NewInstantVectorOperatorBuffer(d.Inner, nil, len(innerMetadata), d.MemoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(innerMetadata, d.MemoryConsumptionTracker)
 
 	return outputMetadata, nil
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where a `SeriesMetadata` slice is used after being returned to the pool. This could lead to unexpected behaviour, including incorrect query results and panics.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
