### PR TITLE
distributor(ha-tracker): WatchPrefix - handle error on type assertion…

### DIFF
--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -357,7 +357,8 @@ func (h *defaultHaTracker) loop(ctx context.Context) error {
 	h.client.WatchPrefix(ctx, "", func(key string, value interface{}) bool {
 		replica, ok := value.(*ReplicaDesc)
 		if !ok {
-			return false
+			level.Warn(h.logger).Log("msg", "failed to process value while watching for changes", "key", key)
+			return true
 		}
 		h.processKVStoreEntry(key, replica)
 		return true


### PR DESCRIPTION
… gracefully

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When replica, ok := value.(*ReplicaDesc) failed to do the type assertion, we just log a warn message but return true, so WatchPrefix keep working and checking notifications.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
