### PR TITLE
Update mimir-prometheus on branch pushes

### DIFF
--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -14,6 +14,9 @@ on:
         default: 'main'
         type: string
 
+  repository_dispatch:
+    types: [ mimir-prometheus-branch-push ]
+
 permissions:
   contents: write
   pull-requests: write
@@ -23,10 +26,31 @@ jobs:
   update-mimir-prometheus:
     runs-on: ubuntu-latest
     steps:
+      - name: Determine branch names
+        id: branch-names
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            # For repository_dispatch, use the branch_name from client_payload for mimir_prometheus_branch.
+            # The main use case is for weekly branches, so we just use the same branch name here too.
+            MIMIR_PROMETHEUS_BRANCH="${{ github.event.client_payload.branch_name }}"
+            MIMIR_BRANCH=$MIMIR_PROMETHEUS_BRANCH
+            echo "Triggered by repository_dispatch"
+            echo "Using mimir-prometheus branch from payload: $MIMIR_PROMETHEUS_BRANCH"
+          else
+            # For workflow_dispatch, use the input values
+            MIMIR_BRANCH="${{ inputs.mimir_branch }}"
+            MIMIR_PROMETHEUS_BRANCH="${{ inputs.mimir_prometheus_branch }}"
+            echo "Triggered by workflow_dispatch"
+            echo "Using input values - mimir branch: $MIMIR_BRANCH, mimir-prometheus branch: $MIMIR_PROMETHEUS_BRANCH"
+          fi
+          
+          echo "mimir_branch=$MIMIR_BRANCH" >> $GITHUB_OUTPUT
+          echo "mimir_prometheus_branch=$MIMIR_PROMETHEUS_BRANCH" >> $GITHUB_OUTPUT
+
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.mimir_branch }}
+          ref: ${{ steps.branch-names.outputs.mimir_branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           set-safe-directory: '*'
@@ -36,6 +60,11 @@ jobs:
         with:
           # We only use this to run `go mod` commands, so it doesn't need to follow the version used in the Dockerfile.
           go-version: "1.24.4"
+
+      - name: Get current mimir-prometheus version
+        id: get-current-version
+        run: |
+
 
       # This job uses "mimir-vendoring bot" instead of "github-actions bot" (secrets.GITHUB_TOKEN)
       # because any events triggered by the later don't spawn GitHub actions.
@@ -60,7 +89,7 @@ jobs:
       - name: Get mimir-prometheus commit info
         id: get-commit-info
         env:
-          MIMIR_PROMETHEUS_BRANCH: ${{ inputs.mimir_prometheus_branch }}
+          MIMIR_PROMETHEUS_BRANCH: ${{ steps.branch-names.outputs.mimir_prometheus_branch }}
         run: |
           # Fetch the latest commit hash from the specified branch
           NEW_HASH=$(git ls-remote https://github.com/grafana/mimir-prometheus.git "${MIMIR_PROMETHEUS_BRANCH}" | cut -f1)
@@ -117,12 +146,12 @@ jobs:
             *This PR was automatically created by the [update-vendored-mimir-prometheus.yml](https://github.com/grafana/mimir/blob/main/.github/workflows/update-vendored-mimir-prometheus.yml) workflow.*
 
             ### Details:
-            - **Source branch/ref**: ${{ format('[`{0}`](https://github.com/grafana/mimir-prometheus/tree/{0})', inputs.mimir_prometheus_branch) }}
+            - **Source branch/ref**: ${{ format('[`{0}`](https://github.com/grafana/mimir-prometheus/tree/{0})', steps.branch-names.outputs.mimir_prometheus_branch) }}
             - **Previous commit**: ${{ format('[`{0}`](https://github.com/grafana/mimir-prometheus/commit/{0})', steps.get-commit-info.outputs.old_hash) }}
             - **New commit**: ${{ format('[`{0}`](https://github.com/grafana/mimir-prometheus/commit/{0})', steps.get-commit-info.outputs.new_hash) }}
             - **Changes**: ${{ format('[`{0}...{1}`](https://github.com/grafana/mimir-prometheus/compare/{0}...{1})', steps.get-commit-info.outputs.old_hash, steps.get-commit-info.outputs.new_hash) }}
           commit-message: Update mimir-prometheus to `${{ steps.get-commit-info.outputs.short_hash }}`
-          branch: bot/${{ inputs.mimir_branch }}/update-mimir-prometheus-${{ steps.get-commit-info.outputs.short_hash }}-${{ steps.get-commit-info.outputs.timestamp }}
-          base: ${{ inputs.mimir_branch }}
+          branch: bot/${{ steps.branch-names.outputs.mimir_branch }}/update-mimir-prometheus-${{ steps.get-commit-info.outputs.short_hash }}-${{ steps.get-commit-info.outputs.timestamp }}
+          base: ${{ steps.branch-names.outputs.mimir_branch }}
           labels: vendored-mimir-prometheus-update
           delete-branch: true

--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -30,14 +30,14 @@ jobs:
         id: branch-names-dispatch
         if: github.event_name == 'repository_dispatch'
         env:
-          MIMIR_BRANCH: ${{ github.event.client_payload.branch_name }}
+          MIMIR_PROMETHEUS_BRANCH: ${{ github.event.client_payload.branch_name }}
         run: |
           # For repository_dispatch, use the env-injected mimir_prometheus_branch.
           # The main use case is for weekly branches, so we just use the same branch name here too.
           echo "Triggered by repository_dispatch"
           echo "Using mimir-prometheus branch from payload: $MIMIR_PROMETHEUS_BRANCH"
           
-          echo "mimir_branch=$MIMIR_BRANCH" >> $GITHUB_OUTPUT
+          echo "mimir_branch=$MIMIR_PROMETHEUS_BRANCH" >> $GITHUB_OUTPUT
           echo "mimir_prometheus_branch=$MIMIR_PROMETHEUS_BRANCH" >> $GITHUB_OUTPUT
 
       - name: Determine branch names (workflow_dispatch)

--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -26,26 +26,39 @@ jobs:
   update-mimir-prometheus:
     runs-on: ubuntu-latest
     steps:
-      - name: Determine branch names
-        id: branch-names
+      - name: Determine branch names (repository_dispatch)
+        id: branch-names-dispatch
+        if: github.event_name == 'repository_dispatch'
+        env:
+          MIMIR_BRANCH: ${{ github.event.client_payload.branch_name }}
         run: |
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            # For repository_dispatch, use the branch_name from client_payload for mimir_prometheus_branch.
-            # The main use case is for weekly branches, so we just use the same branch name here too.
-            MIMIR_PROMETHEUS_BRANCH="${{ github.event.client_payload.branch_name }}"
-            MIMIR_BRANCH=$MIMIR_PROMETHEUS_BRANCH
-            echo "Triggered by repository_dispatch"
-            echo "Using mimir-prometheus branch from payload: $MIMIR_PROMETHEUS_BRANCH"
-          else
-            # For workflow_dispatch, use the input values
-            MIMIR_BRANCH="${{ inputs.mimir_branch }}"
-            MIMIR_PROMETHEUS_BRANCH="${{ inputs.mimir_prometheus_branch }}"
-            echo "Triggered by workflow_dispatch"
-            echo "Using input values - mimir branch: $MIMIR_BRANCH, mimir-prometheus branch: $MIMIR_PROMETHEUS_BRANCH"
-          fi
+          # For repository_dispatch, use the env-injected mimir_prometheus_branch.
+          # The main use case is for weekly branches, so we just use the same branch name here too.
+          echo "Triggered by repository_dispatch"
+          echo "Using mimir-prometheus branch from payload: $MIMIR_PROMETHEUS_BRANCH"
           
           echo "mimir_branch=$MIMIR_BRANCH" >> $GITHUB_OUTPUT
           echo "mimir_prometheus_branch=$MIMIR_PROMETHEUS_BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Determine branch names (workflow_dispatch)
+        id: branch-names-manual
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          MIMIR_BRANCH: ${{ inputs.mimir_branch }}
+          MIMIR_PROMETHEUS_BRANCH: ${{ inputs.mimir_prometheus_branch }}
+        run: |
+          # For workflow_dispatch, use the env-injected branch names.
+          echo "Triggered by workflow_dispatch"
+          echo "Using input values - mimir branch: $MIMIR_BRANCH, mimir-prometheus branch: $MIMIR_PROMETHEUS_BRANCH"
+
+          echo "mimir_branch=$MIMIR_BRANCH" >> $GITHUB_OUTPUT
+          echo "mimir_prometheus_branch=$MIMIR_PROMETHEUS_BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Determine branch names (combined)
+        id: branch-names
+        run: |
+          echo "mimir_branch=${{ steps.branch-names-dispatch.outputs.mimir_branch || steps.branch-names-manual.outputs.mimir_branch }}" >> $GITHUB_OUTPUT
+          echo "mimir_prometheus_branch=${{ steps.branch-names-dispatch.outputs.mimir_prometheus_branch || steps.branch-names-manual.outputs.mimir_prometheus_branch }}" >> $GITHUB_OUTPUT
 
       - name: Check out repository
         uses: actions/checkout@v4
@@ -60,11 +73,6 @@ jobs:
         with:
           # We only use this to run `go mod` commands, so it doesn't need to follow the version used in the Dockerfile.
           go-version: "1.24.4"
-
-      - name: Get current mimir-prometheus version
-        id: get-current-version
-        run: |
-
 
       # This job uses "mimir-vendoring bot" instead of "github-actions bot" (secrets.GITHUB_TOKEN)
       # because any events triggered by the later don't spawn GitHub actions.


### PR DESCRIPTION
This pull request enhances the `update-vendored-mimir-prometheus.yml` workflow by introducing support for triggering updates via `repository_dispatch` events triggered by https://github.com/grafana/mimir-prometheus/pull/877

I addressed the zizmor checks, but I can't hide the comments
