### PR TITLE
ruler: handle gRPC status error from when tenant has rules disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 * [ENHANCEMENT] OTLP: Add support for converting OTel explicit bucket histograms to Prometheus native histograms with custom buckets using the `distributor.otel-convert-histograms-to-nhcb` flag. #11077
 * [ENHANCEMENT] Add configurable per-tenant `limited_queries`, which you can only run at or less than an allowed frequency. #11097
 * [ENHANCEMENT] Ingest-Storage: Add `ingest-storage.kafka.producer-record-version` to allow control Kafka record versioning. #11244
-* [ENHANCEMENT] Ruler: Update `<prometheus-http-prefix>/api/v1/rules` and `<prometheus-http-prefix>/api/v1/alerts` to reply with HTTP error 422 if rule evaluation is completely disabled for the tenant. If only recording rule- or alerting rule evaluation is disabled for the tenant, the response now includes a corresponding warning. #11321
+* [ENHANCEMENT] Ruler: Update `<prometheus-http-prefix>/api/v1/rules` and `<prometheus-http-prefix>/api/v1/alerts` to reply with HTTP error 422 if rule evaluation is completely disabled for the tenant. If only recording rule- or alerting rule evaluation is disabled for the tenant, the response now includes a corresponding warning. #11321 #11495
 * [ENHANCEMENT] Add tenant configuration block `ruler_alertmanager_client_config` which allows the Ruler's Alertmanager client options to be specified on a per-tenant basis. #10816
 * [ENHANCEMENT] Store-gateway: Retry querying blocks from store-gateways with dynamic replication until trying all possible store-gateways. #11354 #11398
 * [ENHANCEMENT] Query-frontend: Avoid some re-parsing of PromQL, to improve efficiency. #11437


### PR DESCRIPTION
#### What this PR does

This is the fixup for https://github.com/grafana/mimir/pull/11321

The above changes missed the part that returned error is wrapped into a gRPC status error

```
rpc error: code = Unknown desc = all rule evaluation is disabled for user
```

This causes the ruler to reply with HTTP status 500.

Tested these new changes in a dev cluster:

```
› curl --no-progress-meter -g -v 'http://127.1:8080/prometheus/api/v1/rules' -H 'x-scope-orgid: 10637'

< HTTP/1.1 422 Unprocessable Entity
< Content-Type: application/json
< Server: GEM/vldmr-ruler-err-tenant-rule-eval-disabled-fe79082a-WIP
< Vary: Accept-Encoding
< Date: Tue, 20 May 2025 12:53:16 GMT
< Content-Length: 109
<
{"status":"error","data":null,"errorType":"execution","error":"rule evaluation is disabled for tenant 10637"}
```