### PR TITLE
Mimirtool: Support multiple selectors in remote read commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [ENHANCEMENT] Ruler: Update `<prometheus-http-prefix>/api/v1/rules` and `<prometheus-http-prefix>/api/v1/alerts` to reply with HTTP error 422 if rule evaluation is completely disabled for the tenant. If only recording rule or alerting rule evaluation is disabled for the tenant, the response now includes a corresponding warning. #11321 #11495 #11511
 * [ENHANCEMENT] Add tenant configuration block `ruler_alertmanager_client_config` which allows the Ruler's Alertmanager client options to be specified on a per-tenant basis. #10816
 * [ENHANCEMENT] Store-gateway: Retry querying blocks from store-gateways with dynamic replication until trying all possible store-gateways. #11354 #11398
+* [ENHANCEMENT] Mimirtool: Support multiple `--selector` flags in remote read commands to send multiple queries in a single protobuf request, leveraging the remote read protocol's native batching capabilities. Added `--use-chunks` flag to control response type preference (chunked streaming vs sampled). #XXXXX
 * [ENHANCEMENT] Distributor: Gracefully handle type assertion of WatchPrefix in HA Tracker to continue checking for updates. #11411 #11461
 * [ENHANCEMENT] Querier: Include chunks streamed from store-gateway in Mimir Query Engine memory estimate of query memory usage. #11453 #11465
 * [ENHANCEMENT] Querier: Include chunks streamed from ingester in Mimir Query Engine memory estimate of query memory usage. #11457

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -571,16 +571,26 @@ Only one of the namespace selection flags can be specified.
 Grafana Mimir exposes a [remote read API] which allows the system to access the stored series.
 The `remote-read` subcommand `mimirtool` enables you to interact with its API, and to determine which series are stored.
 
+The remote-read commands support multiple `--selector` flags to query multiple series selectors in a single request, leveraging the remote read protocol's native batching capabilities for improved performance.
+
+Additionally, you can control the response format using the `--use-chunks` flag:
+- `--use-chunks=true` (default): Requests chunked streaming response for better performance with large datasets
+- `--use-chunks=false`: Requests traditional sampled response format
+
 [remote read api]: https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations
 
 #### Stats
 
-The `remote-read stats` command summarizes statistics of the stored series that match the selector.
+The `remote-read stats` command summarizes statistics of the stored series that match the specified selector(s).
 
 ##### Example
 
 ```bash
+# Single selector
 mimirtool remote-read stats --selector '{job="node"}' --address http://demo.robustperception.io:9090 --remote-read-path /api/v1/read
+
+# Multiple selectors in a single request
+mimirtool remote-read stats --selector '{job="node"}' --selector 'up' --selector 'go_memstats_alloc_bytes' --address http://demo.robustperception.io:9090 --remote-read-path /api/v1/read
 ```
 
 Running the command results in the following output:
@@ -594,12 +604,16 @@ INFO[0000] 2020-12-30 14:00:00.629 +0000 UTC  2020-12-30 14:59:59.629 +0000 UTC 
 
 #### Dump
 
-The `remote-read dump` command prints all series and samples that match the selector.
+The `remote-read dump` command prints all series and samples that match the specified selector(s).
 
 ##### Example
 
 ```bash
+# Single selector
 mimirtool remote-read dump --selector 'up{job="node"}' --address http://demo.robustperception.io:9090 --remote-read-path /api/v1/read
+
+# Multiple selectors
+mimirtool remote-read dump --selector 'up{job="node"}' --selector 'go_memstats_alloc_bytes' --address http://demo.robustperception.io:9090 --remote-read-path /api/v1/read
 ```
 
 Running the command results in the following output:
@@ -612,12 +626,15 @@ Running the command results in the following output:
 
 #### Export
 
