### PR TITLE
Add MQE-related dashboard panels to Queries dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * [ENHANCEMENT] Alerts: Improve `MimirIngesterFailsToProcessRecordsFromKafka` to not fire during forced TSDB head compaction. #11006
 * [ENHANCEMENT] Alerts: Add alerts for invalid cluster validation labels. #11255 #11282 #11413
 * [ENHANCEMENT] Dashboards: Improve "Kafka 100th percentile end-to-end latency when ingesters are running (outliers)" panel, computing the baseline latency on `max(10, 10%)` of ingesters instead of a fixed 10 replicas. #11581
+* [ENHANCEMENT] Dashboards: Add "per-query memory consumption" and "fallback to Prometheus' query engine" panels to the Queries dashboard. #11626
 * [CHANGE] Alerts: Update query for `MimirBucketIndexNotUpdated`. Use `max_over_time` to prevent alert firing when pods rotate. #11311, #11426
 * [CHANGE] Alerts: Make alerting threshold for `DistributorGcUsesTooMuchCpu` configurable. #11508.
 * [BUGFIX] Dashboards: fix "Mimir / Tenants" legends for non-Kubernetes deployments. #10891

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -12965,7 +12965,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
-                      "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if MQE is enabled and the query was evaluated with MQE.\n\n",
+                      "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if the Mimir query engine (MQE) is enabled and the query was evaluated with MQE.\n\n",
                       "id": 20,
                       "options": {
                          "calculate": true,
@@ -13008,7 +13008,7 @@ data:
                    },
                    {
                       "datasource": "$datasource",
-                      "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if MQE is enabled.\n\n",
+                      "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if the Mimir query engine (MQE) is enabled.\n\n",
                       "fieldConfig": {
                          "defaults": {
                             "custom": {

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -12714,7 +12714,7 @@ data:
                             "sort": "none"
                          }
                       },
-                      "span": 3,
+                      "span": 4,
                       "targets": [
                          {
                             "expr": "histogram_quantile(0.99, sum(rate(cortex_querier_storegateway_instances_hit_per_query_bucket{$read_path_matcher}[$__rate_interval])) by (le)) * 1",
@@ -12793,7 +12793,7 @@ data:
                             "sort": "none"
                          }
                       },
-                      "span": 3,
+                      "span": 4,
                       "targets": [
                          {
                             "expr": "histogram_quantile(0.99, sum(rate(cortex_querier_storegateway_refetches_per_query_bucket{$read_path_matcher}[$__rate_interval])) by (le)) * 1",
@@ -12889,7 +12889,7 @@ data:
                             "sort": "none"
                          }
                       },
-                      "span": 3,
+                      "span": 4,
                       "targets": [
                          {
                             "expr": "sum(rate(cortex_querier_blocks_consistency_checks_failed_total{$read_path_matcher}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{$read_path_matcher}[$__rate_interval]))",
@@ -12900,7 +12900,19 @@ data:
                       ],
                       "title": "Consistency checks failed",
                       "type": "timeseries"
-                   },
+                   }
+                ],
+                "repeat": null,
+                "repeatIteration": null,
+                "repeatRowId": null,
+                "showTitle": true,
+                "title": "Querier",
+                "titleSize": "h6"
+             },
+             {
+                "collapse": false,
+                "height": "250px",
+                "panels": [
                    {
                       "datasource": "$datasource",
                       "description": "### Rejected queries\nThe proportion of all queries received by queriers that were rejected for some reason.\n\n",
@@ -12939,7 +12951,7 @@ data:
                             "sort": "none"
                          }
                       },
-                      "span": 3,
+                      "span": 4,
                       "targets": [
                          {
                             "expr": "sum by (reason) (rate(cortex_querier_queries_rejected_total{$read_path_matcher}[$__rate_interval])) / ignoring (reason) group_left sum(rate(cortex_querier_request_duration_seconds_count{$read_path_matcher, route=~\"(prometheus|api_prom)_api_v1_query(_range)?\"}[$__rate_interval]))",
@@ -12950,13 +12962,105 @@ data:
                       ],
                       "title": "Rejected queries",
                       "type": "timeseries"
+                   },
+                   {
+                      "datasource": "$datasource",
+                      "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if MQE is enabled and the query was evaluated with MQE.\n\n",
+                      "id": 20,
+                      "options": {
+                         "calculate": true,
+                         "calculation": {
+                            "xBuckets": {
+                               "mode": "count",
+                               "value": 60
+                            },
+                            "yBuckets": {
+                               "mode": "count",
+                               "value": 40
+                            }
+                         },
+                         "cellGap": 0,
+                         "cellValues": {
+                            "unit": "reqps"
+                         },
+                         "legend": {
+                            "show": false
+                         },
+                         "tooltip": {
+                            "yHistogram": true
+                         },
+                         "yAxis": {
+                            "min": 0,
+                            "unit": "bytes"
+                         }
+                      },
+                      "span": 4,
+                      "targets": [
+                         {
+                            "expr": "sum(rate(cortex_mimir_query_engine_estimated_query_peak_memory_consumption{$read_path_matcher}[$__rate_interval]))",
+                            "format": "time_series",
+                            "legendFormat": "Estimated memory consumption",
+                            "legendLink": null
+                         }
+                      ],
+                      "title": "Estimated per-query memory consumption",
+                      "type": "heatmap"
+                   },
+                   {
+                      "datasource": "$datasource",
+                      "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if MQE is enabled.\n\n",
+                      "fieldConfig": {
+                         "defaults": {
+                            "custom": {
+                               "drawStyle": "line",
+                               "fillOpacity": 1,
+                               "lineWidth": 1,
+                               "pointSize": 5,
+                               "showPoints": "never",
+                               "spanNulls": false,
+                               "stacking": {
+                                  "group": "A",
+                                  "mode": "none"
+                               }
+                            },
+                            "min": 0,
+                            "thresholds": {
+                               "mode": "absolute",
+                               "steps": [ ]
+                            },
+                            "unit": "reqps"
+                         },
+                         "overrides": [ ]
+                      },
+                      "id": 21,
+                      "links": [ ],
+                      "options": {
+                         "legend": {
+                            "showLegend": true
+                         },
+                         "tooltip": {
+                            "mode": "multi",
+                            "sort": "none"
+                         }
+                      },
+                      "span": 4,
+                      "targets": [
+                         {
+                            "expr": "sum(rate(cortex_mimir_query_engine_unsupported_queries_total{$read_path_matcher}[$__rate_interval])) or vector(0)",
+                            "format": "time_series",
+                            "legendFormat": "Queries",
+                            "legendLink": null
+                         }
+                      ],
+                      "title": "Fallback to Prometheus' query engine",
+                      "type": "timeseries"
                    }
                 ],
                 "repeat": null,
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": true,
-                "title": "Querier",
+                "title": "",
                 "titleSize": "h6"
              },
              {
@@ -12988,7 +13092,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 20,
+                      "id": 22,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13079,7 +13183,7 @@ data:
                             }
                          ]
                       },
