### PR TITLE
operations: add mimir-github-bot codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,4 +34,4 @@ go.sum @stevesg @grafana/mimir-maintainers
 /vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers
 
 # Operations - allow mimir-github-bot to approve automated PRs
-/operations/helm/ @mimir-github-bot @grafana/mimir-maintainers
+/operations/helm/ @mimir-github-bot[bot] @grafana/mimir-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,3 +32,6 @@ go.sum @stevesg @grafana/mimir-maintainers
 /vendor/ @stevesg @grafana/mimir-maintainers
 /vendor/github.com/prometheus/alertmanager @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers
 /vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers
+
+# Operations - allow mimir-github-bot to approve automated PRs
+/operations/helm/ @mimir-github-bot @grafana/mimir-maintainers


### PR DESCRIPTION
#### What this PR does

The PR adds `mimir-github-bot` to the codeowners of the `/operations/helm/` tree. We want to allow the bot to approve the automated weekly PRs, like https://github.com/grafana/mimir/pull/11704