### PR TITLE
Make output of -modules stable

### DIFF
--- a/cmd/mimir/main.go
+++ b/cmd/mimir/main.go
@@ -222,7 +222,7 @@ func main() {
 		for _, m := range t.ModuleManager.UserVisibleModuleNames() {
 			fmt.Print(m)
 			if dependents, ok := dependentsByModule[m]; ok {
-				fmt.Print(" (in: ", strings.Join(slices.Collect(maps.Keys(dependents)), ", "), ")")
+				fmt.Print(" (in: ", strings.Join(slices.Sorted(maps.Keys(dependents)), ", "), ")")
 			}
 			fmt.Println()
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

`TestFlagParsing` is flaky because the list of dependents is taken from a map's keys, whose order is randomized.

```
      --- FAIL: TestFlagParsing/user_visible_module_listing (0.06s)
          main_test.go:246: Expected on stdout: "ingester (in: all, write)\n", stdout: alertmanager (in: backend)
...
              ingester (in: write, all)
 ```

Use `slices.Sorted` instead of `slices.Collect` to make the output deterministic.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
