### PR TITLE
MQE: clarify logic and remove outdated comments

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -156,12 +156,12 @@ func TestNewInstantQuery_Strings(t *testing.T) {
 		q, err := mimirEngine.NewInstantQuery(ctx, storage, nil, expr, time.Now())
 		require.NoError(t, err)
 		mimir := q.Exec(context.Background())
-		q.Close()
+		defer q.Close()
 
 		q, err = prometheusEngine.NewInstantQuery(ctx, storage, nil, expr, time.Now())
 		require.NoError(t, err)
 		prometheus := q.Exec(context.Background())
-		q.Close()
+		defer q.Close()
 
 		testutils.RequireEqualResults(t, expr, prometheus, mimir, false)
 	})

--- a/pkg/streamingpromql/operators/series_merging.go
+++ b/pkg/streamingpromql/operators/series_merging.go
@@ -98,7 +98,6 @@ func mergeOneSideFloats(data []types.InstantVectorSeriesData, sourceSeriesIndice
 
 		// We're going to create a new slice, so return this one to the pool.
 		// We must defer here, rather than at the end, as the merge loop below reslices Floats.
-		// FIXME: this isn't correct for many-to-one / one-to-many matching - we'll need the series again (unless we store the result of the merge)
 		defer types.FPointSlicePool.Put(second.Floats, memoryConsumptionTracker)
 
 		if len(second.Floats) == 0 {
@@ -127,7 +126,6 @@ func mergeOneSideFloats(data []types.InstantVectorSeriesData, sourceSeriesIndice
 	// We're going to create a new slice, so return this one to the pool.
 	// We'll return the other slices in the for loop below.
 	// We must defer here, rather than at the end, as the merge loop below reslices Floats.
-	// FIXME: this isn't correct for many-to-one / one-to-many matching - we'll need the series again (unless we store the result of the merge)
 	defer types.FPointSlicePool.Put(data[0].Floats, memoryConsumptionTracker)
 
 	// Re-slice the data with just the series with floats to make the rest of our job easier

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -692,6 +692,12 @@ func (q *Query) populateVectorFromInstantVectorOperator(ctx context.Context, o t
 			return nil, err
 		}
 
+		if len(d.Floats)+len(d.Histograms) > 1 {
+			types.PutInstantVectorSeriesData(d, q.memoryConsumptionTracker)
+			return nil, fmt.Errorf("expected exactly one sample for series %s, but got %v floats, %v histograms", s.Labels.String(), len(d.Floats), len(d.Histograms))
+		}
+
+		// In addition to the two cases below, a series may also have no data points, in which case we don't need to do anything.
 		if len(d.Floats) == 1 && len(d.Histograms) == 0 {
 			point := d.Floats[0]
 			v = append(v, promql.Sample{
@@ -709,12 +715,6 @@ func (q *Query) populateVectorFromInstantVectorOperator(ctx context.Context, o t
 
 			// Remove histogram from slice to ensure it's not mutated when the slice is reused.
 			d.Histograms[0].H = nil
-		} else if len(d.Floats) == 0 && len(d.Histograms) == 0 {
-			// A series may have no data points.
-			// There's nothing to do, fall through to return 'd' to the pool below.
-		} else {
-			types.PutInstantVectorSeriesData(d, q.memoryConsumptionTracker)
-			return nil, fmt.Errorf("expected exactly one sample for series %s, but got %v floats, %v histograms", s.Labels.String(), len(d.Floats), len(d.Histograms))
 		}
 
 		types.PutInstantVectorSeriesData(d, q.memoryConsumptionTracker)

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -850,9 +850,13 @@ func (q *Query) Close() {
 		// Nothing to do, we already returned the slice in populateScalarFromScalarOperator.
 	case promql.String:
 		// Nothing to do as strings don't come from a pool
+	case nil:
+		// Nothing to do if there is no value.
 	default:
 		panic(fmt.Sprintf("unknown result value type %T", q.result.Value))
 	}
+
+	q.result.Value = nil
 
 	if q.engine.pedantic && q.result.Err == nil {
 		if q.memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes() > 0 {

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -709,14 +709,11 @@ func (q *Query) populateVectorFromInstantVectorOperator(ctx context.Context, o t
 
 			// Remove histogram from slice to ensure it's not mutated when the slice is reused.
 			d.Histograms[0].H = nil
+		} else if len(d.Floats) == 0 && len(d.Histograms) == 0 {
+			// A series may have no data points.
+			// There's nothing to do, fall through to return 'd' to the pool below.
 		} else {
 			types.PutInstantVectorSeriesData(d, q.memoryConsumptionTracker)
-
-			// A series may have no data points.
-			if len(d.Floats) == 0 && len(d.Histograms) == 0 {
-				continue
-			}
-
 			return nil, fmt.Errorf("expected exactly one sample for series %s, but got %v floats, %v histograms", s.Labels.String(), len(d.Floats), len(d.Histograms))
 		}
 


### PR DESCRIPTION
#### What this PR does

This PR makes three minor changes to MQE:

* it removes some outdated comments in `operators.mergeOneSideFloats`
* it clarifies the logic in `Query.populateVectorFromInstantVectorOperator`
* it ensures the query result is not returned to the pool multiple times if `Query.Close` is called multiple times

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
