### PR TITLE
ruler: Add new limit on minimum rule evaluation interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [ENHANCEMENT] Ruler: Ignore rulers in non-operation states when getting and syncing rules #11569
 * [ENHANCEMENT] Query-frontend: add optional reason to blocked_queries config. #11407 #11434
 * [ENHANCEMENT] Tracing: Add HTTP headers as span attributes when `-server.trace-request-headers` is enabled. You can configure which headers to exclude using the `-server.trace-request-headers-exclude-list` flag. #11655
+* [ENHANCEMENT] Ruler: Add new per-tenant limit on minimum rule evaluation interval. #11665
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5360,6 +5360,17 @@
         },
         {
           "kind": "field",
+          "name": "ruler_min_rule_evaluation_interval",
+          "required": false,
+          "desc": "Minimum allowable evaluation interval for rule groups.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "ruler.min-rule-evaluation-interval",
+          "fieldType": "duration",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "store_gateway_tenant_shard_size",
           "required": false,
           "desc": "The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3063,6 +3063,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
   -ruler.max-rules-per-rule-group-by-namespace value
     	Maximum number of rules per rule group by namespace. Value is a map, where each key is the namespace and value is the number of rules allowed in the namespace (int). On the command line, this map is given in a JSON format. The number of rules specified has the same meaning as -ruler.max-rules-per-rule-group, but only applies for the specific namespace. If specified, it supersedes -ruler.max-rules-per-rule-group. (default {})
+  -ruler.min-rule-evaluation-interval duration
+    	[experimental] Minimum allowable evaluation interval for rule groups.
   -ruler.notification-queue-capacity int
     	Capacity of the queue for notifications to be sent to the Alertmanager. (default 10000)
   -ruler.notification-timeout duration

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -87,6 +87,7 @@ The following features are currently experimental:
   - Allow control over rule sync intervals.
     - `ruler.outbound-sync-queue-poll-interval`
     - `ruler.inbound-sync-queue-poll-interval`
+  - `-ruler.min-rule-evaluation-interval`
 - Distributor
   - Influx ingestion
     - `/api/v1/push/influx/write` endpoint

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3941,6 +3941,10 @@ ruler_alertmanager_client_config:
   # CLI flag: -ruler.alertmanager-client.proxy-url
   [proxy_url: <string> | default = ""]
 
+# (experimental) Minimum allowable evaluation interval for rule groups.
+# CLI flag: -ruler.min-rule-evaluation-interval
+[ruler_min_rule_evaluation_interval: <duration> | default = 0s]
+
 # The tenant's shard size, used when store-gateway sharding is enabled. Value of
 # 0 disables shuffle sharding for the tenant, that is all tenant blocks are
 # sharded across all store-gateway replicas.

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -382,6 +382,102 @@ overrides:
 	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 }
 