-                      "id": 21,
+                      "id": 23,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13133,7 +13237,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 22,
+                      "id": 24,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -13225,7 +13329,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 23,
+                      "id": 25,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13279,7 +13383,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 24,
+                      "id": 26,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13327,7 +13431,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 25,
+                      "id": 27,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13387,7 +13491,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 26,
+                      "id": 28,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13435,7 +13539,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 27,
+                      "id": 29,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13485,7 +13589,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 28,
+                      "id": 30,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13546,7 +13650,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 29,
+                      "id": 31,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13625,7 +13729,7 @@ data:
                             }
                          ]
                       },
-                      "id": 30,
+                      "id": 32,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13710,7 +13814,7 @@ data:
                             }
                          ]
                       },
-                      "id": 31,
+                      "id": 33,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13776,7 +13880,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 32,
+                      "id": 34,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -13824,7 +13928,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 33,
+                      "id": 35,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -13904,7 +14008,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 34,
+                      "id": 36,
                       "links": [ ],
                       "nullPointMode": "null as zero",
                       "options": {
@@ -13996,7 +14100,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 35,
+                      "id": 37,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -14045,7 +14149,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 36,
+                      "id": 38,
                       "links": [ ],
                       "options": {
                          "legend": {
@@ -14094,7 +14198,7 @@ data:
                          },
                          "overrides": [ ]
                       },
-                      "id": 37,
+                      "id": 39,
                       "links": [ ],
                       "options": {
                          "legend": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -1280,7 +1280,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if MQE is enabled and the query was evaluated with MQE.\n\n",
+                  "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if the Mimir query engine (MQE) is enabled and the query was evaluated with MQE.\n\n",
                   "id": 20,
                   "options": {
                      "calculate": true,
@@ -1323,7 +1323,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if MQE is enabled.\n\n",
+                  "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if the Mimir query engine (MQE) is enabled.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -1029,7 +1029,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "histogram_quantile(0.99, sum(rate(cortex_querier_storegateway_instances_hit_per_query_bucket{$read_path_matcher}[$__rate_interval])) by (le)) * 1",
@@ -1108,7 +1108,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "histogram_quantile(0.99, sum(rate(cortex_querier_storegateway_refetches_per_query_bucket{$read_path_matcher}[$__rate_interval])) by (le)) * 1",
@@ -1204,7 +1204,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_querier_blocks_consistency_checks_failed_total{$read_path_matcher}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{$read_path_matcher}[$__rate_interval]))",
@@ -1215,7 +1215,19 @@
                   ],
                   "title": "Consistency checks failed",
                   "type": "timeseries"
