### PR TITLE
Skip changelog check for automated PRs

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -11,15 +11,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check if changelog-not-needed label exists
+      - name: Check if changelog should be skipped
         id: check-label
         run: |
-          if gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | grep -q "changelog-not-needed"; then
+          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
+          
+          if echo "$LABELS" | grep -qE "(changelog-not-needed|dependency-update|vendored-mimir-prometheus-update|helm-weekly-release)"; then
             echo "skip=true" >> $GITHUB_OUTPUT
-            echo "PR has changelog-not-needed label, skipping changelog check"
+            echo "PR has a label that skips changelog check, skipping changelog check"
           else
             echo "skip=false" >> $GITHUB_OUTPUT
-            echo "PR does not have changelog-not-needed label, will check changelog"
+            echo "PR does not have any labels that skip changelog check, will check changelog"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,6 +34,6 @@ jobs:
             echo "✅ PR #${PR_NUMBER} is referenced in CHANGELOG.md"
           else
             echo "❌ PR #${PR_NUMBER} is not referenced in CHANGELOG.md"
-            echo "Please add an entry for this PR in CHANGELOG.md or add the 'changelog-not-needed' label if this change doesn't require a changelog entry."
+            echo "Please add an entry for this PR in CHANGELOG.md or add one of these labels if this change doesn't require a changelog entry: 'changelog-not-needed', 'dependency-update', 'vendored-mimir-prometheus-update', 'helm-weekly-release'"
             exit 1
           fi

--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -53,4 +53,6 @@ jobs:
           commit-message: Update mimir-distributed chart to ${{ steps.update.outputs.new_chart_version }}
           branch: helm-chart-weekly-${{ steps.update.outputs.new_chart_version }}
           base: main
-          labels: helm
+          labels: |
+            helm
+            helm-weekly-release

--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -124,4 +124,5 @@ jobs:
           commit-message: Update mimir-prometheus to `${{ steps.get-commit-info.outputs.short_hash }}`
           branch: bot/${{ inputs.mimir_branch }}/update-mimir-prometheus-${{ steps.get-commit-info.outputs.short_hash }}-${{ steps.get-commit-info.outputs.timestamp }}
           base: ${{ inputs.mimir_branch }}
+          labels: vendored-mimir-prometheus-update
           delete-branch: true

--- a/renovate.json5
+++ b/renovate.json5
@@ -53,6 +53,7 @@
       }
     ],
     "branchPrefix": "deps-update/",
+    "labels": ["dependency-update"],
     "vulnerabilityAlerts": {
       "enabled": true,
       "labels": ["security-update"]


### PR DESCRIPTION
## Summary
- Skip changelog check for automated PRs with specific labels
- Add appropriate labels to automated workflows

## Changes
- **changelog-check.yml**: Skip validation for PRs with `dependency-update`, `vendored-mimir-prometheus-update`, or `helm-weekly-release` labels
- **helm-weekly-release-pr.yaml**: Add `helm-weekly-release` label to weekly helm release PRs
- **update-vendored-mimir-prometheus.yml**: Add `vendored-mimir-prometheus-update` label to vendored prometheus update PRs  
- **renovate.json5**: Configure Renovate to add `dependency-update` label to all dependency update PRs