### PR TITLE
fix split between Parquet Stores and individual tenant Store

### DIFF
--- a/pkg/storegateway/parquet_bucket_block.go
+++ b/pkg/storegateway/parquet_bucket_block.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package storegateway
+
+import (
+	"sync"
+
+	"github.com/grafana/dskit/multierror"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus-community/parquet-common/storage"
+	"go.uber.org/atomic"
+)
+
+// parquetBlockSet holds all blocks.
+type parquetBlockSet struct {
+	mtx          sync.RWMutex            // nolint:unused
+	blockSet     sync.Map                // nolint:unused                // Maps block's ulid.ULID to the *bucketBlock.
+	sortedBlocks []*parquetBlockWithMeta // nolint:unused // Blocks sorted by mint, then maxt.
+}
+
+// closeAll closes all blocks in the set and returns all encountered errors after trying all blocks.
+func (s *parquetBlockSet) closeAll() error {
+	errs := multierror.New()
+	s.blockSet.Range(func(_, val any) bool {
+		errs.Add(val.(*parquetBlockWithMeta).Close())
+		return true
+	})
+	return errs.Err()
+}
+
+// parquetBlockWithMeta wraps storage.ParquetShardOpener with metadata adds metadata about the block.
+type parquetBlockWithMeta struct {
+	storage.ParquetShardOpener
+	BlockID ulid.ULID
+
+	pendingReaders sync.WaitGroup
+	closedMtx      sync.RWMutex
+	closed         bool
+
+	// Indicates whether the block was queried.
+	queried atomic.Bool
+}
+
+func (b *parquetBlockWithMeta) MarkQueried() {
+	b.queried.Store(true)
+}
+
+// Close waits for all pending readers to finish and then closes all underlying resources.
+func (b *parquetBlockWithMeta) Close() error {
+	b.closedMtx.Lock()
+	b.closed = true
+	b.closedMtx.Unlock()
+
+	b.pendingReaders.Wait()
+
+	return nil // TODO manage reader opening and closing through pools like indexheader does.
+}

