### PR TITLE
Update block-builder alerts

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1289,21 +1289,18 @@ spec:
             for: 5m
             labels:
               severity: critical
-          - alert: MimirBlockBuilderNoCycleProcessing
-            annotations:
-              message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
-            expr: |
-              max by(cluster, namespace, pod) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[60m]))) == 0
-            for: 60m
-            labels:
-              severity: critical
           - alert: MimirBlockBuilderLagging
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
             expr: |
-              max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+              max by(cluster, namespace, pod) (
+              max_over_time(
+              (
+              cortex_blockbuilder_scheduler_partition_end_offset offset 1h
+              -
+              cortex_blockbuilder_scheduler_partition_committed_offset
+              )[10m:])) > 4e6
             for: 75m
             labels:
               severity: warning
@@ -1312,7 +1309,13 @@ spec:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
             expr: |
-              max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+              max by(cluster, namespace, pod) (
+              max_over_time(
+              (
+              cortex_blockbuilder_scheduler_partition_end_offset offset 1h
+              -
+              cortex_blockbuilder_scheduler_partition_committed_offset
+              )[10m:])) > 4e6
             for: 140m
             labels:
               severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1263,21 +1263,18 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirBlockBuilderNoCycleProcessing
-          annotations:
-            message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
-          expr: |
-            max by(cluster, namespace, instance) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[60m]))) == 0
-          for: 60m
-          labels:
-            severity: critical
         - alert: MimirBlockBuilderLagging
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
           expr: |
-            max by(cluster, namespace, instance) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+            max by(cluster, namespace, instance) (
+            max_over_time(
+            (
+            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
+            -
+            cortex_blockbuilder_scheduler_partition_committed_offset
+            )[10m:])) > 4e6
           for: 75m
           labels:
             severity: warning
@@ -1286,7 +1283,13 @@ groups:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
           expr: |
-            max by(cluster, namespace, instance) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+            max by(cluster, namespace, instance) (
+            max_over_time(
+            (
+            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
+            -
+            cortex_blockbuilder_scheduler_partition_committed_offset
+            )[10m:])) > 4e6
           for: 140m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -1277,21 +1277,18 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirBlockBuilderNoCycleProcessing
-          annotations:
-            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
-          expr: |
-            max by(cluster, namespace, pod) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[60m]))) == 0
-          for: 60m
-          labels:
-            severity: critical
         - alert: MimirBlockBuilderLagging
           annotations:
             message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
           expr: |
-            max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+            max by(cluster, namespace, pod) (
+            max_over_time(
+            (
+            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
+            -
+            cortex_blockbuilder_scheduler_partition_committed_offset
+            )[10m:])) > 4e6
           for: 75m
           labels:
             severity: warning
@@ -1300,7 +1297,13 @@ groups:
             message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
           expr: |
-            max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+            max by(cluster, namespace, pod) (
+            max_over_time(
+            (
+            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
+            -
+            cortex_blockbuilder_scheduler_partition_committed_offset
+            )[10m:])) > 4e6
           for: 140m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1277,21 +1277,18 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirBlockBuilderNoCycleProcessing
-          annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not processed cycles in the past hour.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildernocycleprocessing
-          expr: |
-            max by(cluster, namespace, pod) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[60m]))) == 0
-          for: 60m
-          labels:
-            severity: critical
         - alert: MimirBlockBuilderLagging
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
           expr: |
-            max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+            max by(cluster, namespace, pod) (
+            max_over_time(
+            (
+            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
+            -
+            cortex_blockbuilder_scheduler_partition_committed_offset
+            )[10m:])) > 4e6
           for: 75m
           labels:
             severity: warning
@@ -1300,7 +1297,13 @@ groups:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
           expr: |
-            max by(cluster, namespace, pod) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+            max by(cluster, namespace, pod) (
+            max_over_time(
+            (
+            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
+            -
+            cortex_blockbuilder_scheduler_partition_committed_offset
+            )[10m:])) > 4e6
           for: 140m
           labels:
             severity: critical

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -233,29 +233,20 @@
           },
         },
 
-        // Alert if block-builder didn't process cycles in the past hour.
-        {
-          alert: $.alertName('BlockBuilderNoCycleProcessing'),
-          'for': '60m',
-          expr: |||
-            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (histogram_count(increase(cortex_blockbuilder_consume_cycle_duration_seconds[60m]))) == 0
-          ||| % $._config,
-          labels: {
-            severity: 'critical',
-          },
-          annotations: {
-            message: '%(product)s {{ $labels.%(per_instance_label)s }} in %(alert_aggregation_variables)s has not processed cycles in the past hour.' % $._config,
-          },
-        },
-
         // Alert if block-builder per partition lag is higher than the threshhold.
-        // The value of the threshhold is arbitary large for now. We will reconsider this alert after we get the block-builder-scheduler.
+        // The value of the threshhold is arbitary large for now. We will reconsider it as we get more operational experience.
         // Note on "for: 75m": we assume one cycle is 1hr; with 10m loopback we expect the warning to trigger only if the metric is above the threshold for more than one cycle.
         {
           alert: $.alertName('BlockBuilderLagging'),
           'for': '75m',
           expr: |||
-            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (
+            max_over_time(
+            (
+            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
+            -
+            cortex_blockbuilder_scheduler_partition_committed_offset
+            )[10m:])) > 4e6
           ||| % $._config,
           labels: {
             severity: 'warning',
@@ -268,7 +259,13 @@
           alert: $.alertName('BlockBuilderLagging'),
           'for': '140m',  // 2h20m. Indicating the lag did not come down for ~2 consumption cycles.
           expr: |||
-            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(cortex_blockbuilder_consumer_lag_records[10m])) > 4e6
+            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (
+            max_over_time(
+            (
+            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
+            -
+            cortex_blockbuilder_scheduler_partition_committed_offset
+            )[10m:])) > 4e6
           ||| % $._config,
           labels: {
             severity: 'critical',


### PR DESCRIPTION
#### What this PR does

Here I'm updating the experimental block-builder alerts to rely on the metrics exposed by the block-builder-scheduler. Moving forward, we will completely get rid of the block-builder stand-alone mode.