### PR TITLE
Configure Renovate to update Go version in all locations in one PR

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,12 +30,11 @@
         ],
         "enabled": false
       },
-      // Pin Go at the current version, since we want to upgrade it manually.
-      // Remember to keep this in sync when upgrading our Go version!
       {
-        "matchDatasources": ["docker", "golang-version"],
+        // Update Go version everywhere at once: build image, go.mod and GitHub Actions workflows.
+        "matchDatasources": ["docker", "golang-version", "github-releases"],
         "matchPackageNames": ["go", "golang"],
-        "allowedVersions": "<=1.22.5"
+        "groupName": "Go"
       },
       // Keep deps for the dashboard screenshotting tool up to date
       {


### PR DESCRIPTION
#### What this PR does

This PR configures Renovate to update Go in all places as part of a single PR:

* `go.mod`
* the build image
* any GitHub Actions workflows that use `actions/setup-go`

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
