### PR TITLE
Fix rare panic when the ruler is shutting down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 * [BUGFIX] Querier: Fix rare panic if a query is canceled while a request to ingesters or store-gateways has just begun. #11613
 * [BUGFIX] Ruler: Fix QueryOffset and AlignEvaluationTimeOnInterval being ignored when either recording or alerting rule evaluation is disabled. #11647
 * [BUGFIX] Ingester: Fix issue where ingesters could leave read-only mode during forced compactions, resulting in write errors. #11664
+* [BUGFIX] Ruler: Fix rare panic when the ruler is shutting down. #11781
 
 ### Mixin
 

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -204,7 +204,7 @@ func (w *Writer) getKafkaWriterForPartition(partitionID int32) (*KafkaProducer, 
 	w.writersMx.Lock()
 	defer w.writersMx.Unlock()
 
-	// Ensure the service is in the Running state. We want to avoid the case someone tries to
+	// Ensure the service is in the Running state. We want to avoid the case where someone tries to
 	// re-create a client after the service has been stopped.
 	if w.Service.State() != services.Running {
 		return nil, ErrWriterNotRunning

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -50,6 +50,10 @@ var (
 	// fails only if bigger than the upper limit.
 	ErrWriteRequestDataItemTooLarge = errors.New(globalerror.DistributorMaxWriteRequestDataItemSize.Message(
 		fmt.Sprintf("the write request contains a timeseries or metadata item which is larger that the maximum allowed size of %d bytes", maxProducerRecordDataBytesLimit)))
+
+	// ErrWriterNotRunning is the error returned if someone tries to use Writer but the service is not
+	// in the running state.
+	ErrWriterNotRunning = errors.New("the Kafka writer client is not in the running state")
 )
 
 // Writer is responsible to write incoming data to the ingest storage.
@@ -199,6 +203,12 @@ func (w *Writer) getKafkaWriterForPartition(partitionID int32) (*KafkaProducer, 
 
 	w.writersMx.Lock()
 	defer w.writersMx.Unlock()
+
+	// Ensure the service is in the Running state. We want to avoid the case someone tries to
+	// re-create a client after the service has been stopped.
+	if w.Service.State() != services.Running {
+		return nil, ErrWriterNotRunning
+	}
 
 	// Ensure a new writer wasn't created in the meanwhile. If so, use it.
 	writer = w.writers[clientID]


### PR DESCRIPTION
#### What this PR does

We've seen a rare panic on ruler shutdown. The stack trace is:

```
	/__w/TRUNCATED/vendor/github.com/grafana/dskit/concurrency/worker.go:12 +0x98
created by github.com/grafana/dskit/concurrency.NewReusableGoroutinesPool in goroutine 1
	/__w/TRUNCATED/vendor/github.com/grafana/dskit/concurrency/worker.go:16 +0x30
	/__w/TRUNCATED/vendor/github.com/grafana/dskit/ring/batch.go:181 +0x98
	/__w/TRUNCATED/vendor/github.com/grafana/mimir/pkg/distributor/distributor.go:1854 +0xf8
github.com/grafana/mimir/pkg/distributor.(*Distributor).sendWriteRequestToPartitions.func1({{0x3be65d6, 0x2}, 0x0, 0x0, {0x0, 0x0, 0x0}, {0x0, 0x0}, 0x0, ...}, ...)
	/__w/TRUNCATED/vendor/github.com/grafana/mimir/pkg/storage/ingest/writer.go:150 +0xb0
github.com/grafana/mimir/pkg/storage/ingest.(*Writer).WriteSync(0x4002130000, {0x43f3400, 0x41817a0cb0}, 0x29, {0x4002b80516, 0x5}, 0x427cb03550)
	/__w/TRUNCATED/vendor/github.com/grafana/mimir/pkg/storage/ingest/writer.go:212 +0x374
github.com/grafana/mimir/pkg/storage/ingest.(*Writer).getKafkaWriterForPartition(0x4002130000, 0x4ab?)
	/__w/TRUNCATED/vendor/github.com/grafana/mimir/pkg/storage/ingest/writer_client.go:118 +0x14c
github.com/grafana/mimir/pkg/storage/ingest.NewKafkaProducer(0x422a096a88, 0x100000000, {0x43e0e60, 0x4181898d20})
	/__w/TRUNCATED/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go:329 +0x144
github.com/prometheus/client_golang/prometheus/promauto.Factory.NewSummary({{0x43e0e60?, 0x4181898d20?}}, {{0x0, 0x0}, {0x0, 0x0}, {0x3a90b48, 0x16}, {0x3bce4b0, 0x6e}, ...})
	/__w/TRUNCATED/vendor/github.com/prometheus/client_golang/prometheus/wrap.go:104 +0x144
github.com/prometheus/client_golang/prometheus.(*wrappingRegisterer).MustRegister(0x4181898d20, {0x413217df20?, 0x0?, 0x0?})
goroutine 1084 [running]:
panic: duplicate metrics collector registration attempted
```

My theory is that this can happen due to a race condition in the `rules.Group.Eval()` on shutdown, specifically the `appender.Commit()` called by `cleanupStaleSeries()` after the Group is terminated ([code](https://github.com/grafana/mimir/blob/main/vendor/github.com/prometheus/prometheus/rules/group.go#L259)). There's a check on `g.managerDone` being closed, but it gets closed at the very end of `rules.Manager.Stop()` so there could easily be race conditions, especially if a rule group interval is low or the ruler takes some time to terminate, considering that `cleanupStaleSeries()` is called after `rule group evaluation interval * 2` (keep in mind that in Mimir we have multi-tenant rule manager, so the ruler process terminates once all per-tenant managers are terminated, and this could leave a quite large time window to hit the `rule group evaluation interval * 2` delay.

Fixing the race condition in the ruler is pretty hard, and I don't find it much interesting, given the fix would be just trying to avoid `cleanupStaleSeries()` on shutdown.

I think an easier fix could just be avoiding `ingest.Writer` to panic if someone tries to use it after being stopped, which is what I propose in this PR.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
