### PR TITLE
ingest-storage: Add a common symbols table to record format V2

### DIFF
--- a/pkg/mimirpb/compat_rw2.go
+++ b/pkg/mimirpb/compat_rw2.go
@@ -61,7 +61,7 @@ func (ps *rw2PagedSymbols) get(ref uint32) (string, error) {
 		if len(ps.commonSymbols) == 0 {
 			return "", fmt.Errorf("symbol %d is under the offset %d, but no common symbols table was registered", ref, ps.offset)
 		}
-		if ref < 0 || ref > uint32(len(ps.commonSymbols)) {
+		if ref > uint32(len(ps.commonSymbols)) {
 			return "", fmt.Errorf("common symbol reference %d is out of bounds", ref)
 		}
 		return ps.commonSymbols[ref], nil

--- a/pkg/mimirpb/compat_rw2.go
+++ b/pkg/mimirpb/compat_rw2.go
@@ -32,9 +32,10 @@ const rw2SymbolPageSize = 16
 // mechanism, we would have to allocate a large amount of memory
 // or do reallocation. This is a compromise between the two.
 type rw2PagedSymbols struct {
-	count  uint32
-	pages  []*[]string
-	offset uint32
+	count         uint32
+	pages         []*[]string
+	offset        uint32
+	commonSymbols []string
 }
 
 func (ps *rw2PagedSymbols) append(symbol string) {
@@ -56,12 +57,21 @@ func (ps *rw2PagedSymbols) releasePages() {
 }
 
 func (ps *rw2PagedSymbols) get(ref uint32) (string, error) {
+	if ref < ps.offset {
+		if len(ps.commonSymbols) == 0 {
+			return "", fmt.Errorf("symbol %d is under the offset %d, but no common symbols table was registered", ref, ps.offset)
+		}
+		if ref < 0 || ref > uint32(len(ps.commonSymbols)) {
+			return "", fmt.Errorf("common symbol reference %d is out of bounds", ref)
+		}
+		return ps.commonSymbols[ref], nil
+	}
 	ref = ref - ps.offset
 	if ref < ps.count {
 		page := ps.pages[ref>>rw2SymbolPageSize]
 		return (*page)[ref&((1<<rw2SymbolPageSize)-1)], nil
 	}
-	return "", fmt.Errorf("symbol reference %d is out of bounds", ref)
+	return "", fmt.Errorf("symbol reference %d (offset %d) is out of bounds", ref, ps.offset)
 }
 
 var (

--- a/pkg/mimirpb/compat_rw2.go
+++ b/pkg/mimirpb/compat_rw2.go
@@ -61,7 +61,7 @@ func (ps *rw2PagedSymbols) get(ref uint32) (string, error) {
 		if len(ps.commonSymbols) == 0 {
 			return "", fmt.Errorf("symbol %d is under the offset %d, but no common symbols table was registered", ref, ps.offset)
 		}
-		if ref > uint32(len(ps.commonSymbols)) {
+		if ref >= uint32(len(ps.commonSymbols)) {
 			return "", fmt.Errorf("common symbol reference %d is out of bounds", ref)
 		}
 		return ps.commonSymbols[ref], nil

--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -118,7 +118,7 @@ func TestRW2Unmarshal(t *testing.T) {
 	})
 
 	t.Run("rw2 with offset produces expected WriteRequest", func(t *testing.T) {
-		syms := test.NewSymbolTableBuilderWithOffset(nil, 256)
+		syms := test.NewSymbolTableBuilderWithCommon(nil, 256, nil)
 		// Create a new WriteRequest with some sample data.
 		writeRequest := makeTestRW2WriteRequest(syms)
 		data, err := writeRequest.Marshal()
@@ -191,7 +191,7 @@ func TestRW2Unmarshal(t *testing.T) {
 	})
 
 	t.Run("wrong offset fails to unmarshal", func(t *testing.T) {
-		syms := test.NewSymbolTableBuilderWithOffset(nil, 256)
+		syms := test.NewSymbolTableBuilderWithCommon(nil, 256, nil)
 		// Create a new WriteRequest with some sample data.
 		writeRequest := makeTestRW2WriteRequest(syms)
 		data, err := writeRequest.Marshal()
@@ -211,6 +211,82 @@ func TestRW2Unmarshal(t *testing.T) {
 		err = received.Unmarshal(data)
 
 		require.ErrorContains(t, err, "invalid")
+	})
+
+	t.Run("offset and shared symbols produces expected write request", func(t *testing.T) {
+		commonSymbols := []string{"__name__", "job"}
+		syms := test.NewSymbolTableBuilderWithCommon(nil, uint32(len(commonSymbols)), commonSymbols)
+		// Create a new WriteRequest with some sample data.
+		writeRequest := makeTestRW2WriteRequest(syms)
+		data, err := writeRequest.Marshal()
+		require.NoError(t, err)
+
+		// Unmarshal the data back into Mimir's WriteRequest.
+		received := PreallocWriteRequest{}
+		received.UnmarshalFromRW2 = true
+		received.RW2SymbolOffset = uint32(len(commonSymbols))
+		received.RW2CommonSymbols = commonSymbols
+		err = received.Unmarshal(data)
+		require.NoError(t, err)
+
+		expected := &PreallocWriteRequest{
+			WriteRequest: WriteRequest{
+				Timeseries: []PreallocTimeseries{
+					{
+						TimeSeries: &TimeSeries{
+							Labels: []LabelAdapter{
+								{
+									Name:  "__name__",
+									Value: "test_metric_total",
+								},
+								{
+									Name:  "job",
+									Value: "test_job",
+								},
+							},
+							Samples: []Sample{
+								{
+									Value:       123.456,
+									TimestampMs: 1234567890,
+								},
+							},
+							Exemplars: []Exemplar{
+								{
+									Value:       123.456,
+									TimestampMs: 1234567890,
+									Labels: []LabelAdapter{
+										{
+											Name:  "__name__",
+											Value: "test_metric_total",
+										},
+										{
+											Name:  "traceID",
+											Value: "1234567890abcdef",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Metadata: []*MetricMetadata{
+					{
+						MetricFamilyName: "test_metric_total",
+						Type:             COUNTER,
+						Help:             "test_metric_help",
+						Unit:             "test_metric_unit",
+					},
+				},
+				unmarshalFromRW2: true,
+				rw2symbols:       rw2PagedSymbols{offset: 2, commonSymbols: commonSymbols},
+			},
+			UnmarshalFromRW2: true,
+			RW2SymbolOffset:  2,
+			RW2CommonSymbols: commonSymbols,
+		}
+
+		// Check that the unmarshalled data matches the original data.
+		require.Equal(t, expected, &received)
 	})
 }
 

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -70,6 +70,9 @@ type PreallocWriteRequest struct {
 	// RW2SymbolOffset is an optimization used for RW2-adjacent applications where typical symbol refs are shifted by an offset.
 	// This allows certain symbols to be reserved without being present in the symbols list.
 	RW2SymbolOffset uint32
+	// RW2CommonSymbols optionally allows the sender and receiver to understand a common set of reserved symbols.
+	// These symbols are never sent in the request to begin with.
+	RW2CommonSymbols []string
 }
 
 // Unmarshal implements proto.Message.
@@ -80,6 +83,7 @@ func (p *PreallocWriteRequest) Unmarshal(dAtA []byte) error {
 	p.skipUnmarshalingExemplars = p.SkipUnmarshalingExemplars
 	p.unmarshalFromRW2 = p.UnmarshalFromRW2
 	p.rw2symbols.offset = p.RW2SymbolOffset
+	p.rw2symbols.commonSymbols = p.RW2CommonSymbols
 	return p.WriteRequest.Unmarshal(dAtA)
 }
 

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -17,6 +17,56 @@ const (
 	V2RecordSymbolOffset   = 64
 )
 
+var (
+	// Bake in a shared symbols table for extremely common symbols.
+	// The index corresponds to the symbol value.
+	// The first `V2RecordSymbolOffset` symbols are reserved for this table.
+	// Note: V2 is not yet stabilized.
+	V2CommonSymbols = []string{
+		// Prometheus/Mimir symbols
+		"__name__",
+		"__aggregation__",
+		"<aggregated>",
+		"le",
+		"component",
+		"cortex_request_duration_seconds_bucket",
+		"storage_operation_duration_seconds_bucket",
+		// Grafana Labs products
+		"grafana",
+		"asserts_env",
+		"asserts_request_context",
+		"asserts_source",
+		"asserts_entity_type",
+		"asserts_request_type",
+		// General symbols
+		"name",
+		"image",
+		// Kubernetes symbols
+		"cluster",
+		"namespace",
+		"pod",
+		"job",
+		"instance",
+		"container",
+		"replicaset",
+		// Networking, HTTP
+		"interface",
+		"status_code",
+		"resource",
+		"operation",
+		"method",
+		// Common tools
+		"kube-system",
+		"kube-system/cadvisor",
+		"node-exporter",
+		"node-exporter/node-exporter",
+		"kube-system/kubelet",
+		"kube-system/node-local-dns",
+		"kube-state-metrics/kube-state-metrics",
+		"default/kubernetes",
+	}
+)
+
 func ValidateRecordVersion(version int) error {
 	switch version {
 	case 0:
@@ -107,5 +157,6 @@ func deserializeRecordContentV1(content []byte, wr *mimirpb.PreallocWriteRequest
 func deserializeRecordContentV2(content []byte, wr *mimirpb.PreallocWriteRequest) error {
 	wr.UnmarshalFromRW2 = true
 	wr.RW2SymbolOffset = V2RecordSymbolOffset
+	wr.RW2CommonSymbols = V2CommonSymbols
 	return wr.Unmarshal(content)
 }

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
+func TestV2SymbolsCompat(t *testing.T) {
+	t.Run("v2 symbols cannot be larger than v2 offset", func(t *testing.T) {
+		require.GreaterOrEqual(t, len(V2CommonSymbols), V2RecordSymbolOffset)
+	})
+}
+
 func TestRecordVersionHeader(t *testing.T) {
 	t.Run("no version header is assumed to be v0", func(t *testing.T) {
 		rec := &kgo.Record{

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -113,7 +113,7 @@ func TestDeserializeRecordContent(t *testing.T) {
 	})
 
 	t.Run("v2", func(t *testing.T) {
-		syms := test.NewSymbolTableBuilderWithOffset(nil, V2RecordSymbolOffset)
+		syms := test.NewSymbolTableBuilderWithCommon(nil, V2RecordSymbolOffset, V2CommonSymbols)
 		reqv2 := &mimirpb.WriteRequestRW2{
 			Timeseries: []mimirpb.TimeSeriesRW2{{
 				LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_total"), syms.GetSymbol("job"), syms.GetSymbol("test_job")},

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestV2SymbolsCompat(t *testing.T) {
 	t.Run("v2 symbols cannot be larger than v2 offset", func(t *testing.T) {
-		require.GreaterOrEqual(t, len(V2CommonSymbols), V2RecordSymbolOffset)
+		require.LessOrEqual(t, len(V2CommonSymbols), V2RecordSymbolOffset)
 	})
 }
 

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -151,6 +151,8 @@ func TestDeserializeRecordContent(t *testing.T) {
 			}},
 		}
 		reqv2.Symbols = syms.GetSymbols()
+		// Symbols should not contain common labels "__name__" and "job"
+		require.Equal(t, []string{"test_metric_total", "test_job", "traceID", "1234567890abcdef", "Help for test_metric_total", "seconds"}, reqv2.Symbols)
 		v2bytes, err := reqv2.Marshal()
 		require.NoError(t, err)
 

--- a/pkg/util/test/rw2.go
+++ b/pkg/util/test/rw2.go
@@ -100,25 +100,34 @@ type SymbolTableBuilder struct {
 	count   uint32
 	symbols map[string]uint32
 	offset  uint32
+	common  map[string]uint32
 }
 
 func NewSymbolTableBuilder(symbols []string) *SymbolTableBuilder {
-	return NewSymbolTableBuilderWithOffset(symbols, 0)
+	return NewSymbolTableBuilderWithCommon(symbols, 0, nil)
 }
 
-func NewSymbolTableBuilderWithOffset(symbols []string, offset uint32) *SymbolTableBuilder {
+func NewSymbolTableBuilderWithCommon(symbols []string, offset uint32, commonSymbols []string) *SymbolTableBuilder {
 	symbolsMap := make(map[string]uint32)
 	for i, sym := range symbols {
 		symbolsMap[sym] = uint32(i) + offset
+	}
+	commonSymbolsMap := make(map[string]uint32)
+	for i, commonSym := range commonSymbols {
+		commonSymbolsMap[commonSym] = uint32(i)
 	}
 	return &SymbolTableBuilder{
 		count:   uint32(len(symbols)),
 		symbols: symbolsMap,
 		offset:  offset,
+		common:  commonSymbolsMap,
 	}
 }
 
 func (symbols *SymbolTableBuilder) GetSymbol(sym string) uint32 {
+	if i, ok := symbols.common[sym]; ok {
+		return i
+	}
 	if i, ok := symbols.symbols[sym]; ok {
 		return i
 	}


### PR DESCRIPTION
#### What this PR does

**Note that record format V2 is still considered unstable.**

This PR introduces a shared table of frequently-used symbols. This starts to fill in the "reserved" symbol space from 0 to 64 in record format V2, that is never used by an ordinary request.

This means that producers need not send certain frequently symbols in the per-request symbol table at all - they can instead send the shared symbol and trust that the consumer will understand it.

Note that the contents of the table are subject to change as we do more analysis. As a first pass, it's populated with various frequently-used symbols from a test cell. The symbols chosen are based on a combination of length and frequency in sampled data, as well as cleaned to represent symbols from Mimir or software that Mimir is frequently used with in practice (e.g. Kubernetes ecosystem or other Grafana Labs projects).

Once V2 is considered stabilized in the future, we cannot change the symbols table further without incrementing the version. Most likely this symbols table will change before stabilization.

#### Which issue(s) this PR fixes or relates to

Rel https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
