### PR TITLE
Block-builder-scheduler: fix bug where startup job is erroneously skipped based on commit movement

### DIFF
--- a/pkg/blockbuilder/scheduler/jobs.go
+++ b/pkg/blockbuilder/scheduler/jobs.go
@@ -227,7 +227,7 @@ func (s *jobQueue[T]) clearExpiredLeases() {
 			// An expired job gets to go to the front of the unassigned list.
 			s.unassigned.PushFront(j)
 
-			level.Debug(s.logger).Log("msg", "unassigned expired lease", "job_id", j.key.id, "epoch", j.key.epoch, "assignee", priorAssignee)
+			level.Info(s.logger).Log("msg", "unassigned expired lease", "job_id", j.key.id, "epoch", j.key.epoch, "assignee", priorAssignee)
 		}
 	}
 }

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -304,7 +304,7 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 			// The job discovery process happens concurrently with ongoing job
 			// completions. Now that we have the lock, ignore this job if it's
 			// older than our committed offset.
-			if c, ok := s.committed.Lookup(s.cfg.Kafka.Topic, partition); ok && or.start < c.At {
+			if c, ok := s.committed.Lookup(s.cfg.Kafka.Topic, partition); ok && or.end <= c.At {
 				ps.pendingJobs.Remove(e)
 				continue
 			}

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -305,6 +305,8 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 			// completions. Now that we have the lock, ignore this job if it's
 			// older than our committed offset.
 			if c, ok := s.committed.Lookup(s.cfg.Kafka.Topic, partition); ok && or.end <= c.At {
+				level.Info(s.logger).Log("msg", "ignoring pending job as it's behind the committed offset (expected at startup)",
+					"partition", partition, "start", or.start, "end", or.end, "committed", c.At)
 				ps.pendingJobs.Remove(e)
 				continue
 			}
@@ -509,7 +511,8 @@ func (s *BlockBuilderScheduler) consumptionOffsets(ctx context.Context, topic st
 				return nil, fmt.Errorf("partition %d not found in end offsets for topic %s", partition, t)
 			}
 
-			level.Debug(s.logger).Log("msg", "consumptionOffsets", "topic", t, "partition", partition, "start", startOffset.At, "end", end.Offset, "consumeOffset", consumeOffset)
+			level.Debug(s.logger).Log("msg", "consumptionOffsets", "topic", t, "partition", partition,
+				"start", startOffset.At, "end", end.Offset, "consumeOffset", consumeOffset)
 
 			s.metrics.partitionStartOffset.WithLabelValues(partStr).Set(float64(startOffset.At))
 			s.metrics.partitionEndOffset.WithLabelValues(partStr).Set(float64(end.Offset))


### PR DESCRIPTION
#### What this PR does

This PR fixes a bug in handling "initial" jobs computed at startup. Here's an example of the bug:

1. scheduler knows that its committed offset is 10.
1. a job J1 is computed over offsets (10, 20) and is assigned to a worker 1. it is in progress.
1. the scheduler restarts and learns about J1 in progress.
1. this new scheduler scans for initial jobs for all partitions, and it computes a job J2 (10, 30)
1. we only allow one outstanding job per partition so J2 goes into a feeder queue.
1. worker 1 completes J1. scheduler moves the committed offset to 20.
1. Now that there's room in the job queue, we can move J2 over there. But, there was a bug where we were [skipping feeder-queue jobs if `j.start < committed`](https://github.com/grafana/mimir/blob/cd4127dd571cc03c6edb3277ccd086b1e0045365/pkg/blockbuilder/scheduler/scheduler.go#L307). (then we'd lose offsets 20 to 30.) It should instead skip the feeder queue job if `j.end <= committed`.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
