### PR TITLE
Renovate: Use `config:recommended` preset

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-      "config:base"
+      "config:recommended"
     ],
     "baseBranches": ["main", "release-2.16", "release-2.15"],
     "postUpdateOptions": [


### PR DESCRIPTION
#### What this PR does

Switch Renovate configuration to use `config:recommended` preset, instead of `config:base`. `config:recommended` is the [preferred Renovate preset](https://docs.renovatebot.com/config-presets/#example-configs), I can't even find documentation on `config:base`. I'm going to guess it's legacy.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
