### PR TITLE
Improve block-builder dashboard

### DIFF
--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -710,6 +710,10 @@
         enabled: false,
         hpa_name: $._config.autoscaling_hpa_prefix + 'compactor',
       },
+      block_builder: {
+        enabled: false,
+        hpa_name: $._config.autoscaling_hpa_prefix + 'block-builder',
+      },
     },
 
 

--- a/operations/mimir-mixin/dashboards/block-builder.libsonnet
+++ b/operations/mimir-mixin/dashboards/block-builder.libsonnet
@@ -17,7 +17,8 @@ local filename = 'mimir-block-builder.json';
         $.queryPanel(
           '(cortex_blockbuilder_scheduler_partition_end_offset{%(job)s} -cortex_blockbuilder_scheduler_partition_committed_offset{%(job)s}) > 0' % { job: $.jobMatcher($._config.job_names.block_builder_scheduler) },
           '{{partition}}',
-        )
+        ) +
+        { fieldConfig+: { defaults+: { custom+: { unit: 'short', fillOpacity: 0 } } } },
       )
       .addPanel(
         $.timeseriesPanel('Jobs') +
@@ -34,7 +35,8 @@ local filename = 'mimir-block-builder.json';
             'outstanding',
             'active',
           ],
-        )
+        ) +
+        { fieldConfig+: { defaults+: { custom+: { unit: 'short', fillOpacity: 100 } } } },
       )
       .addPanel(
         $.timeseriesPanel('Job Update Duration') +
@@ -200,6 +202,19 @@ local filename = 'mimir-block-builder.json';
       )
       .addPanel(
         $.containerMemoryWorkingSetPanelByComponent('block_builder'),
+      )
+    )
+    .addRowIf(
+      $._config.autoscaling.block_builder.enabled,
+      $.row('Block builder - autoscaling')
+      .addPanel(
+        $.autoScalingActualReplicas('block_builder')
+      )
+      .addPanel(
+        $.autoScalingDesiredReplicasByAverageValueScalingMetricPanel('block_builder', scalingMetricName='', scalingMetricID='')
+      )
+      .addPanel(
+        $.autoScalingFailuresPanel('block_builder')
       )
     )
     .addRow(


### PR DESCRIPTION
#### What this PR does

Following to #11358, the PR improves the "Mimir / Block-builder" dashboard with the following

1. Use solid colours for the "Jobs" panel

<img width="1461" alt="Screenshot 2025-05-26 at 14 10 00" src="https://github.com/user-attachments/assets/ef998c45-9209-4ecb-bae8-3de51ed6d554" />

2. Add the "Autoscaling" panels (when enabled in the config)

<img width="1463" alt="Screenshot 2025-05-26 at 14 10 09" src="https://github.com/user-attachments/assets/6391f19b-fc9f-4b98-9fb0-4fa3c34a3535" />
