### PR TITLE
Add TotalSamplesPerStep stats to the MQE

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -168,7 +168,6 @@ func New(cfg Config, limits *validation.Overrides, distributor Distributor, quer
 	parser.EnableExperimentalFunctions = true
 
 	var eng promql.QueryEngine
-
 	switch cfg.QueryEngine {
 	case prometheusEngine:
 		eng = promql.NewEngine(opts)

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -43,10 +43,6 @@ func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *sta
 		return nil, errors.New("disabling negative offsets not supported by Mimir query engine")
 	}
 
-	if opts.CommonOpts.EnablePerStepStats {
-		return nil, errors.New("enabling per-step stats not supported by Mimir query engine")
-	}
-
 	if opts.CommonOpts.EnableDelayedNameRemoval {
 		return nil, errors.New("enabling delayed name removal not supported by Mimir query engine")
 	}
@@ -66,6 +62,7 @@ func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *sta
 		limitsProvider:           limitsProvider,
 		activeQueryTracker:       activeQueryTracker,
 		noStepSubqueryIntervalFn: opts.CommonOpts.NoStepSubqueryIntervalFn,
+		enablePerStepStats:       opts.CommonOpts.EnablePerStepStats,
 
 		logger: logger,
 		estimatedPeakMemoryConsumption: promauto.With(opts.CommonOpts.Reg).NewHistogram(prometheus.HistogramOpts{
@@ -86,6 +83,7 @@ type Engine struct {
 	timeout            time.Duration
 	limitsProvider     QueryLimitsProvider
 	activeQueryTracker promql.QueryTracker
+	enablePerStepStats bool
 
 	noStepSubqueryIntervalFn func(rangeMillis int64) int64
 

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -103,8 +103,7 @@ func (m *RangeVectorSelector) NextStepSamples() (*types.RangeVectorStepData, err
 	m.stepData.Histograms = m.histograms.ViewUntilSearchingBackwards(rangeEnd, m.stepData.Histograms)
 	m.stepData.RangeStart = rangeStart
 	m.stepData.RangeEnd = rangeEnd
-
-	m.Stats.TotalSamples += int64(m.stepData.Floats.Count()) + m.stepData.Histograms.EquivalentFloatSampleCount()
+	m.Stats.IncrementSamplesAtTimestamp(m.stepData.StepT, int64(m.stepData.Floats.Count())+m.stepData.Histograms.EquivalentFloatSampleCount())
 
 	return m.stepData, nil
 }

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -21,9 +21,57 @@ type QueryStats struct {
 	// For example, if a query is running with a step of 30s with a range vector selector with range 45s,
 	// then samples in the overlapping 15s are counted twice.
 	TotalSamples int64
+
+	TotalSamplesPerStep []int64
+
+	EnablePerStepStats bool
+	startTimestamp     int64
+	interval           int64
+}
+
+type stepStat struct {
+	T int64
+	V float64
 }
 
 const timestampFieldSize = int64(unsafe.Sizeof(int64(0)))
+
+func (qs *QueryStats) InitStepTracking(start, end, interval int64) {
+	if !qs.EnablePerStepStats {
+		return
+	}
+
+	numSteps := int((end-start)/interval) + 1
+	qs.TotalSamplesPerStep = make([]int64, numSteps)
+	qs.startTimestamp = start
+	qs.interval = interval
+}
+
+// IncrementSamplesAtStep increments the total samples count. Use this if you know the step index.
+func (qs *QueryStats) IncrementSamplesAtStep(i int, samples int64) {
+	if qs == nil {
+		return
+	}
+	qs.TotalSamples += samples
+
+	if qs.TotalSamplesPerStep != nil {
+		qs.TotalSamplesPerStep[i] += samples
+	}
+}
+
+// IncrementSamplesAtTimestamp increments the total samples count. Use this if you only have the corresponding step
+// timestamp.
+func (qs *QueryStats) IncrementSamplesAtTimestamp(t, samples int64) {
+	if qs == nil {
+		return
+	}
+	qs.TotalSamples += samples
+
+	if qs.TotalSamplesPerStep != nil {
+		i := int((t - qs.startTimestamp) / qs.interval)
+		qs.TotalSamplesPerStep[i] += samples
+	}
+}
 
 func EquivalentFloatSampleCount(h *histogram.FloatHistogram) int64 {
 	return (int64(h.Size()) + timestampFieldSize) / int64(FPointSize)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Adds TotalSamplesPerStep stats to the MQE, simular to [prometheus implementation](https://github.com/prometheus/prometheus/pull/10369)

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
