### PR TITLE
Add alert for high volume level 1 blocks queried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * [FEATURE] You can configure Mimir to export traces in OTLP exposition format through the standard `OTEL_` environment variables. #11618
 * [FEATURE] distributor: Allow configuring tenant-specific HA tracker failover timeouts. #11774
 * [ENHANCEMENT] Dashboards: Add "Influx write requests" row to Writes Dashboard. #11731
-* [ENHANCEMENT] Mixin: Add `MimirHighVolumeLevel1BlocksQueried` alert that fires when level 1 blocks are queried for more than 1 hour, indicating potential compactor performance issues. #11803
+* [ENHANCEMENT] Mixin: Add `MimirHighVolumeLevel1BlocksQueried` alert that fires when level 1 blocks are queried for more than 6 hours, indicating potential compactor performance issues. #11803
 * [ENHANCEMENT] Querier: Make the maximum series limit for cardinality API requests configurable on a per-tenant basis with the `cardinality_analysis_max_results` option. #11456
 * [ENHANCEMENT] Dashboards: Add "Queries / sec by read path" to Queries Dashboard. #11640
 * [ENHANCEMENT] Dashboards: Add "Added Latency" row to Writes Dashboard. #11579

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [FEATURE] You can configure Mimir to export traces in OTLP exposition format through the standard `OTEL_` environment variables. #11618
 * [FEATURE] distributor: Allow configuring tenant-specific HA tracker failover timeouts. #11774
 * [ENHANCEMENT] Dashboards: Add "Influx write requests" row to Writes Dashboard. #11731
+* [ENHANCEMENT] Mixin: Add `MimirHighVolumeLevel1BlocksQueried` alert that fires when level 1 blocks are queried for more than 1 hour, indicating potential compactor performance issues. #11803
 * [ENHANCEMENT] Querier: Make the maximum series limit for cardinality API requests configurable on a per-tenant basis with the `cardinality_analysis_max_results` option. #11456
 * [ENHANCEMENT] Dashboards: Add "Queries / sec by read path" to Queries Dashboard. #11640
 * [ENHANCEMENT] Dashboards: Add "Added Latency" row to Writes Dashboard. #11579

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -610,7 +610,7 @@ This alert fires when the store-gateway is querying level 1 blocks for more than
 
 How it **works**:
 
-- Level 1 blocks are deduplicated 2-hour blocks and contain less optimized data compared to higher-level blocks
+- Level 1 blocks are 2-hour blocks shipped by ingesters, not yet optimized by the compactor
 - When the compactor falls behind, store-gateways must serve queries from these less efficient level 1 blocks instead of well-compacted higher-level blocks
 - This can lead to increased query latency and resource usage
 - Out-of-order blocks are excluded from this alert as they may be shipped for previous dates and queried before being compacted into bigger blocks

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -613,6 +613,7 @@ How it **works**:
 - Level 1 blocks are deduplicated 2-hour blocks and contain less optimized data compared to higher-level blocks
 - When the compactor falls behind, store-gateways must serve queries from these less efficient level 1 blocks instead of well-compacted higher-level blocks
 - This can lead to increased query latency and resource usage
+- Out-of-order blocks are excluded from this alert as they may be shipped for previous dates and queried before being compacted into bigger blocks
 
 How to **investigate**:
 
@@ -625,6 +626,8 @@ How to **fix**:
 
 - Scale up the compactor horizontally if it's CPU or memory constrained
 - Check and increase compactor resources if needed
+- Preventatively check store-gateway CPU/memory/disk usage and scale out if constrained
+- Verify store-gateway auto-scaling has sufficient headroom to handle increased load during compactor catch-up
 - If the issue persists, investigate for corrupted blocks that might be blocking compaction
 
 ### MimirCompactorHasNotSuccessfullyRunCompaction

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -606,7 +606,7 @@ How to **investigate**:
 
 ### MimirHighVolumeLevel1BlocksQueried
 
