### PR TITLE
mqe: Allow usage of Mimir Query Engine in query-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [CHANGE] Memcached: Ignore initial DNS resolution failure, meaning don't depend on Memcached on startup. #11602
 * [FEATURE] Distributor: Experimental support for Prometheus Remote-Write 2.0 protocol. Limitations: Created timestamp is ignored, per series metadata is merged on metric family level automatically, ingestion might fail if client sends ProtoBuf fields out of order. The label `version` is added to the metric `cortex_distributor_requests_in_total` with a value of either `1.0` or `2.0` depending on the detected Remote-Write protocol. #11100 #11101 #11192 #11143
 * [FEATURE] Query-frontend: expand `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` configuration options to cache non-transient response failures for instant queries. #11120
+* [FEATURE] Query-frontend: Allow use of Mimir Query Engine (MQE) via the experimental CLI flags `-query-frontend.query-engine` or `-query-frontend.enable-query-engine-fallback` or corresponding YAML. #11417
 * [FEATURE] Querier, query-frontend, ruler: Enable experimental support for duration expressions in PromQL, which are simple arithmetics on numbers in offset and range specification. #11344
 * [FEATURE] You can configure Mimir to export traces in OTLP exposition format through the standard `OTEL_` environment variables. #11618
 * [ENHANCEMENT] Querier: Make the maximum series limit for cardinality API requests configurable on a per-tenant basis with the `cardinality_analysis_max_results` option. #11456

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7552,6 +7552,28 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
+        },
+        {
+          "kind": "field",
+          "name": "query_engine",
+          "required": false,
+          "desc": "Query engine to use, either 'prometheus' or 'mimir'",
+          "fieldValue": null,
+          "fieldDefaultValue": "prometheus",
+          "fieldFlag": "query-frontend.query-engine",
+          "fieldType": "string",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "enable_query_engine_fallback",
+          "required": false,
+          "desc": "If set to true and the Mimir query engine is in use, fall back to using the Prometheus query engine for any queries not supported by the Mimir query engine.",
+          "fieldValue": null,
+          "fieldDefaultValue": true,
+          "fieldFlag": "query-frontend.enable-query-engine-fallback",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2339,6 +2339,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Optionally define the cluster validation label.
   -query-frontend.downstream-url string
     	URL of downstream Prometheus.
+  -query-frontend.enable-query-engine-fallback
+    	[experimental] If set to true and the Mimir query engine is in use, fall back to using the Prometheus query engine for any queries not supported by the Mimir query engine. (default true)
   -query-frontend.enabled-promql-experimental-functions comma-separated-list-of-strings
     	[experimental] Enable certain experimental PromQL functions, which are subject to being changed or removed at any time, on a per-tenant basis. Defaults to empty which means all experimental functions are disabled. Set to 'all' to enable all experimental functions.
   -query-frontend.grpc-client-config.backoff-max-period duration
@@ -2421,6 +2423,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] True to enable pruning dead code (eg. expressions that cannot produce any results) and simplifying expressions (eg. expressions that can be evaluated immediately) in queries.
   -query-frontend.querier-forget-delay duration
     	[experimental] If a querier disconnects without sending notification about graceful shutdown, the query-frontend will keep the querier in the tenant's shard until the forget delay has passed. This feature is useful to reduce the blast radius when shuffle-sharding is enabled.
+  -query-frontend.query-engine string
+    	[experimental] Query engine to use, either 'prometheus' or 'mimir' (default "prometheus")
   -query-frontend.query-result-response-format string
     	Format to use when retrieving query results from queriers. Supported values: json, protobuf (default "protobuf")
   -query-frontend.query-sharding-max-regexp-size-bytes int

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -220,6 +220,7 @@ The following features are currently experimental:
     Requests with invalid cluster validation labels are tracked via the `cortex_client_invalid_cluster_validation_label_requests_total` metric.
   - Support for duration expressions in PromQL, which are simple arithmetics on numbers in offset and range specification.
   - Support for configuring the maximum series limit for cardinality API requests on a per-tenant basis via `cardinality_analysis_max_results`.
+  - [Mimir query engine](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/mimir-query-engine) (`-query-frontend.query-engine` and `-query-frontend.enable-query-engine-fallback`)
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
 - Store-gateway

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1816,6 +1816,16 @@ client_cluster_validation:
   # (experimental) Optionally define the cluster validation label.
   # CLI flag: -query-frontend.client-cluster-validation.label
   [label: <string> | default = ""]
+
+# (experimental) Query engine to use, either 'prometheus' or 'mimir'
+# CLI flag: -query-frontend.query-engine
+[query_engine: <string> | default = "prometheus"]
+
+# (experimental) If set to true and the Mimir query engine is in use, fall back
+# to using the Prometheus query engine for any queries not supported by the
+# Mimir query engine.
+# CLI flag: -query-frontend.enable-query-engine-fallback
+[enable_query_engine_fallback: <boolean> | default = true]
 ```
 
 ### query_scheduler

--- a/pkg/frontend/querymiddleware/prune_test.go
+++ b/pkg/frontend/querymiddleware/prune_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/stretchr/testify/require"
 )
@@ -27,18 +28,10 @@ func TestQueryPruning(t *testing.T) {
 			<series name>{series="4"} 0+4x<num samples>
 			<series name>{series="5"} 0+5x<num samples>
 	`)
-	queryable := promqltest.LoadedStorage(t, data)
 
 	const step = 20 * time.Second
 
-	engine := newEngine()
-	pruningware := newPruneMiddleware(
-		log.NewNopLogger(),
-	)
-	downstream := &downstreamHandler{
-		engine:    engine,
-		queryable: queryable,
-	}
+	queryable := promqltest.LoadedStorage(t, data)
 
 	type template struct {
 		query   string
@@ -53,43 +46,51 @@ func TestQueryPruning(t *testing.T) {
 	}
 	for _, template := range templates {
 		t.Run(template.query, func(t *testing.T) {
-			query := fmt.Sprintf(template.query, seriesName)
-			req := &PrometheusRangeQueryRequest{
-				path:      "/query_range",
-				start:     0,
-				end:       int64(numSamples) * time.Minute.Milliseconds(),
-				step:      step.Milliseconds(),
-				queryExpr: parseQuery(t, query),
-			}
+			runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+				pruningware := newPruneMiddleware(log.NewNopLogger())
+				downstream := &downstreamHandler{
+					engine:    eng,
+					queryable: queryable,
+				}
 
-			injectedContext := user.InjectOrgID(context.Background(), "test")
+				query := fmt.Sprintf(template.query, seriesName)
+				req := &PrometheusRangeQueryRequest{
+					path:      "/query_range",
+					start:     0,
+					end:       int64(numSamples) * time.Minute.Milliseconds(),
+					step:      step.Milliseconds(),
+					queryExpr: parseQuery(t, query),
+				}
 
-			// Run the query without pruning.
-			expectedRes, err := downstream.Do(injectedContext, req)
-			require.Nil(t, err)
-			expectedPrometheusResponse, ok := expectedRes.GetPrometheusResponse()
-			require.True(t, ok)
+				injectedContext := user.InjectOrgID(context.Background(), "test")
 
-			if !template.IsEmpty {
-				// Ensure the query produces some results.
-				require.NotEmpty(t, expectedPrometheusResponse.Data.Result)
-				requireValidSamples(t, expectedPrometheusResponse.Data.Result)
-			}
+				// Run the query without pruning.
+				expectedRes, err := downstream.Do(injectedContext, req)
+				require.Nil(t, err)
+				expectedPrometheusResponse, ok := expectedRes.GetPrometheusResponse()
+				require.True(t, ok)
 
-			// Run the query with pruning.
-			prunedRes, err := pruningware.Wrap(downstream).Do(injectedContext, req)
-			require.Nil(t, err)
-			prunedPromethusResponse, ok := prunedRes.GetPrometheusResponse()
-			require.True(t, ok)
+				if !template.IsEmpty {
+					// Ensure the query produces some results.
+					require.NotEmpty(t, expectedPrometheusResponse.Data.Result)
+					requireValidSamples(t, expectedPrometheusResponse.Data.Result)
+				}
 
-			if !template.IsEmpty {
-				// Ensure the query produces some results.
-				require.NotEmpty(t, prunedPromethusResponse.Data.Result)
-				requireValidSamples(t, prunedPromethusResponse.Data.Result)
-			}
+				// Run the query with pruning.
+				prunedRes, err := pruningware.Wrap(downstream).Do(injectedContext, req)
+				require.Nil(t, err)
+				prunedPromethusResponse, ok := prunedRes.GetPrometheusResponse()
+				require.True(t, ok)
 
-			// Ensure the results are approximately equal.
-			approximatelyEqualsSamples(t, expectedPrometheusResponse, prunedPromethusResponse)
+				if !template.IsEmpty {
+					// Ensure the query produces some results.
+					require.NotEmpty(t, prunedPromethusResponse.Data.Result)
+					requireValidSamples(t, prunedPromethusResponse.Data.Result)
+				}
+
+				// Ensure the results are approximately equal.
+				approximatelyEqualsSamples(t, expectedPrometheusResponse, prunedPromethusResponse)
+			})
 		})
 	}
 }

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/storage/sharding"
+	"github.com/grafana/mimir/pkg/streamingpromql/compat"
 	"github.com/grafana/mimir/pkg/util"
 )
 
