### PR TITLE
Alertmanager: stop using isGrafanaTenant

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -16644,7 +16644,7 @@
           "kind": "field",
           "name": "grafana_alertmanager_idle_grace_period",
           "required": false,
-          "desc": "Duration to wait before shutting down an idle Alertmanager for a tenant that matches grafana-alertmanager-conditionally-skip-tenant-suffix and is using an unpromoted or default configuration.",
+          "desc": "Duration to wait before shutting down an idle Alertmanager using an unpromoted or default configuration when strict initialization is enabled.",
           "fieldValue": null,
           "fieldDefaultValue": 300000000000,
           "fieldFlag": "alertmanager.grafana-alertmanager-grace-period",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -16642,17 +16642,6 @@
         },
         {
           "kind": "field",
-          "name": "grafana_alertmanager_conditionally_skip_tenant_suffix",
-          "required": false,
-          "desc": "Skip starting the Alertmanager for tenants matching this suffix unless they have a promoted, non-default Grafana Alertmanager configuration or they are receiving requests.",
-          "fieldValue": null,
-          "fieldDefaultValue": "",
-          "fieldFlag": "alertmanager.grafana-alertmanager-conditionally-skip-tenant-suffix",
-          "fieldType": "string",
-          "fieldCategory": "experimental"
-        },
-        {
-          "kind": "field",
           "name": "grafana_alertmanager_idle_grace_period",
           "required": false,
           "desc": "Duration to wait before shutting down an idle Alertmanager for a tenant that matches grafana-alertmanager-conditionally-skip-tenant-suffix and is using an unpromoted or default configuration.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -242,7 +242,7 @@ Usage of ./cmd/mimir/mimir:
   -alertmanager.grafana-alertmanager-compatibility-enabled
     	[experimental] Enable routes to support the migration and operation of the Grafana Alertmanager.
   -alertmanager.grafana-alertmanager-grace-period duration
-    	[experimental] Duration to wait before shutting down an idle Alertmanager for a tenant that matches grafana-alertmanager-conditionally-skip-tenant-suffix and is using an unpromoted or default configuration. (default 5m0s)
+    	[experimental] Duration to wait before shutting down an idle Alertmanager using an unpromoted or default configuration when strict initialization is enabled. (default 5m0s)
   -alertmanager.log-parsing-label-matchers
     	[experimental] Enable logging when parsing label matchers. This flag is intended to be used with -alertmanager.utf8-strict-mode-enabled to validate UTF-8 strict mode is working as intended.
   -alertmanager.max-alerts-count int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -241,8 +241,6 @@ Usage of ./cmd/mimir/mimir:
     	Enables periodic cleanup of alertmanager stateful data (notification logs and silences) from object storage. When enabled, data is removed for any tenant that does not have a configuration. (default true)
   -alertmanager.grafana-alertmanager-compatibility-enabled
     	[experimental] Enable routes to support the migration and operation of the Grafana Alertmanager.
-  -alertmanager.grafana-alertmanager-conditionally-skip-tenant-suffix string
-    	[experimental] Skip starting the Alertmanager for tenants matching this suffix unless they have a promoted, non-default Grafana Alertmanager configuration or they are receiving requests.
   -alertmanager.grafana-alertmanager-grace-period duration
     	[experimental] Duration to wait before shutting down an idle Alertmanager for a tenant that matches grafana-alertmanager-conditionally-skip-tenant-suffix and is using an unpromoted or default configuration. (default 5m0s)
   -alertmanager.log-parsing-label-matchers

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2419,9 +2419,9 @@ sharding_ring:
 # CLI flag: -alertmanager.grafana-alertmanager-compatibility-enabled
 [grafana_alertmanager_compatibility_enabled: <boolean> | default = false]
 
-# (experimental) Duration to wait before shutting down an idle Alertmanager for
-# a tenant that matches grafana-alertmanager-conditionally-skip-tenant-suffix
-# and is using an unpromoted or default configuration.
+# (experimental) Duration to wait before shutting down an idle Alertmanager
+# using an unpromoted or default configuration when strict initialization is
+# enabled.
 # CLI flag: -alertmanager.grafana-alertmanager-grace-period
 [grafana_alertmanager_idle_grace_period: <duration> | default = 5m]
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2419,12 +2419,6 @@ sharding_ring:
 # CLI flag: -alertmanager.grafana-alertmanager-compatibility-enabled
 [grafana_alertmanager_compatibility_enabled: <boolean> | default = false]
 
-# (experimental) Skip starting the Alertmanager for tenants matching this suffix
-# unless they have a promoted, non-default Grafana Alertmanager configuration or
-# they are receiving requests.
-# CLI flag: -alertmanager.grafana-alertmanager-conditionally-skip-tenant-suffix
-[grafana_alertmanager_conditionally_skip_tenant_suffix: <string> | default = ""]
-
 # (experimental) Duration to wait before shutting down an idle Alertmanager for
 # a tenant that matches grafana-alertmanager-conditionally-skip-tenant-suffix
 # and is using an unpromoted or default configuration.

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -108,7 +108,6 @@ type Config struct {
 	PersisterConfig   PersisterConfig
 
 	GrafanaAlertmanagerCompatibility bool
-	GrafanaAlertmanagerTenantSuffix  string
 	EnableNotifyHooks                bool
 }
 
@@ -689,12 +688,6 @@ func (am *Alertmanager) buildIntegrationsMap(emailCfg alertingReceivers.EmailSen
 	}
 
 	return integrationsMap, nil
-}
-
-// isGrafanaTenant returns true if the Alertmanager is a Grafana tenant.
-// DEPRECATED: this should be cleaned up soon. It was added to be used as a feature toggle for strict initialization but is no longer needed.
-func (am *Alertmanager) isGrafanaTenant() bool {
-	return am.cfg.GrafanaAlertmanagerTenantSuffix != "" && strings.HasSuffix(am.cfg.UserID, am.cfg.GrafanaAlertmanagerTenantSuffix)
 }
 
 func (am *Alertmanager) buildGrafanaReceiverIntegrations(rcv *alertingNotify.APIReceiver, tmpl alertingNotify.TemplatesProvider) ([]*nfstatus.Integration, error) {

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -444,7 +444,7 @@ func clusterWait(position func() int, timeout time.Duration) func() time.Duratio
 }
 
 // ApplyConfig applies a new configuration to an Alertmanager.
