### PR TITLE
Add TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency

### DIFF
--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -38,6 +38,8 @@ const (
 	maxProducerRecordDataBytesLimit = producerBatchMaxBytes - 16384
 	minProducerRecordDataBytesLimit = 1024 * 1024
 
+	defaultMaxInflightProduceRequests = 20
+
 	writerMetricsPrefix = "cortex_ingest_storage_writer_"
 )
 
@@ -80,7 +82,7 @@ func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registere
 		registerer:                 reg,
 		writers:                    make([]*KafkaProducer, kafkaCfg.WriteClients),
 		serializer:                 recordSerializerFromCfg(kafkaCfg),
-		maxInflightProduceRequests: 20,
+		maxInflightProduceRequests: defaultMaxInflightProduceRequests,
 
 		// Metrics.
 		writeLatency: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{


### PR DESCRIPTION
#### What this PR does

I wanted to investigate how `MaxProduceRequestsInflightPerBroker` works in practice and I've added a test to easily see how it works. I have found that `MaxProduceRequestsInflightPerBroker` is not really honored if set to a value higher than 9 ([see here](https://github.com/twmb/franz-go/issues/1041)) but, on the other hand, I haven't found a proof that this could reduce the throughput in our case. I would like to commit the test I've added. It's a slow test (12s) but I think it's worth it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
