### PR TITLE
chore: Rename limit method to match limit name

### DIFF
--- a/pkg/querier/cardinality_analysis_handler.go
+++ b/pkg/querier/cardinality_analysis_handler.go
@@ -36,7 +36,7 @@ func LabelNamesCardinalityHandler(d Distributor, limits *validation.Overrides) h
 			return
 		}
 
-		tenantMaxLimit := limits.CardinalityAPIMaxSeriesLimit(tenantID)
+		tenantMaxLimit := limits.CardinalityAnalysisMaxResults(tenantID)
 		cardinalityRequest, err := cardinality.DecodeLabelNamesRequest(r, tenantMaxLimit)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -66,7 +66,7 @@ func LabelValuesCardinalityHandler(distributor Distributor, limits *validation.O
 			http.Error(w, fmt.Sprintf("cardinality analysis is disabled for the tenant: %v", tenantID), http.StatusBadRequest)
 			return
 		}
-		tenantMaxLimit := limits.CardinalityAPIMaxSeriesLimit(tenantID)
+		tenantMaxLimit := limits.CardinalityAnalysisMaxResults(tenantID)
 		cardinalityRequest, err := cardinality.DecodeLabelValuesRequest(r, tenantMaxLimit)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -1309,9 +1309,9 @@ func (o *Overrides) SubquerySpinOffEnabled(userID string) bool {
 	return o.getOverridesForUser(userID).SubquerySpinOffEnabled
 }
 
-// CardinalityAPIMaxSeriesLimit returns the maximum number of series that
-// can be requested in a single cardinality API request.
-func (o *Overrides) CardinalityAPIMaxSeriesLimit(userID string) int {
+// CardinalityAnalysisMaxResults returns the maximum number of results that
+// can be returned in a single cardinality API request.
+func (o *Overrides) CardinalityAnalysisMaxResults(userID string) int {
 	return o.getOverridesForUser(userID).CardinalityAnalysisMaxResults
 }
 


### PR DESCRIPTION
#### What this PR does

Rename the method for getting cardinality analysis limits introduced in #11456 to match the name of the limit itself.

#### Which issue(s) this PR fixes or relates to

Related #11456

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
