### PR TITLE
query-frontend: Move step alignment metric to step align middleware

### DIFF
--- a/pkg/frontend/querymiddleware/stats_test.go
+++ b/pkg/frontend/querymiddleware/stats_test.go
@@ -42,9 +42,6 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				}},
 			},
 			expectedMetrics: strings.NewReader(`
-			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
-			# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
-			cortex_query_frontend_non_step_aligned_queries_total 1
 			# HELP cortex_query_frontend_regexp_matcher_count Total number of regexp matchers
 			# TYPE cortex_query_frontend_regexp_matcher_count counter
 			cortex_query_frontend_regexp_matcher_count 1
@@ -73,9 +70,6 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				}},
 			},
 			expectedMetrics: strings.NewReader(`
-			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
-			# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
-			cortex_query_frontend_non_step_aligned_queries_total 1
 			# HELP cortex_query_frontend_regexp_matcher_count Total number of regexp matchers
 			# TYPE cortex_query_frontend_regexp_matcher_count counter
 			cortex_query_frontend_regexp_matcher_count 1
@@ -108,9 +102,6 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				)},
 			},
 			expectedMetrics: strings.NewReader(`
-			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
-			# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
-			cortex_query_frontend_non_step_aligned_queries_total 0
 			# HELP cortex_query_frontend_regexp_matcher_count Total number of regexp matchers
 			# TYPE cortex_query_frontend_regexp_matcher_count counter
 			cortex_query_frontend_regexp_matcher_count 1
@@ -160,9 +151,6 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				},
 			},
 			expectedMetrics: strings.NewReader(`
-			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
-			# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
-			cortex_query_frontend_non_step_aligned_queries_total 0
 			# HELP cortex_query_frontend_regexp_matcher_count Total number of regexp matchers
 			# TYPE cortex_query_frontend_regexp_matcher_count counter
 			cortex_query_frontend_regexp_matcher_count 2
@@ -203,9 +191,6 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				},
 			},
 			expectedMetrics: strings.NewReader(`
-			# HELP cortex_query_frontend_non_step_aligned_queries_total Total queries sent that are not step aligned.
-			# TYPE cortex_query_frontend_non_step_aligned_queries_total counter
-			cortex_query_frontend_non_step_aligned_queries_total 0
 			# HELP cortex_query_frontend_regexp_matcher_count Total number of regexp matchers
 			# TYPE cortex_query_frontend_regexp_matcher_count counter
 			cortex_query_frontend_regexp_matcher_count 1

--- a/pkg/frontend/querymiddleware/step_align.go
+++ b/pkg/frontend/querymiddleware/step_align.go
@@ -18,26 +18,32 @@ import (
 )
 
 type stepAlignMiddleware struct {
-	next    MetricsQueryHandler
-	limits  Limits
-	logger  log.Logger
-	aligned *prometheus.CounterVec
+	next       MetricsQueryHandler
+	limits     Limits
+	logger     log.Logger
+	notAligned prometheus.Counter
+	adjusted   *prometheus.CounterVec
 }
 
 // newStepAlignMiddleware creates a middleware that aligns the start and end of request to the step to
 // improve the cacheability of the query results based on per-tenant configuration.
 func newStepAlignMiddleware(limits Limits, logger log.Logger, registerer prometheus.Registerer) MetricsQueryMiddleware {
-	aligned := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-		Name: "cortex_query_frontend_queries_step_aligned_total",
+	notAligned := promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_query_frontend_non_step_aligned_queries_total",
+		Help: "Total queries sent that are not step aligned.",
+	})
+	adjusted := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_query_frontend_non_step_aligned_queries_adjusted_total",
 		Help: "Number of queries whose start or end times have been adjusted to be step-aligned.",
 	}, []string{"user"})
 
 	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return &stepAlignMiddleware{
-			next:    next,
-			limits:  limits,
-			logger:  logger,
-			aligned: aligned,
+			next:       next,
+			limits:     limits,
+			logger:     logger,
+			notAligned: notAligned,
+			adjusted:   adjusted,
 		}
 	})
 }
@@ -48,33 +54,35 @@ func (s *stepAlignMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Re
 		return s.next.Do(ctx, r)
 	}
 
-	if validation.AllTrueBooleansPerTenant(tenants, s.limits.AlignQueriesWithStep) {
-		start := (r.GetStart() / r.GetStep()) * r.GetStep()
-		end := (r.GetEnd() / r.GetStep()) * r.GetStep()
+	start := (r.GetStart() / r.GetStep()) * r.GetStep()
+	end := (r.GetEnd() / r.GetStep()) * r.GetStep()
+	stepAligned := start == r.GetStart() && end == r.GetEnd()
+	if !stepAligned {
+		s.notAligned.Inc()
+	}
 
-		if start != r.GetStart() || end != r.GetEnd() {
-			for _, id := range tenants {
-				s.aligned.WithLabelValues(id).Inc()
-			}
-
-			spanlog := spanlogger.FromContext(ctx, s.logger)
-			spanlog.DebugLog(
-				"msg", "query start or end has been adjusted to be step-aligned",
-				spanlogger.TenantIDsTagName, tenants,
-				"original_start", r.GetStart(),
-				"original_end", r.GetEnd(),
-				"adjusted_start", start,
-				"adjusted_end", end,
-				"step", r.GetStep(),
-			)
-
-			updatedReq, err := r.WithStartEnd(start, end)
-			if err != nil {
-				return nil, err
-			}
-
-			return s.next.Do(ctx, updatedReq)
+	if !stepAligned && validation.AllTrueBooleansPerTenant(tenants, s.limits.AlignQueriesWithStep) {
+		for _, id := range tenants {
+			s.adjusted.WithLabelValues(id).Inc()
 		}
+
+		spanlog := spanlogger.FromContext(ctx, s.logger)
+		spanlog.DebugLog(
+			"msg", "query start or end has been adjusted to be step-aligned",
+			spanlogger.TenantIDsTagName, tenants,
+			"original_start", r.GetStart(),
+			"original_end", r.GetEnd(),
+			"adjusted_start", start,
+			"adjusted_end", end,
+			"step", r.GetStep(),
+		)
+
+		updatedReq, err := r.WithStartEnd(start, end)
+		if err != nil {
+			return nil, err
+		}
+
+		return s.next.Do(ctx, updatedReq)
 	}
 
 	return s.next.Do(ctx, r)


### PR DESCRIPTION
#### What this PR does

Move the metric emitted for non-step aligned queries to the middleware responsible for adjusting query start and end times when enabled.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
