### PR TITLE
[r346] Backport 11810 to r346

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -344,7 +344,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250602172627-3f093cd74ca2
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250623111934-2cfe60bc124c
 
 // Replace memberlist with our fork which includes some fixes that haven't been
 // merged upstream yet:

--- a/go.sum
+++ b/go.sum
@@ -573,8 +573,8 @@ github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700 h1:0t7iOQ5ZkB
 github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700/go.mod h1:Ri9p/tRShbjYnpNf4FFPXG7wxEGY4Nrcn6E7jrVa//4=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250527173959-2573485683d5 h1:H4Del07v9UAYJgky9oeRY1oNqs6dh8lmHRUWiGCKXoE=
 github.com/grafana/mimir-otlptranslator v0.0.0-20250527173959-2573485683d5/go.mod h1:v1PzmPjSnNkmZSDvKJ9OmsWcmWMEF5+JdllEcXrRfzM=
-github.com/grafana/mimir-prometheus v1.8.2-0.20250602172627-3f093cd74ca2 h1:UmYcUEn20U7XzY7EWgFeu8qLD882c9LaMs4PcbW6LYQ=
-github.com/grafana/mimir-prometheus v1.8.2-0.20250602172627-3f093cd74ca2/go.mod h1:wxNDaTwYlAYXHIlsXbCj1xQZik2CB+GGqYW6LUJq6s4=
+github.com/grafana/mimir-prometheus v1.8.2-0.20250623111934-2cfe60bc124c h1:J/kwW1NpKUYRAJN7vdwmgR3wv8RfIOGMld6GZm4r3A8=
+github.com/grafana/mimir-prometheus v1.8.2-0.20250623111934-2cfe60bc124c/go.mod h1:wxNDaTwYlAYXHIlsXbCj1xQZik2CB+GGqYW6LUJq6s4=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=

--- a/pkg/distributor/otlp/metrics_to_prw_generated.go
+++ b/pkg/distributor/otlp/metrics_to_prw_generated.go
@@ -93,7 +93,7 @@ func translatorMetricFromOtelMetric(metric pmetric.Metric) otlptranslator.Metric
 	case pmetric.MetricTypeGauge:
 		m.Type = otlptranslator.MetricTypeGauge
 	case pmetric.MetricTypeSum:
-		if metric.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+		if metric.Sum().IsMonotonic() {
 			m.Type = otlptranslator.MetricTypeMonotonicCounter
 		} else {
 			m.Type = otlptranslator.MetricTypeNonMonotonicCounter

--- a/vendor/github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite/metrics_to_prw.go
@@ -90,7 +90,7 @@ func translatorMetricFromOtelMetric(metric pmetric.Metric) otlptranslator.Metric
 	case pmetric.MetricTypeGauge:
 		m.Type = otlptranslator.MetricTypeGauge
 	case pmetric.MetricTypeSum:
-		if metric.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+		if metric.Sum().IsMonotonic() {
 			m.Type = otlptranslator.MetricTypeMonotonicCounter
 		} else {
 			m.Type = otlptranslator.MetricTypeNonMonotonicCounter

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1196,7 +1196,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20250602172627-3f093cd74ca2
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20250623111934-2cfe60bc124c
 ## explicit; go 1.23.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -2113,7 +2113,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250602172627-3f093cd74ca2
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20250623111934-2cfe60bc124c
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20250428154222-f7d51a6f6700
 # gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20240531075221-3685f1377d7b


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Upgrade mimir-prometheus to a version that converts non-monotonic OTel sum metrics correctly, i.e. doesn't append a `_total` suffix. The reason is that non-monotonic OTel sums act like gauges (in that they can go up and down), and not counters (which only increase).

This got broken in https://github.com/grafana/mimir/pull/11607.

(cherry picked from commit cebf99cfca9fcb3b6913f16da676fa9a2f502325)

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
