### PR TITLE
ci: Don't install Docker for jobs that run directly on the host

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -199,6 +199,8 @@ jobs:
           persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
+      - name: Install Docker Client
+        run: ./.github/workflows/scripts/install-docker.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
@@ -323,6 +325,8 @@ jobs:
           persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
+      - name: Install Docker Client
+        run: ./.github/workflows/scripts/install-docker.sh
       - name: Symlink Expected Path to Workspace
         run: |
           mkdir -p /go/src/github.com/grafana/mimir

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -199,8 +199,6 @@ jobs:
           persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
-      - name: Install Docker Client
-        run: ./.github/workflows/scripts/install-docker.sh
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
@@ -257,8 +255,6 @@ jobs:
           persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
-      - name: Install Docker Client
-        run: sudo ./.github/workflows/scripts/install-docker.sh
       - name: Symlink Expected Path to Workspace
         run: |
           sudo mkdir -p /go/src/github.com/grafana/mimir
@@ -327,8 +323,6 @@ jobs:
           persist-credentials: false
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
-      - name: Install Docker Client
-        run: ./.github/workflows/scripts/install-docker.sh
       - name: Symlink Expected Path to Workspace
         run: |
           mkdir -p /go/src/github.com/grafana/mimir


### PR DESCRIPTION
#### What this PR does

The runner already has Docker on it. The integration tests run directly on the runner and don't need to double install it. Double installing it with mismatched versions is documented as a possible cause of a CI error we've been seeing lately: https://github.com/docker/cli/issues/6023

The other 2 jobs run in the build image instead:
```
    container:
      image: ${{ needs.prepare.outputs.build_image }}
```
thus still need the docker install.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

n/a
