### PR TITLE
golangci-lint: display unlimited same issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 version: "2"
+issues:
+  # Disaply as many same issues as possible. This should make it easier to address all issues in one go.
+  max-same-issues: 0
 run:
   timeout: 10m
   # List of build tags, all linters use it.


### PR DESCRIPTION
This uncaps the number of occurrences of the same issue that the linter will output. This should make it easier to address all issues in one go instead of pushing a change and running the linter again.

For example, if the `errcheck` has failed in 7 places in the PR, by default golangci lint will only show the first 3. With this change it will show all 7.