+func TestRulerAPIEvaluationIntervalLimits(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Start dependencies.
+	consul := e2edb.NewConsul()
+	minio := e2edb.NewMinio(9000, mimirBucketName, rulesBucketName)
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	runtimeConfig := `
+overrides:
+  user-1:
+    ruler_min_rule_evaluation_interval: 30s`
+	require.NoError(t, writeFileToSharedDir(s, "runtime.yaml", []byte(runtimeConfig)))
+
+	// Configure the ruler.
+	rulerFlags := mergeFlags(
+		CommonStorageBackendFlags(),
+		RulerFlags(),
+		BlocksStorageFlags(),
+		RulerStorageS3Flags(),
+		RulerShardingFlags(consul.NetworkHTTPEndpoint()),
+		map[string]string{
+			"-runtime-config.file":          filepath.Join(e2e.ContainerSharedDir, "runtime.yaml"),
+			"-runtime-config.reload-period": "100ms",
+			// Disable rule group limit
+			"-ruler.max-rule-groups-per-tenant": "0",
+		},
+	)
+
+	// Start rulers.
+	ruler1 := e2emimir.NewRuler("ruler-1", consul.NetworkHTTPEndpoint(), rulerFlags)
+	ruler2 := e2emimir.NewRuler("ruler-2", consul.NetworkHTTPEndpoint(), rulerFlags)
+	rulers := e2emimir.NewCompositeMimirService(ruler1, ruler2)
+	require.NoError(t, s.StartAndWaitReady(ruler1, ruler2))
+
+	user1Client, err := e2emimir.NewClient("", "", "", ruler1.HTTPEndpoint(), "user-1")
+	require.NoError(t, err)
+	user2Client, err := e2emimir.NewClient("", "", "", ruler1.HTTPEndpoint(), "user-2")
+	require.NoError(t, err)
+
+	// User1 cannot create a group that runs faster than the interval limit
+	group := ruleGroupWithRules("group-1", time.Second,
+		recordingRule("series_1:count", "count(series_1)"),
+	)
+	require.ErrorContains(t, user1Client.SetRuleGroup(group, "namespace-1"), "400")
+
+	// User2 can create groups with arbitrarily low intervals
+	group = ruleGroupWithRules("group-2", time.Second,
+		recordingRule("series_1:count", "count(series_1)"),
+	)
+	require.NoError(t, user2Client.SetRuleGroup(group, "namespace-2"))
+
+	// User2's limit is changed to 10s
+	runtimeConfig = `
+overrides:
+  user-1:
+    ruler_min_rule_evaluation_interval: 30s
+  user-2:
+    ruler_min_rule_evaluation_interval: 10s`
+	require.NoError(t, writeFileToSharedDir(s, "runtime.yaml", []byte(runtimeConfig)))
+
+	// Block until the config updates.
+	require.NoError(t, rulers.WaitSumMetricsWithOptions(
+		e2e.Equals(2),
+		[]string{"cortex_runtime_config_hash"},
+		e2e.WaitMissingMetrics,
+		e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "sha256", "e2cd55ae7f6c926aae885315a57c895c74b50cd758b4564b6cdba730995a853b")),
+	))
+
+	// User2 can no longer create new groups with low intervals
+	group = ruleGroupWithRules("group-3", time.Second,
+		recordingRule("series_1:count", "count(series_1)"),
+	)
+	require.ErrorContains(t, user2Client.SetRuleGroup(group, "namespace-2"), "400")
+
+	// User2 can still create other groups that pass limits.
+	group = ruleGroupWithRules("group-4", 10*time.Second,
+		recordingRule("series_1:count", "count(series_1)"),
+	)
+	require.NoError(t, user2Client.SetRuleGroup(group, "namespace-2"))
+
+	// User2 cannot update the previously created group while keeping the low interval
+	group = ruleGroupWithRules("group-2", time.Second,
+		recordingRule("series_1:count", "count(series_1) + 1"),
+	)
+	require.ErrorContains(t, user2Client.SetRuleGroup(group, "namespace-2"), "400")
+
+	// User2 can update the previously created group if they fix the interval
+	group = ruleGroupWithRules("group-2", 10*time.Second,
+		recordingRule("series_1:count", "count(series_1) + 1"),
+	)
+	require.NoError(t, user2Client.SetRuleGroup(group, "namespace-2"))
+}
+
 func TestRulerSharding(t *testing.T) {
 	const numRulesGroups = 100
 

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -436,6 +436,12 @@ overrides:
 	)
 	require.NoError(t, user2Client.SetRuleGroup(group, "namespace-2"))
 
+	// User1 can still allow the ruler to decide the interval.
+	group = ruleGroupWithRules("group-0", 0,
+		recordingRule("series_1:count", "count(series_1)"),
+	)
+	require.NoError(t, user2Client.SetRuleGroup(group, "namespace-0"))
+
 	// User2's limit is changed to 10s
 	runtimeConfig = `
 overrides:

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -680,13 +680,13 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if err := a.ruler.AssertMaxRulesPerRuleGroup(userID, namespace, len(rg.Rules)); err != nil {
-		level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
+		level.Warn(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	if err := a.ruler.AssertMinRuleEvaluationInterval(userID, time.Duration(rg.Interval)); err != nil {
-		level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
+		level.Warn(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -703,7 +703,7 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		}
 
 		if err := a.ruler.AssertMaxRuleGroups(userID, namespace, len(rgs)+1); err != nil {
-			level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
+			level.Warn(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -685,6 +685,12 @@ func (a *API) CreateRuleGroup(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	if err := a.ruler.AssertMinRuleEvaluationInterval(userID, time.Duration(rg.Interval)); err != nil {
+		level.Error(logger).Log("msg", "limit validation failure", "err", err.Error(), "user", userID)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	// Only list rule groups when enforcing a max number of groups for this tenant and namespace.
 	if a.ruler.IsMaxRuleGroupsLimited(userID, namespace) {
 		// Disable any caching when getting list of all rule groups since listing results

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/dskit/user"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1682,6 +1683,7 @@ func TestRuler_LimitsPerGroup(t *testing.T) {
 	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart(), withLimits(validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 1
 		defaults.RulerMaxRulesPerRuleGroup = 1
+		defaults.RulerMinRuleEvaluationInterval = model.Duration(15 * time.Second)
 	})))
 
 	a := NewAPI(r, r.store, mimirtest.NewTestingLogger(t))
@@ -1711,6 +1713,23 @@ rules:
     test: test
 `,
 			output: "per-user rules per rule group limit (limit: 1 actual: 2) exceeded\n",