-               },
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Querier",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
                {
                   "datasource": "$datasource",
                   "description": "### Rejected queries\nThe proportion of all queries received by queriers that were rejected for some reason.\n\n",
@@ -1254,7 +1266,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by (reason) (rate(cortex_querier_queries_rejected_total{$read_path_matcher}[$__rate_interval])) / ignoring (reason) group_left sum(rate(cortex_querier_request_duration_seconds_count{$read_path_matcher, route=~\"(prometheus|api_prom)_api_v1_query(_range)?\"}[$__rate_interval]))",
@@ -1265,13 +1277,105 @@
                   ],
                   "title": "Rejected queries",
                   "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if MQE is enabled and the query was evaluated with MQE.\n\n",
+                  "id": 20,
+                  "options": {
+                     "calculate": true,
+                     "calculation": {
+                        "xBuckets": {
+                           "mode": "count",
+                           "value": 60
+                        },
+                        "yBuckets": {
+                           "mode": "count",
+                           "value": 40
+                        }
+                     },
+                     "cellGap": 0,
+                     "cellValues": {
+                        "unit": "reqps"
+                     },
+                     "legend": {
+                        "show": false
+                     },
+                     "tooltip": {
+                        "yHistogram": true
+                     },
+                     "yAxis": {
+                        "min": 0,
+                        "unit": "bytes"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(rate(cortex_mimir_query_engine_estimated_query_peak_memory_consumption{$read_path_matcher}[$__rate_interval]))",
+                        "format": "time_series",
+                        "legendFormat": "Estimated memory consumption",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Estimated per-query memory consumption",
+                  "type": "heatmap"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if MQE is enabled.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "reqps"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 21,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(rate(cortex_mimir_query_engine_unsupported_queries_total{$read_path_matcher}[$__rate_interval])) or vector(0)",
+                        "format": "time_series",
+                        "legendFormat": "Queries",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Fallback to Prometheus' query engine",
+                  "type": "timeseries"
                }
             ],
             "repeat": null,
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Querier",
+            "title": "",
             "titleSize": "h6"
          },
          {
@@ -1303,7 +1407,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 20,
+                  "id": 22,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1394,7 +1498,7 @@
                         }
                      ]
                   },
