### PR TITLE
fix scheduler panic when serving dequeue request for disconnected querier-worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [BUGFIX] Query-frontend: Fix a panic in monolithic mode caused by a clash in labels of the `cortex_client_invalid_cluster_validation_label_requests_total` metric definition. #11455
 * [BUGFIX] Compactor: Fix issue where `MimirBucketIndexNotUpdated` can fire even though the index has been updated within the alert threshold. #11303
 * [BUGFIX] Distributor: fix old entries in the HA Tracker with zero valued "elected at" timestamp. #11462
+* [BUGFIX] Query-scheduler: Fix issue where deregistered querier goroutines can cause a panic if their backlogged dequeue requests are serviced #11510
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 * [BUGFIX] Query-frontend: Fix a panic in monolithic mode caused by a clash in labels of the `cortex_client_invalid_cluster_validation_label_requests_total` metric definition. #11455
 * [BUGFIX] Compactor: Fix issue where `MimirBucketIndexNotUpdated` can fire even though the index has been updated within the alert threshold. #11303
 * [BUGFIX] Distributor: fix old entries in the HA Tracker with zero valued "elected at" timestamp. #11462
-* [BUGFIX] Query-scheduler: Fix issue where deregistered querier goroutines can cause a panic if their backlogged dequeue requests are serviced #11510
+* [BUGFIX] Query-scheduler: Fix issue where deregistered querier goroutines can cause a panic if their backlogged dequeue requests are serviced. #11510
 
 ### Mixin
 

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -27,10 +27,11 @@ const (
 )
 
 var (
-	ErrInvalidTenantID     = errors.New("invalid tenant id")
-	ErrTooManyRequests     = errors.New("too many outstanding requests")
-	ErrStopped             = errors.New("queue is stopped")
-	ErrQuerierShuttingDown = errors.New("querier has informed the scheduler it is shutting down")
+	ErrInvalidTenantID           = errors.New("invalid tenant id")
+	ErrTooManyRequests           = errors.New("too many outstanding requests")
+	ErrStopped                   = errors.New("queue is stopped")
+	ErrQuerierShuttingDown       = errors.New("querier has informed the scheduler it is shutting down")
+	ErrQuerierWorkerDisconnected = errors.New("querier worker has disconnected")
 )
 
 type RequestKey struct {

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -338,7 +338,9 @@ func (q *RequestQueue) dispatcherLoop() {
 			for currentElement != nil {
 				waitingDequeueReq := currentElement.Value.(*QuerierWorkerDequeueRequest)
 				waitingDequeueReq.sendError(ErrStopped)
-				currentElement = currentElement.Next()
+				nextElement := currentElement.Next()
+				q.waitingDequeueRequestsToDispatch.Remove(currentElement)
+				currentElement = nextElement
 			}
 
 			if !q.queueBroker.isEmpty() {

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -117,12 +117,13 @@ type RequestQueue struct {
 	stopRequested chan struct{} // Written to by stop() to wake up dispatcherLoop() in response to a stop request.
 	stopCompleted chan struct{} // Closed by dispatcherLoop() after a stop is requested and the dispatcher has stopped.
 
-	requestsToEnqueue                chan requestToEnqueue
-	requestsSent                     chan *SchedulerRequest
-	requestsCompleted                chan *SchedulerRequest
-	querierWorkerOperations          chan *querierWorkerOperation
-	waitingDequeueRequests           chan *QuerierWorkerDequeueRequest
-	waitingDequeueRequestsToDispatch *list.List
+	requestsToEnqueue                     chan requestToEnqueue
+	requestsSent                          chan *SchedulerRequest
+	requestsCompleted                     chan *SchedulerRequest
+	querierWorkerOperations               chan *querierWorkerOperation
+	waitingDequeueRequests                chan *QuerierWorkerDequeueRequest
+	waitingDequeueRequestsToDispatch      *list.List
+	waitingDequeueRequestsToDispatchCount *atomic.Int64
 
 	// QueryComponentUtilization encapsulates tracking requests from the time they are forwarded to a querier
 	// to the time are completed by the querier or failed due to cancel, timeout, or disconnect.
@@ -238,12 +239,13 @@ func NewRequestQueue(
 		stopRequested: make(chan struct{}),
 		stopCompleted: make(chan struct{}),
 
-		requestsToEnqueue:                make(chan requestToEnqueue),
-		requestsSent:                     make(chan *SchedulerRequest),
-		requestsCompleted:                make(chan *SchedulerRequest),
-		querierWorkerOperations:          make(chan *querierWorkerOperation),
-		waitingDequeueRequests:           make(chan *QuerierWorkerDequeueRequest),
-		waitingDequeueRequestsToDispatch: list.New(),
+		requestsToEnqueue:                     make(chan requestToEnqueue),
+		requestsSent:                          make(chan *SchedulerRequest),
+		requestsCompleted:                     make(chan *SchedulerRequest),
+		querierWorkerOperations:               make(chan *querierWorkerOperation),
+		waitingDequeueRequests:                make(chan *QuerierWorkerDequeueRequest),
+		waitingDequeueRequestsToDispatch:      list.New(),
+		waitingDequeueRequestsToDispatchCount: atomic.NewInt64(0),
 
 		QueryComponentUtilization: queryComponentCapacity,
 		queueBroker:               newQueueBroker(maxOutstandingPerTenant, forgetDelay),
@@ -310,6 +312,7 @@ func (q *RequestQueue) dispatcherLoop() {
 			requestSent := q.trySendNextRequestForQuerier(waitingDequeueReq)
 			if !requestSent {
 				// No requests available for this querier; add it to the list to try later.
+				q.waitingDequeueRequestsToDispatchCount.Inc()
 				q.waitingDequeueRequestsToDispatch.PushBack(waitingDequeueReq)
 			}
 		}
@@ -322,6 +325,7 @@ func (q *RequestQueue) dispatcherLoop() {
 				nextElement := currentElement.Next() // We have to capture the next element before calling Remove(), as Remove() clears it.
 
 				if q.trySendNextRequestForQuerier(call) {
+					q.waitingDequeueRequestsToDispatchCount.Dec()
 					q.waitingDequeueRequestsToDispatch.Remove(currentElement)
 				}
 
@@ -339,6 +343,7 @@ func (q *RequestQueue) dispatcherLoop() {
 				waitingDequeueReq := currentElement.Value.(*QuerierWorkerDequeueRequest)
 				waitingDequeueReq.sendError(ErrStopped)
 				nextElement := currentElement.Next()
+				q.waitingDequeueRequestsToDispatchCount.Dec()
 				q.waitingDequeueRequestsToDispatch.Remove(currentElement)
 				currentElement = nextElement
 			}

--- a/pkg/scheduler/queue/queue_broker.go
+++ b/pkg/scheduler/queue/queue_broker.go
@@ -132,6 +132,11 @@ func (qb *queueBroker) dequeueRequestForQuerier(
 		return nil, nil, qb.tenantQuerierAssignments.queuingAlgorithm.TenantOrderIndex(), ErrQuerierShuttingDown
 	}
 
+	// check if the specific querier-worker connection was deregistered since its dequeue request was submitted
+	if dequeueReq.WorkerID == unregisteredWorkerID {
+		return nil, nil, qb.tenantQuerierAssignments.queuingAlgorithm.TenantOrderIndex(), ErrQuerierWorkerDisconnected
+	}
+
 	var queuePath tree.QueuePath
 	var queueElement any
 	queuePath, queueElement = qb.tree.Dequeue(

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -442,6 +442,11 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 		dequeueReq := queue.NewQuerierWorkerDequeueRequest(querierWorkerConn, lastTenantIdx)
 		queryReq, idx, err := s.requestQueue.AwaitRequestForQuerier(dequeueReq)
 		if err != nil {
+			// The error returned can either be ErrQuerierShuttingDown or ErrQuerierWorkerDisconnected.
+			// ErrQuerierShuttingDown is a control-flow message between services to exit this loop.
+			// (see note in transformRequestQueueError).
+			// ErrQuerierWorkerDisconnected is caused by connection/goroutine crash;
+			// we expect this loop is no longer alive to receive the error anyway.
 			return s.transformRequestQueueError(err)
 		}
 


### PR DESCRIPTION
and reproduce with test

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #11337 

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
