### PR TITLE
label/metric name validation: use prometheus legacy validation scheme, avoid global variable

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,9 +47,16 @@ linters:
       comparison: true
     forbidigo:
       # We can't use faillint for a rule like this, because it does not support matching methods on structs or interfaces (see https://github.com/fatih/faillint/issues/18)
+      analyze-types: true
       forbid:
         - pattern: ^.*\.CloseSend.*$
           msg: Do not use CloseSend on a server-streaming gRPC stream. Use util.CloseAndExhaust instead. See the documentation on CloseAndExhaust for further explanation.
+        - pattern: ^.*model\.LabelName\.IsValid$
+          pkg: ^github.com/prometheus/common/model$
+          msg: it depends on model.NameValidationScheme. Use pkg/validation.IsValidLabelName instead.
+        - pattern: ^.*model\.IsValidMetricName$
+          pkg: ^github.com/prometheus/common/model$
+          msg: it depends on model.NameValidationScheme. Use pkg/validation.IsValidMetricName instead.
     gocritic:
       disable-all: true
       enabled-checks:

--- a/go.mod
+++ b/go.mod
@@ -344,7 +344,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250611134813-2510b5041da2
+replace github.com/prometheus/prometheus => github.com/juliusmh/mimir-prometheus v1.8.2-0.20250618091651-809285202792
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -573,8 +573,6 @@ github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700 h1:0t7iOQ5ZkB
 github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700/go.mod h1:Ri9p/tRShbjYnpNf4FFPXG7wxEGY4Nrcn6E7jrVa//4=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250527173959-2573485683d5 h1:H4Del07v9UAYJgky9oeRY1oNqs6dh8lmHRUWiGCKXoE=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250527173959-2573485683d5/go.mod h1:v1PzmPjSnNkmZSDvKJ9OmsWcmWMEF5+JdllEcXrRfzM=
-github.com/grafana/mimir-prometheus v1.8.2-0.20250611134813-2510b5041da2 h1:MJTw9VpZ2I65F5JkF4tUhRjskq9LmR5W0dmJUkBT3zY=
-github.com/grafana/mimir-prometheus v1.8.2-0.20250611134813-2510b5041da2/go.mod h1:wxNDaTwYlAYXHIlsXbCj1xQZik2CB+GGqYW6LUJq6s4=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
@@ -715,6 +713,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/juliusmh/mimir-prometheus v1.8.2-0.20250618091651-809285202792 h1:Tk/0EGEqvUBs0H5gNmy23wDaFKUpZu4p5p0asR97o6Q=
+github.com/juliusmh/mimir-prometheus v1.8.2-0.20250618091651-809285202792/go.mod h1:wxNDaTwYlAYXHIlsXbCj1xQZik2CB+GGqYW6LUJq6s4=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=

--- a/integration/legacy_name_validation_test.go
+++ b/integration/legacy_name_validation_test.go
@@ -14,12 +14,13 @@ import (
 
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
-	"github.com/grafana/mimir/integration/e2emimir"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/prompb"
 	promRW2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/integration/e2emimir"
 )
 
 // TestLegacyNameValidation_DistributorWrite ensures that distributors discard invalid
@@ -28,6 +29,8 @@ func TestLegacyNameValidation_DistributorWrite(t *testing.T) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
+
+	require.NoError(t, writeFileToSharedDir(s, "runtime.yaml", []byte("")))
 
 	consul := e2edb.NewConsul()
 	minio := e2edb.NewMinio(9000, blocksBucketName)

