### PR TITLE
Mixin: Improve "Kafka 100th percentile end-to-end latency when ingesters are running (outliers)" panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * [ENHANCEMENT] Dashboards: Add panels to the `Mimir / Tenants` and `Mimir / Top Tenants` dashboards showing the rate of gateway requests. #10978
 * [ENHANCEMENT] Alerts: Improve `MimirIngesterFailsToProcessRecordsFromKafka` to not fire during forced TSDB head compaction. #11006
 * [ENHANCEMENT] Alerts: Add alerts for invalid cluster validation labels. #11255 #11282 #11413
+* [ENHANCEMENT] Dashboards: Improve "Kafka 100th percentile end-to-end latency when ingesters are running (outliers)" panel, computing the baseline latency on `max(10, 10%)` of ingesters instead of a fixed 10 replicas. #11581
 * [CHANGE] Alerts: Update query for `MimirBucketIndexNotUpdated`. Use `max_over_time` to prevent alert firing when pods rotate. #11311, #11426
 * [CHANGE] Alerts: Make alerting threshold for `DistributorGcUsesTooMuchCpu` configurable. #11508.
 * [BUGFIX] Dashboards: fix "Mimir / Tenants" legends for non-Kubernetes deployments. #10891

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -1891,19 +1891,31 @@ local utils = import 'mixin-utils/utils.libsonnet';
         histogram_quantile(1.0, sum by(pod) (rate(cortex_ingest_storage_reader_receive_delay_seconds{%(job_matcher)s, phase="running"}[$__rate_interval])))
 
         # Add a filter to show only the outliers. We consider an ingester an outlier if its
-        # 100th percentile latency is greater than the 200%% of the average 100th of the 10
-        # worst ingesters (if there are less than 10 ingesters, then all ingesters will be took
-        # in account).
+        # 100th percentile latency is greater than the 200%% of the average 100th of the 10%%
+        # worst ingesters (minimum 10 ingesters; if there are less than 10 ingesters, then all
+        # ingesters will be took in account).
         > scalar(
           avg(
-            topk(10,
-                histogram_quantile(1.0, sum by(pod) (rate(cortex_ingest_storage_reader_receive_delay_seconds{%(job_matcher)s, phase="running"}[$__rate_interval])))
+            topk(
+                scalar(
+                    clamp_min(
+                        ceil(
+                            count(count by(%(per_namespace_label)s, %(per_instance_label)s) (cortex_ingest_storage_reader_receive_delay_seconds{%(job_matcher)s, phase="running"}))
+                            * 0.1
+                        ), 10
+                    )
+                ),
+                histogram_quantile(1.0, sum by(%(per_instance_label)s) (rate(cortex_ingest_storage_reader_receive_delay_seconds{%(job_matcher)s, phase="running"}[$__rate_interval])))
                 > 0
             )
           )
           * 2
         )
-      ||| % { job_matcher: $.jobMatcher($._config.job_names.ingester) },
+      ||| % {
+        job_matcher: $.jobMatcher($._config.job_names.ingester),
+        per_instance_label: $._config.per_instance_label,
+        per_namespace_label: $._config.per_namespace_label,
+      },
       '{{pod}}',
     ) + {
       fieldConfig+: {


### PR DESCRIPTION
#### What this PR does

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
