### PR TITLE
Improve err-mimir-sample-duplicate-timestamp error message

### DIFF
--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -49,7 +49,7 @@ type TSDBBuilder struct {
 // We use this only to identify the soft errors.
 var softErrProcessor = mimir_storage.NewSoftAppendErrorProcessor(
 	func() {}, func(int64, []mimirpb.LabelAdapter) {}, func(int64, []mimirpb.LabelAdapter) {},
-	func(int64, []mimirpb.LabelAdapter) {}, func(int64, []mimirpb.LabelAdapter) {}, func(int64, []mimirpb.LabelAdapter) {},
+	func(int64, []mimirpb.LabelAdapter) {}, func(int64, []mimirpb.LabelAdapter) {}, func(string, int64, []mimirpb.LabelAdapter) {},
 	func([]mimirpb.LabelAdapter) {}, func([]mimirpb.LabelAdapter) {}, func(error, int64, []mimirpb.LabelAdapter) {},
 	func(error, int64, []mimirpb.LabelAdapter) {}, func(error, int64, []mimirpb.LabelAdapter) {},
 	func(error, int64, []mimirpb.LabelAdapter) {}, func(error, int64, []mimirpb.LabelAdapter) {},

--- a/pkg/ingester/errors.go
+++ b/pkg/ingester/errors.go
@@ -129,8 +129,8 @@ func newSampleOutOfOrderError(timestamp model.Time, labels []mimirpb.LabelAdapte
 	return newSampleError(globalerror.SampleOutOfOrder, "the sample has been rejected because another sample with a more recent timestamp has already been ingested and out-of-order samples are not allowed", timestamp, labels)
 }
 
-func newSampleDuplicateTimestampError(timestamp model.Time, labels []mimirpb.LabelAdapter) sampleError {
-	return newSampleError(globalerror.SampleDuplicateTimestamp, "the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested", timestamp, labels)
+func newSampleDuplicateTimestampError(errMsg string, timestamp model.Time, labels []mimirpb.LabelAdapter) sampleError {
+	return newSampleError(globalerror.SampleDuplicateTimestamp, errMsg, timestamp, labels)
 }
 
 // exemplarError is an ingesterError indicating a problem with an exemplar.

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -167,8 +167,8 @@ func TestNewSampleError(t *testing.T) {
 			expectedMsg: `the sample has been rejected because another sample with a more recent timestamp has already been ingested and out-of-order samples are not allowed (err-mimir-sample-out-of-order). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series test`,
 		},
 		"newSampleDuplicateTimestampError": {
-			err:         newSampleDuplicateTimestampError(timestamp, seriesLabels),
-			expectedMsg: `the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested (err-mimir-sample-duplicate-timestamp). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series test`,
+			err:         newSampleDuplicateTimestampError(fmt.Sprintf("duplicate sample for timestamp %d; overrides not allowed: existing %g, new value %g", timestamp, 1.5, 2.5), timestamp, seriesLabels),
+			expectedMsg: `duplicate sample for timestamp 1575043969; overrides not allowed: existing 1.5, new value 2.5 (err-mimir-sample-duplicate-timestamp). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series test`,
 		},
 	}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -1279,11 +1279,11 @@ func (i *Ingester) PushWithCleanup(ctx context.Context, req *mimirpb.WriteReques
 					return newSampleTimestampTooFarInFutureError(model.Time(timestamp), labels)
 				})
 			},
-			func(timestamp int64, labels []mimirpb.LabelAdapter) {
+			func(errMsg string, timestamp int64, labels []mimirpb.LabelAdapter) {
 				stats.newValueForTimestampCount++
 				cast.IncrementDiscardedSamples(labels, 1, reasonNewValueForTimestamp, startAppend)
 				updateFirstPartial(i.errorSamplers.sampleDuplicateTimestamp, func() softError {
-					return newSampleDuplicateTimestampError(model.Time(timestamp), labels)
+					return newSampleDuplicateTimestampError(errMsg, model.Time(timestamp), labels)
 				})
 			},
 			func(labels []mimirpb.LabelAdapter) {

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -3117,7 +3117,7 @@ func TestIngester_Push(t *testing.T) {
 					mimirpb.API,
 				),
 			},
-			expectedErr: newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), userID), codes.InvalidArgument),
+			expectedErr: newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError("duplicate sample for timestamp 1575043969; overrides not allowed: existing 2, new value 1", model.Time(1575043969), metricLabelAdapters), userID), codes.InvalidArgument),
 			expectedIngested: model.Matrix{
 				&model.SampleStream{Metric: metricLabelSet, Values: []model.SamplePair{{Value: 2, Timestamp: 1575043969}}},
 			},
