### PR TITLE
Add new test case for query sharding to test summing a histogram_sum

### DIFF
--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -570,6 +570,10 @@ func TestQuerySharding_Correctness(t *testing.T) {
 			query:                  `sum(metric_native_histogram)`,
 			expectedShardedQueries: 1,
 		},
+		`sum(histogram_sum(metric_native_histogram))`: {
+			query:                  `sum(histogram_sum(metric_native_histogram))`,
+			expectedShardedQueries: 1,
+		},
 		`sum by (group_1) (metric_native_histogram)`: {
 			query:                  `sum by (group_1) (metric_native_histogram)`,
 			expectedShardedQueries: 1,


### PR DESCRIPTION
#### What this PR does

Adds a new test case to test summing a histogram_sum, ensuring that it returns the same results with or without query sharding.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/issues/11102

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Only updating a unit test.