### PR TITLE
Use Mimir fork of prometheus/otlptranslator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -352,3 +352,7 @@ replace cloud.google.com/go/auth => cloud.google.com/go/auth v0.15.0
 
 // Temporarily exclude v1.72 until we've fully tested the unpinning of v1.65 and upgrade to v1.71
 exclude google.golang.org/grpc v1.72.0
+
+// Use Mimir fork of prometheus/otlptranslator to allow for higher velocity of upstream development,
+// while allowing Mimir to move at a more conservative pace.
+replace github.com/prometheus/otlptranslator => github.com/grafana/mimir-otlptranslator v0.0.0-20250501145537-53ceaec28820

--- a/go.sum
+++ b/go.sum
@@ -542,6 +542,8 @@ github.com/grafana/gomemcache v0.0.0-20250428181140-a78a5f9b0a0e h1:U+881aNy2wY4
 github.com/grafana/gomemcache v0.0.0-20250428181140-a78a5f9b0a0e/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn7VNWBIvM71O2QsgfgW9fRXZNR0DXe6pDU=
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
+github.com/grafana/mimir-otlptranslator v0.0.0-20250501145537-53ceaec28820 h1:miNRHpJa5yKnZ76AhIczXQYvcj7EcyvJ/+gTu2gW5c4=
+github.com/grafana/mimir-otlptranslator v0.0.0-20250501145537-53ceaec28820/go.mod h1:V0TUd7DeAE+iAmlOAKtl62xsR/oM06cMV7nVGr3lR7c=
 github.com/grafana/mimir-prometheus v1.8.2-0.20250423083340-007de9b763aa h1:iuyvsaMOVGaU808vvAabd+BdztRTpb8qa3pOHH7BEP8=
 github.com/grafana/mimir-prometheus v1.8.2-0.20250423083340-007de9b763aa/go.mod h1:mSFhqMCiZAtXdeqwMGrOMKvd+2QWIcSUF7hEvYu/8JE=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
@@ -882,8 +884,6 @@ github.com/prometheus/common/sigv4 v0.1.0 h1:qoVebwtwwEhS85Czm2dSROY5fTo2PAPEVdD
 github.com/prometheus/common/sigv4 v0.1.0/go.mod h1:2Jkxxk9yYvCkE5G1sQT7GuEXm57JrvHu9k5YwTjsNtI=
 github.com/prometheus/exporter-toolkit v0.14.0 h1:NMlswfibpcZZ+H0sZBiTjrA3/aBFHkNZqE+iCj5EmRg=
 github.com/prometheus/exporter-toolkit v0.14.0/go.mod h1:Gu5LnVvt7Nr/oqTBUC23WILZepW0nffNo10XdhQcwWA=
-github.com/prometheus/otlptranslator v0.0.0-20250501145537-53ceaec28820 h1:e8gRYipcGQebrp1XLUyYffLSkK5FTfbpU2O9gK7MkY8=
-github.com/prometheus/otlptranslator v0.0.0-20250501145537-53ceaec28820/go.mod h1:V0TUd7DeAE+iAmlOAKtl62xsR/oM06cMV7nVGr3lR7c=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1094,7 +1094,7 @@ github.com/prometheus/common/sigv4
 # github.com/prometheus/exporter-toolkit v0.14.0
 ## explicit; go 1.22
 github.com/prometheus/exporter-toolkit/web
-# github.com/prometheus/otlptranslator v0.0.0-20250501145537-53ceaec28820
+# github.com/prometheus/otlptranslator v0.0.0-20250501145537-53ceaec28820 => github.com/grafana/mimir-otlptranslator v0.0.0-20250501145537-53ceaec28820
 ## explicit; go 1.23.0
 github.com/prometheus/otlptranslator
 # github.com/prometheus/procfs v0.15.1
@@ -1862,3 +1862,4 @@ sigs.k8s.io/yaml/goyaml.v3
 # github.com/opentracing-contrib/go-grpc => github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f
 # github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20250424093311-7163931461c6
 # cloud.google.com/go/auth => cloud.google.com/go/auth v0.15.0
+# github.com/prometheus/otlptranslator => github.com/grafana/mimir-otlptranslator v0.0.0-20250501145537-53ceaec28820


### PR DESCRIPTION
#### What this PR does

It's been agreed upon offline with [prometheus/otlptranslator](https://github.com/prometheus/otlptranslator/) co-maintainers @ywwg and @ArthurSens, plus @armandgrillet, that Mimir will use its own fork: [mimir-otlptranslator](https://github.com/grafana/mimir-otlptranslator). The motivation is to allow for a higher pace of development of the upstream project, while we ensure that nothing breaks for Mimir. This PR makes the change through a corresponding go.mod `replace` directive.

There are at the current time no differences between the fork and upstream.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