--- a/pkg/storegateway/parquet_bucket_store.go
+++ b/pkg/storegateway/parquet_bucket_store.go
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/thanos-io/thanos/blob/main/pkg/store/bucket.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Thanos Authors.
+
+package storegateway
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/gogo/protobuf/types"
+	"github.com/grafana/dskit/gate"
+	"github.com/grafana/dskit/multierror"
+	"github.com/grafana/dskit/runutil"
+	"github.com/grafana/dskit/services"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/thanos-io/objstore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/grafana/mimir/pkg/storage/sharding"
+	"github.com/grafana/mimir/pkg/storage/tsdb"
+	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	"github.com/grafana/mimir/pkg/storegateway/hintspb"
+	"github.com/grafana/mimir/pkg/storegateway/storegatewaypb"
+	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+)
+
+// ParquetBucketStore implements the store API backed by a bucket.
+// It loads all Parquet block labels files to local disk.
+type ParquetBucketStore struct {
+	services.Service
+
+	logger log.Logger
+
+	userID        string
+	localDir      string
+	bucketMetrics *BucketStoreMetrics // TODO: Create ParquetBucketStoreMetrics
+	bkt           objstore.InstrumentedBucketReader
+	fetcher       block.MetadataFetcher
+
+	// Set of blocks that have the same labels
+	blockSet *parquetBlockSet
+
+	// Number of goroutines to use when syncing blocks from object storage.
+	blockSyncConcurrency int
+
+	// Query gate which limits the maximum amount of concurrent queries.
+	queryGate gate.Gate
+
+	// Gate used to limit concurrency on loading index-headers across all tenants.
+	lazyLoadingGate gate.Gate
+
+	// chunksLimiterFactory creates a new limiter used to limit the number of chunks fetched by each Series() call.
+	chunksLimiterFactory ChunksLimiterFactory
+	// seriesLimiterFactory creates a new limiter used to limit the number of touched series by each Series() call,
+	// or LabelName and LabelValues calls when used with matchers.
+	seriesLimiterFactory SeriesLimiterFactory
+
+	// maxSeriesPerBatch controls the batch size to use when fetching series.
+	// This is not restricted to the Series() RPC.
+	// This value must be greater than zero.
+	maxSeriesPerBatch int
+}
+
+// NewParquetBucketStore creates a new bucket backed store that implements the store API against
+// an object store bucket. It is optimized to work against high latency backends.
+func NewParquetBucketStore(
+	userID string,
+	localDir string,
+	bkt objstore.InstrumentedBucketReader,
+	bucketStoreConfig tsdb.BucketStoreConfig,
+	blockMetaFetcher block.MetadataFetcher,
+	queryGate gate.Gate,
+	lazyLoadingGate gate.Gate,
+	chunksLimiterFactory ChunksLimiterFactory,
+	seriesLimiterFactory SeriesLimiterFactory,
+	metrics *BucketStoreMetrics,
+	logger log.Logger,
+) (*ParquetBucketStore, error) {
+	s := &ParquetBucketStore{
+		logger: logger,
+
+		userID:   userID,
+		localDir: localDir,
+
+		bucketMetrics: metrics,
+		bkt:           bkt,
+		fetcher:       blockMetaFetcher,
+
+		blockSet:             &parquetBlockSet{},
+		blockSyncConcurrency: bucketStoreConfig.BlockSyncConcurrency,
+
+		queryGate:       queryGate,
+		lazyLoadingGate: lazyLoadingGate,
+
+		chunksLimiterFactory: chunksLimiterFactory,
+		seriesLimiterFactory: seriesLimiterFactory,
+		maxSeriesPerBatch:    bucketStoreConfig.StreamingBatchSize,
+	}
+
+	if err := os.MkdirAll(localDir, 0750); err != nil {
+		return nil, errors.Wrap(err, "create local localDir")
+	}
+
+	s.Service = services.NewIdleService(s.start, s.stop)
+	return s, nil
+}
+
+func (s *ParquetBucketStore) start(_ context.Context) error {
+	// Use context.Background() so that we stop the index reader pool ourselves and do it after closing all blocks.
+	return services.StartAndAwaitRunning(context.Background(), nil)
+}
+
+func (s *ParquetBucketStore) stop(err error) error {
+	errs := multierror.New(err)
+	errs.Add(s.closeAllBlocks())
+	// The snapshotter depends on the reader pool, so we close the snapshotter first.
+	errs.Add(services.StopAndAwaitTerminated(context.Background(), nil)) // TODO insert snapshotter
+	errs.Add(services.StopAndAwaitTerminated(context.Background(), nil)) // TODO insert index reader pool
+	return errs.Err()
+}
+
+func (s *ParquetBucketStore) Series(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer) (err error) {
+	if req.SkipChunks {
+		// We don't do the streaming call if we are not requesting the chunks.
+		req.StreamingChunksBatchSize = 0
+	}
+	defer func() { err = mapSeriesError(err) }()
+
+	matchers, err := storepb.MatchersToPromMatchers(req.Matchers...)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Check if matchers include the query shard selector.
+	shardSelector, matchers, err := sharding.RemoveShardFromMatchers(matchers)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, errors.Wrap(err, "parse query sharding label").Error())
+	}
+
+	var (
+		spanLogger       = spanlogger.FromContext(srv.Context(), s.logger)
+		ctx              = srv.Context()
+		stats            = newSafeQueryStats()
+		reqBlockMatchers []*labels.Matcher
+	)
+	defer s.recordSeriesCallResult(stats)
+	defer s.recordRequestAmbientTime(stats, time.Now())
+
+	if req.Hints != nil {
+		reqHints := &hintspb.SeriesRequestHints{}
+		if err := types.UnmarshalAny(req.Hints, reqHints); err != nil {
+			return status.Error(codes.InvalidArgument, errors.Wrap(err, "unmarshal series request hints").Error())
+		}
+
+		reqBlockMatchers, err = storepb.MatchersToPromMatchers(reqHints.BlockMatchers...)
+		if err != nil {
+			return status.Error(codes.InvalidArgument, errors.Wrap(err, "translate request hints labels matchers").Error())
+		}
+	}
+
+	logSeriesRequestToSpan(srv.Context(), s.logger, req.MinTime, req.MaxTime, matchers, reqBlockMatchers, shardSelector, req.StreamingChunksBatchSize)
+
+	shards := s.openParquetShardsForReading(ctx, req.SkipChunks, req.MinTime, req.MaxTime, reqBlockMatchers, stats)
+	// We must keep the readers open until all their data has been sent.
+	for _, shard := range shards {
+		defer runutil.CloseWithLogOnErr(s.logger, shard, "close block shard")
+	}
+
+	// Wait for the query gate only after opening blocks. Opening blocks is usually fast (~1ms),
+	// but sometimes it can take minutes if the block isn't loaded and there is a surge in queries for unloaded blocks.
+	done, err := s.limitConcurrentQueries(ctx, stats)
+	if err != nil {
+		return err
+	}
+	defer done()
+
+	var (
+		resHints = &hintspb.SeriesResponseHints{}
+	)
+	for _, shard := range shards {
+		resHints.AddQueriedBlock(shard.BlockID)
+		shard.MarkQueried()
+	}
+	if err := s.sendHints(srv, resHints); err != nil {
+		return err
+	}
+
+	streamingSeriesCount := 0
+	if req.StreamingChunksBatchSize > 0 {
+		var (
+			seriesSet       storepb.SeriesSet
+			seriesLoadStart = time.Now()
+			chunksLimiter   = s.chunksLimiterFactory(s.bucketMetrics.queriesDropped.WithLabelValues("chunks"))
+			seriesLimiter   = s.seriesLimiterFactory(s.bucketMetrics.queriesDropped.WithLabelValues("series"))
+		)
+
+		// Placeholder: Create series set for streaming labels from parquet shards
+		seriesSet, err = s.createParquetSeriesSetForLabels(ctx, req, shards, shardSelector, matchers, chunksLimiter, seriesLimiter, stats)
+		if err != nil {
+			return err
+		}
+
+		streamingSeriesCount, err = s.sendStreamingSeriesLabelsAndStats(req, srv, stats, seriesSet)
+		if err != nil {
+			return err
+		}
+		spanLogger.DebugLog(
+			"msg", "sent streaming series",
+			"num_series", streamingSeriesCount,
+			"duration", time.Since(seriesLoadStart),
+		)
+
+		if streamingSeriesCount == 0 {
+			// There is no series to send chunks for.
+			return nil
+		}
+	}
+
+	// We create the limiter twice in the case of streaming so that we don't double count the series
+	// and hit the limit prematurely.
+	chunksLimiter := s.chunksLimiterFactory(s.bucketMetrics.queriesDropped.WithLabelValues("chunks"))
+	seriesLimiter := s.seriesLimiterFactory(s.bucketMetrics.queriesDropped.WithLabelValues("series"))
+
+	start := time.Now()
+	if req.StreamingChunksBatchSize > 0 {
+		seriesChunkIt := s.createParquetSeriesChunksSetIterator(ctx, req, shards, shardSelector, matchers, chunksLimiter, seriesLimiter, stats)
+		err = s.sendStreamingChunks(req, srv, seriesChunkIt, stats, streamingSeriesCount)
+	} else {
+		var seriesSet storepb.SeriesSet
+		seriesSet, err = s.createParquetSeriesSetWithChunks(ctx, req, shards, shardSelector, matchers, chunksLimiter, seriesLimiter, stats)
+		if err != nil {
+			return err
+		}
+		err = s.sendSeriesChunks(req, srv, seriesSet, stats)
+	}
+	if err != nil {
+		return
+	}
+
+	numSeries, numChunks := stats.seriesAndChunksCount()
+	debugMessage := "sent series"
+	if req.StreamingChunksBatchSize > 0 {
+		debugMessage = "sent streaming chunks"
+	}
+	spanLogger.DebugLog(
+		"msg", debugMessage,
+		"num_series", numSeries,
+		"num_chunks", numChunks,
+		"duration", time.Since(start),
+	)
+
+	if req.StreamingChunksBatchSize == 0 {
+		// Stats were not sent before, so send it now.
+		return s.sendStats(srv, stats)
+	}
+
+	return nil
+}
+
+func (s *ParquetBucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (s *ParquetBucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+// Placeholder methods for parquet-specific functionality
+func (s *ParquetBucketStore) openParquetShardsForReading(ctx context.Context, skipChunks bool, minTime, maxTime int64, reqBlockMatchers []*labels.Matcher, stats *safeQueryStats) []*parquetBlockWithMeta {
+	// TODO: Implement parquet shard discovery and opening logic
+	// This should:
+	// 1. Discover parquet shards that intersect with the time range
+	// 2. Use storage.ParquetShardOpener to open .labels.parquet and .chunks.parquet files
+	// 3. Read parquet schemas and metadata for efficient querying using shard.TSDBSchema()
+	// 4. Wrap opened ParquetShard with metadata (BlockID, queried status)
+	panic("TODO: implement openParquetShardsForReading")
+}
+
+func (s *ParquetBucketStore) limitConcurrentQueries(ctx context.Context, stats *safeQueryStats) (func(), error) {
+	// TODO: Can potentially reuse BucketStore.limitConcurrentQueries
+	// or implement parquet-specific version if needed
+	panic("TODO: implement limitConcurrentQueries")
+}
+
+func (s *ParquetBucketStore) sendHints(srv storegatewaypb.StoreGateway_SeriesServer, resHints *hintspb.SeriesResponseHints) error {
+	// TODO: Implement hints sending for parquet stores
+	panic("TODO: implement sendHints")
+}
+
+func (s *ParquetBucketStore) createParquetSeriesSetForLabels(ctx context.Context, req *storepb.SeriesRequest, shards []*parquetBlockWithMeta, shardSelector *sharding.ShardSelector, matchers []*labels.Matcher, chunksLimiter ChunksLimiter, seriesLimiter SeriesLimiter, stats *safeQueryStats) (storepb.SeriesSet, error) {
+	// TODO: Implement parquet series set creation for labels phase
+	// This should:
+	// 1. "Stream read" .labels.parquet files from shards using shard.LabelsFile()
+	// 2. Create and return storepb.SeriesSet that iterates over series labels without chunks
+	// Please note that storepb.SeriesSet assumes series are ordered.
+	panic("TODO: implement createParquetSeriesSetForLabels")
+}
+
+func (s *ParquetBucketStore) sendStreamingSeriesLabelsAndStats(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer, stats *safeQueryStats, seriesSet storepb.SeriesSet) (int, error) {
+	// TODO: Can potentially reuse BucketStore.sendStreamingSeriesLabelsAndStats
+	// or implement parquet-specific version if needed
+	panic("TODO: implement sendStreamingSeriesLabelsAndStats")
+}
+
+func (s *ParquetBucketStore) sendStreamingChunks(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer, seriesChunkIt iterator[seriesChunksSet], stats *safeQueryStats, streamingSeriesCount int) error {
+	// TODO: Can potentially reuse BucketStore.sendStreamingChunks
+	// or implement parquet-specific version if needed
+	panic("TODO: implement sendStreamingChunks")
+}
+
+func (s *ParquetBucketStore) createParquetSeriesChunksSetIterator(ctx context.Context, req *storepb.SeriesRequest, shards []*parquetBlockWithMeta, shardSelector *sharding.ShardSelector, matchers []*labels.Matcher, chunksLimiter ChunksLimiter, seriesLimiter SeriesLimiter, stats *safeQueryStats) iterator[seriesChunksSet] {
+	// TODO: Implement parquet series chunks iterator creation
+	// This should:
+	// 1. Stream read .chunks.parquet files from shards using shard.ChunksFile()
+	// 2. Return iterator[seriesChunksSet] / or the new iterator Nico is workisng on in his PR that streams chunks for the series discovered in labels phase
+	panic("TODO: implement createParquetSeriesChunksSetIterator")
+}
+
+func (s *ParquetBucketStore) sendSeriesChunks(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer, seriesSet storepb.SeriesSet, stats *safeQueryStats) error {
+	// TODO: Can potentially reuse BucketStore.sendSeriesChunks
+	// or implement parquet-specific version if needed
+	panic("TODO: implement sendSeriesChunks")
+}
+
+func (s *ParquetBucketStore) createParquetSeriesSetWithChunks(ctx context.Context, req *storepb.SeriesRequest, shards []*parquetBlockWithMeta, shardSelector *sharding.ShardSelector, matchers []*labels.Matcher, chunksLimiter ChunksLimiter, seriesLimiter SeriesLimiter, stats *safeQueryStats) (storepb.SeriesSet, error) {
+	// TODO: Implement parquet series set creation for non-streaming request
+	// I think this should create a series that includes the labels in one go and its typically called when skipchunks is true
+	panic("TODO: implement createParquetSeriesSetWithChunks")
+}
+
+func (s *ParquetBucketStore) recordSeriesCallResult(stats *safeQueryStats) {
+	// TODO: Implement series call result recording for parquet stores
+	panic("TODO: implement recordSeriesCallResult")
+}
+
+func (s *ParquetBucketStore) recordRequestAmbientTime(stats *safeQueryStats, startTime time.Time) {
+	// TODO: Implement request ambient time recording for parquet stores
+	panic("TODO: implement recordRequestAmbientTime")
+}
+
+func (s *ParquetBucketStore) sendStats(srv storegatewaypb.StoreGateway_SeriesServer, stats *safeQueryStats) error {
+	// TODO: Implement stats sending for parquet stores
+	panic("TODO: implement sendStats")
+}
+
+func (s *ParquetBucketStore) closeAllBlocks() error {
+	return s.blockSet.closeAll()
+}

--- a/pkg/storegateway/parquet_bucket_stores.go
+++ b/pkg/storegateway/parquet_bucket_stores.go
@@ -1,27 +1,28 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/cortexproject/cortex/blob/master/pkg/storegateway/bucket_stores.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: The Cortex Authors.
 
 package storegateway
 
 import (
 	"context"
-	"time"
+	"fmt"
+	"sync"
 
 	"github.com/go-kit/log"
-	"github.com/gogo/protobuf/types"
+	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/dskit/gate"
 	"github.com/grafana/dskit/services"
-	"github.com/oklog/ulid/v2"
-	"github.com/pkg/errors"
-	"github.com/prometheus-community/parquet-common/storage"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/model/labels"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"github.com/thanos-io/objstore"
 
-	"github.com/grafana/mimir/pkg/storage/sharding"
-	"github.com/grafana/mimir/pkg/storegateway/hintspb"
+	"github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storegateway/storegatewaypb"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
+	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 type ParquetBucketStores struct {
@@ -30,9 +31,30 @@ type ParquetBucketStores struct {
 	logger log.Logger
 	reg    prometheus.Registerer
 
-	metrics              *BucketStoreMetrics // TODO: Create ParquetBucketStoreMetrics
-	chunksLimiterFactory ChunksLimiterFactory
-	seriesLimiterFactory SeriesLimiterFactory
+	limits *validation.Overrides // nolint:unused
+	// Tenants that are specifically enabled or disabled via configuration
+	allowedTenants *util.AllowList
+
+	bucket objstore.Bucket
+	// Metrics specific to bucket store operations
+	bucketStoreMetrics *BucketStoreMetrics     // nolint:unused    // TODO: Create ParquetBucketStoreMetrics
+	metaFetcherMetrics *MetadataFetcherMetrics // nolint:unused
+	shardingStrategy   ShardingStrategy        // nolint:unused
+	syncBackoffConfig  backoff.Config          // nolint:unused
+
+	// Gate used to limit concurrency on loading index-headers across all tenants.
+	lazyLoadingGate gate.Gate // nolint:unused
+
+	// Keeps a bucket store for each tenant.
+	storesMu sync.RWMutex
+	stores   map[string]*ParquetBucketStore
+
+	// Block sync metrics.
+	syncTimes         prometheus.Histogram // nolint:unused
+	syncLastSuccess   prometheus.Gauge     // nolint:unused
+	tenantsDiscovered prometheus.Gauge     // nolint:unused
+	tenantsSynced     prometheus.Gauge     // nolint:unused
+	blocksLoaded      *prometheus.Desc     // nolint:unused
 }
 
 // NewParquetBucketStores initializes a Parquet implementation of the Stores interface.
@@ -50,259 +72,88 @@ func NewParquetBucketStores(
 	return stores, nil
 }
 
-func (ss ParquetBucketStores) Series(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer) (err error) {
-	if req.SkipChunks {
-		// We don't do the streaming call if we are not requesting the chunks.
-		req.StreamingChunksBatchSize = 0
-	}
-	defer func() { err = mapSeriesError(err) }()
+// Series implements the storegatewaypb.StoreGatewayServer interface, making a series request to the underlying user bucket store.
+func (ss *ParquetBucketStores) Series(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer) error {
+	spanLog, spanCtx := spanlogger.New(srv.Context(), ss.logger, tracer, "ParquetBucketStores.Series")
+	defer spanLog.Finish()
 
-	matchers, err := storepb.MatchersToPromMatchers(req.Matchers...)
-	if err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
+	userID := getUserIDFromGRPCContext(spanCtx)
+	if userID == "" {
+		return fmt.Errorf("no userID")
 	}
 
-	// Check if matchers include the query shard selector.
-	shardSelector, matchers, err := sharding.RemoveShardFromMatchers(matchers)
-	if err != nil {
-		return status.Error(codes.InvalidArgument, errors.Wrap(err, "parse query sharding label").Error())
+	store := ss.getStore(userID)
+	if store == nil {
+		return nil
 	}
 
-	var (
-		spanLogger       = spanlogger.FromContext(srv.Context(), ss.logger)
-		ctx              = srv.Context()
-		stats            = newSafeQueryStats()
-		reqBlockMatchers []*labels.Matcher
-	)
-	defer ss.recordSeriesCallResult(stats)
-	defer ss.recordRequestAmbientTime(stats, time.Now())
-
-	if req.Hints != nil {
-		reqHints := &hintspb.SeriesRequestHints{}
-		if err := types.UnmarshalAny(req.Hints, reqHints); err != nil {
-			return status.Error(codes.InvalidArgument, errors.Wrap(err, "unmarshal series request hints").Error())
-		}
-
-		reqBlockMatchers, err = storepb.MatchersToPromMatchers(reqHints.BlockMatchers...)
-		if err != nil {
-			return status.Error(codes.InvalidArgument, errors.Wrap(err, "translate request hints labels matchers").Error())
-		}
-	}
-
-	logSeriesRequestToSpan(srv.Context(), ss.logger, req.MinTime, req.MaxTime, matchers, reqBlockMatchers, shardSelector, req.StreamingChunksBatchSize)
-
-	shards := ss.openParquetShardsForReading(ctx, req.SkipChunks, req.MinTime, req.MaxTime, reqBlockMatchers, stats)
-	defer ss.closeParquetShards(shards)
-
-	// Wait for the query gate only after opening blocks. Opening blocks is usually fast (~1ms),
-	// but sometimes it can take minutes if the block isn't loaded and there is a surge in queries for unloaded blocks.
-	done, err := ss.limitConcurrentQueries(ctx, stats)
-	if err != nil {
-		return err
-	}
-	defer done()
-
-	var (
-		resHints = &hintspb.SeriesResponseHints{}
-	)
-	for _, shard := range shards {
-		resHints.AddQueriedBlock(shard.BlockID)
-		shard.MarkQueried()
-	}
-	if err := ss.sendHints(srv, resHints); err != nil {
-		return err
-	}
-
-	streamingSeriesCount := 0
-	if req.StreamingChunksBatchSize > 0 {
-		var (
-			seriesSet       storepb.SeriesSet
-			seriesLoadStart = time.Now()
-			chunksLimiter   = ss.chunksLimiterFactory(ss.metrics.queriesDropped.WithLabelValues("chunks"))
-			seriesLimiter   = ss.seriesLimiterFactory(ss.metrics.queriesDropped.WithLabelValues("series"))
-		)
-
-		// Placeholder: Create series set for streaming labels from parquet shards
-		seriesSet, err = ss.createParquetSeriesSetForLabels(ctx, req, shards, shardSelector, matchers, chunksLimiter, seriesLimiter, stats)
-		if err != nil {
-			return err
-		}
-
-		streamingSeriesCount, err = ss.sendStreamingSeriesLabelsAndStats(req, srv, stats, seriesSet)
-		if err != nil {
-			return err
-		}
-		spanLogger.DebugLog(
-			"msg", "sent streaming series",
-			"num_series", streamingSeriesCount,
-			"duration", time.Since(seriesLoadStart),
-		)
-
-		if streamingSeriesCount == 0 {
-			// There is no series to send chunks for.
-			return nil
-		}
-	}
-
-	// We create the limiter twice in the case of streaming so that we don't double count the series
-	// and hit the limit prematurely.
-	chunksLimiter := ss.chunksLimiterFactory(ss.metrics.queriesDropped.WithLabelValues("chunks"))
-	seriesLimiter := ss.seriesLimiterFactory(ss.metrics.queriesDropped.WithLabelValues("series"))
-
-	start := time.Now()
-	if req.StreamingChunksBatchSize > 0 {
-		seriesChunkIt := ss.createParquetSeriesChunksSetIterator(ctx, req, shards, shardSelector, matchers, chunksLimiter, seriesLimiter, stats)
-		err = ss.sendStreamingChunks(req, srv, seriesChunkIt, stats, streamingSeriesCount)
-	} else {
-		var seriesSet storepb.SeriesSet
-		seriesSet, err = ss.createParquetSeriesSetWithChunks(ctx, req, shards, shardSelector, matchers, chunksLimiter, seriesLimiter, stats)
-		if err != nil {
-			return err
-		}
-		err = ss.sendSeriesChunks(req, srv, seriesSet, stats)
-	}
-	if err != nil {
-		return
-	}
-
-	numSeries, numChunks := stats.seriesAndChunksCount()
-	debugMessage := "sent series"
-	if req.StreamingChunksBatchSize > 0 {
-		debugMessage = "sent streaming chunks"
-	}
-	spanLogger.DebugLog(
-		"msg", debugMessage,
-		"num_series", numSeries,
-		"num_chunks", numChunks,
-		"duration", time.Since(start),
-	)
-
-	if req.StreamingChunksBatchSize == 0 {
-		// Stats were not sent before, so send it now.
-		return ss.sendStats(srv, stats)
-	}
-
-	return nil
+	return store.Series(req, spanSeriesServer{
+		StoreGateway_SeriesServer: srv,
+		ctx:                       spanCtx,
+	})
 }
 
-func (ss ParquetBucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
+// LabelNames implements the storegatewaypb.StoreGatewayServer interface.
+func (ss *ParquetBucketStores) LabelNames(ctx context.Context, req *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
+	spanLog, spanCtx := spanlogger.New(ctx, ss.logger, tracer, "ParquetBucketStores.LabelNames")
+	defer spanLog.Finish()
+
+	userID := getUserIDFromGRPCContext(spanCtx)
+	if userID == "" {
+		return nil, fmt.Errorf("no userID")
+	}
+
+	store := ss.getStore(userID)
+	if store == nil {
+		return &storepb.LabelNamesResponse{}, nil
+	}
+
+	return store.LabelNames(ctx, req)
+}
+
+// LabelValues implements the storegatewaypb.StoreGatewayServer interface.
+func (ss *ParquetBucketStores) LabelValues(ctx context.Context, req *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
+	spanLog, spanCtx := spanlogger.New(ctx, ss.logger, tracer, "ParquetBucketStores.LabelValues")
+	defer spanLog.Finish()
+
+	userID := getUserIDFromGRPCContext(spanCtx)
+	if userID == "" {
+		return nil, fmt.Errorf("no userID")
+	}
+
+	store := ss.getStore(userID)
+	if store == nil {
+		return &storepb.LabelValuesResponse{}, nil
+	}
+
+	return store.LabelValues(ctx, req)
+}
+
+func (ss *ParquetBucketStores) SyncBlocks(ctx context.Context) error {
 	// TODO implement me
 	panic("implement me")
 }
 
-func (ss ParquetBucketStores) LabelValues(ctx context.Context, req *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
-	// TODO implement me
-	panic("implement me")
-}
+// scanUsers in the bucket and return the list of found users, respecting any specifically
+// enabled or disabled users.
+func (ss *ParquetBucketStores) scanUsers(ctx context.Context) ([]string, error) {
+	users, err := tsdb.ListUsers(ctx, ss.bucket)
+	if err != nil {
+		return nil, err
+	}
 
-func (ss ParquetBucketStores) SyncBlocks(ctx context.Context) error {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (ss ParquetBucketStores) scanUsers(ctx context.Context) ([]string, error) {
-	// TODO implement me
-	panic("implement me")
-}
-
-type parquetShardWithMetadata struct {
-	storage.ParquetShardOpener
-	BlockID ulid.ULID
-	queried bool
-}
-
-func (ps *parquetShardWithMetadata) MarkQueried() {
-	ps.queried = true
-}
-
-// Placeholder methods for parquet-specific functionality
-func (ss *ParquetBucketStores) openParquetShardsForReading(ctx context.Context, skipChunks bool, minTime, maxTime int64, reqBlockMatchers []*labels.Matcher, stats *safeQueryStats) []*parquetShardWithMetadata {
-	// TODO: Implement parquet shard discovery and opening logic
-	// This should:
-	// 1. Discover parquet shards that intersect with the time range
-	// 2. Use storage.ParquetShardOpener to open .labels.parquet and .chunks.parquet files
-	// 3. Read parquet schemas and metadata for efficient querying using shard.TSDBSchema()
-	// 4. Wrap opened ParquetShard with metadata (BlockID, queried status)
-	panic("TODO: implement openParquetShardsForReading")
-}
-
-func (ss *ParquetBucketStores) closeParquetShards(shards []*parquetShardWithMetadata) {
-	for _, shard := range shards {
-		if shard == nil {
-			continue
-		}
-		if err := shard.Close(); err != nil {
-			ss.logger.Log("msg", "failed to close parquet shard", "block_id", shard.BlockID, "err", err)
+	filtered := make([]string, 0, len(users))
+	for _, user := range users {
+		if ss.allowedTenants.IsAllowed(user) {
+			filtered = append(filtered, user)
 		}
 	}
-	// TODO: Implement parquet shard cleanup
-	// Close any open parquet file handles and release resources
-	panic("TODO: implement closeParquetShards")
+
+	return filtered, nil
 }
 
-func (ss *ParquetBucketStores) limitConcurrentQueries(ctx context.Context, stats *safeQueryStats) (func(), error) {
-	// TODO: Can potentially reuse BucketStore.limitConcurrentQueries
-	// or implement parquet-specific version if needed
-	panic("TODO: implement limitConcurrentQueries")
-}
-
-func (ss *ParquetBucketStores) sendHints(srv storegatewaypb.StoreGateway_SeriesServer, resHints *hintspb.SeriesResponseHints) error {
-	// TODO: Implement hints sending for parquet stores
-	panic("TODO: implement sendHints")
-}
-
-func (ss *ParquetBucketStores) createParquetSeriesSetForLabels(ctx context.Context, req *storepb.SeriesRequest, shards []*parquetShardWithMetadata, shardSelector *sharding.ShardSelector, matchers []*labels.Matcher, chunksLimiter ChunksLimiter, seriesLimiter SeriesLimiter, stats *safeQueryStats) (storepb.SeriesSet, error) {
-	// TODO: Implement parquet series set creation for labels phase
-	// This should:
-	// 1. "Stream read" .labels.parquet files from shards using shard.LabelsFile()
-	// 2. Create and return storepb.SeriesSet that iterates over series labels without chunks
-	// Please note that storepb.SeriesSet assumes series are ordered.
-	panic("TODO: implement createParquetSeriesSetForLabels")
-}
-
-func (ss *ParquetBucketStores) sendStreamingSeriesLabelsAndStats(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer, stats *safeQueryStats, seriesSet storepb.SeriesSet) (int, error) {
-	// TODO: Can potentially reuse BucketStore.sendStreamingSeriesLabelsAndStats
-	// or implement parquet-specific version if needed
-	panic("TODO: implement sendStreamingSeriesLabelsAndStats")
-}
-
-func (ss *ParquetBucketStores) createParquetSeriesChunksSetIterator(ctx context.Context, req *storepb.SeriesRequest, shards []*parquetShardWithMetadata, shardSelector *sharding.ShardSelector, matchers []*labels.Matcher, chunksLimiter ChunksLimiter, seriesLimiter SeriesLimiter, stats *safeQueryStats) iterator[seriesChunksSet] {
-	// TODO: Implement parquet series chunks iterator creation
-	// This should:
-	// 1. Stream read .chunks.parquet files from shards using shard.ChunksFile()
-	// 2. Return iterator[seriesChunksSet] / or the new iterator Nico is workisng on in his PR that streams chunks for the series discovered in labels phase
-	panic("TODO: implement createParquetSeriesChunksSetIterator")
-}
-
-func (ss *ParquetBucketStores) sendStreamingChunks(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer, seriesChunkIt iterator[seriesChunksSet], stats *safeQueryStats, streamingSeriesCount int) error {
-	// TODO: Can potentially reuse BucketStore.sendStreamingChunks
-	// or implement parquet-specific version if needed
-	panic("TODO: implement sendStreamingChunks")
-}
-
-func (ss *ParquetBucketStores) createParquetSeriesSetWithChunks(ctx context.Context, req *storepb.SeriesRequest, shards []*parquetShardWithMetadata, shardSelector *sharding.ShardSelector, matchers []*labels.Matcher, chunksLimiter ChunksLimiter, seriesLimiter SeriesLimiter, stats *safeQueryStats) (storepb.SeriesSet, error) {
-	// TODO: Implement parquet series set creation for non-streaming request
-	// I think this should create a series that includes the labels in one go and its typically called when skipchunks is true
-	panic("TODO: implement createParquetSeriesSetWithChunks")
-}
-
-func (ss *ParquetBucketStores) sendSeriesChunks(req *storepb.SeriesRequest, srv storegatewaypb.StoreGateway_SeriesServer, seriesSet storepb.SeriesSet, stats *safeQueryStats) error {
-	// TODO: Can potentially reuse BucketStore.sendSeriesChunks
-	// or implement parquet-specific version if needed
-	panic("TODO: implement sendSeriesChunks")
-}
-
-func (ss *ParquetBucketStores) sendStats(srv storegatewaypb.StoreGateway_SeriesServer, stats *safeQueryStats) error {
-	// TODO: Implement stats sending for parquet stores
-	panic("TODO: implement sendStats")
-}
-
-func (ss *ParquetBucketStores) recordSeriesCallResult(stats *safeQueryStats) {
-	// TODO: Implement series call result recording for parquet stores
-	panic("TODO: implement recordSeriesCallResult")
-}
-
-func (ss *ParquetBucketStores) recordRequestAmbientTime(stats *safeQueryStats, startTime time.Time) {
-	// TODO: Implement request ambient time recording for parquet stores
-	panic("TODO: implement recordRequestAmbientTime")
+func (ss *ParquetBucketStores) getStore(userID string) *ParquetBucketStore {
+	ss.storesMu.RLock()
+	defer ss.storesMu.RUnlock()
+	return ss.stores[userID]
 }


### PR DESCRIPTION
fix split between Parquet Stores and each tenant's Store - those two were accidentially combined in the previous PR.

The `Stores` (one object, plural name) keeps track of each tenant's `Store` and just dispatches to them to satisfy query calls.
The `Stores` also coordinates blocks syncing, keeping track of allowed and disallowed tenants and dispatching sync calls to each tenant's `Store`

The individual `Store` does most of the actual work.

Also broke out a new file to hold the parquet version of `bucketBlock`, now called `parquetBlockWithMeta`. It was named `parquetShardWithMetadata`, but it appears every usage of this code has punted on the idea of having more than 1 shard per block now, so I figured we would try to keep the names as analogous to the main store-gateway types as possible for now.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