+		},
+		{
+			name:   "when exceeding the rule group eval interval limit",
+			status: 400,
+			input: `
+name: test
+interval: 14s
+rules:
+- alert: up_alert
+  expr: sum(up{}) > 1
+  for: 30s
+  annotations:
+    test: test
+  labels:
+    test: test
+`,
+			output: "per-user minimum rule evaluation interval limit (limit: 15s actual: 14s) exceeded\n",
 		},
 	}
 
@@ -1795,6 +1814,7 @@ func TestRuler_RulerGroupLimitsDisabled(t *testing.T) {
 	r := prepareRuler(t, cfg, newMockRuleStore(make(map[string]rulespb.RuleGroupList)), withStart(), withLimits(validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
 		defaults.RulerMaxRuleGroupsPerTenant = 0
 		defaults.RulerMaxRulesPerRuleGroup = 0
+		defaults.RulerMinRuleEvaluationInterval = 0
 	})))
 
 	a := NewAPI(r, r.store, mimirtest.NewTestingLogger(t))

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -215,6 +215,7 @@ type RulesLimits interface {
 	RulerProtectedNamespaces(userID string) []string
 	RulerMaxIndependentRuleEvaluationConcurrencyPerTenant(userID string) int64
 	RulerAlertmanagerClientConfig(userID string) notifierCfg.AlertmanagerClientConfig
+	RulerMinRuleEvaluationInterval(userID string) time.Duration
 }
 
 func MetricsQueryFunc(qf rules.QueryFunc, userID string, queries, failedQueries *prometheus.CounterVec, remoteQuerier bool) rules.QueryFunc {

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -1377,6 +1377,10 @@ func (r *Ruler) AssertMinRuleEvaluationInterval(userID string, interval time.Dur
 		return nil
 	}
 
+	// Zero or blank interval means to fall back to "ruler.evaluation-interval" - not actually use zero. It's an allowed value.
+	if interval == 0 {
+		return nil
+	}
 	if interval >= limit {
 		return nil
 	}

--- a/pkg/ruler/ruler_test.go
+++ b/pkg/ruler/ruler_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/prometheus/prometheus/notifier"
@@ -2406,6 +2407,144 @@ func TestFilterRuleGroupsByNotMissing(t *testing.T) {
 	}
 }
 