@@ -680,7 +681,7 @@ func TestQuerySharding_Correctness(t *testing.T) {
 
 	// Add native histogram series.
 	for i := 0; i < numNativeHistograms; i++ {
-		gen := factor(float64(i) * 0.1)
+		gen := factor(float64(i) * 0.5)
 		if i >= numNativeHistograms-numStaleNativeHistograms {
 			// Wrap the generator to inject the staleness marker between minute 10 and 20.
 			gen = stale(start.Add(10*time.Minute), start.Add(20*time.Minute), gen)
@@ -715,63 +716,63 @@ func TestQuerySharding_Correctness(t *testing.T) {
 
 			for _, req := range reqs {
 				t.Run(fmt.Sprintf("%T", req), func(t *testing.T) {
-					engine := newEngine()
-					downstream := &downstreamHandler{
-						engine:                                  engine,
-						queryable:                               queryable,
-						includePositionInformationInAnnotations: true,
-					}
+					runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+						downstream := &downstreamHandler{
+							engine:                                  eng,
+							queryable:                               queryable,
+							includePositionInformationInAnnotations: true,
+						}
 
-					// Run the query without sharding.
-					expectedRes, err := downstream.Do(context.Background(), req)
-					require.Nil(t, err)
-					expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
-					require.True(t, ok)
-					if !testData.expectSpecificOrder {
-						sort.Sort(byLabels(expectedPrometheusRes.Data.Result))
-					}
+						// Run the query without sharding.
+						expectedRes, err := downstream.Do(context.Background(), req)
+						require.Nil(t, err)
+						expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
+						require.True(t, ok)
+						if !testData.expectSpecificOrder {
+							sort.Sort(byLabels(expectedPrometheusRes.Data.Result))
+						}
 
-					// Ensure the query produces some results.
-					require.NotEmpty(t, expectedPrometheusRes.Data.Result)
-					requireValidSamples(t, expectedPrometheusRes.Data.Result)
+						// Ensure the query produces some results.
+						require.NotEmpty(t, expectedPrometheusRes.Data.Result)
+						requireValidSamples(t, expectedPrometheusRes.Data.Result)
 
-					if testData.expectedShardedQueries > 0 {
-						// Remove position information from annotations, to mirror what we expect from the sharded queries below.
-						removeAllAnnotationPositionInformation(expectedPrometheusRes.Infos)
-						removeAllAnnotationPositionInformation(expectedPrometheusRes.Warnings)
-					}
+						if testData.expectedShardedQueries > 0 {
+							// Remove position information from annotations, to mirror what we expect from the sharded queries below.
+							removeAllAnnotationPositionInformation(expectedPrometheusRes.Infos)
+							removeAllAnnotationPositionInformation(expectedPrometheusRes.Warnings)
+						}
 
-					for _, numShards := range []int{2, 4, 8, 16} {
-						t.Run(fmt.Sprintf("shards=%d", numShards), func(t *testing.T) {
-							reg := prometheus.NewPedanticRegistry()
-							shardingware := newQueryShardingMiddleware(
-								log.NewNopLogger(),
-								engine,
-								mockLimits{totalShards: numShards},
-								0,
-								reg,
-							)
+						for _, numShards := range []int{2, 4, 8, 16} {
+							t.Run(fmt.Sprintf("shards=%d", numShards), func(t *testing.T) {
+								reg := prometheus.NewPedanticRegistry()
+								shardingware := newQueryShardingMiddleware(
+									log.NewNopLogger(),
+									eng,
+									mockLimits{totalShards: numShards},
+									0,
+									reg,
+								)
 
-							// Run the query with sharding.
-							shardedRes, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-							require.Nil(t, err)
+								// Run the query with sharding.
+								shardedRes, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+								require.Nil(t, err)
 
-							// Ensure the two results matches (float precision can slightly differ, there's no guarantee in PromQL engine too
-							// if you rerun the same query twice).
-							shardedPrometheusRes, ok := shardedRes.GetPrometheusResponse()
-							require.True(t, ok)
-							if !testData.expectSpecificOrder {
-								sort.Sort(byLabels(shardedPrometheusRes.Data.Result))
-							}
-							approximatelyEquals(t, expectedPrometheusRes, shardedPrometheusRes)
+								// Ensure the two results matches (float precision can slightly differ, there's no guarantee in PromQL engine too
+								// if you rerun the same query twice).
+								shardedPrometheusRes, ok := shardedRes.GetPrometheusResponse()
+								require.True(t, ok)
+								if !testData.expectSpecificOrder {
+									sort.Sort(byLabels(shardedPrometheusRes.Data.Result))
+								}
+								approximatelyEquals(t, expectedPrometheusRes, shardedPrometheusRes)
 
-							// Ensure the query has been sharded/not sharded as expected.
-							expectedSharded := 0
-							if testData.expectedShardedQueries > 0 {
-								expectedSharded = 1
-							}
+								// Ensure the query has been sharded/not sharded as expected.
+								expectedSharded := 0
+								if testData.expectedShardedQueries > 0 {
+									expectedSharded = 1
+								}
 
-							assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+								assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_frontend_query_sharding_rewrites_attempted_total Total number of queries the query-frontend attempted to shard.
 					# TYPE cortex_frontend_query_sharding_rewrites_attempted_total counter
 					cortex_frontend_query_sharding_rewrites_attempted_total 1
@@ -782,11 +783,12 @@ func TestQuerySharding_Correctness(t *testing.T) {
 					# TYPE cortex_frontend_sharded_queries_total counter
 					cortex_frontend_sharded_queries_total %d
 				`, expectedSharded, testData.expectedShardedQueries*numShards)),
-								"cortex_frontend_query_sharding_rewrites_attempted_total",
-								"cortex_frontend_query_sharding_rewrites_succeeded_total",
-								"cortex_frontend_sharded_queries_total"))
-						})
-					}
+									"cortex_frontend_query_sharding_rewrites_attempted_total",
+									"cortex_frontend_query_sharding_rewrites_succeeded_total",
+									"cortex_frontend_sharded_queries_total"))
+							})
+						}
+					})
 				})
 			}
 		})
@@ -798,7 +800,7 @@ func TestQuerySharding_NonMonotonicHistogramBuckets(t *testing.T) {
 		`histogram_quantile(1, sum by(le) (rate(metric_histogram_bucket[1m])))`,
 	}
 
-	series := []storage.Series{}
+	var series []storage.Series
 	for i := 0; i < 100; i++ {
 		series = append(series, newSeries(labels.FromStrings(labels.MetricName, "metric_histogram_bucket", "app", strconv.Itoa(i), "le", "10"), start.Add(-lookbackDelta), end, step, arithmeticSequence(1)))
 		series = append(series, newSeries(labels.FromStrings(labels.MetricName, "metric_histogram_bucket", "app", strconv.Itoa(i), "le", "20"), start.Add(-lookbackDelta), end, step, arithmeticSequence(3)))
@@ -810,63 +812,64 @@ func TestQuerySharding_NonMonotonicHistogramBuckets(t *testing.T) {
 	// Create a queryable on the fixtures.
 	queryable := storageSeriesQueryable(series)
 
-	engine := newEngine()
-	downstream := &downstreamHandler{
-		engine:    engine,
-		queryable: queryable,
-	}
-
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
-			req := &PrometheusRangeQueryRequest{
-				path:      "/query_range",
-				start:     util.TimeToMillis(start),
-				end:       util.TimeToMillis(end),
-				step:      step.Milliseconds(),
-				queryExpr: parseQuery(t, query),
-			}
+			runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+				downstream := &downstreamHandler{
+					engine:    eng,
+					queryable: queryable,
+				}
 
-			// Run the query without sharding.
-			expectedRes, err := downstream.Do(context.Background(), req)
-			require.Nil(t, err)
+				req := &PrometheusRangeQueryRequest{
+					path:      "/query_range",
+					start:     util.TimeToMillis(start),
+					end:       util.TimeToMillis(end),
+					step:      step.Milliseconds(),
+					queryExpr: parseQuery(t, query),
+				}
 
-			expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
-			require.True(t, ok)
-			sort.Sort(byLabels(expectedPrometheusRes.Data.Result))
+				// Run the query without sharding.
+				expectedRes, err := downstream.Do(context.Background(), req)
+				require.Nil(t, err)
 
-			// Ensure the query produces some results.
-			require.NotEmpty(t, expectedPrometheusRes.Data.Result)
-			requireValidSamples(t, expectedPrometheusRes.Data.Result)
+				expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
+				require.True(t, ok)
+				sort.Sort(byLabels(expectedPrometheusRes.Data.Result))
 
-			// Ensure the bucket monotonicity has not been fixed by PromQL engine.
-			require.Len(t, expectedPrometheusRes.GetWarnings(), 0)
+				// Ensure the query produces some results.
+				require.NotEmpty(t, expectedPrometheusRes.Data.Result)
+				requireValidSamples(t, expectedPrometheusRes.Data.Result)
 
-			for _, numShards := range []int{8, 16} {
-				t.Run(fmt.Sprintf("shards=%d", numShards), func(t *testing.T) {
-					reg := prometheus.NewPedanticRegistry()
-					shardingware := newQueryShardingMiddleware(
-						log.NewNopLogger(),
-						engine,
-						mockLimits{totalShards: numShards},
-						0,
-						reg,
-					)
+				// Ensure the bucket monotonicity has not been fixed by PromQL engine.
+				require.Len(t, expectedPrometheusRes.GetWarnings(), 0)
 
-					// Run the query with sharding.
-					shardedRes, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-					require.Nil(t, err)
+				for _, numShards := range []int{8, 16} {
+					t.Run(fmt.Sprintf("shards=%d", numShards), func(t *testing.T) {
+						reg := prometheus.NewPedanticRegistry()
+						shardingware := newQueryShardingMiddleware(
+							log.NewNopLogger(),
+							eng,
+							mockLimits{totalShards: numShards},
+							0,
+							reg,
+						)
 
-					// Ensure the two results matches (float precision can slightly differ, there's no guarantee in PromQL engine too
-					// if you rerun the same query twice).
-					shardedPrometheusRes, ok := shardedRes.GetPrometheusResponse()
-					require.True(t, ok)
-					sort.Sort(byLabels(shardedPrometheusRes.Data.Result))
-					approximatelyEquals(t, expectedPrometheusRes, shardedPrometheusRes)
+						// Run the query with sharding.
+						shardedRes, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+						require.Nil(t, err)
 
-					// Ensure the warning about bucket monotonicity from PromQL engine is hidden.
-					require.Len(t, shardedPrometheusRes.GetWarnings(), 0)
-				})
-			}
+						// Ensure the two results matches (float precision can slightly differ, there's no guarantee in PromQL engine too
+						// if you rerun the same query twice).
+						shardedPrometheusRes, ok := shardedRes.GetPrometheusResponse()
+						require.True(t, ok)
+						sort.Sort(byLabels(shardedPrometheusRes.Data.Result))
+						approximatelyEquals(t, expectedPrometheusRes, shardedPrometheusRes)
+
+						// Ensure the warning about bucket monotonicity from PromQL engine is hidden.
+						require.Len(t, shardedPrometheusRes.GetWarnings(), 0)
+					})
+				}
+			})
 		})
 	}
 }
@@ -927,36 +930,39 @@ func TestQueryshardingDeterminism(t *testing.T) {
 		newSeries(labelsForShard(1), from, to, step, constant(evilFloatA)),
 		newSeries(labelsForShard(2), from, to, step, constant(evilFloatB)),
 	}
+	queryable := storageSeriesQueryable(storageSeries)
 
-	shardingware := newQueryShardingMiddleware(log.NewNopLogger(), newEngine(), mockLimits{totalShards: shards}, 0, prometheus.NewPedanticRegistry())
-	downstream := &downstreamHandler{engine: newEngine(), queryable: storageSeriesQueryable(storageSeries)}
+	runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+		shardingware := newQueryShardingMiddleware(log.NewNopLogger(), eng, mockLimits{totalShards: shards}, 0, prometheus.NewPedanticRegistry())
+		downstream := &downstreamHandler{engine: eng, queryable: queryable}
 
-	req := &PrometheusInstantQueryRequest{
-		path:      "/query",
-		time:      to.UnixMilli(),
-		queryExpr: parseQuery(t, `sum(metric)`),
-	}
-
-	var lastVal float64
-	for i := 0; i <= 100; i++ {
-		shardedRes, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-		require.NoError(t, err)
-
-		shardedPrometheusRes, ok := shardedRes.GetPrometheusResponse()
-		require.True(t, ok)
-
-		sampleStreams, err := ResponseToSamples(shardedPrometheusRes)
-		require.NoError(t, err)
-
-		require.Lenf(t, sampleStreams, 1, "There should be 1 samples stream (query %d)", i)
-		require.Lenf(t, sampleStreams[0].Samples, 1, "There should be 1 sample in the first stream (query %d)", i)
-		val := sampleStreams[0].Samples[0].Value
-
-		if i > 0 {
-			require.Equalf(t, lastVal, val, "Value differs on query %d", i)
+		req := &PrometheusInstantQueryRequest{
+			path:      "/query",
+			time:      to.UnixMilli(),
+			queryExpr: parseQuery(t, `sum(metric)`),
 		}
-		lastVal = val
-	}
+
+		var lastVal float64
+		for i := 0; i <= 100; i++ {
+			shardedRes, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+			require.NoError(t, err)
+
+			shardedPrometheusRes, ok := shardedRes.GetPrometheusResponse()
+			require.True(t, ok)
+
+			sampleStreams, err := ResponseToSamples(shardedPrometheusRes)
+			require.NoError(t, err)
+
+			require.Lenf(t, sampleStreams, 1, "There should be 1 samples stream (query %d)", i)
+			require.Lenf(t, sampleStreams[0].Samples, 1, "There should be 1 sample in the first stream (query %d)", i)
+			val := sampleStreams[0].Samples[0].Value
+
+			if i > 0 {
+				require.Equalf(t, lastVal, val, "Value differs on query %d", i)
+			}
+			lastVal = val
+		}
+	})
 }
 
 // labelsForShardsGenerator returns a function that provides labels.Labels for the shard requested
@@ -987,6 +993,7 @@ type queryShardingFunctionCorrectnessTest struct {
 	args       []string
 	rangeQuery bool
 	tpl        string
+	allowedErr error
 }
 
 // TestQuerySharding_FunctionCorrectness is the old test that probably at some point inspired the TestQuerySharding_Correctness,
@@ -1002,8 +1009,8 @@ func TestQuerySharding_FunctionCorrectness(t *testing.T) {
 		{fn: "increase", rangeQuery: true},
 		{fn: "rate", rangeQuery: true},
 		{fn: "resets", rangeQuery: true},
-		{fn: "sort_by_label"},
-		{fn: "sort_by_label_desc"},
+		{fn: "sort_by_label", allowedErr: compat.NotSupportedError{}},
+		{fn: "sort_by_label_desc", allowedErr: compat.NotSupportedError{}},
 		{fn: "last_over_time", rangeQuery: true},
 		{fn: "present_over_time", rangeQuery: true},
 		{fn: "timestamp"},
@@ -1058,7 +1065,7 @@ func TestQuerySharding_FunctionCorrectness(t *testing.T) {
 		{fn: "sum_over_time", rangeQuery: true},
 		{fn: "quantile_over_time", rangeQuery: true, tpl: `(<fn>(0.5,bar1{}))`},
 		{fn: "quantile_over_time", rangeQuery: true, tpl: `(<fn>(0.99,bar1{}))`},
-		{fn: "mad_over_time", rangeQuery: true, tpl: `(<fn>(bar1{}))`},
+		{fn: "mad_over_time", rangeQuery: true, tpl: `(<fn>(bar1{}))`, allowedErr: compat.NotSupportedError{}},
 		{fn: "sgn"},
 		{fn: "predict_linear", args: []string{"1"}, rangeQuery: true},
 		{fn: "double_exponential_smoothing", args: []string{"0.5", "0.7"}, rangeQuery: true},
@@ -1084,6 +1091,7 @@ func TestQuerySharding_FunctionCorrectness(t *testing.T) {
 			newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blop", "foo", "buzz"), start.Add(-lookbackDelta), end, step, factor(8)),
 			newSeries(labels.FromStrings("__name__", "bar1", "baz", "blip", "bar", "blap", "foo", "bazz"), start.Add(-lookbackDelta), end, step, arithmeticSequence(10)),
 		})
+
 		testQueryShardingFunctionCorrectness(t, queryableFloats, append(testsForBoth, testsForFloatsOnly...), testsForNativeHistogramsOnly)
 	})
 
@@ -1132,46 +1140,55 @@ func testQueryShardingFunctionCorrectness(t *testing.T, queryable storage.Querya
 		const numShards = 4
 		for _, query := range mkQueries(tc.tpl, tc.fn, tc.rangeQuery, tc.args) {
 			t.Run(query, func(t *testing.T) {
-				req := &PrometheusRangeQueryRequest{
-					path:      "/query_range",
-					start:     util.TimeToMillis(start),
-					end:       util.TimeToMillis(end),
-					step:      step.Milliseconds(),
-					queryExpr: parseQuery(t, query),
-				}
+				runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+					req := &PrometheusRangeQueryRequest{
+						path:      "/query_range",
+						start:     util.TimeToMillis(start),
+						end:       util.TimeToMillis(end),
+						step:      step.Milliseconds(),
+						queryExpr: parseQuery(t, query),
+					}
 
-				reg := prometheus.NewPedanticRegistry()
-				engine := newEngine()
-				shardingware := newQueryShardingMiddleware(
-					log.NewNopLogger(),
-					engine,
-					mockLimits{totalShards: numShards},
-					0,
-					reg,
-				)
-				downstream := &downstreamHandler{
-					engine:    engine,
-					queryable: queryable,
-				}
+					reg := prometheus.NewPedanticRegistry()
+					shardingware := newQueryShardingMiddleware(
+						log.NewNopLogger(),
+						eng,
+						mockLimits{totalShards: numShards},
+						0,
+						reg,
+					)
+					downstream := &downstreamHandler{
+						engine:    eng,
+						queryable: queryable,
+					}
 
-				// Run the query without sharding.
-				expectedRes, err := downstream.Do(context.Background(), req)
-				require.Nil(t, err)
-				expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
-				require.True(t, ok)
+					// Run the query without sharding.
+					expectedRes, err := downstream.Do(context.Background(), req)
+					// The Mimir Query Engine doesn't (currently) support experimental functions
+					// so it's expected for it to return an error in some cases. Short-circuit the
+					// rest of this test in that case.
+					if err != nil && tc.allowedErr != nil {
+						require.ErrorAs(t, err, &tc.allowedErr)
+						return
+					}
 
-				// Ensure the query produces some results.
-				require.NotEmpty(t, expectedPrometheusRes.Data.Result)
+					require.NoError(t, err)
+					expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
+					require.True(t, ok)
 
-				// Run the query with sharding.
-				shardedRes, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-				require.Nil(t, err)
-				shardedPrometheusRes, ok := shardedRes.GetPrometheusResponse()
-				require.True(t, ok)
+					// Ensure the query produces some results.
+					require.NotEmpty(t, expectedPrometheusRes.Data.Result)
 
-				// Ensure the two results matches (float precision can slightly differ, there's no guarantee in PromQL engine too
-				// if you rerun the same query twice).
-				approximatelyEquals(t, expectedPrometheusRes, shardedPrometheusRes)
+					// Run the query with sharding.
+					shardedRes, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+					require.Nil(t, err)
+					shardedPrometheusRes, ok := shardedRes.GetPrometheusResponse()
+					require.True(t, ok)
+
+					// Ensure the two results matches (float precision can slightly differ, there's no guarantee in PromQL engine too
+					// if you rerun the same query twice).
+					approximatelyEquals(t, expectedPrometheusRes, shardedPrometheusRes)
+				})
 			})
 		}
 	}
@@ -1214,20 +1231,21 @@ func TestQuerySharding_ShouldSkipShardingViaOption(t *testing.T) {
 		},
 	}
 
-	shardingware := newQueryShardingMiddleware(log.NewNopLogger(), newEngine(), mockLimits{totalShards: 16}, 0, nil)
+	runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+		shardingware := newQueryShardingMiddleware(log.NewNopLogger(), eng, mockLimits{totalShards: 16}, 0, nil)
+		downstream := &mockHandler{}
+		downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{Status: statusSuccess}, nil)
 
-	downstream := &mockHandler{}
-	downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{Status: statusSuccess}, nil)
+		res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+		require.NoError(t, err)
+		shardedPrometheusRes, ok := res.GetPrometheusResponse()
+		require.True(t, ok)
 
-	res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-	require.NoError(t, err)
-	shardedPrometheusRes, ok := res.GetPrometheusResponse()
-	require.True(t, ok)
-
-	assert.Equal(t, statusSuccess, shardedPrometheusRes.GetStatus())
-	// Ensure we get the same request downstream. No sharding
-	downstream.AssertCalled(t, "Do", mock.Anything, req)
-	downstream.AssertNumberOfCalls(t, "Do", 1)
+		assert.Equal(t, statusSuccess, shardedPrometheusRes.GetStatus())
+		// Ensure we get the same request downstream. No sharding
+		downstream.AssertCalled(t, "Do", mock.Anything, req)
+		downstream.AssertNumberOfCalls(t, "Do", 1)
+	})
 }
 
 func TestQuerySharding_ShouldOverrideShardingSizeViaOption(t *testing.T) {
@@ -1242,24 +1260,26 @@ func TestQuerySharding_ShouldOverrideShardingSizeViaOption(t *testing.T) {
 		},
 	}
 
-	shardingware := newQueryShardingMiddleware(log.NewNopLogger(), newEngine(), mockLimits{totalShards: 16}, 0, nil)
+	runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+		shardingware := newQueryShardingMiddleware(log.NewNopLogger(), eng, mockLimits{totalShards: 16}, 0, nil)
 
-	downstream := &mockHandler{}
-	downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
-		Status: statusSuccess, Data: &PrometheusData{
-			ResultType: string(parser.ValueTypeVector),
-		},
-	}, nil)
+		downstream := &mockHandler{}
+		downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
+			Status: statusSuccess, Data: &PrometheusData{
+				ResultType: string(parser.ValueTypeVector),
+			},
+		}, nil)
 
-	res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-	require.NoError(t, err)
-	shardedPrometheusRes, ok := res.GetPrometheusResponse()
-	require.True(t, ok)
+		res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+		require.NoError(t, err)
+		shardedPrometheusRes, ok := res.GetPrometheusResponse()
+		require.True(t, ok)
 
-	assert.Equal(t, statusSuccess, shardedPrometheusRes.GetStatus())
-	downstream.AssertCalled(t, "Do", mock.Anything, mock.Anything)
-	// we expect 128 calls to the downstream handler and not the original 16.
-	downstream.AssertNumberOfCalls(t, "Do", 128)
+		assert.Equal(t, statusSuccess, shardedPrometheusRes.GetStatus())
+		downstream.AssertCalled(t, "Do", mock.Anything, mock.Anything)
+		// we expect 128 calls to the downstream handler and not the original 16.
+		downstream.AssertNumberOfCalls(t, "Do", 128)
+	})
 }
 
 func TestQuerySharding_ShouldSupportMaxShardedQueries(t *testing.T) {
@@ -1423,48 +1443,51 @@ func TestQuerySharding_ShouldSupportMaxShardedQueries(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			req := &PrometheusRangeQueryRequest{
-				path:      "/query_range",
-				start:     util.TimeToMillis(start),
-				end:       util.TimeToMillis(end),
-				step:      step.Milliseconds(),
-				queryExpr: parseQuery(t, testData.query),
-				hints:     testData.hints,
-			}
+			runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+				req := &PrometheusRangeQueryRequest{
+					path:      "/query_range",
+					start:     util.TimeToMillis(start),
+					end:       util.TimeToMillis(end),
+					step:      step.Milliseconds(),
+					queryExpr: parseQuery(t, testData.query),
+					hints:     testData.hints,
+				}
 
-			limits := mockLimits{
-				totalShards:                      testData.totalShards,
-				maxShardedQueries:                testData.maxShardedQueries,
-				compactorShards:                  testData.compactorShards,
-				nativeHistogramsIngestionEnabled: testData.nativeHistograms,
-			}
-			shardingware := newQueryShardingMiddleware(log.NewNopLogger(), newEngine(), limits, 0, nil)
+				limits := mockLimits{
+					totalShards:                      testData.totalShards,
+					maxShardedQueries:                testData.maxShardedQueries,
+					compactorShards:                  testData.compactorShards,
+					nativeHistogramsIngestionEnabled: testData.nativeHistograms,
+				}
 
-			// Keep track of the unique number of shards queried to downstream.
-			uniqueShardsMx := sync.Mutex{}
-			uniqueShards := map[string]struct{}{}
+				shardingware := newQueryShardingMiddleware(log.NewNopLogger(), eng, limits, 0, nil)
 
-			downstream := &mockHandler{}
-			downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
-				Status: statusSuccess, Data: &PrometheusData{
-					ResultType: string(parser.ValueTypeVector),
-				},
-			}, nil).Run(func(args mock.Arguments) {
-				req := args[1].(MetricsQueryRequest)
-				reqShard := regexp.MustCompile(`__query_shard__="[^"]+"`).FindString(req.GetQuery())
+				// Keep track of the unique number of shards queried to downstream.
+				uniqueShardsMx := sync.Mutex{}
+				uniqueShards := map[string]struct{}{}
 
-				uniqueShardsMx.Lock()
-				uniqueShards[reqShard] = struct{}{}
-				uniqueShardsMx.Unlock()
+				downstream := &mockHandler{}
+				downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
+					Status: statusSuccess, Data: &PrometheusData{
+						ResultType: string(parser.ValueTypeVector),
+					},
+				}, nil).Run(func(args mock.Arguments) {
+					req := args[1].(MetricsQueryRequest)
+					reqShard := regexp.MustCompile(`__query_shard__="[^"]+"`).FindString(req.GetQuery())
+
+					uniqueShardsMx.Lock()
+					uniqueShards[reqShard] = struct{}{}
+					uniqueShardsMx.Unlock()
+				})
+
+				res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+				require.NoError(t, err)
+				shardedPrometheusRes, ok := res.GetPrometheusResponse()
+				require.True(t, ok)
+
+				assert.Equal(t, statusSuccess, shardedPrometheusRes.GetStatus())
+				assert.Equal(t, testData.expectedShardsPerPartialQuery, len(uniqueShards))
 			})
-
-			res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-			require.NoError(t, err)
-			shardedPrometheusRes, ok := res.GetPrometheusResponse()
-			require.True(t, ok)
-
-			assert.Equal(t, statusSuccess, shardedPrometheusRes.GetStatus())
-			assert.Equal(t, testData.expectedShardsPerPartialQuery, len(uniqueShards))
 		})
 	}
 }
@@ -1519,48 +1542,52 @@ func TestQuerySharding_ShouldSupportMaxRegexpSizeBytes(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			req := &PrometheusRangeQueryRequest{
-				path:      "/query_range",
-				start:     util.TimeToMillis(start),
-				end:       util.TimeToMillis(end),
-				step:      step.Milliseconds(),
-				queryExpr: parseQuery(t, testData.query),
-			}
+			runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
 
-			limits := mockLimits{
-				totalShards:                      totalShards,
-				maxShardedQueries:                maxShardedQueries,
-				maxRegexpSizeBytes:               testData.maxRegexpSizeBytes,
-				compactorShards:                  0,
-				nativeHistogramsIngestionEnabled: false,
-			}
-			shardingware := newQueryShardingMiddleware(log.NewNopLogger(), newEngine(), limits, 0, nil)
+				req := &PrometheusRangeQueryRequest{
+					path:      "/query_range",
+					start:     util.TimeToMillis(start),
+					end:       util.TimeToMillis(end),
+					step:      step.Milliseconds(),
+					queryExpr: parseQuery(t, testData.query),
+				}
 
-			// Keep track of the unique number of shards queried to downstream.
-			uniqueShardsMx := sync.Mutex{}
-			uniqueShards := map[string]struct{}{}
+				limits := mockLimits{
+					totalShards:                      totalShards,
+					maxShardedQueries:                maxShardedQueries,
+					maxRegexpSizeBytes:               testData.maxRegexpSizeBytes,
+					compactorShards:                  0,
+					nativeHistogramsIngestionEnabled: false,
+				}
 
-			downstream := &mockHandler{}
-			downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
-				Status: statusSuccess, Data: &PrometheusData{
-					ResultType: string(parser.ValueTypeVector),
-				},
-			}, nil).Run(func(args mock.Arguments) {
-				req := args[1].(MetricsQueryRequest)
-				reqShard := regexp.MustCompile(`__query_shard__="[^"]+"`).FindString(req.GetQuery())
+				shardingware := newQueryShardingMiddleware(log.NewNopLogger(), eng, limits, 0, nil)
 
-				uniqueShardsMx.Lock()
-				uniqueShards[reqShard] = struct{}{}
-				uniqueShardsMx.Unlock()
+				// Keep track of the unique number of shards queried to downstream.
+				uniqueShardsMx := sync.Mutex{}
+				uniqueShards := map[string]struct{}{}
+
+				downstream := &mockHandler{}
+				downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
+					Status: statusSuccess, Data: &PrometheusData{
+						ResultType: string(parser.ValueTypeVector),
+					},
+				}, nil).Run(func(args mock.Arguments) {
+					req := args[1].(MetricsQueryRequest)
+					reqShard := regexp.MustCompile(`__query_shard__="[^"]+"`).FindString(req.GetQuery())
+
+					uniqueShardsMx.Lock()
+					uniqueShards[reqShard] = struct{}{}
+					uniqueShardsMx.Unlock()
+				})
+
+				res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+				require.NoError(t, err)
+				shardedPrometheusRes, ok := res.GetPrometheusResponse()
+				require.True(t, ok)
+
+				assert.Equal(t, statusSuccess, shardedPrometheusRes.GetStatus())
+				assert.Equal(t, testData.expectedShards, len(uniqueShards))
 			})
-
-			res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-			require.NoError(t, err)
-			shardedPrometheusRes, ok := res.GetPrometheusResponse()
-			require.True(t, ok)
-
-			assert.Equal(t, statusSuccess, shardedPrometheusRes.GetStatus())
-			assert.Equal(t, testData.expectedShards, len(uniqueShards))
 		})
 	}
 }
