### PR TITLE
Backport #11615 to r344

### DIFF
--- a/pkg/ingester/client/streaming_test.go
+++ b/pkg/ingester/client/streaming_test.go
@@ -80,7 +80,7 @@ func TestSeriesChunksStreamReader_HappyPaths(t *testing.T) {
 			cleanedUp := atomic.NewBool(false)
 			cleanup := func() { cleanedUp.Store(true) }
 			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 5, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 
@@ -123,7 +123,7 @@ func TestSeriesChunksStreamReader_AbortsWhenParentContextCancelled(t *testing.T)
 
 	parentCtx, cancel := context.WithCancel(context.Background())
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	reader := NewSeriesChunksStreamReader(parentCtx, mockClient, "ingester", 3, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	cancel()
 	reader.StartBuffering()
@@ -170,7 +170,7 @@ func TestSeriesChunksStreamReader_DoesNotAbortWhenStreamContextCancelled(t *test
 
 	parentCtx := context.Background()
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	reader := NewSeriesChunksStreamReader(parentCtx, mockClient, "ingester", 3, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	cancel()
 	reader.StartBuffering()
@@ -195,7 +195,7 @@ func TestSeriesChunksStreamReader_ReadingSeriesOutOfOrder(t *testing.T) {
 	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 	cleanup := func() {}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
@@ -223,7 +223,7 @@ func TestSeriesChunksStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
 	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 	cleanup := func() {}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
@@ -256,7 +256,7 @@ func TestSeriesChunksStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) 
 	cleanedUp := atomic.NewBool(false)
 	cleanup := func() { cleanedUp.Store(true) }
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 3, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
@@ -306,7 +306,7 @@ func TestSeriesChunksStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 			cleanedUp := atomic.NewBool(false)
 			cleanup := func() { cleanedUp.Store(true) }
 			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 
@@ -380,7 +380,7 @@ func TestSeriesChunksStreamReader_QueryAndChunksLimits(t *testing.T) {
 			})
 
 			queryLimiter := limiter.NewQueryLimiter(0, testCase.maxChunkBytes, testCase.maxChunks, 0, queryMetrics)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(uint64(testCase.maxEstimatedMemory), rejectionCount)
+			memoryTracker := limiter.NewMemoryConsumptionTracker(uint64(testCase.maxEstimatedMemory), rejectionCount, "")
 			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 

--- a/pkg/querier/block_streaming_test.go
+++ b/pkg/querier/block_streaming_test.go
@@ -317,7 +317,7 @@ func TestStoreGatewayStreamReader_HappyPaths(t *testing.T) {
 			ctx := context.Background()
 			mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: testCase.messages}
 			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 			reader := newStoreGatewayStreamReader(ctx, mockClient, 5, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 			reader.StartBuffering()
@@ -389,7 +389,7 @@ func TestStoreGatewayStreamReader_AbortsWhenParentContextCancelled(t *testing.T)
 
 			parentCtx, cancel := context.WithCancel(context.Background())
 			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 			reader := newStoreGatewayStreamReader(parentCtx, mockClient, 3, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 			cancel()
@@ -418,7 +418,7 @@ func TestStoreGatewayStreamReader_DoesNotAbortWhenStreamContextCancelled(t *test
 	const expectedChunksEstimate uint64 = 5
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: streamCtx, messages: batchesToMessages(expectedChunksEstimate, batches...)}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 
 	parentCtx := context.Background()
@@ -444,7 +444,7 @@ func TestStoreGatewayStreamReader_ReadingSeriesOutOfOrder(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 	reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
@@ -463,7 +463,7 @@ func TestStoreGatewayStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 	reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
@@ -493,7 +493,7 @@ func TestStoreGatewayStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) 
 	ctx := context.Background()
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 	reader := newStoreGatewayStreamReader(ctx, mockClient, 3, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
@@ -548,7 +548,7 @@ func TestStoreGatewayStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 			ctx := context.Background()
 			mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
 			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 			reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())
 			reader.StartBuffering()
@@ -623,7 +623,7 @@ func TestStoreGatewayStreamReader_QueryAndChunksLimits(t *testing.T) {
 			})
 			queryMetrics := stats.NewQueryMetrics(registry)
 			queryLimiter := limiter.NewQueryLimiter(0, testCase.maxChunkBytes, testCase.maxChunks, 0, queryMetrics)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(uint64(testCase.maxEstimatedMemory), rejectionCount)
+			memoryTracker := limiter.NewMemoryConsumptionTracker(uint64(testCase.maxEstimatedMemory), rejectionCount, "")
 			metrics := newBlocksStoreQueryableMetrics(registry)
 
 			reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.Stats{}, metrics, log.NewNopLogger())

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -159,7 +159,7 @@ func createTestStreamReader(batches ...[]client.QueryStreamSeriesChunks) *client
 
 	cleanup := func() {}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 
 	reader := client.NewSeriesChunksStreamReader(ctx, mockClient, "ingester", seriesCount, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()

--- a/pkg/streamingpromql/operators/aggregations/aggregation_test.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation_test.go
@@ -85,7 +85,7 @@ func TestAggregation_ReturnsGroupsFinishedFirstEarliest(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			aggregator := &Aggregation{
 				Inner:                    &operators.TestOperator{Series: testCase.inputSeries, MemoryConsumptionTracker: memoryConsumptionTracker},
 				Grouping:                 testCase.grouping,
@@ -352,7 +352,7 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			timeRange := rangeQueryTimeRange
 
 			if testCase.instant {

--- a/pkg/streamingpromql/operators/aggregations/aggregations_safety_test.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregations_safety_test.go
@@ -27,7 +27,7 @@ func TestAggregationGroupNativeHistogramSafety(t *testing.T) {
 
 	for name, group := range groups {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			timeRange := types.NewRangeQueryTimeRange(timestamp.Time(0), timestamp.Time(4), time.Millisecond)
 
 			// First series: all histograms should be nil-ed out after returning, as they're all retained for use.

--- a/pkg/streamingpromql/operators/aggregations/count_values_test.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values_test.go
@@ -208,7 +208,7 @@ func TestCountValues_GroupLabelling(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			floats, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)
 			require.NoError(t, err)
 			floats = append(floats, promql.FPoint{T: 0, F: 123})

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query_test.go
@@ -363,7 +363,7 @@ func TestTopKBottomKInstantQuery_GroupingAndSorting(t *testing.T) {
 			require.ElementsMatch(t, allExpectedOutputSeries, testCase.inputSeries, "invalid test case: list of input series and all output series do not match")
 
 			timeRange := types.NewInstantQueryTimeRange(timestamp.Time(0))
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 
 			data := make([]types.InstantVectorSeriesData, 0, len(testCase.inputSeries))
 			for idx := range testCase.inputSeries {

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query_test.go
@@ -300,7 +300,7 @@ func TestTopKBottomKRangeQuery_GroupingAndSorting(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			timeRange := types.NewRangeQueryTimeRange(timestamp.Time(0), timestamp.Time(0).Add(2*time.Minute), time.Minute)
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 
 			o := New(
 				&operators.TestOperator{Series: testCase.inputSeries, MemoryConsumptionTracker: memoryConsumptionTracker},

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
@@ -50,7 +50,7 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					for name, readSeries := range map[string]bool{"read one series": true, "read no series": false} {
 						t.Run(name, func(t *testing.T) {
-							memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+							memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 
 							inner := &operators.TestOperator{
 								Series: inputSeries,

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -310,7 +310,7 @@ func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testin
 			}
 
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
@@ -432,7 +432,7 @@ func TestAndUnlessBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *test
 			for name, testCase := range testCases {
 				t.Run(name, func(t *testing.T) {
 					timeRange := types.NewInstantQueryTimeRange(time.Now())
-					memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+					memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 					left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 					right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 					vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -296,7 +296,7 @@ func TestGroupedVectorVectorBinaryOperation_OutputSeriesSorting(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			left := &operators.TestOperator{Series: testCase.leftSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 
@@ -466,7 +466,7 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 			}
 
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}, Card: parser.CardOneToMany}
@@ -562,7 +562,7 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			ts := int64(0)
 			timeRange := types.NewInstantQueryTimeRange(timestamp.Time(ts))
 

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -195,7 +195,7 @@ func TestOneToOneVectorVectorBinaryOperation_SeriesMerging(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			o := &OneToOneVectorVectorBinaryOperation{
 				// Simulate an expression with "on (env)".
 				// This is used to generate error messages.
@@ -619,7 +619,7 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 			}
 
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
@@ -693,7 +693,7 @@ func TestOneToOneVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEa
 			timeRange := types.NewRangeQueryTimeRange(step1, step2, time.Minute)
 
 			var err error
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 
 			left1Data := types.InstantVectorSeriesData{}
 			left1Data.Floats, err = types.FPointSlicePool.Get(1, memoryConsumptionTracker)

--- a/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
@@ -291,7 +291,7 @@ func TestOrBinaryOperationSorting(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			left := &operators.TestOperator{Series: testCase.leftSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 
@@ -530,7 +530,7 @@ func TestOrBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
 			}
 
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
@@ -675,7 +675,7 @@ func TestOrBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *testing.T) 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}

--- a/pkg/streamingpromql/operators/deduplicate_and_merge_test.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge_test.go
@@ -157,7 +157,7 @@ func TestDeduplicateAndMerge(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			inner := &TestOperator{Series: testCase.inputSeries, Data: testCase.inputData, MemoryConsumptionTracker: memoryConsumptionTracker}
 			o := NewDeduplicateAndMerge(inner, memoryConsumptionTracker)
 

--- a/pkg/streamingpromql/operators/functions/absent_test.go
+++ b/pkg/streamingpromql/operators/functions/absent_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAbsent_NextSeries_ExhaustedCondition(t *testing.T) {
-	memTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 
 	a := &Absent{
 		TimeRange: types.QueryTimeRange{

--- a/pkg/streamingpromql/operators/functions/common_test.go
+++ b/pkg/streamingpromql/operators/functions/common_test.go
@@ -25,7 +25,7 @@ func TestDropSeriesName(t *testing.T) {
 		{Labels: labels.FromStrings("label2", "value2")},
 	}
 
-	modifiedMetadata, err := DropSeriesName.Func(seriesMetadata, limiter.NewMemoryConsumptionTracker(0, nil))
+	modifiedMetadata, err := DropSeriesName.Func(seriesMetadata, limiter.NewMemoryConsumptionTracker(0, nil, ""))
 	require.NoError(t, err)
 	require.Equal(t, expected, modifiedMetadata)
 }
@@ -33,7 +33,7 @@ func TestDropSeriesName(t *testing.T) {
 func TestFloatTransformationFunc(t *testing.T) {
 	transform := func(f float64) float64 { return f * 2 }
 	transformFunc := floatTransformationFunc(transform)
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 
 	seriesData := types.InstantVectorSeriesData{
 		Floats: []promql.FPoint{
@@ -66,7 +66,7 @@ func TestFloatTransformationFunc(t *testing.T) {
 func TestFloatTransformationDropHistogramsFunc(t *testing.T) {
 	transform := func(f float64) float64 { return f * 2 }
 	transformFunc := FloatTransformationDropHistogramsFunc(transform)
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 
 	seriesData := types.InstantVectorSeriesData{
 		Floats: []promql.FPoint{

--- a/pkg/streamingpromql/operators/functions/function_over_instant_vector_test.go
+++ b/pkg/streamingpromql/operators/functions/function_over_instant_vector_test.go
@@ -29,7 +29,7 @@ func TestFunctionOverInstantVector(t *testing.T) {
 			{Floats: []promql.FPoint{{T: 0, F: 1}}},
 			{Floats: []promql.FPoint{{T: 0, F: 2}}},
 		},
-		MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil),
+		MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil, ""),
 	}
 
 	metadataFuncCalled := false
@@ -47,7 +47,7 @@ func TestFunctionOverInstantVector(t *testing.T) {
 
 	operator := &FunctionOverInstantVector{
 		Inner:                    inner,
-		MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil),
+		MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil, ""),
 		Func: FunctionOverInstantVectorDefinition{
 			SeriesDataFunc: mustBeCalledSeriesData,
 			SeriesMetadataFunction: SeriesMetadataFunctionDefinition{
@@ -75,7 +75,7 @@ func TestFunctionOverInstantVectorWithScalarArgs(t *testing.T) {
 			{Floats: []promql.FPoint{{T: 0, F: 1}}},
 			{Floats: []promql.FPoint{{T: 0, F: 2}}},
 		},
-		MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil),
+		MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil, ""),
 	}
 
 	scalarOperator1 := &testScalarOperator{
@@ -99,7 +99,7 @@ func TestFunctionOverInstantVectorWithScalarArgs(t *testing.T) {
 	operator := &FunctionOverInstantVector{
 		Inner:                    inner,
 		ScalarArgs:               []types.ScalarOperator{scalarOperator1, scalarOperator2},
-		MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil),
+		MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil, ""),
 		Func: FunctionOverInstantVectorDefinition{
 			SeriesDataFunc:         mustBeCalledSeriesData,
 			SeriesMetadataFunction: DropSeriesName,

--- a/pkg/streamingpromql/operators/functions/histogram_function_test.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function_test.go
@@ -113,7 +113,7 @@ func TestHistogramFunction_ReturnsGroupsFinishedFirstEarliest(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			hOp := &HistogramFunction{
 				f: &histogramQuantile{
 					phArg: &testScalarOperator{},

--- a/pkg/streamingpromql/operators/operator_buffer_test.go
+++ b/pkg/streamingpromql/operators/operator_buffer_test.go
@@ -44,7 +44,7 @@ func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) 
 	}
 
 	seriesUsed := []bool{true, false, true, true, true}
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*6)) // We have 6 FPoints from the inner series.
 	buffer := NewInstantVectorOperatorBuffer(inner, seriesUsed, 4, memoryConsumptionTracker)
 	ctx := context.Background()
@@ -114,7 +114,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 		},
 	}
 
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*6)) // We have 6 FPoints from the inner series.
 	buffer := NewInstantVectorOperatorBuffer(inner, nil, 6, memoryConsumptionTracker)
 	ctx := context.Background()
@@ -162,7 +162,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 }
 
 func TestInstantVectorOperatorBuffer_ReleasesBufferWhenClosedEarly(t *testing.T) {
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 
 	createTestData := func(val float64) types.InstantVectorSeriesData {
 		floats, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)

--- a/pkg/streamingpromql/operators/selectors/instant_vector_selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/instant_vector_selector_test.go
@@ -186,7 +186,7 @@ func TestInstantVectorSelector_NativeHistogramPointerHandling(t *testing.T) {
 			startTime := time.Unix(0, 0)
 			endTime := startTime.Add(time.Duration(testCase.stepCount-1) * time.Minute)
 
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			selector := &InstantVectorSelector{
 				Selector: &Selector{
 					Queryable: storage,
@@ -232,7 +232,7 @@ func TestInstantVectorSelector_SliceSizing(t *testing.T) {
 			startTime := timeZero.Add(time.Duration(startT) * time.Minute)
 			endTime := timeZero.Add(7 * time.Minute)
 
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 			selector := &InstantVectorSelector{
 				Selector: &Selector{
 					Queryable: storage,

--- a/pkg/streamingpromql/operators/selectors/selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/selector_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestSeriesList_BasicListOperations(t *testing.T) {
-	list := newSeriesList(limiter.NewMemoryConsumptionTracker(0, nil))
+	list := newSeriesList(limiter.NewMemoryConsumptionTracker(0, nil, ""))
 	require.Equal(t, 0, list.Len())
 
 	series1 := mockSeries{labels.FromStrings("series", "1")}
@@ -57,7 +57,7 @@ func TestSeriesList_OperationsNearBatchBoundaries(t *testing.T) {
 
 	for _, seriesCount := range cases {
 		t.Run(fmt.Sprintf("N=%v", seriesCount), func(t *testing.T) {
-			list := newSeriesList(limiter.NewMemoryConsumptionTracker(0, nil))
+			list := newSeriesList(limiter.NewMemoryConsumptionTracker(0, nil, ""))
 
 			seriesAdded := make([]storage.Series, 0, seriesCount)
 
@@ -118,7 +118,7 @@ func TestSelector_QueryRanges(t *testing.T) {
 			Queryable:                queryable,
 			TimeRange:                timeRange,
 			LookbackDelta:            lookbackDelta,
-			MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil),
+			MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil, ""),
 		}
 
 		_, err := s.SeriesMetadata(context.Background())
@@ -139,7 +139,7 @@ func TestSelector_QueryRanges(t *testing.T) {
 			Queryable:                queryable,
 			TimeRange:                timeRange,
 			Range:                    selectorRange,
-			MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil),
+			MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(0, nil, ""),
 		}
 
 		_, err := s.SeriesMetadata(context.Background())

--- a/pkg/streamingpromql/operators/series_merging_test.go
+++ b/pkg/streamingpromql/operators/series_merging_test.go
@@ -758,7 +758,7 @@ func TestMergeSeries(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result, conflict, err := MergeSeries(testCase.input, testCase.sourceSeriesIndices, limiter.NewMemoryConsumptionTracker(0, nil))
+			result, conflict, err := MergeSeries(testCase.input, testCase.sourceSeriesIndices, limiter.NewMemoryConsumptionTracker(0, nil, ""))
 
 			require.NoError(t, err)
 

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestOperator_Buffering(t *testing.T) {
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	inner, expectedData := createTestOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -113,7 +113,7 @@ func TestOperator_Buffering(t *testing.T) {
 }
 
 func TestOperator_ClosedWithBufferedData(t *testing.T) {
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	inner, expectedData := createTestOperator(t, 3, memoryConsumptionTracker)
 
 	buffer := NewDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -183,7 +183,7 @@ func TestOperator_Cloning(t *testing.T) {
 		},
 	}
 
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	inner := &operators.TestOperator{
 		Series:                   []labels.Labels{labels.FromStrings(labels.MetricName, "test_series")},
 		Data:                     []types.InstantVectorSeriesData{series},
@@ -255,7 +255,7 @@ func createTestOperator(t *testing.T, seriesCount int, memoryConsumptionTracker 
 }
 
 func TestOperator_ClosingAfterFirstReadFails(t *testing.T) {
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	series, err := types.SeriesMetadataSlicePool.Get(1, memoryConsumptionTracker)
 	require.NoError(t, err)
 
@@ -281,7 +281,7 @@ func TestOperator_ClosingAfterFirstReadFails(t *testing.T) {
 }
 
 func TestOperator_ClosingAfterSubsequentReadFails(t *testing.T) {
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	series, err := types.SeriesMetadataSlicePool.Get(2, memoryConsumptionTracker)
 	require.NoError(t, err)
 

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -424,7 +424,11 @@ func (e *Engine) Materialize(ctx context.Context, plan *planning.QueryPlan, quer
 
 	defer e.activeQueryTracker.Delete(queryID)
 
-	q, err := e.newQuery(ctx, queryable, opts, plan.TimeRange)
+	// HACK: we need an expression to use in the active query tracker, but there's no guarantee the plan we're working with
+	// is for the original expression (the plan may represent a subexpression of the original plan, for example).
+	// So we pass plan.OriginalExpression, which is good enough for now, but something to revisit later - perhaps
+	// we can use some kind of request ID?
+	q, err := e.newQuery(ctx, queryable, opts, plan.TimeRange, plan.OriginalExpression)
 	if err != nil {
 		return nil, err
 	}
@@ -437,11 +441,6 @@ func (e *Engine) Materialize(ctx context.Context, plan *planning.QueryPlan, quer
 		Stats:                    q.stats,
 		LookbackDelta:            q.lookbackDelta,
 	}
-
-	// HACK: we need an expression to use in the active query tracker, but there's no guarantee the plan we're working with
-	// is for the original expression (the plan may represent a subexpression of the original plan, for example).
-	// This is good enough for now, but something to revisit later - perhaps we can use some kind of request ID?
-	q.originalExpression = plan.OriginalExpression
 
 	q.statement = &parser.EvalStmt{
 		Expr:          nil, // Nothing seems to use this, and we don't have a good expression to use here anyway, so don't bother setting this.

--- a/pkg/streamingpromql/types/data_test.go
+++ b/pkg/streamingpromql/types/data_test.go
@@ -27,7 +27,7 @@ func TestInstantVectorSeriesData_Clone(t *testing.T) {
 		},
 	}
 
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 	cloned, err := original.Clone(memoryConsumptionTracker)
 
 	require.NoError(t, err)

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -22,7 +22,7 @@ const rejectedQueriesMetricName = "rejected_queries"
 
 func TestLimitingBucketedPool_Unlimited(t *testing.T) {
 	reg, metric := createRejectedMetric()
-	tracker := limiter.NewMemoryConsumptionTracker(0, metric)
+	tracker := limiter.NewMemoryConsumptionTracker(0, metric, "")
 
 	p := NewLimitingBucketedPool(
 		pool.NewBucketedPool(1024, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
@@ -75,7 +75,7 @@ func TestLimitingBucketedPool_Unlimited(t *testing.T) {
 func TestLimitingPool_Limited(t *testing.T) {
 	reg, metric := createRejectedMetric()
 	limit := 11 * FPointSize
-	tracker := limiter.NewMemoryConsumptionTracker(limit, metric)
+	tracker := limiter.NewMemoryConsumptionTracker(limit, metric, "")
 
 	p := NewLimitingBucketedPool(
 		pool.NewBucketedPool(1024, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
@@ -142,7 +142,7 @@ func TestLimitingPool_Limited(t *testing.T) {
 }
 
 func TestLimitingPool_ClearsReturnedSlices(t *testing.T) {
-	tracker := limiter.NewMemoryConsumptionTracker(0, nil)
+	tracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
 
 	// Get a slice, put it back in the pool and get it back again.
 	// Make sure all elements are zero or false when we get it back.
@@ -200,7 +200,7 @@ func TestLimitingPool_Mangling(t *testing.T) {
 	}()
 
 	_, metric := createRejectedMetric()
-	tracker := limiter.NewMemoryConsumptionTracker(0, metric)
+	tracker := limiter.NewMemoryConsumptionTracker(0, metric, "")
 
 	p := NewLimitingBucketedPool(
 		pool.NewBucketedPool(1024, func(size int) []int { return make([]int, 0, size) }),

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -54,7 +54,7 @@ func TestRingBuffer(t *testing.T) {
 			{T: 8, F: 800},
 			{T: 9, F: 900},
 		}
-		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil))}
+		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil, ""))}
 		testRingBuffer(t, buf, points)
 	})
 
@@ -70,7 +70,7 @@ func TestRingBuffer(t *testing.T) {
 			{T: 8, H: &histogram.FloatHistogram{Count: 800}},
 			{T: 9, H: &histogram.FloatHistogram{Count: 900}},
 		}
-		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil))}
+		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil, ""))}
 		testRingBuffer(t, buf, points)
 	})
 }
@@ -155,7 +155,7 @@ func TestRingBuffer_DiscardPointsBefore_ThroughWrapAround(t *testing.T) {
 			{T: 5, F: 500},
 			{T: 6, F: 600},
 		}
-		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil))}
+		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil, ""))}
 		testDiscardPointsBeforeThroughWrapAround(t, buf, points)
 	})
 
@@ -168,7 +168,7 @@ func TestRingBuffer_DiscardPointsBefore_ThroughWrapAround(t *testing.T) {
 			{T: 5, H: &histogram.FloatHistogram{Count: 500}},
 			{T: 6, H: &histogram.FloatHistogram{Count: 600}},
 		}
-		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil))}
+		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil, ""))}
 		testDiscardPointsBeforeThroughWrapAround(t, buf, points)
 	})
 }
@@ -215,7 +215,7 @@ func TestRingBuffer_RemoveLastPoint(t *testing.T) {
 		{T: 6, H: &histogram.FloatHistogram{Count: 600}},
 	}
 
-	buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil))}
+	buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil, ""))}
 
 	t.Run("test removing points until none exist", func(t *testing.T) {
 		buf.Reset()
@@ -296,7 +296,7 @@ func TestRingBuffer_RemoveLastPoint(t *testing.T) {
 
 func TestRingBuffer_ViewUntilWithExistingView(t *testing.T) {
 	t.Run("FPoint ring buffer", func(t *testing.T) {
-		buf := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil))
+		buf := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil, ""))
 		require.NoError(t, buf.Append(promql.FPoint{T: 1, F: 100}))
 		require.NoError(t, buf.Append(promql.FPoint{T: 2, F: 200}))
 		require.NoError(t, buf.Append(promql.FPoint{T: 3, F: 300}))
@@ -322,7 +322,7 @@ func TestRingBuffer_ViewUntilWithExistingView(t *testing.T) {
 		h3 := &histogram.FloatHistogram{Count: 300}
 		h4 := &histogram.FloatHistogram{Count: 400}
 
-		buf := NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil))
+		buf := NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(0, nil, ""))
 		require.NoError(t, buf.Append(promql.HPoint{T: 1, H: h1}))
 		require.NoError(t, buf.Append(promql.HPoint{T: 2, H: h2}))
 		require.NoError(t, buf.Append(promql.HPoint{T: 3, H: h3}))

--- a/pkg/util/limiter/memory_consumption.go
+++ b/pkg/util/limiter/memory_consumption.go
@@ -21,7 +21,7 @@ const (
 func MemoryTrackerFromContextWithFallback(ctx context.Context) *MemoryConsumptionTracker {
 	tracker, ok := ctx.Value(memoryConsumptionTracker).(*MemoryConsumptionTracker)
 	if !ok {
-		return NewMemoryConsumptionTracker(0, nil)
+		return NewMemoryConsumptionTracker(0, nil, "")
 	}
 
 	return tracker
@@ -44,6 +44,7 @@ type MemoryConsumptionTracker struct {
 
 	rejectionCount        prometheus.Counter
 	haveRecordedRejection bool
+	queryDescription      string
 
 	// mtx protects all mutable state of the memory consumption tracker. We use a mutex
 	// rather than atomics because we only want to adjust the memory used after checking
@@ -51,11 +52,12 @@ type MemoryConsumptionTracker struct {
 	mtx sync.Mutex
 }
 
-func NewMemoryConsumptionTracker(maxEstimatedMemoryConsumptionBytes uint64, rejectionCount prometheus.Counter) *MemoryConsumptionTracker {
+func NewMemoryConsumptionTracker(maxEstimatedMemoryConsumptionBytes uint64, rejectionCount prometheus.Counter, queryDescription string) *MemoryConsumptionTracker {
 	return &MemoryConsumptionTracker{
 		maxEstimatedMemoryConsumptionBytes: maxEstimatedMemoryConsumptionBytes,
 
-		rejectionCount: rejectionCount,
+		rejectionCount:   rejectionCount,
+		queryDescription: queryDescription,
 	}
 }
 
@@ -87,8 +89,9 @@ func (l *MemoryConsumptionTracker) DecreaseMemoryConsumption(b uint64) {
 	defer l.mtx.Unlock()
 
 	if b > l.currentEstimatedMemoryConsumptionBytes {
-		panic("Estimated memory consumption of this query is negative. This indicates something has been returned to a pool more than once, which is a bug.")
+		panic("Estimated memory consumption of this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: " + l.queryDescription)
 	}
+
 	l.currentEstimatedMemoryConsumptionBytes -= b
 }
 

--- a/pkg/util/limiter/memory_consumption_test.go
+++ b/pkg/util/limiter/memory_consumption_test.go
@@ -28,7 +28,7 @@ func TestFromContextWithFallback(t *testing.T) {
 
 	t.Run("exists", func(t *testing.T) {
 		ctx := context.Background()
-		existing := NewMemoryConsumptionTracker(0, nil)
+		existing := NewMemoryConsumptionTracker(0, nil, "")
 		require.NoError(t, existing.IncreaseMemoryConsumption(uint64(512)))
 
 		ctx = context.WithValue(ctx, memoryConsumptionTracker, existing)
@@ -40,7 +40,7 @@ func TestFromContextWithFallback(t *testing.T) {
 
 func TestAddToContext(t *testing.T) {
 	ctx := context.Background()
-	existing := NewMemoryConsumptionTracker(0, nil)
+	existing := NewMemoryConsumptionTracker(0, nil, "")
 	require.NoError(t, existing.IncreaseMemoryConsumption(uint64(512)))
 
 	ctx = AddMemoryTrackerToContext(ctx, existing)
@@ -51,7 +51,7 @@ func TestAddToContext(t *testing.T) {
 
 func TestMemoryConsumptionTracker_Unlimited(t *testing.T) {
 	reg, metric := createRejectedMetric()
-	tracker := NewMemoryConsumptionTracker(0, metric)
+	tracker := NewMemoryConsumptionTracker(0, metric, "foo + bar")
 
 	require.NoError(t, tracker.IncreaseMemoryConsumption(128))
 	require.Equal(t, uint64(128), tracker.CurrentEstimatedMemoryConsumptionBytes())
@@ -79,13 +79,13 @@ func TestMemoryConsumptionTracker_Unlimited(t *testing.T) {
 
 	assertRejectedQueriesCount(t, reg, 0)
 
-	// Test reducing memory consumption to a negative panics
-	require.Panics(t, func() { tracker.DecreaseMemoryConsumption(150) })
+	// Test reducing memory consumption to a negative value panics
+	require.PanicsWithValue(t, `Estimated memory consumption of this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: foo + bar`, func() { tracker.DecreaseMemoryConsumption(150) })
 }
 
 func TestMemoryConsumptionTracker_Limited(t *testing.T) {
 	reg, metric := createRejectedMetric()
-	tracker := NewMemoryConsumptionTracker(11, metric)
+	tracker := NewMemoryConsumptionTracker(11, metric, "foo + bar")
 
 	// Add some memory consumption beneath the limit.
 	require.NoError(t, tracker.IncreaseMemoryConsumption(8))
@@ -131,8 +131,8 @@ func TestMemoryConsumptionTracker_Limited(t *testing.T) {
 	require.Equal(t, uint64(11), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 1)
 
-	// Test reducing memory consumption to a negative panics
-	require.Panics(t, func() { tracker.DecreaseMemoryConsumption(150) })
+	// Test reducing memory consumption to a negative value panics
+	require.PanicsWithValue(t, `Estimated memory consumption of this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: foo + bar`, func() { tracker.DecreaseMemoryConsumption(150) })
 }
 
 func assertRejectedQueriesCount(t *testing.T, reg *prometheus.Registry, expectedRejectionCount int) {
@@ -159,7 +159,7 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 	const memoryLimit = 1024 * 1024 * 1024
 
 	b.Run("no limits single threaded", func(b *testing.B) {
-		l := NewMemoryConsumptionTracker(0, nil)
+		l := NewMemoryConsumptionTracker(0, nil, "")
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = l.IncreaseMemoryConsumption(uint64(b.N))
@@ -174,7 +174,7 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 			Name: "cortex_test_rejections_total",
 		})
 
-		l := NewMemoryConsumptionTracker(memoryLimit, counter)
+		l := NewMemoryConsumptionTracker(memoryLimit, counter, "")
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			if err := l.IncreaseMemoryConsumption(uint64(b.N)); err == nil {
@@ -186,7 +186,7 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 	})
 
 	b.Run("no limits multiple threads", func(b *testing.B) {
-		l := NewMemoryConsumptionTracker(0, nil)
+		l := NewMemoryConsumptionTracker(0, nil, "")
 		wg := sync.WaitGroup{}
 		run := atomic.NewBool(true)
 
@@ -217,7 +217,7 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 			Name: "cortex_test_rejections_total",
 		})
 
-		l := NewMemoryConsumptionTracker(memoryLimit, counter)
+		l := NewMemoryConsumptionTracker(memoryLimit, counter, "")
 		wg := sync.WaitGroup{}
 		run := atomic.NewBool(true)
 


### PR DESCRIPTION
#### What this PR does

This PR manually backports https://github.com/grafana/mimir/pull/11615 to r344.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/11615

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
