### PR TITLE
ruler: Fix QueryOffset being ignored when recording xor alerting rule evaluation is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * [BUGFIX] Querier and query-frontend: Fix issue where aggregation functions like `topk` and `quantile` could return incorrect results if the scalar parameter is not a constant and Prometheus' query engine is in use. #11548
 * [BUGFIX] Querier and query-frontend: Fix issue where range vector selectors could incorrectly ignore samples at the beginning of the range. #11548
 * [BUGFIX] Querier: Fix rare panic if a query is canceled while a request to ingesters or store-gateways has just begun. #11613
+* [BUGFIX] Ruler: Fix QueryOffset and AlignEvaluationTimeOnInterval being ignored when recording xor alerting rule evaluation is disabled. #11647
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 * [BUGFIX] Querier and query-frontend: Fix issue where aggregation functions like `topk` and `quantile` could return incorrect results if the scalar parameter is not a constant and Prometheus' query engine is in use. #11548
 * [BUGFIX] Querier and query-frontend: Fix issue where range vector selectors could incorrectly ignore samples at the beginning of the range. #11548
 * [BUGFIX] Querier: Fix rare panic if a query is canceled while a request to ingesters or store-gateways has just begun. #11613
-* [BUGFIX] Ruler: Fix QueryOffset and AlignEvaluationTimeOnInterval being ignored when recording xor alerting rule evaluation is disabled. #11647
+* [BUGFIX] Ruler: Fix QueryOffset and AlignEvaluationTimeOnInterval being ignored when either recording or alerting rule evaluation is disabled. #11647
 
 ### Mixin
 

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -907,15 +907,9 @@ func filterRuleGroupByEnabled(group *rulespb.RuleGroupDesc, recordingEnabled, al
 	}
 
 	// Create a copy of the group and remove some rules.
-	filtered = &rulespb.RuleGroupDesc{
-		Name:          group.Name,
-		Namespace:     group.Namespace,
-		Interval:      group.Interval,
-		Rules:         make([]*rulespb.RuleDesc, 0, len(group.Rules)-removedRules),
-		User:          group.User,
-		Options:       group.Options,
-		SourceTenants: group.SourceTenants,
-	}
+	filtered = &rulespb.RuleGroupDesc{}
+	*filtered = *group
+	filtered.Rules = make([]*rulespb.RuleDesc, 0, len(group.Rules)-removedRules)
 
 	for _, rule := range group.Rules {
 		if rule.Record != "" && !recordingEnabled {

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/gogo/protobuf/types"
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
@@ -2504,11 +2505,16 @@ func createAlertingRule(alert, expr string) *rulespb.RuleDesc {
 // are copied when a rule group is cloned.
 func createRuleGroup(name, user string, rules ...*rulespb.RuleDesc) *rulespb.RuleGroupDesc {
 	return &rulespb.RuleGroupDesc{
-		Name:      name,
-		Namespace: "test",
-		Interval:  time.Minute,
-		Rules:     rules,
-		User:      user,
+		Name:                          name,
+		Namespace:                     "test",
+		Interval:                      time.Minute,
+		Rules:                         rules,
+		User:                          user,
+		Options:                       []*types.Any{},
+		SourceTenants:                 []string{},
+		EvaluationDelay:               1 * time.Minute,
+		QueryOffset:                   1 * time.Minute,
+		AlignEvaluationTimeOnInterval: true,
 	}
 }
 


### PR DESCRIPTION
#### What this PR does

When evaluation of one rule type is disabled but the other is enabled, the sync logic makes a filtered copy of each rule group. The copy logic ignores newly added fields `QueryOffset` and `AlignEvaluationTimeOnInterval`. We then sync these groups with the fields blapped.

This PR changes the copy + tests to consider all fields as of today, and also be tolerant of newly added fields so it doesn't break again in the future.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
