### PR TITLE
Update dskit to support JAEGER_EXPORTER_MAX_QUEUE_SIZE again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20250606150612-d37b26647ad9
+	github.com/grafana/dskit v0.0.0-20250611073354-5866fd7b61fe
 	github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.7.12

--- a/go.sum
+++ b/go.sum
@@ -561,8 +561,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20250610043455-3e20fda3b872 h1:bhUBPxMHtQB+AJaPcASElgwC7WFjWQvEiD3FoMEAv0E=
 github.com/grafana/alerting v0.0.0-20250610043455-3e20fda3b872/go.mod h1:VANfU4LMnOR4Gv4hkCN9fGyQ/8Lf2DKOvzG70vI2IS4=
-github.com/grafana/dskit v0.0.0-20250606150612-d37b26647ad9 h1:/bX64qDoQmeIa3wmu5ls5uKpcNYv3ao0TG3VENNN5fc=
-github.com/grafana/dskit v0.0.0-20250606150612-d37b26647ad9/go.mod h1:OiN4P4aC6LwLzLbEupH3Ue83VfQoNMfG48rsna8jI/E=
+github.com/grafana/dskit v0.0.0-20250611073354-5866fd7b61fe h1:3vlhwZ6CwpEHEv59gdBvw/NMYMoSbA3TCvZQwV1AoRM=
+github.com/grafana/dskit v0.0.0-20250611073354-5866fd7b61fe/go.mod h1:OiN4P4aC6LwLzLbEupH3Ue83VfQoNMfG48rsna8jI/E=
 github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673 h1:Va04sDlP33f1SFUHRTho4QJfDlGTz+/HnBIpYwlqV9Q=
 github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -724,7 +724,7 @@ github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
 github.com/grafana/alerting/templates/gomplate
 github.com/grafana/alerting/templates/mimir
-# github.com/grafana/dskit v0.0.0-20250606150612-d37b26647ad9
+# github.com/grafana/dskit v0.0.0-20250611073354-5866fd7b61fe
 ## explicit; go 1.23.0
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
This updates dskit to https://github.com/grafana/dskit/pull/712 to support the JAEGER_EXPORTER_MAX_QUEUE_SIZE env var again when tracing is configured using the deprecated Jaeger env vars.

When not configured, the OTel's default 2048 is used.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