-                  "id": 21,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1448,7 +1552,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 24,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -1540,7 +1644,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 23,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1594,7 +1698,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 26,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1642,7 +1746,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 25,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1702,7 +1806,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 26,
+                  "id": 28,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1750,7 +1854,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 27,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1800,7 +1904,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 28,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1861,7 +1965,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 29,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1940,7 +2044,7 @@
                         }
                      ]
                   },
-                  "id": 30,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2025,7 +2129,7 @@
                         }
                      ]
                   },
-                  "id": 31,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2091,7 +2195,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 32,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2139,7 +2243,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 35,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2219,7 +2323,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 34,
+                  "id": 36,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2311,7 +2415,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 37,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2360,7 +2464,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2409,7 +2513,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 39,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-queries.json
@@ -1091,7 +1091,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "histogram_quantile(0.99, sum(rate(cortex_querier_storegateway_instances_hit_per_query_bucket{$read_path_matcher}[$__rate_interval])) by (le)) * 1",
@@ -1170,7 +1170,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "histogram_quantile(0.99, sum(rate(cortex_querier_storegateway_refetches_per_query_bucket{$read_path_matcher}[$__rate_interval])) by (le)) * 1",
@@ -1266,7 +1266,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_querier_blocks_consistency_checks_failed_total{$read_path_matcher}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{$read_path_matcher}[$__rate_interval]))",
@@ -1277,7 +1277,19 @@
                   ],
                   "title": "Consistency checks failed",
                   "type": "timeseries"
-               },
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Querier",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
                {
                   "datasource": "$datasource",
                   "description": "### Rejected queries\nThe proportion of all queries received by queriers that were rejected for some reason.\n\n",
@@ -1316,7 +1328,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by (reason) (rate(cortex_querier_queries_rejected_total{$read_path_matcher}[$__rate_interval])) / ignoring (reason) group_left sum(rate(cortex_querier_request_duration_seconds_count{$read_path_matcher, route=~\"(prometheus|api_prom)_api_v1_query(_range)?\"}[$__rate_interval]))",
@@ -1327,13 +1339,105 @@
                   ],
                   "title": "Rejected queries",
                   "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if MQE is enabled and the query was evaluated with MQE.\n\n",
+                  "id": 21,
+                  "options": {
+                     "calculate": true,
+                     "calculation": {
+                        "xBuckets": {
+                           "mode": "count",
+                           "value": 60
+                        },
+                        "yBuckets": {
+                           "mode": "count",
+                           "value": 40
+                        }
+                     },
+                     "cellGap": 0,
+                     "cellValues": {
+                        "unit": "reqps"
+                     },
+                     "legend": {
+                        "show": false
+                     },
+                     "tooltip": {
+                        "yHistogram": true
+                     },
+                     "yAxis": {
+                        "min": 0,
+                        "unit": "bytes"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(rate(cortex_mimir_query_engine_estimated_query_peak_memory_consumption{$read_path_matcher}[$__rate_interval]))",
+                        "format": "time_series",
+                        "legendFormat": "Estimated memory consumption",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Estimated per-query memory consumption",
+                  "type": "heatmap"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if MQE is enabled.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "reqps"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 22,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(rate(cortex_mimir_query_engine_unsupported_queries_total{$read_path_matcher}[$__rate_interval])) or vector(0)",
+                        "format": "time_series",
+                        "legendFormat": "Queries",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Fallback to Prometheus' query engine",
+                  "type": "timeseries"
                }
             ],
             "repeat": null,
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Querier",
+            "title": "",
             "titleSize": "h6"
          },
          {
@@ -1365,7 +1469,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 21,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1456,7 +1560,7 @@
                         }
                      ]
                   },