--- a/integration/legacy_name_validation_test.go
+++ b/integration/legacy_name_validation_test.go
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/integration/alertmanager_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
+//go:build requires_docker
+
+package integration
+
+import (
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grafana/e2e"
+	e2edb "github.com/grafana/e2e/db"
+	"github.com/grafana/mimir/integration/e2emimir"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/prometheus/prometheus/prompb"
+	promRW2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLegacyNameValidation_DistributorWrite ensures that distributors discard invalid
+// metric and label names in the write path.
+func TestLegacyNameValidation_DistributorWrite(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	consul := e2edb.NewConsul()
+	minio := e2edb.NewMinio(9000, blocksBucketName)
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	baseFlags := map[string]string{
+		"-distributor.ingestion-tenant-shard-size":           "0",
+		"-ingester.ring.heartbeat-period":                    "1s",
+		"-distributor.ha-tracker.enable":                     "true",
+		"-distributor.ha-tracker.enable-for-all-users":       "true",
+		"-distributor.ha-tracker.store":                      "consul",
+		"-distributor.ha-tracker.consul.hostname":            consul.NetworkHTTPEndpoint(),
+		"-distributor.ha-tracker.prefix":                     "prom_ha/",
+		"-timeseries-unmarshal-caching-optimization-enabled": "false",
+	}
+
+	flags := mergeFlags(
+		BlocksStorageFlags(),
+		BlocksStorageS3Flags(),
+		baseFlags,
+	)
+
+	// We want only distributor to be reloading runtime config.
+	distributorFlags := mergeFlags(flags, map[string]string{
+		"-runtime-config.file":          filepath.Join(e2e.ContainerSharedDir, "runtime.yaml"),
+		"-runtime-config.reload-period": "100ms",
+		// Set non-zero default for number of exemplars. That way our values used in the test (0 and 100) will show up in runtime config diff.
+		"-ingester.max-global-exemplars-per-user": "3",
+	})
+
+	// Ingester will not reload runtime config.
+	ingesterFlags := mergeFlags(flags, map[string]string{
+		// Ingester will always see exemplars enabled. We do this to avoid waiting for ingester to apply new setting to TSDB.
+		"-ingester.max-global-exemplars-per-user": "100",
+	})
+
+	// Start Mimir components.
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), distributorFlags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), ingesterFlags)
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
+	require.NoError(t, s.StartAndWaitReady(distributor, ingester, querier))
+
+	// Wait until distributor has updated the ring.
+	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	// Wait until querier has updated the ring.
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+
+	now := time.Now().Truncate(time.Millisecond).UnixMilli()
+
+	testCases := []struct {
+		name       string
+		rw1request *prompb.WriteRequest
+		rw2request *promRW2.Request
+	}{
+		{
+			name: "utf8 metric name",
+			rw1request: &prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels:  []prompb.Label{{Name: "__name__", Value: "utf_metric😀C"}},
+						Samples: []prompb.Sample{{Timestamp: now, Value: 100}},
+					},
+				},
+				Metadata: []prompb.MetricMetadata{
+					{
+						MetricFamilyName: "utf_metric😀C_total",
+						Help:             "some helpC",
+						Unit:             "someunitC",
+						Type:             prompb.MetricMetadata_COUNTER,
+					},
+				},
+			},
+			rw2request: &promRW2.Request{
+				Timeseries: []promRW2.TimeSeries{
+					{
+						LabelsRefs: []uint32{0, 1},
+						Samples:    []promRW2.Sample{{Timestamp: now, Value: 100}},
+						Metadata: promRW2.Metadata{
+							Type:    promRW2.Metadata_METRIC_TYPE_COUNTER,
+							HelpRef: 2,
+							UnitRef: 3,
+						},
+					},
+				},
+				Symbols: []string{
+					"__name__", "utf_metric😀C_total",
+					"some helpC",
+					"someunitC",
+				},
+			},
+		},
+		{
+			name: "utf8 label name",
+			rw1request: &prompb.WriteRequest{
+				Timeseries: []prompb.TimeSeries{
+					{
+						Labels: []prompb.Label{
+							{Name: "__name__", Value: "legacy_metricC"},
+							{Name: "utf8_label😀", Value: "test"},
+						},
+						Samples: []prompb.Sample{{Timestamp: now, Value: 100}},
+					},
+				},
+			},
+			rw2request: &promRW2.Request{
+				Timeseries: []promRW2.TimeSeries{
+					{
+						LabelsRefs: []uint32{0, 1, 2, 3},
+						Samples:    []promRW2.Sample{{Timestamp: now, Value: 100}},
+					},
+				},
+				Symbols: []string{
+					"__name__", "legacy_metricC_total",
+					"utf8_label😀", "test",
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("rw1", func(t *testing.T) {
+				res, err := client.PushRW1(tc.rw1request)
+				require.NoError(t, err)
+				require.Equal(t, res.StatusCode, http.StatusBadRequest)
+			})
+			t.Run("rw2", func(t *testing.T) {
+				res, err := client.PushRW2(tc.rw2request)
+				require.NoError(t, err)
+				require.Equal(t, res.StatusCode, http.StatusBadRequest)
+			})
+		})
+	}
+}
+
+// TestLegacyNameValidation_Read ensures that Mimir discards queries containing
+// invalid metric and label names.
+func TestLegacyNameValidation_Querier(t *testing.T) {
+	for _, queryEngine := range []string{"mimir", "prometheus"} {
+		t.Run(queryEngine, func(t *testing.T) {
+			testLegacyNameValidationQuerier(t, queryEngine)
+		})
+	}
+}
+
+func testLegacyNameValidationQuerier(t *testing.T, queryEngine string) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	consul := e2edb.NewConsul()
+	minio := e2edb.NewMinio(9000, blocksBucketName)
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	// Configure the blocks storage to frequently compact TSDB head
+	// and ship blocks to the storage.
+	const blockRangePeriod = 5 * time.Second
+	flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(), map[string]string{
+		"-blocks-storage.tsdb.block-ranges-period":   blockRangePeriod.String(),
+		"-blocks-storage.tsdb.ship-interval":         "1s",
+		"-blocks-storage.bucket-store.sync-interval": "1s",
+		"-blocks-storage.tsdb.retention-period":      ((blockRangePeriod * 2) - 1).String(),
+		"-querier.max-fetched-series-per-query":      "3",
+		"-querier.query-engine":                      queryEngine,
+	})
+
+	// Start Mimir components.
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
+	storeGateway := e2emimir.NewStoreGateway("store-gateway", consul.NetworkHTTPEndpoint(), flags)
+	require.NoError(t, s.StartAndWaitReady(distributor, ingester, storeGateway))
+
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
+	require.NoError(t, s.StartAndWaitReady(querier)) // Wait until distributor has updated the ring.
+
+	client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+
+	now := time.Now().Truncate(time.Millisecond)
+
+	// Initialize mimir with some test data:
+	res, err := client.PushRW2(&promRW2.Request{
+		Timeseries: []promRW2.TimeSeries{
+			{
+				LabelsRefs: []uint32{0, 1, 2, 3},
+				Samples:    []promRW2.Sample{{Timestamp: now.UnixMilli(), Value: 100}},
+			},
+		},
+		Symbols: []string{
+			"__name__", "legacy_metricC_total",
+			"label_name", "label_value",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, res.StatusCode, http.StatusOK)
+
+	testCases := []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{
+			// this passes always, no matter model.NameValidationScheme
+			name:  "utf8 metric name",
+			query: `{"invalid_metric😀C_total"}`,
+		},
+		{
+			// this passes always, no matter model.NameValidationScheme
+			name:  "utf8 label name",
+			query: `legacy_metricC_total{"😀"="test"}`,
+		},
+		{
+			// Invalid promql:
+			// see: https://prometheus.io/docs/guides/utf8/
+			name:    "invalid promql syntax",
+			query:   `invalid_metric😀C_total`,
+			wantErr: `bad_data: invalid parameter "query": 1:15: parse error: unexpected character: '😀'`,
+		},
+		{
+			name:    "utf8 label_join",
+			query:   `label_join(legacy_metricC_total, "invalid😀", "-", "label_name")`,
+			wantErr: `execution: invalid destination label name in label_join(): invalid😀`,
+		},
+		{
+			name:    "utf8 label_replace",
+			query:   `label_replace(legacy_metricC_total, "invalid😀", "$1", "label_name", "(.*):.*")`,
+			wantErr: `execution: invalid destination label name in label_replace(): invalid😀`,
+		},
+		{
+			name:    "utf8 count_values",
+			query:   `count_values("invalid😀", series)`,
+			wantErr: `execution: invalid label name "invalid😀"`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := client.Query(tc.query, now)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestLegacyNameValidation_Ruler ensures rule only accepts rules that are
+// adhere to legacy naming conventions
+func TestLegacyNameValidation_Ruler(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Start dependencies.
+	consul := e2edb.NewConsul()
+	minio := e2edb.NewMinio(9000, mimirBucketName, rulesBucketName)
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	// Configure the ruler.
+	rulerFlags := mergeFlags(CommonStorageBackendFlags(), RulerFlags(), RulerStorageS3Flags(), BlocksStorageFlags())
+
+	// Start Mimir components.
+	ruler := e2emimir.NewRuler("ruler", consul.NetworkHTTPEndpoint(), rulerFlags)
+	require.NoError(t, s.StartAndWaitReady(ruler))
+
+	// Create a client with the ruler address configured
+	c, err := e2emimir.NewClient("", "", "", ruler.HTTPEndpoint(), "user-1")
+	require.NoError(t, err)
+
+	const namespace = "test_/encoded_+namespace/?"
+	testCases := []struct {
+		name string
+		rg   rulefmt.RuleGroup
+	}{
+		{
+			name: "utf8 rule group label nanme",
+			rg: rulefmt.RuleGroup{
+				Name: "test",
+				Rules: []rulefmt.Rule{
+					{
+						Record: "test",
+					},
+				},
+				Labels: map[string]string{
+					"invalid😀": "test",
+				},
+			},
+		},
+		{
+			name: "utf8 recording rule metric name",
+			rg: rulefmt.RuleGroup{
+				Name: "test",
+				Rules: []rulefmt.Rule{
+					{
+						Record: "invalid😀",
+					},
+				},
+			},
+		},
+		{
+			name: "utf8 rule label name",
+			rg: rulefmt.RuleGroup{
+				Name: "test",
+				Rules: []rulefmt.Rule{
+					{
+						Record: "valid",
+						Labels: map[string]string{
+							"invalid😀": "test",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "utf8 rule annotations",
+			rg: rulefmt.RuleGroup{
+				Name: "test",
+				Rules: []rulefmt.Rule{
+					{
+						Record: "valid",
+						Annotations: map[string]string{
+							"invalid😀": "test",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.SetRuleGroup(tc.rg, namespace)
+			require.EqualError(t, err, `unexpected status code: 400`)
+		})
+	}
+
+}

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -27,6 +27,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/config"
+	prom_validation "github.com/prometheus/prometheus/model/validation"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	v1 "github.com/prometheus/prometheus/web/api/v1"
@@ -287,6 +288,7 @@ func NewQuerierHandler(
 		0,
 	)
 
+	api.NamingScheme = prom_validation.LegacyNamingScheme
 	api.InstallCodec(protobufCodec{})
 
 	router := mux.NewRouter()

--- a/pkg/cardinality/request.go
+++ b/pkg/cardinality/request.go
@@ -14,6 +14,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 type CountMethod string
@@ -263,7 +265,7 @@ func extractLabelNames(values url.Values) ([]model.LabelName, error) {
 	labelNames := make([]model.LabelName, 0, len(labelNamesParams))
 	for _, labelNameParam := range labelNamesParams {
 		labelName := model.LabelName(labelNameParam)
-		if !labelName.IsValid() {
+		if !validation.IsValidLabelName(labelNameParam) {
 			return nil, fmt.Errorf("invalid 'label_names' param '%v'", labelNameParam)
 		}
 		labelNames = append(labelNames, labelName)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -67,12 +67,6 @@ import (
 
 var tracer = otel.Tracer("pkg/distributor")
 
-func init() {
-	// Mimir doesn't support Prometheus' UTF-8 metric/label name scheme yet.
-	// nolint:staticcheck
-	model.NameValidationScheme = model.LegacyValidation
-}
-
 var (
 	// Validation errors.
 	errInvalidTenantShardSize = errors.New("invalid tenant shard size, the value must be greater than or equal to zero")

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -410,7 +410,7 @@ func validateLabels(m *sampleValidationMetrics, cfg labelValidationConfig, userI
 		return errors.New(noMetricNameMsgFormat)
 	}
 
-	if !model.IsValidMetricName(model.LabelValue(unsafeMetricName)) {
+	if !validation.IsValidMetricName(unsafeMetricName) {
 		cat.IncrementDiscardedSamples(ls, 1, reasonInvalidMetricName, ts)
 		m.invalidMetricName.WithLabelValues(userID, group).Inc()
 		return fmt.Errorf(invalidMetricNameMsgFormat, removeNonASCIIChars(unsafeMetricName))
@@ -436,7 +436,7 @@ func validateLabels(m *sampleValidationMetrics, cfg labelValidationConfig, userI
 	maxLabelValueLength := cfg.MaxLabelValueLength(userID)
 	lastLabelName := ""
 	for _, l := range ls {
-		if !skipLabelValidation && !model.LabelName(l.Name).IsValid() {
+		if !skipLabelValidation && !validation.IsValidLabelName(l.Name) {
 			m.invalidLabel.WithLabelValues(userID, group).Inc()
 			cat.IncrementDiscardedSamples(ls, 1, reasonInvalidLabel, ts)
 			return fmt.Errorf(invalidLabelMsgFormat, l.Name, mimirpb.FromLabelAdaptersToString(ls))

--- a/pkg/frontend/querymiddleware/request_validation.go
+++ b/pkg/frontend/querymiddleware/request_validation.go
@@ -7,14 +7,7 @@ import (
 	"net/http"
 
 	"github.com/grafana/dskit/cancellation"
-	"github.com/prometheus/common/model"
 )
-
-func init() {
-	// Mimir doesn't support Prometheus' UTF-8 metric/label name scheme yet.
-	// nolint:staticcheck
-	model.NameValidationScheme = model.LegacyValidation
-}
 
 const requestValidationFailedFmt = "request validation failed for "
 

--- a/pkg/mimir/promexts.go
+++ b/pkg/mimir/promexts.go
@@ -3,14 +3,9 @@
 package mimir
 
 import (
-	"github.com/prometheus/common/model"
-
 	"github.com/grafana/mimir/pkg/util/promqlext"
 )
 
 func init() {
 	promqlext.ExtendPromQL()
-	// Mimir doesn't support Prometheus' UTF-8 metric/label name scheme yet.
-	// nolint:staticcheck
-	model.NameValidationScheme = model.LegacyValidation
 }

--- a/pkg/mimirtool/rules/rules.go
+++ b/pkg/mimirtool/rules/rules.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/prometheus/prometheus/model/validation"
 	"github.com/prometheus/prometheus/promql/parser"
 	log "github.com/sirupsen/logrus"
 
@@ -255,7 +256,7 @@ func (r RuleNamespace) Validate(groupNodes []rulefmt.RuleGroupNode) []error {
 func ValidateRuleGroup(g rwrulefmt.RuleGroup, node rulefmt.RuleGroupNode) []error {
 	var errs []error
 	for i, r := range g.Rules {
-		for _, err := range r.Validate(node.Rules[i]) {
+		for _, err := range r.Validate(node.Rules[i], validation.LegacyNamingScheme) {
 			var ruleName string
 			if r.Alert != "" {
 				ruleName = r.Alert

--- a/pkg/querier/engine/config.go
+++ b/pkg/querier/engine/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/validation"
 	"github.com/prometheus/prometheus/promql"
 
 	"github.com/grafana/mimir/pkg/streamingpromql"      //lint:ignore faillint streamingpromql is fine
@@ -66,6 +67,7 @@ func NewPromQLEngineOptions(cfg Config, activityTracker *activitytracker.Activit
 		NoStepSubqueryIntervalFn: func(int64) int64 {
 			return cfg.DefaultEvaluationInterval.Milliseconds()
 		},
+		ValidationScheme: validation.LegacyNamingScheme,
 	}
 
 	cfg.MimirQueryEngine.CommonOpts = commonOpts

--- a/pkg/querier/stats_renderer_test.go
+++ b/pkg/querier/stats_renderer_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/config"
@@ -25,12 +24,6 @@ import (
 
 	mimir_stats "github.com/grafana/mimir/pkg/querier/stats"
 )
-
-func init() {
-	// Mimir doesn't support Prometheus' UTF-8 metric/label name scheme yet.
-	// nolint:staticcheck
-	model.NameValidationScheme = model.LegacyValidation
-}
 
 func TestStatsRenderer(t *testing.T) {
 

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
+	"github.com/prometheus/prometheus/model/validation"
 	"github.com/prometheus/prometheus/notifier"
 	promRules "github.com/prometheus/prometheus/rules"
 	"go.opentelemetry.io/otel"
@@ -440,7 +441,7 @@ func (r *DefaultMultiTenantManager) ValidateRuleGroup(g rulefmt.RuleGroup, node 
 	}
 
 	for i, r := range g.Rules {
-		for _, err := range r.Validate(node.Rules[i]) {
+		for _, err := range r.Validate(node.Rules[i], validation.LegacyNamingScheme) {
 			var ruleName string
 			if r.Alert != "" {
 				ruleName = r.Alert

--- a/pkg/streamingpromql/config.go
+++ b/pkg/streamingpromql/config.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/prometheus/prometheus/model/validation"
 	"github.com/prometheus/prometheus/promql"
 )
 
@@ -41,6 +42,7 @@ func NewTestEngineOpts() EngineOpts {
 			EnableAtModifier:         true,
 			EnableNegativeOffset:     true,
 			NoStepSubqueryIntervalFn: func(int64) int64 { return time.Minute.Milliseconds() },
+			ValidationScheme:         validation.LegacyNamingScheme,
 		},
 
 		Pedantic: true,

--- a/pkg/streamingpromql/operators/aggregations/count_values.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values.go
@@ -12,13 +12,13 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/limiter"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 type CountValues struct {
@@ -152,7 +152,7 @@ func (c *CountValues) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadat
 
 func (c *CountValues) loadLabelName() error {
 	c.resolvedLabelName = c.LabelName.GetValue()
-	if !model.LabelName(c.resolvedLabelName).IsValid() {
+	if !validation.IsValidLabelName(c.resolvedLabelName) {
 		return fmt.Errorf("invalid label name %q", c.resolvedLabelName)
 	}
 

--- a/pkg/streamingpromql/operators/functions/label.go
+++ b/pkg/streamingpromql/operators/functions/label.go
@@ -11,25 +11,25 @@ import (
 	"strings"
 
 	"github.com/grafana/regexp"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/limiter"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 func LabelJoinFactory(dstLabelOp, separatorOp types.StringOperator, srcLabelOps []types.StringOperator) SeriesMetadataFunction {
 	return func(seriesMetadata []types.SeriesMetadata, _ *limiter.MemoryConsumptionTracker) ([]types.SeriesMetadata, error) {
 		dst := dstLabelOp.GetValue()
-		if !model.LabelName(dst).IsValid() {
+		if !validation.IsValidLabelName(dst) {
 			return nil, fmt.Errorf("invalid destination label name in label_join(): %s", dst)
 		}
 		separator := separatorOp.GetValue()
 		srcLabels := make([]string, len(srcLabelOps))
 		for i, op := range srcLabelOps {
 			src := op.GetValue()
-			if !model.LabelName(src).IsValid() {
-				return nil, fmt.Errorf("invalid source label name in label_join(): %s", dst)
+			if !validation.IsValidLabelName(src) {
+				return nil, fmt.Errorf("invalid source label name in label_join(): %s", src)
 			}
 			srcLabels[i] = src
 		}
@@ -66,7 +66,7 @@ func LabelReplaceFactory(dstLabelOp, replacementOp, srcLabelOp, regexOp types.St
 			return nil, fmt.Errorf("invalid regular expression in label_replace(): %s", regexStr)
 		}
 		dst := dstLabelOp.GetValue()
-		if !model.LabelName(dst).IsValid() {
+		if !validation.IsValidLabelName(dst) {
 			return nil, fmt.Errorf("invalid destination label name in label_replace(): %s", dst)
 		}
 		repl := replacementOp.GetValue()

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/model/validation"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
@@ -108,7 +109,7 @@ func (p *QueryPlanner) NewQueryPlan(ctx context.Context, qs string, timeRange ty
 
 	defer p.activeQueryTracker.Delete(queryID)
 
-	expr, err := p.runASTStage("Parsing", observer, func() (parser.Expr, error) { return parser.ParseExpr(qs) })
+	expr, err := p.runASTStage("Parsing", observer, func() (parser.Expr, error) { return ParseExpr(qs) })
 	if err != nil {
 		return nil, err
 	}
@@ -703,4 +704,13 @@ func parseDuration(s string) (time.Duration, error) {
 		return time.Duration(d), nil
 	}
 	return 0, fmt.Errorf("cannot parse %q to a valid duration", s)
+}
+
+// ParseExpr is like parser.ParseExpr but uses legacy naming scheme.
+func ParseExpr(expr string) (parser.Expr, error) {
+	p := parser.NewParser(
+		expr,
+		parser.WithValidationScheme(validation.LegacyNamingScheme),
+	)
+	return p.ParseExpr()
 }

--- a/pkg/streamingpromql/testdata/ours-only/aggregators.test
+++ b/pkg/streamingpromql/testdata/ours-only/aggregators.test
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# count_values() tests
+load 6m
+  series{idx="0", case="Inf"}   Inf  Inf  Inf
+  series{idx="0", case="-Inf"}  -Inf -Inf _
+
+# Prometheus uses UTF-8 validation as of v0.62.0.
+# Mimir only supports classic/legacy  label names.
+eval range from 0 to 12m step 6m count_values("(value)", series)
+  expect fail msg: invalid label name "(value)"

--- a/pkg/streamingpromql/testdata/ours-only/functions.test
+++ b/pkg/streamingpromql/testdata/ours-only/functions.test
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
 load 6m
   series{label="a", idx="1"} 2 _
   series{label="a", idx="2"} _ 4
@@ -5,3 +7,30 @@ load 6m
 # Currently prometheus does not merge series: https://github.com/prometheus/prometheus/issues/15114
 eval range from 0 to 6m step 6m label_replace(series, "idx", "replaced", "idx", ".*")
   series{label="a", idx="replaced"} 2 4
+
+clear
+
+# label_join() tests
+load 5m
+  series{label="a", opt="1", this="that"} 1.1  5.0
+
+# Prometheus uses UTF-8 validation as of v0.62.0.
+# Mimir only supports classic/legacy (source) label names.
+eval instant at 0m label_join(series, "export", ",", "(opt)", "this")
+  expect fail msg: invalid source label name in label_join(): (opt)
+
+# Prometheus uses UTF-8 validation as of v0.62.0.
+# Mimir only supports classic/legacy (destination) label names.
+eval instant at 0m label_join(series, "(export)", "-", "label", "opt")
+  expect fail msg: invalid destination label name in label_join(): (export)
+
+clear
+
+# label_replace() tests
+load 5m
+  series{label="a"} 1.1
+
+# Prometheus uses UTF-8 validation as of v0.62.0.
+# Mimir only supports classic/legacy (source) label names.
+eval instant at 0m label_replace(series, "(export)", "$1", "label", "(.*)")
+  expect fail msg: invalid destination label name in label_replace(): (export)

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -290,18 +290,6 @@ eval instant at 0m floor(label_join(series, "__name__", "", "label"))
   {label="b", opt="2", this="there"} 2
   {label="c", opt="3"} NaN
 
-# Passes due to UTF-8 validation of source labels
-eval range from 0 to 10m step 5m label_join(series, "export", ",", "(opt)", "this")
-  series{export=",", label="c", opt="3"} NaN
-  series{export=",that", label="a", opt="1", this="that"} 1.1 5
-  series{export=",there", label="b", opt="2", this="there"} 2.9 {{sum:4 count:23 buckets:[1 2 4]}}
-
-# Passes due to UTF-8 validation of dest labels
-eval range from 0 to 10m step 5m label_join(series, "(export)", "-", "label", "opt")
-  series{"(export)"="a-1", label="a", opt="1", this="that"} 1.1 5.0
-  series{"(export)"="b-2", label="b", opt="2", this="there"} 2.9 {{sum:4 count:23 buckets:[1 2 4]}}
-  series{"(export)"="c-3", label="c", opt="3"} NaN _
-
 clear
 
 # The following tests pass prometheus' engine when promql-delayed-name-removal is enabled.

--- a/pkg/util/validation/labels.go
+++ b/pkg/util/validation/labels.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package validation
+
+import (
+	"github.com/prometheus/common/model"
+)
+
+// IsValidLabelName returns true iff name matches prometheus
+// "LegacyValidation" name validation scheme.
+func IsValidLabelName(name string) bool {
+	return model.LabelName(name).IsValidLegacy()
+}
+
+// IsValidMetricName returns true iff the name matches prometheus
+// "LegacyValidation" name validation scheme.
+func IsValidMetricName(name string) bool {
+	return model.IsValidLegacyMetricName(name)
+}

--- a/pkg/util/validation/labels_test.go
+++ b/pkg/util/validation/labels_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidLabelName(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "invalid empty string",
+			input: "",
+			want:  false,
+		},
+		{
+			name:  "invalid character",
+			input: "invalid.character",
+			want:  false,
+		},
+		{
+			name:  "invalid UTF-8",
+			input: "2H₂ + O₂ ⇌ 2H₂O",
+			want:  false,
+		},
+		{
+			name:  "valid label name",
+			input: "label_name",
+			want:  true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsValidLabelName(tc.input))
+		})
+	}
+}
+
+func TestIsValidMetricName(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "invalid empty string",
+			input: "",
+			want:  false,
+		},
+		{
+			name:  "invalid start with number",
+			input: "123test",
+			want:  false,
+		},
+		{
+			name:  "invalid UTF-8",
+			input: "2H₂ + O₂ ⇌ 2H₂O",
+			want:  false,
+		},
+		{
+			name:  "valid underscore",
+			input: "metric_name",
+			want:  true,
+		},
+		{
+			name:  "valid colon",
+			input: "metric:name",
+			want:  true,
+		},
+		{
+			name:  "valid numbers",
+			input: "metric_name_123",
+			want:  true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsValidMetricName(tc.input))
+		})
+	}
+}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/model/validation"
 	"go.uber.org/atomic"
 	"golang.org/x/time/rate"
 	"gopkg.in/yaml.v3"
@@ -528,6 +529,10 @@ func (l *Limits) validate() error {
 	for _, cfg := range l.MetricRelabelConfigs {
 		if cfg == nil {
 			return errors.New("invalid metric_relabel_configs")
+		}
+		cfg.MetricNameValidationScheme = validation.LegacyNamingScheme
+		if err := cfg.Validate(validation.LegacyNamingScheme); err != nil {
+			return err
 		}
 	}
 

--- a/vendor/github.com/prometheus/prometheus/model/rulefmt/rulefmt.go
+++ b/vendor/github.com/prometheus/prometheus/model/rulefmt/rulefmt.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/model/validation"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/template"
@@ -96,7 +97,7 @@ type ruleGroups struct {
 }
 
 // Validate validates all rules in the rule groups.
-func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
+func (g *RuleGroups) Validate(node ruleGroups, namingScheme validation.NamingScheme) (errs []error) {
 	set := map[string]struct{}{}
 
 	for j, g := range g.Groups {
@@ -112,7 +113,7 @@ func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
 		}
 
 		for k, v := range g.Labels {
-			if !model.LabelName(k).IsValid() || k == model.MetricNameLabel {
+			if !namingScheme.IsValidLabelName(k) || k == model.MetricNameLabel {
 				errs = append(
 					errs, fmt.Errorf("invalid label name: %s", k),
 				)
@@ -128,7 +129,7 @@ func (g *RuleGroups) Validate(node ruleGroups) (errs []error) {
 		set[g.Name] = struct{}{}
 
 		for i, r := range g.Rules {
-			for _, node := range r.Validate(node.Groups[j].Rules[i]) {
+			for _, node := range r.Validate(node.Groups[j].Rules[i], namingScheme) {
 				var ruleName string
 				if r.Alert != "" {
 					ruleName = r.Alert
@@ -198,7 +199,7 @@ type RuleNode struct {
 }
 
 // Validate the rule and return a list of encountered errors.
-func (r *Rule) Validate(node RuleNode) (nodes []WrappedError) {
+func (r *Rule) Validate(node RuleNode, namingScheme validation.NamingScheme) (nodes []WrappedError) {
 	if r.Record != "" && r.Alert != "" {
 		nodes = append(nodes, WrappedError{
 			err:     errors.New("only one of 'record' and 'alert' must be set"),
@@ -244,7 +245,7 @@ func (r *Rule) Validate(node RuleNode) (nodes []WrappedError) {
 				node: &node.Record,
 			})
 		}
-		if !model.IsValidMetricName(model.LabelValue(r.Record)) {
+		if !namingScheme.IsValidMetricName(r.Record) {
 			nodes = append(nodes, WrappedError{
 				err:  fmt.Errorf("invalid recording rule name: %s", r.Record),
 				node: &node.Record,
@@ -261,7 +262,7 @@ func (r *Rule) Validate(node RuleNode) (nodes []WrappedError) {
 	}
 
 	for k, v := range r.Labels {
-		if !model.LabelName(k).IsValid() || k == model.MetricNameLabel {
+		if !namingScheme.IsValidLabelName(k) || k == model.MetricNameLabel {
 			nodes = append(nodes, WrappedError{
 				err: fmt.Errorf("invalid label name: %s", k),
 			})
@@ -275,7 +276,7 @@ func (r *Rule) Validate(node RuleNode) (nodes []WrappedError) {
 	}
 
 	for k := range r.Annotations {
-		if !model.LabelName(k).IsValid() {
+		if !namingScheme.IsValidLabelName(k) {
 			nodes = append(nodes, WrappedError{
 				err: fmt.Errorf("invalid annotation name: %s", k),
 			})
@@ -338,8 +339,27 @@ func testTemplateParsing(rl *Rule) (errs []error) {
 	return errs
 }
 
+type parseArgs struct {
+	namingScheme validation.NamingScheme
+}
+
+type ParseOption func(*parseArgs)
+
+func WithNamingScheme(scheme validation.NamingScheme) ParseOption {
+	return func(args *parseArgs) {
+		args.namingScheme = scheme
+	}
+}
+
 // Parse parses and validates a set of rules.
-func Parse(content []byte, ignoreUnknownFields bool) (*RuleGroups, []error) {
+func Parse(content []byte, ignoreUnknownFields bool, opts ...ParseOption) (*RuleGroups, []error) {
+	args := &parseArgs{
+		namingScheme: validation.UTF8NamingScheme,
+	}
+	for _, opt := range opts {
+		opt(args)
+	}
+
 	var (
 		groups RuleGroups
 		node   ruleGroups
@@ -364,16 +384,16 @@ func Parse(content []byte, ignoreUnknownFields bool) (*RuleGroups, []error) {
 		return nil, errs
 	}
 
-	return &groups, groups.Validate(node)
+	return &groups, groups.Validate(node, args.namingScheme)
 }
 
 // ParseFile reads and parses rules from a file.
-func ParseFile(file string, ignoreUnknownFields bool) (*RuleGroups, []error) {
+func ParseFile(file string, ignoreUnknownFields bool, opts ...ParseOption) (*RuleGroups, []error) {
 	b, err := os.ReadFile(file)
 	if err != nil {
 		return nil, []error{fmt.Errorf("%s: %w", file, err)}
 	}
-	rgs, errs := Parse(b, ignoreUnknownFields)
+	rgs, errs := Parse(b, ignoreUnknownFields, opts...)
 	for i := range errs {
 		errs[i] = fmt.Errorf("%s: %w", file, errs[i])
 	}

--- a/vendor/github.com/prometheus/prometheus/model/textparse/protobufparse.go
+++ b/vendor/github.com/prometheus/prometheus/model/textparse/protobufparse.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/validation"
 	dto "github.com/prometheus/prometheus/prompb/io/prometheus/client"
 	"github.com/prometheus/prometheus/schema"
 )
@@ -80,11 +81,21 @@ type ProtobufParser struct {
 	// native histogram.
 	parseClassicHistograms  bool
 	enableTypeAndUnitLabels bool
+
+	namingScheme validation.NamingScheme
+}
+
+type ProtobufParserOption func(p *ProtobufParser)
+
+func WithNamingScheme(scheme validation.NamingScheme) ProtobufParserOption {
+	return func(p *ProtobufParser) {
+		p.namingScheme = scheme
+	}
 }
 
 // NewProtobufParser returns a parser for the payload in the byte slice.
-func NewProtobufParser(b []byte, parseClassicHistograms, enableTypeAndUnitLabels bool, st *labels.SymbolTable) Parser {
-	return &ProtobufParser{
+func NewProtobufParser(b []byte, parseClassicHistograms, enableTypeAndUnitLabels bool, st *labels.SymbolTable, opts ...ProtobufParserOption) Parser {
+	pp := &ProtobufParser{
 		dec:        dto.NewMetricStreamingDecoder(b),
 		entryBytes: &bytes.Buffer{},
 		builder:    labels.NewScratchBuilderWithSymbolTable(st, 16), // TODO(bwplotka): Try base builder.
@@ -92,7 +103,12 @@ func NewProtobufParser(b []byte, parseClassicHistograms, enableTypeAndUnitLabels
 		state:                   EntryInvalid,
 		parseClassicHistograms:  parseClassicHistograms,
 		enableTypeAndUnitLabels: enableTypeAndUnitLabels,
+		namingScheme:            validation.UTF8NamingScheme,
 	}
+	for _, opt := range opts {
+		opt(pp)
+	}
+	return pp
 }
 
 // Series returns the bytes of a series with a simple float64 as a
@@ -428,7 +444,7 @@ func (p *ProtobufParser) Next() (Entry, error) {
 		// We are at the beginning of a metric family. Put only the name
 		// into entryBytes and validate only name, help, and type for now.
 		name := p.dec.GetName()
-		if !model.IsValidMetricName(model.LabelValue(name)) {
+		if !p.namingScheme.IsValidMetricName(name) {
 			return EntryInvalid, fmt.Errorf("invalid metric name: %s", name)
 		}
 		if help := p.dec.GetHelp(); !utf8.ValidString(help) {

--- a/vendor/github.com/prometheus/prometheus/model/validation/name_validation.go
+++ b/vendor/github.com/prometheus/prometheus/model/validation/name_validation.go
@@ -1,0 +1,58 @@
+package validation
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/prometheus/common/model"
+)
+
+// NamingScheme that is used for validation label and metric names.
+type NamingScheme string
+
+const (
+	// LegacyNamingScheme validates label and metric names with the legacy naming convention.
+	LegacyNamingScheme NamingScheme = "legacy"
+	// UTF8NamingScheme validates label and metric names according to UTF8 naming convention.
+	UTF8NamingScheme NamingScheme = "utf8"
+)
+
+// Validate the NamingScheme is one of LegacyNamingScheme, UTF8NamingScheme, or unset ("").
+// If s is unset, NamingScheme defaults to UTF8NamingScheme.
+func (s NamingScheme) Validate() error {
+	switch s {
+	case "", LegacyNamingScheme, UTF8NamingScheme:
+		return nil
+	}
+	return fmt.Errorf("invalid name validation scheme %q", s)
+}
+
+// WithDefault returns s if it is set (s != ""), defaultScheme otherwise.
+func (s NamingScheme) WithDefault(defaultScheme NamingScheme) NamingScheme {
+	if s == "" {
+		return defaultScheme
+	}
+	return s
+}
+
+// IsValidLabelName ensures name adheres to the NamingScheme.
+func (s NamingScheme) IsValidLabelName(name string) bool {
+	if s == LegacyNamingScheme {
+		return model.LabelName(name).IsValidLegacy()
+	}
+	if len(name) == 0 {
+		return false
+	}
+	return utf8.ValidString(name)
+}
+
+// IsValidMetricName ensures name adheres to the NamingScheme.
+func (s NamingScheme) IsValidMetricName(name string) bool {
+	if s == LegacyNamingScheme {
+		return model.IsValidLegacyMetricName(name)
+	}
+	if len(name) == 0 {
+		return false
+	}
+	return utf8.ValidString(name)
+}

--- a/vendor/github.com/prometheus/prometheus/promql/functions.go
+++ b/vendor/github.com/prometheus/prometheus/promql/functions.go
@@ -1504,7 +1504,7 @@ func (ev *evaluator) evalLabelReplace(ctx context.Context, args parser.Expressio
 	if err != nil {
 		panic(fmt.Errorf("invalid regular expression in label_replace(): %s", regexStr))
 	}
-	if !model.LabelName(dst).IsValid() {
+	if !ev.nameValidationScheme.IsValidLabelName(dst) {
 		panic(fmt.Errorf("invalid destination label name in label_replace(): %s", dst))
 	}
 
@@ -1552,12 +1552,12 @@ func (ev *evaluator) evalLabelJoin(ctx context.Context, args parser.Expressions)
 	)
 	for i := 3; i < len(args); i++ {
 		src := stringFromArg(args[i])
-		if !model.LabelName(src).IsValid() {
+		if !ev.nameValidationScheme.IsValidLabelName(src) {
 			panic(fmt.Errorf("invalid source label name in label_join(): %s", src))
 		}
 		srcLabels[i-3] = src
 	}
-	if !model.LabelName(dst).IsValid() {
+	if !ev.nameValidationScheme.IsValidLabelName(dst) {
 		panic(fmt.Errorf("invalid destination label name in label_join(): %s", dst))
 	}
 

--- a/vendor/github.com/prometheus/prometheus/promql/parser/generated_parser.y
+++ b/vendor/github.com/prometheus/prometheus/promql/parser/generated_parser.y
@@ -23,8 +23,6 @@ import (
         "github.com/prometheus/prometheus/model/value"
         "github.com/prometheus/prometheus/model/histogram"
         "github.com/prometheus/prometheus/promql/parser/posrange"
-
-        "github.com/prometheus/common/model"
 )
 
 %}
@@ -377,14 +375,14 @@ grouping_label_list:
 
 grouping_label  : maybe_label
                         {
-                        if !model.LabelName($1.Val).IsValid() {
+                        if !yylex.(*parser).nameValidationScheme.IsValidLabelName($1.Val) {
                                 yylex.(*parser).addParseErrf($1.PositionRange(),"invalid label name for grouping: %q", $1.Val)
                         }
                         $$ = $1
                         }
                 | STRING {
                         unquoted := yylex.(*parser).unquoteString($1.Val)
-                        if !model.LabelName(unquoted).IsValid() {
+                        if !yylex.(*parser).nameValidationScheme.IsValidLabelName(unquoted) {
                                 yylex.(*parser).addParseErrf($1.PositionRange(),"invalid label name for grouping: %q", unquoted)
                         }
                         $$ = $1

--- a/vendor/github.com/prometheus/prometheus/promql/parser/generated_parser.y.go
+++ b/vendor/github.com/prometheus/prometheus/promql/parser/generated_parser.y.go
@@ -12,8 +12,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
-
-	"github.com/prometheus/common/model"
 )
 
 type yySymType struct {
@@ -1292,7 +1290,7 @@ yydefault:
 	case 59:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
-			if !model.LabelName(yyDollar[1].item.Val).IsValid() {
+			if !yylex.(*parser).nameValidationScheme.IsValidLabelName(yyDollar[1].item.Val) {
 				yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "invalid label name for grouping: %q", yyDollar[1].item.Val)
 			}
 			yyVAL.item = yyDollar[1].item
@@ -1301,7 +1299,7 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			unquoted := yylex.(*parser).unquoteString(yyDollar[1].item.Val)
-			if !model.LabelName(unquoted).IsValid() {
+			if !yylex.(*parser).nameValidationScheme.IsValidLabelName(unquoted) {
 				yylex.(*parser).addParseErrf(yyDollar[1].item.PositionRange(), "invalid label name for grouping: %q", unquoted)
 			}
 			yyVAL.item = yyDollar[1].item

--- a/vendor/github.com/prometheus/prometheus/scrape/scrape.go
+++ b/vendor/github.com/prometheus/prometheus/scrape/scrape.go
@@ -46,6 +46,7 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/model/validation"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/logging"
@@ -103,7 +104,7 @@ type scrapePool struct {
 	scrapeFailureLogger    FailureLogger
 	scrapeFailureLoggerMtx sync.RWMutex
 
-	validationScheme model.ValidationScheme
+	validationScheme validation.NamingScheme
 	escapingScheme   model.EscapingScheme
 }
 
@@ -149,8 +150,8 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, offsetSeed 
 		return nil, fmt.Errorf("error creating HTTP client: %w", err)
 	}
 
-	validationScheme, err := config.ToValidationScheme(cfg.MetricNameValidationScheme)
-	if err != nil {
+	validationScheme := cfg.MetricNameValidationScheme
+	if err := validationScheme.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid metric name validation scheme: %w", err)
 	}
 	var escapingScheme model.EscapingScheme
@@ -325,8 +326,8 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 	sp.config = cfg
 	oldClient := sp.client
 	sp.client = client
-	validationScheme, err := config.ToValidationScheme(cfg.MetricNameValidationScheme)
-	if err != nil {
+	validationScheme := cfg.MetricNameValidationScheme
+	if err := validationScheme.Validate(); err != nil {
 		return fmt.Errorf("invalid metric name validation scheme: %w", err)
 	}
 	sp.validationScheme = validationScheme
@@ -926,7 +927,7 @@ type scrapeLoop struct {
 	timeout                  time.Duration
 	alwaysScrapeClassicHist  bool
 	convertClassicHistToNHCB bool
-	validationScheme         model.ValidationScheme
+	validationScheme         validation.NamingScheme
 	escapingScheme           model.EscapingScheme
 	fallbackScrapeProtocol   string
 
@@ -1248,7 +1249,7 @@ func newScrapeLoop(ctx context.Context,
 	passMetadataInContext bool,
 	metrics *scrapeMetrics,
 	skipOffsetting bool,
-	validationScheme model.ValidationScheme,
+	validationScheme validation.NamingScheme,
 	escapingScheme model.EscapingScheme,
 	fallbackScrapeProtocol string,
 ) *scrapeLoop {

--- a/vendor/github.com/prometheus/prometheus/storage/remote/codec.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/codec.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/validation"
 	"github.com/prometheus/prometheus/prompb"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
 	"github.com/prometheus/prometheus/storage"
@@ -173,12 +174,31 @@ func ToQueryResult(ss storage.SeriesSet, sampleLimit int) (*prompb.QueryResult, 
 	return resp, ss.Warnings(), ss.Err()
 }
 
+type FromQueryResultArgs struct {
+	nameValidation validation.NamingScheme
+}
+
+type FromQueryResultOption func(*FromQueryResultArgs)
+
+func WithNameValidation(nameValidation validation.NamingScheme) FromQueryResultOption {
+	return func(args *FromQueryResultArgs) {
+		args.nameValidation = nameValidation
+	}
+}
+
 // FromQueryResult unpacks and sorts a QueryResult proto.
-func FromQueryResult(sortSeries bool, res *prompb.QueryResult) storage.SeriesSet {
+func FromQueryResult(sortSeries bool, res *prompb.QueryResult, opts ...FromQueryResultOption) storage.SeriesSet {
+	args := &FromQueryResultArgs{
+		nameValidation: validation.UTF8NamingScheme,
+	}
+	for _, opt := range opts {
+		opt(args)
+	}
+
 	b := labels.NewScratchBuilder(0)
 	series := make([]storage.Series, 0, len(res.Timeseries))
 	for _, ts := range res.Timeseries {
-		if err := validateLabelsAndMetricName(ts.Labels); err != nil {
+		if err := validateLabelsAndMetricName(ts.Labels, args.nameValidation); err != nil {
 			return errSeriesSet{err: err}
 		}
 		lbls := ts.ToLabels(&b, nil)
@@ -756,12 +776,12 @@ func (it *chunkedSeriesIterator) Err() error {
 
 // validateLabelsAndMetricName validates the label names/values and metric names returned from remote read,
 // also making sure that there are no labels with duplicate names.
-func validateLabelsAndMetricName(ls []prompb.Label) error {
+func validateLabelsAndMetricName(ls []prompb.Label, namingScheme validation.NamingScheme) error {
 	for i, l := range ls {
-		if l.Name == labels.MetricName && !model.IsValidMetricName(model.LabelValue(l.Value)) {
+		if l.Name == labels.MetricName && !namingScheme.IsValidMetricName(l.Value) {
 			return fmt.Errorf("invalid metric name: %v", l.Value)
 		}
-		if !model.LabelName(l.Name).IsValid() {
+		if !namingScheme.IsValidLabelName(l.Name) {
 			return fmt.Errorf("invalid label name: %v", l.Name)
 		}
 		if !model.LabelValue(l.Value).IsValid() {

--- a/vendor/github.com/prometheus/prometheus/storage/remote/storage.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/storage.go
@@ -122,6 +122,7 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 			ChunkedReadLimit: rrConf.ChunkedReadLimit,
 			HTTPClientConfig: rrConf.HTTPClientConfig,
 			Headers:          rrConf.Headers,
+			NamingScheme:     rrConf.MetricNameValidationScheme,
 		})
 		if err != nil {
 			return err

--- a/vendor/github.com/prometheus/prometheus/storage/remote/write_handler.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/write_handler.go
@@ -27,7 +27,6 @@ import (
 	deltatocumulative "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/common/model"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -39,6 +38,7 @@ import (
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/model/validation"
 	"github.com/prometheus/prometheus/prompb"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
 	"github.com/prometheus/prometheus/storage"
@@ -249,7 +249,7 @@ func (h *writeHandler) write(ctx context.Context, req *prompb.WriteRequest) (err
 
 		// TODO(bwplotka): Even as per 1.0 spec, this should be a 400 error, while other samples are
 		// potentially written. Perhaps unify with fixed writeV2 implementation a bit.
-		if !ls.Has(labels.MetricName) || !ls.IsValid(model.UTF8Validation) {
+		if !ls.Has(labels.MetricName) || !ls.IsValid(validation.UTF8NamingScheme) {
 			h.logger.Warn("Invalid metric names or labels", "got", ls.String())
 			samplesWithInvalidLabels++
 			continue
@@ -390,7 +390,7 @@ func (h *writeHandler) appendV2(app storage.Appender, req *writev2.Request, rs *
 		// Validate series labels early.
 		// NOTE(bwplotka): While spec allows UTF-8, Prometheus Receiver may impose
 		// specific limits and follow https://prometheus.io/docs/specs/remote_write_spec_2_0/#invalid-samples case.
-		if !ls.Has(labels.MetricName) || !ls.IsValid(model.UTF8Validation) {
+		if !ls.Has(labels.MetricName) || !ls.IsValid(validation.UTF8NamingScheme) {
 			badRequestErrs = append(badRequestErrs, fmt.Errorf("invalid metric name or labels, got %v", ls.String()))
 			samplesWithInvalidLabels += len(ts.Samples) + len(ts.Histograms)
 			continue

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1196,7 +1196,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20250611134813-2510b5041da2
+# github.com/prometheus/prometheus v1.99.0 => github.com/juliusmh/mimir-prometheus v1.8.2-0.20250618091651-809285202792
 ## explicit; go 1.23.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1210,6 +1210,7 @@ github.com/prometheus/prometheus/model/relabel
 github.com/prometheus/prometheus/model/rulefmt
 github.com/prometheus/prometheus/model/textparse
 github.com/prometheus/prometheus/model/timestamp
+github.com/prometheus/prometheus/model/validation
 github.com/prometheus/prometheus/model/value
 github.com/prometheus/prometheus/notifier
 github.com/prometheus/prometheus/prompb
@@ -2113,7 +2114,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250611134813-2510b5041da2
+# github.com/prometheus/prometheus => github.com/juliusmh/mimir-prometheus v1.8.2-0.20250618091651-809285202792
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Mimir does not support prometheus `UTF8Validation` name validation scheme. Validation helpers
in prometheus `common/model` package rely on a global variable `NameValidationScheme` which
defaults to `UTF8Validation`.

This PR replaces direct calls to prometheus `LabelName.IsValid` and `IsValidMetricName` with
a validation wrapper that always uses `LegacyValidation` scheme and does not rely on the global
variable. 

Where I need feedback:

Many of prometheus internal functions still rely on the `NameValidationScheme` variable. Mimir 
uses those functions in `distributor`, `mimirtool`, `querier` and `ruler`. Hence, I'm not sure if 
removing global overrides (see below) introduces side effects.

```
func init() {
    model.NameValidationScheme = model.LegacyValidation
}
```

#### Which issue(s) this PR fixes or relates to

Fixes #11503

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
