### PR TITLE
MQE: fix possible panic while evaluating a query containing `group_left` or `group_right`

### DIFF
--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -683,6 +683,7 @@ func (g *GroupedVectorVectorBinaryOperation) updateOneSidePresence(side *oneSide
 
 	if matchGroup.oneSideCount == 0 {
 		types.IntSlicePool.Put(matchGroup.presence, g.MemoryConsumptionTracker)
+		matchGroup.presence = nil
 	}
 
 	return nil

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -530,7 +530,7 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 
 		expectedOutputSeries []labels.Labels
 	}{
-		"multiple series from 'one' side match to a single 'many' series": {
+		"multiple series from 'many' side match to a single 'one' series": {
 			leftSeries: []labels.Labels{
 				labels.FromStrings("group", "1", labels.MetricName, "left_1"),
 				labels.FromStrings("group", "1", labels.MetricName, "left_2"),
@@ -544,7 +544,7 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 				labels.FromStrings("group", "1", labels.MetricName, "left_2", "env", "prod"),
 			},
 		},
-		"multiple series from 'many' side match to a single 'one' series": {
+		"multiple series from 'one' side match to a single 'many' series": {
 			leftSeries: []labels.Labels{
 				labels.FromStrings("group", "1", labels.MetricName, "left_1"),
 			},

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -525,12 +525,13 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 
 func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *testing.T) {
 	testCases := map[string]struct {
-		leftSeries  []labels.Labels
-		rightSeries []labels.Labels
+		leftSeries   []labels.Labels
+		rightSeries  []labels.Labels
+		seriesToRead int
 
 		expectedOutputSeries []labels.Labels
 	}{
-		"multiple series from 'many' side match to a single 'one' series": {
+		"closed after reading no series: multiple series from 'many' side match to a single 'one' series": {
 			leftSeries: []labels.Labels{
 				labels.FromStrings("group", "1", labels.MetricName, "left_1"),
 				labels.FromStrings("group", "1", labels.MetricName, "left_2"),
@@ -538,13 +539,14 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 			rightSeries: []labels.Labels{
 				labels.FromStrings("group", "1", "env", "prod"),
 			},
+			seriesToRead: 0,
 
 			expectedOutputSeries: []labels.Labels{
 				labels.FromStrings("group", "1", labels.MetricName, "left_1", "env", "prod"),
 				labels.FromStrings("group", "1", labels.MetricName, "left_2", "env", "prod"),
 			},
 		},
-		"multiple series from 'one' side match to a single 'many' series": {
+		"closed after reading no series: multiple series from 'one' side match to a single 'many' series": {
 			leftSeries: []labels.Labels{
 				labels.FromStrings("group", "1", labels.MetricName, "left_1"),
 			},
@@ -552,6 +554,37 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 				labels.FromStrings("group", "1", "env", "prod"),
 				labels.FromStrings("group", "1", "env", "test"),
 			},
+			seriesToRead: 0,
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", labels.MetricName, "left_1", "env", "prod"),
+				labels.FromStrings("group", "1", labels.MetricName, "left_1", "env", "test"),
+			},
+		},
+		"closed after reading first series: multiple series from 'many' side match to a single 'one' series": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", labels.MetricName, "left_1"),
+				labels.FromStrings("group", "1", labels.MetricName, "left_2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "env", "prod"),
+			},
+			seriesToRead: 1,
+
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("group", "1", labels.MetricName, "left_1", "env", "prod"),
+				labels.FromStrings("group", "1", labels.MetricName, "left_2", "env", "prod"),
+			},
+		},
+		"closed after reading first series: multiple series from 'one' side match to a single 'many' series": {
+			leftSeries: []labels.Labels{
+				labels.FromStrings("group", "1", labels.MetricName, "left_1"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("group", "1", "env", "prod"),
+				labels.FromStrings("group", "1", "env", "test"),
+			},
+			seriesToRead: 1,
 
 			expectedOutputSeries: []labels.Labels{
 				labels.FromStrings("group", "1", labels.MetricName, "left_1", "env", "prod"),
@@ -595,10 +628,11 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 
-			// Read the first series.
-			d, err := o.NextSeries(ctx)
-			require.NoError(t, err)
-			types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
+			for range testCase.seriesToRead {
+				d, err := o.NextSeries(ctx)
+				require.NoError(t, err)
+				types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
+			}
 
 			// Return any unread data to the pool and update the current memory consumption estimate to match.
 			left.ReleaseUnreadData(memoryConsumptionTracker)


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where queriers could panic with `estimated memory consumption of this query is negative` while evaluating a query containing a one-to-many or many-to-one binary operation (aka `group_left` / `group_right`).

Specifically, the issue is triggered if all of the series with the same group matching labels on the "one" side are read and then the operator is closed before all of the corresponding output series have been emitted. (This can happen if, for example, the query contains further binary operations that only need a subset of the output series.)

In this case, the `matchGroup`'s `presence` slice would be returned to the pool multiple times: once in `updateOneSidePresence`, and again when `oneSide.Close` was called by the first remaining output series in that group.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
