### PR TITLE
Fix retries panel unit from milliseconds to short

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -11820,7 +11820,7 @@ data:
                                "mode": "absolute",
                                "steps": [ ]
                             },
-                            "unit": "ms"
+                            "unit": "short"
                          },
                          "overrides": [ ]
                       },
@@ -11861,7 +11861,7 @@ data:
                       "type": "timeseries",
                       "yaxes": [
                          {
-                            "format": "short",
+                            "format": "ms",
                             "label": null,
                             "logBase": 1,
                             "max": null,

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -135,7 +135,7 @@
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "ms"
+                        "unit": "short"
                      },
                      "overrides": [ ]
                   },
@@ -176,7 +176,7 @@
                   "type": "timeseries",
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "ms",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-queries.json
@@ -197,7 +197,7 @@
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "ms"
+                        "unit": "short"
                      },
                      "overrides": [ ]
                   },
@@ -238,7 +238,7 @@
                   "type": "timeseries",
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "ms",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -135,7 +135,7 @@
                            "mode": "absolute",
                            "steps": [ ]
                         },
-                        "unit": "ms"
+                        "unit": "short"
                      },
                      "overrides": [ ]
                   },
@@ -176,7 +176,7 @@
                   "type": "timeseries",
                   "yaxes": [
                      {
-                        "format": "short",
+                        "format": "ms",
                         "label": null,
                         "logBase": 1,
                         "max": null,

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -46,7 +46,7 @@ local filename = 'mimir-queries.json';
       .addPanel(
         $.timeseriesPanel('Retries') +
         $.latencyPanel('cortex_query_frontend_retries', '{$read_path_matcher}', multiplier=1) +
-        { yaxes: $.yaxes('short') },
+        { fieldConfig+: { defaults+: { unit: 'short' } } },
       )
       .addPanel(
         $.timeseriesPanel('Queue length (per %s)' % $._config.per_instance_label) +


### PR DESCRIPTION
The retries panel in the mimir-queries dashboard was incorrectly showing units in milliseconds when it should show raw counts with short formatting.