### PR TITLE
query-frontend: Reverse error retry logic

### DIFF
--- a/pkg/api/error/error.go
+++ b/pkg/api/error/error.go
@@ -133,18 +133,21 @@ func AddDetails(err error, details string) error {
 	return apiErr
 }
 
-// IsNonRetryableAPIError returns true if err is an apiError which should be failed and not retried.
-func IsNonRetryableAPIError(err error) bool {
+// IsRetryableAPIError returns true if err is an apiError which should be retried, false otherwise.
+func IsRetryableAPIError(err error) bool {
 	apiErr := &APIError{}
-	return errors.As(err, &apiErr) && IsNonRetryableAPIErrorType(apiErr.Type)
-}
+	// If this isn't actually an APIError we can't determine if it should or should not be
+	// retried. We count on the Prometheus API converting errors into APIErrors before we
+	// apply our retry logic.
+	if !errors.As(err, &apiErr) {
+		return true
+	}
 
-func IsNonRetryableAPIErrorType(typ Type) bool {
 	// Reasoning:
 	// TypeNone and TypeNotFound are not used anywhere in Mimir nor Prometheus;
 	// TypeTimeout, TypeTooManyRequests, TypeNotAcceptable, TypeUnavailable we presume a retry of the same request will fail in the same way.
 	// TypeCanceled means something wants us to stop.
 	// TypeExec, TypeBadData and TypeTooLargeEntry are caused by the input data.
 	// TypeInternal can be a 500 error e.g. from querier failing to contact store-gateway.
-	return typ != TypeInternal
+	return apiErr.Type == TypeInternal
 }

--- a/pkg/api/error/error_test.go
+++ b/pkg/api/error/error_test.go
@@ -3,12 +3,15 @@
 package error
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,4 +59,42 @@ func extractPrometheusStrings(t *testing.T, constantType string) []string {
 	require.NotEmpty(t, strings)
 
 	return strings
+}
+
+func TestIsRetryableAPIError(t *testing.T) {
+	retryable := []error{
+		New(TypeInternal, string(TypeInternal)),
+		context.Canceled,
+		context.DeadlineExceeded,
+		errors.New("something bad"),
+	}
+
+	nonRetryable := []error{
+		New(TypeNone, "none"),
+		New(TypeNotFound, string(TypeNotFound)),
+		New(TypeTimeout, string(TypeTimeout)),
+		New(TypeTooManyRequests, string(TypeTooManyRequests)),
+		New(TypeNotAcceptable, string(TypeNotAcceptable)),
+		New(TypeUnavailable, string(TypeUnavailable)),
+		New(TypeCanceled, string(TypeCanceled)),
+		New(TypeExec, string(TypeExec)),
+		New(TypeBadData, string(TypeBadData)),
+		New(TypeTooLargeEntry, string(TypeTooLargeEntry)),
+	}
+
+	t.Run("retryable", func(t *testing.T) {
+		for _, err := range retryable {
+			t.Run(err.Error(), func(t *testing.T) {
+				assert.True(t, IsRetryableAPIError(err))
+			})
+		}
+	})
+
+	t.Run("non-retryable", func(t *testing.T) {
+		for _, err := range nonRetryable {
+			t.Run(err.Error(), func(t *testing.T) {
+				assert.False(t, IsRetryableAPIError(err))
+			})
+		}
+	})
 }

--- a/pkg/frontend/querymiddleware/retry.go
+++ b/pkg/frontend/querymiddleware/retry.go
@@ -39,7 +39,7 @@ func doWithRetries[T any](ctx context.Context, log log.Logger, maxRetries int, m
 			return resp, nil
 		}
 
-		if apierror.IsNonRetryableAPIError(err) || errors.Is(err, context.Canceled) {
+		if !apierror.IsRetryableAPIError(err) || errors.Is(err, context.Canceled) {
 			return zero, err
 		}
 

--- a/pkg/frontend/querymiddleware/shard_active_native_histogram_metrics_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_native_histogram_metrics_test.go
@@ -76,7 +76,7 @@ func Test_shardActiveNativeHistogramMetricsMiddleware_RoundTrip(t *testing.T) {
 				return request
 			},
 			checkResponseErr: func(t *testing.T, err error) (cont bool) {
-				assert.True(t, apierror.IsNonRetryableAPIError(err))
+				assert.False(t, apierror.IsRetryableAPIError(err))
 				return false
 			},
 		},
@@ -89,7 +89,7 @@ func Test_shardActiveNativeHistogramMetricsMiddleware_RoundTrip(t *testing.T) {
 				return r
 			},
 			checkResponseErr: func(t *testing.T, err error) (cont bool) {
-				assert.True(t, apierror.IsNonRetryableAPIError(err))
+				assert.False(t, apierror.IsRetryableAPIError(err))
 				return false
 			},
 		},

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -88,7 +88,7 @@ func runTestShardActiveSeriesMiddlewareRoundTrip(t *testing.T, useZeroAllocation
 				return request
 			},
 			checkResponseErr: func(t *testing.T, err error) (cont bool) {
-				assert.True(t, apierror.IsNonRetryableAPIError(err))
+				assert.False(t, apierror.IsRetryableAPIError(err))
 				return false
 			},
 		},
@@ -103,7 +103,7 @@ func runTestShardActiveSeriesMiddlewareRoundTrip(t *testing.T, useZeroAllocation
 				return r
 			},
 			checkResponseErr: func(t *testing.T, err error) (cont bool) {
-				assert.True(t, apierror.IsNonRetryableAPIError(err))
+				assert.False(t, apierror.IsRetryableAPIError(err))
 				return false
 			},
 		},


### PR DESCRIPTION


#### What this PR does

The existing logic uses double-negatives which is difficult to understand at a glance. This change reverses it to be affirmative.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
