### PR TITLE
Display all dependents in -modules message, not just "all"

### DIFF
--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -11,9 +11,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/go-kit/log/level"
@@ -206,21 +207,26 @@ func main() {
 	util_log.CheckFatal("initializing application", err)
 
 	if mainFlags.printModules {
-		allDeps := t.ModuleManager.DependenciesForModule(mimir.All)
-
+		dependentsByModule := map[string]map[string]struct{}{}
 		for _, m := range t.ModuleManager.UserVisibleModuleNames() {
-			ix := sort.SearchStrings(allDeps, m)
-			included := ix < len(allDeps) && allDeps[ix] == m
-
-			if included {
-				fmt.Fprintln(os.Stdout, m, "*")
-			} else {
-				fmt.Fprintln(os.Stdout, m)
+			for _, mdep := range t.ModuleManager.DependenciesForModule(m) {
+				dependents, ok := dependentsByModule[mdep]
+				if !ok {
+					dependents = map[string]struct{}{}
+					dependentsByModule[mdep] = dependents
+				}
+				dependents[m] = struct{}{}
 			}
 		}
 
-		fmt.Fprintln(os.Stdout)
-		fmt.Fprintln(os.Stdout, "Modules marked with * are included in target All.")
+		for _, m := range t.ModuleManager.UserVisibleModuleNames() {
+			fmt.Print(m)
+			if dependents, ok := dependentsByModule[m]; ok {
+				fmt.Print(" (in: ", strings.Join(slices.Collect(maps.Keys(dependents)), ", "), ")")
+			}
+			fmt.Println()
+		}
+
 		return
 	}
 

--- a/cmd/mimir/main_test.go
+++ b/cmd/mimir/main_test.go
@@ -88,13 +88,13 @@ func TestFlagParsing(t *testing.T) {
 
 		"user visible module listing": {
 			arguments:      []string{"-modules"},
-			stdoutMessage:  "ingester (in all, write)\n",
+			stdoutMessage:  "ingester (in: all, write)\n",
 			stderrExcluded: "ingester\n",
 		},
 
 		"user visible module listing flag take precedence over target flag": {
 			arguments:      []string{"-modules", "-target=blah"},
-			stdoutMessage:  "ingester (in all, write)\n",
+			stdoutMessage:  "ingester (in: all, write)\n",
 			stderrExcluded: "ingester\n",
 		},
 

--- a/cmd/mimir/main_test.go
+++ b/cmd/mimir/main_test.go
@@ -88,13 +88,13 @@ func TestFlagParsing(t *testing.T) {
 
 		"user visible module listing": {
 			arguments:      []string{"-modules"},
-			stdoutMessage:  "ingester *\n",
+			stdoutMessage:  "ingester (in all, write)\n",
 			stderrExcluded: "ingester\n",
 		},
 
 		"user visible module listing flag take precedence over target flag": {
 			arguments:      []string{"-modules", "-target=blah"},
-			stdoutMessage:  "ingester *\n",
+			stdoutMessage:  "ingester (in all, write)\n",
 			stderrExcluded: "ingester\n",
 		},
 
@@ -414,7 +414,7 @@ func TestWithGoogleCloudServiceAccountEnvVariable(t *testing.T) {
 		gcs:
 		  service_account: >-
 		    ${COMMON_STORAGE_GCS_SERVICE_ACCOUNT}
-	
+
 	blocks_storage:
 	  storage_prefix: monitoringmetricsv1blocks
 	  tsdb:
@@ -439,7 +439,7 @@ func TestWithGoogleCloudServiceAccountEnvVariable(t *testing.T) {
 		gcs:
 		  service_account: >-
 		    {	  "type": "service_account",	  "project_id": "my-project",	  "private_key_id": "1234abc",	  "private_key": "-----BEGIN PRIVATE KEY-----\n\n-----END PRIVATE KEY-----\n",	  "client_email": "test@my-project.iam.gserviceaccount.com",	  "client_id": "5678",	  "auth_uri": "https://accounts.google.com/o/oauth2/auth",	  "token_uri": "https://oauth2.googleapis.com/token",	  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",	  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test%40my-project.iam.gserviceaccount.com"	}
-	
+
 	blocks_storage:
 	  storage_prefix: monitoringmetricsv1blocks
 	  tsdb:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

I wanted to understand which modules were ran in "read",  "write", and "backend" modes, but the `-modules` flag wasn't helpful, so I had to check the code to find out.

`-modules` already marks dependencies of `all` with a `*`. Now this is generalized to all dependents, with a explicit list.

<details>
<summary><b>Before</b></summary>

```
alertmanager
all
backend
block-builder
block-builder-scheduler
compactor *
continuous-test
distributor *
flusher
ingester *
memberlist-kv *
overrides-exporter
querier *
query-frontend *
query-scheduler
read
ruler *
store-gateway *
write

Modules marked with * are included in target All.
```
</details>

**After**

```
$ mimir -modules
alertmanager (in: backend)
all
backend
block-builder
block-builder-scheduler
compactor (in: backend, all)
continuous-test
distributor (in: write, all)
flusher
ingester (in: all, write)
memberlist-kv (in: all, compactor, distributor, ingester, overrides-exporter, querier, query-scheduler, read, alertmanager, backend, query-frontend, ruler, store-gateway, write)
overrides-exporter (in: backend)
querier (in: all, read)
query-frontend (in: all, read)
query-scheduler (in: backend)
read
ruler (in: all, backend)
store-gateway (in: all, backend)
write
```

#### Which issue(s) this PR fixes or relates to

—

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
