### PR TITLE
MQE: label each source of memory consumption to make it easier to identify where something is returned to the pool multiple times

### DIFF
--- a/pkg/streamingpromql/operators/aggregations/quantile.go
+++ b/pkg/streamingpromql/operators/aggregations/quantile.go
@@ -125,6 +125,7 @@ var qGroupPool = types.NewLimitingBucketedPool(
 	pool.NewBucketedPool(maxExpectedQuantileGroups, func(size int) []qGroup {
 		return make([]qGroup, 0, size)
 	}),
+	limiter.QuantileGroupSlices,
 	uint64(unsafe.Sizeof(qGroup{})),
 	false,
 	nil,

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
@@ -317,6 +317,7 @@ var instantQuerySeriesSlicePool = types.NewLimitingBucketedPool(
 	pool.NewBucketedPool(types.MaxExpectedSeriesPerResult, func(size int) []instantQuerySeries {
 		return make([]instantQuerySeries, 0, size)
 	}),
+	limiter.TopKBottomKInstantQuerySeriesSlices,
 	uint64(unsafe.Sizeof(instantQuerySeries{})),
 	true,
 	nil,

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
@@ -494,6 +494,7 @@ var rangeQuerySeriesSlicePool = types.NewLimitingBucketedPool(
 	pool.NewBucketedPool(types.MaxExpectedSeriesPerResult, func(size int) []rangeQuerySeries {
 		return make([]rangeQuerySeries, 0, size)
 	}),
+	limiter.TopKBottomKRangeQuerySeriesSlices,
 	uint64(unsafe.Sizeof(rangeQuerySeries{})),
 	true,
 	nil,
@@ -503,6 +504,7 @@ var intSliceSlicePool = types.NewLimitingBucketedPool(
 	pool.NewBucketedPool(types.MaxExpectedPointsPerSeries, func(size int) [][]int {
 		return make([][]int, 0, size)
 	}),
+	limiter.IntSliceSlice,
 	uint64(unsafe.Sizeof([][]int{})),
 	true,
 	nil,

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -207,7 +207,8 @@ func TestOneToOneVectorVectorBinaryOperation_SeriesMerging(t *testing.T) {
 			}
 			for _, s := range testCase.input {
 				// Count the memory for the given floats + histograms
-				require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*uint64(len(s.Floats))+types.HPointSize*uint64(len(s.Histograms))))
+				require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*uint64(len(s.Floats)), limiter.FPointSlices))
+				require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.HPointSize*uint64(len(s.Histograms)), limiter.HPointSlices))
 			}
 
 			result, err := o.mergeSingleSide(testCase.input, testCase.sourceSeriesIndices, testCase.sourceSeriesMetadata, "right")

--- a/pkg/streamingpromql/operators/functions/common_test.go
+++ b/pkg/streamingpromql/operators/functions/common_test.go
@@ -45,7 +45,8 @@ func TestFloatTransformationFunc(t *testing.T) {
 		},
 	}
 	// Increase the memory tracker for 2 FPoints, and 1 HPoint