-                  "id": 22,
+                  "id": 24,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1510,7 +1614,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 23,
+                  "id": 25,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -1602,7 +1706,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 26,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1656,7 +1760,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 25,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1704,7 +1808,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 26,
+                  "id": 28,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1764,7 +1868,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 27,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1812,7 +1916,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 28,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1862,7 +1966,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 29,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1923,7 +2027,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 30,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2002,7 +2106,7 @@
                         }
                      ]
                   },
-                  "id": 31,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2087,7 +2191,7 @@
                         }
                      ]
                   },
-                  "id": 32,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2153,7 +2257,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 35,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2201,7 +2305,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 34,
+                  "id": 36,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2281,7 +2385,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 37,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2373,7 +2477,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2422,7 +2526,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 39,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2471,7 +2575,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 38,
+                  "id": 40,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-queries.json
@@ -1342,7 +1342,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if MQE is enabled and the query was evaluated with MQE.\n\n",
+                  "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if the Mimir query engine (MQE) is enabled and the query was evaluated with MQE.\n\n",
                   "id": 21,
                   "options": {
                      "calculate": true,
@@ -1385,7 +1385,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if MQE is enabled.\n\n",
+                  "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if the Mimir query engine (MQE) is enabled.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -1280,7 +1280,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if MQE is enabled and the query was evaluated with MQE.\n\n",
+                  "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if the Mimir query engine (MQE) is enabled and the query was evaluated with MQE.\n\n",
                   "id": 20,
                   "options": {
                      "calculate": true,
@@ -1323,7 +1323,7 @@
                },
                {
                   "datasource": "$datasource",
-                  "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if MQE is enabled.\n\n",
+                  "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if the Mimir query engine (MQE) is enabled.\n\n",
                   "fieldConfig": {
                      "defaults": {
                         "custom": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -1029,7 +1029,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "histogram_quantile(0.99, sum(rate(cortex_querier_storegateway_instances_hit_per_query_bucket{$read_path_matcher}[$__rate_interval])) by (le)) * 1",
@@ -1108,7 +1108,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "histogram_quantile(0.99, sum(rate(cortex_querier_storegateway_refetches_per_query_bucket{$read_path_matcher}[$__rate_interval])) by (le)) * 1",
@@ -1204,7 +1204,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum(rate(cortex_querier_blocks_consistency_checks_failed_total{$read_path_matcher}[$__rate_interval])) / sum(rate(cortex_querier_blocks_consistency_checks_total{$read_path_matcher}[$__rate_interval]))",
@@ -1215,7 +1215,19 @@
                   ],
                   "title": "Consistency checks failed",
                   "type": "timeseries"
-               },
+               }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": true,
+            "title": "Querier",
+            "titleSize": "h6"
+         },
+         {
+            "collapse": false,
+            "height": "250px",
+            "panels": [
                {
                   "datasource": "$datasource",
                   "description": "### Rejected queries\nThe proportion of all queries received by queriers that were rejected for some reason.\n\n",
@@ -1254,7 +1266,7 @@
                         "sort": "none"
                      }
                   },
-                  "span": 3,
+                  "span": 4,
                   "targets": [
                      {
                         "expr": "sum by (reason) (rate(cortex_querier_queries_rejected_total{$read_path_matcher}[$__rate_interval])) / ignoring (reason) group_left sum(rate(cortex_querier_request_duration_seconds_count{$read_path_matcher, route=~\"(prometheus|api_prom)_api_v1_query(_range)?\"}[$__rate_interval]))",
@@ -1265,13 +1277,105 @@
                   ],
                   "title": "Rejected queries",
                   "type": "timeseries"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Estimated per-query memory consumption\nThe esimated memory consumption of all queries evaluated by queriers. Only applicable if MQE is enabled and the query was evaluated with MQE.\n\n",
+                  "id": 20,
+                  "options": {
+                     "calculate": true,
+                     "calculation": {
+                        "xBuckets": {
+                           "mode": "count",
+                           "value": 60
+                        },
+                        "yBuckets": {
+                           "mode": "count",
+                           "value": 40
+                        }
+                     },
+                     "cellGap": 0,
+                     "cellValues": {
+                        "unit": "reqps"
+                     },
+                     "legend": {
+                        "show": false
+                     },
+                     "tooltip": {
+                        "yHistogram": true
+                     },
+                     "yAxis": {
+                        "min": 0,
+                        "unit": "bytes"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(rate(cortex_mimir_query_engine_estimated_query_peak_memory_consumption{$read_path_matcher}[$__rate_interval]))",
+                        "format": "time_series",
+                        "legendFormat": "Estimated memory consumption",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Estimated per-query memory consumption",
+                  "type": "heatmap"
+               },
+               {
+                  "datasource": "$datasource",
+                  "description": "### Fallback to Prometheus' query engine\nThe rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if MQE is enabled.\n\n",
+                  "fieldConfig": {
+                     "defaults": {
+                        "custom": {
+                           "drawStyle": "line",
+                           "fillOpacity": 1,
+                           "lineWidth": 1,
+                           "pointSize": 5,
+                           "showPoints": "never",
+                           "spanNulls": false,
+                           "stacking": {
+                              "group": "A",
+                              "mode": "none"
+                           }
+                        },
+                        "min": 0,
+                        "thresholds": {
+                           "mode": "absolute",
+                           "steps": [ ]
+                        },
+                        "unit": "reqps"
+                     },
+                     "overrides": [ ]
+                  },
+                  "id": 21,
+                  "links": [ ],
+                  "options": {
+                     "legend": {
+                        "showLegend": true
+                     },
+                     "tooltip": {
+                        "mode": "multi",
+                        "sort": "none"
+                     }
+                  },
+                  "span": 4,
+                  "targets": [
+                     {
+                        "expr": "sum(rate(cortex_mimir_query_engine_unsupported_queries_total{$read_path_matcher}[$__rate_interval])) or vector(0)",
+                        "format": "time_series",
+                        "legendFormat": "Queries",
+                        "legendLink": null
+                     }
+                  ],
+                  "title": "Fallback to Prometheus' query engine",
+                  "type": "timeseries"
                }
             ],
             "repeat": null,
             "repeatIteration": null,
             "repeatRowId": null,
             "showTitle": true,
-            "title": "Querier",
+            "title": "",
             "titleSize": "h6"
          },
          {
@@ -1303,7 +1407,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 20,
+                  "id": 22,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1394,7 +1498,7 @@
                         }
                      ]
                   },
