### PR TITLE
HA Tracker: fix old entries with zero valued ElectedAt timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [BUGFIX] Query-frontend: Fix an issue where errors from date/time parsing methods did not include the name of the invalid parameter. #11304
 * [BUGFIX] Query-frontend: Fix a panic in monolithic mode caused by a clash in labels of the `cortex_client_invalid_cluster_validation_label_requests_total` metric definition. #11455
 * [BUGFIX] Compactor: Fix issue where `MimirBucketIndexNotUpdated` can fire even though the index has been updated within the alert threshold. #11303
+* [BUGFIX] Distributor: fix old entries in the HA Tracker with zero valued "elected at" timestamp. #11462
 
 ### Mixin
 

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -638,6 +638,14 @@ func (h *defaultHaTracker) updateKVStore(ctx context.Context, userID, cluster, r
 			}
 			electedAtTime = desc.ElectedAt
 			electedChanges = desc.ElectedChanges
+
+			// In the past we had a bug that caused ElectedAt timestamp to not be set (so it was the default zero value).
+			// The bug is fixed now, but we may still have very old entries around with a zero ElectedAt timestamp.
+			// To avoid misunderstandings, we proactively fix it by setting the ElectedAt to now.
+			if electedAtTime == 0 {
+				electedAtTime = timestamp.FromTime(now)
+			}
+
 			// If our replica is different, wait until the failover time
 			if desc.Replica != replica {
 				if now.Sub(timestamp.Time(desc.ReceivedAt)) < h.cfg.FailoverTimeout {
@@ -649,13 +657,11 @@ func (h *defaultHaTracker) updateKVStore(ctx context.Context, userID, cluster, r
 				electedChanges = desc.ElectedChanges + 1
 			}
 		} else {
-			if desc == nil || (desc.DeletedAt > 0) {
-				// if there is no desc in the kvStore , or if the entry in kvStore is marked as deleted but not yet removed,
-				// set the electedAtTime to avoid being zero
-				// The second part, (desc.DeletedAt > 0), ensures the replica is elected to "revive" the cluster entry after the previous one was deleted.
-				electedAtTime = timestamp.FromTime(now)
-			}
+			// The replica doesn't exist in the KV store yet, or it's marked for deletion. We have to re-create it,
+			// making sure the ElectedAt timestamp is set.
+			electedAtTime = timestamp.FromTime(now)
 		}
+
 		// Attempt to update KVStore to our timestamp and replica.
 		desc = &ReplicaDesc{
 			Replica:        replica,


### PR DESCRIPTION
#### What this PR does

In this PR there are two changes:

1. Simplify the `defaultHaTracker.updateKVStore()` `else` branch, removing a superfluous extra condition (the only case where the code wouldn't enter the extra condition `if desc == nil || (desc.DeletedAt > 0)` is if `DeletedAt` is negative, which can never happen
2. Add a small logic to set `ElectedAt` timestamp in case its value is zero. In the past we had a bug causing zero value to be stored. If a replica has never changed since then, the `ElectedAt` timestamp is still zero (we've seen it in prod). In this case we can just set it to "now": even if it's not true that it has been elected "now" (it was in the past), we do fix it to avoid misunderstandings when you look at the HA tracker web page.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