-The `remote-read export` command exports all series and samples that match the selector into a local TSDB.
+The `remote-read export` command exports all series and samples that match the specified selector(s) into a local TSDB.
 You can use local tooling such as `prometheus` and [`promtool`](https://github.com/prometheus/prometheus/tree/main/cmd/promtool) to further analyze the TSDB.
 
 ```bash
-# Use Remote Read API to download all metrics with label job=name into local tsdb
+# Use Remote Read API to download all metrics with label job=node into local tsdb
 mimirtool remote-read export --selector '{job="node"}' --address http://demo.robustperception.io:9090 --remote-read-path /api/v1/read --tsdb-path ./local-tsdb
+
+# Download multiple metric families in a single request
+mimirtool remote-read export --selector '{job="node"}' --selector 'up' --selector 'prometheus_build_info' --address http://demo.robustperception.io:9090 --remote-read-path /api/v1/read --tsdb-path ./local-tsdb
 ```
 
 Running the command results in the following output:

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -16,21 +16,26 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/annotations"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/grafana/mimir/pkg/mimirtool/backfill"
@@ -51,10 +56,11 @@ type RemoteReadCommand struct {
 	readTimeout time.Duration
 	tsdbPath    string
 
-	selector      string
+	selectors     []string
 	from          string
 	to            string
 	readSizeLimit uint64
+	useChunks     bool
 }
 
 func (c *RemoteReadCommand) Register(app *kingpin.Application, envVars EnvVarNames) {
@@ -84,9 +90,9 @@ func (c *RemoteReadCommand) Register(app *kingpin.Application, envVars EnvVarNam
 			Default("30s").
 			DurationVar(&c.readTimeout)
 
-		cmd.Flag("selector", `PromQL selector to filter metrics on. To return all metrics '{__name__!=""}' can be used.`).
+		cmd.Flag("selector", `PromQL selector to filter metrics on. To return all metrics '{__name__!=""}' can be used. Can be specified multiple times to send multiple queries in a single remote read request.`).
 			Default("up").
-			StringVar(&c.selector)
+			StringsVar(&c.selectors)
 
 		cmd.Flag("from", "Start of the time window to select metrics.").
 			Default(now.Add(-time.Hour).Format(time.RFC3339)).
@@ -97,6 +103,9 @@ func (c *RemoteReadCommand) Register(app *kingpin.Application, envVars EnvVarNam
 		cmd.Flag("read-size-limit", "Maximum number of bytes to read.").
 			Default(strconv.Itoa(DefaultChunkedReadLimit)).
 			Uint64Var(&c.readSizeLimit)
+		cmd.Flag("use-chunks", "Request chunked streaming response (STREAMED_XOR_CHUNKS) instead of sampled response (SAMPLES).").
+			Default("true").
+			BoolVar(&c.useChunks)
 	}
 
 	exportCmd.Flag("tsdb-path", "Path to the folder where to store the TSDB blocks, if not set a new directory in $TEMP is created.").
@@ -247,9 +256,28 @@ func (c *RemoteReadCommand) prepare() (query func(context.Context) (storage.Seri
 		return nil, time.Time{}, time.Time{}, fmt.Errorf("error parsing to: '%s' value: %w", c.to, err)
 	}
 
-	matchers, err := parser.ParseMetricSelector(c.selector)
-	if err != nil {
-		return nil, time.Time{}, time.Time{}, err
+	if len(c.selectors) == 0 {
+		return nil, time.Time{}, time.Time{}, fmt.Errorf("at least one selector must be specified")
+	}
+
+	// Parse all selectors
+	var pbQueries []*prompb.Query
+	for _, selector := range c.selectors {
+		matchers, err := parser.ParseMetricSelector(selector)
+		if err != nil {
+			return nil, time.Time{}, time.Time{}, fmt.Errorf("error parsing selector '%s': %w", selector, err)
+		}
+
+		pbQuery, err := remote.ToQuery(
+			int64(model.TimeFromUnixNano(from.UnixNano())),
+			int64(model.TimeFromUnixNano(to.UnixNano())),
+			matchers,
+			nil,
+		)
+		if err != nil {
+			return nil, time.Time{}, time.Time{}, fmt.Errorf("error creating query for selector '%s': %w", selector, err)
+		}
+		pbQueries = append(pbQueries, pbQuery)
 	}
 
 	readClient, err := c.readClient()
@@ -257,26 +285,333 @@ func (c *RemoteReadCommand) prepare() (query func(context.Context) (storage.Seri
 		return nil, time.Time{}, time.Time{}, err
 	}
 
-	pbQuery, err := remote.ToQuery(
-		int64(model.TimeFromUnixNano(from.UnixNano())),
-		int64(model.TimeFromUnixNano(to.UnixNano())),
-		matchers,
-		nil,
-	)
-	if err != nil {
-		return nil, time.Time{}, time.Time{}, err
+	return func(ctx context.Context) (storage.SeriesSet, error) {
+		log.Infof("Querying time from=%s to=%s with %d selectors", from.Format(time.RFC3339), to.Format(time.RFC3339), len(c.selectors))
+	for i, selector := range c.selectors {
+		log.Debugf("Selector %d: %s", i+1, selector)
+	}
+		return c.executeMultipleQueries(ctx, readClient, pbQueries)
+	}, from, to, nil
+}
+
+// executeMultipleQueries sends multiple queries in a single protobuf request
+func (c *RemoteReadCommand) executeMultipleQueries(ctx context.Context, readClient remote.ReadClient, queries []*prompb.Query) (storage.SeriesSet, error) {
+	// We'll use reflection to access the private fields of the client to send a batched request
+	// This is hacky but gets the job done for now
+	client, ok := readClient.(*remote.Client)
+	if !ok {
+		return nil, fmt.Errorf("unexpected readClient type: %T", readClient)
 	}
 
-	return func(ctx context.Context) (storage.SeriesSet, error) {
-		log.Infof("Querying time from=%s to=%s with selector=%s", from.Format(time.RFC3339), to.Format(time.RFC3339), c.selector)
-		resp, err := readClient.Read(ctx, pbQuery, false)
+	// Build the batched request with user-selected response type preference
+	var acceptedTypes []prompb.ReadRequest_ResponseType
+	if c.useChunks {
+		log.Debugf("Requesting chunked streaming response (STREAMED_XOR_CHUNKS)")
+		acceptedTypes = []prompb.ReadRequest_ResponseType{
+			prompb.ReadRequest_STREAMED_XOR_CHUNKS,
+			prompb.ReadRequest_SAMPLES, // fallback
+		}
+	} else {
+		log.Debugf("Requesting sampled response (SAMPLES)")
+		acceptedTypes = []prompb.ReadRequest_ResponseType{
+			prompb.ReadRequest_SAMPLES,
+		}
+	}
+
+	req := &prompb.ReadRequest{
+		Queries:               queries,
+		AcceptedResponseTypes: acceptedTypes,
+	}
+
+	// Marshal the batched request
+	data, err := proto.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal read request: %w", err)
+	}
+
+	compressed := snappy.Encode(nil, data)
+
+	// Use reflection to get the URL from the client
+	clientValue := reflect.ValueOf(client).Elem()
+	urlStringField := clientValue.FieldByName("urlString")
+	if !urlStringField.IsValid() {
+		return nil, fmt.Errorf("unable to access urlString field")
+	}
+	urlString := urlStringField.String()
+
+	// Create HTTP request
+	httpReq, err := http.NewRequest(http.MethodPost, urlString, bytes.NewReader(compressed))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+	httpReq.Header.Add("Content-Encoding", "snappy")
+	httpReq.Header.Add("Accept-Encoding", "snappy")
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	httpReq.Header.Set("User-Agent", "mimirtool")
+	httpReq.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
+
+	// Send the request using the client's HTTP client
+	httpResp, err := client.Client.Do(httpReq.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("error sending request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(httpResp.Body)
+		errStr := strings.TrimSpace(string(body))
+		return nil, fmt.Errorf("remote server returned http status %s: %s", httpResp.Status, errStr)
+	}
+
+	contentType := httpResp.Header.Get("Content-Type")
+	log.Debugf("Response content type: %s", contentType)
+
+	// Handle different response types
+	switch {
+	case strings.HasPrefix(contentType, "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse"):
+		log.Debugf("Processing chunked streaming response")
+		return c.handleChunkedResponse(httpResp, queries)
+	case strings.HasPrefix(contentType, "application/x-protobuf"):
+		log.Debugf("Processing sampled response")
+		return c.handleSampledResponse(httpResp, queries)
+	default:
+		return nil, fmt.Errorf("unsupported content type: %s", contentType)
+	}
+}
+
+// combinedSeriesSet implements storage.SeriesSet for multiple series
+type combinedSeriesSet struct {
+	series []storage.Series
+	index  int
+	err    error
+}
+
+func (c *combinedSeriesSet) Next() bool {
+	c.index++
+	return c.index < len(c.series)
+}
+
+func (c *combinedSeriesSet) At() storage.Series {
+	if c.index < 0 || c.index >= len(c.series) {
+		return nil
+	}
+	return c.series[c.index]
+}
+
+func (c *combinedSeriesSet) Err() error {
+	return c.err
+}
+
+func (c *combinedSeriesSet) Warnings() annotations.Annotations {
+	return nil
+}
+
+// handleSampledResponse handles the traditional sampled response format
+func (c *RemoteReadCommand) handleSampledResponse(httpResp *http.Response, queries []*prompb.Query) (storage.SeriesSet, error) {
+	// Read and decompress response
+	compressedResp, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response: %w", err)
+	}
+
+	uncompressed, err := snappy.Decode(nil, compressedResp)
+	if err != nil {
+		return nil, fmt.Errorf("error decompressing response: %w", err)
+	}
+
+	// Unmarshal response
+	var resp prompb.ReadResponse
+	err = proto.Unmarshal(uncompressed, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response body: %w", err)
+	}
+
+	if len(resp.Results) != len(queries) {
+		return nil, fmt.Errorf("responses: want %d, got %d", len(queries), len(resp.Results))
+	}
+
+	// Combine all results from all queries
+	var allSeries []storage.Series
+	for i, result := range resp.Results {
+		log.Infof("Processing result %d/%d with %d series", i+1, len(resp.Results), len(result.Timeseries))
+		seriesSet := remote.FromQueryResult(false, result)
+		for seriesSet.Next() {
+			allSeries = append(allSeries, seriesSet.At())
+		}
+		if err := seriesSet.Err(); err != nil {
+			return nil, fmt.Errorf("error reading series from query %d: %w", i, err)
+		}
+	}
+
+	log.Infof("Combined %d series from %d queries", len(allSeries), len(queries))
+	return &combinedSeriesSet{series: allSeries, index: -1}, nil
+}
+
+// handleChunkedResponse handles the streamed chunked response format
+func (c *RemoteReadCommand) handleChunkedResponse(httpResp *http.Response, queries []*prompb.Query) (storage.SeriesSet, error) {
+	// Use the chunked reader from the remote package
+	reader := remote.NewChunkedReader(httpResp.Body, c.readSizeLimit, nil)
+
+	// Collect all series from all queries
+	var allSeries []storage.Series
+	processedQueries := make(map[int64]int)
+	totalBytes := 0
+
+	for {
+		var chunkedResp prompb.ChunkedReadResponse
+		err := reader.NextProto(&chunkedResp)
+		if err == io.EOF {
+			break
+		}
+		totalBytes += chunkedResp.Size()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error reading chunked response: %w", err)
 		}
 
-		return resp, nil
+		queryIndex := chunkedResp.QueryIndex
+		if queryIndex < 0 || queryIndex >= int64(len(queries)) {
+			return nil, fmt.Errorf("invalid query index %d, expected 0-%d", queryIndex, len(queries)-1)
+		}
 
-	}, from, to, nil
+		processedQueries[queryIndex]++
+		if processedQueries[queryIndex] == 1 {
+			log.Infof("Processing chunked response for query %d", queryIndex)
+		}
+
+		// Each ChunkedSeries contains chunks for a single series
+		for _, chunkSeries := range chunkedResp.ChunkedSeries {
+			// Create a series that can iterate over the chunks
+			// Convert protobuf labels to labels.Labels
+			lbs := make(labels.Labels, len(chunkSeries.Labels))
+			for i, l := range chunkSeries.Labels {
+				lbs[i] = labels.Label{Name: l.Name, Value: l.Value}
+			}
+			series := &multiQueryChunkedSeries{
+				labels: lbs,
+				chunks: chunkSeries.Chunks,
+				mint:   queries[queryIndex].StartTimestampMs,
+				maxt:   queries[queryIndex].EndTimestampMs,
+			}
+			allSeries = append(allSeries, series)
+		}
+	}
+
+	log.Infof("Combined %d series from %d queries using chunked streaming (%d bytes)", len(allSeries), len(queries), totalBytes)
+	return &combinedSeriesSet{series: allSeries, index: -1}, nil
+}
+
+// multiQueryChunkedSeries implements storage.Series for chunked data from multiple queries
+type multiQueryChunkedSeries struct {
+	labels     labels.Labels
+	chunks     []prompb.Chunk
+	mint, maxt int64
+}
+
+func (s *multiQueryChunkedSeries) Labels() labels.Labels {
+	return s.labels
+}
+
+func (s *multiQueryChunkedSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
+	// Create a new chunked series iterator
+	return newMultiQueryChunkedIterator(s.chunks, s.mint, s.maxt)
+}
+
+// newMultiQueryChunkedIterator creates an iterator for chunked series data
+func newMultiQueryChunkedIterator(chunks []prompb.Chunk, mint, maxt int64) chunkenc.Iterator {
+	return &multiQueryChunkedIterator{
+		chunks:   chunks,
+		mint:     mint,
+		maxt:     maxt,
+		chunkIdx: 0,
+	}
+}
+
+// multiQueryChunkedIterator implements an iterator for chunked data
+type multiQueryChunkedIterator struct {
+	chunks     []prompb.Chunk
+	mint, maxt int64
+	chunkIdx   int
+	cur        chunkenc.Iterator
+	s          storage.Series
+	err        error
+}
+
+func (it *multiQueryChunkedIterator) Next() chunkenc.ValueType {
+	// If we have a current chunk iterator, try to get next value
+	if it.cur != nil {
+		if vt := it.cur.Next(); vt != chunkenc.ValNone {
+			return vt
+		}
+		// Current chunk is exhausted, move to next
+		it.chunkIdx++
+	}
+
+	// Find next non-empty chunk
+	for it.chunkIdx < len(it.chunks) {
+		chunk := it.chunks[it.chunkIdx]
+		// Convert protobuf chunk to storage chunk
+		c, err := chunkenc.FromData(chunkenc.Encoding(chunk.Type), chunk.Data)
+		if err != nil {
+			it.err = fmt.Errorf("error decoding chunk %d: %w", it.chunkIdx, err)
+			return chunkenc.ValNone
+		}
+		it.cur = c.Iterator(nil)
+		if vt := it.cur.Next(); vt != chunkenc.ValNone {
+			return vt
+		}
+		// This chunk was empty, try next
+		it.chunkIdx++
+	}
+
+	// No more chunks
+	return chunkenc.ValNone
+}
+
+func (it *multiQueryChunkedIterator) At() (int64, float64) {
+	if it.cur == nil {
+		return 0, 0
+	}
+	return it.cur.At()
+}
+
+func (it *multiQueryChunkedIterator) AtHistogram(h *histogram.Histogram) (int64, *histogram.Histogram) {
+	if it.cur == nil {
+		return 0, nil
+	}
+	return it.cur.AtHistogram(h)
+}
+
+func (it *multiQueryChunkedIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+	if it.cur == nil {
+		return 0, nil
+	}
+	return it.cur.AtFloatHistogram(fh)
+}
+
+func (it *multiQueryChunkedIterator) AtT() int64 {
+	if it.cur == nil {
+		return 0
+	}
+	return it.cur.AtT()
+}
+
+func (it *multiQueryChunkedIterator) Seek(t int64) chunkenc.ValueType {
+	// Reset to beginning and iterate until we find t
+	it.chunkIdx = 0
+	it.cur = nil
+	for {
+		vt := it.Next()
+		if vt == chunkenc.ValNone {
+			return chunkenc.ValNone
+		}
+		if it.AtT() >= t {
+			return vt
+		}
+	}
+}
+
+func (it *multiQueryChunkedIterator) Err() error {
+	return it.err
 }
 
 func (c *RemoteReadCommand) dump(_ *kingpin.ParseContext) error {

--- a/pkg/mimirtool/commands/remote_read_test.go
+++ b/pkg/mimirtool/commands/remote_read_test.go
@@ -6,15 +6,25 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/mimirtool/backfill"
 )
@@ -166,4 +176,319 @@ func TestEarlyCommit(t *testing.T) {
 	}
 	err := backfill.CreateBlocks(iterator, start, end, maxSamplesPerBlock, t.TempDir(), true, io.Discard)
 	assert.NoError(t, err)
+}
+
+func TestRemoteReadCommand_prepare(t *testing.T) {
+	tests := []struct {
+		name        string
+		selectors   []string
+		from        string
+		to          string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "single selector",
+			selectors:   []string{"up"},
+			from:        "2023-01-01T00:00:00Z",
+			to:          "2023-01-01T01:00:00Z",
+			expectError: false,
+		},
+		{
+			name:        "multiple selectors",
+			selectors:   []string{"up", "go_memstats_alloc_bytes", "prometheus_build_info"},
+			from:        "2023-01-01T00:00:00Z",
+			to:          "2023-01-01T01:00:00Z",
+			expectError: false,
+		},
+		{
+			name:        "empty selectors",
+			selectors:   []string{},
+			from:        "2023-01-01T00:00:00Z",
+			to:          "2023-01-01T01:00:00Z",
+			expectError: true,
+			errorMsg:    "at least one selector must be specified",
+		},
+		{
+			name:        "invalid selector",
+			selectors:   []string{"invalid{selector"},
+			from:        "2023-01-01T00:00:00Z",
+			to:          "2023-01-01T01:00:00Z",
+			expectError: true,
+			errorMsg:    "error parsing selector",
+		},
+		{
+			name:        "invalid from time",
+			selectors:   []string{"up"},
+			from:        "invalid-time",
+			to:          "2023-01-01T01:00:00Z",
+			expectError: true,
+			errorMsg:    "error parsing from",
+		},
+		{
+			name:        "invalid to time",
+			selectors:   []string{"up"},
+			from:        "2023-01-01T00:00:00Z",
+			to:          "invalid-time",
+			expectError: true,
+			errorMsg:    "error parsing to",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock server that returns success
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/x-protobuf")
+				// Return empty response
+				resp := &prompb.ReadResponse{}
+				data, _ := proto.Marshal(resp)
+				compressed := snappy.Encode(nil, data)
+				w.Write(compressed)
+			}))
+			defer server.Close()
+
+			cmd := &RemoteReadCommand{
+				address:        server.URL,
+				remoteReadPath: "/api/v1/read",
+				selectors:      tt.selectors,
+				from:           tt.from,
+				to:             tt.to,
+				readTimeout:    30 * time.Second,
+				useChunks:      true,
+			}
+
+			_, _, _, err := cmd.prepare()
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRemoteReadCommand_executeMultipleQueries(t *testing.T) {
+	tests := []struct {
+		name             string
+		responseType     string
+		responseBody     func() []byte
+		queriesCount     int
+		expectedSeries   int
+		expectError      bool
+		errorMsg        string
+	}{
+		{
+			name:         "sampled response single query",
+			responseType: "application/x-protobuf",
+			responseBody: func() []byte {
+				resp := &prompb.ReadResponse{
+					Results: []*prompb.QueryResult{
+						{
+							Timeseries: []*prompb.TimeSeries{
+								{
+									Labels: []prompb.Label{{Name: "__name__", Value: "up"}},
+									Samples: []prompb.Sample{
+										{Timestamp: 1000, Value: 1.0},
+										{Timestamp: 2000, Value: 1.0},
+									},
+								},
+							},
+						},
+					},
+				}
+				data, _ := proto.Marshal(resp)
+				return snappy.Encode(nil, data)
+			},
+			queriesCount:   1,
+			expectedSeries: 1,
+			expectError:    false,
+		},
+		{
+			name:         "sampled response multiple queries",
+			responseType: "application/x-protobuf",
+			responseBody: func() []byte {
+				resp := &prompb.ReadResponse{
+					Results: []*prompb.QueryResult{
+						{
+							Timeseries: []*prompb.TimeSeries{
+								{
+									Labels: []prompb.Label{{Name: "__name__", Value: "up"}},
+									Samples: []prompb.Sample{{Timestamp: 1000, Value: 1.0}},
+								},
+							},
+						},
+						{
+							Timeseries: []*prompb.TimeSeries{
+								{
+									Labels: []prompb.Label{{Name: "__name__", Value: "go_memstats_alloc_bytes"}},
+									Samples: []prompb.Sample{{Timestamp: 1000, Value: 12345.0}},
+								},
+							},
+						},
+					},
+				}
+				data, _ := proto.Marshal(resp)
+				return snappy.Encode(nil, data)
+			},
+			queriesCount:   2,
+			expectedSeries: 2,
+			expectError:    false,
+		},
+		{
+			name:         "response query count mismatch",
+			responseType: "application/x-protobuf",
+			responseBody: func() []byte {
+				resp := &prompb.ReadResponse{
+					Results: []*prompb.QueryResult{
+						{Timeseries: []*prompb.TimeSeries{}},
+					},
+				}
+				data, _ := proto.Marshal(resp)
+				return snappy.Encode(nil, data)
+			},
+			queriesCount: 2,
+			expectError:  true,
+			errorMsg:     "responses: want 2, got 1",
+		},
+		{
+			name:         "http error response",
+			responseType: "text/plain",
+			responseBody: func() []byte { return []byte("server error") },
+			queriesCount: 1,
+			expectError:  true,
+			errorMsg:     "remote server returned http status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.name == "http error response" {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+				w.Header().Set("Content-Type", tt.responseType)
+				w.Write(tt.responseBody())
+			}))
+			defer server.Close()
+
+			cmd := &RemoteReadCommand{
+				address:        server.URL,
+				remoteReadPath: "/api/v1/read",
+				readTimeout:    30 * time.Second,
+				useChunks:      false, // Use sampled response for simplicity
+			}
+
+			// Create mock queries
+			queries := make([]*prompb.Query, tt.queriesCount)
+			for i := 0; i < tt.queriesCount; i++ {
+				matchers, _ := parser.ParseMetricSelector("up")
+				query, _ := remote.ToQuery(1000, 2000, matchers, nil)
+				queries[i] = query
+			}
+
+			client, err := cmd.readClient()
+			require.NoError(t, err)
+
+			seriesSet, err := cmd.executeMultipleQueries(context.Background(), client, queries)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, seriesSet)
+
+				// Count series
+				seriesCount := 0
+				for seriesSet.Next() {
+					seriesCount++
+				}
+				assert.Equal(t, tt.expectedSeries, seriesCount)
+				assert.NoError(t, seriesSet.Err())
+			}
+		})
+	}
+}
+
+func TestCombinedSeriesSet(t *testing.T) {
+	tests := []struct {
+		name           string
+		series         []storage.Series
+		expectedCount  int
+	}{
+		{
+			name:          "empty series",
+			series:        []storage.Series{},
+			expectedCount: 0,
+		},
+		{
+			name: "single series",
+			series: []storage.Series{
+				storage.MockSeries([]int64{1000}, []float64{1.0}, []string{"__name__", "up"}),
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "multiple series",
+			series: []storage.Series{
+				storage.MockSeries([]int64{1000}, []float64{1.0}, []string{"__name__", "up"}),
+				storage.MockSeries([]int64{1000}, []float64{12345.0}, []string{"__name__", "go_memstats_alloc_bytes"}),
+				storage.MockSeries([]int64{1000}, []float64{1.0}, []string{"__name__", "prometheus_build_info"}),
+			},
+			expectedCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seriesSet := &combinedSeriesSet{
+				series: tt.series,
+				index:  -1,
+			}
+
+			count := 0
+			for seriesSet.Next() {
+				count++
+				assert.NotNil(t, seriesSet.At())
+			}
+			assert.Equal(t, tt.expectedCount, count)
+			assert.NoError(t, seriesSet.Err())
+			assert.Nil(t, seriesSet.Warnings())
+		})
+	}
+}
+
+func TestMultiQueryChunkedIterator(t *testing.T) {
+	// Test basic iterator functionality
+	chunks := []prompb.Chunk{
+		{
+			Type: prompb.Chunk_XOR,
+			Data: createMockXORChunk(t, []int64{1000, 2000}, []float64{1.0, 2.0}),
+		},
+	}
+
+	iter := newMultiQueryChunkedIterator(chunks, 1000, 2000)
+
+	// Test iteration
+	vt := iter.Next()
+	assert.NotEqual(t, chunkenc.ValNone, vt)
+
+	// Test error handling
+	assert.NoError(t, iter.Err())
+}
+
+// createMockXORChunk creates a simple XOR encoded chunk for testing
+func createMockXORChunk(t *testing.T, timestamps []int64, values []float64) []byte {
+	require.Equal(t, len(timestamps), len(values))
+	
+	chunk := chunkenc.NewXORChunk()
+	appender, err := chunk.Appender()
+	require.NoError(t, err)
+	
+	for i := range timestamps {
+		appender.Append(timestamps[i], values[i])
+	}
+	
+	return chunk.Bytes()
 }


### PR DESCRIPTION
## Summary

Add support for multiple `--selector` flags in mimirtool remote read commands (`stats`, `dump`, `export`) to send multiple queries in a single protobuf request, leveraging the remote read protocol's native batching capabilities.

## Changes

- Modified RemoteReadCommand to accept multiple selectors via StringsVar
- Implemented executeMultipleQueries to send batched requests
- Added --use-chunks flag to control response type preference
- Enhanced chunked response handling with proper chunk decoding
- Added comprehensive unit tests for new functionality
- Updated documentation with examples of multiple selector usage