### PR TITLE
Really configure Renovate to update Go version in all locations in one PR

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -33,7 +33,7 @@
       {
         // Update Go version everywhere at once: build image, go.mod and GitHub Actions workflows.
         "matchDatasources": ["docker", "golang-version", "github-releases"],
-        "matchPackageNames": ["go", "golang"],
+        "matchPackageNames": ["go", "golang", "actions/go-versions"],
         "groupName": "Go"
       },
       // Keep deps for the dashboard screenshotting tool up to date


### PR DESCRIPTION
#### What this PR does

This PR is a follow up to #11743 that fixes the issue where updates to the Go version in GitHub Actions workflows (eg. for `actions/setup-go` steps) weren't grouped together with the main Go version update PR.

#### Which issue(s) this PR fixes or relates to

#11743

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
