### PR TITLE
Fix issue where a query containing a common subexpression that returned an error could also panic with `integer divide by zero`

### DIFF
--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator.go
@@ -159,8 +159,13 @@ func (b *DuplicationBuffer) CloseConsumer(consumerIndex int) {
 	// If this consumer was the lagging consumer, free any data that was being buffered for it.
 	for b.nextSeriesIndex[consumerIndex] < lowestNextSeriesIndexOfOtherConsumers {
 		seriesIdx := b.nextSeriesIndex[consumerIndex]
-		d := b.buffer.Remove(seriesIdx)
-		types.PutInstantVectorSeriesData(d, b.MemoryConsumptionTracker)
+
+		// Only try to remove the buffered series if it was actually buffered (we might not have stored it if an error occurred reading the series).
+		if b.buffer.IsPresent(seriesIdx) {
+			d := b.buffer.Remove(seriesIdx)
+			types.PutInstantVectorSeriesData(d, b.MemoryConsumptionTracker)
+		}
+
 		b.nextSeriesIndex[consumerIndex]++
 	}
 

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator_test.go
@@ -4,12 +4,14 @@ package commonsubexpressionelimination
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators"
@@ -250,4 +252,50 @@ func createTestOperator(t *testing.T, seriesCount int, memoryConsumptionTracker 
 		Data:                     operatorData,
 		MemoryConsumptionTracker: memoryConsumptionTracker,
 	}, expectedData
+}
+
+func TestOperator_ClosingAfterFailedRead(t *testing.T) {
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	series, err := types.SeriesMetadataSlicePool.Get(1, memoryConsumptionTracker)
+	require.NoError(t, err)
+
+	series = append(series, types.SeriesMetadata{Labels: labels.FromStrings(labels.MetricName, "test_series")})
+
+	buffer := NewDuplicationBuffer(&failingOperator{series}, memoryConsumptionTracker)
+	consumer1 := buffer.AddConsumer()
+	consumer2 := buffer.AddConsumer()
+	ctx := context.Background()
+
+	metadata1, err := consumer1.SeriesMetadata(ctx)
+	require.NoError(t, err)
+	require.Equal(t, series, metadata1, "first consumer should get expected series metadata")
+	types.SeriesMetadataSlicePool.Put(metadata1, memoryConsumptionTracker)
+
+	data, err := consumer1.NextSeries(ctx)
+	require.EqualError(t, err, "something went wrong reading data")
+	require.Equal(t, types.InstantVectorSeriesData{}, data)
+
+	consumer2.Close()
+	consumer1.Close()
+	require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+}
+
+type failingOperator struct {
+	series []types.SeriesMetadata
+}
+
+func (o *failingOperator) SeriesMetadata(_ context.Context) ([]types.SeriesMetadata, error) {
+	return o.series, nil
+}
+
+func (o *failingOperator) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+	return types.InstantVectorSeriesData{}, errors.New("something went wrong reading data")
+}
+
+func (o *failingOperator) ExpressionPosition() posrange.PositionRange {
+	return posrange.PositionRange{}
+}
+
+func (o *failingOperator) Close() {
+	// Nothing to do.
 }

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator_test.go
@@ -254,14 +254,14 @@ func createTestOperator(t *testing.T, seriesCount int, memoryConsumptionTracker 
 	}, expectedData
 }
 
