### PR TITLE
Don't try to create a `Query` instance just to compute stats for remote read requests

### DIFF
--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -225,21 +225,6 @@ func newQuery(ctx context.Context, r MetricsQueryRequest, engine *promql.Engine,
 			r.GetQuery(),
 			util.TimeFromMillis(r.GetTime()),
 		)
-	case *remoteReadQueryRequest:
-		return engine.NewRangeQuery(
-			ctx,
-			queryable,
-			// Lookback period is not applied to remote read queries in the same way
-			// as regular queries. However we cannot set a zero lookback period
-			// because the engine will just use the default 5 minutes instead. So we
-			// set a lookback period of 1ns and add that amount to the start time so
-			// the engine will calculate an effective 0 lookback period.
-			promql.NewPrometheusQueryOpts(false, 1*time.Nanosecond),
-			r.GetQuery(),
-			util.TimeFromMillis(r.GetStart()).Add(1*time.Nanosecond),
-			util.TimeFromMillis(r.GetEnd()),
-			time.Duration(r.GetStep())*time.Millisecond,
-		)
 	default:
 		return nil, fmt.Errorf("unsupported query type %T", r)
 	}


### PR DESCRIPTION
#### What this PR does

This PR modifies the behaviour of the query stats middleware to no longer create a `promql.Query` instance when computing query stats for remote read requests.

This is completely unnecessary, and also [doesn't work as expected with MQE](https://github.com/grafana/mimir/pull/11417#discussion_r2092556045).

I haven't added a changelog entry given this is just a refactoring.

#### Which issue(s) this PR fixes or relates to

#11417

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
