### PR TITLE
block-builder: refactor dashboard

### DIFF
--- a/operations/mimir-mixin/dashboards/block-builder.libsonnet
+++ b/operations/mimir-mixin/dashboards/block-builder.libsonnet
@@ -142,21 +142,6 @@ local filename = 'mimir-block-builder.json';
         )
       )
       .addPanel(
-        $.timeseriesPanel('Lag records') +
-        $.panelDescription(
-          'Per partition records lag',
-          |||
-            **Deprecated**. This panel is only relevant in the stand-alone mode.
-
-            Number of records in the backlog of a partition, as seen when starting a consumption cycle.
-          |||
-        ) +
-        $.queryPanel(
-          'max by (partition) (cortex_blockbuilder_consumer_lag_records{%(job)s}) > 0' % [$.jobMatcher($._config.job_names.block_builder)],
-          '{{partition}}',
-        )
-      )
-      .addPanel(
         $.timeseriesPanel('Partition processing duration') +
         $.panelDescription(
           'Partition processing duration',

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -100,7 +100,7 @@ func (s *BlockBuilderScheduler) running(ctx context.Context) error {
 		s.metrics.fetchOffsetsFailed.Inc()
 		return fmt.Errorf("fetch committed offsets: %w", err)
 	}
-	level.Debug(s.logger).Log("msg", "loaded initial committed offsets", "offsets", offsetsStr(c))
+	level.Info(s.logger).Log("msg", "loaded initial committed offsets", "offsets", offsetsStr(c))
 	s.mu.Lock()
 	s.committed = c
 	s.mu.Unlock()


### PR DESCRIPTION
This PR does two separate but tiny things, so I don't want to bother with opening separate PRs for them

1\. The scheduler now tracks the lag. So the old "Partition lag" worker's panel is no longer needed.

<img width="1464" alt="Screenshot 2025-06-20 at 14 15 52" src="https://github.com/user-attachments/assets/284d2a17-1e3d-43d1-942c-e07a5c976490" />

2\. Update the scheduler's logging

Today I was investigating an issue in a dev cell, and the `loaded initial committed offsets` logs were fairly helpful. They are cheap so we should have them in production too.