### PR TITLE
Fix issue regenerating OTLP files when updating vendored mimir-prometheus

### DIFF
--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -144,7 +144,7 @@ jobs:
           echo "Dependencies updated successfully"
 
       - name: Regenerate OTLP files
-        run: make generate-otlp
+        run: go install github.com/uber-go/gopatch@v0.4.0 && make generate-otlp
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue introduced in https://github.com/grafana/mimir/pull/11792 where the OTLP file generation step would fail because `gopatch` is not installed.

#### Which issue(s) this PR fixes or relates to

#11792

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