@@ -1574,48 +1601,23 @@ func TestQuerySharding_ShouldReturnErrorOnDownstreamHandlerFailure(t *testing.T)
 		queryExpr: parseQuery(t, "vector(1)"), // A non shardable query.
 	}
 
-	shardingware := newQueryShardingMiddleware(log.NewNopLogger(), newEngine(), mockLimits{totalShards: 16}, 0, nil)
+	runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+		shardingware := newQueryShardingMiddleware(log.NewNopLogger(), eng, mockLimits{totalShards: 16}, 0, nil)
 
-	// Mock the downstream handler to always return error.
-	downstreamErr := errors.Errorf("some err")
-	downstream := mockHandlerWith(nil, downstreamErr)
+		// Mock the downstream handler to always return error.
+		downstreamErr := errors.Errorf("some err")
+		downstream := mockHandlerWith(nil, downstreamErr)
 
-	// Run the query with sharding middleware wrapping the downstream one.
-	// We expect to get the downstream error.
-	_, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-	require.Error(t, err)
-	assert.Equal(t, downstreamErr, err)
+		// Run the query with sharding middleware wrapping the downstream one.
+		// We expect to get the downstream error.
+		_, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+		require.Error(t, err)
+		assert.Equal(t, downstreamErr, err)
+	})
 }
 
 func TestQuerySharding_ShouldReturnErrorInCorrectFormat(t *testing.T) {
 	var (
-		engine        = newEngine()
-		engineTimeout = promql.NewEngine(promql.EngineOpts{
-			Logger:               promslog.NewNopLogger(),
-			Reg:                  nil,
-			MaxSamples:           10e6,
-			Timeout:              50 * time.Millisecond,
-			ActiveQueryTracker:   nil,
-			LookbackDelta:        lookbackDelta,
-			EnableAtModifier:     true,
-			EnableNegativeOffset: true,
-			NoStepSubqueryIntervalFn: func(int64) int64 {
-				return int64(1 * time.Minute / (time.Millisecond / time.Nanosecond))
-			},
-		})
-		engineSampleLimit = promql.NewEngine(promql.EngineOpts{
-			Logger:               promslog.NewNopLogger(),
-			Reg:                  nil,
-			MaxSamples:           1,
-			Timeout:              time.Hour,
-			ActiveQueryTracker:   nil,
-			LookbackDelta:        lookbackDelta,
-			EnableAtModifier:     true,
-			EnableNegativeOffset: true,
-			NoStepSubqueryIntervalFn: func(int64) int64 {
-				return int64(1 * time.Minute / (time.Millisecond / time.Nanosecond))
-			},
-		})
 		queryableInternalErr = storage.QueryableFunc(func(int64, int64) (storage.Querier, error) {
 			return nil, apierror.New(apierror.TypeInternal, "some internal error")
 		})
@@ -1635,48 +1637,79 @@ func TestQuerySharding_ShouldReturnErrorInCorrectFormat(t *testing.T) {
 	)
 
 	for _, tc := range []struct {
-		name             string
-		engineDownstream *promql.Engine
-		engineSharding   *promql.Engine
-		expError         error
-		queryable        storage.Queryable
+		name                 string
+		engineType           string
+		engineDownstreamOpts []engineOpt
+		engineShardingOpts   []engineOpt
+		expError             error
+		queryable            storage.Queryable
 	}{
+		// Prometheus engine tests.
+
 		{
-			name:             "downstream - timeout",
-			engineDownstream: engineTimeout,
-			engineSharding:   engine,
-			expError:         apierror.New(apierror.TypeTimeout, "query timed out in expression evaluation"),
-			queryable:        queryableSlow,
+			name:                 "downstream - timeout",
+			engineType:           querier.PrometheusEngine,
+			engineDownstreamOpts: []engineOpt{withTimeout(50 * time.Millisecond)},
+			expError:             apierror.New(apierror.TypeTimeout, "query timed out in expression evaluation"),
+			queryable:            queryableSlow,
 		},
 		{
-			name:             "sharding - sample limit",
-			engineDownstream: engineSampleLimit,
-			engineSharding:   engine,
-			expError:         apierror.New(apierror.TypeExec, "query processing would load too many samples into memory in query execution"),
+			name:                 "downstream - sample limit",
+			engineType:           querier.PrometheusEngine,
+			engineDownstreamOpts: []engineOpt{withMaxSamples(1)},
+			expError:             apierror.New(apierror.TypeExec, "query processing would load too many samples into memory in query execution"),
 		},
 		{
-			name:             "sharding - timeout",
-			engineDownstream: engine,
-			engineSharding:   engineTimeout,
-			expError:         apierror.New(apierror.TypeTimeout, "query timed out in expression evaluation"),
-			queryable:        queryableSlow,
+			name:               "sharding - timeout",
+			engineType:         querier.PrometheusEngine,
+			engineShardingOpts: []engineOpt{withTimeout(50 * time.Millisecond)},
+			expError:           apierror.New(apierror.TypeTimeout, "query timed out in expression evaluation"),
+			queryable:          queryableSlow,
 		},
 		{
-			name:             "downstream - storage internal error",
-			engineDownstream: engine,
-			engineSharding:   engineSampleLimit,
-			queryable:        queryableInternalErr,
-			expError:         apierror.New(apierror.TypeInternal, "some internal error"),
+			name:       "downstream - storage internal error",
+			engineType: querier.PrometheusEngine,
+			queryable:  queryableInternalErr,
+			expError:   apierror.New(apierror.TypeInternal, "some internal error"),
 		},
 		{
-			name:             "downstream - storage prometheus execution error",
-			engineDownstream: engine,
-			engineSharding:   engineSampleLimit,
-			queryable:        queryablePrometheusExecErr,
-			expError:         apierror.Newf(apierror.TypeExec, "expanding series: %s", querier.NewMaxQueryLengthError(744*time.Hour, 720*time.Hour)),
+			name:       "downstream - storage prometheus execution error",
+			engineType: querier.PrometheusEngine,
+			queryable:  queryablePrometheusExecErr,
+			expError:   apierror.Newf(apierror.TypeExec, "expanding series: %s", querier.NewMaxQueryLengthError(744*time.Hour, 720*time.Hour)),
+		},
+
+		// MQE equivalents when applicable. For example, MQE doesn't have a sample limit
+		// and returns different error messages for timeouts when executing a query.
+
+		{
+			name:                 "downstream - timeout",
+			engineType:           querier.MimirEngine,
+			engineDownstreamOpts: []engineOpt{withTimeout(50 * time.Millisecond)},
+			expError:             apierror.New(apierror.TypeTimeout, "context deadline exceeded"),
+			queryable:            queryableSlow,
+		},
+		{
+			name:               "sharding - timeout",
+			engineType:         querier.MimirEngine,
+			engineShardingOpts: []engineOpt{withTimeout(50 * time.Millisecond)},
+			expError:           apierror.New(apierror.TypeTimeout, "context deadline exceeded"),
+			queryable:          queryableSlow,
+		},
+		{
+			name:       "downstream - storage internal error",
+			engineType: querier.MimirEngine,
+			queryable:  queryableInternalErr,
+			expError:   apierror.New(apierror.TypeInternal, "some internal error"),
+		},
+		{
+			name:       "downstream - storage prometheus execution error",
+			engineType: querier.MimirEngine,
+			queryable:  queryablePrometheusExecErr,
+			expError:   apierror.Newf(apierror.TypeExec, "expanding series: %s", querier.NewMaxQueryLengthError(744*time.Hour, 720*time.Hour)),
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s engine=%s", tc.name, tc.engineType), func(t *testing.T) {
 			req := &PrometheusRangeQueryRequest{
 				path:      "/query_range",
 				start:     util.TimeToMillis(start),
@@ -1685,14 +1718,17 @@ func TestQuerySharding_ShouldReturnErrorInCorrectFormat(t *testing.T) {
 				queryExpr: parseQuery(t, "sum(bar1)"),
 			}
 
-			shardingware := newQueryShardingMiddleware(log.NewNopLogger(), tc.engineSharding, mockLimits{totalShards: 3}, 0, nil)
+			_, engineSharding := newEngineForTesting(t, tc.engineType, tc.engineShardingOpts...)
+			_, engineDownstream := newEngineForTesting(t, tc.engineType, tc.engineDownstreamOpts...)
+
+			shardingware := newQueryShardingMiddleware(log.NewNopLogger(), engineSharding, mockLimits{totalShards: 3}, 0, nil)
 
 			if tc.queryable == nil {
 				tc.queryable = queryable
 			}
 
 			downstream := &downstreamHandler{
-				engine:    tc.engineDownstream,
+				engine:    engineDownstream,
 				queryable: tc.queryable,
 			}
 
@@ -1715,6 +1751,7 @@ func TestQuerySharding_ShouldReturnErrorInCorrectFormat(t *testing.T) {
 				assert.Equal(t, expResp.GetCode(), gotResp.GetCode())
 				assert.JSONEq(t, string(expResp.GetBody()), string(gotResp.GetBody()))
 			}
+
 		})
 	}
 }
@@ -1723,9 +1760,6 @@ func TestQuerySharding_EngineErrorMapping(t *testing.T) {
 	const (
 		numSeries = 30
 		numShards = 8
-	)
-	var (
-		engine = newEngine()
 	)
 
 	series := make([]storage.Series, 0, numSeries)
@@ -1745,13 +1779,15 @@ func TestQuerySharding_EngineErrorMapping(t *testing.T) {
 		queryExpr: parseQuery(t, `sum by (group_1) (metric_counter) - on(group_1) group_right(unique) (sum by (group_1,unique) (metric_counter))`),
 	}
 
-	downstream := &downstreamHandler{engine: newEngine(), queryable: queryable}
-	reg := prometheus.NewPedanticRegistry()
-	shardingware := newQueryShardingMiddleware(log.NewNopLogger(), engine, mockLimits{totalShards: numShards}, 0, reg)
+	runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+		downstream := &downstreamHandler{engine: eng, queryable: queryable}
+		reg := prometheus.NewPedanticRegistry()
+		shardingware := newQueryShardingMiddleware(log.NewNopLogger(), eng, mockLimits{totalShards: numShards}, 0, reg)
 
-	// Run the query with sharding.
-	_, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-	assert.Equal(t, apierror.New(apierror.TypeExec, "multiple matches for labels: grouping labels must ensure unique matches"), err)
+		// Run the query with sharding.
+		_, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+		assert.Equal(t, apierror.New(apierror.TypeExec, "multiple matches for labels: grouping labels must ensure unique matches"), err)
+	})
 }
 
 func TestQuerySharding_WrapMultipleTime(t *testing.T) {
@@ -1763,13 +1799,15 @@ func TestQuerySharding_WrapMultipleTime(t *testing.T) {
 		queryExpr: parseQuery(t, "vector(1)"), // A non shardable query.
 	}
 
-	shardingware := newQueryShardingMiddleware(log.NewNopLogger(), newEngine(), mockLimits{totalShards: 16}, 0, prometheus.NewRegistry())
+	runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+		shardingware := newQueryShardingMiddleware(log.NewNopLogger(), eng, mockLimits{totalShards: 16}, 0, prometheus.NewRegistry())
 
-	require.NotPanics(t, func() {
-		_, err := shardingware.Wrap(mockHandlerWith(nil, nil)).Do(user.InjectOrgID(context.Background(), "test"), req)
-		require.Nil(t, err)
-		_, err = shardingware.Wrap(mockHandlerWith(nil, nil)).Do(user.InjectOrgID(context.Background(), "test"), req)
-		require.Nil(t, err)
+		require.NotPanics(t, func() {
+			_, err := shardingware.Wrap(mockHandlerWith(nil, nil)).Do(user.InjectOrgID(context.Background(), "test"), req)
+			require.Nil(t, err)
+			_, err = shardingware.Wrap(mockHandlerWith(nil, nil)).Do(user.InjectOrgID(context.Background(), "test"), req)
+			require.Nil(t, err)
+		})
 	})
 }
 