-func TestOperator_ClosingAfterFailedRead(t *testing.T) {
+func TestOperator_ClosingAfterFirstReadFails(t *testing.T) {
 	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
 	series, err := types.SeriesMetadataSlicePool.Get(1, memoryConsumptionTracker)
 	require.NoError(t, err)
 
 	series = append(series, types.SeriesMetadata{Labels: labels.FromStrings(labels.MetricName, "test_series")})
 
-	buffer := NewDuplicationBuffer(&failingOperator{series}, memoryConsumptionTracker)
+	buffer := NewDuplicationBuffer(&failingOperator{series: series}, memoryConsumptionTracker)
 	consumer1 := buffer.AddConsumer()
 	consumer2 := buffer.AddConsumer()
 	ctx := context.Background()
@@ -280,8 +280,46 @@ func TestOperator_ClosingAfterFailedRead(t *testing.T) {
 	require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 }
 
+func TestOperator_ClosingAfterSubsequentReadFails(t *testing.T) {
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	series, err := types.SeriesMetadataSlicePool.Get(2, memoryConsumptionTracker)
+	require.NoError(t, err)
+
+	series = append(series, types.SeriesMetadata{Labels: labels.FromStrings(labels.MetricName, "test_series_1")})
+	series = append(series, types.SeriesMetadata{Labels: labels.FromStrings(labels.MetricName, "test_series_2")})
+
+	buffer := NewDuplicationBuffer(&failingOperator{series: series, returnErrorAtSeriesIdx: 1}, memoryConsumptionTracker)
+	consumer1 := buffer.AddConsumer()
+	consumer2 := buffer.AddConsumer()
+	ctx := context.Background()
+
+	metadata1, err := consumer1.SeriesMetadata(ctx)
+	require.NoError(t, err)
+	require.Equal(t, series, metadata1, "first consumer should get expected series metadata")
+	types.SeriesMetadataSlicePool.Put(metadata1, memoryConsumptionTracker)
+
+	data, err := consumer1.NextSeries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, types.InstantVectorSeriesData{}, data)
+
+	data, err = consumer2.NextSeries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, types.InstantVectorSeriesData{}, data)
+
+	data, err = consumer1.NextSeries(ctx)
+	require.EqualError(t, err, "something went wrong reading data")
+	require.Equal(t, types.InstantVectorSeriesData{}, data)
+
+	consumer2.Close()
+	consumer1.Close()
+	require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+}
+
 type failingOperator struct {
-	series []types.SeriesMetadata
+	series                 []types.SeriesMetadata
+	returnErrorAtSeriesIdx int
+
+	seriesRead int
 }
 
 func (o *failingOperator) SeriesMetadata(_ context.Context) ([]types.SeriesMetadata, error) {
@@ -289,7 +327,12 @@ func (o *failingOperator) SeriesMetadata(_ context.Context) ([]types.SeriesMetad
 }
 
 func (o *failingOperator) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
-	return types.InstantVectorSeriesData{}, errors.New("something went wrong reading data")
+	if o.seriesRead >= o.returnErrorAtSeriesIdx {
+		return types.InstantVectorSeriesData{}, errors.New("something went wrong reading data")
+	}
+
+	o.seriesRead++
+	return types.InstantVectorSeriesData{}, nil
 }
 
 func (o *failingOperator) ExpressionPosition() posrange.PositionRange {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/series_data_ring_buffer.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/series_data_ring_buffer.go
@@ -39,8 +39,12 @@ func (b *SeriesDataRingBuffer) Append(d types.InstantVectorSeriesData, seriesInd
 }
 
 func (b *SeriesDataRingBuffer) Remove(seriesIndex int) types.InstantVectorSeriesData {
-	if seriesIndex != b.firstSeriesIndex {
-		panic(fmt.Sprintf("attempted to remove series at index %v, but first series index is %v", seriesIndex, b.firstSeriesIndex))
+	if b.seriesCount == 0 {
+		panic(fmt.Sprintf("attempted to remove series at index %v, but buffer is empty", seriesIndex))
+	}
+
+	if seriesIndex < b.firstSeriesIndex || seriesIndex >= (b.firstSeriesIndex+b.seriesCount) {
+		panic(fmt.Sprintf("attempted to remove series at index %v, but have series from index %v to %v", seriesIndex, b.firstSeriesIndex, b.firstSeriesIndex+b.seriesCount-1))
 	}
 
 	idx := b.startIndex % len(b.data)


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where a query containing a common subexpression that returned an error could also panic with `integer divide by zero` when the query was closed. 

This would occur if:

* the first series read by the duplication operator returned an error
* all consumers other than the one that made the first `NextSeries` call were closed before the first `NextSeries` caller

If these conditions were met, `SeriesDataRingBuffer.Remove` would panic when evaluating `b.startIndex % len(b.data)`.

As the query was closed after the HTTP response was sent, the user still saw the expected error message, but the querier would have crashed and restarted, so other inflight queries may have been affected.

#### Which issue(s) this PR fixes or relates to

#11189

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
