### PR TITLE
MQE: make capitalisation of `cortex_mimir_query_engine_plan_stage_latency_seconds` label values consistent

### DIFF
--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -199,7 +199,7 @@ func (p *QueryPlanner) runPlanningStage(stageName string, observer PlanningObser
 	}
 
 	duration := timeSince(start)
-	p.planStageLatency.WithLabelValues("plan", stageName).Observe(duration.Seconds())
+	p.planStageLatency.WithLabelValues("Plan", stageName).Observe(duration.Seconds())
 
 	if err := observer.OnPlanningStageComplete(stageName, plan, duration); err != nil {
 		return nil, err

--- a/pkg/streamingpromql/planning_test.go
+++ b/pkg/streamingpromql/planning_test.go
@@ -1034,7 +1034,7 @@ func TestPlanCreationEncodingAndDecoding(t *testing.T) {
 			require.NoError(t, err)
 
 			requireHistogramCounts(t, reg, "cortex_mimir_query_engine_plan_stage_latency_seconds", `
-{stage="Original plan", stage_type="plan"} 1
+{stage="Original plan", stage_type="Plan"} 1
 {stage="Parsing", stage_type="AST"} 1
 {stage="Pre-processing", stage_type="AST"} 1
 			`)


### PR DESCRIPTION
#### What this PR does

This PR makes the capitalisation of the values for the `stage_type` label consistent. 

Given `stage` has capitalised, human-readable names, I've chosen to make `stage_type` follow that pattern as well.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/11127

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