@@ -1805,25 +1843,26 @@ func TestQuerySharding_ShouldUseCardinalityEstimate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			shardingware := newQueryShardingMiddleware(log.NewNopLogger(), newEngine(), mockLimits{totalShards: 16}, 10_000, nil)
-			downstream := &mockHandler{}
-			downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
-				Status: statusSuccess, Data: &PrometheusData{
-					ResultType: string(parser.ValueTypeVector),
-				},
-			}, nil)
+			runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+				shardingware := newQueryShardingMiddleware(log.NewNopLogger(), eng, mockLimits{totalShards: 16}, 10_000, nil)
+				downstream := &mockHandler{}
+				downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
+					Status: statusSuccess, Data: &PrometheusData{
+						ResultType: string(parser.ValueTypeVector),
+					},
+				}, nil)
 
-			res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), tt.req)
-			require.NoError(t, err)
-			shardedPrometheusRes, ok := res.GetPrometheusResponse()
-			require.True(t, ok)
+				res, err := shardingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), tt.req)
+				require.NoError(t, err)
+				shardedPrometheusRes, ok := res.GetPrometheusResponse()
+				require.True(t, ok)
 
-			assert.Equal(t, statusSuccess, shardedPrometheusRes.GetStatus())
-			downstream.AssertCalled(t, "Do", mock.Anything, mock.Anything)
-			downstream.AssertNumberOfCalls(t, "Do", tt.expectedCalls)
+				assert.Equal(t, statusSuccess, shardedPrometheusRes.GetStatus())
+				downstream.AssertCalled(t, "Do", mock.Anything, mock.Anything)
+				downstream.AssertNumberOfCalls(t, "Do", tt.expectedCalls)
+			})
 		})
 	}
