### PR TITLE
Create separate span for query-frontend request to query-schedulers / queriers

### DIFF
--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -283,6 +283,9 @@ type roundTripperHandler struct {
 }
 
 func (rth roundTripperHandler) Do(ctx context.Context, r MetricsQueryRequest) (Response, error) {
+	spanLogger, ctx := spanlogger.NewWithLogger(ctx, rth.logger, "roundTripperHandler.Do")
+	defer spanLogger.Finish()
+
 	request, err := rth.codec.EncodeMetricsQueryRequest(ctx, r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What this PR does

This PR improves the traces emitted by query-frontends.

Previously, events related to the request being sent to the query-scheduler or querier were attached to the span for the last middleware in the chain, for example:

<img width="1918" alt="Screenshot 2025-05-26 at 10 42 16 am" src="https://github.com/user-attachments/assets/65d2097f-fd8f-457c-9049-2eaf3aa37324" />


This makes them difficult to find, and is potentially confusing.

In this PR, I've added a separate span to the round-tripper to act as the parent for these events:

<img width="1918" alt="Screenshot 2025-05-26 at 10 38 26 am" src="https://github.com/user-attachments/assets/724cc52d-11b5-4f25-b3ce-7817d892ca21" />

I haven't added a changelog entry given this is a minor improvement to the debugging experience.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