-This alert fires when the store-gateway is querying level 1 blocks for more than 1 hour, indicating that the compactor may not be keeping up with compaction work.
+This alert fires when the store-gateway is querying level 1 blocks for more than 6 hours, indicating that the compactor may not be keeping up with compaction work.
 
 How it **works**:
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -610,7 +610,7 @@ This alert fires when the store-gateway is querying level 1 blocks for more than
 
 How it **works**:
 
-- Level 1 blocks are the result of the first compaction level and contain less optimized data compared to higher-level blocks
+- Level 1 blocks are deduplicated 2-hour blocks and contain less optimized data compared to higher-level blocks
 - When the compactor falls behind, store-gateways must serve queries from these less efficient level 1 blocks instead of well-compacted higher-level blocks
 - This can lead to increased query latency and resource usage
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -604,6 +604,29 @@ How to **investigate**:
 - Ensure ingesters are successfully shipping blocks to the storage
 - Look for any error in the compactor logs
 
+### MimirHighVolumeLevel1BlocksQueried
+
+This alert fires when the store-gateway is querying level 1 blocks for more than 1 hour, indicating that the compactor may not be keeping up with compaction work.
+
+How it **works**:
+
+- Level 1 blocks are the result of the first compaction level and contain less optimized data compared to higher-level blocks
+- When the compactor falls behind, store-gateways must serve queries from these less efficient level 1 blocks instead of well-compacted higher-level blocks
+- This can lead to increased query latency and resource usage
+
+How to **investigate**:
+
+- Check the `Mimir / Compactor` dashboard to see if the compactor is healthy and processing blocks normally
+- Look for errors in the compactor logs that might indicate why compaction is falling behind
+- Monitor the `Mimir / Queries` dashboard to see the "Blocks queried / sec by compaction level" panel for the volume of level 1 block queries
+- Check if there's increased write load that the compactor cannot keep up with
+
+How to **fix**:
+
+- Scale up the compactor horizontally if it's CPU or memory constrained
+- Check and increase compactor resources if needed
+- If the issue persists, investigate for corrupted blocks that might be blocking compaction
+
 ### MimirCompactorHasNotSuccessfullyRunCompaction
 
 This alert fires if the compactor is not able to successfully compact all discovered compactable blocks (across all tenants).

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -950,6 +950,15 @@ spec:
               min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
             labels:
               severity: critical
+          - alert: MimirHighVolumeLevel1BlocksQueried
+            annotations:
+              message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
+            expr: |
+              sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+            for: 6h
+            labels:
+              severity: warning
       - name: mimir_compactor_alerts
         rules:
           - alert: MimirCompactorHasNotSuccessfullyCleanedUpBlocks

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -955,7 +955,7 @@ spec:
               message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
             expr: |
-              sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+              sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
             for: 6h
             labels:
               severity: warning

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -955,7 +955,7 @@ spec:
               message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
             expr: |
-              sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+              sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
             for: 6h
             labels:
               severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -929,7 +929,7 @@ groups:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
-            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
           for: 6h
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -929,7 +929,7 @@ groups:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
-            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
           for: 6h
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -924,6 +924,15 @@ groups:
             min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
           labels:
             severity: critical
+        - alert: MimirHighVolumeLevel1BlocksQueried
+          annotations:
+            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
+          expr: |
+            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+          for: 6h
+          labels:
+            severity: warning
     - name: mimir_compactor_alerts
       rules:
         - alert: MimirCompactorHasNotSuccessfullyCleanedUpBlocks

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -943,7 +943,7 @@ groups:
             message: GEM store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
-            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
           for: 6h
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -938,6 +938,15 @@ groups:
             min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
           labels:
             severity: critical
+        - alert: MimirHighVolumeLevel1BlocksQueried
+          annotations:
+            message: GEM store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
+          expr: |
+            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+          for: 6h
+          labels:
+            severity: warning
     - name: mimir_compactor_alerts
       rules:
         - alert: MimirCompactorHasNotSuccessfullyCleanedUpBlocks

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -943,7 +943,7 @@ groups:
             message: GEM store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
