### PR TITLE
Renovate: Re-enable google.golang.org/grpc

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -25,7 +25,6 @@
           "github.com/grafana/goautoneg",
           "github.com/grafana/opentracing-contrib-go-stdlib",
           "github.com/charleskorn/go-grpc",
-          "google.golang.org/grpc",
           "github.com/charleskorn/objstore",
         ],
         "enabled": false


### PR DESCRIPTION
#### What this PR does

As the `google.golang.org/grpc` dependency is no longer pinned, re-enable Renovate updates of it. Thanks to @charleskorn for pointing it out.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
