### PR TITLE
WIP: OTLP: Remove duplicated metadata conversion

### DIFF
--- a/pkg/distributor/otlp/metrics_to_prw_generated.go
+++ b/pkg/distributor/otlp/metrics_to_prw_generated.go
@@ -76,7 +76,7 @@ type MimirConverter struct {
 	unique    map[uint64]*mimirpb.TimeSeries
 	conflicts map[uint64][]*mimirpb.TimeSeries
 	everyN    everyNTimes
-	metadata  []mimirpb.MetricMetadata
+	metadata  []*mimirpb.MetricMetadata
 }
 
 func NewMimirConverter() *MimirConverter {
@@ -145,7 +145,7 @@ func (c *MimirConverter) FromMetrics(ctx context.Context, md pmetric.Metrics, se
 			numMetrics += scopeMetricsSlice.At(j).Metrics().Len()
 		}
 	}
-	c.metadata = make([]mimirpb.MetricMetadata, 0, numMetrics)
+	c.metadata = make([]*mimirpb.MetricMetadata, 0, numMetrics)
 
 	for i := 0; i < resourceMetricsSlice.Len(); i++ {
 		resourceMetrics := resourceMetricsSlice.At(i)
@@ -185,7 +185,7 @@ func (c *MimirConverter) FromMetrics(ctx context.Context, md pmetric.Metrics, se
 				}
 
 				promName := namer.Build(TranslatorMetricFromOtelMetric(metric))
-				c.metadata = append(c.metadata, mimirpb.MetricMetadata{
+				c.metadata = append(c.metadata, &mimirpb.MetricMetadata{
 					Type:             otelMetricTypeToPromMetricType(metric),
 					MetricFamilyName: promName,
 					Help:             metric.Description(),

--- a/pkg/distributor/otlp/mimirpb.patch
+++ b/pkg/distributor/otlp/mimirpb.patch
@@ -16,6 +16,18 @@ var x expression
 
 @@
 @@
+-[]prompb.MetricMetadata
++[]*mimirpb.MetricMetadata
+
+@@
+@@
+-prompb.MetricMetadata{
++&mimirpb.MetricMetadata{
+...,
+}
+
+@@
+@@
 -prompb.MetricMetadata_GAUGE
 +mimirpb.GAUGE
 

--- a/pkg/distributor/otlp/timeseries.go
+++ b/pkg/distributor/otlp/timeseries.go
@@ -33,3 +33,8 @@ func (c *MimirConverter) TimeSeries() []mimirpb.PreallocTimeseries {
 
 	return allTS
 }
+
+// Metadata returns a slice of the mimirpb.Metadata that were converted from OTel format.
+func (c *MimirConverter) Metadata() []*mimirpb.MetricMetadata {
+	return c.metadata
+}

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pmetric"
 	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -64,65 +63,6 @@ func TestHandler_remoteWriteWithMalformedRequest(t *testing.T) {
 	handler := Handler(100000, nil, nil, false, false, validation.MockDefaultOverrides(), RetryConfig{}, verifyWritePushFunc(t, mimirpb.API), nil, log.NewNopLogger())
 	handler.ServeHTTP(resp, req)
 	assert.Equal(t, 200, resp.Code)
-}
-
-func TestOTelMetricsToMetadata(t *testing.T) {
-	otelMetrics := pmetric.NewMetrics()
-	rs := otelMetrics.ResourceMetrics().AppendEmpty()
-	metrics := rs.ScopeMetrics().AppendEmpty().Metrics()
-
-	metricOne := metrics.AppendEmpty()
-	metricOne.SetName("name")
-	metricOne.SetUnit("Count")
-	gaugeMetricOne := metricOne.SetEmptyGauge()
-	gaugeDatapoint := gaugeMetricOne.DataPoints().AppendEmpty()
-	gaugeDatapoint.Attributes().PutStr("label1", "value1")
-
-	metricTwo := metrics.AppendEmpty()
-	metricTwo.SetName("test")
-	metricTwo.SetUnit("Count")
-	gaugeMetricTwo := metricTwo.SetEmptyGauge()
-	gaugeDatapointTwo := gaugeMetricTwo.DataPoints().AppendEmpty()
-	gaugeDatapointTwo.Attributes().PutStr("label1", "value2")
-
-	testCases := []struct {
-		name           string
-		enableSuffixes bool
-	}{
-		{
-			name:           "OTel metric suffixes enabled",
-			enableSuffixes: true,
-		},
-		{
-			name:           "OTel metric suffixes disabled",
-			enableSuffixes: false,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			countSfx := ""
-			if tc.enableSuffixes {
-				countSfx = "_Count"
-			}
-			sampleMetadata := []*mimirpb.MetricMetadata{
-				{
-					Help:             "",
-					Unit:             "Count",
-					Type:             mimirpb.GAUGE,
-					MetricFamilyName: "name" + countSfx,
-				},
-				{
-					Help:             "",
-					Unit:             "Count",
-					Type:             mimirpb.GAUGE,
-					MetricFamilyName: "test" + countSfx,
-				},
-			}
-
-			res := otelMetricsToMetadata(tc.enableSuffixes, otelMetrics)
-			assert.Equal(t, sampleMetadata, res)
-		})
-	}
 }
 
 func TestHandler_mimirWriteRequest(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Remove duplicated metadata conversion in OTLP endpoint. Should make things faster.

TODO:

- [ ] Modify tests to check also metadata

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
