### PR TITLE
Tracing docs: fix OTLP endpoints examples

### DIFF
--- a/docs/sources/mimir/configure/configure-tracing.md
+++ b/docs/sources/mimir/configure/configure-tracing.md
@@ -39,8 +39,8 @@ To configure Grafana Mimir with OpenTelemetry format tracing, set any of the fol
 
 OpenTelemetry configuration follows the standard documentation from [OpenTelemetry SDK Configuration](https://opentelemetry.io/docs/languages/sdk-configuration/general/).
 
-- `OTEL_EXPORTER_OTLP_ENDPOINT`: The OTLP endpoint URL. For example, `http://tempo:4318/v1/traces`.
-- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`: The OTLP traces-specific endpoint URL. This value overrides the previous variable.
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: The OTLP endpoint URL. For example, `http://tempo:4318`.
+- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`: The OTLP traces-specific endpoint URL. This value overrides the previous variable. For example, `http://tempo:4318/v1/traces`.
 - `OTEL_TRACES_EXPORTER`: The traces exporter to use. Default: `otlp`.
 - `OTEL_TRACES_SAMPLER`: The sampling strategy to use.
 


### PR DESCRIPTION
#### What this PR does

Fixes the example OTLP endpoints in the docs as pointed out by @cyrille-leclerc . See [the official docs](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) for references.

#### Which issue(s) this PR fixes or relates to

Ref: https://github.com/grafana/mimir/issues/2708

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
