### PR TITLE
Don't end trace span early in `Ingester.QueryStream`

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2205,8 +2205,6 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 
 	ctx := stream.Context()
 	spanlog := spanlogger.FromContext(ctx, i.logger)
-	defer spanlog.Finish()
-
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue introduced in #11712 where the parent trace span would be ended early by `QueryStream()`.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/pull/11712#discussion_r2142233048

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
