### PR TITLE
[r347] Block-builder-scheduler: Bug: assigned job skipped if start < commit < end (#11785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 * [BUGFIX] Querier: Fix rare panic if a query is canceled while a request to ingesters or store-gateways has just begun. #11613
 * [BUGFIX] Ruler: Fix QueryOffset and AlignEvaluationTimeOnInterval being ignored when either recording or alerting rule evaluation is disabled. #11647
 * [BUGFIX] Ingester: Fix issue where ingesters could leave read-only mode during forced compactions, resulting in write errors. #11664
+* [BUGFIX] Block-builder-scheduler: Fix data loss bug in job assignment. #11785
 
 ### Mixin
 

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -724,8 +724,11 @@ func (s *BlockBuilderScheduler) assignJob(workerID string) (jobKey, schedulerpb.
 			return k, spec, err
 		}
 
-		if c, ok := s.committed.Lookup(spec.Topic, spec.Partition); ok && spec.StartOffset < c.At {
+		if c, ok := s.committed.Lookup(spec.Topic, spec.Partition); ok && spec.EndOffset <= c.At {
 			// Job is before the committed offset. Remove it.
+			level.Info(s.logger).Log(
+				"msg", "removing job as it's behind the committed offset", "job_id", k.id, "epoch", k.epoch,
+				"partition", spec.Partition, "start_offset", spec.StartOffset, "end_offset", spec.EndOffset, "committed", c.At)
 			s.jobs.removeJob(k)
 			continue
 		}


### PR DESCRIPTION
Backport 57235b06864d219026e1168f221efdf2b3be8d53 from #11785

(cherry picked from commit 57235b06864d219026e1168f221efdf2b3be8d53)