-            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
           for: 6h
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -938,6 +938,15 @@ groups:
             min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
           labels:
             severity: critical
+        - alert: MimirHighVolumeLevel1BlocksQueried
+          annotations:
+            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
+          expr: |
+            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[$__rate_interval])) > 0
+          for: 1h
+          labels:
+            severity: warning
     - name: mimir_compactor_alerts
       rules:
         - alert: MimirCompactorHasNotSuccessfullyCleanedUpBlocks

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -943,7 +943,7 @@ groups:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
-            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
           for: 6h
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -943,7 +943,7 @@ groups:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
-            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[$__rate_interval])) > 0
+            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
           for: 1h
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -943,7 +943,7 @@ groups:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
-            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
+            sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
           for: 6h
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -944,7 +944,7 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
             sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",job=~".*/(store-gateway.*|cortex|mimir|mimir-backend.*)"}[5m])) > 0
-          for: 1h
+          for: 6h
           labels:
             severity: warning
     - name: mimir_compactor_alerts

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -235,6 +235,21 @@
             message: '%(product)s bucket index for tenant {{ $labels.user }} in %(alert_aggregation_variables)s has not been updated since {{ $value | humanizeDuration }}.' % $._config,
           },
         },
+        {
+          // Alert if there's sustained querying of level 1 blocks, which indicates the compactor
+          // is not keeping up and the store-gateway is serving blocks that aren't well compacted.
+          alert: $.alertName('HighVolumeLevel1BlocksQueried'),
+          'for': '1h',
+          expr: |||
+            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",%s}[$__rate_interval])) > 0
+          ||| % $.jobMatcher($._config.job_names.store_gateway),
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s store-gateway in %(alert_aggregation_variables)s is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.' % $._config,
+          },
+        },
       ],
     },
   ],

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -241,8 +241,8 @@
           alert: $.alertName('HighVolumeLevel1BlocksQueried'),
           'for': '1h',
           expr: |||
-            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",%s}[$__rate_interval])) > 0
-          ||| % $.jobMatcher($._config.job_names.store_gateway),
+            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",%s}[%s])) > 0
+          ||| % [$.jobMatcher($._config.job_names.store_gateway), $.alertRangeInterval(5)],
           labels: {
             severity: 'warning',
           },

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -241,8 +241,8 @@
           alert: $.alertName('HighVolumeLevel1BlocksQueried'),
           'for': '6h',
           expr: |||
-            sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",%s}[%s])) > 0
-          ||| % [$.jobMatcher($._config.job_names.store_gateway), $.alertRangeInterval(5)],
+            sum by(%s) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",%s}[%s])) > 0
+          ||| % [$._config.alert_aggregation_labels, $.jobMatcher($._config.job_names.store_gateway), $.alertRangeInterval(5)],
           labels: {
             severity: 'warning',
           },

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -241,7 +241,7 @@
           alert: $.alertName('HighVolumeLevel1BlocksQueried'),
           'for': '6h',
           expr: |||
-            sum by(%s) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",%s}[%s])) > 0
+            sum by(%s) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",%s}[%s])) > 0
           ||| % [$._config.alert_aggregation_labels, $.jobMatcher($._config.job_names.store_gateway), $.alertRangeInterval(5)],
           labels: {
             severity: 'warning',

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -239,7 +239,7 @@
           // Alert if there's sustained querying of level 1 blocks, which indicates the compactor
           // is not keeping up and the store-gateway is serving blocks that aren't well compacted.
           alert: $.alertName('HighVolumeLevel1BlocksQueried'),
-          'for': '1h',
+          'for': '6h',
           expr: |||
             sum(rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",%s}[%s])) > 0
           ||| % [$.jobMatcher($._config.job_names.store_gateway), $.alertRangeInterval(5)],


### PR DESCRIPTION
## Summary
- Add warning alert that fires when level 1 blocks are queried for more than 1 hour
- Indicates potential compactor performance issues when store-gateway serves non-compacted blocks

## Test plan
- Verify alert compiles correctly in mixin
- Monitor for false positives in production environments