### PR TITLE
MQE: Inject memory tracker to context on query execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 * [ENHANCEMENT] Store-gateway: Retry querying blocks from store-gateways with dynamic replication until trying all possible store-gateways. #11354 #11398
 * [ENHANCEMENT] Query-frontend: Avoid some re-parsing of PromQL, to improve efficiency. #11437
 * [ENHANCEMENT] Distributor: Gracefully handle type assertion of WatchPrefix in HA Tracker to continue checking for updates. #11411 #11461
-* [ENHANCEMENT] Querier: Include chunks streamed from store-gateway in Mimir Query Engine memory estimate of query memory usage. #11453
+* [ENHANCEMENT] Querier: Include chunks streamed from store-gateway in Mimir Query Engine memory estimate of query memory usage. #11453 #11465
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/pkg/streamingpromql/operators/selectors/selector.go
+++ b/pkg/streamingpromql/operators/selectors/selector.go
@@ -85,11 +85,6 @@ func (s *Selector) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, 
 		return nil, err
 	}
 
-	// Add the memory consumption tracker to the context of this querier before performing the
-	// query so that we can keep track of memory used loading chunks. We use the context since
-	// we can't modify the Queryable/Querier interfaces and the limit is actually specific to
-	// this request (and hence a good fit for storing in the context).
-	ctx = limiting.AddToContext(ctx, s.MemoryConsumptionTracker)
 	ss := s.querier.Select(ctx, true, hints, s.Matchers...)
 	s.series = newSeriesList(s.MemoryConsumptionTracker)
 

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -558,6 +558,11 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 		defer q.root.Close()
 	}
 
+	// Add the memory consumption tracker to the context of this query before executing it so
+	// that we can pass it to the rest of the read path and keep track of memory used loading
+	// chunks from store-gateways or ingesters.
+	ctx = limiting.AddToContext(ctx, q.memoryConsumptionTracker)
+
 	ctx, cancel := context.WithCancelCause(ctx)
 	q.cancel = cancel
 


### PR DESCRIPTION
#### What this PR does

Inject the memory consumption tracker into the context for the query when the query is executed instead of within a selector.

See https://github.com/grafana/mimir/pull/11453#discussion_r2092540847

#### Which issue(s) this PR fixes or relates to

Related #11453

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
