### PR TITLE
Alerts: Enrich alerts for invalid cluster validation labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 * [ENHANCEMENT] Alerts: Make `MimirRolloutStuck` a critical alert if it has been firing for 6h. #10890
 * [ENHANCEMENT] Dashboards: Add panels to the `Mimir / Tenants` and `Mimir / Top Tenants` dashboards showing the rate of gateway requests. #10978
 * [ENHANCEMENT] Alerts: Improve `MimirIngesterFailsToProcessRecordsFromKafka` to not fire during forced TSDB head compaction. #11006
-* [ENHANCEMENT] Alerts: Add alerts for invalid cluster validation labels. #11255 #11282
+* [ENHANCEMENT] Alerts: Add alerts for invalid cluster validation labels. #11255 #11282 #11413
 * [CHANGE] Alerts: Update query for `MimirBucketIndexNotUpdated`. Use `max_over_time` to prevent alert firing when pods rotate. #11311
 * [BUGFIX] Dashboards: fix "Mimir / Tenants" legends for non-Kubernetes deployments. #10891
 * [BUGFIX] Recording rules: fix `cluster_namespace_deployment:actual_replicas:count` recording rule when there's a mix on single-zone and multi-zone deployments. #11287

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -247,9 +247,9 @@ spec:
               message: Mimir servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclustervalidationlabelrequests
             expr: |
-              (sum by (cluster, namespace) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+              (sum by (cluster, namespace, protocol) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
               # Alert only for namespaces with Mimir clusters.
-              and (count by (cluster, namespace) (mimir_build_info) > 0)
+              and on (cluster, namespace) (mimir_build_info > 0)
             labels:
               severity: warning
           - alert: MimirClientInvalidClusterValidationLabelRequests
@@ -257,9 +257,9 @@ spec:
               message: Mimir clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclustervalidationlabelrequests
             expr: |
-              (sum by (cluster, namespace) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+              (sum by (cluster, namespace, protocol) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
               # Alert only for namespaces with Mimir clusters.
-              and (count by (cluster, namespace) (mimir_build_info) > 0)
+              and on (cluster, namespace) (mimir_build_info > 0)
             labels:
               severity: warning
           - alert: MimirRingMembersMismatch

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -235,9 +235,9 @@ groups:
             message: Mimir servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace, protocol) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
-            and (count by (cluster, namespace) (mimir_build_info) > 0)
+            and on (cluster, namespace) (mimir_build_info > 0)
           labels:
             severity: warning
         - alert: MimirClientInvalidClusterValidationLabelRequests
@@ -245,9 +245,9 @@ groups:
             message: Mimir clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace, protocol) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
-            and (count by (cluster, namespace) (mimir_build_info) > 0)
+            and on (cluster, namespace) (mimir_build_info > 0)
           labels:
             severity: warning
         - alert: MimirRingMembersMismatch

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -235,9 +235,9 @@ groups:
             message: GEM servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace, protocol) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
-            and (count by (cluster, namespace) (mimir_build_info) > 0)
+            and on (cluster, namespace) (mimir_build_info > 0)
           labels:
             severity: warning
         - alert: MimirClientInvalidClusterValidationLabelRequests
@@ -245,9 +245,9 @@ groups:
             message: GEM clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace, protocol) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
-            and (count by (cluster, namespace) (mimir_build_info) > 0)
+            and on (cluster, namespace) (mimir_build_info > 0)
           labels:
             severity: warning
         - alert: MimirRingMembersMismatch

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -235,9 +235,9 @@ groups:
             message: Mimir servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace, protocol) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
-            and (count by (cluster, namespace) (mimir_build_info) > 0)
+            and on (cluster, namespace) (mimir_build_info > 0)
           labels:
             severity: warning
         - alert: MimirClientInvalidClusterValidationLabelRequests
@@ -245,9 +245,9 @@ groups:
             message: Mimir clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclustervalidationlabelrequests
           expr: |
-            (sum by (cluster, namespace) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
+            (sum by (cluster, namespace, protocol) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
-            and (count by (cluster, namespace) (mimir_build_info) > 0)
+            and on (cluster, namespace) (mimir_build_info > 0)
           labels:
             severity: warning
         - alert: MimirRingMembersMismatch

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -406,9 +406,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
           // Alert if servers are receiving requests with invalid cluster validation labels (i.e. meant for other clusters).
           alert: $.alertName('ServerInvalidClusterValidationLabelRequests'),
           expr: |||
-            (sum by (%(alert_aggregation_labels)s) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[%(range_interval)s]))) > 0
+            (sum by (%(alert_aggregation_labels)s, protocol) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[%(range_interval)s]))) > 0
             # Alert only for namespaces with Mimir clusters.
-            and (count by (%(alert_aggregation_labels)s) (mimir_build_info) > 0)
+            and on (%(alert_aggregation_labels)s) (mimir_build_info > 0)
           ||| % $._config {
             range_interval: $.alertRangeInterval(5),
           },
@@ -423,9 +423,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
           // Alert if clients' requests are rejected due to invalid cluster validation labels (i.e. there's a mismatch between clients' and servers' cluster validation labels).
           alert: $.alertName('ClientInvalidClusterValidationLabelRequests'),
           expr: |||
-            (sum by (%(alert_aggregation_labels)s) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[%(range_interval)s]))) > 0
+            (sum by (%(alert_aggregation_labels)s, protocol) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[%(range_interval)s]))) > 0
             # Alert only for namespaces with Mimir clusters.
-            and (count by (%(alert_aggregation_labels)s) (mimir_build_info) > 0)
+            and on (%(alert_aggregation_labels)s) (mimir_build_info > 0)
           ||| % $._config {
             range_interval: $.alertRangeInterval(5),
           },


### PR DESCRIPTION
#### What this PR does

Enrich alerts for invalid cluster validation labels with an additional label: `protocol`. The extra label means that the operator can differentiate between alerts firing for HTTP and gRPC requests.

I've tested the revised query and it gives the right results for me.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
