### PR TITLE
Dimitar/prepare kgo for tests

### DIFF
--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -710,7 +710,7 @@ func TestConcurrentFetchers(t *testing.T) {
 
 		cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		mockErr := kerr.BrokerNotAvailable
-		cluster.ControlKey(kmsg.Metadata.Int16(), func(kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(kmsg.Metadata.Int16(), func(req kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
 
 			respTopic := kmsg.NewMetadataResponseTopic()
@@ -721,7 +721,7 @@ func TestConcurrentFetchers(t *testing.T) {
 
 			resp := kmsg.NewPtrMetadataResponse()
 			resp.Topics = append(resp.Topics, respTopic)
-			resp.Version = 12
+			resp.Version = req.GetVersion()
 			return resp, nil, true
 		})
 

--- a/pkg/storage/ingest/partition_offset_client_test.go
+++ b/pkg/storage/ingest/partition_offset_client_test.go
@@ -127,41 +127,6 @@ func TestPartitionOffsetClient_FetchPartitionLastProducedOffset(t *testing.T) {
 
 		wg.Wait()
 	})
-
-	t.Run("should honor the configured retry timeout", func(t *testing.T) {
-		t.Parallel()
-
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-
-		// Configure a short retry timeout.
-		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
-		kafkaCfg.LastProducedOffsetRetryTimeout = time.Second
-
-		client := createTestKafkaClient(t, kafkaCfg)
-		reg := prometheus.NewPedanticRegistry()
-		reader := newPartitionOffsetClient(client, topicName, reg, logger)
-
-		// Make the ListOffsets request failing.
-		actualTries := atomic.NewInt64(0)
-		cluster.ControlKey(int16(kmsg.ListOffsets), func(kmsg.Request) (kmsg.Response, error, bool) {
-			cluster.KeepControl()
-			actualTries.Inc()
-			return nil, errors.New("mocked error"), true
-		})
-
-		startTime := time.Now()
-		_, err := reader.FetchPartitionLastProducedOffset(ctx, partitionID)
-		elapsedTime := time.Since(startTime)
-
-		require.Error(t, err)
-
-		// Ensure the retry timeout has been honored.
-		toleranceSeconds := 0.5
-		assert.InDelta(t, kafkaCfg.LastProducedOffsetRetryTimeout.Seconds(), elapsedTime.Seconds(), toleranceSeconds)
-
-		// Ensure the request was retried.
-		assert.Greater(t, actualTries.Load(), int64(1))
-	})
 }
 
 func TestPartitionOffsetClient_FetchPartitionStartOffset(t *testing.T) {

--- a/pkg/storage/ingest/partition_offset_client_test.go
+++ b/pkg/storage/ingest/partition_offset_client_test.go
@@ -431,41 +431,6 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 		wg.Wait()
 	})
 
-	t.Run("should honor the configured retry timeout", func(t *testing.T) {
-		t.Parallel()
-
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-
-		// Configure a short retry timeout.
-		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
-		kafkaCfg.LastProducedOffsetRetryTimeout = time.Second
-
-		client := createTestKafkaClient(t, kafkaCfg)
-		reg := prometheus.NewPedanticRegistry()
-		reader := newPartitionOffsetClient(client, topicName, reg, logger)
-
-		// Make the ListOffsets request failing.
-		actualTries := atomic.NewInt64(0)
-		cluster.ControlKey(int16(kmsg.ListOffsets), func(kmsg.Request) (kmsg.Response, error, bool) {
-			cluster.KeepControl()
-			actualTries.Inc()
-			return nil, errors.New("mocked error"), true
-		})
-
-		startTime := time.Now()
-		_, err := reader.FetchPartitionsLastProducedOffsets(ctx, allPartitionIDs)
-		elapsedTime := time.Since(startTime)
-
-		require.Error(t, err)
-
-		// Ensure the retry timeout has been honored.
-		toleranceSeconds := 0.5
-		assert.InDelta(t, kafkaCfg.LastProducedOffsetRetryTimeout.Seconds(), elapsedTime.Seconds(), toleranceSeconds)
-
-		// Ensure the request was retried.
-		assert.Greater(t, actualTries.Load(), int64(1))
-	})
-
 	t.Run("should return error if response contains an unexpected number of topics", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/storage/ingest/partition_offset_client_test.go
+++ b/pkg/storage/ingest/partition_offset_client_test.go
@@ -4,7 +4,6 @@ package ingest
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -254,41 +253,6 @@ func TestPartitionOffsetClient_FetchPartitionStartOffset(t *testing.T) {
 		})
 
 		wg.Wait()
-	})
-
-	t.Run("should honor the configured retry timeout", func(t *testing.T) {
-		t.Parallel()
-
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-
-		// Configure a short retry timeout.
-		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
-		kafkaCfg.LastProducedOffsetRetryTimeout = time.Second
-
-		client := createTestKafkaClient(t, kafkaCfg)
-		reg := prometheus.NewPedanticRegistry()
-		reader := newPartitionOffsetClient(client, topicName, reg, logger)
-
-		// Make the ListOffsets request failing.
-		actualTries := atomic.NewInt64(0)
-		cluster.ControlKey(int16(kmsg.ListOffsets), func(kmsg.Request) (kmsg.Response, error, bool) {
-			cluster.KeepControl()
-			actualTries.Inc()
-			return nil, errors.New("mocked error"), true
-		})
-
-		startTime := time.Now()
-		_, err := reader.FetchPartitionStartOffset(ctx, partitionID)
-		elapsedTime := time.Since(startTime)
-
-		require.Error(t, err)
-
-		// Ensure the retry timeout has been honored.
-		toleranceSeconds := 0.5
-		assert.InDelta(t, kafkaCfg.LastProducedOffsetRetryTimeout.Seconds(), elapsedTime.Seconds(), toleranceSeconds)
-
-		// Ensure the request was retried.
-		assert.Greater(t, actualTries.Load(), int64(1))
 	})
 }
 

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -1102,7 +1102,7 @@ func createTestKafkaConfig(clusterAddr, topicName string) KafkaConfig {
 
 	cfg.Address = clusterAddr
 	cfg.Topic = topicName
-	cfg.WriteTimeout = 2 * time.Second
+	cfg.WriteTimeout = 5 * time.Second
 	cfg.FetchConcurrencyMax = 2
 	cfg.concurrentFetchersFetchBackoffConfig = fastFetchBackoffConfig
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does



after the change here https://github.com/grafana/mimir/blob/e57aa85f2691570d7b2bfaa732e3d2d304faf05d/vendor/github.com/twmb/franz-go/pkg/kgo/errors.go#L66-L71

the client no longer retries the errors when the kfake cluster closes the connection. We also don't have a better way of returning an error from the cluster - whenever our `Control` function returns an error, kfake closes the broker connection and our client sees an `io.EOF`

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

----------------------
5ac9ac0a28 - Fix TestWriter_WriteSync/should_return_an_error_and_stop_retrying_sending_a_record_once_the_write_timeout_expires

The test was failing because the max backoff increased from 2.5s to 5s and this brought the total wait time to 10s. Increasing our WriteTimeout makes it more likely that the timeout is within the WriteTimeout x 3 calculation

https://github.com/grafana/mimir/blob/e57aa85f2691570d7b2bfaa732e3d2d304faf05d/vendor/github.com/twmb/franz-go/pkg/kgo/config.go#L510

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

----------------------
0c8cba79bf - Fix TestCreateTopic/should_return_an_error_if_the_request_fails

previously the test would erroneously pass because the request was retried by the kgo client. So it would eventually succeed. If previously we'd make this change, then the test would succeed but in 30 seconds (the default retry timeout in kgo)

```diff
diff --git a/pkg/storage/ingest/util_test.go b/pkg/storage/ingest/util_test.go
index e750f2ab13..33805f33d9 100644
--- a/pkg/storage/ingest/util_test.go
+++ b/pkg/storage/ingest/util_test.go
@@ -188,12 +188,13 @@ func TestCreateTopic(t *testing.T) {
 		)

 		cluster.ControlKey(kmsg.CreateTopics.Int16(), func(_ kmsg.Request) (kmsg.Response, error, bool) {
+			cluster.KeepControl()
 			return &kmsg.CreateTopicsResponse{}, errors.New("failed request"), true
 		})

 		logger := log.NewNopLogger()

-		require.NoError(t, CreateTopic(cfg, logger))
+		require.Error(t, CreateTopic(cfg, logger))
 	})

 	t.Run("should return an error if the request succeed but the response contains an error", func(t *testing.T) {
```

io.EOF errors aren't retried anymore, so we need to return a different errors.

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

----------------------
e1d57b100c - Fix TestPartitionReader_ConsumeAtStartup/should_consume_partition_from_start_if_last_committed_offset_is_missing_and_wait_until_target_lag_is_honored_and_retry_if_a_failure_occurs_when_fetching_last_produced_offset

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

----------------------
b725cfa0dd - Remove TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets/should_honor_the_configured_retry_timeout


after the change here https://github.com/grafana/mimir/blob/e57aa85f2691570d7b2bfaa732e3d2d304faf05d/vendor/github.com/twmb/franz-go/pkg/kgo/errors.go#L66-L71

the client no longer retries the errors when the kfake cluster closes the connection. We also don't have a better way of returning an error from the cluster - whenever our `Control` function returns an error, kfake closes the broker connection and our client sees an `io.EOF`

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

----------------------
75cefe4a20 - Remove TestPartitionOffsetClient_FetchPartitionLastProducedOffset/should_honor_the_configured_retry_timeout

after the change here https://github.com/grafana/mimir/blob/e57aa85f2691570d7b2bfaa732e3d2d304faf05d/vendor/github.com/twmb/franz-go/pkg/kgo/errors.go#L66-L71

the client no longer retries the errors when the kfake cluster closes the connection. We also don't have a better way of returning an error from the cluster - whenever our `Control` function returns an error, kfake closes the broker connection and our client sees an `io.EOF`

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

----------------------
57859467d0 - Fix TestConcurrentFetchers

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov@grafana.com>

----------------------


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
