### PR TITLE
Alertmanager: Add 'user' label to 'error applying/computing config' log lines

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -677,7 +677,7 @@ func (am *MultitenantAlertmanager) syncConfigs(ctx context.Context, cfgMap map[s
 		cfg, startAM, err := am.computeConfig(cfgs)
 		if err != nil {
 			am.multitenantMetrics.lastReloadSuccessful.WithLabelValues(user).Set(float64(0))
-			level.Warn(am.logger).Log("msg", "error computing config", "err", err)
+			level.Warn(am.logger).Log("msg", "error computing config", "err", err, "user", user)
 			continue
 		}
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -695,7 +695,7 @@ func (am *MultitenantAlertmanager) syncConfigs(ctx context.Context, cfgMap map[s
 
 		if err := am.setConfig(cfg); err != nil {
 			am.multitenantMetrics.lastReloadSuccessful.WithLabelValues(user).Set(float64(0))
-			level.Warn(am.logger).Log("msg", "error applying config", "err", err)
+			level.Warn(am.logger).Log("msg", "error applying config", "err", err, "user", user)
 			continue
 		}
 


### PR DESCRIPTION
As the title says :+1: 