### PR TITLE
[release-2.15] Upgrade Alpine Linux in Dockerfiles to 3.20.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Mimirtool
 
-* [BUGFIX] Upgrade Alpine Linux to 3.20.6. #11530
+* [BUGFIX] Upgrade Alpine Linux to 3.20.6, fixes CVE-2025-26519. #11530
 
 ### Mimir Continuous Test
 
-* [BUGFIX] Upgrade Alpine Linux to 3.20.6. #11530
+* [BUGFIX] Upgrade Alpine Linux to 3.20.6, fixes CVE-2025-26519. #11530
 
 ## 2.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## main / unreleased
+## 2.15.x / unreleased
 
 ### Mimirtool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## main / unreleased
+
+### Mimirtool
+
+* [BUGFIX] Upgrade Alpine Linux to 3.20.6. #11530
+
+### Mimir Continuous Test
+
+* [BUGFIX] Upgrade Alpine Linux to 3.20.6. #11530
+
 ## 2.15.2
 
 ### Grafana Mimir

--- a/cmd/metaconvert/Dockerfile
+++ b/cmd/metaconvert/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.20.3
+FROM       alpine:3.20.6
 ARG        EXTRA_PACKAGES
 RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.

--- a/cmd/mimir/Dockerfile.alpine
+++ b/cmd/mimir/Dockerfile.alpine
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.20.3
+FROM       alpine:3.20.6
 ARG        EXTRA_PACKAGES
 RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.

--- a/cmd/mimir/Dockerfile.continuous-test
+++ b/cmd/mimir/Dockerfile.continuous-test
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM       alpine:3.20.3
+FROM       alpine:3.20.6
 ARG        EXTRA_PACKAGES
 RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.

--- a/cmd/mimirtool/Dockerfile
+++ b/cmd/mimirtool/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM       alpine:3.20.3
+FROM       alpine:3.20.6
 ARG        EXTRA_PACKAGES
 RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.20.3
+FROM       alpine:3.20.6
 ARG        EXTRA_PACKAGES
 RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.

--- a/development/mimir-ingest-storage/dev.dockerfile
+++ b/development/mimir-ingest-storage/dev.dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.22.0
 
-FROM alpine:3.20.3
+FROM alpine:3.20.6
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/mimir-microservices-mode/dev.dockerfile
+++ b/development/mimir-microservices-mode/dev.dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.23.0
 
-FROM alpine:3.20.3
+FROM alpine:3.20.6
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/mimir-monolithic-mode-with-swift-storage/dev.dockerfile
+++ b/development/mimir-monolithic-mode-with-swift-storage/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.3
+FROM alpine:3.20.6
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/mimir-monolithic-mode/dev.dockerfile
+++ b/development/mimir-monolithic-mode/dev.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.3
+FROM alpine:3.20.6
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/development/mimir-read-write-mode/dev.dockerfile
+++ b/development/mimir-read-write-mode/dev.dockerfile
@@ -3,7 +3,7 @@ FROM $BUILD_IMAGE
 ENV CGO_ENABLED=0
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.22.0
 
-FROM alpine:3.20.3
+FROM alpine:3.20.6
 
 RUN     mkdir /mimir
 WORKDIR /mimir

--- a/tools/copyblocks/Dockerfile
+++ b/tools/copyblocks/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM       alpine:3.20.3
+FROM       alpine:3.20.6
 ARG        EXTRA_PACKAGES
 RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.


### PR DESCRIPTION
#### What this PR does

Upgrade Alpine Linux in Dockerfiles to 3.20.6, to fix [CVE-2025-26519](https://security.alpinelinux.org/vuln/CVE-2025-26519).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
