### PR TITLE
Backport #10664 and #11546 to r344

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -358,3 +358,6 @@ replace github.com/prometheus/alertmanager => github.com/grafana/prometheus-aler
 // Use Mimir fork of prometheus/otlptranslator to allow for higher velocity of upstream development,
 // while allowing Mimir to move at a more conservative pace.
 replace github.com/prometheus/otlptranslator => github.com/grafana/mimir-otlptranslator v0.0.0-20250501145537-53ceaec28820
+
+// Replace objstore with a fork containing https://github.com/thanos-io/objstore/pull/181.
+replace github.com/thanos-io/objstore => github.com/charleskorn/objstore v0.0.0-20250527015333-2865768f74cc

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f h1:P1GSPnbxmhUafKGBcaY2qqx34mBdC4GVDm/RN3iKKuE=
 github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
+github.com/charleskorn/objstore v0.0.0-20250527015333-2865768f74cc h1:mYczEn9/UiMqwEvgRm9PuvBb1OGFpPyLLKaNKk4IB/Y=
+github.com/charleskorn/objstore v0.0.0-20250527015333-2865768f74cc/go.mod h1:Nmy3+M2UM7wu2sEvg0h5M/c3mu1QaxmdyPvoGUPGlaU=
 github.com/chromedp/cdproto v0.0.0-20210526005521-9e51b9051fd0/go.mod h1:At5TxYYdxkbQL0TSefRjhLE3Q0lgvqKKMSFUglJ7i1U=
 github.com/chromedp/cdproto v0.0.0-20210706234513-2bc298e8be7f/go.mod h1:At5TxYYdxkbQL0TSefRjhLE3Q0lgvqKKMSFUglJ7i1U=
 github.com/chromedp/cdproto v0.0.0-20230802225258-3cf4e6d46a89 h1:aPflPkRFkVwbW6dmcVqfgwp1i+UWGFH6VgR1Jim5Ygc=
@@ -997,8 +999,6 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40 h1:W6vDGKCHe4wBACI1d2UgE6+50sJFhRWU4O8IB2ozzxM=
 github.com/tencentyun/cos-go-sdk-v5 v0.7.40/go.mod h1:4dCEtLHGh8QPxHEkgq+nFaky7yZxQuYwgSJM87icDaw=
-github.com/thanos-io/objstore v0.0.0-20250129163715-ec72e5a88a79 h1:sVc5fCMlPFEZfhIfdiEJqMmNIP3sEnRZv9K83Nz/mR8=
-github.com/thanos-io/objstore v0.0.0-20250129163715-ec72e5a88a79/go.mod h1:Quz9HUDjGidU0RQpoytzK4KqJ7kwzP+DMAm4K57/usM=
 github.com/tjhop/slog-gokit v0.1.4 h1:uj/vbDt3HaF0Py8bHPV4ti/s0utnO0miRbO277FLBKM=
 github.com/tjhop/slog-gokit v0.1.4/go.mod h1:Bbu5v2748qpAWH7k6gse/kw3076IJf6owJmh7yArmJs=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=

--- a/pkg/ingester/shipper_test.go
+++ b/pkg/ingester/shipper_test.go
@@ -170,8 +170,8 @@ type deceivingUploadBucket struct {
 	objectBaseName string
 }
 
