### PR TITLE
store-gateway: download sparse headers on startup when lazy loading is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [ENHANCEMENT] Ruler: Ignore rulers in non-operation states when getting and syncing rules #11569
 * [ENHANCEMENT] Query-frontend: add optional reason to blocked_queries config. #11407 #11434
 * [ENHANCEMENT] Tracing: Add HTTP headers as span attributes when `-server.trace-request-headers` is enabled. You can configure which headers to exclude using the `-server.trace-request-headers-exclude-list` flag. #11655
+* [ENHANCEMENT] store-gateway: download sparse headers on startup when lazy loading is enabled. #11686
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/pkg/storage/indexheader/lazy_binary_reader.go
+++ b/pkg/storage/indexheader/lazy_binary_reader.go
@@ -121,6 +121,8 @@ type unloadRequest struct {
 // on the local disk at dir location, this function will build it downloading required
 // sections from the full index stored in the bucket. However, this function doesn't load
 // (mmap or streaming read) the index-header; it will be loaded at first Reader function call.
+// NewLazyBinaryReader tries to download the sparse index header from the bucket and save it on disk.
+// It does not try to parse the sparse index header.
 func NewLazyBinaryReader(
 	ctx context.Context,
 	readerFactory func() (Reader, error),

--- a/pkg/storage/indexheader/stream_binary_reader.go
+++ b/pkg/storage/indexheader/stream_binary_reader.go
@@ -190,7 +190,7 @@ func (r *StreamBinaryReader) loadSparseHeader(ctx context.Context, logger log.Lo
 	}
 
 	// 2. Fall back to the bucket
-	bucketSparseHeaderBytes, err := tryDownloadSparseHeader(ctx, logger, bkt, id)
+	bucketSparseHeaderBytes, err := tryReadBucketSparseHeader(ctx, logger, bkt, id)
 	if err == nil {
 		// Try to load the downloaded sparse header
 		err = r.loadFromSparseIndexHeader(logger, bucketSparseHeaderBytes, postingOffsetsInMemSampling)
@@ -213,9 +213,9 @@ func (r *StreamBinaryReader) loadSparseHeader(ctx context.Context, logger log.Lo
 	return nil
 }
 
-// tryDownloadSparseHeader attempts to download the sparse header from the object store.
+// tryReadBucketSparseHeader attempts to download the sparse header from the object store.
 // It returns the sparse header data if successful, nil + error otherwise.
-func tryDownloadSparseHeader(ctx context.Context, logger log.Logger, bkt objstore.InstrumentedBucketReader, id ulid.ULID) ([]byte, error) {
+func tryReadBucketSparseHeader(ctx context.Context, logger log.Logger, bkt objstore.InstrumentedBucketReader, id ulid.ULID) ([]byte, error) {
 	if bkt == nil {
 		return nil, fmt.Errorf("bucket is nil")
 	}


### PR DESCRIPTION


Without this the store-gateway would only download the sparse header and store it on disk when the block is queried. For clusters with many tenants, this means the store-gateway spends roughly 3 minutes downloading sparse headers and this contributes (not sure how much) to a spike in latency after store-gateway scale-out

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
