### PR TITLE
Fix description of admin Alertmanager > Config link

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -187,7 +187,7 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, api
 
 	a.indexPage.AddLinks(defaultWeight, "Alertmanager", []IndexPageLink{
 		{Desc: "Status", Path: "/multitenant_alertmanager/status"},
-		{Desc: "Status", Path: "/multitenant_alertmanager/configs"},
+		{Desc: "Config", Path: "/multitenant_alertmanager/configs"},
 		{Desc: "Ring status", Path: "/multitenant_alertmanager/ring"},
 		{Desc: "Alertmanager", Path: "/alertmanager"},
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Fixes the link to the alertmanager config in the admin UI, which right now shows "Status" twice.

**Before**

<img width="226" alt="Screenshot 2025-06-06 at 15 36 36" src="https://github.com/user-attachments/assets/e4e64134-b2f3-4709-a968-592624e737e9" />

**After**

<img width="261" alt="Screenshot 2025-06-06 at 15 38 20" src="https://github.com/user-attachments/assets/98c59510-1b1c-4af5-82a0-34f797af4f91" />

#### Which issue(s) this PR fixes or relates to

—

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
