### PR TITLE
MQE: Include chunks loaded from store-gateway in memory estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [ENHANCEMENT] Store-gateway: Retry querying blocks from store-gateways with dynamic replication until trying all possible store-gateways. #11354 #11398
 * [ENHANCEMENT] Query-frontend: Avoid some re-parsing of PromQL, to improve efficiency. #11437
 * [ENHANCEMENT] Distributor: Gracefully handle type assertion of WatchPrefix in HA Tracker to continue checking for updates. #11411
+* [ENHANCEMENT] Querier: Include chunks streamed from store-gateway in Mimir Query Engine memory estimate of query memory usage. #11453
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -143,6 +143,11 @@ func (bqs *blockStreamingQuerierSeries) Iterator(reuse chunkenc.Iterator) chunke
 	return newBlockQuerierSeriesIterator(reuse, bqs.Labels(), allChunks)
 }
 
+type memoryConsumptionTracker interface {
+	IncreaseMemoryConsumption(b uint64) error
+	DecreaseMemoryConsumption(b uint64)
+}
+
 // storeGatewayStreamReader is responsible for managing the streaming of chunks from a storegateway and buffering
 // chunks in memory until they are consumed by the PromQL engine.
 type storeGatewayStreamReader struct {
@@ -150,6 +155,7 @@ type storeGatewayStreamReader struct {
 	client              storegatewaypb.StoreGateway_SeriesClient
 	expectedSeriesCount int
 	queryLimiter        *limiter.QueryLimiter
+	memoryTracker       memoryConsumptionTracker
 	stats               *stats.Stats
 	metrics             *blocksStoreQueryableMetrics
 	log                 log.Logger
@@ -162,12 +168,13 @@ type storeGatewayStreamReader struct {
 	err                    error
 }
 
-func newStoreGatewayStreamReader(ctx context.Context, client storegatewaypb.StoreGateway_SeriesClient, expectedSeriesCount int, queryLimiter *limiter.QueryLimiter, stats *stats.Stats, metrics *blocksStoreQueryableMetrics, log log.Logger) *storeGatewayStreamReader {
+func newStoreGatewayStreamReader(ctx context.Context, client storegatewaypb.StoreGateway_SeriesClient, expectedSeriesCount int, queryLimiter *limiter.QueryLimiter, memoryTracker memoryConsumptionTracker, stats *stats.Stats, metrics *blocksStoreQueryableMetrics, log log.Logger) *storeGatewayStreamReader {
 	return &storeGatewayStreamReader{
 		ctx:                 ctx,
 		client:              client,
 		expectedSeriesCount: expectedSeriesCount,
 		queryLimiter:        queryLimiter,
+		memoryTracker:       memoryTracker,
 		stats:               stats,
 		metrics:             metrics,
 		log:                 log,
@@ -189,9 +196,18 @@ func (s *storeGatewayStreamReader) Close() {
 // It is safe to call FreeBuffer multiple times, or to alternate GetChunks and FreeBuffer calls.
 func (s *storeGatewayStreamReader) FreeBuffer() {
 	if s.lastMessage != nil {
+		s.memoryTracker.DecreaseMemoryConsumption(uint64(s.lastMessage.Size()))
 		s.lastMessage.FreeBuffer()
 		s.lastMessage = nil
 	}
+}
+
+func (s *storeGatewayStreamReader) setLastMessage(msg *storepb.SeriesResponse) error {
+	if err := s.memoryTracker.IncreaseMemoryConsumption(uint64(msg.Size())); err != nil {
+		return err
+	}
+	s.lastMessage = msg
+	return nil
 }
 
 // StartBuffering begins streaming series' chunks from the storegateway associated with
@@ -414,13 +430,10 @@ func (s *storeGatewayStreamReader) GetChunks(seriesIndex uint64) (_ []storepb.Ag
 }
 
 func (s *storeGatewayStreamReader) readNextBatch(seriesIndex uint64) error {
-	if s.lastMessage != nil {
-		s.lastMessage.FreeBuffer()
-		s.lastMessage = nil
-	}
+	// Discard the last message we read and release any resources.
+	s.FreeBuffer()
 
 	msg, channelOpen := <-s.seriesMessageChan
-
 	if !channelOpen {
 		// If there's an error, report it.
 		select {
@@ -437,7 +450,12 @@ func (s *storeGatewayStreamReader) readNextBatch(seriesIndex uint64) error {
 		return fmt.Errorf("attempted to read series at index %v from store-gateway chunks stream, but the stream has already been exhausted (was expecting %v series)", seriesIndex, s.expectedSeriesCount)
 	}
 
-	s.lastMessage = msg
+	// It's possible that loading this batch of chunks has put us over the memory limit
+	// for this query. Return the error in that case.
+	if err := s.setLastMessage(msg); err != nil {
+		return err
+	}
+
 	s.chunksBatch = msg.GetStreamingChunks().Series
 	return nil
 }

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -203,6 +203,13 @@ func (s *storeGatewayStreamReader) FreeBuffer() {
 }
 
 func (s *storeGatewayStreamReader) setLastMessage(msg *storepb.SeriesResponse) error {
+	// We should only attempt to store a message if there is no previous message or, we have
+	// already cleaned up the previous message. Return an error to make it obvious that this
+	// is a bug in Mimir.
+	if s.lastMessage != nil {
+		return fmt.Errorf("must call FreeBuffer() before storing the next message - this indicates a bug")
+	}
+
 	if err := s.memoryTracker.IncreaseMemoryConsumption(uint64(msg.Size())); err != nil {
 		return err
 	}

--- a/pkg/querier/block_streaming_test.go
+++ b/pkg/querier/block_streaming_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
 	"github.com/grafana/mimir/pkg/util/limiter"
 	"github.com/grafana/mimir/pkg/util/test"
 )
@@ -315,8 +317,10 @@ func TestStoreGatewayStreamReader_HappyPaths(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: testCase.messages}
+			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+			memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 			metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
-			reader := newStoreGatewayStreamReader(ctx, mockClient, 5, limiter.NewQueryLimiter(0, 0, 0, 0, nil), &stats.Stats{}, metrics, log.NewNopLogger())
+			reader := newStoreGatewayStreamReader(ctx, mockClient, 5, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 			reader.StartBuffering()
 
 			actualChunksEstimate := reader.EstimateChunkCount()
@@ -385,8 +389,10 @@ func TestStoreGatewayStreamReader_AbortsWhenParentContextCancelled(t *testing.T)
 			mockClient := &mockStoreGatewayQueryStreamClient{ctx: streamCtx, messages: batchesToMessages(3, batches...)}
 
 			parentCtx, cancel := context.WithCancel(context.Background())
+			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+			memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 			metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
-			reader := newStoreGatewayStreamReader(parentCtx, mockClient, 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), &stats.Stats{}, metrics, log.NewNopLogger())
+			reader := newStoreGatewayStreamReader(parentCtx, mockClient, 3, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 			cancel()
 			reader.StartBuffering()
 
@@ -412,10 +418,12 @@ func TestStoreGatewayStreamReader_DoesNotAbortWhenStreamContextCancelled(t *test
 	cancel()
 	const expectedChunksEstimate uint64 = 5
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: streamCtx, messages: batchesToMessages(expectedChunksEstimate, batches...)}
+	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+	memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 
 	parentCtx := context.Background()
-	reader := newStoreGatewayStreamReader(parentCtx, mockClient, 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), &stats.Stats{}, metrics, log.NewNopLogger())
+	reader := newStoreGatewayStreamReader(parentCtx, mockClient, 3, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
 
 	actualChunksEstimate := reader.EstimateChunkCount()
@@ -436,8 +444,10 @@ func TestStoreGatewayStreamReader_ReadingSeriesOutOfOrder(t *testing.T) {
 
 	ctx := context.Background()
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
+	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+	memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
-	reader := newStoreGatewayStreamReader(ctx, mockClient, 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), &stats.Stats{}, metrics, log.NewNopLogger())
+	reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
 
 	s, err := reader.GetChunks(1)
@@ -453,8 +463,10 @@ func TestStoreGatewayStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
 
 	ctx := context.Background()
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
+	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+	memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
-	reader := newStoreGatewayStreamReader(ctx, mockClient, 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), &stats.Stats{}, metrics, log.NewNopLogger())
+	reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
 
 	s, err := reader.GetChunks(0)
@@ -481,8 +493,10 @@ func TestStoreGatewayStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) 
 
 	ctx := context.Background()
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
+	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+	memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
-	reader := newStoreGatewayStreamReader(ctx, mockClient, 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), &stats.Stats{}, metrics, log.NewNopLogger())
+	reader := newStoreGatewayStreamReader(ctx, mockClient, 3, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
 
 	s, err := reader.GetChunks(0)
@@ -534,8 +548,10 @@ func TestStoreGatewayStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
+			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+			memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 			metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
-			reader := newStoreGatewayStreamReader(ctx, mockClient, 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), &stats.Stats{}, metrics, log.NewNopLogger())
+			reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 			reader.StartBuffering()
 
 			s, err := reader.GetChunks(0)
@@ -555,26 +571,36 @@ func TestStoreGatewayStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 	}
 }
 
-func TestStoreGatewayStreamReader_ChunksLimits(t *testing.T) {
+func TestStoreGatewayStreamReader_QueryAndChunksLimits(t *testing.T) {
 	testCases := map[string]struct {
-		maxChunks     int
-		maxChunkBytes int
-		expectedError string
+		maxChunks          int
+		maxChunkBytes      int
+		maxEstimatedMemory int
+		expectedError      string
 	}{
 		"query under both limits": {
-			maxChunks:     4,
-			maxChunkBytes: 200,
-			expectedError: "",
+			maxChunks:          4,
+			maxChunkBytes:      200,
+			maxEstimatedMemory: 400,
+			expectedError:      "",
 		},
 		"query selects too many chunks": {
-			maxChunks:     2,
-			maxChunkBytes: 200,
-			expectedError: "the query exceeded the maximum number of chunks (limit: 2 chunks) (err-mimir-max-chunks-per-query). Consider reducing the time range and/or number of series selected by the query. One way to reduce the number of selected series is to add more label matchers to the query. Otherwise, to adjust the related per-tenant limit, configure -querier.max-fetched-chunks-per-query, or contact your service administrator.",
+			maxChunks:          2,
+			maxChunkBytes:      200,
+			maxEstimatedMemory: 400,
+			expectedError:      "the query exceeded the maximum number of chunks (limit: 2 chunks) (err-mimir-max-chunks-per-query). Consider reducing the time range and/or number of series selected by the query. One way to reduce the number of selected series is to add more label matchers to the query. Otherwise, to adjust the related per-tenant limit, configure -querier.max-fetched-chunks-per-query, or contact your service administrator.",
 		},
 		"query selects too many chunk bytes": {
-			maxChunks:     4,
-			maxChunkBytes: 50,
-			expectedError: "the query exceeded the aggregated chunks size limit (limit: 50 bytes) (err-mimir-max-chunks-bytes-per-query). Consider reducing the time range and/or number of series selected by the query. One way to reduce the number of selected series is to add more label matchers to the query. Otherwise, to adjust the related per-tenant limit, configure -querier.max-fetched-chunk-bytes-per-query, or contact your service administrator.",
+			maxChunks:          4,
+			maxChunkBytes:      50,
+			maxEstimatedMemory: 400,
+			expectedError:      "the query exceeded the aggregated chunks size limit (limit: 50 bytes) (err-mimir-max-chunks-bytes-per-query). Consider reducing the time range and/or number of series selected by the query. One way to reduce the number of selected series is to add more label matchers to the query. Otherwise, to adjust the related per-tenant limit, configure -querier.max-fetched-chunk-bytes-per-query, or contact your service administrator.",
+		},
+		"query uses too much estimated memory": {
+			maxChunks:          4,
+			maxChunkBytes:      200,
+			maxEstimatedMemory: 50,
+			expectedError:      "the query exceeded the maximum allowed estimated amount of memory consumed by a single query (limit: 50 bytes) (err-mimir-max-estimated-memory-consumption-per-query). Consider reducing the time range and/or number of series selected by the query. One way to reduce the number of selected series is to add more label matchers to the query. Otherwise, to adjust the related per-tenant limit, configure -querier.max-estimated-memory-consumption-per-query, or contact your service administrator.",
 		},
 		// Estimated limits are enforced by the consumer of the reader, so that we can check the total estimate is beneath the limit before loading too many batches from too many streams.
 	}
@@ -592,10 +618,16 @@ func TestStoreGatewayStreamReader_ChunksLimits(t *testing.T) {
 			ctx := context.Background()
 			mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
 			registry := prometheus.NewPedanticRegistry()
-			metrics := newBlocksStoreQueryableMetrics(registry)
+			rejectionCount := promauto.With(registry).NewCounter(prometheus.CounterOpts{
+				Name: "rejections",
+				Help: "test",
+			})
 			queryMetrics := stats.NewQueryMetrics(registry)
+			queryLimiter := limiter.NewQueryLimiter(0, testCase.maxChunkBytes, testCase.maxChunks, 0, queryMetrics)
+			memoryTracker := limiting.NewMemoryConsumptionTracker(uint64(testCase.maxEstimatedMemory), rejectionCount)
+			metrics := newBlocksStoreQueryableMetrics(registry)
 
-			reader := newStoreGatewayStreamReader(ctx, mockClient, 1, limiter.NewQueryLimiter(0, testCase.maxChunkBytes, testCase.maxChunks, 0, queryMetrics), &stats.Stats{}, metrics, log.NewNopLogger())
+			reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 			reader.StartBuffering()
 
 			_, err := reader.GetChunks(0)
@@ -615,6 +647,10 @@ func TestStoreGatewayStreamReader_ChunksLimits(t *testing.T) {
 				_, err = reader.GetChunks(2)
 				require.EqualError(t, err, "attempted to read series at index 2 from store-gateway chunks stream, but the stream previously failed and returned an error: "+testCase.expectedError)
 			}
+
+			// Make sure that the reader frees any memory it was using.
+			reader.FreeBuffer()
+			require.Equal(t, uint64(0), memoryTracker.CurrentEstimatedMemoryConsumptionBytes())
 		})
 	}
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/grpcclient"
+	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -229,7 +230,7 @@ func newQueryable(
 	logger log.Logger,
 ) storage.Queryable {
 	return storage.QueryableFunc(func(minT, maxT int64) (storage.Querier, error) {
-		return multiQuerier{
+		return &multiQuerier{
 			queryables:   queryables,
 			queryMetrics: queryMetrics,
 			cfg:          cfg,
@@ -265,13 +266,17 @@ type multiQuerier struct {
 	queryMetrics *stats.QueryMetrics
 	cfg          Config
 	minT, maxT   int64
+	queriers     []storage.Querier
+	queriersMtx  sync.Mutex
 
 	limits *validation.Overrides
 
 	logger log.Logger
 }
 
-func (mq multiQuerier) getQueriers(ctx context.Context, matchers ...*labels.Matcher) (context.Context, []storage.Querier, error) {
+// getQueriers returns a context with per-tenant query limits applied, queriers applicable to the provided
+// time range, and the possibly adjusted min and max times.
+func (mq *multiQuerier) getQueriers(ctx context.Context, minT, maxT int64, matchers ...*labels.Matcher) (context.Context, []storage.Querier, int64, int64, error) {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, mq.logger, "multiQuerier.getQueriers")
 	defer spanLog.Finish()
 
@@ -279,7 +284,7 @@ func (mq multiQuerier) getQueriers(ctx context.Context, matchers ...*labels.Matc
 
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, 0, err
 	}
 
 	ctx = limiter.AddQueryLimiterToContext(ctx, limiter.NewQueryLimiter(
@@ -290,9 +295,9 @@ func (mq multiQuerier) getQueriers(ctx context.Context, matchers ...*labels.Matc
 		mq.queryMetrics,
 	))
 
-	mq.minT, mq.maxT, err = validateQueryTimeRange(tenantID, mq.minT, mq.maxT, now.UnixMilli(), mq.limits, spanlogger.FromContext(ctx, mq.logger))
+	minT, maxT, err = validateQueryTimeRange(tenantID, minT, maxT, now.UnixMilli(), mq.limits, spanlogger.FromContext(ctx, mq.logger))
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, 0, err
 	}
 
 	var queriers []storage.Querier
@@ -306,12 +311,12 @@ func (mq multiQuerier) getQueriers(ctx context.Context, matchers ...*labels.Matc
 			}
 		}
 
-		isApplicable := queryable.IsApplicable(ctx, tenantID, now, mq.minT, mq.maxT, mq.logger, matchers...)
+		isApplicable := queryable.IsApplicable(ctx, tenantID, now, minT, maxT, mq.logger, matchers...)
 		level.Debug(spanLog).Log("queryable_name", queryable.StorageName, "use_queryable", true, "is_applicable", isApplicable)
 		if isApplicable {
-			q, err := queryable.Querier(mq.minT, mq.maxT)
+			q, err := queryable.Querier(minT, maxT)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, 0, 0, err
 			}
 
 			queriers = append(queriers, q)
@@ -319,16 +324,22 @@ func (mq multiQuerier) getQueriers(ctx context.Context, matchers ...*labels.Matc
 		}
 	}
 
-	return ctx, queriers, nil
+	// If we didn't encounter any errors, store any created queriers here so that
+	// we can make sure to close them when this querier is eventually closed. This
+	// is required since they may be lazy queriers and not allocate any resources
+	// when methods are initially called: we need to wait until the caller of this
+	// querier closes it.
+	mq.storeQueriers(queriers)
+	return ctx, queriers, minT, maxT, nil
 }
 
 // Select implements storage.Querier interface.
 // The bool passed is ignored because the series are always sorted.
-func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) (set storage.SeriesSet) {
+func (mq *multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHints, matchers ...*labels.Matcher) (set storage.SeriesSet) {
 	spanLog, ctx := spanlogger.NewWithLogger(ctx, mq.logger, "querier.Select")
 	defer spanLog.Finish()
 
-	ctx, queriers, err := mq.getQueriers(ctx, matchers...)
+	ctx, queriers, minT, maxT, err := mq.getQueriers(ctx, mq.minT, mq.maxT, matchers...)
 	if errors.Is(err, errEmptyTimeRange) {
 		return storage.EmptySeriesSet()
 	}
@@ -338,8 +349,8 @@ func (mq multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHin
 
 	if sp == nil {
 		sp = &storage.SelectHints{
-			Start: mq.minT,
-			End:   mq.maxT,
+			Start: minT,
+			End:   maxT,
 		}
 	} else {
 		// Make a copy, to avoid changing shared SelectHints.
@@ -489,8 +500,8 @@ func clampToMaxSeriesQueryLimit(spanLog *spanlogger.SpanLogger, limit, maxSeries
 }
 
 // LabelValues implements storage.Querier.
-func (mq multiQuerier) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
-	ctx, queriers, err := mq.getQueriers(ctx, matchers...)
+func (mq *multiQuerier) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	ctx, queriers, _, _, err := mq.getQueriers(ctx, mq.minT, mq.maxT, matchers...)
 	if errors.Is(err, errEmptyTimeRange) {
 		return nil, nil, nil
 	}
@@ -534,8 +545,8 @@ func (mq multiQuerier) LabelValues(ctx context.Context, name string, hints *stor
 	return util.MergeSlices(sets...), warnings, nil
 }
 
-func (mq multiQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
-	ctx, queriers, err := mq.getQueriers(ctx, matchers...)
+func (mq *multiQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	ctx, queriers, _, _, err := mq.getQueriers(ctx, mq.minT, mq.maxT, matchers...)
 	if errors.Is(err, errEmptyTimeRange) {
 		return nil, nil, nil
 	}
@@ -579,11 +590,27 @@ func (mq multiQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints
 	return util.MergeSlices(sets...), warnings, nil
 }
 
-func (multiQuerier) Close() error {
-	return nil
+// storeQueriers stores the created queriers so they can be cleaned up when this querier is eventually cleaned up.
+func (mq *multiQuerier) storeQueriers(queriers []storage.Querier) {
+	mq.queriersMtx.Lock()
+	mq.queriers = append(mq.queriers, queriers...)
+	mq.queriersMtx.Unlock()
 }
 
-func (mq multiQuerier) mergeSeriesSets(sets []storage.SeriesSet) storage.SeriesSet {
+func (mq *multiQuerier) Close() error {
+	mq.queriersMtx.Lock()
+	defer mq.queriersMtx.Unlock()
+
+	me := multierror.New()
+	for _, c := range mq.queriers {
+		me.Add(c.Close())
+	}
+
+	mq.queriers = nil
+	return me.Err()
+}
+
+func (mq *multiQuerier) mergeSeriesSets(sets []storage.SeriesSet) storage.SeriesSet {
 	// Here we deal with sets that are based on chunks and build single set from them.
 	// Remaining sets are merged with chunks-based one using storage.NewMergeSeriesSet
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -327,8 +327,8 @@ func (mq *multiQuerier) getQueriers(ctx context.Context, minT, maxT int64, match
 	// If we didn't encounter any errors, store any created queriers here so that
 	// we can make sure to close them when this querier is eventually closed. This
 	// is required since they may be lazy queriers and not allocate any resources
-	// when methods are initially called: we need to wait until the caller of this
-	// querier closes it.
+	// when methods are initially called: we need to wait until the results are
+	// consumed and the caller of this querier closes it.
 	mq.storeQueriers(queriers)
 	return ctx, queriers, minT, maxT, nil
 }

--- a/pkg/querier/stats/stats.go
+++ b/pkg/querier/stats/stats.go
@@ -25,7 +25,8 @@ func ContextWithEmptyStats(ctx context.Context) (*Stats, context.Context) {
 }
 
 // FromContext gets the Stats out of the Context. Returns nil if stats have not
-// been initialised in the context.
+// been initialised in the context. Note that Stats methods are safe to call with
+// a nil receiver.
 func FromContext(ctx context.Context) *Stats {
 	o := ctx.Value(ctxKey)
 	if o == nil {

--- a/pkg/streamingpromql/operators/selectors/selector.go
+++ b/pkg/streamingpromql/operators/selectors/selector.go
@@ -85,6 +85,11 @@ func (s *Selector) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, 
 		return nil, err
 	}
 
+	// Add the memory consumption tracker to the context of this querier before performing the
+	// query so that we can keep track of memory used loading chunks. We use the context since
+	// we can't modify the Queryable/Querier interfaces and the limit is actually specific to
+	// this request (and hence a good fit for storing in the context).
+	ctx = limiting.AddToContext(ctx, s.MemoryConsumptionTracker)
 	ss := s.querier.Select(ctx, true, hints, s.Matchers...)
 	s.series = newSeriesList(s.MemoryConsumptionTracker)
 

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -859,8 +859,8 @@ func (q *Query) Close() {
 	q.result.Value = nil
 
 	if q.engine.pedantic && q.result.Err == nil {
-		if q.memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes() > 0 {
-			panic("Memory consumption tracker still estimates > 0 bytes used. This indicates something has not been returned to a pool.")
+		if bytesUsed := q.memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(); bytesUsed > 0 {
+			panic(fmt.Sprintf("Memory consumption tracker still estimates %d bytes used for %q. This indicates something has not been returned to a pool.", bytesUsed, q.originalExpression))
 		}
 	}
 }


### PR DESCRIPTION
#### What this PR does

Include chunks streamed from the store-gateway that are currently in memory in the MQE memory usage estimate. The memory usage tracker for the current query is propagated through the read path using the context for the current request. This change takes advantage of the recent gRPC update that introduced a `FreeBuffer` lifecycle method.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