-                  "id": 21,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1448,7 +1552,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 24,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -1540,7 +1644,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 23,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1594,7 +1698,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 24,
+                  "id": 26,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1642,7 +1746,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 25,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1702,7 +1806,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 26,
+                  "id": 28,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1750,7 +1854,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 27,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1800,7 +1904,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 28,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1861,7 +1965,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 29,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1940,7 +2044,7 @@
                         }
                      ]
                   },
-                  "id": 30,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2025,7 +2129,7 @@
                         }
                      ]
                   },
-                  "id": 31,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2091,7 +2195,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 32,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2139,7 +2243,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 35,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2219,7 +2323,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 34,
+                  "id": 36,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2311,7 +2415,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 37,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2360,7 +2464,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2409,7 +2513,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 39,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -224,6 +224,15 @@ local utils = import 'mixin-utils/utils.libsonnet';
       },
     },
 
+  heatmapPanel(title):: {
+    datasource: '$datasource',
+    title: title,
+    type: 'heatmap',
+    options: {
+      calculate: true,
+    },
+  },
+
   qpsPanel(selector, statusLabelName='status_code')::
     super.qpsPanel(selector, statusLabelName) +
     $.aliasColors({

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -366,7 +366,7 @@ local filename = 'mimir-queries.json';
         $.panelDescription(
           'Estimated per-query memory consumption',
           |||
-            The esimated memory consumption of all queries evaluated by queriers. Only applicable if MQE is enabled and the query was evaluated with MQE.
+            The esimated memory consumption of all queries evaluated by queriers. Only applicable if the Mimir query engine (MQE) is enabled and the query was evaluated with MQE.
           |||
         ),
       )
@@ -377,7 +377,7 @@ local filename = 'mimir-queries.json';
         $.panelDescription(
           "Fallback to Prometheus' query engine",
           |||
-            The rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if MQE is enabled.
+            The rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if the Mimir query engine (MQE) is enabled.
           |||
         ),
       )

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -318,6 +318,9 @@ local filename = 'mimir-queries.json';
           |||
         ),
       )
