### PR TITLE
OTLP: Fix conversion of non-monotonic sum metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -344,7 +344,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250620055426-d1217a3b6036
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250623074142-d4f9840f8e38
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -573,8 +573,8 @@ github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700 h1:0t7iOQ5ZkB
 github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700/go.mod h1:Ri9p/tRShbjYnpNf4FFPXG7wxEGY4Nrcn6E7jrVa//4=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250527173959-2573485683d5 h1:H4Del07v9UAYJgky9oeRY1oNqs6dh8lmHRUWiGCKXoE=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250527173959-2573485683d5/go.mod h1:v1PzmPjSnNkmZSDvKJ9OmsWcmWMEF5+JdllEcXrRfzM=
-github.com/grafana/mimir-prometheus v1.8.2-0.20250620055426-d1217a3b6036 h1:dm6yMCAe2Umuu7SXujDO5eRb1mj6qVLt+R097M6cIDg=
-github.com/grafana/mimir-prometheus v1.8.2-0.20250620055426-d1217a3b6036/go.mod h1:fwYE2p93ndH1ZwuzEEma8reSR5DU6uD3MllcbGLwRuA=
+github.com/grafana/mimir-prometheus v1.8.2-0.20250623074142-d4f9840f8e38 h1:Gw6/GS8y9ZTq1hMlugW737Hgdp7ICdwdQm1Hyz3S5oY=
+github.com/grafana/mimir-prometheus v1.8.2-0.20250623074142-d4f9840f8e38/go.mod h1:fwYE2p93ndH1ZwuzEEma8reSR5DU6uD3MllcbGLwRuA=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=

--- a/pkg/distributor/otlp/helper_generated.go
+++ b/pkg/distributor/otlp/helper_generated.go
@@ -128,9 +128,9 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, scope s
 
 	promotedAttrs := settings.PromoteResourceAttributes.promotedAttributes(resourceAttrs)
 
-	convertScope := settings.ConvertScopeMetadata && scope.name != ""
+	promoteScope := settings.PromoteScopeMetadata && scope.name != ""
 	scopeLabelCount := 0
-	if convertScope {
+	if promoteScope {
 		// Include name, version and schema URL.
 		scopeLabelCount = scope.attributes.Len() + 3
 	}
@@ -180,7 +180,7 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, scope s
 			l[normalized] = lbl.Value
 		}
 	}