@@ -11297,8 +11297,8 @@ func TestIngester_PushWithSampledErrors(t *testing.T) {
 				),
 			},
 			expectedErrs: []globalerror.ErrorWithStatus{
-				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), users[0]), codes.InvalidArgument),
-				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError(model.Time(1575043969), metricLabelAdapters), users[1]), codes.InvalidArgument),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError("duplicate sample for timestamp 1575043969; overrides not allowed: existing 2, new value 1", model.Time(1575043969), metricLabelAdapters), users[0]), codes.InvalidArgument),
+				newErrorWithStatus(wrapOrAnnotateWithUser(newSampleDuplicateTimestampError("duplicate sample for timestamp 1575043969; overrides not allowed: existing 2, new value 1", model.Time(1575043969), metricLabelAdapters), users[1]), codes.InvalidArgument),
 			},
 			expectedSampling: true,
 			expectedMetrics: `

--- a/pkg/storage/soft_append_error_processor.go
+++ b/pkg/storage/soft_append_error_processor.go
@@ -21,7 +21,7 @@ type SoftAppendErrorProcessor struct {
 	errOutOfOrderSample            func(int64, []mimirpb.LabelAdapter)
 	errTooOldSample                func(int64, []mimirpb.LabelAdapter)
 	sampleTooFarInFuture           func(int64, []mimirpb.LabelAdapter)
-	errDuplicateSampleForTimestamp func(int64, []mimirpb.LabelAdapter)
+	errDuplicateSampleForTimestamp func(string, int64, []mimirpb.LabelAdapter)
 	maxSeriesPerUser               func(labels []mimirpb.LabelAdapter)
 	maxSeriesPerMetric             func(labels []mimirpb.LabelAdapter)
 	// Native histogram errors.
@@ -42,7 +42,7 @@ func NewSoftAppendErrorProcessor(
 	errOutOfOrderSample func(int64, []mimirpb.LabelAdapter),
 	errTooOldSample func(int64, []mimirpb.LabelAdapter),
 	sampleTooFarInFuture func(int64, []mimirpb.LabelAdapter),
-	errDuplicateSampleForTimestamp func(int64, []mimirpb.LabelAdapter),
+	errDuplicateSampleForTimestamp func(string, int64, []mimirpb.LabelAdapter),
 	maxSeriesPerUser func([]mimirpb.LabelAdapter),
 	maxSeriesPerMetric func(labels []mimirpb.LabelAdapter),
 	errHistogramCountMismatch func(error, int64, []mimirpb.LabelAdapter),
@@ -94,7 +94,7 @@ func (e *SoftAppendErrorProcessor) ProcessErr(err error, ts int64, labels []mimi
 		e.sampleTooFarInFuture(ts, labels)
 		return true
 	case errors.Is(err, storage.ErrDuplicateSampleForTimestamp):
-		e.errDuplicateSampleForTimestamp(ts, labels)
+		e.errDuplicateSampleForTimestamp(err.Error(), ts, labels)
 		return true
 	case errors.Is(err, globalerror.MaxSeriesPerUser):
 		e.maxSeriesPerUser(labels)


### PR DESCRIPTION
#### What this PR does

This PR improves the `err-mimir-sample-duplicate-timestamp` error message. Currently, the error message doesn't say anything about the involved values. This is an example of an error message of this type:
```
the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested (err-mimir-sample-duplicate-timestamp). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series test-series{cluster=\"my-cluster\", namespace=\"my-namespace\"}
```

On the other hand, Mimir returns this type of errors when it receives the `storage.ErrDuplicateSampleForTimestamp` error from Prometheus. Given that the latter already contains all the data that we need, i.e., both currently ingested value and the value that a write request is trying to ingest, we have decided to reuse that message. Therefore, the previous example error message becomes: 
```
duplicate sample for timestamp 1575043969; overrides not allowed: existing 1.5, new value 2.5 (err-mimir-sample-duplicate-timestamp). The affected sample has timestamp 1970-01-19T05:30:43.969Z and is from series test-series{cluster=\"my-cluster\", namespace=\"my-namespace\"}
```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
