### PR TITLE
mimirtool: Add chunk digest flag to remote-read dump command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@
 * [ENHANCEMENT] Distributor: Trace when deduplicating a metric's samples or histograms. #11159 #11715
 * [ENHANCEMENT] Store-gateway: Retry querying blocks from store-gateways with dynamic replication until trying all possible store-gateways. #11354 #11398
 * [ENHANCEMENT] Mimirtool: Support multiple `--selector` flags in remote read commands to send multiple queries in a single protobuf request, leveraging the remote read protocol's native batching capabilities. Added `--use-chunks` flag to control response type preference (chunked streaming vs sampled). #11733
-* [ENHANCEMENT] Mimirtool: Add `--chunk-digest` flag to `remote-read dump` command to print chunk metadata (min time, max time, checksum) instead of decoding samples. Useful for inspecting chunk-level information and data integrity verification. #11734
+* [ENHANCEMENT] Mimirtool: Add `--chunk-digest` flag to `remote-read dump` command to print chunk metadata (min time, max time, SHA256 checksum) instead of decoding samples. Useful for inspecting chunk-level information and data integrity verification. #11734
 * [ENHANCEMENT] Query-frontend: Add optional reason to blocked_queries config. #11407 #11434
 * [ENHANCEMENT] Distributor: Gracefully handle type assertion of WatchPrefix in HA Tracker to continue checking for updates. #11411 #11461
 * [ENHANCEMENT] Querier: Include chunks streamed from store-gateway in Mimir Query Engine memory estimate of query memory usage. #11453 #11465

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -577,7 +577,7 @@ Additionally, you can control the response format using the `--use-chunks` flag:
 
 - `--use-chunks=true` (default): Requests chunked streaming response for better performance with large datasets
 - `--use-chunks=false`: Requests traditional sampled response format
-- `--chunk-digest`: Print chunk metadata (min time, max time, checksum) instead of decoding samples when using chunked responses. Can only be combined with `--use-chunks`
+- `--chunk-digest`: Print chunk metadata (min time, max time, SHA256 checksum) instead of decoding samples when using chunked responses. Can only be combined with `--use-chunks`
 
 [remote read api]: https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations
 

--- a/pkg/mimirtool/commands/remote_read_test.go
+++ b/pkg/mimirtool/commands/remote_read_test.go
@@ -596,7 +596,7 @@ func TestRemoteReadCommand_prepare_chunkDigestValidation(t *testing.T) {
 			chunkDigest: true,
 			useChunks:   false,
 			expectError: true,
-			errorMsg:    "-chunks-digest only works with -use-chunks",
+			errorMsg:    "-chunk-digest only works with -use-chunks",
 		},
 		{
 			name:        "chunk digest disabled",
@@ -614,7 +614,8 @@ func TestRemoteReadCommand_prepare_chunkDigestValidation(t *testing.T) {
 				resp := &prompb.ReadResponse{}
 				data, _ := proto.Marshal(resp)
 				compressed := snappy.Encode(nil, data)
-				w.Write(compressed)
+				_, err := w.Write(compressed)
+				require.NoError(t, err)
 			}))
 			defer server.Close()
 


### PR DESCRIPTION
This is being built upon https://github.com/grafana/mimir/pull/11733 because I've had these changes locally on a branch for a while now

## Summary

Add `--chunk-digest` flag to `remote-read dump` command to print chunk metadata (min time, max time, checksum) instead of decoding samples. This is useful for inspecting chunk-level information and data integrity verification.

Here is sample output 

```
{__name__="up", asserts_env="dev-us-central-0", cluster="dev-us-central-0", container="compactor", instance="compactor-1:compactor:http-metrics", job="mimir-dev-14/compactor", namespace="mimir-dev-14", pod="compactor-1"} chunk_0 min_time=1734507020045 max_time=1734507905045 checksum=79cae89c080017ff2378bbb953d2976b
{__name__="up", asserts_env="dev-us-east-0", cluster="dev-us-east-0", container="compactor", instance="compactor-1:compactor:http-metrics", job="cortex-dev-05/compactor", namespace="cortex-dev-05", pod="compactor-1"} chunk_0 min_time=1734507022648 max_time=1734507907648 checksum=dfa1facd5ae3f808e0766245f2de5bfc
{__name__="up", asserts_env="dev-us-east-0", cluster="dev-us-east-0", container="compactor", instance="compactor-1:compactor:http-metrics", job="mimir-dev-15/compactor", namespace="mimir-dev-15", pod="compactor-1"} chunk_0 min_time=1734507015654 max_time=1734507900654 checksum=55a287a1c576641d463f6610c49a9b54
```