### PR TITLE
Set explicit version for Minio in development environments to ensure `development/tools/upload-block` works with latest `aws` CLI

### DIFF
--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -126,7 +126,7 @@ std.manifestYamlDoc({
 
   minio:: {
     minio: {
-      image: 'minio/minio',
+      image: 'minio/minio:RELEASE.2025-05-24T17-08-30Z',
       command: ['server', '--console-address', ':9001', '/data'],
       environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
       ports: [

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -360,7 +360,7 @@
     "environment":
       - "MINIO_ROOT_USER=mimir"
       - "MINIO_ROOT_PASSWORD=supersecret"
-    "image": "minio/minio"
+    "image": "minio/minio:RELEASE.2025-05-24T17-08-30Z"
     "ports":
       - "9000:9000"
       - "9001:9001"

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -293,7 +293,7 @@ std.manifestYamlDoc({
 
   minio:: {
     minio: {
-      image: 'minio/minio',
+      image: 'minio/minio:RELEASE.2025-05-24T17-08-30Z',
       command: ['server', '--console-address', ':9001', '/data'],
       environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
       ports: [

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -304,7 +304,7 @@
     "environment":
       - "MINIO_ROOT_USER=mimir"
       - "MINIO_ROOT_PASSWORD=supersecret"
-    "image": "minio/minio"
+    "image": "minio/minio:RELEASE.2025-05-24T17-08-30Z"
     "ports":
       - "9000:9000"
       - "9001:9001"

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 8510:8500
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2025-05-24T17-08-30Z
     command: [ "server", "--console-address", ":9101", "/data" ]
     environment:
       - MINIO_ROOT_USER=mimir

--- a/development/mimir-read-write-mode/docker-compose.jsonnet
+++ b/development/mimir-read-write-mode/docker-compose.jsonnet
@@ -78,7 +78,7 @@ std.manifestYamlDoc({
 
   minio:: {
     minio: {
-      image: 'minio/minio',
+      image: 'minio/minio:RELEASE.2025-05-24T17-08-30Z',
       command: ['server', '--console-address', ':9701', '/data'],
       environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
       ports: [

--- a/development/mimir-read-write-mode/docker-compose.yml
+++ b/development/mimir-read-write-mode/docker-compose.yml
@@ -165,7 +165,7 @@
     "environment":
       - "MINIO_ROOT_USER=mimir"
       - "MINIO_ROOT_PASSWORD=supersecret"
-    "image": "minio/minio"
+    "image": "minio/minio:RELEASE.2025-05-24T17-08-30Z"
     "ports":
       - "9700:9700"
       - "9701:9701"


### PR DESCRIPTION
#### What this PR does

`development/tools/upload-block` uses the AWS CLI to upload files to the local Minio instance used in our Docker Compose environments.

Recent versions of the AWS CLI trigger the issue described in https://github.com/minio/minio/issues/19670, which is fixed in recent versions of Minio.

However, we had not set an explicit Docker image tag when pulling Minio, so there's no guarantee that Minio is any particular version.

So in this PR, I'm pinning Minio to the most recent stable version, to ensure this fix is included.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