-func (am *Alertmanager) ApplyConfig(conf *definition.PostableApiAlertingConfig, tmpls []alertingTemplates.TemplateDefinition, rawCfg string, tmplExternalURL *url.URL, staticHeaders map[string]string) error {
+func (am *Alertmanager) ApplyConfig(conf *definition.PostableApiAlertingConfig, tmpls []alertingTemplates.TemplateDefinition, rawCfg string, tmplExternalURL *url.URL, staticHeaders map[string]string, usingGrafanaConfig bool) error {
 	cfg := definition.GrafanaToUpstreamConfig(conf)
 
 	emailCfg := alertingReceivers.EmailSenderConfig{
@@ -463,7 +463,7 @@ func (am *Alertmanager) ApplyConfig(conf *definition.PostableApiAlertingConfig, 
 		SentBy:        fmt.Sprintf("Mimir v%s", version.Version),
 	}
 
-	integrationsMap, err := am.buildIntegrationsMap(emailCfg, conf.Receivers, tmpls, tmplExternalURL)
+	integrationsMap, err := am.buildIntegrationsMap(emailCfg, conf.Receivers, tmpls, tmplExternalURL, usingGrafanaConfig)
 	if err != nil {
 		return err
 	}
@@ -621,7 +621,7 @@ func (am *Alertmanager) wrapNotifier(integrationName string, notifier notify.Not
 }
 
 // buildIntegrationsMap builds a map of name to the list of integration notifiers off of a list of receiver config.
-func (am *Alertmanager) buildIntegrationsMap(emailCfg alertingReceivers.EmailSenderConfig, nc []*definition.PostableApiReceiver, tmpls []alertingTemplates.TemplateDefinition, tmplExternalURL *url.URL) (map[string][]*nfstatus.Integration, error) {
+func (am *Alertmanager) buildIntegrationsMap(emailCfg alertingReceivers.EmailSenderConfig, nc []*definition.PostableApiReceiver, tmpls []alertingTemplates.TemplateDefinition, tmplExternalURL *url.URL, usingGrafanaConfig bool) (map[string][]*nfstatus.Integration, error) {
 	// Create a firewall binded to the per-tenant config.
 	firewallDialer := util_net.NewFirewallDialer(newFirewallDialerConfigProvider(am.cfg.UserID, am.cfg.Limits))
 
@@ -675,7 +675,7 @@ func (am *Alertmanager) buildIntegrationsMap(emailCfg alertingReceivers.EmailSen
 	// This might appear different from the above dynamic approach that depends on receiver types, and it is, but
 	// currently AMs should not have mixed receiver types. So, this is a safe (and necessary) workaround.
 	var err error
-	if am.isGrafanaTenant() {
+	if usingGrafanaConfig {
 		var f *alertingTemplates.Factory
 		f, err = alertingTemplates.NewFactory(tmpls, am.logger, tmplExternalURL.String(), am.cfg.UserID)
 		if err == nil {
@@ -692,6 +692,7 @@ func (am *Alertmanager) buildIntegrationsMap(emailCfg alertingReceivers.EmailSen
 }
 
 // isGrafanaTenant returns true if the Alertmanager is a Grafana tenant.
+// DEPRECATED: this should be cleaned up soon. It was added to be used as a feature toggle for strict initialization but is no longer needed.
 func (am *Alertmanager) isGrafanaTenant() bool {
 	return am.cfg.GrafanaAlertmanagerTenantSuffix != "" && strings.HasSuffix(am.cfg.UserID, am.cfg.GrafanaAlertmanagerTenantSuffix)
 }

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -643,7 +643,6 @@ func TestGrafanaAlertmanager(t *testing.T) {
 		// We have to set this interval non-zero, though we don't need the persister to do anything.
 		PersisterConfig:                  PersisterConfig{Interval: time.Hour},
 		GrafanaAlertmanagerCompatibility: true,
-		GrafanaAlertmanagerTenantSuffix:  suffix,
 	}, prometheus.NewPedanticRegistry())
 	require.NoError(t, err)
 	defer am.StopAndWait()

--- a/pkg/alertmanager/alertmanager_test.go
+++ b/pkg/alertmanager/alertmanager_test.go
@@ -99,7 +99,7 @@ route:
 	cfg, err := definition.LoadCompat([]byte(cfgRaw))
 	require.NoError(t, err)
 	tmpls := make([]alertingTemplates.TemplateDefinition, 0)
-	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, nil))
+	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, nil, false))
 
 	now := time.Now()
 
@@ -184,7 +184,7 @@ route:
 	cfg, err := definition.LoadCompat([]byte(cfgRaw))
 	require.NoError(t, err)
 	tmpls := make([]alertingTemplates.TemplateDefinition, 0)
-	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, nil))
+	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, nil, false))
 
 	now := time.Now()
 	inputAlerts := []*types.Alert{
@@ -535,7 +535,7 @@ route:
 	cfg, err := definition.LoadCompat([]byte(cfgRaw))
 	require.NoError(t, err)
 	tmpls := make([]alertingTemplates.TemplateDefinition, 0)
-	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, nil))
+	require.NoError(t, am.ApplyConfig(cfg, tmpls, cfgRaw, &url.URL{}, nil, false))
 
 	doGetReceivers := func() []alertingmodels.Receiver {
 		rr := httptest.NewRecorder()
@@ -696,7 +696,7 @@ func TestGrafanaAlertmanager(t *testing.T) {
 
 	expectedImageURL := "http://example.com/image.png"
 
-	require.NoError(t, am.ApplyConfig(cfg, []alertingTemplates.TemplateDefinition{testTemplate}, cfgRaw, &url.URL{}, nil))
+	require.NoError(t, am.ApplyConfig(cfg, []alertingTemplates.TemplateDefinition{testTemplate}, cfgRaw, &url.URL{}, nil, true))
 
 	now := time.Now()
 	alert := types.Alert{
@@ -740,7 +740,7 @@ func TestGrafanaAlertmanager(t *testing.T) {
 	cfg, err = definition.LoadCompat([]byte(cfgRaw))
 	require.NoError(t, err)
 
-	require.NoError(t, am.ApplyConfig(cfg, []alertingTemplates.TemplateDefinition{testTemplate}, cfgRaw, &url.URL{}, nil))
+	require.NoError(t, am.ApplyConfig(cfg, []alertingTemplates.TemplateDefinition{testTemplate}, cfgRaw, &url.URL{}, nil, true))
 
 	// Now attempt to use a template function that doesn't exist. Ensure ApplyConfig fails to validate even if there are no non-empty receivers.
 	testTemplate = alertingTemplates.TemplateDefinition{
@@ -748,5 +748,5 @@ func TestGrafanaAlertmanager(t *testing.T) {
 		Template: `{{ define "test" -}} {{ DOESNTEXIST "field" "value" }} {{- end }}`,
 		Kind:     alertingTemplates.GrafanaKind,
 	}
-	require.Error(t, am.ApplyConfig(cfg, []alertingTemplates.TemplateDefinition{testTemplate}, cfgRaw, &url.URL{}, nil))
+	require.Error(t, am.ApplyConfig(cfg, []alertingTemplates.TemplateDefinition{testTemplate}, cfgRaw, &url.URL{}, nil, true))
 }

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -137,7 +137,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet, logger 
 
 	f.BoolVar(&cfg.EnableAPI, "alertmanager.enable-api", true, "Enable the alertmanager config API.")
 	f.BoolVar(&cfg.GrafanaAlertmanagerCompatibilityEnabled, "alertmanager.grafana-alertmanager-compatibility-enabled", false, "Enable routes to support the migration and operation of the Grafana Alertmanager.")
-	f.DurationVar(&cfg.GrafanaAlertmanagerIdleGracePeriod, "alertmanager.grafana-alertmanager-grace-period", defaultGrafanaAlertmanagerGracePeriod, "Duration to wait before shutting down an idle Alertmanager for a tenant that matches grafana-alertmanager-conditionally-skip-tenant-suffix and is using an unpromoted or default configuration.")
+	f.DurationVar(&cfg.GrafanaAlertmanagerIdleGracePeriod, "alertmanager.grafana-alertmanager-grace-period", defaultGrafanaAlertmanagerGracePeriod, "Duration to wait before shutting down an idle Alertmanager using an unpromoted or default configuration when strict initialization is enabled.")
 	f.IntVar(&cfg.MaxConcurrentGetRequestsPerTenant, "alertmanager.max-concurrent-get-requests-per-tenant", 0, "Maximum number of concurrent GET requests allowed per tenant. The zero value (and negative values) result in a limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served for GET requests that would exceed the concurrency limit.")
 
 	f.BoolVar(&cfg.EnableStateCleanup, "alertmanager.enable-state-cleanup", true, "Enables periodic cleanup of alertmanager stateful data (notification logs and silences) from object storage. When enabled, data is removed for any tenant that does not have a configuration.")

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -97,10 +97,10 @@ type MultitenantAlertmanagerConfig struct {
 	// Allow disabling of full_state object cleanup.
 	EnableStateCleanup bool `yaml:"enable_state_cleanup" category:"advanced"`
 
-	// StrictInitialization is an experimental feature that allows the multi-tenant Alertmanager
+	// StrictInitializationEnabled is an experimental feature that allows the multi-tenant Alertmanager
 	// to skip starting Alertmanagers for tenants without a non-default, non-empty configuration.
 	// For Grafana Alertmanager tenants, configurations must also be marked as "promoted".
-	StrictInitialization bool `yaml:"strict_initialization" category:"experimental"`
+	StrictInitializationEnabled bool `yaml:"strict_initialization" category:"experimental"`
 
 	// Enable UTF-8 strict mode. When enabled, Alertmanager uses the new UTF-8 parser
 	// when parsing label matchers in tenant configurations and HTTP requests, instead
@@ -148,7 +148,7 @@ func (cfg *MultitenantAlertmanagerConfig) RegisterFlags(f *flag.FlagSet, logger 
 
 	f.DurationVar(&cfg.PeerTimeout, "alertmanager.peer-timeout", defaultPeerTimeout, "Time to wait between peers to send notifications.")
 
-	f.BoolVar(&cfg.StrictInitialization, "alertmanager.strict-initialization-enabled", false, "Skip initializing Alertmanagers for tenants without a non-default, non-empty configuration. For Grafana Alertmanager tenants, configurations not marked as 'promoted' will also be skipped.")
+	f.BoolVar(&cfg.StrictInitializationEnabled, "alertmanager.strict-initialization-enabled", false, "Skip initializing Alertmanagers for tenants without a non-default, non-empty configuration. For Grafana Alertmanager tenants, configurations not marked as 'promoted' will also be skipped.")
 
 	f.BoolVar(&cfg.UTF8StrictMode, "alertmanager.utf8-strict-mode-enabled", false, "Enable UTF-8 strict mode. Allows UTF-8 characters in the matchers for routes and inhibition rules, in silences, and in the labels for alerts. It is recommended that all tenants run the `migrate-utf8` command in mimirtool before enabling this mode. Otherwise, some tenant configurations might fail to load. For more information, refer to [Enable UTF-8](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/components/alertmanager/#enable-utf-8). Enabling and then disabling UTF-8 strict mode can break existing Alertmanager configurations if tenants added UTF-8 characters to their Alertmanager configuration while it was enabled.")
 	f.BoolVar(&cfg.LogParsingLabelMatchers, "alertmanager.log-parsing-label-matchers", false, "Enable logging when parsing label matchers. This flag is intended to be used with -alertmanager.utf8-strict-mode-enabled to validate UTF-8 strict mode is working as intended.")
@@ -765,7 +765,7 @@ func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs)
 	}
 
 	// Check if tenants can be skipped (strict initialization enabled).
-	skippable := am.cfg.StrictInitialization
+	skippable := am.cfg.StrictInitializationEnabled
 
 	// Check if the mimir config is non-empty and non-default.
 	isMimirConfigCustom := cfgs.Mimir.RawConfig != am.fallbackConfig && cfgs.Mimir.RawConfig != ""

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -764,8 +764,8 @@ func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs)
 		tmplExternalURL: am.cfg.ExternalURL.URL,
 	}
 
-	// Check if this tenant can be skipped (Grafana suffix matching).
-	skippable := am.canSkipTenant(userID)
+	// Check if tenants can be skipped (strict initialization enabled).
+	skippable := am.cfg.StrictInitialization
 
 	// Check if the mimir config is non-empty and non-default.
 	isMimirConfigCustom := cfgs.Mimir.RawConfig != am.fallbackConfig && cfgs.Mimir.RawConfig != ""
@@ -814,12 +814,6 @@ func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs)
 // isGrafanaConfigUsable returns true if the Grafana configuration is promoted, non-default, and not empty.
 func isGrafanaConfigUsable(cfg alertspb.GrafanaAlertConfigDesc) bool {
 	return cfg.Promoted && !cfg.Default && cfg.RawConfig != ""
-}
-
-// canSkipTenant returns true if the tenant can be skipped, either because strict initialization is enabled,
-// or because the tenant ID matches the provided Grafana tenant suffix.
-func (am *MultitenantAlertmanager) canSkipTenant(userID string) bool {
-	return am.cfg.StrictInitialization
 }
 
 // syncStates promotes/unpromotes the Grafana state and updates the 'promoted' flag if needed.

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -3440,31 +3440,6 @@ func TestComputeConfig(t *testing.T) {
 				require.Equal(t, test.expURL, cfg.tmplExternalURL.String())
 			}
 		})