-
 }
 
 func TestQuerySharding_Annotations(t *testing.T) {
@@ -1852,34 +1891,6 @@ func TestQuerySharding_Annotations(t *testing.T) {
 	const numShards = 8
 	const step = 20 * time.Second
 	const splitInterval = 15 * time.Second
-
-	reg := prometheus.NewPedanticRegistry()
-	engine := newEngine()
-	shardingware := newQueryShardingMiddleware(
-		log.NewNopLogger(),
-		engine,
-		mockLimits{totalShards: numShards},
-		0,
-		reg,
-	)
-	splitware := newSplitAndCacheMiddleware(
-		true,
-		false, // Cache disabled.
-		splitInterval,
-		mockLimits{},
-		newTestPrometheusCodec(),
-		nil,
-		nil,
-		nil,
-		nil,
-		log.NewNopLogger(),
-		reg,
-	)
-	downstream := &downstreamHandler{
-		engine:                                  engine,
-		queryable:                               queryable,
-		includePositionInformationInAnnotations: true,
-	}
 
 	type template struct {
 		query     string
@@ -1913,63 +1924,86 @@ func TestQuerySharding_Annotations(t *testing.T) {
 	}
 	for _, template := range templates {
 		t.Run(template.query, func(t *testing.T) {
-			query := fmt.Sprintf(template.query, seriesName)
-			req := &PrometheusRangeQueryRequest{
-				path:      "/query_range",
-				start:     0,
-				end:       int64(endTime * 1000),
-				step:      step.Milliseconds(),
-				queryExpr: parseQuery(t, query),
-			}
+			runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+				reg := prometheus.NewPedanticRegistry()
+				shardingware := newQueryShardingMiddleware(log.NewNopLogger(), eng, mockLimits{totalShards: numShards}, 0, reg)
+				splitware := newSplitAndCacheMiddleware(
+					true,
+					false, // Cache disabled.
+					splitInterval,
+					mockLimits{},
+					newTestPrometheusCodec(),
+					nil,
+					nil,
+					nil,
+					nil,
+					log.NewNopLogger(),
+					reg,
+				)
+				downstream := &downstreamHandler{
+					engine:                                  eng,
+					queryable:                               queryable,
+					includePositionInformationInAnnotations: true,
+				}
 
-			injectedContext := user.InjectOrgID(context.Background(), "test")
+				query := fmt.Sprintf(template.query, seriesName)
+				req := &PrometheusRangeQueryRequest{
+					path:      "/query_range",
+					start:     0,
+					end:       int64(endTime * 1000),
+					step:      step.Milliseconds(),
+					queryExpr: parseQuery(t, query),
+				}
 
-			// Run the query without sharding.
-			expectedRes, err := downstream.Do(injectedContext, req)
-			require.Nil(t, err)
-			expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
-			require.True(t, ok)
+				injectedContext := user.InjectOrgID(context.Background(), "test")
 
-			// Ensure the query produces some results.
-			require.NotEmpty(t, expectedPrometheusRes.Data.Result)
+				// Run the query without sharding.
+				expectedRes, err := downstream.Do(injectedContext, req)
+				require.Nil(t, err)
+				expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
+				require.True(t, ok)
 
-			// Run the query with sharding.
-			shardedRes, err := shardingware.Wrap(downstream).Do(injectedContext, req)
-			require.Nil(t, err)
-			shardedPrometheusRes, ok := shardedRes.GetPrometheusResponse()
-			require.True(t, ok)
+				// Ensure the query produces some results.
+				require.NotEmpty(t, expectedPrometheusRes.Data.Result)
 
-			// Ensure the query produces some results.
-			require.NotEmpty(t, shardedPrometheusRes.Data.Result)
+				// Run the query with sharding.
+				shardedRes, err := shardingware.Wrap(downstream).Do(injectedContext, req)
+				require.Nil(t, err)
+				shardedPrometheusRes, ok := shardedRes.GetPrometheusResponse()
+				require.True(t, ok)
 
-			// Run the query with splitting.
-			splitRes, err := splitware.Wrap(downstream).Do(injectedContext, req)
-			require.Nil(t, err)
-			splitPrometheusRes, ok := splitRes.GetPrometheusResponse()
-			require.True(t, ok)
+				// Ensure the query produces some results.
+				require.NotEmpty(t, shardedPrometheusRes.Data.Result)
 
-			// Ensure the query produces some results.
-			require.NotEmpty(t, splitPrometheusRes.Data.Result)
+				// Run the query with splitting.
+				splitRes, err := splitware.Wrap(downstream).Do(injectedContext, req)
+				require.Nil(t, err)
+				splitPrometheusRes, ok := splitRes.GetPrometheusResponse()
+				require.True(t, ok)
 
-			expected := expectedPrometheusRes.Infos
-			actualSharded := shardedPrometheusRes.Infos
-			actualSplit := splitPrometheusRes.Infos
+				// Ensure the query produces some results.
+				require.NotEmpty(t, splitPrometheusRes.Data.Result)
 
-			if template.isWarning {
-				expected = expectedPrometheusRes.Warnings
-				actualSharded = shardedPrometheusRes.Warnings
-				actualSplit = splitPrometheusRes.Warnings
-			}
+				expected := expectedPrometheusRes.Infos
+				actualSharded := shardedPrometheusRes.Infos
+				actualSplit := splitPrometheusRes.Infos
 
-			require.NotEmpty(t, expected)
-			require.Equal(t, expected, actualSplit)
+				if template.isWarning {
+					expected = expectedPrometheusRes.Warnings
+					actualSharded = shardedPrometheusRes.Warnings
+					actualSplit = splitPrometheusRes.Warnings
+				}
 
-			if template.isSharded {
-				// Remove position information from annotations generated with the unsharded query, to mirror what we expect from the sharded query.
-				removeAllAnnotationPositionInformation(expected)
-			}
+				require.NotEmpty(t, expected)
+				require.Equal(t, expected, actualSplit)
 
-			require.Equal(t, expected, actualSharded)
+				if template.isSharded {
+					// Remove position information from annotations generated with the unsharded query, to mirror what we expect from the sharded query.
+					removeAllAnnotationPositionInformation(expected)
+				}
+
+				require.Equal(t, expected, actualSharded)
+			})
 		})
 	}
 }
@@ -2294,7 +2328,7 @@ func TestLongestRegexpMatcherBytes(t *testing.T) {
 }
 
 type downstreamHandler struct {
-	engine                                  *promql.Engine
+	engine                                  promql.QueryEngine
 	queryable                               storage.Queryable
 	includePositionInformationInAnnotations bool
 }
