### PR TITLE
Renovate: Don't update charleskorn/objstore

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,6 +26,7 @@
           "github.com/grafana/opentracing-contrib-go-stdlib",
           "github.com/charleskorn/go-grpc",
           "google.golang.org/grpc",
+          "github.com/charleskorn/objstore",
         ],
         "enabled": false
       },


### PR DESCRIPTION
#### What this PR does

Configure Renovate to not update our thanos-io/objstore fork: github.com/charleskorn/objstore. For motivation, see https://github.com/grafana/mimir/pull/11585, which attempted to downgrade this dependency (to latest upstream).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