-	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*2+types.HPointSize*1))
+	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*2, limiter.FPointSlices))
+	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.HPointSize*1, limiter.HPointSlices))
 
 	expected := types.InstantVectorSeriesData{
 		Floats: []promql.FPoint{
@@ -78,7 +79,8 @@ func TestFloatTransformationDropHistogramsFunc(t *testing.T) {
 		},
 	}
 	// Increase the memory tracker for 2 FPoints, and 1 HPoint
-	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*2+types.HPointSize*1))
+	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*2, limiter.FPointSlices))
+	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.HPointSize*1, limiter.HPointSlices))
 
 	expected := types.InstantVectorSeriesData{
 		Floats: []promql.FPoint{

--- a/pkg/streamingpromql/operators/functions/histogram_function.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function.go
@@ -79,6 +79,7 @@ var pointBucketPool = types.NewLimitingBucketedPool(
 	pool.NewBucketedPool(types.MaxExpectedPointsPerSeries, func(size int) []promql.Buckets {
 		return make([]promql.Buckets, 0, size)
 	}),
+	limiter.BucketSlices,
 	uint64(unsafe.Sizeof(promql.Buckets{})),
 	true,
 	mangleBuckets,
@@ -98,6 +99,7 @@ var bucketSliceBucketedPool = types.NewLimitingBucketedPool(
 	pool.NewBucketedPool(maxExpectedBucketsPerHistogram, func(size int) []promql.Bucket {
 		return make([]promql.Bucket, 0, size)
 	}),
+	limiter.BucketSlices,
 	uint64(unsafe.Sizeof(promql.Bucket{})),
 	true,
 	nil,

--- a/pkg/streamingpromql/operators/operator_buffer_test.go
+++ b/pkg/streamingpromql/operators/operator_buffer_test.go
@@ -45,7 +45,7 @@ func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) 
 
 	seriesUsed := []bool{true, false, true, true, true}
 	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
-	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*6)) // We have 6 FPoints from the inner series.
+	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*6, limiter.FPointSlices)) // We have 6 FPoints from the inner series.
 	buffer := NewInstantVectorOperatorBuffer(inner, seriesUsed, 4, memoryConsumptionTracker)
 	ctx := context.Background()
 
@@ -115,7 +115,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 	}
 
 	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(0, nil, "")
