### PR TITLE
Alertmanager: Save the original config string when updating Grafana configuration

### DIFF
--- a/pkg/alertmanager/api_grafana_test.go
+++ b/pkg/alertmanager/api_grafana_test.go
@@ -67,6 +67,45 @@ const (
 			}]
 		}
 	}`
+	testGrafanaConfigWithMixedReceivers = `{
+		"template_files": {},
+		"alertmanager_config": {
+			"route": {
+				"receiver": "test_receiver",
+				"group_by": ["alertname"],
+				"routes": [{
+					"receiver": "standard_email_receiver",
+					"matchers": ["imported=\"true\""]
+				}]
+			},
+			"global": {
+				"resolve_timeout": "5m",
+				"smtp_smarthost": "localhost:587"
+			},
+			"receivers": [{
+				"name": "test_receiver",
+				"grafana_managed_receiver_configs": [{
+					"uid": "",
+					"name": "email test",
+					"type": "email",
+					"disableResolveMessage": true,
+					"settings": {
+						"addresses": "test@test.com"
+					}
+				}]
+			}, {
+				"name": "standard_email_receiver",
+				"email_configs": [{
+					"to": "alerts@example.com",
+					"from": "alertmanager@example.com",
+					"smarthost": "localhost:587",
+					"auth_username": "alertmanager@localhost",
+					"auth_password": "my_secret_password",
+					"subject": "Alert: {{ .GroupLabels.alertname }}"
+				}]
+			}]
+		}
+	}`
 )
 
 func TestMultitenantAlertmanager_DeleteUserGrafanaConfig(t *testing.T) {
@@ -329,13 +368,14 @@ func TestMultitenantAlertmanager_GetUserGrafanaState(t *testing.T) {
 
 func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 	cases := []struct {
-		name            string
-		maxConfigSize   int
-		orgID           string
-		body            string
-		expStatusCode   int
-		expResponseBody string
-		expStorageKey   string
+		name              string
+		maxConfigSize     int
+		orgID             string
+		body              string
+		expStatusCode     int
+		expResponseBody   string
+		expStorageKey     string
+		checkStoredObject func(t *testing.T, storedData []byte)
 	}{
 		{
 			name:          "missing org id",
@@ -380,7 +420,7 @@ func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 			expStatusCode: http.StatusBadRequest,
 			expResponseBody: `
 			{
-				"error": "error marshalling JSON Grafana Alertmanager config: no route provided in config",
+				"error": "error unmarshalling JSON Grafana Alertmanager config: no route provided in config",
 				"status": "error"
 			}
 			`,
@@ -486,6 +526,30 @@ func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 			}
 			`,
 		},
+		{
+			name: "with mixed receiver formats",
+			body: fmt.Sprintf(`
+			{
+				"configuration": %s,
+				"configuration_hash": "some-hash",
+				"created": 12312414343,
+				"default": false,
+				"promoted": true,
+				"external_url": "http://test.grafana.com",
+				"static_headers": {
+					"Header-1": "Value-1"
+				}
+			}
+			`, testGrafanaConfigWithMixedReceivers),
+			orgID:           "test_user",
+			expStatusCode:   http.StatusCreated,
+			expResponseBody: successJSON,
+			expStorageKey:   "grafana_alertmanager/test_user/grafana_config",
+			checkStoredObject: func(t *testing.T, storedData []byte) {
+				assert.Contains(t, string(storedData), `"auth_password": "my_secret_password"`)
+				assert.Contains(t, string(storedData), `"email_configs"`)
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -525,8 +589,12 @@ func TestMultitenantAlertmanager_SetUserGrafanaConfig(t *testing.T) {
 				assert.Len(t, storage.Objects(), 0)
 			} else {
 				assert.Len(t, storage.Objects(), 1)
-				_, ok := storage.Objects()[tc.expStorageKey]
+				storedObject, ok := storage.Objects()[tc.expStorageKey]
 				assert.True(t, ok)
+
+				if tc.checkStoredObject != nil {
+					tc.checkStoredObject(t, storedObject)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
#### What this PR does

This PR changes the handler that saves Grafana Alertmanager configurtion to preserve the original JSON string during unmarshaling, instead of re-marshaling the parsed Go struct before saving it.

If we do a JSON marshalling round-trip and the Grafana config contains an upstream Alertmanager configuration, secrets, [example](https://github.com/prometheus/alertmanager/blob/0ce3cfb962db3cbb1649d3e816a49a13c4036cd1/config/config.go#L56), in this configuration are lost during marshalling and saved to the storage as redacted strings. 

Instead this PR makes the handler use JSON unmarshalling to validate the configuration, and save the original JSON to the storage.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
