### PR TITLE
Query-frontend: Avoid some re-parsing of PromQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [ENHANCEMENT] Ruler: Update `<prometheus-http-prefix>/api/v1/rules` and `<prometheus-http-prefix>/api/v1/alerts` to reply with HTTP error 422 if rule evaluation is completely disabled for the tenant. If only recording rule- or alerting rule evaluation is disabled for the tenant, the response now includes a corresponding warning. #11321
 * [ENHANCEMENT] Add tenant configuration block `ruler_alertmanager_client_config` which allows the Ruler's Alertmanager client options to be specified on a per-tenant basis. #10816
 * [ENHANCEMENT] Store-gateway: Retry querying blocks from store-gateways with dynamic replication until trying all possible store-gateways. #11354 #11398
+* [ENHANCEMENT] Query-frontend: Avoid some re-parsing of PromQL, to improve efficiency. #11437
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -125,6 +125,8 @@ type MetricsQueryRequest interface {
 	GetStep() int64
 	// GetQuery returns the query of the request.
 	GetQuery() string
+	// GetParsedQuery returns the query, parsed into an AST.
+	GetParsedQuery() parser.Expr
 	// GetMinT returns the minimum timestamp in milliseconds of data to be queried,
 	// as determined from the start timestamp and any range vector or offset in the query.
 	GetMinT() int64

--- a/pkg/frontend/querymiddleware/experimental_functions.go
+++ b/pkg/frontend/querymiddleware/experimental_functions.go
@@ -58,11 +58,7 @@ func (m *experimentalFunctionsMiddleware) Do(ctx context.Context, req MetricsQue
 		return m.next.Do(ctx, req)
 	}
 
-	expr, err := parser.ParseExpr(req.GetQuery())
-	if err != nil {
-		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
-	}
-	funcs := containedExperimentalFunctions(expr)
+	funcs := containedExperimentalFunctions(req.GetParsedQuery())
 	if len(funcs) == 0 {
 		// This query does not contain any experimental functions, so we can continue to the next middleware.
 		return m.next.Do(ctx, req)

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -133,6 +133,10 @@ func (r *PrometheusRangeQueryRequest) GetQuery() string {
 	return ""
 }
 
+func (r *PrometheusRangeQueryRequest) GetParsedQuery() parser.Expr {
+	return r.queryExpr
+}
+
 // GetMinT returns the minimum timestamp in milliseconds of data to be queried,
 // as determined from the start timestamp and any range vector or offset in the query.
 func (r *PrometheusRangeQueryRequest) GetMinT() int64 {
@@ -315,6 +319,10 @@ func (r *PrometheusInstantQueryRequest) GetQuery() string {
 		return r.queryExpr.String()
 	}
 	return ""
+}
+
+func (r *PrometheusInstantQueryRequest) GetParsedQuery() parser.Expr {
+	return r.queryExpr
 }
 
 func (r *PrometheusInstantQueryRequest) GetStart() int64 {

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -106,13 +106,7 @@ func (s *querySharding) Do(ctx context.Context, r MetricsQueryRequest) (Response
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
-	// Parse the query.
-	queryExpr, err := parser.ParseExpr(r.GetQuery())
-	if err != nil {
-		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
-	}
-
-	totalShards := s.getShardsForQuery(ctx, tenantIDs, r, queryExpr, log)
+	totalShards := s.getShardsForQuery(ctx, tenantIDs, r, r.GetParsedQuery(), log)
 	if totalShards <= 1 {
 		level.Debug(log).Log("msg", "query sharding is disabled for this query or tenant")
 		return s.next.Do(ctx, r)

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -282,6 +282,16 @@ func (r *remoteReadQueryRequest) GetQuery() string {
 	return r.promQuery
 }
 
+func (r *remoteReadQueryRequest) GetParsedQuery() parser.Expr {
+	if r.promQuery != "" {
+		expr, err := parser.ParseExpr(r.promQuery)
+		if err == nil {
+			return expr
+		}
+	}
+	return nil
+}
+
 func (r *remoteReadQueryRequest) GetHeaders() []*PrometheusHeader {
 	return nil
 }

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -326,14 +326,10 @@ func areEvaluationTimeModifiersCachable(r MetricsQueryRequest, maxCacheTime int6
 	if !strings.Contains(query, "@") && !strings.Contains(query, "offset") {
 		return true, ""
 	}
-	expr, err := parser.ParseExpr(query)
-	if err != nil {
-		// We are being pessimistic in such cases.
-		return false, notCachableReasonModifiersNotCachableFailedParse
-	}
+	expr := r.GetParsedQuery()
 
 	// This resolves the start() and end() used with the @ modifier.
-	expr, err = promql.PreprocessExpr(expr, timestamp.Time(r.GetStart()), timestamp.Time(r.GetEnd()))
+	expr, err := promql.PreprocessExpr(expr, timestamp.Time(r.GetStart()), timestamp.Time(r.GetEnd()))
 	if err != nil {
 		// We are being pessimistic in such cases.
 		return false, notCachableReasonModifiersNotCachableFailedPreprocess

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -696,6 +696,10 @@ func splitQueryByInterval(req MetricsQueryRequest, interval time.Duration) ([]Me
 // For example given the start of the query is 10.00, `http_requests_total[1h] @ start()` query will be replaced with `http_requests_total[1h] @ 10.00`
 // If the modifier is already a constant, it will be returned as is.
 func evaluateAtModifierFunction(expr parser.Expr, start, end int64) (string, error) {
+	expr, err := cloneExpr(expr) // Clone to avoid changing the original.
+	if err != nil {
+		return "", err
+	}
 	parser.Inspect(expr, func(n parser.Node, _ []parser.Node) error {
 		switch exprAt := n.(type) {
 		case *parser.VectorSelector:
@@ -718,6 +722,11 @@ func evaluateAtModifierFunction(expr parser.Expr, start, end int64) (string, err
 		return nil
 	})
 	return expr.String(), nil
+}
+
+// cloneExpr is a helper function to clone an expr.
+func cloneExpr(expr parser.Expr) (parser.Expr, error) {
+	return parser.ParseExpr(expr.String())
 }
 
 // Round up to the step before the next interval boundary.

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -2029,9 +2029,11 @@ func Test_evaluateAtModifier(t *testing.T) {
 	} {
 		t.Run(tt.in, func(t *testing.T) {
 			t.Parallel()
+			expr, err := parser.ParseExpr(tt.in)
+			require.NoError(t, err)
 			expectedExpr, err := parser.ParseExpr(tt.expected)
 			require.NoError(t, err)
-			out, err := evaluateAtModifierFunction(tt.in, start, end)
+			out, err := evaluateAtModifierFunction(expr, start, end)
 			if tt.err != nil {
 				require.Equal(t, tt.err, err)
 				return

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
-	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/util"
@@ -2025,7 +2024,6 @@ func Test_evaluateAtModifier(t *testing.T) {
 				[2m:])
 			[10m:])`, nil,
 		},
-		{"sum by (foo) (bar[buzz])", "foo{}", apierror.New(apierror.TypeBadData, `invalid parameter "query": 1:19: parse error: unexpected character in duration expression: 'b'`)},
 	} {
 		t.Run(tt.in, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/frontend/querymiddleware/stats.go
+++ b/pkg/frontend/querymiddleware/stats.go
@@ -71,11 +71,7 @@ func (s queryStatsMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (
 }
 
 func (s queryStatsMiddleware) trackRegexpMatchers(req MetricsQueryRequest) {
-	expr, err := parser.ParseExpr(req.GetQuery())
-	if err != nil {
-		return
-	}
-	for _, selectors := range parser.ExtractSelectors(expr) {
+	for _, selectors := range parser.ExtractSelectors(req.GetParsedQuery()) {
 		for _, matcher := range selectors {
 			if matcher.Type != labels.MatchRegexp && matcher.Type != labels.MatchNotRegexp {
 				continue


### PR DESCRIPTION
#### What this PR does

Avoid turning the parsed expression into a string only to immediately parse it again.

Based on observations like this, which is a heap alloc_space profile of query-frontend, that `ParseExpr` was getting called over and over again.

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/99a8022d-983a-4464-adda-5b0074887ef2" />

Here's `GetQuery` from the same profile:

<img width="1178" alt="image" src="https://github.com/user-attachments/assets/674135af-f6b9-4c2e-b403-b8443e2fd231" />

So this change should save ~20% of garbage.

#### Checklist

- NA Tests updated.
- NA Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- NA [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