-	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*6)) // We have 6 FPoints from the inner series.
+	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*6, limiter.FPointSlices)) // We have 6 FPoints from the inner series.
 	buffer := NewInstantVectorOperatorBuffer(inner, nil, 6, memoryConsumptionTracker)
 	ctx := context.Background()
 

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -26,6 +26,7 @@ func TestLimitingBucketedPool_Unlimited(t *testing.T) {
 
 	p := NewLimitingBucketedPool(
 		pool.NewBucketedPool(1024, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
+		limiter.FPointSlices,
 		FPointSize,
 		false,
 		nil,
@@ -79,6 +80,7 @@ func TestLimitingPool_Limited(t *testing.T) {
 
 	p := NewLimitingBucketedPool(
 		pool.NewBucketedPool(1024, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
+		limiter.FPointSlices,
 		FPointSize,
 		false,
 		nil,
@@ -204,6 +206,7 @@ func TestLimitingPool_Mangling(t *testing.T) {
 
 	p := NewLimitingBucketedPool(
 		pool.NewBucketedPool(1024, func(size int) []int { return make([]int, 0, size) }),
+		limiter.IntSlices,
 		1,
 		false,
 		func(_ int) int { return 123 },

--- a/pkg/util/limiter/memory_consumption.go
+++ b/pkg/util/limiter/memory_consumption.go
@@ -58,23 +58,47 @@ const (
 	memoryConsumptionSourceCount = TopKBottomKRangeQuerySeriesSlices + 1
 )
 
-var memoryConsumptionSourceNames = map[MemoryConsumptionSource]string{
-	IngesterChunks:                      "ingester chunks",
-	StoreGatewayChunks:                  "store-gateway chunks",
-	FPointSlices:                        "[]promql.FPoint",
-	HPointSlices:                        "[]promql.HPoint",
-	Vectors:                             "promql.Vector",
-	Float64Slices:                       "[]float64",
-	IntSlices:                           "[]int",
-	IntSliceSlice:                       "[][]int",
-	Int64Slices:                         "[]int64",
-	BoolSlices:                          "[]bool",
-	HistogramPointerSlices:              "[]*histogram.FloatHistogram",
-	SeriesMetadataSlices:                "[]SeriesMetadata",
-	BucketSlices:                        "[]promql.Buckets",
-	QuantileGroupSlices:                 "[]aggregations.qGroup",
-	TopKBottomKInstantQuerySeriesSlices: "[]topkbottom.instantQuerySeries",
-	TopKBottomKRangeQuerySeriesSlices:   "[]topkbottom.rangeQuerySeries",
+const (
+	unknownMemorySource = "unknown memory source"
+)
+
+func (s MemoryConsumptionSource) String() string {
+	switch s {
+	case IngesterChunks:
+		return "ingester chunks"
+	case StoreGatewayChunks:
+		return "store-gateway chunks"
+	case FPointSlices:
+		return "[]promql.FPoint"
+	case HPointSlices:
+		return "[]promql.HPoint"
+	case Vectors:
+		return "promql.Vector"
+	case Float64Slices:
+		return "[]float64"
+	case IntSlices:
+		return "[]int"
+	case IntSliceSlice:
+		return "[][]int"
+	case Int64Slices:
+		return "[]int64"
+	case BoolSlices:
+		return "[]bool"
+	case HistogramPointerSlices:
+		return "[]*histogram.FloatHistogram"
+	case SeriesMetadataSlices:
+		return "[]SeriesMetadata"
+	case BucketSlices:
+		return "[]promql.Buckets"
+	case QuantileGroupSlices:
+		return "[]aggregations.qGroup"
+	case TopKBottomKInstantQuerySeriesSlices:
+		return "[]topkbottom.instantQuerySeries"
+	case TopKBottomKRangeQuerySeriesSlices:
+		return "[]topkbottom.rangeQuerySeries"
+	default:
+		return unknownMemorySource
+	}
 }
 
 // MemoryConsumptionTracker tracks the current memory utilisation of a single query, and applies any max in-memory bytes limit.
@@ -135,7 +159,7 @@ func (l *MemoryConsumptionTracker) DecreaseMemoryConsumption(b uint64, source Me
 	defer l.mtx.Unlock()
 
 	if b > l.currentEstimatedMemoryConsumptionBySource[source] {
-		panic(fmt.Sprintf("Estimated memory consumption of all instances of %v in this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: %v", memoryConsumptionSourceNames[source], l.queryDescription))
+		panic(fmt.Sprintf("Estimated memory consumption of all instances of %s in this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: %v", source, l.queryDescription))
 	}
 
 	l.currentEstimatedMemoryConsumptionBytes -= b

--- a/pkg/util/limiter/memory_consumption.go
+++ b/pkg/util/limiter/memory_consumption.go
@@ -34,6 +34,38 @@ func AddMemoryTrackerToContext(ctx context.Context, tracker *MemoryConsumptionTr
 	return context.WithValue(ctx, interface{}(memoryConsumptionTracker), tracker)
 }
 
+type MemoryConsumptionSource int
+
+const (
+	IngesterChunks MemoryConsumptionSource = iota
+	StoreGatewayChunks
+	FPointSlices
+	HPointSlices
+	SampleSlices
+	Float64Slices
+	IntSlices
+	Int64Slices
+	BoolSlices
+	HistogramPointerSlices
+	SeriesMetadataSlices
+
+	memoryConsumptionSourceCount = SeriesMetadataSlices+1
+)
+
+var memoryConsumptionSourceNames = map[MemoryConsumptionSource]string{
+	IngesterChunks:    "ingester chunks",
+	StoreGatewayChunks: "store-gateway chunks",
+	FPointSlices:      "[]promql.FPoint",
+	HPointSlices:      "[]promql.HPoint",
+	SampleSlices:      "promql.Vector",
+	Float64Slices:     "[]float64",
+	IntSlices:         "[]int",
+	Int64Slices:       "[]int64",
+	BoolSlices:        "[]bool",
+	HistogramPointerSlices: "[]*histogram.FloatHistogram",
+	SeriesMetadataSlices:    "[]SeriesMetadata",
+}
+
 // MemoryConsumptionTracker tracks the current memory utilisation of a single query, and applies any max in-memory bytes limit.
 //
 // It also tracks the peak number of in-memory bytes for use in query statistics.
@@ -41,6 +73,8 @@ type MemoryConsumptionTracker struct {
 	maxEstimatedMemoryConsumptionBytes     uint64
 	currentEstimatedMemoryConsumptionBytes uint64
 	peakEstimatedMemoryConsumptionBytes    uint64
+
+	currentEstimatedMemoryConsumptionBySource [memoryConsumptionSourceCount]uint64
 
 	rejectionCount        prometheus.Counter
 	haveRecordedRejection bool

--- a/pkg/util/limiter/memory_consumption_test.go
+++ b/pkg/util/limiter/memory_consumption_test.go
@@ -29,7 +29,7 @@ func TestFromContextWithFallback(t *testing.T) {
 	t.Run("exists", func(t *testing.T) {
 		ctx := context.Background()
 		existing := NewMemoryConsumptionTracker(0, nil, "")
-		require.NoError(t, existing.IncreaseMemoryConsumption(uint64(512)))
+		require.NoError(t, existing.IncreaseMemoryConsumption(uint64(512), IngesterChunks))
 
 		ctx = context.WithValue(ctx, memoryConsumptionTracker, existing)
 		stored := MemoryTrackerFromContextWithFallback(ctx)
@@ -41,7 +41,7 @@ func TestFromContextWithFallback(t *testing.T) {
 func TestAddToContext(t *testing.T) {
 	ctx := context.Background()
 	existing := NewMemoryConsumptionTracker(0, nil, "")
-	require.NoError(t, existing.IncreaseMemoryConsumption(uint64(512)))
+	require.NoError(t, existing.IncreaseMemoryConsumption(uint64(512), IngesterChunks))
 
 	ctx = AddMemoryTrackerToContext(ctx, existing)
 	stored := ctx.Value(memoryConsumptionTracker).(*MemoryConsumptionTracker)
@@ -53,34 +53,35 @@ func TestMemoryConsumptionTracker_Unlimited(t *testing.T) {
 	reg, metric := createRejectedMetric()
 	tracker := NewMemoryConsumptionTracker(0, metric, "foo + bar")
 
-	require.NoError(t, tracker.IncreaseMemoryConsumption(128))
+	require.NoError(t, tracker.IncreaseMemoryConsumption(128, IngesterChunks))
 	require.Equal(t, uint64(128), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(128), tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Add some more memory consumption. The current and peak stats should be updated.
-	require.NoError(t, tracker.IncreaseMemoryConsumption(2))
+	require.NoError(t, tracker.IncreaseMemoryConsumption(2, StoreGatewayChunks))
 	require.Equal(t, uint64(130), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(130), tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Reduce memory consumption. The current consumption should be updated, but the peak should be unchanged.
-	tracker.DecreaseMemoryConsumption(128)
+	tracker.DecreaseMemoryConsumption(128, IngesterChunks)
 	require.Equal(t, uint64(2), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(130), tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Add some more memory consumption that doesn't take us over the previous peak.
-	require.NoError(t, tracker.IncreaseMemoryConsumption(8))
+	require.NoError(t, tracker.IncreaseMemoryConsumption(8, FPointSlices))
 	require.Equal(t, uint64(10), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(130), tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Add some more memory consumption that takes us over the previous peak.
-	require.NoError(t, tracker.IncreaseMemoryConsumption(121))
+	require.NoError(t, tracker.IncreaseMemoryConsumption(121, HPointSlices))
 	require.Equal(t, uint64(131), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(131), tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	assertRejectedQueriesCount(t, reg, 0)
 
 	// Test reducing memory consumption to a negative value panics
-	require.PanicsWithValue(t, `Estimated memory consumption of this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: foo + bar`, func() { tracker.DecreaseMemoryConsumption(150) })
+	require.PanicsWithValue(t, `Estimated memory consumption of all instances of []promql.FPoint in this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: foo + bar`, func() { tracker.DecreaseMemoryConsumption(9, FPointSlices) })
+	require.PanicsWithValue(t, `Estimated memory consumption of all instances of []promql.HPoint in this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: foo + bar`, func() { tracker.DecreaseMemoryConsumption(130, HPointSlices) })
 }
 
 func TestMemoryConsumptionTracker_Limited(t *testing.T) {
@@ -88,51 +89,52 @@ func TestMemoryConsumptionTracker_Limited(t *testing.T) {
 	tracker := NewMemoryConsumptionTracker(11, metric, "foo + bar")
 
 	// Add some memory consumption beneath the limit.
-	require.NoError(t, tracker.IncreaseMemoryConsumption(8))
+	require.NoError(t, tracker.IncreaseMemoryConsumption(8, IngesterChunks))
 	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(8), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 0)
 
 	// Add some more memory consumption beneath the limit.
-	require.NoError(t, tracker.IncreaseMemoryConsumption(1))
+	require.NoError(t, tracker.IncreaseMemoryConsumption(1, StoreGatewayChunks))
 	require.Equal(t, uint64(9), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 0)
 
 	// Reduce memory consumption.
-	tracker.DecreaseMemoryConsumption(1)
+	tracker.DecreaseMemoryConsumption(1, StoreGatewayChunks)
 	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 0)
 
 	// Try to add some more memory consumption where we would go over the limit.
 	const expectedError = "the query exceeded the maximum allowed estimated amount of memory consumed by a single query (limit: 11 bytes) (err-mimir-max-estimated-memory-consumption-per-query)"
-	require.ErrorContains(t, tracker.IncreaseMemoryConsumption(4), expectedError)
+	require.ErrorContains(t, tracker.IncreaseMemoryConsumption(4, StoreGatewayChunks), expectedError)
 	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 1)
 
 	// Make sure we don't increment the rejection count a second time for the same query.
-	require.ErrorContains(t, tracker.IncreaseMemoryConsumption(4), expectedError)
+	require.ErrorContains(t, tracker.IncreaseMemoryConsumption(4, IngesterChunks), expectedError)
 	require.Equal(t, uint64(8), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(9), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 1)
 
 	// Keep adding more memory consumption up to the limit to make sure the failed increases weren't counted.
 	for i := 0; i < 3; i++ {
-		require.NoError(t, tracker.IncreaseMemoryConsumption(1))
+		require.NoError(t, tracker.IncreaseMemoryConsumption(1, FPointSlices))
 		require.Equal(t, uint64(9+i), tracker.CurrentEstimatedMemoryConsumptionBytes())
 		require.Equal(t, uint64(9+i), tracker.PeakEstimatedMemoryConsumptionBytes())
 	}
 
 	// Try to add some more memory consumption when we're already at the limit.
-	require.ErrorContains(t, tracker.IncreaseMemoryConsumption(1), expectedError)
+	require.ErrorContains(t, tracker.IncreaseMemoryConsumption(1, FPointSlices), expectedError)
 	require.Equal(t, uint64(11), tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, uint64(11), tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueriesCount(t, reg, 1)
 
 	// Test reducing memory consumption to a negative value panics
-	require.PanicsWithValue(t, `Estimated memory consumption of this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: foo + bar`, func() { tracker.DecreaseMemoryConsumption(150) })
+	require.PanicsWithValue(t, `Estimated memory consumption of all instances of []promql.FPoint in this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: foo + bar`, func() { tracker.DecreaseMemoryConsumption(150, FPointSlices) })
+	require.PanicsWithValue(t, `Estimated memory consumption of all instances of []promql.HPoint in this query is negative. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: foo + bar`, func() { tracker.DecreaseMemoryConsumption(150, HPointSlices) })
 }
 
 func assertRejectedQueriesCount(t *testing.T, reg *prometheus.Registry, expectedRejectionCount int) {
@@ -157,13 +159,14 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 	// limit since this should be rare. Instead, we want to benchmark having to check the
 	// limit.
 	const memoryLimit = 1024 * 1024 * 1024
+	const source = IngesterChunks
 
 	b.Run("no limits single threaded", func(b *testing.B) {
 		l := NewMemoryConsumptionTracker(0, nil, "")
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_ = l.IncreaseMemoryConsumption(uint64(b.N))
-			l.DecreaseMemoryConsumption(uint64(b.N))
+			_ = l.IncreaseMemoryConsumption(uint64(b.N), source)
+			l.DecreaseMemoryConsumption(uint64(b.N), source)
 		}
 
 		require.Equal(b, uint64(0), l.CurrentEstimatedMemoryConsumptionBytes())
@@ -177,8 +180,8 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 		l := NewMemoryConsumptionTracker(memoryLimit, counter, "")
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if err := l.IncreaseMemoryConsumption(uint64(b.N)); err == nil {
-				l.DecreaseMemoryConsumption(uint64(b.N))
+			if err := l.IncreaseMemoryConsumption(uint64(b.N), source); err == nil {
+				l.DecreaseMemoryConsumption(uint64(b.N), source)
 			}
 		}
 
@@ -195,15 +198,15 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 			defer wg.Done()
 
 			for run.Load() {
-				_ = l.IncreaseMemoryConsumption(1024)
-				l.DecreaseMemoryConsumption(1024)
+				_ = l.IncreaseMemoryConsumption(1024, source)
+				l.DecreaseMemoryConsumption(1024, source)
 			}
 		}()
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_ = l.IncreaseMemoryConsumption(uint64(b.N))
-			l.DecreaseMemoryConsumption(uint64(b.N))
+			_ = l.IncreaseMemoryConsumption(uint64(b.N), source)
+			l.DecreaseMemoryConsumption(uint64(b.N), source)
 		}
 
 		run.Store(false)
@@ -226,16 +229,16 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 			defer wg.Done()
 
 			for run.Load() {
-				if err := l.IncreaseMemoryConsumption(1024); err == nil {
-					l.DecreaseMemoryConsumption(1024)
+				if err := l.IncreaseMemoryConsumption(1024, source); err == nil {
+					l.DecreaseMemoryConsumption(1024, source)
 				}
 			}
 		}()
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if err := l.IncreaseMemoryConsumption(uint64(b.N)); err == nil {
-				l.DecreaseMemoryConsumption(uint64(b.N))
+			if err := l.IncreaseMemoryConsumption(uint64(b.N), source); err == nil {
+				l.DecreaseMemoryConsumption(uint64(b.N), source)
 			}
 		}
 

--- a/pkg/util/limiter/memory_consumption_test.go
+++ b/pkg/util/limiter/memory_consumption_test.go
@@ -244,5 +244,12 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 
 		require.Equal(b, uint64(0), l.CurrentEstimatedMemoryConsumptionBytes())
 	})
+}
 
+func TestMemoryConsumptionSourceNames(t *testing.T) {
+	for i := range memoryConsumptionSourceCount {
+		require.Containsf(t, memoryConsumptionSourceNames, i, "missing name for source %v", i)
+	}
+
+	require.Len(t, memoryConsumptionSourceNames, int(memoryConsumptionSourceCount), "source names map contains more entries than expected, is memoryConsumptionSourceCount out of sync with the list of sources?")
 }

--- a/pkg/util/limiter/memory_consumption_test.go
+++ b/pkg/util/limiter/memory_consumption_test.go
@@ -251,8 +251,6 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 
 func TestMemoryConsumptionSourceNames(t *testing.T) {
 	for i := range memoryConsumptionSourceCount {
-		require.Containsf(t, memoryConsumptionSourceNames, i, "missing name for source %v", i)
+		require.NotEqual(t, unknownMemorySource, i.String(), "source %d should have a String() representation", i)
 	}
-
-	require.Len(t, memoryConsumptionSourceNames, int(memoryConsumptionSourceCount), "source names map contains more entries than expected, is memoryConsumptionSourceCount out of sync with the list of sources?")
 }


### PR DESCRIPTION
#### What this PR does

This PR extends `limiting.MemoryConsumptionTracker` to track memory consumption by source.

This allows us to include more information in `Estimated memory consumption of this query is negative` panics, and also makes it easier to debug failures when MQE is running in pedantic mode during tests. 

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