+func TestApplyRuleGroupLimits(t *testing.T) {
+	tcs := []struct {
+		name     string
+		configs  map[string]rulespb.RuleGroupList
+		limits   RulesLimits
+		expected map[string]rulespb.RuleGroupList
+	}{
+		{
+			name:     "returns nil for nil rule groups",
+			configs:  nil,
+			limits:   validation.MockDefaultOverrides(),
+			expected: nil,
+		},
+		{
+			name:     "returns empty for empty rule groups",
+			configs:  map[string]rulespb.RuleGroupList{},
+			limits:   validation.MockDefaultOverrides(),
+			expected: map[string]rulespb.RuleGroupList{},
+		},
+		{
+			name: "returns group list for tenant with empty group list",
+			configs: map[string]rulespb.RuleGroupList{
+				"user1": {},
+			},
+			limits: validation.MockDefaultOverrides(),
+			expected: map[string]rulespb.RuleGroupList{
+				"user1": {},
+			},
+		},
+		{
+			name: "no adjustments if the limit is 0 for one tenant",
+			configs: map[string]rulespb.RuleGroupList{
+				"user1": {
+					createRuleGroupWithInterval("group1", "user1", 10*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+			},
+			limits: validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				tenantLimits["user1"] = validation.MockDefaultLimits()
+				tenantLimits["user1"].RulerMinRuleEvaluationInterval = 0
+				tenantLimits["user2"] = validation.MockDefaultLimits()
+				tenantLimits["user2"].RulerMinRuleEvaluationInterval = model.Duration(20 * time.Second)
+				tenantLimits["user3"] = validation.MockDefaultLimits()
+				tenantLimits["user3"].RulerMinRuleEvaluationInterval = model.Duration(40 * time.Second)
+			}),
+			expected: map[string]rulespb.RuleGroupList{
+				"user1": {
+					createRuleGroupWithInterval("group1", "user1", 10*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+			},
+		},
+		{
+			name: "no adjustments to rules over the min limit for a tenant",
+			configs: map[string]rulespb.RuleGroupList{
+				"user2": {
+					createRuleGroupWithInterval("group1", "user2", 30*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+			},
+			limits: validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				tenantLimits["user1"] = validation.MockDefaultLimits()
+				tenantLimits["user1"].RulerMinRuleEvaluationInterval = 0
+				tenantLimits["user2"] = validation.MockDefaultLimits()
+				tenantLimits["user2"].RulerMinRuleEvaluationInterval = model.Duration(20 * time.Second)
+				tenantLimits["user3"] = validation.MockDefaultLimits()
+				tenantLimits["user3"].RulerMinRuleEvaluationInterval = model.Duration(40 * time.Second)
+			}),
+			expected: map[string]rulespb.RuleGroupList{
+				"user2": {
+					createRuleGroupWithInterval("group1", "user2", 30*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+			},
+		},
+		{
+			name: "rules under a tenant limit are adjusted up",
+			configs: map[string]rulespb.RuleGroupList{
+				"user3": {
+					createRuleGroupWithInterval("group1", "user3", 30*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+			},
+			limits: validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				tenantLimits["user1"] = validation.MockDefaultLimits()
+				tenantLimits["user1"].RulerMinRuleEvaluationInterval = 0
+				tenantLimits["user2"] = validation.MockDefaultLimits()
+				tenantLimits["user2"].RulerMinRuleEvaluationInterval = model.Duration(20 * time.Second)
+				tenantLimits["user3"] = validation.MockDefaultLimits()
+				tenantLimits["user3"].RulerMinRuleEvaluationInterval = model.Duration(40 * time.Second)
+			}),
+			expected: map[string]rulespb.RuleGroupList{
+				"user3": {
+					createRuleGroupWithInterval("group1", "user3", 40*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+			},
+		},
+		{
+			name: "different tenants with different limits are applied simultaneously",
+			configs: map[string]rulespb.RuleGroupList{
+				"user1": {
+					createRuleGroupWithInterval("group1", "user1", 5*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+				"user2": {
+					createRuleGroupWithInterval("group1", "user2", 5*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+				"user3": {
+					createRuleGroupWithInterval("group1", "user3", 5*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+			},
+			limits: validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				tenantLimits["user1"] = validation.MockDefaultLimits()
+				tenantLimits["user1"].RulerMinRuleEvaluationInterval = 0
+				tenantLimits["user2"] = validation.MockDefaultLimits()
+				tenantLimits["user2"].RulerMinRuleEvaluationInterval = model.Duration(20 * time.Second)
+				tenantLimits["user3"] = validation.MockDefaultLimits()
+				tenantLimits["user3"].RulerMinRuleEvaluationInterval = model.Duration(40 * time.Second)
+			}),
+			expected: map[string]rulespb.RuleGroupList{
+				"user1": {
+					createRuleGroupWithInterval("group1", "user1", 5*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+				"user2": {
+					createRuleGroupWithInterval("group1", "user2", 20*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+				"user3": {
+					// TODO wrong, debug
+					createRuleGroupWithInterval("group1", "user3", 40*time.Second, createAlertingRule("record:1", "1"), createRecordingRule("alert2", "2")),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := log.NewNopLogger()
+
+			actual := applyRuleGroupLimits(tc.configs, tc.limits, logger)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 func BenchmarkFilterRuleGroupsByEnabled(b *testing.B) {
 	const (
 		numTenants                    = 1000
@@ -2516,6 +2655,12 @@ func createRuleGroup(name, user string, rules ...*rulespb.RuleDesc) *rulespb.Rul
 		QueryOffset:                   1 * time.Minute,
 		AlignEvaluationTimeOnInterval: true,
 	}
+}
+
+func createRuleGroupWithInterval(name, user string, interval time.Duration, rules ...*rulespb.RuleDesc) *rulespb.RuleGroupDesc {
+	rg := createRuleGroup(name, user, rules...)
+	rg.Interval = interval
+	return rg
 }
 
 func TestConfig_Validate(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Introduces a new per-tenant limit, `ruler_min_rule_evaluation_interval`, which allows administrators to limit the speed at which rules may evaluate.

It defaults to zero, zero indicates no limit.

When the limit is raised and a rule already exists with an interval below the limit:
- The rule is still evaluated, but artificially slowed down to match the limit.
- The rule can't be edited until the limit is fixed.

This means administrators can use this as a knob to throttle a tenant's rule evaluations at runtime if needed. We still do a best-effort evaluation to avoid disrupting the tenant.

#### Which issue(s) this PR fixes or relates to

Rel https://github.com/grafana/mimir/issues/11272

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
