### PR TITLE
Regenerate OTLP files when updating vendored mimir-prometheus

### DIFF
--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -143,6 +143,9 @@ jobs:
           
           echo "Dependencies updated successfully"
 
+      - name: Regenerate OTLP files
+        run: make generate-otlp
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
         with:


### PR DESCRIPTION
#### What this PR does

This PR extends the automated mimir-prometheus vendoring workflow to automatically run `make generate-otlp` before committing.

This will prevent build failures like those seen in https://github.com/grafana/mimir/pull/11791.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/11518

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
