### PR TITLE
Don't emit unnecessary "Ingester.QueryStream" trace spans

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2203,7 +2203,8 @@ const queryStreamBatchMessageSize = 1 * 1024 * 1024
 func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_QueryStreamServer) (err error) {
 	defer func() { err = i.mapReadErrorToErrorWithStatus(err) }()
 
-	spanlog, ctx := spanlogger.New(stream.Context(), i.logger, tracer, "Ingester.QueryStream")
+	ctx := stream.Context()
+	spanlog := spanlogger.FromContext(ctx, i.logger)
 	defer spanlog.Finish()
 
 	userID, err := tenant.TenantID(ctx)


### PR DESCRIPTION
#### What this PR does

This PR improves the clarity of traces emitted during queries by removing unnecessary "Ingester.QueryStream" trace spans emitted by ingesters that are nested beneath "cortex.Ingester/QueryStream" trace spans also emitted by ingesters.

Instead, any events that were previously attached to the "Ingester.QueryStream" span are now attached to the "cortex.Ingester/QueryStream" span. 

The only major difference is that the list of tenant IDs will no longer be on a trace span emitted by ingesters, but this information is available on parent spans emitted by other components (eg. the "Distributor.queryIngesterStream" span emitted by queriers).

Before:

<img width="1672" alt="Screenshot 2025-06-12 at 2 39 13 pm" src="https://github.com/user-attachments/assets/655fbdf7-a64a-45c9-acc7-5530ae1ca20e" />


After:

<img width="1672" alt="Screenshot 2025-06-12 at 2 40 06 pm" src="https://github.com/user-attachments/assets/259130d4-66f7-43bb-8aa6-a9d7b80d7807" />


I haven't added a changelog entry given this is a minor change to tracing.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
