### PR TITLE
Block-builder: Gracefully shutdown pull-mode worker.

### DIFF
--- a/development/mimir-ingest-storage/config/mimir.yaml
+++ b/development/mimir-ingest-storage/config/mimir.yaml
@@ -29,7 +29,7 @@ ingester:
 
 block_builder:
   scheduler_config:
-    address: mimir-block-builder-scheduler-1:9095
+    address: mimir-block-builder-scheduler-0:9095
     update_interval: 5s
     max_update_age: 30m
 

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -196,11 +196,9 @@ func (b *BlockBuilder) stoppingPullMode(_ error) error {
 func (b *BlockBuilder) runningPullMode(svcCtx context.Context) error {
 	// We control our own context here. We'll stop processing jobs when the
 	// service context is cancelled, but let any in-flight jobs complete.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	// Kick off the scheduler's run loop.
-	go b.scheduler.Run(ctx)
+	go b.scheduler.Run(svcCtx)
 
 	for {
 		if err := svcCtx.Err(); err != nil {
@@ -221,7 +219,7 @@ func (b *BlockBuilder) runningPullMode(svcCtx context.Context) error {
 
 		// Once we've gotten a job, we attempt to complete it even if the context is cancelled.
 
-		if _, err := b.consumeJob(ctx, key, spec); err != nil {
+		if _, err := b.consumeJob(context.Background(), key, spec); err != nil {
 			level.Error(b.logger).Log("msg", "failed to consume job", "job_id", key.Id, "epoch", key.Epoch, "err", err)
 			continue
 		}

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -57,8 +57,6 @@ type BlockBuilder struct {
 
 	blockBuilderMetrics blockBuilderMetrics
 	tsdbBuilderMetrics  tsdbBuilderMetrics
-
-	runDone chan struct{}
 }
 
 func New(
@@ -109,7 +107,6 @@ func newWithSchedulerClient(
 			}
 		}
 
-		b.runDone = make(chan struct{})
 		runningFunc = b.runningPullMode
 		stoppingFunc = b.stoppingPullMode
 		b.committer = &noOpCommitter{}
@@ -185,9 +182,6 @@ func (b *BlockBuilder) starting(context.Context) (err error) {
 }
 
 func (b *BlockBuilder) stoppingPullMode(_ error) error {
-	// Wait for the run loop to exit.
-	<-b.runDone
-
 	b.kafkaClient.Close()
 	b.scheduler.Close()
 
@@ -199,21 +193,24 @@ func (b *BlockBuilder) stoppingPullMode(_ error) error {
 
 // runningPullMode is a service `running` function for pull mode, where we learn
 // about jobs from a block-builder-scheduler. We consume one job at a time.
-func (b *BlockBuilder) runningPullMode(ctx context.Context) error {
-	defer close(b.runDone)
+func (b *BlockBuilder) runningPullMode(svcCtx context.Context) error {
+	// We control our own context here. We'll stop processing jobs when the
+	// service context is cancelled, but let any in-flight jobs complete.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Kick off the scheduler's run loop.
 	go b.scheduler.Run(ctx)
 
 	for {
-		if err := ctx.Err(); err != nil {
+		if err := svcCtx.Err(); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
 			}
 			return err
 		}
 
-		key, spec, err := b.scheduler.GetJob(ctx)
+		key, spec, err := b.scheduler.GetJob(svcCtx)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
@@ -224,7 +221,7 @@ func (b *BlockBuilder) runningPullMode(ctx context.Context) error {
 
 		// Once we've gotten a job, we attempt to complete it even if the context is cancelled.
 
-		if _, err := b.consumeJob(context.Background(), key, spec); err != nil {
+		if _, err := b.consumeJob(ctx, key, spec); err != nil {
 			level.Error(b.logger).Log("msg", "failed to consume job", "job_id", key.Id, "epoch", key.Epoch, "err", err)
 			continue
 		}


### PR DESCRIPTION
#### What this PR does

#### Which issue(s) this PR fixes or relates to

This change allows an assigned job to finish processing when the service's context is canceled.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
