### PR TITLE
[ENHANCEMENT] Rule: Introduce a new metric to get number consequently missed individual rule evaluations

### DIFF
--- a/pkg/ruler/manager_metrics.go
+++ b/pkg/ruler/manager_metrics.go
@@ -21,6 +21,7 @@ type ManagerMetrics struct {
 	IterationsMissed         *prometheus.Desc
 	IterationsScheduled      *prometheus.Desc
 	EvalTotal                *prometheus.Desc
+	EvalMissed               *prometheus.Desc
 	EvalFailures             *prometheus.Desc
 	GroupInterval            *prometheus.Desc
 	GroupLastEvalTime        *prometheus.Desc
@@ -63,6 +64,12 @@ func NewManagerMetrics(logger log.Logger) *ManagerMetrics {
 		EvalTotal: prometheus.NewDesc(
 			"cortex_prometheus_rule_evaluations_total",
 			"The total number of rule evaluations.",
+			[]string{"user", "rule_group"},
+			nil,
+		),
+		EvalMissed: prometheus.NewDesc(
+			"cortex_prometheus_rule_evaluations_missed_total",
+			"The total number of rule evaluations missed across all rules in a group.",
 			[]string{"user", "rule_group"},
 			nil,
 		),
@@ -134,6 +141,7 @@ func (m *ManagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.IterationsMissed
 	out <- m.IterationsScheduled
 	out <- m.EvalTotal
+	out <- m.EvalMissed
 	out <- m.EvalFailures
 	out <- m.GroupInterval
 	out <- m.GroupLastEvalTime
@@ -160,6 +168,7 @@ func (m *ManagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCountersPerTenant(out, m.IterationsMissed, "prometheus_rule_group_iterations_missed_total", dskit_metrics.WithLabels("rule_group"))
 	data.SendSumOfCountersPerTenant(out, m.IterationsScheduled, "prometheus_rule_group_iterations_total", dskit_metrics.WithLabels("rule_group"))
 	data.SendSumOfCountersPerTenant(out, m.EvalTotal, "prometheus_rule_evaluations_total", dskit_metrics.WithLabels("rule_group"))
+	data.SendSumOfCountersPerTenant(out, m.EvalMissed, "prometheus_rule_evaluations_missed_total", dskit_metrics.WithLabels("rule_group"))
 	data.SendSumOfCountersPerTenant(out, m.EvalFailures, "prometheus_rule_evaluation_failures_total", dskit_metrics.WithLabels("rule_group"))
 	data.SendSumOfGaugesPerTenant(out, m.GroupInterval, "prometheus_rule_group_interval_seconds", dskit_metrics.WithLabels("rule_group"))
 	data.SendSumOfGaugesPerTenant(out, m.GroupLastEvalTime, "prometheus_rule_group_last_evaluation_timestamp_seconds", dskit_metrics.WithLabels("rule_group"))

--- a/pkg/ruler/manager_metrics_test.go
+++ b/pkg/ruler/manager_metrics_test.go
@@ -159,6 +159,8 @@ func populateManager(base float64) *prometheus.Registry {
 	metrics.IterationsMissed.WithLabelValues("group_two").Add(base)
 	metrics.EvalTotal.WithLabelValues("group_one").Add(base)
 	metrics.EvalTotal.WithLabelValues("group_two").Add(base)
+	metrics.EvalMissed.WithLabelValues("group_one").Add(base)
+	metrics.EvalMissed.WithLabelValues("group_two").Add(base)
 	metrics.EvalFailures.WithLabelValues("group_one").Add(base)
 	metrics.EvalFailures.WithLabelValues("group_two").Add(base)
 

--- a/vendor/github.com/prometheus/prometheus/rules/group.go
+++ b/vendor/github.com/prometheus/prometheus/rules/group.go
@@ -113,6 +113,7 @@ func NewGroup(o GroupOptions) *Group {
 	metrics.IterationsMissed.WithLabelValues(key)
 	metrics.IterationsScheduled.WithLabelValues(key)
 	metrics.EvalTotal.WithLabelValues(key)
+	metrics.EvalMissed.WithLabelValues(key)
 	metrics.EvalFailures.WithLabelValues(key)
 	metrics.GroupLastEvalTime.WithLabelValues(key)
 	metrics.GroupLastDuration.WithLabelValues(key)
@@ -275,6 +276,10 @@ func (g *Group) run(ctx context.Context) {
 			if missed > 0 {
 				g.metrics.IterationsMissed.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
 				g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
+				numRulesInGroup := uint64(len(g.rules))
+				if numRulesInGroup > 0 {
+					g.metrics.EvalMissed.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(uint64(missed) * numRulesInGroup))
+				}
 			}
 			evalTimestamp = evalTimestamp.Add((missed + 1) * g.interval)
 			g.evalIterationFunc(ctx, g, evalTimestamp)
@@ -301,6 +306,10 @@ func (g *Group) run(ctx context.Context) {
 				if missed > 0 {
 					g.metrics.IterationsMissed.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
 					g.metrics.IterationsScheduled.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(missed))
+					numRulesInGroup := uint64(len(g.rules))
+					if numRulesInGroup > 0 {
+						g.metrics.EvalMissed.WithLabelValues(GroupKey(g.file, g.name)).Add(float64(uint64(missed) * numRulesInGroup))
+					}
 				}
 				evalTimestamp = evalTimestamp.Add((missed + 1) * g.interval)
 
@@ -953,6 +962,7 @@ type Metrics struct {
 	IterationsMissed         *prometheus.CounterVec
 	IterationsScheduled      *prometheus.CounterVec
 	EvalTotal                *prometheus.CounterVec
+	EvalMissed               *prometheus.CounterVec
 	EvalFailures             *prometheus.CounterVec
 	GroupInterval            *prometheus.GaugeVec
 	GroupLastEvalTime        *prometheus.GaugeVec
@@ -1001,6 +1011,14 @@ func NewGroupMetrics(reg prometheus.Registerer) *Metrics {
 				Namespace: namespace,
 				Name:      "rule_evaluations_total",
 				Help:      "The total number of rule evaluations.",
+			},
+			[]string{"rule_group"},
+		),
+		EvalMissed: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "rule_evaluations_missed_total",
+				Help:      "The total number of rule evaluations missed across all rules in a group.",
 			},
 			[]string{"rule_group"},
 		),
@@ -1077,6 +1095,7 @@ func NewGroupMetrics(reg prometheus.Registerer) *Metrics {
 			m.IterationsMissed,
 			m.IterationsScheduled,
 			m.EvalTotal,
+			m.EvalMissed,
 			m.EvalFailures,
 			m.GroupInterval,
 			m.GroupLastEvalTime,

--- a/vendor/github.com/prometheus/prometheus/rules/manager.go
+++ b/vendor/github.com/prometheus/prometheus/rules/manager.go
@@ -281,6 +281,7 @@ func (m *Manager) Update(interval time.Duration, files []string, externalLabels 
 				m.IterationsMissed.DeleteLabelValues(n)
 				m.IterationsScheduled.DeleteLabelValues(n)
 				m.EvalTotal.DeleteLabelValues(n)
+				m.EvalMissed.DeleteLabelValues(n)
 				m.EvalFailures.DeleteLabelValues(n)
 				m.GroupInterval.DeleteLabelValues(n)
 				m.GroupLastEvalTime.DeleteLabelValues(n)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
the new `cortex_prometheus_rule_evaluations_missed_total` metric is incremented by the number of rules defined in that specific group for each missed iteration.
 `rule_evaluations_missed_total = (number of missed iterations for the group) * (number of rules in that group)`

#### Which issue(s) this PR fixes or relates to

Fixes #11500 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