+    )
+    .addRow(
+      $.row('')
       .addPanel(
         $.timeseriesPanel('Rejected queries') +
         $.queryPanel('sum by (reason) (rate(cortex_querier_queries_rejected_total{$read_path_matcher}[$__rate_interval])) / ignoring (reason) group_left sum(rate(cortex_querier_request_duration_seconds_count{$read_path_matcher, route=~"%(routes_regex)s"}[$__rate_interval]))' % { routes_regex: $.queries.query_http_routes_regex }, '{{reason}}') +
@@ -326,6 +329,55 @@ local filename = 'mimir-queries.json';
           'Rejected queries',
           |||
             The proportion of all queries received by queriers that were rejected for some reason.
+          |||
+        ),
+      )
+      .addPanel(
+        $.heatmapPanel('Estimated per-query memory consumption') +
+        $.queryPanel('sum(rate(cortex_mimir_query_engine_estimated_query_peak_memory_consumption{$read_path_matcher}[$__rate_interval]))', 'Estimated memory consumption') +
+        {
+          options+: {
+            legend+: {
+              show: false,
+            },
+            tooltip+: {
+              yHistogram: true,
+            },
+            cellValues+: {
+              unit: 'reqps',
+            },
+            yAxis+: {
+              min: 0,
+              unit: 'bytes',
+            },
+            cellGap: 0,
+            calculation+: {
+              xBuckets: {
+                mode: 'count',
+                value: 60,
+              },
+              yBuckets: {
+                mode: 'count',
+                value: 40,
+              },
+            },
+          },
+        } +
+        $.panelDescription(
+          'Estimated per-query memory consumption',
+          |||
+            The esimated memory consumption of all queries evaluated by queriers. Only applicable if MQE is enabled and the query was evaluated with MQE.
+          |||
+        ),
+      )
+      .addPanel(
+        $.timeseriesPanel("Fallback to Prometheus' query engine") +
+        $.queryPanel('sum(rate(cortex_mimir_query_engine_unsupported_queries_total{$read_path_matcher}[$__rate_interval])) or vector(0)', 'Queries') +
+        { fieldConfig+: { defaults+: { unit: 'reqps' } } } +
+        $.panelDescription(
+          "Fallback to Prometheus' query engine",
+          |||
+            The rate of queries that fell back to Prometheus' query engine in queriers. Only applicable if MQE is enabled.
           |||
         ),
       )


### PR DESCRIPTION
#### What this PR does

This PR adds two panels to the Queries dashboard in the mixin:

* a heatmap of estimated per-query memory consumption
* a timeseries panel showing the rate of fallback to Prometheus' engine

This is how the affected area of the dashboard now looks:

<img width="1508" alt="Screenshot 2025-06-04 at 4 13 27 pm" src="https://github.com/user-attachments/assets/a8d5c623-fe1a-4b4b-8fcf-61389453fdb1" />


#### Which issue(s) this PR fixes or relates to

#10067

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
