### PR TITLE
Improve ingest storage Kafka records production observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * [CHANGE] Memcached: Ignore initial DNS resolution failure, meaning don't depend on Memcached on startup. #11602
 * [CHANGE] Ingester: The `-ingester.stream-chunks-when-using-blocks` CLI flag and `ingester_stream_chunks_when_using_blocks` runtime configuration option have been deprecated and will be removed in a future release. #11711
 * [CHANGE] Distributor: track `cortex_ingest_storage_writer_latency_seconds` metric for failed writes too. Added `outcome` label to distinguish between `success` and `failure`. #11770
+* [CHANGE] Distributor: renamed few metrics used by experimental ingest storage. #11766
+  * Renamed `cortex_ingest_storage_writer_produce_requests_total` to `cortex_ingest_storage_writer_produce_records_enqueued_total`
+  * Renamed `cortex_ingest_storage_writer_produce_failures_total` to `cortex_ingest_storage_writer_produce_records_failed_total`
 * [FEATURE] Distributor: Experimental support for Prometheus Remote-Write 2.0 protocol. Limitations: Created timestamp is ignored, per series metadata is merged on metric family level automatically, ingestion might fail if client sends ProtoBuf fields out of order. The label `version` is added to the metric `cortex_distributor_requests_in_total` with a value of either `1.0` or `2.0` depending on the detected Remote-Write protocol. #11100 #11101 #11192 #11143
 * [FEATURE] Query-frontend: expand `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` configuration options to cache non-transient response failures for instant queries. #11120
 * [FEATURE] Query-frontend: Allow use of Mimir Query Engine (MQE) via the experimental CLI flags `-query-frontend.query-engine` or `-query-frontend.enable-query-engine-fallback` or corresponding YAML. #11417
@@ -70,6 +73,9 @@
 * [ENHANCEMENT] Tracing: Add HTTP headers as span attributes when `-server.trace-request-headers` is enabled. You can configure which headers to exclude using the `-server.trace-request-headers-exclude-list` flag. #11655
 * [ENHANCEMENT] Ruler: Add new per-tenant limit on minimum rule evaluation interval. #11665
 * [ENHANCEMENT] store-gateway: download sparse headers on startup when lazy loading is enabled. #11686
