### PR TITLE
makefile: Fix TTY device error in non-interactive environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,8 @@ LATEST_BUILD_IMAGE_TAG ?= pr11747-73ebde0521
 # TTY is parameterized to allow Google Cloud Builder to run builds,
 # as it currently disallows TTY devices. This value needs to be overridden
 # in any custom cloudbuild.yaml files
-TTY := --tty
+# Auto-detect TTY availability: use --tty if stdin is a TTY, otherwise empty
+TTY := $(shell test -t 0 && echo --tty || echo)
 MIMIR_VERSION := github.com/grafana/mimir/pkg/util/version
 
 REGO_POLICIES_PATH=operations/policies

--- a/Makefile
+++ b/Makefile
@@ -249,9 +249,8 @@ SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
 LATEST_BUILD_IMAGE_TAG ?= pr11747-73ebde0521
 
-# TTY is parameterized to allow Google Cloud Builder to run builds,
-# as it currently disallows TTY devices. This value needs to be overridden
-# in any custom cloudbuild.yaml files
+# TTY is parameterized to allow CI and scripts to run builds,
+# as it currently disallows TTY devices.
 # Auto-detect TTY availability: use --tty if stdin is a TTY, otherwise empty
 TTY := $(shell test -t 0 && echo --tty || echo)
 MIMIR_VERSION := github.com/grafana/mimir/pkg/util/version


### PR DESCRIPTION
## Summary
- Auto-detect TTY availability instead of hardcoding --tty flag in Docker commands
- Fixes "the input device is not a TTY" errors in CI/CD and non-interactive environments like claude
- Preserves colored output and terminal interaction for local development

## Test plan
- [x] Verified make commands work in non-interactive environment (Claude Code CLI)
- [x] Confirmed TTY flag is automatically omitted when stdin is not a TTY
- [x] Existing CI workflows that override TTY still work as before