-func (b deceivingUploadBucket) Upload(ctx context.Context, name string, r io.Reader) error {
-	actualErr := b.Bucket.Upload(ctx, name, r)
+func (b deceivingUploadBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
+	actualErr := b.Bucket.Upload(ctx, name, r, opts...)
 	if actualErr != nil {
 		return actualErr
 	} else if path.Base(name) == b.objectBaseName {

--- a/pkg/mimirtool/commands/bucket_validation.go
+++ b/pkg/mimirtool/commands/bucket_validation.go
@@ -65,8 +65,8 @@ func (c *retryingBucketClient) withRetries(f func() error) error {
 	}
 }
 
-func (c *retryingBucketClient) Upload(ctx context.Context, name string, r io.Reader) error {
-	return c.withRetries(func() error { return c.Bucket.Upload(ctx, name, r) })
+func (c *retryingBucketClient) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
+	return c.withRetries(func() error { return c.Bucket.Upload(ctx, name, r, opts...) })
 }
 
 func (c *retryingBucketClient) Exists(ctx context.Context, name string) (bool, error) {

--- a/pkg/storage/bucket/client_mock.go
+++ b/pkg/storage/bucket/client_mock.go
@@ -29,13 +29,13 @@ func (m *ClientMock) Provider() objstore.ObjProvider {
 }
 
 // Upload mocks objstore.Bucket.Upload()
-func (m *ClientMock) Upload(ctx context.Context, name string, r io.Reader) error {
-	args := m.Called(ctx, name, r)
+func (m *ClientMock) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
+	args := m.Called(ctx, name, r, opts)
 	return args.Error(0)
 }
 
 func (m *ClientMock) MockUpload(name string, err error) {
-	m.On("Upload", mock.Anything, name, mock.Anything).Return(err)
+	m.On("Upload", mock.Anything, name, mock.Anything, mock.Anything).Return(err)
 }
 
 // Delete mocks objstore.Bucket.Delete()

--- a/pkg/storage/bucket/delayed_bucket_client.go
+++ b/pkg/storage/bucket/delayed_bucket_client.go
@@ -36,11 +36,11 @@ func (m *DelayedBucketClient) Provider() objstore.ObjProvider {
 	return m.wrapped.Provider()
 }
 
-func (m *DelayedBucketClient) Upload(ctx context.Context, name string, r io.Reader) error {
+func (m *DelayedBucketClient) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
 	m.delay()
 	defer m.delay()
 
-	return m.wrapped.Upload(ctx, name, r)
+	return m.wrapped.Upload(ctx, name, r, opts...)
 }
 
 func (m *DelayedBucketClient) Delete(ctx context.Context, name string) error {

--- a/pkg/storage/bucket/error_injected_bucket_client.go
+++ b/pkg/storage/bucket/error_injected_bucket_client.go
@@ -57,11 +57,11 @@ func (b *ErrorInjectedBucketClient) Exists(ctx context.Context, name string) (bo
 	return b.Bucket.Exists(ctx, name)
 }
 
-func (b *ErrorInjectedBucketClient) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *ErrorInjectedBucketClient) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
 	if err := b.injectError(OpUpload, name); err != nil {
 		return err
 	}
-	return b.Bucket.Upload(ctx, name, r)
+	return b.Bucket.Upload(ctx, name, r, opts...)
 }
 
 func (b *ErrorInjectedBucketClient) Delete(ctx context.Context, name string) error {

--- a/pkg/storage/bucket/prefixed_bucket_client.go
+++ b/pkg/storage/bucket/prefixed_bucket_client.go
@@ -40,8 +40,8 @@ func (b *PrefixedBucketClient) Provider() objstore.ObjProvider {
 }
 
 // Upload the contents of the reader as an object into the bucket.
-func (b *PrefixedBucketClient) Upload(ctx context.Context, name string, r io.Reader) (err error) {
-	err = b.bucket.Upload(ctx, b.fullName(name), r)
+func (b *PrefixedBucketClient) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) (err error) {
+	err = b.bucket.Upload(ctx, b.fullName(name), r, opts...)
 	return
 }
 

--- a/pkg/storage/bucket/sse_bucket_client.go
+++ b/pkg/storage/bucket/sse_bucket_client.go
@@ -56,7 +56,7 @@ func (b *SSEBucketClient) Provider() objstore.ObjProvider {
 }
 
 // Upload the contents of the reader as an object into the bucket.
-func (b *SSEBucketClient) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *SSEBucketClient) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
 	if sse, err := b.getCustomS3SSEConfig(); err != nil {
 		return err
 	} else if sse != nil {
@@ -65,7 +65,7 @@ func (b *SSEBucketClient) Upload(ctx context.Context, name string, r io.Reader) 
 		ctx = s3.ContextWithSSEConfig(ctx, sse)
 	}
 
-	return b.bucket.Upload(ctx, name, r)
+	return b.bucket.Upload(ctx, name, r, opts...)
 }
 
 // Delete implements objstore.Bucket.

--- a/pkg/storage/tsdb/block/block_test.go
+++ b/pkg/storage/tsdb/block/block_test.go
@@ -509,8 +509,8 @@ type errBucket struct {
 	failSuffix string
 }
 
-func (eb errBucket) Upload(ctx context.Context, name string, r io.Reader) error {
-	err := eb.Bucket.Upload(ctx, name, r)
+func (eb errBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
+	err := eb.Bucket.Upload(ctx, name, r, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/tsdb/block/global_markers_bucket_client.go
+++ b/pkg/storage/tsdb/block/global_markers_bucket_client.go
@@ -35,10 +35,10 @@ func (b *globalMarkersBucket) Provider() objstore.ObjProvider {
 }
 
 // Upload implements objstore.Bucket.
-func (b *globalMarkersBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *globalMarkersBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
 	globalMarkPath := getGlobalMarkPathFromBlockMark(name)
 	if globalMarkPath == "" {
-		return b.parent.Upload(ctx, name, r)
+		return b.parent.Upload(ctx, name, r, opts...)
 	}
 
 	// Read the marker.
@@ -48,12 +48,12 @@ func (b *globalMarkersBucket) Upload(ctx context.Context, name string, r io.Read
 	}
 
 	// Upload it to the original location.
-	if err := b.parent.Upload(ctx, name, bytes.NewReader(body)); err != nil {
+	if err := b.parent.Upload(ctx, name, bytes.NewReader(body), opts...); err != nil {
 		return err
 	}
 
 	// Upload it to the global markers location too.
-	return b.parent.Upload(ctx, globalMarkPath, bytes.NewReader(body))
+	return b.parent.Upload(ctx, globalMarkPath, bytes.NewReader(body), opts...)
 }
 
 // Delete implements objstore.Bucket.

--- a/pkg/storage/tsdb/bucketcache/caching_bucket.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket.go
@@ -166,10 +166,10 @@ func NewCachingBucket(bucketID string, bucketClient objstore.Bucket, cfg *Cachin
 	return cb, nil
 }
 
-func (cb *CachingBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (cb *CachingBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
 	keyGen := newCacheKeyBuilder(cb.bucketID, name)
 	cb.invalidation.start(ctx, name, keyGen)
-	err := cb.Bucket.Upload(ctx, name, r)
+	err := cb.Bucket.Upload(ctx, name, r, opts...)
 	if err == nil {
 		cb.invalidation.finish(ctx, name, keyGen)
 	}

--- a/vendor/github.com/thanos-io/objstore/CHANGELOG.md
+++ b/vendor/github.com/thanos-io/objstore/CHANGELOG.md
@@ -9,9 +9,11 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 We use *breaking :warning:* to mark changes that are not backward compatible (relates only to v0.y.z releases.)
 
 ## Unreleased
+- [#165](https://github.com/thanos-io/objstore/pull/165) GCS: Upgrade cloud.google.com/go/storage version to `v1.50.0`.
 - [#38](https://github.com/thanos-io/objstore/pull/38) GCS: Upgrade cloud.google.com/go/storage version to `v1.43.0`.
 - [#145](https://github.com/thanos-io/objstore/pull/145) Include content length in the response of Get and GetRange.
 - [#157](https://github.com/thanos-io/objstore/pull/157) Azure: Add `az_tenant_id`, `client_id` and `client_secret` configs.
+- [#181](https://github.com/thanos-io/objstore/pull/181) GCS: Fix issue where Exists returns an error when the object does not exist with GCS client v1.51+
 
 ### Fixed
 - [#153](https://github.com/thanos-io/objstore/pull/153) Metrics: Fix `objstore_bucket_operation_duration_seconds_*` for `get` and `get_range` operations.
@@ -70,7 +72,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#70](https://github.com/thanos-io/objstore/pull/70) GCS: Update cloud.google.com/go/storage version to `v1.27.0`.
 - [#71](https://github.com/thanos-io/objstore/pull/71) Replace method `IsCustomerManagedKeyError` for a more generic `IsAccessDeniedErr` on the bucket interface.
 - [#89](https://github.com/thanos-io/objstore/pull/89) GCS: Upgrade cloud.google.com/go/storage version to `v1.35.1`.
-- [#123](https://github.com/thanos-io/objstore/pull/123) *: Upgrade minio-go version to `v7.0.71`.
+- [#123](https://github.com/thanos-io/objstore/pull/123) *: Upgrade minio-go version to `v7.0.72`.
 - [#132](https://github.com/thanos-io/objstore/pull/132) s3: Upgrade aws-sdk-go-v2/config version to `v1.27.30`
 
 ### Removed

--- a/vendor/github.com/thanos-io/objstore/README.md
+++ b/vendor/github.com/thanos-io/objstore/README.md
@@ -670,6 +670,7 @@ config:
     max_conns_per_host: 0         // Optional maximum total number of connections per host.
     disable_compression: false    // Optional. If true, prevents the Transport from requesting compression.
     client_timeout: 90s           // Optional time limit for requests made by the HTTP Client.
+prefix: ""
 ```
 
 #### Instance Principal Provider
@@ -682,6 +683,7 @@ config:
   provider: "instance-principal"
   bucket: ""
   compartment_ocid: ""
+prefix: ""
 ```
 
 You can also include any of the optional configuration just like the example in `Default Provider`.
@@ -702,6 +704,7 @@ config:
   fingerprint: ""
   privatekey: ""
   passphrase: ""         // Optional passphrase to encrypt the private API Signing key
+prefix: ""
 ```
 
 You can also include any of the optional configuration just like the example in `Default Provider`.
@@ -716,6 +719,7 @@ config:
   provider: "oke-workload-identity"
   bucket: ""
   region: ""
+prefix: ""
 ```
 
 The `bucket` and `region` fields are required. The `region` field identifies the bucket region.

--- a/vendor/github.com/thanos-io/objstore/inmem.go
+++ b/vendor/github.com/thanos-io/objstore/inmem.go
@@ -213,7 +213,7 @@ func (b *InMemBucket) Attributes(_ context.Context, name string) (ObjectAttribut
 }
 
 // Upload writes the file specified in src to into the memory.
-func (b *InMemBucket) Upload(_ context.Context, name string, r io.Reader) error {
+func (b *InMemBucket) Upload(_ context.Context, name string, r io.Reader, _ ...ObjectUploadOption) error {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 	body, err := io.ReadAll(r)

--- a/vendor/github.com/thanos-io/objstore/prefixed_bucket.go
+++ b/vendor/github.com/thanos-io/objstore/prefixed_bucket.go
@@ -101,8 +101,8 @@ func (p *PrefixedBucket) Attributes(ctx context.Context, name string) (ObjectAtt
 
 // Upload the contents of the reader as an object into the bucket.
 // Upload should be idempotent.
-func (p *PrefixedBucket) Upload(ctx context.Context, name string, r io.Reader) error {
-	return p.bkt.Upload(ctx, conditionalPrefix(p.prefix, name), r)
+func (p *PrefixedBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...ObjectUploadOption) error {
+	return p.bkt.Upload(ctx, conditionalPrefix(p.prefix, name), r, opts...)
 }
 
 // Delete removes the object with the given name.

--- a/vendor/github.com/thanos-io/objstore/providers/filesystem/filesystem.go
+++ b/vendor/github.com/thanos-io/objstore/providers/filesystem/filesystem.go
@@ -247,7 +247,7 @@ func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 }
 
 // Upload writes the file specified in src to into the memory.
-func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) (err error) {
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, _ ...objstore.ObjectUploadOption) (err error) {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}

--- a/vendor/github.com/thanos-io/objstore/providers/gcs/gcs.go
+++ b/vendor/github.com/thanos-io/objstore/providers/gcs/gcs.go
@@ -325,20 +325,22 @@ func (b *Bucket) Handle() *storage.BucketHandle {
 func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 	if _, err := b.bkt.Object(name).Attrs(ctx); err == nil {
 		return true, nil
-	} else if err != storage.ErrObjectNotExist {
+	} else if b.IsObjNotFoundErr(err) {
 		return false, err
 	}
 	return false, nil
 }
 
 // Upload writes the file specified in src to remote GCS location specified as target.
-func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
 	w := b.bkt.Object(name).NewWriter(ctx)
 
+	uploadOpts := objstore.ApplyObjectUploadOptions(opts...)
 	// if `chunkSize` is 0, we don't set any custom value for writer's ChunkSize.
 	// It uses whatever the default value https://pkg.go.dev/google.golang.org/cloud/storage#Writer
 	if b.chunkSize > 0 {
 		w.ChunkSize = b.chunkSize
+		w.ContentType = uploadOpts.ContentType
 	}
 
 	if _, err := io.Copy(w, r); err != nil {

--- a/vendor/github.com/thanos-io/objstore/providers/swift/swift.go
+++ b/vendor/github.com/thanos-io/objstore/providers/swift/swift.go
@@ -338,13 +338,16 @@ func (c *Container) IsAccessDeniedErr(err error) bool {
 }
 
 // Upload writes the contents of the reader as an object into the container.
-func (c *Container) Upload(_ context.Context, name string, r io.Reader) (err error) {
+func (c *Container) Upload(_ context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) (err error) {
 	size, err := objstore.TryToGetSize(r)
 	if err != nil {
 		level.Warn(c.logger).Log("msg", "could not guess file size, using large object to avoid issues if the file is larger than limit", "name", name, "err", err)
 		// Anything higher or equal to chunk size so the SLO is used.
 		size = c.chunkSize
 	}
+
+	uploadOpts := objstore.ApplyObjectUploadOptions(opts...)
+
 	var file io.WriteCloser
 	if size >= c.chunkSize {
 		opts := swift.LargeObjectOpts{
@@ -353,6 +356,7 @@ func (c *Container) Upload(_ context.Context, name string, r io.Reader) (err err
 			ChunkSize:        c.chunkSize,
 			SegmentContainer: c.segmentsContainer,
 			CheckHash:        true,
+			ContentType:      uploadOpts.ContentType,
 		}
 		if c.useDynamicLargeObjects {
 			if file, err = c.connection.DynamicLargeObjectCreateFile(&opts); err != nil {
@@ -364,7 +368,7 @@ func (c *Container) Upload(_ context.Context, name string, r io.Reader) (err err
 			}
 		}
 	} else {
-		if file, err = c.connection.ObjectCreate(c.name, name, true, "", "", swift.Headers{}); err != nil {
+		if file, err = c.connection.ObjectCreate(c.name, name, true, "", uploadOpts.ContentType, swift.Headers{}); err != nil {
 			return errors.Wrap(err, "create file")
 		}
 	}

--- a/vendor/github.com/thanos-io/objstore/testing.go
+++ b/vendor/github.com/thanos-io/objstore/testing.go
@@ -316,9 +316,9 @@ func (d *delayingBucket) Exists(ctx context.Context, name string) (bool, error) 
 	return d.bkt.Exists(ctx, name)
 }
 
-func (d *delayingBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (d *delayingBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...ObjectUploadOption) error {
 	time.Sleep(d.delay)
-	return d.bkt.Upload(ctx, name, r)
+	return d.bkt.Upload(ctx, name, r, opts...)
 }
 
 func (d *delayingBucket) Delete(ctx context.Context, name string) error {

--- a/vendor/github.com/thanos-io/objstore/tracing/opentracing/opentracing.go
+++ b/vendor/github.com/thanos-io/objstore/tracing/opentracing/opentracing.go
@@ -110,10 +110,10 @@ func (t TracingBucket) Attributes(ctx context.Context, name string) (attrs objst
 	return
 }
 
-func (t TracingBucket) Upload(ctx context.Context, name string, r io.Reader) (err error) {
+func (t TracingBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) (err error) {
 	doWithSpan(ctx, "bucket_upload", func(spanCtx context.Context, span opentracing.Span) {
 		span.LogKV("name", name)
-		err = t.bkt.Upload(spanCtx, name, r)
+		err = t.bkt.Upload(spanCtx, name, r, opts...)
 	})
 	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1327,8 +1327,8 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/assert/yaml
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
-# github.com/thanos-io/objstore v0.0.0-20250129163715-ec72e5a88a79
-## explicit; go 1.22
+# github.com/thanos-io/objstore v0.0.0-20250129163715-ec72e5a88a79 => github.com/charleskorn/objstore v0.0.0-20250527015333-2865768f74cc
+## explicit; go 1.22.7
 github.com/thanos-io/objstore
 github.com/thanos-io/objstore/exthttp
 github.com/thanos-io/objstore/providers/azure
@@ -2037,3 +2037,4 @@ sigs.k8s.io/yaml/goyaml.v3
 # github.com/opentracing-contrib/go-grpc => github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f
 # github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20250424093311-7163931461c6
 # github.com/prometheus/otlptranslator => github.com/grafana/mimir-otlptranslator v0.0.0-20250501145537-53ceaec28820
+# github.com/thanos-io/objstore => github.com/charleskorn/objstore v0.0.0-20250527015333-2865768f74cc


### PR DESCRIPTION
#### What this PR does

This is a manual backport for https://github.com/grafana/mimir/pull/11546 to r344 after the automated backport failed.

It also includes the changes from #10664, as separating just my changes from #11546 is too difficult, and r344 has only just been cut.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