+* [ENHANCEMENT] Distributor: added more metrics to troubleshoot Kafka records production latency when experimental ingest storage is enabled. #11766
+  * Added `cortex_ingest_storage_writer_produce_remaining_deadline_seconds` metric, to measure the remaining deadline (in seconds) when records are requested to be produced.
+  * Added `cortex_ingest_storage_writer_produce_records_enqueue_duration_seconds` metric, to measure how long it takes to enqueue produced Kafka records in the client.
 * [BUGFIX] OTLP: Fix response body and Content-Type header to align with spec. #10852
 * [BUGFIX] Compactor: fix issue where block becomes permanently stuck when the Compactor's block cleanup job partially deletes a block. #10888
 * [BUGFIX] Storage: fix intermittent failures in S3 upload retries. #10952

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -1966,12 +1966,30 @@ local utils = import 'mixin-utils/utils.libsonnet';
     ) +
     $.queryPanel([
       |||
-        sum(rate(cortex_ingest_storage_writer_produce_requests_total{%(job_matcher)s}[$__rate_interval]))
+        sum(
+            # Old metric.
+            rate(cortex_ingest_storage_writer_produce_requests_total{%(job_matcher)s}[$__rate_interval])
+            or
+            # New metric.
+            rate(cortex_ingest_storage_writer_produce_records_enqueued_total{%(job_matcher)s}[$__rate_interval])
+        )
         -
-        (sum(rate(cortex_ingest_storage_writer_produce_failures_total{%(job_matcher)s}[$__rate_interval])) or vector(0))
+        (sum(
+            # Old metric.
+            rate(cortex_ingest_storage_writer_produce_failures_total{%(job_matcher)s}[$__rate_interval])
+            or
+            # New metric.
+            rate(cortex_ingest_storage_writer_produce_records_failed_total{%(job_matcher)s}[$__rate_interval])
+        ) or vector(0))
       ||| % { job_matcher: $.jobMatcher($._config.job_names[jobName]) },
       |||
-        sum by(reason) (rate(cortex_ingest_storage_writer_produce_failures_total{%(job_matcher)s}[$__rate_interval]))
+        sum by(reason) (
+            # Old metric.
+            rate(cortex_ingest_storage_writer_produce_failures_total{%(job_matcher)s}[$__rate_interval])
+            or
+            # New metric.
+            rate(cortex_ingest_storage_writer_produce_records_failed_total{%(job_matcher)s}[$__rate_interval])
+        )
       ||| % { job_matcher: $.jobMatcher($._config.job_names[jobName]) },
     ], [
       'success',

--- a/operations/mimir-mixin/dashboards/ruler.libsonnet
+++ b/operations/mimir-mixin/dashboards/ruler.libsonnet
@@ -57,7 +57,13 @@ local filename = 'mimir-ruler.json';
                 (sum(rate(cortex_ingester_client_request_duration_seconds_count{%(job_matcher)s, operation="/cortex.Ingester/Push"}[$__rate_interval])) or vector(0))
                 +
                 # Ingest storage architecture.
-                (sum(rate(cortex_ingest_storage_writer_produce_requests_total{%(job_matcher)s}[$__rate_interval])) or vector(0))
+                (sum(
+                    # Old metric.
+                    rate(cortex_ingest_storage_writer_produce_requests_total{%(job_matcher)s}[$__rate_interval])
+                    or
+                    # New metric.
+                    rate(cortex_ingest_storage_writer_produce_records_enqueued_total{%(job_matcher)s}[$__rate_interval])
+                ) or vector(0))
               ||| % { job_matcher: $.jobMatcher($._config.job_names.ruler) }
             else
               |||

--- a/pkg/storage/ingest/INTERNALS.md
+++ b/pkg/storage/ingest/INTERNALS.md
@@ -1,0 +1,15 @@
+# Ingest storage internals notes
+
+## franz-go and ProducerBatchMaxBytes
+
+How it works:
+
+- The client allows to configure the max size of a single batch of records, by setting `kgo.ProducerBatchMaxBytes()`.
+- Batches are per topic-partition. Records for a different partition, go to a different batch.
+- When a Produce request is created ([code](https://github.com/twmb/franz-go/blob/37eecbb8927fce0aede1d6af39849839f7b0b3cf/pkg/kgo/sink.go#L111-L122)), the client picks at most 1 batch for each topic-partition, up to the max size (bytes) of the Produce request (configurable with `kgo.BrokerMaxWriteBytes()`, defaults to 100MB).
+
+This means that a low value of `kgo.ProducerBatchMaxBytes()` may put a throughput limit to the Kafka client, because Produce requests may be sent even if they're not full (with regards the max request size) and there are still buffered records (in subsequent batches for the same topic-partition). However, there are other conditions that needs to be true to see a throughput limit due to small max batch size in practice:
+
+- `kgo.ProducerBatchMaxBytes()` is low
+- The number of partitions records are sharded to is low (batches are per topic-partition)
+- `kgo.MaxProduceRequestsInflightPerBroker()` is low and/or the Produce latency is high (e.g. Warpstream)


### PR DESCRIPTION
#### What this PR does

In this PR I'm doing few changes to improve Kafka records production observability (used by ingest storage):

- Added `cortex_ingest_storage_writer_produce_remaining_deadline_seconds` metric, to measure the remaining deadline (in seconds) when records are requested to be produced.
- Added `cortex_ingest_storage_writer_produce_records_enqueue_duration_seconds` metric, to measure how long it takes to enqueue produced Kafka records in the client.
- Renamed `cortex_ingest_storage_writer_produce_requests_total` to `cortex_ingest_storage_writer_produce_records_enqueued_total` (reminder: `cortex_ingest_storage_writer_produce_records_total` also exists and is tracked by the franz-go client; it's the number of records sent over the wire). This metric has been renamed to clarify it's about records and not requests. The tracked value doesn't change.
- Renamed `cortex_ingest_storage_writer_produce_failures_total` to `cortex_ingest_storage_writer_produce_records_failed_total`. This metric has been renamed to clarify it's about records and not requests. The tracked value doesn't change.

**Dashboard changes previews**:

![preview-ruler](https://github.com/user-attachments/assets/df29c4eb-c045-4db2-bbd5-52074aa3c75c)

![preview-produced-records](https://github.com/user-attachments/assets/689e81f2-4a12-4506-bfc1-eaa08f12fc23)


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
