### PR TITLE
helm: don't require codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,6 +25,7 @@
 
 # No owners - allows sub-maintainers to merge changes.
 CHANGELOG.md
+/operations/helm/charts/
 
 # Dependencies
 go.mod @stevesg @grafana/mimir-maintainers
@@ -32,6 +33,3 @@ go.sum @stevesg @grafana/mimir-maintainers
 /vendor/ @stevesg @grafana/mimir-maintainers
 /vendor/github.com/prometheus/alertmanager @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers
 /vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers
-
-# Operations - allow mimir-github-bot to approve automated PRs
-/operations/helm/ @mimir-github-bot[bot] @grafana/mimir-maintainers


### PR DESCRIPTION
#### What this PR does

To help to automate the weekly releases (ref https://github.com/grafana/mimir/pull/11704) we want the bot user to be allowed to auto-merge the release PRs. It's turned out, this can't work with the "Require review from Code Owners" branch protection.

Note that GitHub currently doesn't allow adding bot users to the codeowners.

In order to bypass the problem, I propose we unassign the codeowners from the Helm chart. Any PR opened against the chart's code will still require a code review from the staff.