### PR TITLE
ci: Don't install Docker for jobs that run directly on the host

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -394,8 +394,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
-      - name: Install Docker Client
-        run: sudo ./.github/workflows/scripts/install-docker.sh
       - name: Symlink Expected Path to Workspace
         run: |
           sudo mkdir -p /go/src/github.com/grafana/mimir


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

integration-alpine tests have been removed in newer versions, but not here. They currently fail because we try to install Docker for jobs whose runners already have Docker already installed.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
