### PR TITLE
Distributor.prePushValidationMiddleware: Use safe strings for span event attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 * [ENHANCEMENT] Ingest-Storage: Add `ingest-storage.kafka.producer-record-version` to allow control Kafka record versioning. #11244
 * [ENHANCEMENT] Ruler: Update `<prometheus-http-prefix>/api/v1/rules` and `<prometheus-http-prefix>/api/v1/alerts` to reply with HTTP error 422 if rule evaluation is completely disabled for the tenant. If only recording rule or alerting rule evaluation is disabled for the tenant, the response now includes a corresponding warning. #11321 #11495 #11511
 * [ENHANCEMENT] Add tenant configuration block `ruler_alertmanager_client_config` which allows the Ruler's Alertmanager client options to be specified on a per-tenant basis. #10816
-* [ENHANCEMENT] Distributor: Trace when deduplicating a metric's samples or histograms. #11159
+* [ENHANCEMENT] Distributor: Trace when deduplicating a metric's samples or histograms. #11159 #11715
 * [ENHANCEMENT] Store-gateway: Retry querying blocks from store-gateways with dynamic replication until trying all possible store-gateways. #11354 #11398
 * [ENHANCEMENT] Query-frontend: Add optional reason to blocked_queries config. #11407 #11434
 * [ENHANCEMENT] Distributor: Gracefully handle type assertion of WatchPrefix in HA Tracker to continue checking for updates. #11411 #11461

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1279,7 +1279,8 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 				sp.AddEvent(
 					"Distributor.prePushValidationMiddleware[deduplicated samples/histograms with conflicting timestamps from write request]",
 					trace.WithAttributes(
-						attribute.String("metric", m),
+						// Note that m is an unsafe reference to a gRPC unmarshalling buffer.
+						attribute.String("metric", strings.Clone(m)),
 						attribute.Int("count", c),
 					),
 				)

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1214,7 +1214,7 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 		var removeIndexes []int
 		totalSamples, totalExemplars := 0, 0
 		const maxMetricsWithDeduplicatedSamplesToTrace = 10
-		var dedupedPerMetric map[string]int
+		var dedupedPerUnsafeMetricName map[string]int
 
 		for tsIdx, ts := range req.Timeseries {
 			totalSamples += len(ts.Samples)
@@ -1251,20 +1251,20 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 
 			dedupedSamplesAndHistograms := (rawSamples - len(ts.Samples)) + (rawHistograms - len(ts.Histograms))
 			if dedupedSamplesAndHistograms > 0 {
-				if dedupedPerMetric == nil {
-					dedupedPerMetric = make(map[string]int, maxMetricsWithDeduplicatedSamplesToTrace)
+				if dedupedPerUnsafeMetricName == nil {
+					dedupedPerUnsafeMetricName = make(map[string]int, maxMetricsWithDeduplicatedSamplesToTrace)
 				}
 				name, err := extract.UnsafeMetricNameFromLabelAdapters(ts.Labels)
 				if err != nil {
 					name = "unnamed"
 				}
-				increment := len(dedupedPerMetric) < maxMetricsWithDeduplicatedSamplesToTrace
+				increment := len(dedupedPerUnsafeMetricName) < maxMetricsWithDeduplicatedSamplesToTrace
 				if !increment {
 					// If at max capacity, only touch pre-existing entries.
-					_, increment = dedupedPerMetric[name]
+					_, increment = dedupedPerUnsafeMetricName[name]
 				}
 				if increment {
-					dedupedPerMetric[name] += dedupedSamplesAndHistograms
+					dedupedPerUnsafeMetricName[name] += dedupedSamplesAndHistograms
 				}
 			}
 
@@ -1272,10 +1272,10 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 			validatedExemplars += len(ts.Exemplars)
 		}
 
-		if len(dedupedPerMetric) > 0 {
+		if len(dedupedPerUnsafeMetricName) > 0 {
 			// Emit tracing span events for metrics with deduped samples.
 			sp := trace.SpanFromContext(ctx)
-			for unsafeMetricName, deduped := range dedupedPerMetric {
+			for unsafeMetricName, deduped := range dedupedPerUnsafeMetricName {
 				sp.AddEvent(
 					"Distributor.prePushValidationMiddleware[deduplicated samples/histograms with conflicting timestamps from write request]",
 					trace.WithAttributes(

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1275,13 +1275,14 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 		if len(dedupedPerMetric) > 0 {
 			// Emit tracing span events for metrics with deduped samples.
 			sp := trace.SpanFromContext(ctx)
-			for m, c := range dedupedPerMetric {
+			for unsafeMetricName, deduped := range dedupedPerMetric {
 				sp.AddEvent(
 					"Distributor.prePushValidationMiddleware[deduplicated samples/histograms with conflicting timestamps from write request]",
 					trace.WithAttributes(
-						// Note that m is an unsafe reference to a gRPC unmarshalling buffer.
-						attribute.String("metric", strings.Clone(m)),
-						attribute.Int("count", c),
+						// unsafeMetricName is an unsafe reference to a gRPC unmarshalling buffer,
+						// clone it for safe retention.
+						attribute.String("metric", strings.Clone(unsafeMetricName)),
+						attribute.Int("count", deduped),
 					),
 				)
 			}


### PR DESCRIPTION
#### What this PR does

Follow-up to #11159. I suspect that to avoid memory corruption/data races, we should clone metric name strings as they are originally unsafe gRPC unmarshalling buffer references. I think it ought to be fine performance wise, as we will emit events for a maximum of 10 metrics per write request.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
