### PR TITLE
Fix issue where queriers can panic if the query is cancelled while a `Select` call is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * [BUGFIX] Ruler: Failures during initial sync must be fatal for the service's startup. #11545
 * [BUGFIX] Querier and query-frontend: Fix issue where aggregation functions like `topk` and `quantile` could return incorrect results if the scalar parameter is not a constant and Prometheus' query engine is in use. #11548
 * [BUGFIX] Querier and query-frontend: Fix issue where range vector selectors could incorrectly ignore samples at the beginning of the range. #11548
+* [BUGFIX] Querier: Fix rare panic if a query is canceled while a request to ingesters or store-gateways has just begun. #11613
 
 ### Mixin
 

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -56,6 +56,8 @@ import (
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
+var errAlreadyClosed = errors.New("querier already closed")
+
 // BlocksStoreSet is the interface used to get the clients to query series on a set of blocks.
 type BlocksStoreSet interface {
 	services.Service
@@ -308,6 +310,7 @@ func (q *BlocksStoreQueryable) Querier(mint, maxt int64) (storage.Querier, error
 		consistency:              q.consistency,
 		logger:                   q.logger,
 		queryStoreAfter:          q.queryStoreAfter,
+		streamReadersMtx:         &sync.Mutex{},
 	}, nil
 }
 
@@ -326,7 +329,9 @@ type blocksStoreQuerier struct {
 	// "now - queryStoreAfter" so that most recent blocks are not queried.
 	queryStoreAfter time.Duration
 
-	streamReaders []*storeGatewayStreamReader
+	streamReadersMtx *sync.Mutex
+	closed           bool
+	streamReaders    []*storeGatewayStreamReader
 }
 
 // Select implements storage.Querier interface.
@@ -430,6 +435,11 @@ func (q *blocksStoreQuerier) LabelValues(ctx context.Context, name string, hints
 }
 
 func (q *blocksStoreQuerier) Close() error {
+	q.streamReadersMtx.Lock()
+	defer q.streamReadersMtx.Unlock()
+
+	q.closed = true
+
 	for _, r := range q.streamReaders {
 		r.FreeBuffer()
 	}
@@ -479,11 +489,9 @@ func (q *blocksStoreQuerier) selectSorted(ctx context.Context, sp *storage.Selec
 	if len(resStreamReaders) > 0 {
 		spanLog.DebugLog("msg", "starting streaming")
 
-		q.streamReaders = append(q.streamReaders, resStreamReaders...)
-
-		// If this was a streaming call, start fetching streaming chunks here.
-		for _, r := range resStreamReaders {
-			r.StartBuffering()
+		err := q.startBuffering(resStreamReaders)
+		if err != nil {
+			return storage.ErrSeriesSet(err)
 		}
 
 		spanLog.DebugLog("msg", "streaming started, waiting for chunks estimates")
@@ -503,6 +511,29 @@ func (q *blocksStoreQuerier) selectSorted(ctx context.Context, sp *storage.Selec
 	return series.NewSeriesSetWithWarnings(
 		storage.NewMergeSeriesSet(resSeriesSets, 0, storage.ChainedSeriesMerge),
 		resWarnings)
+}
+
+func (q *blocksStoreQuerier) startBuffering(streamReaders []*storeGatewayStreamReader) error {
+	q.streamReadersMtx.Lock()
+	defer q.streamReadersMtx.Unlock()
+
+	if q.closed {
+		// We were closed while loading, give up now.
+		for _, r := range streamReaders {
+			r.Close()
+		}
+
+		return errAlreadyClosed
+	}
+
+	q.streamReaders = append(q.streamReaders, streamReaders...)
+
+	// If this was a streaming call, start fetching streaming chunks here.
+	for _, r := range streamReaders {
+		r.StartBuffering()
+	}
+
+	return nil
 }
 
 type queryFunc func(clients map[BlocksStoreClient][]ulid.ULID, minT, maxT int64) ([]ulid.ULID, error)

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -310,7 +310,6 @@ func (q *BlocksStoreQueryable) Querier(mint, maxt int64) (storage.Querier, error
 		consistency:              q.consistency,
 		logger:                   q.logger,
 		queryStoreAfter:          q.queryStoreAfter,
-		streamReadersMtx:         &sync.Mutex{},
 	}, nil
 }
 
@@ -329,7 +328,7 @@ type blocksStoreQuerier struct {
 	// "now - queryStoreAfter" so that most recent blocks are not queried.
 	queryStoreAfter time.Duration
 
-	streamReadersMtx *sync.Mutex
+	streamReadersMtx sync.Mutex
 	closed           bool
 	streamReaders    []*storeGatewayStreamReader
 }

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -17,7 +17,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"sync"
 	"testing"
 	"text/template"
 	"time"
@@ -1757,7 +1756,6 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 						logger:             log.NewNopLogger(),
 						metrics:            newBlocksStoreQueryableMetrics(reg),
 						limits:             testData.limits,
-						streamReadersMtx:   &sync.Mutex{},
 					}
 
 					matchers := []*labels.Matcher{
@@ -1883,7 +1881,6 @@ func TestBlocksStoreQuerier_Select_ClosedBeforeSelectFinishes(t *testing.T) {
 		logger:             log.NewNopLogger(),
 		metrics:            newBlocksStoreQueryableMetrics(reg),
 		limits:             &blocksStoreLimitsMock{},
-		streamReadersMtx:   &sync.Mutex{},
 	}
 
 	// For simplicity, we close the querier before issuing the Select call, but in the real world,

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"text/template"
 	"time"
@@ -1756,6 +1757,7 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 						logger:             log.NewNopLogger(),
 						metrics:            newBlocksStoreQueryableMetrics(reg),
 						limits:             testData.limits,
+						streamReadersMtx:   &sync.Mutex{},
 					}
 
 					matchers := []*labels.Matcher{
@@ -1843,6 +1845,56 @@ func TestBlocksStoreQuerier_Select(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBlocksStoreQuerier_Select_ClosedBeforeSelectFinishes(t *testing.T) {
+	const minT = int64(10)
+	const maxT = int64(20)
+
+	block := ulid.MustNew(1, nil)
+	storeSetResponses := []interface{}{
+		map[BlocksStoreClient][]ulid.ULID{
+			&storeGatewayClientMock{
+				remoteAddr: "1.1.1.1",
+				mockedSeriesResponses: generateStreamingResponses([]*storepb.SeriesResponse{
+					mockSeriesResponse(labels.FromStrings(labels.MetricName, "some_metric"), minT, 1),
+					mockHintsResponse(block),
+				}),
+			}: {block},
+		},
+	}
+
+	stores := &blocksStoreSetMock{mockedResponses: storeSetResponses}
+	finder := &blocksFinderMock{}
+	finderResult := bucketindex.Blocks{
+		{ID: block},
+	}
+	finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(finderResult, nil)
+
+	reg := prometheus.NewPedanticRegistry()
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	querier := &blocksStoreQuerier{
+		minT:               minT,
+		maxT:               maxT,
+		finder:             finder,
+		stores:             stores,
+		dynamicReplication: newDynamicReplication(),
+		consistency:        NewBlocksConsistency(0, reg),
+		logger:             log.NewNopLogger(),
+		metrics:            newBlocksStoreQueryableMetrics(reg),
+		limits:             &blocksStoreLimitsMock{},
+		streamReadersMtx:   &sync.Mutex{},
+	}
+
+	// For simplicity, we close the querier before issuing the Select call, but in the real world,
+	// this would likely happen while the Select call is still in progress (eg. because the query was cancelled).
+	require.NoError(t, querier.Close())
+
+	seriesSet := querier.Select(ctx, true, &storage.SelectHints{Start: minT, End: maxT}, labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, ".*"))
+	require.EqualError(t, seriesSet.Err(), "querier already closed")
+
+	// We also expect that the background goroutine launched by the stream reader is either never started or stopped correctly, and this should be
+	// caught by VerifyNoLeak in TestMain().
 }
 
 func TestBlocksStoreQuerier_ShouldReturnContextCanceledIfContextWasCanceledWhileRunningRequestOnStoreGateway(t *testing.T) {

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -7,6 +7,7 @@ package querier
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -67,12 +68,13 @@ type distributorQueryable struct {
 
 func (d distributorQueryable) Querier(mint, maxt int64) (storage.Querier, error) {
 	return &distributorQuerier{
-		logger:       d.logger,
-		distributor:  d.distributor,
-		mint:         mint,
-		maxt:         maxt,
-		queryMetrics: d.queryMetrics,
-		cfgProvider:  d.cfgProvider,
+		logger:           d.logger,
+		distributor:      d.distributor,
+		mint:             mint,
+		maxt:             maxt,
+		queryMetrics:     d.queryMetrics,
+		cfgProvider:      d.cfgProvider,
+		streamReadersMtx: &sync.Mutex{},
 	}, nil
 }
 
@@ -83,7 +85,9 @@ type distributorQuerier struct {
 	cfgProvider  distributorQueryableConfigProvider
 	queryMetrics *stats.QueryMetrics
 
-	streamReaders []*client.SeriesChunksStreamReader
+	streamReadersMtx *sync.Mutex
+	closed           bool
+	streamReaders    []*client.SeriesChunksStreamReader
 }
 
 // Select implements storage.Querier interface.
@@ -195,6 +199,18 @@ func (q *distributorQuerier) streamingSelect(ctx context.Context, minT, maxT int
 	}
 
 	// Store the stream readers so we can free their buffers when we're done using this Querier.
+	q.streamReadersMtx.Lock()
+	defer q.streamReadersMtx.Unlock()
+
+	if q.closed {
+		// We were closed while loading, give up now.
+		for _, r := range results.StreamReaders {
+			r.FreeBuffer()
+		}
+
+		return storage.ErrSeriesSet(errAlreadyClosed)
+	}
+
 	q.streamReaders = append(q.streamReaders, results.StreamReaders...)
 
 	if len(sets) == 0 {
@@ -253,6 +269,11 @@ func (q *distributorQuerier) LabelNames(ctx context.Context, hints *storage.Labe
 }
 
 func (q *distributorQuerier) Close() error {
+	q.streamReadersMtx.Lock()
+	defer q.streamReadersMtx.Unlock()
+
+	q.closed = true
+
 	for _, r := range q.streamReaders {
 		r.FreeBuffer()
 	}


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where queriers can panic if the query is cancelled or fails while a `Select` call is running. 

This happens because queriers wrap the ingester and store-gateway `Querier` instances with a `LazyQuerier`. This can result in `Close` being called while the `Select` call is still running, creating a race to read from / write to `streamReaders` and causing `Close` to call `FreeBuffer()` on a nil reader instance if `Select` has not finished appending the new readers to `streamReaders`.

An alternative solution would be to modify `LazyQuerier` to wait for the `Select` to finish before calling `Close` on the wrapped `Querier`, but this may cause delays in closing the query if the `Select` does not complete promptly.

#### Which issue(s) this PR fixes or relates to

#11136

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