-	if convertScope {
+	if promoteScope {
 		l["otel_scope_name"] = scope.name
 		l["otel_scope_version"] = scope.version
 		l["otel_scope_schema_url"] = scope.schemaURL

--- a/pkg/distributor/otlp/metrics_to_prw_generated.go
+++ b/pkg/distributor/otlp/metrics_to_prw_generated.go
@@ -56,8 +56,8 @@ type Settings struct {
 	ConvertHistogramsToNHCB           bool
 	AllowDeltaTemporality             bool
 
-	// ConvertScopeMetadata controls whether to convert OTel scope metadata to metric labels.
-	ConvertScopeMetadata bool
+	// PromoteScopeMetadata controls whether to promote OTel scope metadata to metric labels.
+	PromoteScopeMetadata bool
 
 	// Mimir specifics.
 	EnableCreatedTimestampZeroIngestion        bool
@@ -96,7 +96,7 @@ func TranslatorMetricFromOtelMetric(metric pmetric.Metric) otlptranslator.Metric
 	case pmetric.MetricTypeGauge:
 		m.Type = otlptranslator.MetricTypeGauge
 	case pmetric.MetricTypeSum:
-		if metric.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+		if metric.Sum().IsMonotonic() {
 			m.Type = otlptranslator.MetricTypeMonotonicCounter
 		} else {
 			m.Type = otlptranslator.MetricTypeNonMonotonicCounter

--- a/vendor/github.com/prometheus/prometheus/config/config.go
+++ b/vendor/github.com/prometheus/prometheus/config/config.go
@@ -1562,9 +1562,9 @@ type OTLPConfig struct {
 	TranslationStrategy               translationStrategyOption `yaml:"translation_strategy,omitempty"`
 	KeepIdentifyingResourceAttributes bool                      `yaml:"keep_identifying_resource_attributes,omitempty"`
 	ConvertHistogramsToNHCB           bool                      `yaml:"convert_histograms_to_nhcb,omitempty"`
-	// ConvertScopeMetadata controls whether to convert OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
+	// PromoteScopeMetadata controls whether to promote OTel scope metadata (i.e. name, version, schema URL, and attributes) to metric labels.
 	// As per OTel spec, the aforementioned scope metadata should be identifying, i.e. made into metric labels.
-	ConvertScopeMetadata bool `yaml:"convert_scope_metadata,omitempty"`
+	PromoteScopeMetadata bool `yaml:"promote_scope_metadata,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/vendor/github.com/prometheus/prometheus/promql/parser/parse.go
+++ b/vendor/github.com/prometheus/prometheus/promql/parser/parse.go
@@ -451,6 +451,11 @@ func (p *parser) newAggregateExpr(op Item, modifier, args Node) (ret *AggregateE
 	ret = modifier.(*AggregateExpr)
 	arguments := args.(Expressions)
 
+	if len(p.closingParens) == 0 {
+		// Prevents invalid array accesses.
+		// The error is already captured by the parser.
+		return
+	}
 	ret.PosRange = posrange.PositionRange{
 		Start: op.Pos,
 		End:   p.closingParens[0],

--- a/vendor/github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite/helper.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite/helper.go
@@ -125,9 +125,9 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, scope s
 
 	promotedAttrs := settings.PromoteResourceAttributes.promotedAttributes(resourceAttrs)
 
-	convertScope := settings.ConvertScopeMetadata && scope.name != ""
+	promoteScope := settings.PromoteScopeMetadata && scope.name != ""
 	scopeLabelCount := 0
-	if convertScope {
+	if promoteScope {
 		// Include name, version and schema URL.
 		scopeLabelCount = scope.attributes.Len() + 3
 	}
@@ -177,7 +177,7 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, scope s
 			l[normalized] = lbl.Value
 		}
 	}
-	if convertScope {
+	if promoteScope {
 		l["otel_scope_name"] = scope.name
 		l["otel_scope_version"] = scope.version
 		l["otel_scope_schema_url"] = scope.schemaURL

--- a/vendor/github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -53,8 +53,8 @@ type Settings struct {
 	ConvertHistogramsToNHCB           bool
 	AllowDeltaTemporality             bool
 
-	// ConvertScopeMetadata controls whether to convert OTel scope metadata to metric labels.
-	ConvertScopeMetadata bool
+	// PromoteScopeMetadata controls whether to promote OTel scope metadata to metric labels.
+	PromoteScopeMetadata bool
 
 	// Mimir specifics.
 	EnableCreatedTimestampZeroIngestion        bool
@@ -93,7 +93,7 @@ func TranslatorMetricFromOtelMetric(metric pmetric.Metric) otlptranslator.Metric
 	case pmetric.MetricTypeGauge:
 		m.Type = otlptranslator.MetricTypeGauge
 	case pmetric.MetricTypeSum:
-		if metric.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+		if metric.Sum().IsMonotonic() {
 			m.Type = otlptranslator.MetricTypeMonotonicCounter
 		} else {
 			m.Type = otlptranslator.MetricTypeNonMonotonicCounter

--- a/vendor/github.com/prometheus/prometheus/storage/remote/write_handler.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/write_handler.go
@@ -602,7 +602,7 @@ func (rw *rwExporter) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) er
 		KeepIdentifyingResourceAttributes: otlpCfg.KeepIdentifyingResourceAttributes,
 		ConvertHistogramsToNHCB:           otlpCfg.ConvertHistogramsToNHCB,
 		AllowDeltaTemporality:             rw.allowDeltaTemporality,
-		ConvertScopeMetadata:              otlpCfg.ConvertScopeMetadata,
+		PromoteScopeMetadata:              otlpCfg.PromoteScopeMetadata,
 
 		// Mimir specifics.
 		EnableCreatedTimestampZeroIngestion:        rw.enableCTZeroIngestion,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1196,7 +1196,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20250620055426-d1217a3b6036
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20250623074142-d4f9840f8e38
 ## explicit; go 1.23.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -2113,7 +2113,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250620055426-d1217a3b6036
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250623074142-d4f9840f8e38
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
#### What this PR does

Upgrade mimir-prometheus to a version that converts non-monotonic OTel sum metrics correctly, i.e. doesn't append a `_total` suffix. The reason is that non-monotonic OTel sums act like gauges (in that they can go up and down), and not counters (which only increase).

This got broken in https://github.com/grafana/mimir/pull/11607.

#### Which issue(s) this PR fixes or relates to

Fixes #11800.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
