### PR TITLE
Upgrade mimir-prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -318,7 +318,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250516094314-228dcc2fe250
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250519034039-420755dfadb2
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -544,8 +544,8 @@ github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe h1:yIXAAbLswn
 github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250501145537-53ceaec28820 h1:miNRHpJa5yKnZ76AhIczXQYvcj7EcyvJ/+gTu2gW5c4=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250501145537-53ceaec28820/go.mod h1:V0TUd7DeAE+iAmlOAKtl62xsR/oM06cMV7nVGr3lR7c=
-github.com/grafana/mimir-prometheus v1.8.2-0.20250516094314-228dcc2fe250 h1:BcKzvWA4rtEZjVBykrRmjzkp608d1s+AcIGg2vnKOuw=
-github.com/grafana/mimir-prometheus v1.8.2-0.20250516094314-228dcc2fe250/go.mod h1:fDiZG8/6hzEQXSPCN5e/Ruqy+SgwESD3AIY64b/hkBQ=
+github.com/grafana/mimir-prometheus v1.8.2-0.20250519034039-420755dfadb2 h1:S/fHreYpJuua8SL36mLVUUa4m0p8BSYZtzUBsXrDCZg=
+github.com/grafana/mimir-prometheus v1.8.2-0.20250519034039-420755dfadb2/go.mod h1:fDiZG8/6hzEQXSPCN5e/Ruqy+SgwESD3AIY64b/hkBQ=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=

--- a/vendor/github.com/prometheus/prometheus/model/labels/labels.go
+++ b/vendor/github.com/prometheus/prometheus/model/labels/labels.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build slicelabels
+//go:build !stringlabels && !dedupelabels
 
 package labels
 
@@ -453,7 +453,7 @@ func (b *ScratchBuilder) Add(name, value string) {
 }
 
 // UnsafeAddBytes adds a name/value pair, using []byte instead of string.
-// The default version of this function is unsafe, hence the name.
+// The '-tags stringlabels' version of this function is unsafe, hence the name.
 // This version is safe - it copies the strings immediately - but we keep the same name so everything compiles.
 func (b *ScratchBuilder) UnsafeAddBytes(name, value []byte) {
 	b.add = append(b.add, Label{Name: string(name), Value: string(value)})

--- a/vendor/github.com/prometheus/prometheus/model/labels/labels_stringlabels.go
+++ b/vendor/github.com/prometheus/prometheus/model/labels/labels_stringlabels.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !slicelabels && !dedupelabels
+//go:build stringlabels
 
 package labels
 
@@ -70,7 +70,7 @@ func (ls Labels) IsZero() bool {
 
 // MatchLabels returns a subset of Labels that matches/does not match with the provided label names based on the 'on' boolean.
 // If on is set to true, it returns the subset of labels that match with the provided label names and its inverse when 'on' is set to false.
-// TODO: This is only used in printing an error message.
+// TODO: This is only used in printing an error message
 func (ls Labels) MatchLabels(on bool, names ...string) Labels {
 	b := NewBuilder(ls)
 	if on {
@@ -292,7 +292,6 @@ func Equal(ls, o Labels) bool {
 func EmptyLabels() Labels {
 	return Labels{}
 }
-
 func yoloBytes(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
@@ -365,7 +364,7 @@ func Compare(a, b Labels) int {
 	return +1
 }
 
-// CopyFrom will copy labels from b on top of whatever was in ls previously, reusing memory or expanding if needed.
+// Copy labels from b on top of whatever was in ls previously, reusing memory or expanding if needed.
 func (ls *Labels) CopyFrom(b Labels) {
 	ls.data = b.data // strings are immutable
 }
@@ -435,11 +434,11 @@ func (ls Labels) DropMetricName() Labels {
 }
 
 // InternStrings is a no-op because it would only save when the whole set of labels is identical.
-func (ls *Labels) InternStrings(_ func(string) string) {
+func (ls *Labels) InternStrings(intern func(string) string) {
 }
 
 // ReleaseStrings is a no-op for the same reason as InternStrings.
-func (ls Labels) ReleaseStrings(_ func(string)) {
+func (ls Labels) ReleaseStrings(release func(string)) {
 }
 
 // Builder allows modifying Labels.
@@ -604,7 +603,7 @@ func (b *ScratchBuilder) Add(name, value string) {
 	b.add = append(b.add, Label{Name: name, Value: value})
 }
 
-// UnsafeAddBytes adds a name/value pair using []byte instead of string to reduce memory allocations.
+// Add a name/value pair, using []byte instead of string to reduce memory allocations.
 // The values must remain live until Labels() is called.
 func (b *ScratchBuilder) UnsafeAddBytes(name, value []byte) {
 	b.add = append(b.add, Label{Name: yoloString(name), Value: yoloString(value)})
@@ -632,7 +631,7 @@ func (b *ScratchBuilder) Labels() Labels {
 	return b.output
 }
 
-// Overwrite will write the newly-built Labels out to ls, reusing an internal buffer.
+// Write the newly-built Labels out to ls, reusing an internal buffer.
 // Callers must ensure that there are no other references to ls, or any strings fetched from it.
 func (b *ScratchBuilder) Overwrite(ls *Labels) {
 	size := labelsSize(b.add)
@@ -645,7 +644,7 @@ func (b *ScratchBuilder) Overwrite(ls *Labels) {
 	ls.data = yoloString(b.overwriteBuffer)
 }
 
-// SymbolTable is no-op, just for api parity with dedupelabels.
+// Symbol-table is no-op, just for api parity with dedupelabels.
 type SymbolTable struct{}
 
 func NewSymbolTable() *SymbolTable { return nil }

--- a/vendor/github.com/prometheus/prometheus/model/labels/sharding.go
+++ b/vendor/github.com/prometheus/prometheus/model/labels/sharding.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build slicelabels
+//go:build !stringlabels && !dedupelabels
 
 package labels
 

--- a/vendor/github.com/prometheus/prometheus/model/labels/sharding_stringlabels.go
+++ b/vendor/github.com/prometheus/prometheus/model/labels/sharding_stringlabels.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !slicelabels && !dedupelabels
+//go:build stringlabels
 
 package labels
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1103,7 +1103,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20250516094314-228dcc2fe250
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20250519034039-420755dfadb2
 ## explicit; go 1.23.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1854,7 +1854,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250516094314-228dcc2fe250
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250519034039-420755dfadb2
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20220714140823-09ffed8adbbe
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
#### What this PR does

This PR updates mimir-prometheus to bring in https://github.com/grafana/mimir-prometheus/pull/872.

This will have no direct impact on Mimir as it explicitly sets `stringlabels` as a build tag.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
