### PR TITLE
actions: split unit tests by test name instead of package

### DIFF
--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -40,11 +40,18 @@ fi
 ALL_TESTS=$(go test "${MIMIR_DIR}/..." -list 'Test.*' | grep '^Test' | sort)
 
 # Filter tests by the requested group.
-GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL=$TOTAL -v INDEX=$INDEX 'NR % TOTAL == INDEX' | tr '\n' '|')
+GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL=$TOTAL -v INDEX=$INDEX 'NR % TOTAL == INDEX')
 
 echo "This group will run the following tests:"
 echo "$GROUP_TESTS"
 echo ""
 
+# Build the regex used to run this group's tests.
+REGEX="^("
+for TEST in $GROUP_TESTS; do
+  REGEX="${REGEX}|${TEST}"
+done
+REGEX="${REGEX})$"
+
 # shellcheck disable=SC2086 # we *want* word splitting of GROUP_TESTS.
-exec go test -tags=netgo,stringlabels -timeout 30m -race -count 1 -run ${GROUP_TESTS} ./...
+exec go test -tags=netgo,stringlabels -timeout 30m -race -count 1 -run ${REGEX} ./...

--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -37,14 +37,14 @@ if [[ -z "$TOTAL" ]]; then
 fi
 
 # List all tests.
-ALL_TESTS=$(go list "${MIMIR_DIR}/..." | sort)
+ALL_TESTS=$(go test "${MIMIR_DIR}/..." -list 'Test.*' | grep '^Test' | sort)
 
 # Filter tests by the requested group.
-GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL=$TOTAL -v INDEX=$INDEX 'NR % TOTAL == INDEX')
+GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL=$TOTAL -v INDEX=$INDEX 'NR % TOTAL == INDEX' | tr '\n' '|')
 
 echo "This group will run the following tests:"
 echo "$GROUP_TESTS"
 echo ""
 
 # shellcheck disable=SC2086 # we *want* word splitting of GROUP_TESTS.
-exec go test -tags=netgo,stringlabels -timeout 30m -race -count 1 ${GROUP_TESTS}
+exec go test -tags=netgo,stringlabels -timeout 30m -race -count 1 -run ${GROUP_TESTS} ./...


### PR DESCRIPTION
I found this out while working on https://github.com/grafana/mimir/pull/11675

the streamingpromql and streamingpromql/benchmarks packages are by far the largest test package taking 14-17m to run each (kudos @charleskorn  @lamida  @jhesketh). So splitting the test packages further doesn't yield any results (some of the other test groups finish in 2-3 minutes)

Because of think I think we can split the test groups by test name instead of by package. This involves a somewhat expensive step - `go test -list`, which takes about 1m on my machine because it needs to compile every package separately. But this brings down the execution from 19m to **TODO**


<details><summary>Before</summary>
<p>

<img width="1367" alt="Screenshot 2025-06-11 at 17 40 49" src="https://github.com/user-attachments/assets/92ed921c-855a-45a2-b08d-768af719c387" />
<img width="1381" alt="Screenshot 2025-06-11 at 17 40 57" src="https://github.com/user-attachments/assets/2eb50707-16f1-467f-aa6f-804cd9f2f863" />
<img width="1381" alt="Screenshot 2025-06-11 at 17 41 03" src="https://github.com/user-attachments/assets/05eabd5d-8caa-49a9-980e-49c13662bbc8" />
<img width="1381" alt="Screenshot 2025-06-11 at 17 41 15" src="https://github.com/user-attachments/assets/8899c2da-9c58-499d-98e6-46b38f63eba3" />


</p>
</details> 


<details><summary>After</summary>
<p>

TODO

</p>
</details> 

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
