### PR TITLE
Revert "Query-frontend: Avoid some re-parsing of PromQL (#11437)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@
 * [ENHANCEMENT] Ruler: Update `<prometheus-http-prefix>/api/v1/rules` and `<prometheus-http-prefix>/api/v1/alerts` to reply with HTTP error 422 if rule evaluation is completely disabled for the tenant. If only recording rule- or alerting rule evaluation is disabled for the tenant, the response now includes a corresponding warning. #11321 #11495
 * [ENHANCEMENT] Add tenant configuration block `ruler_alertmanager_client_config` which allows the Ruler's Alertmanager client options to be specified on a per-tenant basis. #10816
 * [ENHANCEMENT] Store-gateway: Retry querying blocks from store-gateways with dynamic replication until trying all possible store-gateways. #11354 #11398
-* [ENHANCEMENT] Query-frontend: Avoid some re-parsing of PromQL, to improve efficiency. #11437
 * [ENHANCEMENT] Distributor: Gracefully handle type assertion of WatchPrefix in HA Tracker to continue checking for updates. #11411 #11461
 * [ENHANCEMENT] Querier: Include chunks streamed from store-gateway in Mimir Query Engine memory estimate of query memory usage. #11453 #11465
 * [ENHANCEMENT] Querier: Include chunks streamed from ingester in Mimir Query Engine memory estimate of query memory usage. #11457

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -125,8 +125,6 @@ type MetricsQueryRequest interface {
 	GetStep() int64
 	// GetQuery returns the query of the request.
 	GetQuery() string
-	// GetParsedQuery returns the query, parsed into an AST.
-	GetParsedQuery() parser.Expr
 	// GetMinT returns the minimum timestamp in milliseconds of data to be queried,
 	// as determined from the start timestamp and any range vector or offset in the query.
 	GetMinT() int64

--- a/pkg/frontend/querymiddleware/experimental_functions.go
+++ b/pkg/frontend/querymiddleware/experimental_functions.go
@@ -58,7 +58,11 @@ func (m *experimentalFunctionsMiddleware) Do(ctx context.Context, req MetricsQue
 		return m.next.Do(ctx, req)
 	}
 
-	funcs := containedExperimentalFunctions(req.GetParsedQuery())
+	expr, err := parser.ParseExpr(req.GetQuery())
+	if err != nil {
+		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
+	}
+	funcs := containedExperimentalFunctions(expr)
 	if len(funcs) == 0 {
 		// This query does not contain any experimental functions, so we can continue to the next middleware.
 		return m.next.Do(ctx, req)

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -133,10 +133,6 @@ func (r *PrometheusRangeQueryRequest) GetQuery() string {
 	return ""
 }
 
-func (r *PrometheusRangeQueryRequest) GetParsedQuery() parser.Expr {
-	return r.queryExpr
-}
-
 // GetMinT returns the minimum timestamp in milliseconds of data to be queried,
 // as determined from the start timestamp and any range vector or offset in the query.
 func (r *PrometheusRangeQueryRequest) GetMinT() int64 {
@@ -319,10 +315,6 @@ func (r *PrometheusInstantQueryRequest) GetQuery() string {
 		return r.queryExpr.String()
 	}
 	return ""
-}
-
-func (r *PrometheusInstantQueryRequest) GetParsedQuery() parser.Expr {
-	return r.queryExpr
 }
 
 func (r *PrometheusInstantQueryRequest) GetStart() int64 {

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -106,7 +106,13 @@ func (s *querySharding) Do(ctx context.Context, r MetricsQueryRequest) (Response
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
-	totalShards := s.getShardsForQuery(ctx, tenantIDs, r, r.GetParsedQuery(), log)
+	// Parse the query.
+	queryExpr, err := parser.ParseExpr(r.GetQuery())
+	if err != nil {
+		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
+	}
+
+	totalShards := s.getShardsForQuery(ctx, tenantIDs, r, queryExpr, log)
 	if totalShards <= 1 {
 		level.Debug(log).Log("msg", "query sharding is disabled for this query or tenant")
 		return s.next.Do(ctx, r)

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -282,16 +282,6 @@ func (r *remoteReadQueryRequest) GetQuery() string {
 	return r.promQuery
 }
 
-func (r *remoteReadQueryRequest) GetParsedQuery() parser.Expr {
-	if r.promQuery != "" {
-		expr, err := parser.ParseExpr(r.promQuery)
-		if err == nil {
-			return expr
-		}
-	}
-	return nil
-}
-
 func (r *remoteReadQueryRequest) GetHeaders() []*PrometheusHeader {
 	return nil
 }

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -326,10 +326,14 @@ func areEvaluationTimeModifiersCachable(r MetricsQueryRequest, maxCacheTime int6
 	if !strings.Contains(query, "@") && !strings.Contains(query, "offset") {
 		return true, ""
 	}
-	expr := r.GetParsedQuery()
+	expr, err := parser.ParseExpr(query)
+	if err != nil {
+		// We are being pessimistic in such cases.
+		return false, notCachableReasonModifiersNotCachableFailedParse
+	}
 
 	// This resolves the start() and end() used with the @ modifier.
-	expr, err := promql.PreprocessExpr(expr, timestamp.Time(r.GetStart()), timestamp.Time(r.GetEnd()))
+	expr, err = promql.PreprocessExpr(expr, timestamp.Time(r.GetStart()), timestamp.Time(r.GetEnd()))
 	if err != nil {
 		// We are being pessimistic in such cases.
 		return false, notCachableReasonModifiersNotCachableFailedPreprocess

--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
@@ -140,7 +141,14 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 	defer cancel()
 	mapper := astmapper.NewSubquerySpinOffMapper(mapperCtx, s.defaultStepFunc, spanLog, mapperStats)
 
-	spinOffQuery, err := mapper.Map(req.GetParsedQuery())
+	expr, err := parser.ParseExpr(req.GetQuery())
+	if err != nil {
+		level.Warn(spanLog).Log("msg", "failed to parse query", "err", err)
+		s.metrics.spinOffSkipped.WithLabelValues(subquerySpinoffSkippedReasonParsingFailed).Inc()
+		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
+	}
+
+	spinOffQuery, err := mapper.Map(expr)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
 			level.Error(spanLog).Log("msg", "timeout while spinning off subqueries, please fill in a bug report with this query, falling back to try executing without spin-off", "err", err)

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -660,7 +660,7 @@ func doRequests(ctx context.Context, downstream MetricsQueryHandler, reqs []Metr
 func splitQueryByInterval(req MetricsQueryRequest, interval time.Duration) ([]MetricsQueryRequest, error) {
 	// Replace @ modifier function to their respective constant values in the query.
 	// This way subqueries will be evaluated at the same time as the parent query.
-	query, err := evaluateAtModifierFunction(req.GetParsedQuery(), req.GetStart(), req.GetEnd())
+	query, err := evaluateAtModifierFunction(req.GetQuery(), req.GetStart(), req.GetEnd())
 	if err != nil {
 		return nil, err
 	}
@@ -695,10 +695,10 @@ func splitQueryByInterval(req MetricsQueryRequest, interval time.Duration) ([]Me
 // evaluateAtModifierFunction parse the query and evaluates the `start()` and `end()` at modifier functions into actual constant timestamps.
 // For example given the start of the query is 10.00, `http_requests_total[1h] @ start()` query will be replaced with `http_requests_total[1h] @ 10.00`
 // If the modifier is already a constant, it will be returned as is.
-func evaluateAtModifierFunction(expr parser.Expr, start, end int64) (string, error) {
-	expr, err := cloneExpr(expr) // Clone to avoid changing the original.
+func evaluateAtModifierFunction(query string, start, end int64) (string, error) {
+	expr, err := parser.ParseExpr(query)
 	if err != nil {
-		return "", err
+		return "", apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}
 	parser.Inspect(expr, func(n parser.Node, _ []parser.Node) error {
 		switch exprAt := n.(type) {
@@ -722,11 +722,6 @@ func evaluateAtModifierFunction(expr parser.Expr, start, end int64) (string, err
 		return nil
 	})
 	return expr.String(), nil
-}
-
-// cloneExpr is a helper function to clone an expr.
-func cloneExpr(expr parser.Expr) (parser.Expr, error) {
-	return parser.ParseExpr(expr.String())
 }
 
 // Round up to the step before the next interval boundary.

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
+	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/util"
@@ -2024,14 +2025,13 @@ func Test_evaluateAtModifier(t *testing.T) {
 				[2m:])
 			[10m:])`, nil,
 		},
+		{"sum by (foo) (bar[buzz])", "foo{}", apierror.New(apierror.TypeBadData, `invalid parameter "query": 1:19: parse error: unexpected character in duration expression: 'b'`)},
 	} {
 		t.Run(tt.in, func(t *testing.T) {
 			t.Parallel()
-			expr, err := parser.ParseExpr(tt.in)
-			require.NoError(t, err)
 			expectedExpr, err := parser.ParseExpr(tt.expected)
 			require.NoError(t, err)
-			out, err := evaluateAtModifierFunction(expr, start, end)
+			out, err := evaluateAtModifierFunction(tt.in, start, end)
 			if tt.err != nil {
 				require.Equal(t, tt.err, err)
 				return

--- a/pkg/frontend/querymiddleware/split_by_instant_interval.go
+++ b/pkg/frontend/querymiddleware/split_by_instant_interval.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
@@ -125,7 +126,14 @@ func (s *splitInstantQueryByIntervalMiddleware) Do(ctx context.Context, req Metr
 	defer cancel()
 	mapper := astmapper.NewInstantQuerySplitter(mapperCtx, splitInterval, s.logger, mapperStats)
 
-	instantSplitQuery, err := mapper.Map(req.GetParsedQuery())
+	expr, err := parser.ParseExpr(req.GetQuery())
+	if err != nil {
+		level.Warn(spanLog).Log("msg", "failed to parse query", "err", err)
+		s.metrics.splittingSkipped.WithLabelValues(skippedReasonParsingFailed).Inc()
+		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
+	}
+
+	instantSplitQuery, err := mapper.Map(expr)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
 			level.Error(spanLog).Log("msg", "timeout while splitting query by instant interval, please fill in a bug report with this query, falling back to try executing without splitting", "err", err)

--- a/pkg/frontend/querymiddleware/stats.go
+++ b/pkg/frontend/querymiddleware/stats.go
@@ -61,7 +61,11 @@ func (s queryStatsMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (
 }
 
 func (s queryStatsMiddleware) trackRegexpMatchers(req MetricsQueryRequest) {
-	for _, selectors := range parser.ExtractSelectors(req.GetParsedQuery()) {
+	expr, err := parser.ParseExpr(req.GetQuery())
+	if err != nil {
+		return
+	}
+	for _, selectors := range parser.ExtractSelectors(expr) {
 		for _, matcher := range selectors {
 			if matcher.Type != labels.MatchRegexp && matcher.Type != labels.MatchNotRegexp {
 				continue


### PR DESCRIPTION
#### What this PR does

Revert #11437, as we've found it can cause query-frontend panics. This reverts commit 7c71ae995027cdd835cc1180fbdfc0a9c1af4831.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
