### PR TITLE
api: restore IsRetryableAPIErrorType

### DIFF
--- a/pkg/api/error/error.go
+++ b/pkg/api/error/error.go
@@ -142,12 +142,15 @@ func IsRetryableAPIError(err error) bool {
 	if !errors.As(err, &apiErr) {
 		return true
 	}
+	return IsRetryableAPIErrorType(apiErr.Type)
+}
 
+func IsRetryableAPIErrorType(typ Type) bool {
 	// Reasoning:
 	// TypeNone and TypeNotFound are not used anywhere in Mimir nor Prometheus;
 	// TypeTimeout, TypeTooManyRequests, TypeNotAcceptable, TypeUnavailable we presume a retry of the same request will fail in the same way.
 	// TypeCanceled means something wants us to stop.
 	// TypeExec, TypeBadData and TypeTooLargeEntry are caused by the input data.
 	// TypeInternal can be a 500 error e.g. from querier failing to contact store-gateway.
-	return apiErr.Type == TypeInternal
+	return typ == TypeInternal
 }


### PR DESCRIPTION

#### What this PR does
This undoes a tiny change from #11632 .

We need this in GEM because the error struct isn't always present, and we infer the error type from other things.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
