### PR TITLE
MQE: Include chunks loaded from ingesters in memory estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [ENHANCEMENT] Query-frontend: Avoid some re-parsing of PromQL, to improve efficiency. #11437
 * [ENHANCEMENT] Distributor: Gracefully handle type assertion of WatchPrefix in HA Tracker to continue checking for updates. #11411 #11461
 * [ENHANCEMENT] Querier: Include chunks streamed from store-gateway in Mimir Query Engine memory estimate of query memory usage. #11453 #11465
+* [ENHANCEMENT] Querier: Include chunks streamed from ingester in Mimir Query Engine memory estimate of query memory usage. #11457
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/pkg/ingester/client/streaming.go
+++ b/pkg/ingester/client/streaming.go
@@ -34,6 +34,24 @@ type StreamingSeriesSource struct {
 	SeriesIndex  uint64
 }
 
+type memoryConsumptionTracker interface {
+	IncreaseMemoryConsumption(b uint64) error
+	DecreaseMemoryConsumption(b uint64)
+}
+
+func NewSeriesChunksStreamReader(ctx context.Context, client Ingester_QueryStreamClient, ingesterName string, expectedSeriesCount int, queryLimiter *limiter.QueryLimiter, memoryTracker memoryConsumptionTracker, cleanup func(), log log.Logger) *SeriesChunksStreamReader {
+	return &SeriesChunksStreamReader{
+		ctx:                 ctx,
+		client:              client,
+		expectedSeriesCount: expectedSeriesCount,
+		queryLimiter:        queryLimiter,
+		memoryTracker:       memoryTracker,
+		cleanup:             cleanup,
+		log:                 log,
+		ingesterName:        ingesterName,
+	}
+}
+
 // SeriesChunksStreamReader is responsible for managing the streaming of chunks from an ingester and buffering
 // chunks in memory until they are consumed by the PromQL engine.
 type SeriesChunksStreamReader struct {
@@ -41,6 +59,7 @@ type SeriesChunksStreamReader struct {
 	client              Ingester_QueryStreamClient
 	expectedSeriesCount int
 	queryLimiter        *limiter.QueryLimiter
+	memoryTracker       memoryConsumptionTracker
 	cleanup             func()
 	log                 log.Logger
 
@@ -56,18 +75,6 @@ type SeriesChunksStreamReader struct {
 
 func (s *SeriesChunksStreamReader) GetName() string {
 	return s.ingesterName
-}
-
-func NewSeriesChunksStreamReader(ctx context.Context, client Ingester_QueryStreamClient, ingesterName string, expectedSeriesCount int, queryLimiter *limiter.QueryLimiter, cleanup func(), log log.Logger) *SeriesChunksStreamReader {
-	return &SeriesChunksStreamReader{
-		ctx:                 ctx,
-		client:              client,
-		expectedSeriesCount: expectedSeriesCount,
-		queryLimiter:        queryLimiter,
-		cleanup:             cleanup,
-		log:                 log,
-		ingesterName:        ingesterName,
-	}
 }
 
 // Close cleans up all resources associated with this SeriesChunksStreamReader, except any
@@ -87,9 +94,24 @@ func (s *SeriesChunksStreamReader) Close() {
 // It is safe to call FreeBuffer multiple times, or to alternate GetChunks and FreeBuffer calls.
 func (s *SeriesChunksStreamReader) FreeBuffer() {
 	if s.lastMessage != nil {
+		s.memoryTracker.DecreaseMemoryConsumption(uint64(s.lastMessage.Size()))
 		s.lastMessage.FreeBuffer()
 		s.lastMessage = nil
 	}
+}
+
+func (s *SeriesChunksStreamReader) setLastMessage(msg *QueryStreamResponse) error {
+	// We should only attempt to store a message if there is no previous message or, we have
+	// already cleaned up the previous message. Return an error to make it obvious that this
+	// is a bug in Mimir.
+	if s.lastMessage != nil {
+		return fmt.Errorf("must call FreeBuffer() before storing the next message - this indicates a bug")
+	}
+	if err := s.memoryTracker.IncreaseMemoryConsumption(uint64(msg.Size())); err != nil {
+		return err
+	}
+	s.lastMessage = msg
+	return nil
 }
 
 // StartBuffering begins streaming series' chunks from the ingester associated with
@@ -273,7 +295,12 @@ func (s *SeriesChunksStreamReader) readNextBatch(seriesIndex uint64) error {
 		return fmt.Errorf("attempted to read series at index %v from ingester chunks stream, but the stream has already been exhausted (was expecting %v series)", seriesIndex, s.expectedSeriesCount)
 	}
 
-	s.lastMessage = msg
+	// It's possible that loading this batch of chunks has put us over the memory limit
+	// for this query. Return the error in that case.
+	if err := s.setLastMessage(msg); err != nil {
+		return err
+	}
+
 	s.seriesBatch = msg.StreamingSeriesChunks
 	return nil
 }

--- a/pkg/ingester/client/streaming_test.go
+++ b/pkg/ingester/client/streaming_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/storage/chunk"
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
 	"github.com/grafana/mimir/pkg/util/limiter"
 	"github.com/grafana/mimir/pkg/util/test"
 )
@@ -78,7 +80,9 @@ func TestSeriesChunksStreamReader_HappyPaths(t *testing.T) {
 			mockClient := &mockQueryStreamClient{ctx: ctx, batches: testCase.batches}
 			cleanedUp := atomic.NewBool(false)
 			cleanup := func() { cleanedUp.Store(true) }
-			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 5, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+			memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 5, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 
 			for i, expected := range [][]Chunk{series0, series1, series2, series3, series4} {
@@ -119,7 +123,9 @@ func TestSeriesChunksStreamReader_AbortsWhenParentContextCancelled(t *testing.T)
 	cleanup := func() { cleanedUp.Store(true) }
 
 	parentCtx, cancel := context.WithCancel(context.Background())
-	reader := NewSeriesChunksStreamReader(parentCtx, mockClient, "ingester", 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+	memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+	reader := NewSeriesChunksStreamReader(parentCtx, mockClient, "ingester", 3, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	cancel()
 	reader.StartBuffering()
 
@@ -164,7 +170,9 @@ func TestSeriesChunksStreamReader_DoesNotAbortWhenStreamContextCancelled(t *test
 	cleanup := func() { cleanedUp.Store(true) }
 
 	parentCtx := context.Background()
-	reader := NewSeriesChunksStreamReader(parentCtx, mockClient, "ingester", 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+	memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+	reader := NewSeriesChunksStreamReader(parentCtx, mockClient, "ingester", 3, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	cancel()
 	reader.StartBuffering()
 
@@ -187,7 +195,9 @@ func TestSeriesChunksStreamReader_ReadingSeriesOutOfOrder(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 	cleanup := func() {}
-	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+	memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
 	s, err := reader.GetChunks(1)
@@ -213,7 +223,9 @@ func TestSeriesChunksStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 	cleanup := func() {}
-	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+	memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
 	s, err := reader.GetChunks(0)
@@ -244,8 +256,9 @@ func TestSeriesChunksStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) 
 	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 	cleanedUp := atomic.NewBool(false)
 	cleanup := func() { cleanedUp.Store(true) }
-
-	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 3, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+	memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 3, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
 	s, err := reader.GetChunks(0)
@@ -293,8 +306,9 @@ func TestSeriesChunksStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 			mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 			cleanedUp := atomic.NewBool(false)
 			cleanup := func() { cleanedUp.Store(true) }
-
-			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+			memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
+			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 
 			s, err := reader.GetChunks(0)
@@ -314,26 +328,36 @@ func TestSeriesChunksStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 	}
 }
 
-func TestSeriesChunksStreamReader_ChunksLimits(t *testing.T) {
+func TestSeriesChunksStreamReader_QueryAndChunksLimits(t *testing.T) {
 	testCases := map[string]struct {
-		maxChunks     int
-		maxChunkBytes int
-		expectedError string
+		maxChunks          int
+		maxChunkBytes      int
+		maxEstimatedMemory int
+		expectedError      string
 	}{
 		"query under both limits": {
-			maxChunks:     4,
-			maxChunkBytes: 200,
-			expectedError: "",
+			maxChunks:          4,
+			maxChunkBytes:      200,
+			maxEstimatedMemory: 400,
+			expectedError:      "",
 		},
 		"query selects too many chunks": {
-			maxChunks:     2,
-			maxChunkBytes: 200,
-			expectedError: "", // The limit on the number of chunks is enforced earlier, in distributor.queryIngesterStream()
+			maxChunks:          2,
+			maxChunkBytes:      200,
+			maxEstimatedMemory: 400,
+			expectedError:      "", // The limit on the number of chunks is enforced earlier, in distributor.queryIngesterStream()
 		},
 		"query selects too many chunk bytes": {
-			maxChunks:     4,
-			maxChunkBytes: 100,
-			expectedError: "the query exceeded the aggregated chunks size limit (limit: 100 bytes) (err-mimir-max-chunks-bytes-per-query). Consider reducing the time range and/or number of series selected by the query. One way to reduce the number of selected series is to add more label matchers to the query. Otherwise, to adjust the related per-tenant limit, configure -querier.max-fetched-chunk-bytes-per-query, or contact your service administrator.",
+			maxChunks:          4,
+			maxChunkBytes:      100,
+			maxEstimatedMemory: 400,
+			expectedError:      "the query exceeded the aggregated chunks size limit (limit: 100 bytes) (err-mimir-max-chunks-bytes-per-query). Consider reducing the time range and/or number of series selected by the query. One way to reduce the number of selected series is to add more label matchers to the query. Otherwise, to adjust the related per-tenant limit, configure -querier.max-fetched-chunk-bytes-per-query, or contact your service administrator.",
+		},
+		"query uses too much estimated memory": {
+			maxChunks:          4,
+			maxChunkBytes:      200,
+			maxEstimatedMemory: 50,
+			expectedError:      "the query exceeded the maximum allowed estimated amount of memory consumed by a single query (limit: 50 bytes) (err-mimir-max-estimated-memory-consumption-per-query). Consider reducing the time range and/or number of series selected by the query. One way to reduce the number of selected series is to add more label matchers to the query. Otherwise, to adjust the related per-tenant limit, configure -querier.max-estimated-memory-consumption-per-query, or contact your service administrator.",
 		},
 	}
 
@@ -349,8 +373,16 @@ func TestSeriesChunksStreamReader_ChunksLimits(t *testing.T) {
 			mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 			cleanedUp := atomic.NewBool(false)
 			cleanup := func() { cleanedUp.Store(true) }
-			queryMetrics := stats.NewQueryMetrics(prometheus.NewPedanticRegistry())
-			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, limiter.NewQueryLimiter(0, testCase.maxChunkBytes, testCase.maxChunks, 0, queryMetrics), cleanup, log.NewNopLogger())
+			registry := prometheus.NewPedanticRegistry()
+			queryMetrics := stats.NewQueryMetrics(registry)
+			rejectionCount := promauto.With(registry).NewCounter(prometheus.CounterOpts{
+				Name: "rejections",
+				Help: "test",
+			})
+
+			queryLimiter := limiter.NewQueryLimiter(0, testCase.maxChunkBytes, testCase.maxChunks, 0, queryMetrics)
+			memoryTracker := limiting.NewMemoryConsumptionTracker(uint64(testCase.maxEstimatedMemory), rejectionCount)
+			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 
 			_, err := reader.GetChunks(0)
@@ -371,6 +403,10 @@ func TestSeriesChunksStreamReader_ChunksLimits(t *testing.T) {
 				_, err = reader.GetChunks(2)
 				require.EqualError(t, err, "attempted to read series at index 2 from ingester chunks stream, but the stream previously failed and returned an error: "+testCase.expectedError)
 			}
+
+			// Make sure that the reader frees any memory it was using.
+			reader.FreeBuffer()
+			require.Equal(t, uint64(0), memoryTracker.CurrentEstimatedMemoryConsumptionBytes())
 		})
 	}
 }

--- a/pkg/querier/block_streaming.go
+++ b/pkg/querier/block_streaming.go
@@ -209,7 +209,6 @@ func (s *storeGatewayStreamReader) setLastMessage(msg *storepb.SeriesResponse) e
 	if s.lastMessage != nil {
 		return fmt.Errorf("must call FreeBuffer() before storing the next message - this indicates a bug")
 	}
-
 	if err := s.memoryTracker.IncreaseMemoryConsumption(uint64(msg.Size())); err != nil {
 		return err
 	}

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier/batch"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/storage/chunk"
+	"github.com/grafana/mimir/pkg/streamingpromql/limiting"
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
@@ -158,8 +159,10 @@ func createTestStreamReader(batches ...[]client.QueryStreamSeriesChunks) *client
 	}
 
 	cleanup := func() {}
+	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
+	memoryTracker := limiting.NewMemoryConsumptionTracker(0, nil)
 
-	reader := client.NewSeriesChunksStreamReader(ctx, mockClient, "ingester", seriesCount, limiter.NewQueryLimiter(0, 0, 0, 0, nil), cleanup, log.NewNopLogger())
+	reader := client.NewSeriesChunksStreamReader(ctx, mockClient, "ingester", seriesCount, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
 	return reader


### PR DESCRIPTION
#### What this PR does

Include chunks streamed from ingesters that are currently in memory
in the MQE memory usage estimate. The memory tracker for the current
query is propagated through the read path using the context for the
current request.

#### Which issue(s) this PR fixes or relates to

Related #11453

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
