### PR TITLE
ci: update changelog check workflow to skip backports

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -15,8 +15,9 @@ jobs:
         id: check-label
         run: |
           LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
-          
-          if echo "$LABELS" | grep -qE "(changelog-not-needed|dependency-update|vendored-mimir-prometheus-update|helm-weekly-release)"; then
+
+          # "grep -w" to check for the whole words
+          if echo "$LABELS" | grep -w -qE "(changelog-not-needed|dependency-update|vendored-mimir-prometheus-update|helm-weekly-release|backport)"; then
             echo "skip=true" >> $GITHUB_OUTPUT
             echo "PR has a label that skips changelog check, skipping changelog check"
           else


### PR DESCRIPTION
#### What this PR does

This is a follow-up to https://github.com/grafana/mimir/pull/11753

I've realized that currently, the CI fails on a backporting PR. Such a PR typically, doesn't need a dedicated changelog entry, ie. it's upstream PR either had one, or skipped doing it explicitly.

I think, rather than asking a reviewer of the backporting PR to set the "changelog-not-needed" label, we can just skip these PRs.