### PR TITLE
Fix doc: -distributor.otel-promote-resource-attributes wrong spelling

### DIFF
--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -105,7 +105,7 @@ The following features are currently experimental:
   - Enable conversion of OTel start timestamps to Prometheus zero samples to mark series start
     - `-distributor.otel-created-timestamp-zero-ingestion-enabled`
   - Promote a certain set of OTel resource attributes to labels
-    - `-distributor.promote-otel-resource-attributes`
+    - `-distributor.otel-promote-resource-attributes`
   - Add experimental `memberlist` key-value store for ha_tracker. Note that this feature is `experimental`, as the upper limits of propagation times have not yet been validated. Additionally, cleanup operations have not yet been implemented for the memberlist entries.
     - `-distributor.ha-tracker.kvstore.store`
   - Allow keeping OpenTelemetry `service.instance.id`, `service.name` and `service.namespace` resource attributes in `target_info` on top of converting them to the `instance` and `job` labels.

--- a/docs/sources/mimir/release-notes/v2.15.md
+++ b/docs/sources/mimir/release-notes/v2.15.md
@@ -89,7 +89,7 @@ The ingester can now build 24h blocks for out-of-order data which is more than 2
 
 The ruler now supports caching the contents of rule groups via the setting `-ruler-storage.cache.rule-group-enabled`.
 
-The distributor now supports promotion of OTel resource attributes to labels via the setting `-distributor.promote-otel-resource-attributes`.
+The distributor now supports promotion of OTel resource attributes to labels via the setting `-distributor.otel-promote-resource-attributes`.
 
 ## Bug fixes
 


### PR DESCRIPTION
#### What this PR does

The experimental flag `-distributor.otel-promote-resource-attributes` is wrongly spelled as `-distributor.promote-otel-resource-attributes` in a few documents.

#### Which issue(s) this PR fixes or relates to

Fixes 

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
