### PR TITLE
Split cortex_ingest_storage_reader_records_processing_time_seconds by success and failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [ENHANCEMENT] Tracing: Add HTTP headers as span attributes when `-server.trace-request-headers` is enabled. You can configure which headers to exclude using the `-server.trace-request-headers-exclude-list` flag. #11655
 * [ENHANCEMENT] Ruler: Add new per-tenant limit on minimum rule evaluation interval. #11665
 * [ENHANCEMENT] store-gateway: download sparse headers on startup when lazy loading is enabled. #11686
+* [ENHANCEMENT] Ingester: Split `cortex_ingest_storage_reader_records_processing_time_seconds` metric by success and failure. #11730
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 * [ENHANCEMENT] Alerts: Add alerts for invalid cluster validation labels. #11255 #11282 #11413
 * [ENHANCEMENT] Dashboards: Improve "Kafka 100th percentile end-to-end latency when ingesters are running (outliers)" panel, computing the baseline latency on `max(10, 10%)` of ingesters instead of a fixed 10 replicas. #11581
 * [ENHANCEMENT] Dashboards: Add "per-query memory consumption" and "fallback to Prometheus' query engine" panels to the Queries dashboard. #11626
+* [ENHANCEMENT] Dashboards: Add "Process batch attempts / sec (before retries)" panel to the Writes dashboard. #11730
 * [CHANGE] Alerts: Update query for `MimirBucketIndexNotUpdated`. Use `max_over_time` to prevent alert firing when pods rotate. #11311, #11426
 * [CHANGE] Alerts: Make alerting threshold for `DistributorGcUsesTooMuchCpu` configurable. #11508.
 * [BUGFIX] Dashboards: fix "Mimir / Tenants" legends for non-Kubernetes deployments. #10891

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -432,6 +432,29 @@ local filename = 'mimir-writes.json';
     )
     .addRowIf(
       $._config.show_ingest_storage_panels,
+      $.row('')
+      .addPanel(
+        $.timeseriesPanel('Process batch attempts / sec (before retries)') +
+        $.panelDescription(
+          'Process batch attempts (before retries)',
+          |||
+            Shows the rate at which batches of records are processed from Kafka, before any retries.
+          |||
+        ) +
+        $.queryPanel(
+          [
+            'histogram_count(sum(rate(cortex_ingest_storage_reader_records_processing_time_seconds{status="success",%s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+            'histogram_count(sum(rate(cortex_ingest_storage_reader_records_processing_time_seconds{status="failure",%s}[$__rate_interval])))' % [$.jobMatcher($._config.job_names.ingester)],
+          ],
+          [
+            'successful',
+            'failed',
+          ],
+        ) + $.aliasColors({ successful: $._colors.success, failed: $._colors.failed }) + $.stack,
+      )
+    )
+    .addRowIf(
+      $._config.show_ingest_storage_panels,
       $.row('Ingester – end-to-end latency (ingest storage)')
       .addPanel(
         $.ingestStorageIngesterEndToEndLatencyWhenRunningPanel(),

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -62,7 +62,11 @@ func newPusherConsumer(pusher Pusher, kafkaCfg KafkaConfig, metrics *pusherConsu
 // It'll use a separate goroutine to unmarshal the next record while we push the current record to storage.
 func (c pusherConsumer) Consume(ctx context.Context, records []record) (returnErr error) {
 	defer func(processingStart time.Time) {
-		c.metrics.processingTimeSeconds.Observe(time.Since(processingStart).Seconds())
+		status := "success"
+		if returnErr != nil {
+			status = "failure"
+		}
+		c.metrics.processingTimeSeconds.WithLabelValues(status).Observe(time.Since(processingStart).Seconds())
 	}(time.Now())
 
 	type parsedRecord struct {

--- a/pkg/storage/ingest/pusher_metrics.go
+++ b/pkg/storage/ingest/pusher_metrics.go
@@ -11,7 +11,7 @@ import (
 
 // pusherConsumerMetrics holds the metrics for the pusherConsumer.
 type pusherConsumerMetrics struct {
-	processingTimeSeconds prometheus.Observer
+	processingTimeSeconds *prometheus.HistogramVec
 
 	storagePusherMetrics *storagePusherMetrics
 }
@@ -20,14 +20,14 @@ type pusherConsumerMetrics struct {
 func newPusherConsumerMetrics(reg prometheus.Registerer) *pusherConsumerMetrics {
 	return &pusherConsumerMetrics{
 		storagePusherMetrics: newStoragePusherMetrics(reg),
-		processingTimeSeconds: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		processingTimeSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "cortex_ingest_storage_reader_records_processing_time_seconds",
 			Help:                            "Time taken to process a batch of fetched records. Fetched records are effectively a set of WriteRequests read from Kafka. This is the latency of a single attempt and does not include retries.",
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 1 * time.Hour,
 			Buckets:                         prometheus.DefBuckets,
-		}),
+		}, []string{"status"}),
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Splits `cortex_ingest_storage_reader_records_processing_time_seconds` (kafka batch processing time before retries) by sucess and failure. It's useful to be able to see the failures at this point, since failures are retried forever by the partition reader ([code](https://github.com/grafana/mimir/blob/699a122aba83da75ccef884d63af468da4f5127e/pkg/storage/ingest/reader.go#L563)).

Also added a panel to the writes dashboard for pre-retry batch processing split by success and failure.

<img width="1789" alt="image" src="https://github.com/user-attachments/assets/4b21320b-a169-44b1-b5cf-5d6abbb9692b" />

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
