### PR TITLE
MQE: track memory consumption of `[]promql.Bucket` and `[]promql.Buckets` separately

### DIFF
--- a/pkg/streamingpromql/operators/functions/histogram_function.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function.go
@@ -79,7 +79,7 @@ var pointBucketPool = types.NewLimitingBucketedPool(
 	pool.NewBucketedPool(types.MaxExpectedPointsPerSeries, func(size int) []promql.Buckets {
 		return make([]promql.Buckets, 0, size)
 	}),
-	limiter.BucketSlices,
+	limiter.BucketsSlices,
 	uint64(unsafe.Sizeof(promql.Buckets{})),
 	true,
 	mangleBuckets,

--- a/pkg/util/limiter/memory_consumption.go
+++ b/pkg/util/limiter/memory_consumption.go
@@ -51,6 +51,7 @@ const (
 	HistogramPointerSlices
 	SeriesMetadataSlices
 	BucketSlices
+	BucketsSlices
 	QuantileGroupSlices
 	TopKBottomKInstantQuerySeriesSlices
 	TopKBottomKRangeQuerySeriesSlices
@@ -89,6 +90,8 @@ func (s MemoryConsumptionSource) String() string {
 	case SeriesMetadataSlices:
 		return "[]SeriesMetadata"
 	case BucketSlices:
+		return "[]promql.Bucket"
+	case BucketsSlices:
 		return "[]promql.Buckets"
 	case QuantileGroupSlices:
 		return "[]aggregations.qGroup"


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue introduced in #11654 where slices of `[]promql.Bucket` and `[]promql.Buckets` were categorised together.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/11654

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
