### PR TITLE
ruler: Terminate on failires during initial sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * [BUGFIX] Compactor: Fix issue where `MimirBucketIndexNotUpdated` can fire even though the index has been updated within the alert threshold. #11303
 * [BUGFIX] Distributor: fix old entries in the HA Tracker with zero valued "elected at" timestamp. #11462
 * [BUGFIX] Query-scheduler: Fix issue where deregistered querier goroutines can cause a panic if their backlogged dequeue requests are serviced. #11510
+* [BUGFIX] Ruler: Failures during initial sync must be fatal for the service's startup. #11545
 
 ### Mixin
 

--- a/integration/api_endpoints_test.go
+++ b/integration/api_endpoints_test.go
@@ -40,6 +40,8 @@ func newMimirSingleBinaryWithLocalFilesytemBucket(t *testing.T, name string, fla
 
 	setFlagIfNotExistingAlready("-blocks-storage.backend", "filesystem")
 	setFlagIfNotExistingAlready("-blocks-storage.filesystem.dir", "./bucket")
+	setFlagIfNotExistingAlready("-ruler-storage.backend", "filesystem")
+	setFlagIfNotExistingAlready("-ruler-storage.local.directory", "./rules")
 
 	mimir := e2emimir.NewSingleBinary(name, flags, e2emimir.WithPorts(9009, 9095), e2emimir.WithConfigFile(mimirConfigFile))
 

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -26,6 +26,7 @@ const (
 	mimirBucketName    = "mimir"
 	blocksBucketName   = "mimir-blocks"
 	alertsBucketName   = "mimir-alerts"
+	rulesBucketName    = "mimir-rules"
 	mimirConfigFile    = "config.yaml"
 	clientCertFile     = "certs/client.crt"
 	clientKeyFile      = "certs/client.key"
@@ -147,6 +148,24 @@ var (
 		return map[string]string{
 			"-ruler.ring.store":           "consul",
 			"-ruler.ring.consul.hostname": consulAddress,
+		}
+	}
+
+	RulerStorageLocalFlags = func() map[string]string {
+		return map[string]string{
+			"-ruler-storage.backend":         "local",
+			"-ruler-storage.local.directory": "./rules",
+		}
+	}
+
+	RulerStorageS3Flags = func() map[string]string {
+		return map[string]string{
+			"-ruler-storage.backend":              "s3",
+			"-ruler-storage.s3.access-key-id":     e2edb.MinioAccessKey,
+			"-ruler-storage.s3.secret-access-key": e2edb.MinioSecretKey,
+			"-ruler-storage.s3.endpoint":          fmt.Sprintf("%s-minio-9000:9000", networkName),
+			"-ruler-storage.s3.insecure":          "true",
+			"-ruler-storage.s3.bucket-name":       rulesBucketName,
 		}
 	}
 

--- a/integration/influx_ingestion_test.go
+++ b/integration/influx_ingestion_test.go
@@ -28,7 +28,7 @@ func TestInfluxIngestion(t *testing.T) {
 	defer s.Close()
 
 	// Start dependencies.
-	minio := e2edb.NewMinio(9000, blocksBucketName)
+	minio := e2edb.NewMinio(9000, blocksBucketName, rulesBucketName)
 	require.NoError(t, s.StartAndWaitReady(minio))
 
 	// Start Mimir components.
@@ -40,6 +40,7 @@ func TestInfluxIngestion(t *testing.T) {
 		DefaultSingleBinaryFlags(),
 		BlocksStorageFlags(),
 		BlocksStorageS3Flags(),
+		RulerStorageS3Flags(),
 		map[string]string{
 			"-distributor.influx-endpoint-enabled": "true",
 		},

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -47,7 +47,7 @@ func testSingleBinaryEnv(t *testing.T, tlsEnabled bool, flags map[string]string)
 	defer s.Close()
 
 	// Start dependencies.
-	minio := e2edb.NewMinio(9000, blocksBucketName)
+	minio := e2edb.NewMinio(9000, blocksBucketName, rulesBucketName)
 	require.NoError(t, s.StartAndWaitReady(minio))
 
 	var mimir1, mimir2, mimir3 *e2emimir.MimirService
@@ -91,8 +91,8 @@ func testSingleBinaryEnv(t *testing.T, tlsEnabled bool, flags map[string]string)
 	require.NoError(t, mimir2.WaitSumMetrics(e2e.Equals(3), "memberlist_client_cluster_members_count"))
 	require.NoError(t, mimir3.WaitSumMetrics(e2e.Equals(3), "memberlist_client_cluster_members_count"))
 
-	// Each Mimir instance will use (512 ingester tokens + 1 distributor token + 512 compactor tokens + 512 store gateway tokens + 512 tokens seen by store-gateway client).
-	tokensPerInstance := float64(512 + 1 + 512 + 512 + 512)
+	// Each Mimir instance will use (512 ingester tokens + 1 distributor token + 512 compactor tokens + 512 store gateway tokens + 512 tokens seen by store-gateway client + 128 ruler tokens).
+	tokensPerInstance := float64(512 + 1 + 512 + 512 + 512 + 128)
 	// 3 = number of instances.
 	require.NoError(t, mimir1.WaitSumMetrics(e2e.Equals(3*tokensPerInstance), "cortex_ring_tokens_total"))
 	require.NoError(t, mimir2.WaitSumMetrics(e2e.Equals(3*tokensPerInstance), "cortex_ring_tokens_total"))
@@ -103,8 +103,8 @@ func testSingleBinaryEnv(t *testing.T, tlsEnabled bool, flags map[string]string)
 	require.NoError(t, mimir3.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))
 	require.NoError(t, mimir3.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"))
 
-	// Tombstones should increase by four for each server that leaves (once for distributor, ingester, compactor and store-gateway ring)
-	tombstonesPerRemovedInstance := 4.0
+	// Tombstones should increase by five for each server that leaves (once for distributor, ingester, compactor, store-gateway and ruler ring)
+	tombstonesPerRemovedInstance := float64(5)
 	require.NoError(t, s.Stop(mimir1))
 	require.NoError(t, mimir2.WaitSumMetrics(e2e.Equals(2*tokensPerInstance), "cortex_ring_tokens_total"))
 	require.NoError(t, mimir2.WaitSumMetrics(e2e.Equals(2), "memberlist_client_cluster_members_count"))
@@ -144,6 +144,7 @@ func newSingleBinary(name string, servername string, join string, testFlags map[
 			DefaultSingleBinaryFlags(),
 			BlocksStorageFlags(),
 			BlocksStorageS3Flags(),
+			RulerStorageS3Flags(),
 			flags,
 			testFlags,
 			getTLSFlagsWithPrefix("memberlist", servername, servername == ""),
@@ -167,7 +168,7 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	defer s.Close()
 
 	// Start dependencies.
-	minio := e2edb.NewMinio(9000, blocksBucketName)
+	minio := e2edb.NewMinio(9000, blocksBucketName, rulesBucketName)
 	require.NoError(t, s.StartAndWaitReady(minio))
 
 	// Scale up instances. These numbers seem enough to reliably reproduce some unwanted
@@ -205,8 +206,8 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 
 	// Sanity check the ring membership and give each instance time to see every other instance.
 	for _, c := range instances {
-		// we expect 5*maxMimir to account for ingester, distributor, compactor, store-gateway and store-gateway-client rings
-		require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(maxMimir*5)), "cortex_ring_members"), "instance: %s", c.Name())
+		// we expect 6*maxMimir to account for ingester, distributor, compactor, store-gateway, store-gateway-client and ruler rings
+		require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(maxMimir*6)), "cortex_ring_members"), "instance: %s", c.Name())
 		require.NoError(t, c.WaitSumMetrics(e2e.Equals(0), "memberlist_client_kv_store_value_tombstones"), "instance: %s", c.Name())
 	}
 
