### PR TITLE
Update Thanos to Mimir migration guide with relabelling tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@
 
 ### Documentation
 
+* [ENHANCEMENT] Update Thanos to Mimir migration guide with tip to add `__tenant_id__` label. #11584
+
 ### Tools
 
 * [ENHANCEMENT] `kafkatool`: Add `offsets` command for querying various partition offsets. #11115

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@
 
 ### Documentation
 
-* [ENHANCEMENT] Update Thanos to Mimir migration guide with tip to add `__tenant_id__` label. #11584
+* [ENHANCEMENT] Update Thanos to Mimir migration guide with a tip to add the `__tenant_id__` label. #11584
 
 ### Tools
 

--- a/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
+++ b/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
@@ -258,7 +258,7 @@ This may cause that incorrect results are returned for the query.
    {{< /admonition >}}
 
    {{< admonition type="tip" >}}
-   Be sure to add `__tenant_id__` label with value of your target tenant. This is important for Mimir to successfully query the migrated data when tenant federation is enabled and Grafana data source is configured to query multiple tenants.
+   Add the `__tenant_id__` label with the value of your target tenant. This is important for Mimir to successfully query the migrated data when you enable tenant federation and configure the Grafana data source to query multiple tenants.
    {{< /admonition >}}
 
    Create a rewrite configuration that is similar to this:

--- a/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
+++ b/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
@@ -251,10 +251,14 @@ This may cause that incorrect results are returned for the query.
 
 1. Relabel the blocks with external labels.
 
-   Mimir doesn’t inject external labels from the `meta.json` file into query results. Therefore, you need to relabel the blocks with the required external labels in the `meta.json` file. Be sure to add `__tenant_id__` label with value of your target tenant. This is important for Mimir to successfully query the migrated data.
+   Mimir doesn’t inject external labels from the `meta.json` file into query results. Therefore, you need to relabel the blocks with the required external labels in the `meta.json` file.
 
    {{< admonition type="tip" >}}
    You can get the external labels in the `meta.json` file of each block from the CSV file that's imported, and build the rewrite configuration accordingly.
+   {{< /admonition >}}
+
+   {{< admonition type="tip" >}}
+   Be sure to add `__tenant_id__` label with value of your target tenant. This is important for Mimir to successfully query the migrated data when tenant federation is enabled and Grafana data source is configured to query multiple tenants.
    {{< /admonition >}}
 
    Create a rewrite configuration that is similar to this:

--- a/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
+++ b/docs/sources/mimir/set-up/migrate/migrate-from-thanos-or-prometheus.md
@@ -251,7 +251,7 @@ This may cause that incorrect results are returned for the query.
 
 1. Relabel the blocks with external labels.
 
-   Mimir doesn’t inject external labels from the `meta.json` file into query results. Therefore, you need to relabel the blocks with the required external labels in the `meta.json` file.
+   Mimir doesn’t inject external labels from the `meta.json` file into query results. Therefore, you need to relabel the blocks with the required external labels in the `meta.json` file. Be sure to add `__tenant_id__` label with value of your target tenant. This is important for Mimir to successfully query the migrated data.
 
    {{< admonition type="tip" >}}
    You can get the external labels in the `meta.json` file of each block from the CSV file that's imported, and build the rewrite configuration accordingly.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Clarification to the migration guide, to include information about adding `__tenant_id__` label with tenant name as its value. Without this label, migrated data may not be queried correctly when tenant federation is enabled and Grafana data source is configured to query multiple tenants.

#### Which issue(s) this PR fixes or relates to

No issue  in Github. Question raised in Slack: https://grafana.slack.com/archives/C039863E8P7/p1745839615875179

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