@@ -2656,23 +2690,6 @@ func (ssi *ThreadSafeStorageSeriesIterator) Next() chunkenc.ValueType {
 
 func (ssi *ThreadSafeStorageSeriesIterator) Err() error {
 	return nil
-}
-
-// newEngine creates and return a new promql.Engine used for testing.
-func newEngine() *promql.Engine {
-	return promql.NewEngine(promql.EngineOpts{
-		Logger:               promslog.NewNopLogger(),
-		Reg:                  nil,
-		MaxSamples:           10e7,
-		Timeout:              1 * time.Hour,
-		ActiveQueryTracker:   nil,
-		LookbackDelta:        lookbackDelta,
-		EnableAtModifier:     true,
-		EnableNegativeOffset: true,
-		NoStepSubqueryIntervalFn: func(int64) int64 {
-			return int64(1 * time.Minute / (time.Millisecond / time.Nanosecond))
-		},
-	})
 }
 
 func TestRemoveAnnotationPositionInformation(t *testing.T) {

--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -13,17 +13,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/querier"
+	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/storage/series"
 	"github.com/grafana/mimir/pkg/storage/sharding"
+	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
@@ -297,5 +302,77 @@ func TestNewMockShardedQueryable(t *testing.T) {
 
 		}
 		require.Equal(t, expectedSeries, seriesCt)
+	}
+}
+
+type engineOpt func(o *streamingpromql.EngineOpts)
+
+func withTimeout(timeout time.Duration) engineOpt {
+	return func(o *streamingpromql.EngineOpts) {
+		o.CommonOpts.Timeout = timeout
+	}
+}
+
+func withMaxSamples(samples int) engineOpt {
+	return func(o *streamingpromql.EngineOpts) {
+		o.CommonOpts.MaxSamples = samples
+	}
+}
+
+func newEngineForTesting(t *testing.T, engine string, opts ...engineOpt) (promql.EngineOpts, promql.QueryEngine) {
+	t.Helper()
+
+	mqeOpts := streamingpromql.NewTestEngineOpts()
+	for _, o := range opts {
+		o(&mqeOpts)
+	}
+
+	promOpts := mqeOpts.CommonOpts
+
+	switch engine {
+	case querier.PrometheusEngine:
+		return promOpts, promql.NewEngine(promOpts)
+	case querier.MimirEngine:
+		limits := streamingpromql.NewStaticQueryLimitsProvider(0)
+		metrics := stats.NewQueryMetrics(promOpts.Reg)
+		logger := log.NewNopLogger()
+		eng, err := streamingpromql.NewEngine(mqeOpts, limits, metrics, nil, logger)
+		if err != nil {
+			t.Fatalf("error creating MQE engine for testing: %s", err)
+		}
+
+		return promOpts, eng
+	default:
+		t.Fatalf("invalid promql engine: %v", engine)
+	}
+
+	panic("unreachable")
+}
+
+// runForEngines runs the provided test closure with the Prometheus Engine and Mimir Query Engine.
+func runForEngines(t *testing.T, run func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine)) {
+	t.Helper()
+
+	promOpts, promEngine := newEngineForTesting(t, querier.PrometheusEngine)
+	mqeOpts, mqeEngine := newEngineForTesting(t, querier.MimirEngine)
+
+	engines := map[string]struct {
+		engine  promql.QueryEngine
+		options promql.EngineOpts
+	}{
+		querier.PrometheusEngine: {
+			engine:  promEngine,
+			options: promOpts,
+		},
+		querier.MimirEngine: {
+			engine:  mqeEngine,
+			options: mqeOpts,
+		},
+	}
+
+	for name, tc := range engines {
+		t.Run(fmt.Sprintf("engine=%s", name), func(t *testing.T) {
+			run(t, tc.options, tc.engine)
+		})
 	}
 }

--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -35,7 +35,7 @@ type spinOffSubqueriesMiddleware struct {
 	limits    Limits
 	logger    log.Logger
 
-	engine          *promql.Engine
+	engine          promql.QueryEngine
 	defaultStepFunc func(int64) int64
 
 	metrics spinOffSubqueriesMetrics
@@ -90,7 +90,7 @@ func newSpinOffSubqueriesMetrics(registerer prometheus.Registerer) spinOffSubque
 func newSpinOffSubqueriesMiddleware(
 	limits Limits,
 	logger log.Logger,
-	engine *promql.Engine,
+	engine promql.QueryEngine,
 	registerer prometheus.Registerer,
 	rangeMiddleware MetricsQueryMiddleware,
 	defaultStepFunc func(int64) int64,

--- a/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
@@ -266,6 +266,8 @@ func runSubquerySpinOffTests(t *testing.T, tests map[string]subquerySpinOffTest,
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
 			runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
 				downstream := &downstreamHandler{engine: eng, queryable: queryable}
 				req := &PrometheusInstantQueryRequest{

--- a/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestSubquerySpinOff_Correctness(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]subquerySpinOffTest{
 		"skipped: no subquery": {
 			query: `sum(
@@ -54,7 +52,7 @@ func TestSubquerySpinOff_Correctness(t *testing.T) {
 		"subquery max with downstream join": {
 			query: `max_over_time(
 							rate(metric_counter[1m])
-						[2d:1m]
+						[2h:1m]
 					)
 					* on (group_1) group_left()
 					max by (group_1)(
@@ -65,58 +63,58 @@ func TestSubquerySpinOff_Correctness(t *testing.T) {
 		"subquery max": {
 			query: `max_over_time(
 							rate(metric_counter[1m])
-						[2d:1m]
+						[2h:1m]
 					)`,
 			expectedSpunOffSubqueries: 1,
 		},
 		"subquery max with offset": {
 			query: `max_over_time(
 							rate(metric_counter[1m])
-						[2d:1m] offset 1d
+						[2h:1m] offset 1h
 					)`,
 			expectedSpunOffSubqueries: 1,
 		},
 		"subquery min": {
 			query: `min_over_time(
 							rate(metric_counter[1m])
-						[2d:1m]
+						[2h:1m]
 					)`,
 			expectedSpunOffSubqueries: 1,
 		},
 		"subquery min 2": {
-			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
+			query:                     `min_over_time((changes(metric_counter[5m]))[2h:2m])`,
 			expectedSpunOffSubqueries: 1,
 		},
 		"subquery min with small offset": {
-			query:                     `min_over_time((changes(metric_counter[5m]))[1d:1m] offset 20s)`,
+			query:                     `min_over_time((changes(metric_counter[5m]))[1h:1m] offset 20s)`,
 			expectedSpunOffSubqueries: 1,
 		},
 		"subquery min with offset": {
-			query:                     `min_over_time((changes(metric_counter[5m]))[1d:1m] offset 1d)`,
+			query:                     `min_over_time((changes(metric_counter[5m]))[1h:1m] offset 1h)`,
 			expectedSpunOffSubqueries: 1,
 		},
 		"subquery min: offset query time -10m": {
-			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
+			query:                     `min_over_time((changes(metric_counter[5m]))[2h:2m])`,
 			expectedSpunOffSubqueries: 1,
 			offsetQueryTime:           -10 * time.Minute,
 		},
 		"subquery min: offset query time +10m": {
-			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
+			query:                     `min_over_time((changes(metric_counter[5m]))[2h:2m])`,
 			expectedSpunOffSubqueries: 1,
 			offsetQueryTime:           10 * time.Minute,
 		},
 		"subquery min: offset query time -33s": {
-			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
+			query:                     `min_over_time((changes(metric_counter[5m]))[2h:2m])`,
 			expectedSpunOffSubqueries: 1,
 			offsetQueryTime:           -33 * time.Second,
 		},
 		"subquery min: offset query time +33s": {
-			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
+			query:                     `min_over_time((changes(metric_counter[5m]))[2h:2m])`,
 			expectedSpunOffSubqueries: 1,
 			offsetQueryTime:           33 * time.Second,
 		},
 		"subquery min: offset query time +1h": {
-			query:                     `min_over_time((changes(metric_counter[5m]))[2d:2m])`,
+			query:                     `min_over_time((changes(metric_counter[5m]))[2h:2m])`,
 			expectedSpunOffSubqueries: 1,
 			offsetQueryTime:           1 * time.Hour,
 		},
@@ -127,18 +125,18 @@ func TestSubquerySpinOff_Correctness(t *testing.T) {
 								rate(metric_counter[10m])
 							[5m:1m])
 						[2m:])
-					[2d:])`,
+					[2h:])`,
 			expectedSpunOffSubqueries: 1,
 		},
 		"double subquery deriv": {
-			query:                     `max_over_time( deriv( rate(metric_counter[10m])[5m:1m] )[2d:] )`,
+			query:                     `max_over_time( deriv( rate(metric_counter[10m])[5m:1m] )[2h:] )`,
 			expectedSpunOffSubqueries: 1,
 		},
 		"subquery min_over_time with aggr": {
 			query: `min_over_time(
 						sum by(group_1) (
 							rate(metric_counter[5m])
-						)[2d:]
+						)[2h:]
 					)`,
 			expectedSpunOffSubqueries: 1,
 		},
@@ -146,11 +144,11 @@ func TestSubquerySpinOff_Correctness(t *testing.T) {
 			query: `
 sum by (group_1) (
       sum_over_time(
-        avg by (group_1) (metric_counter{group_2="1"})[1d:5m] offset 1m
+        avg by (group_1) (metric_counter{group_2="1"})[1h:5m] offset 1m
       )
     *
       avg by (group_1) (
-        avg_over_time(metric_counter{group_2="2"}[1d:5m] offset 1m)
+        avg_over_time(metric_counter{group_2="2"}[1h:5m] offset 1m)
       )
   *
     0.083333
@@ -159,37 +157,23 @@ sum by (group_1) (
 		},
 	}
 
-	queryable := setupSubquerySpinOffTestSeries(t, 2*24*time.Hour)
-	engine := newEngine()
-	downstream := &downstreamHandler{
-		engine:    engine,
-		queryable: queryable,
-	}
-
-	runSubquerySpinOffTests(t, tests, engine, downstream)
+	queryable := setupSubquerySpinOffTestSeries(t, 2*time.Hour)
+	runSubquerySpinOffTests(t, tests, queryable)
 }
 
 func TestSubquerySpinOff_LongRangeQuery(t *testing.T) {
-	t.Parallel()
-
 	tests := map[string]subquerySpinOffTest{
 		"subquery max: multiple range queries": {
 			query: `max_over_time(
 							rate(metric_counter[1m])
-						[10d:1m]
+						[10h:1m]
 					)`,
 			expectedSpunOffSubqueries: 1,
 		},
 	}
 
-	queryable := setupSubquerySpinOffTestSeries(t, 10*24*time.Hour)
-	engine := newEngine()
-	downstream := &downstreamHandler{
-		engine:    engine,
-		queryable: queryable,
-	}
-
-	runSubquerySpinOffTests(t, tests, engine, downstream)
+	queryable := setupSubquerySpinOffTestSeries(t, 10*time.Hour)
+	runSubquerySpinOffTests(t, tests, queryable)
 }
 
 func TestSubquerySpinOff_ShouldReturnErrorOnDownstreamHandlerFailure(t *testing.T) {
@@ -199,18 +183,20 @@ func TestSubquerySpinOff_ShouldReturnErrorOnDownstreamHandlerFailure(t *testing.
 		queryExpr: parseQuery(t, "vector(1)"),
 	}
 
-	// Mock the downstream handler to always return error.
-	downstreamErr := errors.Errorf("some err")
-	downstream := mockHandlerWith(nil, downstreamErr)
+	runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+		// Mock the downstream handler to always return error.
+		downstreamErr := errors.Errorf("some err")
+		downstream := mockHandlerWith(nil, downstreamErr)
 
-	spinoffMiddleware := newSpinOffSubqueriesMiddleware(mockLimits{subquerySpinOffEnabled: true}, log.NewNopLogger(), newEngine(), nil, nil, defaultStepFunc)
+		spinoffMiddleware := newSpinOffSubqueriesMiddleware(mockLimits{subquerySpinOffEnabled: true}, log.NewNopLogger(), eng, nil, nil, defaultStepFunc)
 
-	// Run the query with subquery spin-off middleware wrapping the downstream one.
-	// We expect to get the downstream error.
-	ctx := user.InjectOrgID(context.Background(), "test")
-	_, err := spinoffMiddleware.Wrap(downstream).Do(ctx, req)
-	require.Error(t, err)
-	assert.Equal(t, downstreamErr, err)
+		// Run the query with subquery spin-off middleware wrapping the downstream one.
+		// We expect to get the downstream error.
+		ctx := user.InjectOrgID(context.Background(), "test")
+		_, err := spinoffMiddleware.Wrap(downstream).Do(ctx, req)
+		require.Error(t, err)
+		assert.Equal(t, downstreamErr, err)
+	})
 }
 
 var defaultStepFunc = func(int64) int64 {
@@ -275,85 +261,85 @@ func setupSubquerySpinOffTestSeries(t *testing.T, timeRange time.Duration) stora
 	return queryable
 }
 
-func runSubquerySpinOffTests(t *testing.T, tests map[string]subquerySpinOffTest, engine *promql.Engine, downstream MetricsQueryHandler) {
+func runSubquerySpinOffTests(t *testing.T, tests map[string]subquerySpinOffTest, queryable storage.Queryable) {
 	t.Helper()
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			t.Parallel()
+			runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+				downstream := &downstreamHandler{engine: eng, queryable: queryable}
+				req := &PrometheusInstantQueryRequest{
+					path:      "/query",
+					time:      util.TimeToMillis(time.Now().Add(testData.offsetQueryTime)),
+					queryExpr: parseQuery(t, testData.query),
+				}
 
-			req := &PrometheusInstantQueryRequest{
-				path:      "/query",
-				time:      util.TimeToMillis(time.Now().Add(testData.offsetQueryTime)),
-				queryExpr: parseQuery(t, testData.query),
-			}
+				// Run the query without subquery spin-off.
+				expectedRes, err := downstream.Do(context.Background(), req)
+				require.Nil(t, err)
+				expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
+				require.True(t, ok)
+				if !testData.expectSpecificOrder {
+					sort.Sort(byLabels(expectedPrometheusRes.Data.Result))
+				}
 
-			// Run the query without subquery spin-off.
-			expectedRes, err := downstream.Do(context.Background(), req)
-			require.Nil(t, err)
-			expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
-			require.True(t, ok)
-			if !testData.expectSpecificOrder {
-				sort.Sort(byLabels(expectedPrometheusRes.Data.Result))
-			}
+				// Ensure the query produces some results.
+				if !testData.expectEmptyResult {
+					require.NotEmpty(t, expectedPrometheusRes.Data.Result)
+					requireValidSamples(t, expectedPrometheusRes.Data.Result)
+				}
 
-			// Ensure the query produces some results.
-			if !testData.expectEmptyResult {
-				require.NotEmpty(t, expectedPrometheusRes.Data.Result)
-				requireValidSamples(t, expectedPrometheusRes.Data.Result)
-			}
+				if testData.expectedSpunOffSubqueries > 0 {
+					// Remove position information from annotations, to mirror what we expect from the sharded queries below.
+					removeAllAnnotationPositionInformation(expectedPrometheusRes.Infos)
+					removeAllAnnotationPositionInformation(expectedPrometheusRes.Warnings)
+				}
 
-			if testData.expectedSpunOffSubqueries > 0 {
-				// Remove position information from annotations, to mirror what we expect from the sharded queries below.
-				removeAllAnnotationPositionInformation(expectedPrometheusRes.Infos)
-				removeAllAnnotationPositionInformation(expectedPrometheusRes.Warnings)
-			}
-
-			// Create a fake middleware that tracks if it was called
-			called := false
-			fakeMiddleware := MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
-				return HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
-					called = true
-					return next.Do(ctx, req)
+				// Create a fake middleware that tracks if it was called
+				called := false
+				fakeMiddleware := MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
+					return HandlerFunc(func(ctx context.Context, req MetricsQueryRequest) (Response, error) {
+						called = true
+						return next.Do(ctx, req)
+					})
 				})
-			})
 
-			reg := prometheus.NewPedanticRegistry()
-			spinoffMiddleware := newSpinOffSubqueriesMiddleware(
-				mockLimits{
-					subquerySpinOffEnabled: true,
-				},
-				log.NewNopLogger(),
-				engine,
-				reg,
-				fakeMiddleware,
-				defaultStepFunc,
-			)
+				reg := prometheus.NewPedanticRegistry()
+				spinoffMiddleware := newSpinOffSubqueriesMiddleware(
+					mockLimits{
+						subquerySpinOffEnabled: true,
+					},
+					log.NewNopLogger(),
+					eng,
+					reg,
+					fakeMiddleware,
+					defaultStepFunc,
+				)
 
-			ctx := user.InjectOrgID(context.Background(), "test")
-			spinoffRes, err := spinoffMiddleware.Wrap(downstream).Do(ctx, req)
-			require.Nil(t, err)
+				ctx := user.InjectOrgID(context.Background(), "test")
+				spinoffRes, err := spinoffMiddleware.Wrap(downstream).Do(ctx, req)
+				require.Nil(t, err)
 
-			if testData.expectedSpunOffSubqueries > 0 {
-				assert.True(t, called, "the fake range middleware should have been called")
-			} else {
-				assert.False(t, called, "the fake range middleware should not have been called")
-			}
+				if testData.expectedSpunOffSubqueries > 0 {
+					assert.True(t, called, "the fake range middleware should have been called")
+				} else {
+					assert.False(t, called, "the fake range middleware should not have been called")
+				}
 
-			// Ensure the two results matches (float precision can slightly differ, there's no guarantee in PromQL engine too
-			// if you rerun the same query twice).
-			shardedPrometheusRes, _ := spinoffRes.GetPrometheusResponse()
-			if !testData.expectSpecificOrder {
-				sort.Sort(byLabels(shardedPrometheusRes.Data.Result))
-			}
-			approximatelyEquals(t, expectedPrometheusRes, shardedPrometheusRes)
+				// Ensure the two results matches (float precision can slightly differ, there's no guarantee in PromQL engine too
+				// if you rerun the same query twice).
+				shardedPrometheusRes, _ := spinoffRes.GetPrometheusResponse()
+				if !testData.expectSpecificOrder {
+					sort.Sort(byLabels(shardedPrometheusRes.Data.Result))
+				}
+				approximatelyEquals(t, expectedPrometheusRes, shardedPrometheusRes)
 
-			var noSubqueries int
-			if testData.expectedSkippedReason == "no-subquery" {
-				noSubqueries = 1
-			}
+				var noSubqueries int
+				if testData.expectedSkippedReason == "no-subquery" {
+					noSubqueries = 1
+				}
 
-			assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+				assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 # HELP cortex_frontend_spun_off_subqueries_total Total number of subqueries that were spun off.
 # TYPE cortex_frontend_spun_off_subqueries_total counter
 cortex_frontend_spun_off_subqueries_total %d
@@ -370,10 +356,11 @@ cortex_frontend_subquery_spinoff_skipped_total{reason="too-many-downstream-queri
 # TYPE cortex_frontend_subquery_spinoff_successes_total counter
 cortex_frontend_subquery_spinoff_successes_total %d
 				`, testData.expectedSpunOffSubqueries, noSubqueries, testData.expectedSpunOffSubqueries)),
-				"cortex_frontend_subquery_spinoff_attempts_total",
-				"cortex_frontend_subquery_spinoff_successes_total",
-				"cortex_frontend_subquery_spinoff_skipped_total",
-				"cortex_frontend_spun_off_subqueries_total"))
+					"cortex_frontend_subquery_spinoff_attempts_total",
+					"cortex_frontend_subquery_spinoff_successes_total",
+					"cortex_frontend_subquery_spinoff_skipped_total",
+					"cortex_frontend_spun_off_subqueries_total"))
+			})
 		})
 	}
 }

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -35,6 +35,7 @@ import (
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/util"
 )