@@ -232,10 +233,9 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	// The logging is mildly spammy, but it has proven extremely useful for debugging convergence cases.
 	// We don't use WaitSumMetrics [over all instances] here so we can log the per-instance metrics.
 
-	// These values are multiplied by three to account for the fact that ingester
-	// distributor, compactor, store-gateway components use a ring.
-	expectedRingMembers := float64(minMimir) * 5 // One extra, because store-gateway-client uses ring too. But it's the same ring as store-gateway.
-	expectedTombstones := float64(maxMimir-minMimir) * 4
+	// These values account for the fact that ingester, distributor, compactor, store-gateway, store-gateway-client and ruler components use rings.
+	expectedRingMembers := float64(minMimir) * 6 // One extra, because store-gateway-client uses ring too. But it's the same ring as store-gateway.
+	expectedTombstones := float64(maxMimir-minMimir) * 5
 
 	require.Eventually(t, func() bool {
 		ok := true

--- a/integration/ooo_ingestion_test.go
+++ b/integration/ooo_ingestion_test.go
@@ -25,7 +25,7 @@ func TestOOOIngestion(t *testing.T) {
 	defer s.Close()
 
 	// Start dependencies.
-	minio := e2edb.NewMinio(9000, blocksBucketName)
+	minio := e2edb.NewMinio(9000, blocksBucketName, rulesBucketName)
 	require.NoError(t, s.StartAndWaitReady(minio))
 
 	// Start Mimir components.
@@ -37,6 +37,7 @@ func TestOOOIngestion(t *testing.T) {
 		DefaultSingleBinaryFlags(),
 		BlocksStorageFlags(),
 		BlocksStorageS3Flags(),
+		RulerStorageS3Flags(),
 		map[string]string{
 			"-ingester.out-of-order-time-window":            "10m",
 			"-ingester.native-histograms-ingestion-enabled": "true",

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -42,7 +42,7 @@ func testOTLPIngestion(t *testing.T, enableSuffixes bool) {
 	defer s.Close()
 
 	// Start dependencies.
-	minio := e2edb.NewMinio(9000, blocksBucketName)
+	minio := e2edb.NewMinio(9000, blocksBucketName, rulesBucketName)
 	require.NoError(t, s.StartAndWaitReady(minio))
 
 	// Start Mimir components.
@@ -54,6 +54,7 @@ func testOTLPIngestion(t *testing.T, enableSuffixes bool) {
 		DefaultSingleBinaryFlags(),
 		BlocksStorageFlags(),
 		BlocksStorageS3Flags(),
+		RulerStorageS3Flags(),
 		map[string]string{
 			"-distributor.otel-metric-suffixes-enabled": strconv.FormatBool(enableSuffixes),
 		},
@@ -206,7 +207,7 @@ func testOTLPHistogramIngestion(t *testing.T, enableExplicitHistogramToNHCB bool
 	defer s.Close()
 
 	// Start dependencies.
-	minio := e2edb.NewMinio(9000, blocksBucketName)
+	minio := e2edb.NewMinio(9000, blocksBucketName, rulesBucketName)
 	require.NoError(t, s.StartAndWaitReady(minio))
 
 	// Start Mimir components.
@@ -218,6 +219,7 @@ func testOTLPHistogramIngestion(t *testing.T, enableExplicitHistogramToNHCB bool
 		DefaultSingleBinaryFlags(),
 		BlocksStorageFlags(),
 		BlocksStorageS3Flags(),
+		RulerStorageS3Flags(),
 		map[string]string{
 			"-distributor.otel-convert-histograms-to-nhcb": strconv.FormatBool(enableExplicitHistogramToNHCB),
 		},

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -51,11 +51,11 @@ func TestRulerAPI(t *testing.T) {
 
 	// Start dependencies.
 	consul := e2edb.NewConsul()
-	minio := e2edb.NewMinio(9000, mimirBucketName)
+	minio := e2edb.NewMinio(9000, mimirBucketName, rulesBucketName)
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 	// Configure the ruler.
-	rulerFlags := mergeFlags(CommonStorageBackendFlags(), RulerFlags(), BlocksStorageFlags())
+	rulerFlags := mergeFlags(CommonStorageBackendFlags(), RulerFlags(), RulerStorageS3Flags(), BlocksStorageFlags())
 
 	// Start Mimir components.
 	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags)
@@ -154,6 +154,7 @@ func TestRulerAPISingleBinary(t *testing.T) {
 	flags := mergeFlags(
 		BlocksStorageFlags(),
 		BlocksStorageS3Flags(),
+		RulerStorageLocalFlags(),
 		map[string]string{
 			"-ruler-storage.local.directory": filepath.Join(e2e.ContainerSharedDir, "ruler_configs"),
 			"-ruler.poll-interval":           "2s",
@@ -220,7 +221,7 @@ func TestRulerAPIRulesPagination(t *testing.T) {
 
 	// Start dependencies.
 	consul := e2edb.NewConsul()
-	minio := e2edb.NewMinio(9000, mimirBucketName)
+	minio := e2edb.NewMinio(9000, mimirBucketName, rulesBucketName)
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 	// Configure the ruler.
@@ -228,6 +229,7 @@ func TestRulerAPIRulesPagination(t *testing.T) {
 		CommonStorageBackendFlags(),
 		RulerFlags(),
 		BlocksStorageFlags(),
+		RulerStorageS3Flags(),
 		RulerShardingFlags(consul.NetworkHTTPEndpoint()),
 		map[string]string{
 			// Disable rule group limit
@@ -339,7 +341,7 @@ func TestRulerAPIRulesEvaluationDisabledForTenant(t *testing.T) {
 
 	// Start dependencies.
 	consul := e2edb.NewConsul()
-	minio := e2edb.NewMinio(9000, mimirBucketName)
+	minio := e2edb.NewMinio(9000, mimirBucketName, rulesBucketName)
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 	runtimeConfig := `
@@ -355,6 +357,7 @@ overrides:
 		CommonStorageBackendFlags(),
 		RulerFlags(),
 		BlocksStorageFlags(),
+		RulerStorageS3Flags(),
 		RulerShardingFlags(consul.NetworkHTTPEndpoint()),
 		map[string]string{
 			"-runtime-config.file":          filepath.Join(e2e.ContainerSharedDir, "runtime.yaml"),
@@ -405,7 +408,7 @@ func TestRulerSharding(t *testing.T) {
 
 	// Start dependencies.
 	consul := e2edb.NewConsul()
-	minio := e2edb.NewMinio(9000, mimirBucketName)
+	minio := e2edb.NewMinio(9000, mimirBucketName, rulesBucketName)
 	require.NoError(t, s.StartAndWaitReady(consul, minio))
 
 	// Configure the ruler.
@@ -413,6 +416,7 @@ func TestRulerSharding(t *testing.T) {
 		CommonStorageBackendFlags(),
 		RulerFlags(),
 		BlocksStorageFlags(),
+		RulerStorageS3Flags(),
 		RulerShardingFlags(consul.NetworkHTTPEndpoint()),
 		map[string]string{
 			// Disable rule group limit

--- a/integration/single_binary_test.go
+++ b/integration/single_binary_test.go
@@ -25,11 +25,11 @@ func TestMimirShouldStartInSingleBinaryModeWithAllMemcachedConfigured(t *testing
 
 	// Start dependencies.
 	consul := e2edb.NewConsul()
-	minio := e2edb.NewMinio(9000, blocksBucketName)
+	minio := e2edb.NewMinio(9000, blocksBucketName, rulesBucketName)
 	memcached := e2ecache.NewMemcached()
 	require.NoError(t, s.StartAndWaitReady(consul, minio, memcached))
 
-	flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(), map[string]string{
+	flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(), RulerStorageS3Flags(), map[string]string{
 		// Memcached.
 		"-query-frontend.cache-results":                                   "true",
 		"-query-frontend.results-cache.backend":                           "memcached",

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcclient"
@@ -347,6 +348,8 @@ type Ruler struct {
 
 	allowedTenants *util.AllowList
 
+	syncBackoffConfig backoff.Config
+
 	registry prometheus.Registerer
 	logger   log.Logger
 }
@@ -369,6 +372,11 @@ func newRuler(cfg Config, manager MultiTenantManager, reg prometheus.Registerer,
 		inboundSyncQueue:  newRulerSyncQueue(cfg.InboundSyncQueuePollInterval),
 		allowedTenants:    util.NewAllowList(cfg.EnabledTenants, cfg.DisabledTenants),
 		metrics:           newRulerMetrics(reg),
+		syncBackoffConfig: backoff.Config{
+			MinBackoff: 3 * time.Second,
+			MaxBackoff: 15 * time.Second,
+			MaxRetries: 3,
+		},
 	}
 
 	ruler.outboundSyncQueueProcessor = newRulerSyncQueueProcessor(ruler.outboundSyncQueue, ruler.notifySyncRules)
@@ -459,7 +467,9 @@ func (r *Ruler) starting(ctx context.Context) (err error) {
 	level.Info(r.logger).Log("msg", "ruler is JOINING in the ring")
 
 	// Here during joining, we can download rules from object storage and sync them to the local rule manager
-	r.syncRules(ctx, nil, rulerSyncReasonInitial, true)
+	if err := r.initialSync(ctx); err != nil {
+		return errors.Wrap(err, "unable to do initial sync")
+	}
 
 	if err = r.lifecycler.ChangeState(ctx, ring.ACTIVE); err != nil {
 		return errors.Wrapf(err, "switch instance to %s in the ring", ring.ACTIVE)
@@ -539,12 +549,13 @@ func (r *Ruler) run(ctx context.Context) error {
 	defer ringTicker.Stop()
 
 	for {
+		var syncErr error
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-periodicTicker.C:
 			// Sync rules for all users.
-			r.syncRules(ctx, nil, rulerSyncReasonPeriodic, true)
+			syncErr = r.syncRules(ctx, nil, rulerSyncReasonPeriodic, true)
 		case <-ringTicker.C:
 			// We ignore the error because in case of error it will return an empty
 			// replication set which we use to compare with the previous state.
@@ -552,15 +563,39 @@ func (r *Ruler) run(ctx context.Context) error {
 
 			if ring.HasReplicationSetChanged(ringLastState, currRingState) {
 				ringLastState = currRingState
-				r.syncRules(ctx, nil, rulerSyncReasonRingChange, true)
+				syncErr = r.syncRules(ctx, nil, rulerSyncReasonRingChange, true)
 			}
 		case userIDs := <-r.inboundSyncQueue.poll():
 			// Sync rules for users who changed their configs.
-			r.syncRules(ctx, userIDs, rulerSyncReasonAPIChange, false)
+			syncErr = r.syncRules(ctx, userIDs, rulerSyncReasonAPIChange, false)
 		case err := <-r.subservicesWatcher.Chan():
 			return errors.Wrap(err, "ruler subservice failed")
 		}
+		if syncErr != nil {
+			level.Error(r.logger).Log("msg", "unable to sync rules", "err", syncErr)
+		}
 	}
+}
+
+func (r *Ruler) initialSync(ctx context.Context) error {
+	boff := backoff.New(ctx, r.syncBackoffConfig)
+
+	var lastErr error
+	for boff.Ongoing() {
+		if lastErr != nil {
+			level.Warn(r.logger).Log("msg", "unable to do initial sync; will retry", "err", lastErr, "num_retries", boff.NumRetries())
+		}
+
+		lastErr = r.syncRules(ctx, nil, rulerSyncReasonInitial, true)
+		if lastErr == nil {
+			return nil
+		}
+		boff.Wait()
+	}
+	if lastErr == nil {
+		return boff.Err()
+	}
+	return lastErr
 }
 
 // syncRules synchronises the rules managed by this ruler instance.
@@ -569,7 +604,7 @@ func (r *Ruler) run(ctx context.Context) error {
 //
 // It's not safe to call this function concurrently.
 // We expect this function is only called from Ruler.run().
-func (r *Ruler) syncRules(ctx context.Context, userIDs []string, reason rulesSyncReason, cacheLookupEnabled bool) {
+func (r *Ruler) syncRules(ctx context.Context, userIDs []string, reason rulesSyncReason, cacheLookupEnabled bool) error {
 	var (
 		configs   map[string]rulespb.RuleGroupList
 		err       error
@@ -589,15 +624,13 @@ func (r *Ruler) syncRules(ctx context.Context, userIDs []string, reason rulesSyn
 		configs, err = r.listRuleGroupsToSyncForAllUsers(ctx, reason, cacheLookupEnabled)
 	}
 	if err != nil {
-		level.Error(r.logger).Log("msg", "unable to list rules to sync", "err", err)
-		return
+		return fmt.Errorf("list rules to sync: %w", err)
 	}
 
 	// Load rule groups to sync.
 	configs, err = r.loadRuleGroupsToSync(ctx, configs)
 	if err != nil {
-		level.Error(r.logger).Log("msg", "unable to load rules to sync", "err", err)
-		return
+		return fmt.Errorf("load rules to sync: %w", err)
 	}
 
 	// Filter out all rules for which their evaluation has been disabled for the given tenant.
@@ -625,6 +658,7 @@ func (r *Ruler) syncRules(ctx context.Context, userIDs []string, reason rulesSyn
 		// This will also delete local group files for users that are no longer in 'configs' map.
 		r.manager.SyncFullRuleGroups(ctx, configs)
 	}
+	return nil
 }
 
 // loadRuleGroupsToSync loads the input rule group configs. This function should be used only when

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -593,7 +593,7 @@ func (r *Ruler) initialSync(ctx context.Context) error {
 		boff.Wait()
 	}
 	if lastErr == nil {
-		return boff.Err()
+		return fmt.Errorf("initial sync: %w", boff.Err())
 	}
 	return lastErr
 }

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -8,6 +8,7 @@ package ruler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -40,6 +41,7 @@ import (
 	promRules "github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 	"go.uber.org/atomic"
@@ -555,7 +557,8 @@ func TestGetRules(t *testing.T) {
 
 			// Sync rules on each ruler.
 			for _, r := range rulerAddrMap {
-				r.syncRules(ctx, nil, rulerSyncReasonInitial, true)
+				err := r.syncRules(ctx, nil, rulerSyncReasonInitial, true)
+				require.NoError(t, err)
 			}
 
 			// Call GetRules() on each ruler.
@@ -1206,6 +1209,63 @@ func TestRuler_NotifySyncRulesAsync_ShouldTriggerRulesSyncingOnAllRulersWhenEnab
 			}
 		})
 	}
+}
+
+func TestRuler_InitialSyncFails(t *testing.T) {
+	cfg := defaultRulerConfig(t)
+	store := &testRuleStore{}
+	reg := prometheus.NewPedanticRegistry()
+	ruler := prepareRuler(t, cfg, store, withPrometheusRegisterer(reg))
+
+	// Override the backoff config to fail the test faster.
+	ruler.syncBackoffConfig.MinBackoff = 10 * time.Millisecond
+	ruler.syncBackoffConfig.MaxRetries = 1
+
+	wantErr := errors.New("test failed")
+	store.On("ListAllUsers", mock.Anything, mock.Anything).Return([]string{}, wantErr)
+
+	require.ErrorIs(t, services.StartAndAwaitRunning(context.Background(), ruler), wantErr)
+
+	verifySyncRulesMetric(t, reg, 1, 0)
+}
+
+type testRuleStore struct {
+	mock.Mock
+}
+
+func (s *testRuleStore) ListAllUsers(ctx context.Context, opts ...rulestore.Option) ([]string, error) {
+	args := s.Called(ctx, opts)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (s *testRuleStore) ListRuleGroupsForUserAndNamespace(ctx context.Context, userID string, namespace string, opts ...rulestore.Option) (rulespb.RuleGroupList, error) {
+	args := s.Called(ctx, userID, namespace, opts)
+	return args.Get(0).(rulespb.RuleGroupList), args.Error(1)
+}
+
+func (s *testRuleStore) LoadRuleGroups(ctx context.Context, groupsToLoad map[string]rulespb.RuleGroupList) (missing rulespb.RuleGroupList, err error) {
+	args := s.Called(ctx, groupsToLoad)
+	return args.Get(0).(rulespb.RuleGroupList), args.Error(1)
+}
+
+func (s *testRuleStore) GetRuleGroup(ctx context.Context, userID, namespace, group string) (*rulespb.RuleGroupDesc, error) {
+	args := s.Called(ctx, userID, namespace, group)
+	return args.Get(0).(*rulespb.RuleGroupDesc), args.Error(1)
+}
+
+func (s *testRuleStore) SetRuleGroup(ctx context.Context, userID, namespace string, group *rulespb.RuleGroupDesc) error {
+	args := s.Called(ctx, userID, namespace, group)
+	return args.Error(0)
+}
+
+func (s *testRuleStore) DeleteRuleGroup(ctx context.Context, userID, namespace string, group string) error {
+	args := s.Called(ctx, userID, namespace, group)
+	return args.Error(0)
+}
+
+func (s *testRuleStore) DeleteNamespace(ctx context.Context, userID, namespace string) error {
+	args := s.Called(ctx, userID, namespace)
+	return args.Error(0)
 }
 
 func TestRuler_NotifySyncRulesAsync_ShouldTriggerRulesSyncingAndCorrectlyHandleTheCaseTheTenantShardHasChanged(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

If the ruler fails to complete its initial sync, it still transitions to the running state. In this case, the tenants, whose rules have been synced, observe a delay in their rule evaluation.

This PR addresses that by making sure the ruler fails to start on a failure during initial sync. During a rolling update, if a failure happens, the running rulers will continue to evaluate the rules, until the new replica manages to transition into the running state.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
