### PR TITLE
Fix Docker Hub login

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -19,6 +19,8 @@ jobs:
       contents: write
       # Allow PR modification for collaborators, forks should remain read-only
       pull-requests: write
+      # Necessary to authenticate with Vault which happens in dockerhub-login
+      id-token: write
     # We want to allow running github actions for all contributors, but don't want all contributors to be able to
     # publish new build images just by sending the PR. Hence this change.
     if: ${{ contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association )}} || github.actor == 'renovate[bot]'
@@ -40,10 +42,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+        uses: grafana/shared-workflows/actions/dockerhub-login@13fb504e3bfe323c1188bf244970d94b2d336e86 # v1.0.1
 
       - name: Prepare Variables
         id: prepare
@@ -78,7 +77,7 @@ jobs:
 
       - name: Add Comment to the PR
         id: notification
-        run: | 
+        run: |
           if [ ${{ steps.check_build.outputs.build }} == 'true' ]; then
            gh pr comment $PR_NUMBER --body "**Building new version of mimir-build-image**. After image is built and pushed to Docker Hub, \
            a new commit will automatically be added to this PR with new image version \`$IMAGE:$TAG\`. This can take up to 1 hour."


### PR DESCRIPTION
This should fix CI for https://github.com/grafana/mimir/pull/11537 by not using outdated repository secrets.