### PR TITLE
Increase unit test groups from 4 to 6

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -151,10 +151,10 @@ jobs:
     strategy:
       # Do not abort other groups when one fails.
       fail-fast: false
-      # Split tests into 4 groups.
+      # Split tests into 6 groups.
       matrix:
-        test_group_id:    [0, 1, 2, 3]
-        test_group_total: [4]
+        test_group_id:    [0, 1, 2, 3, 4, 5]
+        test_group_total: [6]
     needs:
       - prepare
     container:


### PR DESCRIPTION
Increases unit test parallelization from 4 stages to 6 stages


Unit tests are now already taking longer than integration tests; with some groups taking ~30 minutes