### PR TITLE
Jsonnet & Helm: Stop configuring `JAEGER_REPORTER_MAX_QUEUE_SIZE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 * [CHANGE] Update rollout-operator version to 0.26.0. #11232
 * [CHANGE] Memcached: Set a timeout of `500ms` for the `ruler-storage` cache instead of the default `200ms`. #11231
 * [CHANGE] Ruler: If ingest storage is enabled, set the maximum buffered bytes in the Kafka client used by the ruler based on the expected maximum rule evaluation response size, clamping it between 1 GB (default) and 4 GB. #11602
+* [CHANGE] All: Environment variable `JAEGER_REPORTER_MAX_QUEUE_SIZE` is no longer set. Components will use the OTel's default value of `2048` unless explicitly configured otherwise. You can still configure `JAEGER_REPORTER_MAX_QUEUE_SIZE` if you configure tracing using Jaeger env vars, and you can always set `OTEL_BSP_MAX_QUEUE_SIZE` OTel configuration. #11700
 * [FEATURE] Make ingest storage ingester HPA behavior configurable through `_config.ingest_storage_ingester_hpa_behavior`. #11168
 * [FEATURE] Add an alternate ingest storage HPA trigger that targets maximum owned series per pod. #11356
 * [FEATURE] Make tracing of HTTP headers as span attributes configurable through `_config.trace_request_headers`. You can exclude certain headers from being traced using `_config.trace_request_exclude_headers_list`. #11655

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@
 * [CHANGE] Update rollout-operator version to 0.26.0. #11232
 * [CHANGE] Memcached: Set a timeout of `500ms` for the `ruler-storage` cache instead of the default `200ms`. #11231
 * [CHANGE] Ruler: If ingest storage is enabled, set the maximum buffered bytes in the Kafka client used by the ruler based on the expected maximum rule evaluation response size, clamping it between 1 GB (default) and 4 GB. #11602
-* [CHANGE] All: Environment variable `JAEGER_REPORTER_MAX_QUEUE_SIZE` is no longer set. Components will use the OTel's default value of `2048` unless explicitly configured otherwise. You can still configure `JAEGER_REPORTER_MAX_QUEUE_SIZE` if you configure tracing using Jaeger env vars, and you can always set `OTEL_BSP_MAX_QUEUE_SIZE` OTel configuration. #11700
+* [CHANGE] All: Environment variable `JAEGER_REPORTER_MAX_QUEUE_SIZE` is no longer set. Components will use OTel's default value of `2048` unless explicitly configured. You can still configure `JAEGER_REPORTER_MAX_QUEUE_SIZE` if you configure tracing using Jaeger env vars, and you can always set `OTEL_BSP_MAX_QUEUE_SIZE` OTel configuration. #11700
 * [FEATURE] Make ingest storage ingester HPA behavior configurable through `_config.ingest_storage_ingester_hpa_behavior`. #11168
 * [FEATURE] Add an alternate ingest storage HPA trigger that targets maximum owned series per pod. #11356
 * [FEATURE] Make tracing of HTTP headers as span attributes configurable through `_config.trace_request_headers`. You can exclude certain headers from being traced using `_config.trace_request_exclude_headers_list`. #11655

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -202,7 +202,6 @@ std.manifestYamlDoc({
     JAEGER_SAMPLER_TYPE: 'const',
     JAEGER_SAMPLER_PARAM: 1,
     JAEGER_TAGS: 'app=%s' % appName,
-    JAEGER_REPORTER_MAX_QUEUE_SIZE: 1000,
   },
 
   local formatEnv(env) = [

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -13,7 +13,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=alertmanager-1"
@@ -39,7 +38,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=alertmanager-2"
@@ -65,7 +63,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=alertmanager-3"
@@ -91,7 +88,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=compactor"
@@ -127,7 +123,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=continuous-test"
@@ -152,7 +147,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=distributor"
@@ -177,7 +171,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=distributor"
@@ -214,7 +207,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=ingester-1"
@@ -241,7 +233,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=ingester-2"
@@ -268,7 +259,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=ingester-3"
@@ -372,7 +362,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=querier"
@@ -398,7 +387,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=query-frontend"
@@ -424,7 +412,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=query-scheduler"
@@ -450,7 +437,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=ruler-1"
@@ -476,7 +462,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=ruler-2"
@@ -502,7 +487,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=store-gateway-1"
@@ -528,7 +512,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=store-gateway-2"
@@ -554,7 +537,6 @@
     "environment":
       - "JAEGER_AGENT_HOST=jaeger"
       - "JAEGER_AGENT_PORT=6831"
-      - "JAEGER_REPORTER_MAX_QUEUE_SIZE=1000"
       - "JAEGER_SAMPLER_PARAM=1"
       - "JAEGER_SAMPLER_TYPE=const"
       - "JAEGER_TAGS=app=store-gateway-3"

--- a/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
+++ b/development/mimir-monolithic-mode-with-swift-storage/docker-compose.yml
@@ -71,7 +71,6 @@ services:
       - JAEGER_TAGS=app=mimir-1
       - JAEGER_SAMPLER_TYPE=const
       - JAEGER_SAMPLER_PARAM=1
-      - JAEGER_REPORTER_MAX_QUEUE_SIZE=1000
     ports:
       - 8001:8001
     volumes:
@@ -93,7 +92,6 @@ services:
       - JAEGER_TAGS=app=mimir-2
       - JAEGER_SAMPLER_TYPE=const
       - JAEGER_SAMPLER_PARAM=1
-      - JAEGER_REPORTER_MAX_QUEUE_SIZE=1000
     ports:
       - 8002:8002
     volumes:

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -92,7 +92,6 @@ services:
       - JAEGER_TAGS=app=mimir-1
       - JAEGER_SAMPLER_TYPE=const
       - JAEGER_SAMPLER_PARAM=1
-      - JAEGER_REPORTER_MAX_QUEUE_SIZE=1000
     ports:
       - 8101:8001
     volumes:
@@ -114,7 +113,6 @@ services:
       - JAEGER_TAGS=app=mimir-2
       - JAEGER_SAMPLER_TYPE=const
       - JAEGER_SAMPLER_PARAM=1
-      - JAEGER_REPORTER_MAX_QUEUE_SIZE=1000
     ports:
       - 8102:8002
     volumes:

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,7 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Added extraVolumes to provisioner to support mounting TLS certificates. #11400
 * [CHANGE] KEDA Autoscaling: Changed toPromQLLabelSelector from object to list of strings, adding support for all PromQL operators. #10945
 * [CHANGE] Memcached: Set a timeout of `500ms` for the `ruler-storage` cache instead of the default `200ms`. #11231
-* [CHANGE] All: Environment variable `JAEGER_REPORTER_MAX_QUEUE_SIZE` is no longer set. Components will use the OTel's default value of `2048` unless explicitly configured otherwise. You can still configure `JAEGER_REPORTER_MAX_QUEUE_SIZE` if you configure tracing using Jaeger env vars, and you can always set `OTEL_BSP_MAX_QUEUE_SIZE` OTel configuration. #11700
+* [CHANGE] All: Environment variable `JAEGER_REPORTER_MAX_QUEUE_SIZE` is no longer set. Components will use OTel's default value of `2048` unless explicitly configured. You can still configure `JAEGER_REPORTER_MAX_QUEUE_SIZE` if you configure tracing using Jaeger env vars, and you can always set `OTEL_BSP_MAX_QUEUE_SIZE` OTel configuration. #11700
 * [BUGFIX] Memcached: Use `dnssrvnoa+` address prefix instead of `dns+` which results in DNS `SRV` record lookups instead of `A` or `AAAA`. This results in fewer cache evictions when the members of the Memcached cluster change. #11041
 * [BUGFIX] Helm: Fix extra spaces in the extra-manifest helm chart.
 * [BUGFIX] Helm: Work around [Helm PR 12879](https://github.com/helm/helm/pull/12879) not clearing fields with `null`, instead setting them to `null`. #11140

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Added extraVolumes to provisioner to support mounting TLS certificates. #11400
 * [CHANGE] KEDA Autoscaling: Changed toPromQLLabelSelector from object to list of strings, adding support for all PromQL operators. #10945
 * [CHANGE] Memcached: Set a timeout of `500ms` for the `ruler-storage` cache instead of the default `200ms`. #11231
+* [CHANGE] All: Environment variable `JAEGER_REPORTER_MAX_QUEUE_SIZE` is no longer set. Components will use the OTel's default value of `2048` unless explicitly configured otherwise. You can still configure `JAEGER_REPORTER_MAX_QUEUE_SIZE` if you configure tracing using Jaeger env vars, and you can always set `OTEL_BSP_MAX_QUEUE_SIZE` OTel configuration. #11700
 * [BUGFIX] Memcached: Use `dnssrvnoa+` address prefix instead of `dns+` which results in DNS `SRV` record lookups instead of `A` or `AAAA`. This results in fewer cache evictions when the members of the Memcached cluster change. #11041
 * [BUGFIX] Helm: Fix extra spaces in the extra-manifest helm chart.
 * [BUGFIX] Helm: Work around [Helm PR 12879](https://github.com/helm/helm/pull/12879) not clearing fields with `null`, instead setting them to `null`. #11140

--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -88,18 +88,13 @@ spec:
             {{- toYaml .Values.admin_api.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.admin_api.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.admin_api }}
-          {{- if or .Values.global.extraEnv .Values.admin_api.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.admin_api.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{ toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.admin_api.env }}
               {{ toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.admin_api.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -203,18 +203,13 @@ spec:
             {{- toYaml .Values.alertmanager.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.alertmanager.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.alertmanager }}
-          {{- if or .Values.global.extraEnv .Values.alertmanager.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.alertmanager.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.alertmanager.env }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.alertmanager.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -166,18 +166,13 @@ spec:
             {{- toYaml .Values.compactor.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.compactor.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.compactor }}
-          {{- if or .Values.global.extraEnv .Values.compactor.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.compactor.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.compactor.env }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.compactor.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-dep.yaml
@@ -88,18 +88,13 @@ spec:
             {{- toYaml .Values.continuous_test.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.continuous_test.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.continuous_test }}
-          {{- if or .Values.global.extraEnv .Values.continuous_test.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.continuous_test.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{ toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.continuous_test.env }}
               {{ toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.continuous_test.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -111,8 +111,7 @@ spec:
           securityContext:
             {{- toYaml .Values.distributor.containerSecurityContext | nindent 12 }}
           {{- $cpu_request := dig "requests" "cpu" nil .Values.distributor.resources }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.distributor }}
-          {{- if or .Values.global.extraEnv .Values.distributor.env $cpu_request $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.distributor.env $cpu_request }}
           env:
             {{- with .Values.global.extraEnv }}
               {{- toYaml . | nindent 12 }}
@@ -124,10 +123,6 @@ spec:
             {{- $cpu_request_doubled := include "mimir.parseCPU" (dict "value" $cpu_request) | float64 | mulf 2 | ceil }}
             - name: "GOMAXPROCS"
               value: {{ max $cpu_request_doubled 8 | toString | toYaml }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.distributor.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/federation-frontend/federation-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/federation-frontend/federation-frontend-dep.yaml
@@ -77,8 +77,7 @@ spec:
             {{- toYaml .Values.federation_frontend.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.federation_frontend.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.federation_frontend }}
-          {{- if or .Values.global.extraEnv .Values.federation_frontend.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.federation_frontend.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{- toYaml . | nindent 12 }}
@@ -86,10 +85,6 @@ spec:
             {{- with .Values.federation_frontend.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if $jaeger_queue_size }}
-              - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-                value: {{$jaeger_queue_size | toString | toYaml }}
-             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.federation_frontend.extraEnvFrom }}
           envFrom:

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -117,18 +117,13 @@ spec:
             {{- toYaml .resources | nindent 12 }}
           securityContext:
             {{- toYaml .containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil . }}
-          {{- if or $.Values.global.extraEnv .env $jaeger_queue_size }}
+          {{- if or $.Values.global.extraEnv .env }}
           env:
             {{- with $.Values.global.extraEnv }}
               {{ toYaml . | nindent 12 }}
             {{- end }}
             {{- with .env }}
               {{ toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or $.Values.global.extraEnvFrom .extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-querier/graphite-querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-querier/graphite-querier-dep.yaml
@@ -89,18 +89,13 @@ spec:
             {{- toYaml .Values.graphite.querier.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.graphite.querier.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.graphite.querier }}
-          {{- if or .Values.global.extraEnv .Values.graphite.querier.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.graphite.querier.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{ toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.graphite.querier.env }}
               {{ toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.admin_api.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-write-proxy/graphite-write-proxy-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/graphite-proxy/graphite-write-proxy/graphite-write-proxy-dep.yaml
@@ -87,18 +87,13 @@ spec:
             {{- toYaml .Values.graphite.write_proxy.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.graphite.write_proxy.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.graphite.write_proxy }}
-          {{- if or .Values.global.extraEnv .Values.graphite.write_proxy.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.graphite.write_proxy.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{ toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.graphite.write_proxy.env }}
               {{ toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.graphite.write_proxy.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -186,9 +186,9 @@ spec:
             {{- toYaml .Values.ingester.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.ingester.containerSecurityContext | nindent 12 }}
-          {{- if or .Values.global.extraEnv .Values.ingester.env }}
+          {{- $cpu_request := dig "requests" "cpu" nil .Values.ingester.resources }}
+          {{- if or .Values.global.extraEnv .Values.ingester.env $cpu_request }}
           env:
-            {{- $cpu_request := dig "requests" "cpu" nil .Values.ingester.resources }}
             {{- if $cpu_request }}
               {{- $cpu_request_between_3_and_6 := include "mimir.parseCPU" (dict "value" $cpu_request) | float64 | min 6 | max 3 }}
             {{/* copy logic from operations/mimir/ingester.libsonnet */}}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -190,8 +190,8 @@ spec:
           {{- if or .Values.global.extraEnv .Values.ingester.env $cpu_request }}
           env:
             {{- if $cpu_request }}
+              {{- /* copy logic from operations/mimir/ingester.libsonnet */}}
               {{- $cpu_request_between_3_and_6 := include "mimir.parseCPU" (dict "value" $cpu_request) | float64 | min 6 | max 3 }}
-            {{/* copy logic from operations/mimir/ingester.libsonnet */}}
             - name: "GOMAXPROCS"
               value: {{ addf $cpu_request $cpu_request_between_3_and_6 1 | ceil | toString | toYaml }}
             {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -186,8 +186,7 @@ spec:
             {{- toYaml .Values.ingester.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.ingester.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.ingester }}
-          {{- if or .Values.global.extraEnv .Values.ingester.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.ingester.env }}
           env:
             {{- $cpu_request := dig "requests" "cpu" nil .Values.ingester.resources }}
             {{- if $cpu_request }}
@@ -201,10 +200,6 @@ spec:
             {{- end }}
             {{- with .Values.ingester.env }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.ingester.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -87,18 +87,13 @@ spec:
             {{- toYaml .Values.overrides_exporter.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.overrides_exporter.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.overrides_exporter }}
-          {{- if or .Values.global.extraEnv .Values.overrides_exporter.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.overrides_exporter.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.overrides_exporter.env }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.overrides_exporter.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -106,8 +106,7 @@ spec:
           securityContext:
             {{- toYaml .Values.querier.containerSecurityContext | nindent 12 }}
           {{- $cpu_request := dig "requests" "cpu" nil .Values.querier.resources }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.querier }}
-          {{- if or .Values.global.extraEnv .Values.querier.env $cpu_request $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.querier.env $cpu_request }}
           env:
             {{- with .Values.global.extraEnv }}
               {{- toYaml . | nindent 12 }}
@@ -120,10 +119,6 @@ spec:
               {{- $cpu_request_plus_four := include "mimir.parseCPU" (dict "value" $cpu_request) | float64 | addf 4 | ceil }}
             - name: "GOMAXPROCS"
               value: {{ max $cpu_request_doubled $cpu_request_plus_four | toString | toYaml }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.querier.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -95,18 +95,13 @@ spec:
             {{- toYaml .Values.query_frontend.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.query_frontend.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.query_frontend }}
-          {{- if or .Values.global.extraEnv .Values.query_frontend.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.query_frontend.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.query_frontend.env }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.query_frontend.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -86,18 +86,13 @@ spec:
             {{- toYaml .Values.query_scheduler.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.query_scheduler.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.query_scheduler }}
-          {{- if or .Values.global.extraEnv .Values.query_scheduler.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.query_scheduler.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.query_scheduler.env }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.query_scheduler.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
@@ -118,11 +118,6 @@ spec:
             - name: "GOMAXPROCS"
               value: {{ max $cpu_request_doubled $cpu_request_plus_four | toString | toYaml }}
             {{- end }}
-            {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.querier }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
-            {{- end }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
@@ -104,11 +104,6 @@ spec:
             {{- with .Values.ruler_query_frontend.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.query_frontend }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
-            {{- end }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-dep.yaml
@@ -93,11 +93,6 @@ spec:
             {{- with .Values.ruler_query_scheduler.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.query_scheduler }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
-            {{- end }}
           envFrom:
             {{- with .Values.global.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -107,18 +107,13 @@ spec:
             {{- toYaml .Values.ruler.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.ruler.containerSecurityContext | nindent 12 }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.ruler }}
-          {{- if or .Values.global.extraEnv .Values.ruler.env $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.ruler.env }}
           env:
             {{- with .Values.global.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.ruler.env }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.ruler.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -186,8 +186,7 @@ spec:
             {{- toYaml .Values.store_gateway.containerSecurityContext | nindent 12 }}
           {{- $cpu_request := dig "requests" "cpu" nil .Values.store_gateway.resources }}
           {{- $mem_request := dig "requests" "memory" nil .Values.store_gateway.resources }}
-          {{- $jaeger_queue_size := dig "jaegerReporterMaxQueueSize" nil .Values.store_gateway }}
-          {{- if or .Values.global.extraEnv .Values.store_gateway.env $cpu_request $mem_request $jaeger_queue_size }}
+          {{- if or .Values.global.extraEnv .Values.store_gateway.env $cpu_request $mem_request }}
           env:
             {{- with .Values.global.extraEnv }}
               {{- toYaml . | nindent 12 }}
@@ -204,10 +203,6 @@ spec:
             {{- if $mem_request }}
             - name: "GOMEMLIMIT"
               value: {{include "mimir.siToBytes" (dict "value" $mem_request) | toString | toYaml }}
-            {{- end }}
-            {{- if $jaeger_queue_size }}
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: {{$jaeger_queue_size | toString | toYaml }}
             {{- end }}
           {{- end }}
           {{- if or .Values.global.extraEnvFrom .Values.store_gateway.extraEnvFrom }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -766,10 +766,6 @@ alertmanager:
   env: []
   extraEnvFrom: []
 
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: null
-
   # -- Options to configure zone-aware replication for alertmanager
   # Example configuration with full geographical redundancy:
   # rollout_operator:
@@ -965,10 +961,6 @@ distributor:
   env: []
   extraEnvFrom: []
 
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: 1000
-
 ingester:
   # -- Whether to render the manifests related to the ingester component.
   enabled: true
@@ -1116,10 +1108,6 @@ ingester:
   extraVolumeMounts: []
   env: []
   extraEnvFrom: []
-
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: 1000
 
   # -- Options to configure zone-aware replication for ingester
   # Example configuration with full geographical redundancy:
@@ -1300,10 +1288,6 @@ overrides_exporter:
   env: []
   extraEnvFrom: []
 
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: null
-
 ruler:
   enabled: true
 
@@ -1430,10 +1414,6 @@ ruler:
   env: []
   extraEnvFrom: []
 
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: 1000
-
   # -- If set to true, a dedicated query path will be deployed for the ruler and operational mode will be set to use remote evaluation. https://grafana.com/docs/mimir/latest/references/architecture/components/ruler/#remote
   # -- This is useful for isolating the ruler queries from other queriers (api/grafana).
   remoteEvaluationDedicatedQueryPath: false
@@ -1559,10 +1539,6 @@ ruler_querier:
   env: []
   extraEnvFrom: []
 
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: 5000
-
 # -- Only deployed if .Values.ruler.remoteEvaluationDedicatedQueryPath
 ruler_query_frontend:
   # -- Allows to override the container image of the ruler-query-frontend component.
@@ -1680,10 +1656,6 @@ ruler_query_frontend:
   env: []
   extraEnvFrom: []
 
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: 5000
-
 # -- Only deployed if .Values.ruler.remoteEvaluationDedicatedQueryPath
 ruler_query_scheduler:
   # -- Allows to override the container image of the ruler-query-scheduler component.
@@ -1773,10 +1745,6 @@ ruler_query_scheduler:
   extraVolumeMounts: []
   env: []
   extraEnvFrom: []
-
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: null
 
 querier:
   # -- Whether to render the manifests related to the querier component.
@@ -1912,10 +1880,6 @@ querier:
   env: []
   extraEnvFrom: []
 
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: 5000
-
 query_frontend:
   # -- Whether to render the manifests related to the query-frontend component.
   enabled: true
@@ -2035,10 +1999,6 @@ query_frontend:
   env: []
   extraEnvFrom: []
 
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: 5000
-
 query_scheduler:
   enabled: true
 
@@ -2129,10 +2089,6 @@ query_scheduler:
   extraVolumeMounts: []
   env: []
   extraEnvFrom: []
-
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: null
 
 store_gateway:
   # -- Whether to render the manifests related to the store-gateway component.
@@ -2282,10 +2238,6 @@ store_gateway:
   extraVolumeMounts: []
   env: []
   extraEnvFrom: []
-
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: 1000
 
   # -- Options to configure zone-aware replication for store-gateway
   # Example configuration with full geographical redundancy:
@@ -2497,10 +2449,6 @@ compactor:
   extraVolumeMounts: []
   env: []
   extraEnvFrom: []
-
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: null
 
 memcached:
   image:
@@ -3458,9 +3406,6 @@ gateway:
   env: []
   # -- Environment variables from secrets or configmaps to add to the Pods.
   extraEnvFrom: []
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: null
   # -- Volumes to add to the Pods
   extraVolumes: []
   # -- Volume mounts to add to the Pods
@@ -4312,10 +4257,6 @@ admin_api:
   extraVolumeMounts: []
   env: []
   extraEnvFrom: []
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: null
-
 # -- Cache for admin bucket.
 # If this is disabled, in-memory cache will be set by default.
 # You can use Redis too for cache and set the configuration via structuredConfig.
@@ -4486,9 +4427,6 @@ graphite:
 
     env: []
     extraEnvFrom: []
-    # -- Jaeger reporter queue size
-    # Set to 'null' to use the Jaeger client's default value
-    jaegerReporterMaxQueueSize: null
     tolerations: []
     podDisruptionBudget:
       maxUnavailable: 1
@@ -4569,9 +4507,6 @@ graphite:
     terminationGracePeriodSeconds: 180
     env: []
     extraEnvFrom: []
-    # -- Jaeger reporter queue size
-    # Set to 'null' to use the Jaeger client's default value
-    jaegerReporterMaxQueueSize: null
     tolerations: []
     podDisruptionBudget:
       maxUnavailable: 1
@@ -4808,10 +4743,6 @@ federation_frontend:
   podDisruptionBudget:
     maxUnavailable: 1
 
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: null
-
 # -- Settings for the smoke-test job. This is meant to run as a Helm test hook
 # (`helm test RELEASE`) after installing the chart. It quickly verifies
 # that writing and reading metrics works. Currently not supported for
@@ -4892,9 +4823,6 @@ continuous_test:
   extraArgs: {}
   # -- Extra environment from secret/configmap for continuous test containers
   extraEnvFrom: []
-  # -- Jaeger reporter queue size
-  # Set to 'null' to use the Jaeger client's default value
-  jaegerReporterMaxQueueSize: null
   # -- Extra volumes for the continuous test container
   extraVolumes: []
   # -- Extra volume mounts for the continuous test container

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -105,8 +105,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -142,12 +142,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -292,12 +286,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -442,9 +430,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -142,6 +142,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -286,6 +289,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -430,3 +436,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -97,8 +97,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -93,9 +93,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -95,9 +95,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -147,8 +147,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -298,8 +296,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -449,5 +445,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -100,8 +100,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -133,6 +133,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -268,6 +271,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -403,3 +409,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -133,12 +133,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -274,12 +268,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -415,9 +403,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -92,8 +92,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -90,9 +90,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -138,8 +138,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -280,8 +278,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -422,5 +418,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,6 +128,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,6 +261,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -388,3 +394,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,12 +128,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -264,12 +258,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -400,9 +388,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -133,8 +133,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -270,8 +268,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -407,5 +403,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -100,8 +100,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -126,3 +126,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -126,9 +126,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -92,8 +92,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -90,9 +90,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -129,5 +129,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -96,8 +96,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,6 +128,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,6 +261,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -388,3 +394,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,12 +128,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -264,12 +258,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -400,9 +388,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -88,8 +88,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -84,9 +84,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -87,9 +87,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -133,8 +133,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -270,8 +268,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -407,5 +403,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -96,8 +96,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,6 +128,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,6 +261,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -388,3 +394,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,12 +128,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -264,12 +258,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -400,9 +388,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -88,8 +88,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -84,9 +84,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -87,9 +87,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -133,8 +133,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -270,8 +268,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -407,5 +403,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,6 +128,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,6 +261,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -388,3 +394,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,12 +128,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -264,12 +258,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -400,9 +388,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
@@ -92,8 +92,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
           envFrom:
       topologySpreadConstraints:
       - maxSkew: 1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
@@ -89,8 +89,6 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
           envFrom:
       topologySpreadConstraints:
       - maxSkew: 1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -133,8 +133,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -270,8 +268,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -407,5 +403,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -100,8 +100,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -144,12 +144,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -296,12 +290,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -448,9 +436,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -144,6 +144,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "8"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -290,6 +293,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "8"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -436,3 +442,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "8"

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -92,8 +92,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "6"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -90,9 +90,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -149,8 +149,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "6442450944"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -302,8 +300,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "6442450944"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -455,5 +451,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "6442450944"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -121,3 +121,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -121,9 +121,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -124,5 +124,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -97,8 +97,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -130,12 +130,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -268,12 +262,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -406,9 +394,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -130,6 +130,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -262,6 +265,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -394,3 +400,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -89,8 +89,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -85,9 +85,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -87,9 +87,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -135,8 +135,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -274,8 +272,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -413,5 +409,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -129,12 +129,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -266,12 +260,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -403,9 +391,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -129,6 +129,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -260,6 +263,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -391,3 +397,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -134,8 +134,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -272,8 +270,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -410,5 +406,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -100,8 +100,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -144,12 +144,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -296,12 +290,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -448,9 +436,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -144,6 +144,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "8"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -290,6 +293,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "8"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -436,3 +442,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "8"

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -92,8 +92,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "6"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -90,9 +90,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -149,8 +149,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "1610612736"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -302,8 +300,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "1610612736"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -455,5 +451,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "1610612736"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -101,8 +101,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -134,12 +134,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -276,12 +270,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -418,9 +406,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -134,6 +134,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -270,6 +273,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -406,3 +412,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -93,8 +93,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -89,9 +89,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -91,9 +91,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -139,8 +139,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -282,8 +280,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -425,5 +421,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -101,8 +101,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -116,9 +116,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -87,9 +87,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -91,9 +91,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -114,9 +114,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -100,8 +100,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -133,6 +133,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -268,6 +271,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -403,3 +409,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -133,12 +133,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -274,12 +268,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -415,9 +403,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -92,8 +92,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -90,9 +90,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -138,8 +138,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -280,8 +278,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -422,5 +418,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -97,8 +97,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -125,6 +125,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -252,6 +255,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -379,3 +385,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -125,12 +125,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,12 +252,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -391,9 +379,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -89,8 +89,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -87,9 +87,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -130,8 +130,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -264,8 +262,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -398,5 +394,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -100,8 +100,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -130,12 +130,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -268,12 +262,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -406,9 +394,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -130,6 +130,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -262,6 +265,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -394,3 +400,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -92,8 +92,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -90,9 +90,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -135,8 +135,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -274,8 +272,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -413,5 +409,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -105,8 +105,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,6 +128,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,6 +261,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -388,3 +394,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,12 +128,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -264,12 +258,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -400,9 +388,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -93,9 +93,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -95,9 +95,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -140,8 +140,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -284,8 +282,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -428,5 +424,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,6 +128,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,6 +261,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -388,3 +394,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,12 +128,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -264,12 +258,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -400,9 +388,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -133,8 +133,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -270,8 +268,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -407,5 +403,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,6 +128,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,6 +261,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -388,3 +394,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,12 +128,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -264,12 +258,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -400,9 +388,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -133,8 +133,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -270,8 +268,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -407,5 +403,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -99,8 +99,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -129,12 +129,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -266,12 +260,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -403,9 +391,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -129,6 +129,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -260,6 +263,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -391,3 +397,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -91,8 +91,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -87,9 +87,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -89,9 +89,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -134,8 +134,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -272,8 +270,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -410,5 +406,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,6 +128,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,6 +261,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -388,3 +394,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,12 +128,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -264,12 +258,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -400,9 +388,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -133,8 +133,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -270,8 +268,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -407,5 +403,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -117,9 +117,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -239,9 +236,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -361,6 +355,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -85,9 +85,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -84,9 +84,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -117,9 +117,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -239,9 +236,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -361,6 +355,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -151,6 +151,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -304,6 +307,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -457,3 +463,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -151,12 +151,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -310,12 +304,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -469,9 +457,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -149,8 +149,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -302,8 +300,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -455,5 +451,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -100,8 +100,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -149,6 +149,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -300,6 +303,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -451,3 +457,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -149,12 +149,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -306,12 +300,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -463,9 +451,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -92,8 +92,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -90,9 +90,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -143,8 +143,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -290,8 +288,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -437,5 +433,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -99,8 +99,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -111,9 +111,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -85,9 +85,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -89,9 +89,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -109,9 +109,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
           envFrom:
             - secretRef:
                 name: mimir-minio-secret

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,6 +128,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,6 +261,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -388,3 +394,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,12 +128,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -264,12 +258,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -400,9 +388,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -133,8 +133,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "100000000"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -270,8 +268,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "100000000"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -407,5 +403,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "100000000"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -98,8 +98,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,6 +128,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -258,6 +261,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -388,3 +394,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -128,12 +128,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -264,12 +258,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -400,9 +388,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -90,8 +90,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -86,9 +86,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
@@ -92,8 +92,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
           envFrom:
       topologySpreadConstraints:
       - maxSkew: 1

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
@@ -89,8 +89,6 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
           envFrom:
       topologySpreadConstraints:
       - maxSkew: 1

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -88,9 +88,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -133,8 +133,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -270,8 +268,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -407,5 +403,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -105,8 +105,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "8"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -135,12 +135,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -278,12 +272,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -421,9 +409,3 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            
-            - name: "GOMAXPROCS"
-              value: "4"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -135,6 +135,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -272,6 +275,9 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"
 ---
 # Source: mimir-distributed/templates/ingester/ingester-statefulset.yaml
 apiVersion: apps/v1
@@ -409,3 +415,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
+          env:
+            - name: "GOMAXPROCS"
+              value: "4"

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -97,8 +97,6 @@ spec:
           env:
             - name: "GOMAXPROCS"
               value: "5"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -93,9 +93,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "5000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -95,9 +95,6 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          env:
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -140,8 +140,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -284,8 +282,6 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"
 ---
 # Source: mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
 apiVersion: apps/v1
@@ -428,5 +424,3 @@ spec:
               value: "5"
             - name: "GOMEMLIMIT"
               value: "536870912"
-            - name: "JAEGER_REPORTER_MAX_QUEUE_SIZE"
-              value: "1000"

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -629,8 +627,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -709,9 +705,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -875,9 +868,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1164,8 +1154,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1501,8 +1489,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -629,8 +627,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -709,9 +705,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -875,9 +868,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1164,8 +1154,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1501,8 +1489,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
@@ -541,8 +541,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -638,8 +636,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -718,9 +714,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -884,9 +877,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1173,8 +1163,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1510,8 +1498,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -629,8 +627,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -709,9 +705,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -875,9 +868,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1166,8 +1156,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1503,8 +1491,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-chunk-streaming-generated.yaml
@@ -533,8 +533,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -630,8 +628,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -710,9 +706,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -876,9 +869,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1165,8 +1155,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1502,8 +1490,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-all-components-without-pod-topology-constraints-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-pod-topology-constraints-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -622,8 +620,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -695,9 +691,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -854,9 +847,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1136,8 +1126,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1473,8 +1461,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -717,8 +717,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -816,8 +814,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -896,9 +892,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1110,9 +1103,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1416,8 +1406,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1544,8 +1532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1672,8 +1658,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2027,8 +2011,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2170,8 +2152,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2313,8 +2293,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -776,8 +776,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -875,8 +873,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -955,9 +951,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1169,9 +1162,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1479,8 +1469,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1612,8 +1600,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1745,8 +1731,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2100,8 +2084,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2243,8 +2225,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2386,8 +2366,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -648,8 +648,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -744,8 +742,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -823,9 +819,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -990,9 +983,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1083,9 +1073,7 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1167,9 +1155,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1519,8 +1504,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1856,8 +1839,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -648,8 +648,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -744,8 +742,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -823,9 +819,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -990,9 +983,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1083,9 +1073,7 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1167,9 +1155,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1519,8 +1504,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1856,8 +1839,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -539,8 +539,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -636,8 +634,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -716,9 +712,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1031,8 +1024,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1368,8 +1359,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -539,8 +539,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -636,8 +634,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -716,9 +712,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1031,8 +1024,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1368,8 +1359,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -920,8 +920,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1014,8 +1012,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1092,9 +1088,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1258,9 +1251,6 @@ spec:
         - -store-gateway.sharding-ring.store=consul
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1537,8 +1527,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1870,8 +1858,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1093,8 +1093,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1189,8 +1187,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1267,9 +1263,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1481,9 +1474,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1773,8 +1763,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1893,8 +1881,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2013,8 +1999,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2359,8 +2343,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2493,8 +2475,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2627,8 +2607,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -889,8 +889,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -983,8 +981,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1061,9 +1057,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1404,8 +1397,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1737,8 +1728,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -520,8 +520,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -617,8 +615,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -697,9 +693,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -961,8 +954,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1298,8 +1289,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -466,8 +466,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -563,8 +561,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -643,9 +639,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -907,8 +900,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1244,8 +1235,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
+++ b/operations/mimir-tests/test-deployment-mode-migration-generated.yaml
@@ -989,8 +989,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1100,9 +1098,7 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=read
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-read
@@ -1202,8 +1198,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1287,9 +1281,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1511,9 +1502,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1813,8 +1801,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1937,8 +1923,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2061,8 +2045,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2465,9 +2447,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -2658,9 +2637,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -2851,9 +2827,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -2988,9 +2961,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write
@@ -3125,9 +3095,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write
@@ -3262,9 +3229,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write
@@ -3401,8 +3365,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3539,8 +3501,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3677,8 +3637,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -629,8 +627,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -709,9 +705,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -875,9 +868,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1168,8 +1158,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1507,8 +1495,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: 2Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -466,8 +466,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -563,8 +561,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -643,9 +639,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -907,8 +900,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1244,8 +1235,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -540,8 +540,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -642,8 +640,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -727,9 +723,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -903,9 +896,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1207,8 +1197,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1549,8 +1537,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -572,8 +572,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -728,8 +726,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -811,9 +807,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -976,9 +969,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1271,8 +1261,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1608,8 +1596,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "536870912"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -901,8 +901,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1008,8 +1006,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1095,9 +1091,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1326,9 +1319,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1430,9 +1420,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1522,9 +1510,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1925,8 +1910,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2067,8 +2050,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2207,8 +2188,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2564,8 +2543,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2711,8 +2688,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2856,8 +2831,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -901,8 +901,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1008,8 +1006,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1095,9 +1091,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1326,9 +1319,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1430,9 +1420,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1522,9 +1510,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1925,8 +1910,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2067,8 +2050,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2207,8 +2188,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2564,8 +2543,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2711,8 +2688,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2856,8 +2831,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -901,8 +901,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1008,8 +1006,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1095,9 +1091,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1326,9 +1319,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1430,9 +1420,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1522,9 +1510,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1925,8 +1910,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2067,8 +2050,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2207,8 +2188,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2564,8 +2543,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2711,8 +2688,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2856,8 +2831,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -835,8 +835,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -936,8 +934,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1017,9 +1013,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1237,9 +1230,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1335,9 +1325,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1421,9 +1409,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1799,8 +1784,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -1932,8 +1915,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2063,8 +2044,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2416,8 +2395,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2559,8 +2536,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2700,8 +2675,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -905,8 +905,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1007,8 +1005,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1088,9 +1084,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1309,9 +1302,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1408,9 +1398,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1494,9 +1482,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1873,8 +1858,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2022,8 +2005,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2156,8 +2137,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2299,8 +2278,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2431,8 +2408,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2574,8 +2549,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2927,8 +2900,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3070,8 +3041,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3211,8 +3180,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -878,8 +878,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -985,8 +983,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1072,9 +1068,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1303,9 +1296,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1407,9 +1397,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1499,9 +1487,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1898,8 +1883,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2040,8 +2023,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2397,8 +2378,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2544,8 +2523,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2689,8 +2666,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -878,8 +878,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -985,8 +983,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1072,9 +1068,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1303,9 +1296,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1407,9 +1397,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1499,9 +1487,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1902,8 +1887,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2044,8 +2027,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2401,8 +2382,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2548,8 +2527,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2693,8 +2670,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -912,8 +912,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1014,8 +1012,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1095,9 +1091,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1322,9 +1315,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1421,9 +1411,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1507,9 +1495,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1886,8 +1871,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2035,8 +2018,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2169,8 +2150,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2312,8 +2291,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2444,8 +2421,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2587,8 +2562,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2940,8 +2913,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3083,8 +3054,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3224,8 +3193,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -912,8 +912,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1019,8 +1017,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1106,9 +1102,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1333,9 +1326,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1437,9 +1427,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1529,9 +1517,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1908,8 +1893,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2057,8 +2040,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2191,8 +2172,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2334,8 +2313,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2466,8 +2443,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2609,8 +2584,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2962,8 +2935,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3105,8 +3076,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3246,8 +3215,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -911,8 +911,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1018,8 +1016,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1105,9 +1101,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1331,9 +1324,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1435,9 +1425,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1527,9 +1515,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1906,8 +1891,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2055,8 +2038,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2189,8 +2170,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2332,8 +2311,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2464,8 +2441,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2607,8 +2582,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2960,8 +2933,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3103,8 +3074,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3244,8 +3213,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -911,8 +911,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1018,8 +1016,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1105,9 +1101,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1331,9 +1324,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1435,9 +1425,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1527,9 +1515,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1906,8 +1891,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2055,8 +2038,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2189,8 +2170,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2332,8 +2311,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2464,8 +2441,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2607,8 +2582,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2960,8 +2933,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3103,8 +3074,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3244,8 +3213,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -911,8 +911,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1018,8 +1016,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1105,9 +1101,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1331,9 +1324,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1435,9 +1425,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1527,9 +1515,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1906,8 +1891,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2055,8 +2038,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2189,8 +2170,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2332,8 +2311,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2464,8 +2441,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2607,8 +2582,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2960,8 +2933,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3103,8 +3074,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -3244,8 +3213,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -842,8 +842,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -949,8 +947,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1036,9 +1032,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1262,9 +1255,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1366,9 +1356,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1458,9 +1446,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1848,8 +1833,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -1993,8 +1976,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2136,8 +2117,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2489,8 +2468,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2632,8 +2609,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2773,8 +2748,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -842,8 +842,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -949,8 +947,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1036,9 +1032,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1267,9 +1260,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1371,9 +1361,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1463,9 +1451,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1865,8 +1850,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2010,8 +1993,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2153,8 +2134,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2510,8 +2489,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2657,8 +2634,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2802,8 +2777,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -842,8 +842,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -949,8 +947,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1036,9 +1032,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1267,9 +1260,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1371,9 +1361,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1463,9 +1451,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1865,8 +1850,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2010,8 +1993,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2153,8 +2134,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2510,8 +2489,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2657,8 +2634,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2802,8 +2777,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -819,8 +819,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -926,8 +924,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1013,9 +1009,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1244,9 +1237,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1348,9 +1338,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1440,9 +1428,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1839,8 +1824,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -1981,8 +1964,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2338,8 +2319,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2485,8 +2464,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2630,8 +2607,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -901,8 +901,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1008,8 +1006,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1095,9 +1091,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1326,9 +1319,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1430,9 +1420,7 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1522,9 +1510,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1925,8 +1910,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -2067,8 +2050,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2207,8 +2188,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2564,8 +2543,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2711,8 +2688,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2856,8 +2831,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -629,8 +627,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -709,9 +705,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -875,9 +868,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1164,8 +1154,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1501,8 +1489,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -533,8 +533,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -631,8 +629,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -711,9 +707,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -878,9 +871,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1170,8 +1160,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1508,8 +1496,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -534,8 +534,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -633,8 +631,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -713,9 +709,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -881,9 +874,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1176,8 +1166,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1515,8 +1503,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -533,8 +533,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -631,8 +629,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -711,9 +707,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -878,9 +871,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1170,8 +1160,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1508,8 +1496,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -920,8 +920,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1014,8 +1012,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1092,9 +1088,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1258,9 +1251,6 @@ spec:
         - -store-gateway.sharding-ring.store=consul
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1537,8 +1527,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1870,8 +1858,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -964,8 +964,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1067,8 +1065,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1147,9 +1143,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1322,9 +1315,6 @@ spec:
         - -store-gateway.sharding-ring.store=multi
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1620,8 +1610,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1960,8 +1948,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -964,8 +964,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1067,8 +1065,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1147,9 +1143,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1322,9 +1315,6 @@ spec:
         - -store-gateway.sharding-ring.store=multi
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1620,8 +1610,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1960,8 +1948,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -964,8 +964,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1067,8 +1065,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1147,9 +1143,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1322,9 +1315,6 @@ spec:
         - -store-gateway.sharding-ring.store=multi
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1620,8 +1610,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1960,8 +1948,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -964,8 +964,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1067,8 +1065,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1147,9 +1143,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1322,9 +1315,6 @@ spec:
         - -store-gateway.sharding-ring.store=multi
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1620,8 +1610,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1960,8 +1948,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -535,8 +535,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -632,8 +630,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -712,9 +708,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -878,9 +871,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1167,8 +1157,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1504,8 +1492,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -629,8 +627,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -709,9 +705,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -875,9 +868,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1164,8 +1154,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1501,8 +1489,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-memcached-mtls-generated.yaml
+++ b/operations/mimir-tests/test-memcached-mtls-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -635,8 +633,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -739,9 +735,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -935,9 +928,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1224,8 +1214,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1671,8 +1659,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
@@ -760,8 +760,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -870,8 +868,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -974,8 +970,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1054,9 +1048,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1268,9 +1259,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1576,8 +1564,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -1704,8 +1690,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1830,8 +1814,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2182,8 +2164,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2324,8 +2304,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2464,8 +2442,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
@@ -717,8 +717,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -816,8 +814,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -896,9 +892,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1110,9 +1103,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1418,8 +1408,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -1546,8 +1534,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1672,8 +1658,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2024,8 +2008,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2166,8 +2148,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2306,8 +2286,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -717,8 +717,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -816,8 +814,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -896,9 +892,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1110,9 +1103,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1418,8 +1408,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -1546,8 +1534,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1672,8 +1658,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2024,8 +2008,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2166,8 +2148,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2306,8 +2286,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -785,8 +785,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -884,8 +882,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -964,9 +960,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1178,9 +1171,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1467,8 +1457,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1591,8 +1579,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1715,8 +1701,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1839,8 +1823,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2176,8 +2158,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2314,8 +2294,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2452,8 +2430,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2590,8 +2566,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -794,8 +794,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -893,8 +891,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -973,9 +969,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1190,9 +1183,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1498,8 +1488,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -1626,8 +1614,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1752,8 +1738,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2109,8 +2093,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2256,8 +2238,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2401,8 +2381,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -466,8 +466,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -563,8 +561,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -643,9 +639,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -907,8 +900,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1244,8 +1235,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
+++ b/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
@@ -480,8 +480,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -593,8 +591,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -689,9 +685,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -999,8 +992,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1359,8 +1350,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -651,8 +651,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -750,8 +748,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -830,9 +826,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1157,8 +1150,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1283,8 +1274,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1409,8 +1398,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1761,8 +1748,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -1901,8 +1886,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2041,8 +2024,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -920,8 +920,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1017,8 +1015,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1098,9 +1094,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1268,9 +1261,6 @@ spec:
         - -store-gateway.sharding-ring.store=consul
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1547,8 +1537,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1880,8 +1868,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -667,8 +667,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -767,8 +765,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -852,9 +848,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1031,9 +1024,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1128,9 +1118,7 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1218,9 +1206,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1584,8 +1569,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1922,8 +1905,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -541,8 +541,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -641,8 +639,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -726,9 +722,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -903,9 +896,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1195,8 +1185,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1533,8 +1521,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -538,8 +538,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -636,8 +634,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -716,9 +712,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -891,9 +884,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1183,8 +1173,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1521,8 +1509,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -629,8 +627,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -714,9 +710,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -880,9 +873,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1169,8 +1159,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1506,8 +1494,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-autoscaled-generated.yaml
@@ -562,9 +562,7 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=read
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-read
@@ -1003,9 +1001,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -1197,9 +1192,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -1391,9 +1383,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -1529,9 +1518,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write
@@ -1667,9 +1653,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write
@@ -1805,9 +1788,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-caches-disabled-generated.yaml
@@ -425,9 +425,7 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=read
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-read
@@ -629,9 +627,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -798,9 +793,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -967,9 +959,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -1105,9 +1094,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write
@@ -1243,9 +1229,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write
@@ -1381,9 +1364,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write

--- a/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
+++ b/operations/mimir-tests/test-read-write-deployment-mode-s3-generated.yaml
@@ -563,9 +563,7 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=read
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-read
@@ -1004,9 +1002,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -1198,9 +1193,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -1392,9 +1384,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=backend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-backend
@@ -1530,9 +1519,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write
@@ -1668,9 +1654,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write
@@ -1806,9 +1789,6 @@ spec:
         - -shutdown-delay=90s
         - -target=write
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir-write

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -649,8 +649,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -746,8 +744,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -826,9 +822,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -994,9 +987,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1088,9 +1078,7 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1173,9 +1161,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1526,8 +1511,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1863,8 +1846,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -649,8 +649,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -746,8 +744,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -826,9 +822,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -992,9 +985,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1086,9 +1076,7 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=querier
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
+        env: []
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-querier
@@ -1171,9 +1159,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler-query-frontend
@@ -1524,8 +1509,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1861,8 +1844,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -533,8 +533,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -632,8 +630,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -713,9 +709,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -883,9 +876,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1173,8 +1163,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1511,8 +1499,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
@@ -534,8 +534,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -634,8 +632,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -715,9 +711,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -886,9 +879,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1177,8 +1167,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1515,8 +1503,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -533,8 +533,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -632,8 +630,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -713,9 +709,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -884,9 +877,6 @@ spec:
         - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1174,8 +1164,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1512,8 +1500,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
+++ b/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
@@ -786,8 +786,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -891,8 +889,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1001,8 +997,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -1105,8 +1099,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -1185,9 +1177,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -1399,9 +1388,6 @@ spec:
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1707,8 +1693,6 @@ spec:
           value: "9"
         - name: GOMEMLIMIT
           value: 1Gi
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         - name: Z
           value: "123"
         image: grafana/mimir:2.16.0
@@ -1835,8 +1819,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1961,8 +1943,6 @@ spec:
           value: all-ingesters
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -2313,8 +2293,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2455,8 +2433,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway
@@ -2595,8 +2571,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -631,8 +629,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -711,9 +707,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -879,9 +872,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1174,8 +1164,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1513,8 +1501,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -629,8 +627,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -709,9 +705,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -875,9 +868,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1164,8 +1154,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1501,8 +1489,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -532,8 +532,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -630,8 +628,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -710,9 +706,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -877,9 +870,6 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ruler
@@ -1169,8 +1159,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1507,8 +1495,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir-tests/test-without-query-scheduler-generated.yaml
+++ b/operations/mimir-tests/test-without-query-scheduler-generated.yaml
@@ -435,8 +435,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "8"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: distributor
@@ -532,8 +530,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "5"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: querier
@@ -611,9 +607,6 @@ spec:
         - -shutdown-delay=90s
         - -target=query-frontend
         - -usage-stats.installation-mode=jsonnet
-        env:
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "5000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: query-frontend
@@ -810,8 +803,6 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "9"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: ingester
@@ -1147,8 +1138,6 @@ spec:
           value: "5"
         - name: GOMEMLIMIT
           value: "12884901888"
-        - name: JAEGER_REPORTER_MAX_QUEUE_SIZE
-          value: "1000"
         image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: store-gateway

--- a/operations/mimir/distributor.libsonnet
+++ b/operations/mimir/distributor.libsonnet
@@ -63,7 +63,6 @@
         ),
       )
     ),
-    JAEGER_REPORTER_MAX_QUEUE_SIZE: std.toString(1000),
   },
 
   distributor_node_affinity_matchers:: [],

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -55,8 +55,6 @@
   local name = 'ingester',
 
   ingester_env_map:: {
-    JAEGER_REPORTER_MAX_QUEUE_SIZE: '1000',
-
     local requests = $.util.parseCPU($.ingester_container.resources.requests.cpu),
     local requestsWithHeadroom = std.ceil(
       // double the requests, but with headroom of at least 3 and at most 6 CPU

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -47,8 +47,6 @@
     $.util.resourcesLimits(null, '24Gi'),
 
   querier_env_map:: {
-    JAEGER_REPORTER_MAX_QUEUE_SIZE: '5000',
-
     // Dynamically set GOMAXPROCS based on CPU request.
     GOMAXPROCS: std.toString(
       std.ceil(

--- a/operations/mimir/query-frontend.libsonnet
+++ b/operations/mimir/query-frontend.libsonnet
@@ -41,9 +41,7 @@
     $.util.resourcesRequests('2', '600Mi') +
     $.util.resourcesLimits(null, '1200Mi'),
 
-  query_frontend_env_map:: {
-    JAEGER_REPORTER_MAX_QUEUE_SIZE: '5000',
-  },
+  query_frontend_env_map:: {},
 
   query_frontend_node_affinity_matchers:: [],
 

--- a/operations/mimir/read-write-deployment/backend.libsonnet
+++ b/operations/mimir/read-write-deployment/backend.libsonnet
@@ -62,10 +62,7 @@
     $.util.resourcesRequests(1, '12Gi') +
     $.util.resourcesLimits(null, '18Gi') +
     $.util.readinessProbe +
-    $.jaeger_mixin +
-    container.withEnvMixin([
-      envVar.new('JAEGER_REPORTER_MAX_QUEUE_SIZE', '1000'),
-    ]),
+    $.jaeger_mixin,
 
   local mimir_backend_data_pvc =
     pvc.new() +

--- a/operations/mimir/read-write-deployment/write.libsonnet
+++ b/operations/mimir/read-write-deployment/write.libsonnet
@@ -54,10 +54,7 @@
     $.core.v1.container.withVolumeMountsMixin([
       volumeMount.new('mimir-write-data', '/data'),
     ]) +
-    $.jaeger_mixin +
-    container.withEnvMixin([
-      envVar.new('JAEGER_REPORTER_MAX_QUEUE_SIZE', '1000'),
-    ]),
+    $.jaeger_mixin,
 
   local mimir_write_data_pvc =
     pvc.new() +

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -39,9 +39,7 @@
       'ingest-storage.kafka.producer-max-buffered-bytes': std.clamp(10 * $._config.ruler_remote_evaluation_max_query_response_size_bytes, 1024 * 1024 * 1024, 4 * 1024 * 1024 * 1024),
     } else {},
 
-  ruler_env_map:: {
-    JAEGER_REPORTER_MAX_QUEUE_SIZE: '1000',
-  },
+  ruler_env_map:: {},
 
   ruler_node_affinity_matchers:: [],
 

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -59,8 +59,6 @@
     ),
     // Dynamically set GOMEMLIMIT based on memory request.
     GOMEMLIMIT: std.toString(std.floor($.util.siToBytes($.store_gateway_container.resources.requests.memory))),
-
-    JAEGER_REPORTER_MAX_QUEUE_SIZE: '1000',
   },
 
   store_gateway_node_affinity_matchers:: [],


### PR DESCRIPTION
#### What this PR does

This removes the configuration of `JAEGER_REPORTER_MAX_QUEUE_SIZE` from both Helm & Jsonnet operations.

When [we switched the tracing library to opentelemetry](https://github.com/grafana/mimir/pull/11249) we've lost support for the `JAEGER_REPORTER_MAX_QUEUE_SIZE` environment variable.

This queue size was 100 by default in Jaeger lib, but OpenTelemetry sets the default of 2048 which is higher than most of the overrides we have in the operations config, except for queriers that set it to 5000.

Even though we're bringing that env var back in https://github.com/grafana/mimir/pull/11698 just for compatibility, it's a good moment to reduce the configuration amount and just stick to sensible defaults. Users can still configure this on their own using this deprecated env var or refering to the [standard OTel env vars config](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor) and using `OTEL_BSP_MAX_QUEUE_SIZE`.

#### Which issue(s) this PR fixes or relates to

Ref: https://github.com/grafana/mimir/issues/2708

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
