### PR TITLE
Enforce that methods on the same type have the same receiver name

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - loggercheck
     - misspell
     - revive
+    - staticcheck
   settings:
     # path to a file containing a list of functions to exclude from checking
     # see https://github.com/kisielk/errcheck#excluding-functions for details
@@ -70,6 +71,9 @@ linters:
       rules:
         - name: redefines-builtin-id
           disabled: true
+    staticcheck:
+      checks:
+        - ST1016
   exclusions:
     presets:
       - comments

--- a/pkg/blockbuilder/schedulerpb/client_test.go
+++ b/pkg/blockbuilder/schedulerpb/client_test.go
@@ -83,11 +83,11 @@ func TestSendUpdates(t *testing.T) {
 }
 
 // a mutator for tests.
-func (c *schedulerClient) completeJobWithForgetTime(k JobKey, forgetTime time.Time) error {
-	if err := c.CompleteJob(k); err != nil {
+func (s *schedulerClient) completeJobWithForgetTime(k JobKey, forgetTime time.Time) error {
+	if err := s.CompleteJob(k); err != nil {
 		return err
 	}
-	c.jobs[k].forgetTime = forgetTime
+	s.jobs[k].forgetTime = forgetTime
 	return nil
 }
 

--- a/pkg/costattribution/active_tracker.go
+++ b/pkg/costattribution/active_tracker.go
@@ -287,8 +287,8 @@ func (at *ActiveSeriesTracker) fillKeyFromLabels(lbls labels.Labels, buf *bytes.
 	}
 }
 
-func (st *ActiveSeriesTracker) cardinality() (cardinality int, overflown bool) {
-	st.observedMtx.RLock()
-	defer st.observedMtx.RUnlock()
-	return len(st.observed), !st.overflowSince.IsZero()
+func (at *ActiveSeriesTracker) cardinality() (cardinality int, overflown bool) {
+	at.observedMtx.RLock()
+	defer at.observedMtx.RUnlock()
+	return len(at.observed), !at.overflowSince.IsZero()
 }

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -752,7 +752,7 @@ func (m *PrometheusLabelsResponse) Close() {
 	// Nothing to do
 }
 
-func (resp *PrometheusLabelsResponse) GetPrometheusResponse() (*PrometheusResponse, bool) {
+func (m *PrometheusLabelsResponse) GetPrometheusResponse() (*PrometheusResponse, bool) {
 	return nil, false
 }
 
@@ -785,7 +785,7 @@ func (m *PrometheusSeriesResponse) Close() {
 	// Nothing to do
 }
 
-func (resp *PrometheusSeriesResponse) GetPrometheusResponse() (*PrometheusResponse, bool) {
+func (m *PrometheusSeriesResponse) GetPrometheusResponse() (*PrometheusResponse, bool) {
 	return nil, false
 }
 

--- a/pkg/mimirpb/compat.go
+++ b/pkg/mimirpb/compat.go
@@ -44,7 +44,7 @@ func NewWriteRequest(metadata []*MetricMetadata, source WriteRequest_SourceEnum)
 // AddFloatSeries converts matched slices of Labels, Samples, Exemplars into a WriteRequest
 // proto. It gets timeseries from the pool, so ReuseSlice() should be called when done. Note that this
 // method implies that only a single sample and optionally exemplar can be set for each series.
-func (req *WriteRequest) AddFloatSeries(lbls [][]LabelAdapter, samples []Sample, exemplars []*Exemplar) *WriteRequest {
+func (m *WriteRequest) AddFloatSeries(lbls [][]LabelAdapter, samples []Sample, exemplars []*Exemplar) *WriteRequest {
 	for i, s := range samples {
 		ts := TimeseriesFromPool()
 		ts.Labels = append(ts.Labels, lbls[i]...)
@@ -58,15 +58,15 @@ func (req *WriteRequest) AddFloatSeries(lbls [][]LabelAdapter, samples []Sample,
 			}
 		}
 
-		req.Timeseries = append(req.Timeseries, PreallocTimeseries{TimeSeries: ts})
+		m.Timeseries = append(m.Timeseries, PreallocTimeseries{TimeSeries: ts})
 	}
-	return req
+	return m
 }
 
 // AddHistogramSeries converts matched slices of Labels, Histograms, Exemplars into a WriteRequest
 // proto. It gets timeseries from the pool, so ReuseSlice() should be called when done. Note that this
 // method implies that only a single sample and optionally exemplar can be set for each series.
-func (req *WriteRequest) AddHistogramSeries(lbls [][]LabelAdapter, histograms []Histogram, exemplars []*Exemplar) *WriteRequest {
+func (m *WriteRequest) AddHistogramSeries(lbls [][]LabelAdapter, histograms []Histogram, exemplars []*Exemplar) *WriteRequest {
 	for i, s := range histograms {
 		ts := TimeseriesFromPool()
 		ts.Labels = append(ts.Labels, lbls[i]...)
@@ -80,20 +80,20 @@ func (req *WriteRequest) AddHistogramSeries(lbls [][]LabelAdapter, histograms []
 			}
 		}
 
-		req.Timeseries = append(req.Timeseries, PreallocTimeseries{TimeSeries: ts})
+		m.Timeseries = append(m.Timeseries, PreallocTimeseries{TimeSeries: ts})
 	}
 
-	return req
+	return m
 }
 
 // AddExemplarsAt appends exemplars to the timeseries at index i.
 // This is needed as the Add*Series functions only allow for a single exemplar
 // to be added per time series for simplicity.
-func (req *WriteRequest) AddExemplarsAt(i int, exemplars []*Exemplar) *WriteRequest {
+func (m *WriteRequest) AddExemplarsAt(i int, exemplars []*Exemplar) *WriteRequest {
 	for _, e := range exemplars {
-		req.Timeseries[i].Exemplars = append(req.Timeseries[i].Exemplars, *e)
+		m.Timeseries[i].Exemplars = append(m.Timeseries[i].Exemplars, *e)
 	}
-	return req
+	return m
 }
 
 // FromLabelAdaptersToMetric converts []LabelAdapter to a model.Metric.

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -125,9 +125,9 @@ func getMetricName(seriesName string, metricType MetadataRW2_MetricType) (string
 	}
 }
 
-func (p *WriteRequest) ClearTimeseriesUnmarshalData() {
-	for idx := range p.Timeseries {
-		p.Timeseries[idx].clearUnmarshalData()
+func (m *WriteRequest) ClearTimeseriesUnmarshalData() {
+	for idx := range m.Timeseries {
+		m.Timeseries[idx].clearUnmarshalData()
 	}
 }
 
@@ -783,7 +783,7 @@ func copyHistogram(src Histogram) Histogram {
 
 // ForIndexes builds a new WriteRequest from the given WriteRequest, containing only the timeseries and metadata for the given indexes.
 // It assumes the indexes before the initialMetadataIndex are timeseries, and the rest are metadata.
-func (p *WriteRequest) ForIndexes(indexes []int, initialMetadataIndex int) *WriteRequest {
+func (m *WriteRequest) ForIndexes(indexes []int, initialMetadataIndex int) *WriteRequest {
 	var timeseriesCount, metadataCount int
 	for _, i := range indexes {
 		if i >= initialMetadataIndex {
@@ -798,17 +798,17 @@ func (p *WriteRequest) ForIndexes(indexes []int, initialMetadataIndex int) *Writ
 
 	for _, i := range indexes {
 		if i >= initialMetadataIndex {
-			metadata = append(metadata, p.Metadata[i-initialMetadataIndex])
+			metadata = append(metadata, m.Metadata[i-initialMetadataIndex])
 		} else {
-			timeseries = append(timeseries, p.Timeseries[i])
+			timeseries = append(timeseries, m.Timeseries[i])
 		}
 	}
 
 	return &WriteRequest{
 		Timeseries:          timeseries,
 		Metadata:            metadata,
-		Source:              p.Source,
-		SkipLabelValidation: p.SkipLabelValidation,
+		Source:              m.Source,
+		SkipLabelValidation: m.SkipLabelValidation,
 	}
 }
 

--- a/pkg/mimirtool/client/alerts.go
+++ b/pkg/mimirtool/client/alerts.go
@@ -23,7 +23,7 @@ type configCompat struct {
 }
 
 // CreateAlertmanagerConfig creates a new alertmanager config
-func (r *MimirClient) CreateAlertmanagerConfig(ctx context.Context, cfg string, templates map[string]string) error {
+func (c *MimirClient) CreateAlertmanagerConfig(ctx context.Context, cfg string, templates map[string]string) error {
 	payload, err := yaml.Marshal(&configCompat{
 		TemplateFiles:      templates,
 		AlertmanagerConfig: cfg,
@@ -32,7 +32,7 @@ func (r *MimirClient) CreateAlertmanagerConfig(ctx context.Context, cfg string, 
 		return err
 	}
 
-	res, err := r.doRequest(ctx, alertmanagerAPIPath, "POST", bytes.NewBuffer(payload), int64(len(payload)))
+	res, err := c.doRequest(ctx, alertmanagerAPIPath, "POST", bytes.NewBuffer(payload), int64(len(payload)))
 	if err != nil {
 		return err
 	}
@@ -43,8 +43,8 @@ func (r *MimirClient) CreateAlertmanagerConfig(ctx context.Context, cfg string, 
 }
 
 // DeleteAlermanagerConfig deletes the users alertmanagerconfig
-func (r *MimirClient) DeleteAlermanagerConfig(ctx context.Context) error {
-	res, err := r.doRequest(ctx, alertmanagerAPIPath, "DELETE", nil, -1)
+func (c *MimirClient) DeleteAlermanagerConfig(ctx context.Context) error {
+	res, err := c.doRequest(ctx, alertmanagerAPIPath, "DELETE", nil, -1)
 	if err != nil {
 		return err
 	}
@@ -55,8 +55,8 @@ func (r *MimirClient) DeleteAlermanagerConfig(ctx context.Context) error {
 }
 
 // GetAlertmanagerConfig retrieves a Mimir cluster's Alertmanager config.
-func (r *MimirClient) GetAlertmanagerConfig(ctx context.Context) (string, map[string]string, error) {
-	res, err := r.doRequest(ctx, alertmanagerAPIPath, "GET", nil, -1)
+func (c *MimirClient) GetAlertmanagerConfig(ctx context.Context) (string, map[string]string, error) {
+	res, err := c.doRequest(ctx, alertmanagerAPIPath, "GET", nil, -1)
 	if err != nil {
 		log.Debugln("no alert config present in response")
 		return "", nil, err

--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -118,10 +118,10 @@ func New(cfg Config) (*MimirClient, error) {
 }
 
 // Query executes a PromQL query against the Mimir cluster.
-func (r *MimirClient) Query(ctx context.Context, query string) (*http.Response, error) {
+func (c *MimirClient) Query(ctx context.Context, query string) (*http.Response, error) {
 	req := fmt.Sprintf("/prometheus/api/v1/query?query=%s&time=%d", url.QueryEscape(query), time.Now().Unix())
 
-	res, err := r.doRequest(ctx, req, "GET", nil, -1)
+	res, err := c.doRequest(ctx, req, "GET", nil, -1)
 	if err != nil {
 		return nil, err
 	}
@@ -129,14 +129,14 @@ func (r *MimirClient) Query(ctx context.Context, query string) (*http.Response, 
 	return res, nil
 }
 
-func (r *MimirClient) doRequest(ctx context.Context, path, method string, payload io.Reader, contentLength int64) (*http.Response, error) {
-	req, err := buildRequest(ctx, path, method, *r.endpoint, payload, contentLength)
+func (c *MimirClient) doRequest(ctx context.Context, path, method string, payload io.Reader, contentLength int64) (*http.Response, error) {
+	req, err := buildRequest(ctx, path, method, *c.endpoint, payload, contentLength)
 	if err != nil {
 		return nil, err
 	}
 
 	switch {
-	case (r.user != "" || r.key != "") && r.authToken != "":
+	case (c.user != "" || c.key != "") && c.authToken != "":
 		err := errors.New("at most one of basic auth or auth token should be configured")
 		log.WithFields(log.Fields{
 			"url":    req.URL.String(),
@@ -145,28 +145,28 @@ func (r *MimirClient) doRequest(ctx context.Context, path, method string, payloa
 		}).Errorln("error during setting up request to mimir api")
 		return nil, err
 
-	case r.user != "":
-		req.SetBasicAuth(r.user, r.key)
+	case c.user != "":
+		req.SetBasicAuth(c.user, c.key)
 
-	case r.key != "":
-		req.SetBasicAuth(r.id, r.key)
+	case c.key != "":
+		req.SetBasicAuth(c.id, c.key)
 
-	case r.authToken != "":
-		req.Header.Add("Authorization", "Bearer "+r.authToken)
+	case c.authToken != "":
+		req.Header.Add("Authorization", "Bearer "+c.authToken)
 	}
 
-	for k, v := range r.extraHeaders {
+	for k, v := range c.extraHeaders {
 		req.Header.Add(k, v)
 	}
 
-	req.Header.Add(user.OrgIDHeaderName, r.id)
+	req.Header.Add(user.OrgIDHeaderName, c.id)
 
 	log.WithFields(log.Fields{
 		"url":    req.URL.String(),
 		"method": req.Method,
 	}).Debugln("sending request to Grafana Mimir API")
 
-	resp, err := r.Client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"url":    req.URL.String(),

--- a/pkg/mimirtool/client/rules.go
+++ b/pkg/mimirtool/client/rules.go
@@ -20,16 +20,16 @@ import (
 )
 
 // CreateRuleGroup creates a new rule group
-func (r *MimirClient) CreateRuleGroup(ctx context.Context, namespace string, rg rwrulefmt.RuleGroup) error {
+func (c *MimirClient) CreateRuleGroup(ctx context.Context, namespace string, rg rwrulefmt.RuleGroup) error {
 	payload, err := yaml.Marshal(&rg)
 	if err != nil {
 		return err
 	}
 
 	escapedNamespace := url.PathEscape(namespace)
-	path := r.apiPath + "/" + escapedNamespace
+	path := c.apiPath + "/" + escapedNamespace
 
-	res, err := r.doRequest(ctx, path, "POST", bytes.NewBuffer(payload), int64(len(payload)))
+	res, err := c.doRequest(ctx, path, "POST", bytes.NewBuffer(payload), int64(len(payload)))
 	if err != nil {
 		return err
 	}
@@ -40,12 +40,12 @@ func (r *MimirClient) CreateRuleGroup(ctx context.Context, namespace string, rg 
 }
 
 // DeleteRuleGroup deletes a rule group
-func (r *MimirClient) DeleteRuleGroup(ctx context.Context, namespace, groupName string) error {
+func (c *MimirClient) DeleteRuleGroup(ctx context.Context, namespace, groupName string) error {
 	escapedNamespace := url.PathEscape(namespace)
 	escapedGroupName := url.PathEscape(groupName)
-	path := r.apiPath + "/" + escapedNamespace + "/" + escapedGroupName
+	path := c.apiPath + "/" + escapedNamespace + "/" + escapedGroupName
 
-	res, err := r.doRequest(ctx, path, "DELETE", nil, -1)
+	res, err := c.doRequest(ctx, path, "DELETE", nil, -1)
 	if err != nil {
 		return err
 	}
@@ -56,13 +56,13 @@ func (r *MimirClient) DeleteRuleGroup(ctx context.Context, namespace, groupName 
 }
 
 // GetRuleGroup retrieves a rule group
-func (r *MimirClient) GetRuleGroup(ctx context.Context, namespace, groupName string) (*rwrulefmt.RuleGroup, error) {
+func (c *MimirClient) GetRuleGroup(ctx context.Context, namespace, groupName string) (*rwrulefmt.RuleGroup, error) {
 	escapedNamespace := url.PathEscape(namespace)
 	escapedGroupName := url.PathEscape(groupName)
-	path := r.apiPath + "/" + escapedNamespace + "/" + escapedGroupName
+	path := c.apiPath + "/" + escapedNamespace + "/" + escapedGroupName
 
 	fmt.Println(path)
-	res, err := r.doRequest(ctx, path, "GET", nil, -1)
+	res, err := c.doRequest(ctx, path, "GET", nil, -1)
 	if err != nil {
 		return nil, err
 	}
@@ -88,13 +88,13 @@ func (r *MimirClient) GetRuleGroup(ctx context.Context, namespace, groupName str
 }
 
 // ListRules retrieves a rule group
-func (r *MimirClient) ListRules(ctx context.Context, namespace string) (map[string][]rwrulefmt.RuleGroup, error) {
-	path := r.apiPath
+func (c *MimirClient) ListRules(ctx context.Context, namespace string) (map[string][]rwrulefmt.RuleGroup, error) {
+	path := c.apiPath
 	if namespace != "" {
 		path = path + "/" + namespace
 	}
 
-	res, err := r.doRequest(ctx, path, "GET", nil, -1)
+	res, err := c.doRequest(ctx, path, "GET", nil, -1)
 	if err != nil {
 		return nil, err
 	}
@@ -116,11 +116,11 @@ func (r *MimirClient) ListRules(ctx context.Context, namespace string) (map[stri
 }
 
 // DeleteNamespace delete all the rule groups in a namespace including the namespace itself
-func (r *MimirClient) DeleteNamespace(ctx context.Context, namespace string) error {
+func (c *MimirClient) DeleteNamespace(ctx context.Context, namespace string) error {
 	escapedNamespace := url.PathEscape(namespace)
-	path := r.apiPath + "/" + escapedNamespace
+	path := c.apiPath + "/" + escapedNamespace
 
-	res, err := r.doRequest(ctx, path, "DELETE", nil, -1)
+	res, err := c.doRequest(ctx, path, "DELETE", nil, -1)
 	if err != nil {
 		return err
 	}

--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -58,7 +58,7 @@ type richMeta struct {
 	SplitID     *uint32 `json:"splitId,omitempty"`
 }
 
-func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
+func (g *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	tenantID := vars["tenant"]
 	if tenantID == "" {
@@ -82,7 +82,7 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	metasMap, deleteMarkerDetails, noCompactMarkerDetails, err := listblocks.LoadMetaFilesAndMarkers(req.Context(), s.stores.bucket, tenantID, showDeleted, time.Time{})
+	metasMap, deleteMarkerDetails, noCompactMarkerDetails, err := listblocks.LoadMetaFilesAndMarkers(req.Context(), g.stores.bucket, tenantID, showDeleted, time.Time{})
 	if err != nil {
 		util.WriteTextResponse(w, fmt.Sprintf("Failed to read block metadata: %s", err))
 		return

--- a/pkg/storegateway/gateway_ring_http.go
+++ b/pkg/storegateway/gateway_ring_http.go
@@ -34,13 +34,13 @@ func writeMessage(w http.ResponseWriter, message string, logger log.Logger) {
 	}
 }
 
-func (c *StoreGateway) RingHandler(w http.ResponseWriter, req *http.Request) {
-	if c.State() != services.Running {
+func (g *StoreGateway) RingHandler(w http.ResponseWriter, req *http.Request) {
+	if g.State() != services.Running {
 		// we cannot read the ring before the store gateway is in Running state,
 		// because that would lead to race condition.
-		writeMessage(w, "Store gateway is not running yet.", c.logger)
+		writeMessage(w, "Store gateway is not running yet.", g.logger)
 		return
 	}
 
-	c.ring.ServeHTTP(w, req)
+	g.ring.ServeHTTP(w, req)
 }

--- a/pkg/storegateway/gateway_tenants_http.go
+++ b/pkg/storegateway/gateway_tenants_http.go
@@ -21,8 +21,8 @@ type tenantsPageContents struct {
 	Tenants []string  `json:"tenants,omitempty"`
 }
 
-func (s *StoreGateway) TenantsHandler(w http.ResponseWriter, req *http.Request) {
-	tenantIDs, err := s.stores.scanUsers(req.Context())
+func (g *StoreGateway) TenantsHandler(w http.ResponseWriter, req *http.Request) {
+	tenantIDs, err := g.stores.scanUsers(req.Context())
 	if err != nil {
 		util.WriteTextResponse(w, fmt.Sprintf("Can't read tenants: %s", err))
 		return

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -755,12 +755,12 @@ func (g *GroupedVectorVectorBinaryOperation) ExpressionPosition() posrange.Posit
 	return g.expressionPosition
 }
 
-func (a *GroupedVectorVectorBinaryOperation) Prepare(ctx context.Context, params *types.PrepareParams) error {
-	err := a.Left.Prepare(ctx, params)
+func (g *GroupedVectorVectorBinaryOperation) Prepare(ctx context.Context, params *types.PrepareParams) error {
+	err := g.Left.Prepare(ctx, params)
 	if err != nil {
 		return err
 	}
-	return a.Right.Prepare(ctx, params)
+	return g.Right.Prepare(ctx, params)
 }
 
 func (g *GroupedVectorVectorBinaryOperation) Close() {

--- a/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
@@ -186,8 +186,8 @@ func (v *InstantVectorSelector) NextSeries(ctx context.Context) (types.InstantVe
 	return data, nil
 }
 
-func (m *InstantVectorSelector) Prepare(_ context.Context, params *types.PrepareParams) error {
-	m.Stats = params.QueryStats
+func (v *InstantVectorSelector) Prepare(_ context.Context, params *types.PrepareParams) error {
+	v.Stats = params.QueryStats
 	return nil
 }
 


### PR DESCRIPTION
#### What this PR does

This PR enables a linting rule that enforces that all methods on the same type have the same receiver name, and fixes instances where this is not already the case.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