-
-		t.Run(fmt.Sprintf("%s with Grafana tenant suffix", test.name), func(t *testing.T) {
-			userWithPrefix := fmt.Sprintf("%s-grafana", test.cfg.Mimir.User)
-
-			test.cfg.Grafana.User = userWithPrefix
-			test.cfg.Mimir.User = userWithPrefix
-			test.expCfg.User = userWithPrefix
-
-			cfg, startAM, err := amWithSuffix.computeConfig(test.cfg)
-			if test.expErr != "" {
-				require.EqualError(t, err, test.expErr)
-				return
-			}
-			require.NoError(t, err)
-
-			require.Equal(t, test.expStartAM, startAM)
-			require.Equal(t, test.expCfg, cfg.AlertConfigDesc)
-			require.Equal(t, test.expHeaders, cfg.staticHeaders)
-			if test.expURL == "" {
-				require.Equal(t, mimirExternalURL, cfg.tmplExternalURL.String())
-			} else {
-				require.Equal(t, test.expURL, cfg.tmplExternalURL.String())
-			}
-		})
-
 	}
 }
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2521,7 +2521,7 @@ func TestComputeConfig(t *testing.T) {
 
 	reg3 := prometheus.NewPedanticRegistry()
 	cfg3 := mockAlertmanagerConfig(t)
-	cfg3.StrictInitialization = true
+	cfg3.StrictInitializationEnabled = true
 	amWithStrictInit := setupSingleMultitenantAlertmanager(t, cfg3, store, nil, featurecontrol.NoopFlags{}, log.NewNopLogger(), reg3)
 
 	testTenant := "test-tenant"

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -2517,7 +2517,6 @@ func TestComputeConfig(t *testing.T) {
 
 	reg2 := prometheus.NewPedanticRegistry()
 	cfg2 := mockAlertmanagerConfig(t)
-	cfg2.GrafanaAlertmanagerTenantSuffix = "-grafana"
 	amWithSuffix := setupSingleMultitenantAlertmanager(t, cfg2, store, nil, featurecontrol.NoopFlags{}, log.NewNopLogger(), reg2)
 
 	reg3 := prometheus.NewPedanticRegistry()
@@ -3443,7 +3442,7 @@ func TestComputeConfig(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("%s with Grafana tenant suffix", test.name), func(t *testing.T) {
-			userWithPrefix := fmt.Sprintf("%s%s", test.cfg.Mimir.User, cfg2.GrafanaAlertmanagerTenantSuffix)
+			userWithPrefix := fmt.Sprintf("%s-grafana", test.cfg.Mimir.User)
 
 			test.cfg.Grafana.User = userWithPrefix
 			test.cfg.Mimir.User = userWithPrefix


### PR DESCRIPTION
## Context
- `isGrafanaTenant` was added as a helper method for strict AM initialization
- But it relies on a specific flag to be set (`alertmanager.grafana-alertmanager-conditionally-skip-tenant-suffix`)
- If this is not set, the method will return false regardless if it's a Grafana tenant or not
- On https://github.com/grafana/mimir/pull/11609, we started using this in the template validation logic ([here](https://github.com/grafana/mimir/pull/11609/files#diff-8e36fbeb7a03da16fee1b491a126581d93b5dec3b8bd4e4d4398aed38232bbacR678))
- This causes the Grafana AM to error when applying the configuration if the user is using templates with functions which are not supported by Mimir templates
- There's a bool in the `amConfig` (`usingGrafanaConfig`) which indicates whether the tenant is using a Grafana or Mimir config
- Use that instead of the helper method

Note: I was trying to avoid doing clean up in this PR as we're planning to backport it, but since the linter was complaining about it being unused I thought it made sense to remove the flag here as well as to avoid further confusion