@@ -958,10 +959,11 @@ func TestSplitAndCacheMiddleware_ResultsCacheFuzzy(t *testing.T) {
 
 	// Create a queryable on the fixtures.
 	queryable := storageSeriesQueryable(series)
+	_, engine := newEngineForTesting(t, querier.MimirEngine)
 
 	// Create a downstream handler serving range queries based on the provided queryable.
 	downstream := &downstreamHandler{
-		engine:    newEngine(),
+		engine:    engine,
 		queryable: queryable,
 	}
 

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -34,7 +34,7 @@ type splitInstantQueryByIntervalMiddleware struct {
 	limits Limits
 	logger log.Logger
 
-	engine *promql.Engine
+	engine promql.QueryEngine
 
 	metrics instantQuerySplittingMetrics
 }
@@ -85,7 +85,7 @@ func newInstantQuerySplittingMetrics(registerer prometheus.Registerer) instantQu
 func newSplitInstantQueryByIntervalMiddleware(
 	limits Limits,
 	logger log.Logger,
-	engine *promql.Engine,
+	engine promql.QueryEngine,
 	registerer prometheus.Registerer) MetricsQueryMiddleware {
 	metrics := newInstantQuerySplittingMetrics(registerer)
 

--- a/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/assert"
@@ -513,50 +514,50 @@ func TestInstantQuerySplittingCorrectness(t *testing.T) {
 
 					for _, req := range reqs {
 						t.Run(fmt.Sprintf("%T", req), func(t *testing.T) {
-							reg := prometheus.NewPedanticRegistry()
-							engine := newEngine()
-							downstream := &downstreamHandler{
-								engine:                                  engine,
-								queryable:                               queryable,
-								includePositionInformationInAnnotations: true,
-							}
+							runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+								reg := prometheus.NewPedanticRegistry()
+								downstream := &downstreamHandler{
+									engine:                                  eng,
+									queryable:                               queryable,
+									includePositionInformationInAnnotations: true,
+								}
 
-							// Run the query with the normal engine
-							_, ctx := stats.ContextWithEmptyStats(context.Background())
-							expectedRes, err := downstream.Do(ctx, req)
-							require.Nil(t, err)
-							expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
-							require.True(t, ok)
-							sort.Sort(byLabels(expectedPrometheusRes.Data.Result))
+								// Run the query with the normal engine
+								_, ctx := stats.ContextWithEmptyStats(context.Background())
+								expectedRes, err := downstream.Do(ctx, req)
+								require.Nil(t, err)
+								expectedPrometheusRes, ok := expectedRes.GetPrometheusResponse()
+								require.True(t, ok)
+								sort.Sort(byLabels(expectedPrometheusRes.Data.Result))
 
-							// Ensure the query produces some results.
-							require.NotEmpty(t, expectedPrometheusRes.Data.Result)
-							requireValidSamples(t, expectedPrometheusRes.Data.Result)
+								// Ensure the query produces some results.
+								require.NotEmpty(t, expectedPrometheusRes.Data.Result)
+								requireValidSamples(t, expectedPrometheusRes.Data.Result)
 
-							if testData.expectedSplitQueries > 0 {
-								// Remove position information from annotations, to mirror what we expect from the split queries below.
-								removeAllAnnotationPositionInformation(expectedPrometheusRes.Infos)
-								removeAllAnnotationPositionInformation(expectedPrometheusRes.Warnings)
-							}
+								if testData.expectedSplitQueries > 0 {
+									// Remove position information from annotations, to mirror what we expect from the split queries below.
+									removeAllAnnotationPositionInformation(expectedPrometheusRes.Infos)
+									removeAllAnnotationPositionInformation(expectedPrometheusRes.Warnings)
+								}
 
-							splittingware := newSplitInstantQueryByIntervalMiddleware(mockLimits{splitInstantQueriesInterval: 1 * time.Minute}, log.NewNopLogger(), engine, reg)
+								splittingware := newSplitInstantQueryByIntervalMiddleware(mockLimits{splitInstantQueriesInterval: 1 * time.Minute}, log.NewNopLogger(), eng, reg)
 
-							// Run the query with splitting
-							splitRes, err := splittingware.Wrap(downstream).Do(user.InjectOrgID(ctx, "test"), req)
-							require.Nil(t, err)
+								// Run the query with splitting
+								splitRes, err := splittingware.Wrap(downstream).Do(user.InjectOrgID(ctx, "test"), req)
+								require.Nil(t, err)
 
-							splitPrometheusRes, _ := splitRes.GetPrometheusResponse()
-							sort.Sort(byLabels(splitPrometheusRes.Data.Result))
+								splitPrometheusRes, _ := splitRes.GetPrometheusResponse()
+								sort.Sort(byLabels(splitPrometheusRes.Data.Result))
 
-							approximatelyEquals(t, expectedPrometheusRes, splitPrometheusRes)
+								approximatelyEquals(t, expectedPrometheusRes, splitPrometheusRes)
 
-							// Assert metrics
-							expectedSucceeded := 1
-							if testData.expectedSplitQueries == 0 {
-								expectedSucceeded = 0
-							}
+								// Assert metrics
+								expectedSucceeded := 1
+								if testData.expectedSplitQueries == 0 {
+									expectedSucceeded = 0
+								}
 
-							assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+								assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 						# HELP cortex_frontend_instant_query_splitting_rewrites_attempted_total Total number of instant queries the query-frontend attempted to split by interval.
 						# TYPE cortex_frontend_instant_query_splitting_rewrites_attempted_total counter
 						cortex_frontend_instant_query_splitting_rewrites_attempted_total 1
@@ -577,15 +578,16 @@ func TestInstantQuerySplittingCorrectness(t *testing.T) {
 						cortex_frontend_instant_query_splitting_rewrites_skipped_total{reason="subquery"} %d
 						cortex_frontend_instant_query_splitting_rewrites_skipped_total{reason="parsing-failed"} 0
 					`, testData.expectedSplitQueries, expectedSucceeded, testData.expectedSkippedNonSplittable,
-								testData.expectedSkippedSmallInterval, testData.expectedSkippedSubquery)),
-								"cortex_frontend_instant_query_splitting_rewrites_attempted_total",
-								"cortex_frontend_instant_query_split_queries_total",
-								"cortex_frontend_instant_query_splitting_rewrites_succeeded_total",
-								"cortex_frontend_instant_query_splitting_rewrites_skipped_total"))
+									testData.expectedSkippedSmallInterval, testData.expectedSkippedSubquery)),
+									"cortex_frontend_instant_query_splitting_rewrites_attempted_total",
+									"cortex_frontend_instant_query_split_queries_total",
+									"cortex_frontend_instant_query_splitting_rewrites_succeeded_total",
+									"cortex_frontend_instant_query_splitting_rewrites_skipped_total"))
 
-							// Assert query stats from context
-							queryStats := stats.FromContext(ctx)
-							assert.Equal(t, uint32(testData.expectedSplitQueries), queryStats.LoadSplitQueries())
+								// Assert query stats from context
+								queryStats := stats.FromContext(ctx)
+								assert.Equal(t, uint32(testData.expectedSplitQueries), queryStats.LoadSplitQueries())
+							})
 						})
 					}
 				})
@@ -621,28 +623,30 @@ func TestInstantQuerySplittingHTTPOptions(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			req := &PrometheusInstantQueryRequest{
-				path:      "/query",
-				time:      time.Now().UnixNano(),
-				queryExpr: parseQuery(t, "sum_over_time(metric_counter[3h])"), // splittable instant query
-				options:   tt.httpOptions,
-			}
+			runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+				req := &PrometheusInstantQueryRequest{
+					path:      "/query",
+					time:      time.Now().UnixNano(),
+					queryExpr: parseQuery(t, "sum_over_time(metric_counter[3h])"), // splittable instant query
+					options:   tt.httpOptions,
+				}
 
-			// Split by interval middleware with a limit configuration of split instant query interval of 1m
-			splittingware := newSplitInstantQueryByIntervalMiddleware(mockLimits{splitInstantQueriesInterval: 1 * time.Minute}, log.NewNopLogger(), newEngine(), nil)
+				// Split by interval middleware with a limit configuration of split instant query interval of 1m
+				splittingware := newSplitInstantQueryByIntervalMiddleware(mockLimits{splitInstantQueriesInterval: 1 * time.Minute}, log.NewNopLogger(), eng, nil)
 
-			downstream := &mockHandler{}
-			downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
-				Status: statusSuccess, Data: tt.data,
-			}, nil)
+				downstream := &mockHandler{}
+				downstream.On("Do", mock.Anything, mock.Anything).Return(&PrometheusResponse{
+					Status: statusSuccess, Data: tt.data,
+				}, nil)
 
-			res, err := splittingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
-			require.NoError(t, err)
-			promRes, _ := res.GetPrometheusResponse()
-			assert.Equal(t, statusSuccess, promRes.GetStatus())
+				res, err := splittingware.Wrap(downstream).Do(user.InjectOrgID(context.Background(), "test"), req)
+				require.NoError(t, err)
+				promRes, _ := res.GetPrometheusResponse()
+				assert.Equal(t, statusSuccess, promRes.GetStatus())
 
-			downstream.AssertCalled(t, "Do", mock.Anything, mock.Anything)
-			downstream.AssertNumberOfCalls(t, "Do", tt.expectedDownstreamCall)
+				downstream.AssertCalled(t, "Do", mock.Anything, mock.Anything)
+				downstream.AssertNumberOfCalls(t, "Do", tt.expectedDownstreamCall)
+			})
 		})
 	}
 }

--- a/pkg/frontend/querymiddleware/stats.go
+++ b/pkg/frontend/querymiddleware/stats.go
@@ -20,14 +20,14 @@ import (
 )
 
 type queryStatsMiddleware struct {
-	engine                      *promql.Engine
+	engine                      promql.QueryEngine
 	regexpMatcherCount          prometheus.Counter
 	regexpMatcherOptimizedCount prometheus.Counter
 	consistencyCounter          *prometheus.CounterVec
 	next                        MetricsQueryHandler
 }
 
-func newQueryStatsMiddleware(reg prometheus.Registerer, engine *promql.Engine) MetricsQueryMiddleware {
+func newQueryStatsMiddleware(reg prometheus.Registerer, engine promql.QueryEngine) MetricsQueryMiddleware {
 	regexpMatcherCount := promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "cortex_query_frontend_regexp_matcher_count",
 		Help: "Total number of regexp matchers",

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/grafana/mimir/pkg/alertmanager/alertstore"
 	"github.com/grafana/mimir/pkg/compactor"
 	"github.com/grafana/mimir/pkg/distributor"
+	"github.com/grafana/mimir/pkg/frontend"
 	"github.com/grafana/mimir/pkg/frontend/v1/frontendv1pb"
 	"github.com/grafana/mimir/pkg/ingester"
 	"github.com/grafana/mimir/pkg/querier"
@@ -164,6 +165,9 @@ func TestMimir(t *testing.T) {
 			InstanceInterfaceNames: []string{"en0", "eth0", "lo0", "lo"},
 		}},
 		Querier: querier.Config{
+			QueryEngine: "prometheus",
+		},
+		Frontend: frontend.CombinedFrontendConfig{
 			QueryEngine: "prometheus",
 		},
 		MemberlistKV: memberlist.KVConfig{

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -880,7 +880,9 @@ func (t *Mimir) initQueryFrontend() (serv services.Service, err error) {
 	}
 
 	handler := transport.NewHandler(t.Cfg.Frontend.Handler, roundTripper, util_log.Logger, t.Registerer, t.ActivityTracker)
-	t.API.RegisterQueryFrontendHandler(handler, t.BuildInfoHandler)
+	// Allow the Prometheus engine to be explicitly selected if MQE is in use and a fallback is configured.
+	fallbackInjector := streamingpromqlcompat.EngineFallbackInjector{}
+	t.API.RegisterQueryFrontendHandler(fallbackInjector.Wrap(handler), t.BuildInfoHandler)
 
 	w := services.NewFailureWatcher()
 	return services.NewBasicService(func(_ context.Context) error {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -802,6 +802,8 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 	promOpts, mqeOpts := engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, promqlEngineRegisterer)
 	// Disable concurrency limits for sharded queries spawned by the query-frontend.
 	promOpts.ActiveQueryTracker = nil
+	// Always eagerly load selectors so that they are loaded in parallel in the background.
+	mqeOpts.EagerLoadSelectors = true
 
 	// Use either the Prometheus engine or Mimir Query Engine (with optional fallback to Prometheus
 	// if it has been configured) for middlewares that require executing queries using a PromQL engine.

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	prom_storage "github.com/prometheus/prometheus/storage"
 	prom_remote "github.com/prometheus/prometheus/storage/remote"
@@ -51,6 +52,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier"
 	querierapi "github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/querier/engine"
+	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/querier/tenantfederation"
 	querier_worker "github.com/grafana/mimir/pkg/querier/worker"
 	"github.com/grafana/mimir/pkg/ruler"
@@ -59,6 +61,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/ingest"
 	"github.com/grafana/mimir/pkg/storegateway"
 	"github.com/grafana/mimir/pkg/streamingpromql"
+	streamingpromqlcompat "github.com/grafana/mimir/pkg/streamingpromql/compat"
 	"github.com/grafana/mimir/pkg/usagestats"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/activitytracker"
@@ -796,8 +799,30 @@ func (t *Mimir) initQueryFrontendTopicOffsetsReaders() (services.Service, error)
 // to optimize Prometheus query requests.
 func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error) {
 	promqlEngineRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "query-frontend"}, t.Registerer)
+	promOpts, mqeOpts := engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, promqlEngineRegisterer)
+	// Disable concurrency limits for sharded queries spawned by the query-frontend.
+	promOpts.ActiveQueryTracker = nil
 
-	engineOpts, _ := engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, promqlEngineRegisterer)
+	// Use either the Prometheus engine or Mimir Query Engine (with optional fallback to Prometheus
+	// if it has been configured) for middlewares that require executing queries using a PromQL engine.
+	var eng promql.QueryEngine
+	switch t.Cfg.Frontend.QueryEngine {
+	case querier.PrometheusEngine:
+		eng = promql.NewEngine(promOpts)
+	case querier.MimirEngine:
+		streamingEngine, err := streamingpromql.NewEngine(mqeOpts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(mqeOpts.CommonOpts.Reg), nil, util_log.Logger)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create Mimir Query Engine: %w", err)
+		}
+
+		if t.Cfg.Frontend.EnableQueryEngineFallback {
+			eng = streamingpromqlcompat.NewEngineWithFallback(streamingEngine, promql.NewEngine(promOpts), nil, util_log.Logger)
+		} else {
+			eng = streamingEngine
+		}
+	default:
+		panic(fmt.Sprintf("invalid config not caught by validation: unknown PromQL engine '%s'", t.Cfg.Querier.QueryEngine))
+	}
 
 	tripperware, err := querymiddleware.NewTripperware(
 		t.Cfg.Frontend.QueryMiddleware,
@@ -805,7 +830,8 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 		t.Overrides,
 		t.QueryFrontendCodec,
 		querymiddleware.PrometheusResponseExtractor{},
-		engineOpts,
+		eng,
+		promOpts,
 		t.QueryFrontendTopicOffsetsReaders,
 		t.Registerer,
 	)

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -625,7 +625,7 @@ func TestQuerier_QueryIngestersWithinConfig(t *testing.T) {
 		MaxSamples:         1e6,
 		Timeout:            1 * time.Minute,
 	})
-	cfg := Config{QueryEngine: prometheusEngine}
+	cfg := Config{QueryEngine: PrometheusEngine}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 			distributor := &errDistributor{}
@@ -1697,10 +1697,7 @@ func TestTenantQueryLimitsProvider(t *testing.T) {
 	}
 
 	overrides := validation.NewOverrides(defaultLimitsConfig(), tenantLimits)
-
-	provider := &tenantQueryLimitsProvider{
-		limits: overrides,
-	}
+	provider := NewTenantQueryLimitsProvider(overrides)
 
 	testCases := map[string]struct {
 		ctx           context.Context

--- a/pkg/streamingpromql/operators/selectors/selector.go
+++ b/pkg/streamingpromql/operators/selectors/selector.go
@@ -134,15 +134,15 @@ func (s *Selector) Next(ctx context.Context, existing chunkenc.Iterator) (chunke
 		return nil, types.EOS
 	}
 
-	s.seriesIdx++
-
 	// Only check for cancellation every 128 series. This avoids a (relatively) expensive check on every iteration, but aborts
-	// queries quickly enough when cancelled.
+	// queries quickly enough when cancelled. Note that we purposefully check for cancellation before incrementing the series
+	// index so that we check for cancellation at least once for all selectors.
 	// See https://github.com/prometheus/prometheus/pull/14118 for more explanation of why we use 128 (rather than say 100).
 	if s.seriesIdx%128 == 0 && ctx.Err() != nil {
 		return nil, context.Cause(ctx)
 	}
 
+	s.seriesIdx++
 	return s.series.Pop().Iterator(existing), nil
 }
 


### PR DESCRIPTION
#### What this PR does

Introduce configuration to allow the Mimir Query Engine to be used instead of the Prometheus engine in the query-frontend when queries are rewritten to be shardable or subqueries are spun off.

Notable changes:

* New configuration for query-frontend to allow MQE to be used with an optional fallback to the Prometheus engine (same as in queriers).
* Context timeouts are now checked at least once in `Selector` and also every 128 series instead of only every 128 series.
* Query-frontend tests that used a query engine now run with both Prometheus and MQE engines. Results are expected to be the same in most cases, excluding some minor differences like error messages.

#### Which issue(s) this PR fixes or relates to

N/A

#### Notes to reviewers

There are a lot of whitespace changes in test files: click "hide whitespace changes" when reviewing.

#### Checklist

- [X] Tests updated.
- [x] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [X] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
