### PR TITLE
ruler: change ruler.RemoteQuerier.client to an http.RoundTripper

### DIFF
--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -950,11 +950,11 @@ func (t *Mimir) initRuler() (serv services.Service, err error) {
 	var queryFunc rules.QueryFunc
 
 	if t.Cfg.Ruler.QueryFrontend.Address != "" {
-		queryFrontendClient, err := ruler.DialQueryFrontend(t.Cfg.Ruler.QueryFrontend, t.Registerer, util_log.Logger)
+		queryFrontendClient, queryFrontendURL, err := ruler.DialQueryFrontend(t.Cfg.Ruler.QueryFrontend, t.Cfg.API.PrometheusHTTPPrefix, t.Registerer, util_log.Logger)
 		if err != nil {
 			return nil, err
 		}
-		remoteQuerier := ruler.NewRemoteQuerier(queryFrontendClient, t.Cfg.Querier.EngineConfig.Timeout, t.Cfg.Ruler.QueryFrontend.MaxRetriesRate, t.Cfg.Ruler.QueryFrontend.QueryResultResponseFormat, t.Cfg.API.PrometheusHTTPPrefix, util_log.Logger, ruler.WithOrgIDMiddleware)
+		remoteQuerier := ruler.NewRemoteQuerier(queryFrontendClient, t.Cfg.Querier.EngineConfig.Timeout, t.Cfg.Ruler.QueryFrontend.MaxRetriesRate, t.Cfg.Ruler.QueryFrontend.QueryResultResponseFormat, queryFrontendURL, util_log.Logger, ruler.WithOrgIDMiddleware)
 
 		embeddedQueryable = prom_remote.NewSampleAndChunkQueryableClient(
 			remoteQuerier,

--- a/pkg/ruler/grpcroundtripper.go
+++ b/pkg/ruler/grpcroundtripper.go
@@ -1,0 +1,94 @@
+package ruler
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/httpgrpc"
+	"github.com/grafana/dskit/middleware"
+	"github.com/grafana/mimir/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+)
+
+// buffer exists to avoid extra copies of body data when adaping httpgrpc.HTTPClient to an http.RoundTripper
+type buffer struct {
+	buff []byte
+	io.ReadCloser
+}
+
+func wrapBuffer(b []byte) io.ReadCloser {
+	return &buffer{buff: b, ReadCloser: io.NopCloser(bytes.NewReader(b))}
+}
+
+func readAll(r io.Reader) ([]byte, error) {
+	if b, ok := r.(*buffer); ok {
+		return b.buff, nil
+	}
+
+	return io.ReadAll(r)
+}
+
+type grpcRoundTripper struct {
+	client httpgrpc.HTTPClient
+}
+
+func newGrpcRoundTripper(client httpgrpc.HTTPClient) *grpcRoundTripper {
+	return &grpcRoundTripper{client: client}
+}
+
+func (g *grpcRoundTripper) RoundTrip(httpReq *http.Request) (*http.Response, error) {
+	body, err := readAll(httpReq.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	grpcRequest := &httpgrpc.HTTPRequest{
+		Method:  httpReq.Method,
+		Url:     httpReq.URL.Path,
+		Body:    body,
+		Headers: httpgrpc.FromHeader(httpReq.Header),
+	}
+
+	grpcResp, err := g.client.Handle(httpReq.Context(), grpcRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	httpResp := &http.Response{
+		StatusCode: int(grpcResp.Code),
+		Body:       wrapBuffer(grpcResp.Body),
+		Header:     make(http.Header),
+	}
+	httpgrpc.ToHeader(grpcResp.Headers, httpResp.Header)
+
+	return httpResp, nil
+}
+
+// dialQueryFrontend creates and initializes a new httpgrpc.HTTPClient taking a QueryFrontendConfig configuration.
+func dialQueryFrontendGRPC(cfg QueryFrontendConfig, prometheusHTTPPrefix string, reg prometheus.Registerer, logger log.Logger) (http.RoundTripper, *url.URL, error) {
+	invalidClusterValidation := util.NewRequestInvalidClusterValidationLabelsTotalCounter(reg, "ruler-query-frontend", util.GRPCProtocol)
+	opts, err := cfg.GRPCClientConfig.DialOption(
+		[]grpc.UnaryClientInterceptor{
+			middleware.ClientUserHeaderInterceptor,
+		},
+		nil,
+		util.NewInvalidClusterValidationReporter(cfg.GRPCClientConfig.ClusterValidation.Label, invalidClusterValidation, logger),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	opts = append(opts, grpc.WithDefaultServiceConfig(serviceConfig))
+	opts = append(opts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
+
+	// nolint:staticcheck // grpc.Dial() has been deprecated; we'll address it before upgrading to gRPC 2.
+	conn, err := grpc.Dial(cfg.Address, opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return newGrpcRoundTripper(httpgrpc.NewHTTPClient(conn)), &url.URL{Path: prometheusHTTPPrefix}, nil
+}

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -22,7 +22,6 @@ import (
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
-	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -30,13 +29,10 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/time/rate"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/mimir/pkg/querier/api"
-	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/grpcencoding/s2"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/grafana/mimir/pkg/util/version"
@@ -96,39 +92,20 @@ func (c *QueryFrontendConfig) Validate() error {
 }
 
 // DialQueryFrontend creates and initializes a new httpgrpc.HTTPClient taking a QueryFrontendConfig configuration.
-func DialQueryFrontend(cfg QueryFrontendConfig, reg prometheus.Registerer, logger log.Logger) (httpgrpc.HTTPClient, error) {
-	invalidClusterValidation := util.NewRequestInvalidClusterValidationLabelsTotalCounter(reg, "ruler-query-frontend", util.GRPCProtocol)
-	opts, err := cfg.GRPCClientConfig.DialOption(
-		[]grpc.UnaryClientInterceptor{
-			middleware.ClientUserHeaderInterceptor,
-		},
-		nil,
-		util.NewInvalidClusterValidationReporter(cfg.GRPCClientConfig.ClusterValidation.Label, invalidClusterValidation, logger),
-	)
-	if err != nil {
-		return nil, err
-	}
-	opts = append(opts, grpc.WithDefaultServiceConfig(serviceConfig))
-	opts = append(opts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
-
-	// nolint:staticcheck // grpc.Dial() has been deprecated; we'll address it before upgrading to gRPC 2.
-	conn, err := grpc.Dial(cfg.Address, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return httpgrpc.NewHTTPClient(conn), nil
+func DialQueryFrontend(cfg QueryFrontendConfig, prometheusHTTPPrefix string, reg prometheus.Registerer, logger log.Logger) (http.RoundTripper, *url.URL, error) {
+	return dialQueryFrontendGRPC(cfg, prometheusHTTPPrefix, reg, logger)
 }
 
 // Middleware provides a mechanism to inspect outgoing remote querier requests.
-type Middleware func(ctx context.Context, req *httpgrpc.HTTPRequest) error
+type Middleware func(ctx context.Context, req *http.Request) error
 
 // RemoteQuerier executes read operations against a httpgrpc.HTTPClient.
 type RemoteQuerier struct {
-	client                             httpgrpc.HTTPClient
+	client                             http.RoundTripper
 	retryLimiter                       *rate.Limiter
 	timeout                            time.Duration
 	middlewares                        []Middleware
-	promHTTPPrefix                     string
+	promHTTPUrl                        *url.URL
 	logger                             log.Logger
 	preferredQueryResultResponseFormat string
 	decoders                           map[string]decoder
@@ -139,11 +116,11 @@ var protobufDecoderInstance = protobufDecoder{}
 
 // NewRemoteQuerier creates and initializes a new RemoteQuerier instance.
 func NewRemoteQuerier(
-	client httpgrpc.HTTPClient,
+	client http.RoundTripper,
 	timeout time.Duration,
 	maxRetryRate float64, // maxRetryRate is the maximum number of retries for failed queries per second.
 	preferredQueryResultResponseFormat string,
-	prometheusHTTPPrefix string,
+	prometheusHTTPUrl *url.URL,
 	logger log.Logger,
 	middlewares ...Middleware,
 ) *RemoteQuerier {
@@ -152,7 +129,7 @@ func NewRemoteQuerier(
 		timeout:                            timeout,
 		retryLimiter:                       rate.NewLimiter(rate.Limit(maxRetryRate), 1),
 		middlewares:                        middlewares,
-		promHTTPPrefix:                     prometheusHTTPPrefix,
+		promHTTPUrl:                        prometheusHTTPUrl,
 		logger:                             logger,
 		preferredQueryResultResponseFormat: preferredQueryResultResponseFormat,
 		decoders: map[string]decoder{
@@ -178,16 +155,16 @@ func (q *RemoteQuerier) Read(ctx context.Context, query *prompb.Query, sortSerie
 		return nil, errors.Wrapf(err, "unable to marshal read request")
 	}
 
-	req := httpgrpc.HTTPRequest{
+	req := http.Request{
 		Method: http.MethodPost,
-		Url:    q.promHTTPPrefix + readEndpointPath,
-		Body:   snappy.Encode(nil, data),
-		Headers: injectHTTPGrpcReadConsistencyHeader(ctx, []*httpgrpc.Header{
-			{Key: textproto.CanonicalMIMEHeaderKey("Content-Encoding"), Values: []string{"snappy"}},
-			{Key: textproto.CanonicalMIMEHeaderKey("Accept-Encoding"), Values: []string{"snappy"}},
-			{Key: textproto.CanonicalMIMEHeaderKey("Content-Type"), Values: []string{"application/x-protobuf"}},
-			{Key: textproto.CanonicalMIMEHeaderKey("User-Agent"), Values: []string{version.UserAgent()}},
-			{Key: textproto.CanonicalMIMEHeaderKey("X-Prometheus-Remote-Read-Version"), Values: []string{"0.1.0"}},
+		URL:    q.promHTTPUrl.JoinPath(readEndpointPath),
+		Body:   wrapBuffer(snappy.Encode(nil, data)),
+		Header: injectHTTPGrpcReadConsistencyHeader(ctx, http.Header{
+			textproto.CanonicalMIMEHeaderKey("Content-Encoding"):                 []string{"snappy"},
+			textproto.CanonicalMIMEHeaderKey("Accept-Encoding"):                  []string{"snappy"},
+			textproto.CanonicalMIMEHeaderKey("Content-Type"):                     []string{"application/x-protobuf"},
+			textproto.CanonicalMIMEHeaderKey("User-Agent"):                       []string{version.UserAgent()},
+			textproto.CanonicalMIMEHeaderKey("X-Prometheus-Remote-Read-Version"): []string{"0.1.0"},
 		}),
 	}
 
@@ -200,30 +177,31 @@ func (q *RemoteQuerier) Read(ctx context.Context, query *prompb.Query, sortSerie
 	ctx, cancel := context.WithTimeout(ctx, q.timeout)
 	defer cancel()
 
-	resp, err := q.client.Handle(ctx, &req)
+	resp, err := q.client.RoundTrip(req.WithContext(ctx))
 	if err != nil {
 		if code := grpcutil.ErrorToStatusCode(err); code/100 != 4 {
 			level.Warn(log).Log("msg", "failed to perform remote read", "err", err, "qs", query)
 		}
 		return nil, err
 	}
-	if resp.Code/100 != 2 {
-		return nil, httpgrpc.Errorf(int(resp.Code), "unexpected response status code %d: %s", resp.Code, string(resp.Body))
+
+	defer resp.Body.Close()
+	body, err := readAll(resp.Body)
+	if err != nil {
+		return nil, httpgrpc.Errorf(int(resp.StatusCode), "error reading response body for status code %d: %s", resp.StatusCode, err)
+	}
+
+	if resp.StatusCode/100 != 2 {
+		return nil, httpgrpc.Errorf(int(resp.StatusCode), "unexpected response status code %d: %s", resp.StatusCode, string(body))
 	}
 	level.Debug(log).Log("msg", "remote read successfully performed", "qs", query)
 
-	var contentType string
-	for _, h := range resp.GetHeaders() {
-		if strings.ToLower(h.GetKey()) == "content-type" {
-			contentType = h.GetValues()[0]
-			break
-		}
-	}
+	contentType := getHeader(resp.Header, "Content-Type")
 	if len(contentType) > 0 && contentType != "application/x-protobuf" {
 		return nil, errors.Errorf("unexpected response content type %s expected application/x-protobuf", contentType)
 	}
 
-	uncompressed, err := snappy.Decode(nil, resp.Body)
+	uncompressed, err := snappy.Decode(nil, body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading response")
 	}
@@ -266,21 +244,26 @@ func (q *RemoteQuerier) query(ctx context.Context, query string, ts time.Time, l
 		}
 		return promql.Vector{}, err
 	}
-	if resp.Code/100 != 2 {
-		return promql.Vector{}, httpgrpc.Errorf(int(resp.Code), "unexpected response status code %d: %s", resp.Code, string(resp.Body))
+	defer resp.Body.Close()
+	body, err := readAll(resp.Body)
+	if err != nil {
+		return promql.Vector{}, httpgrpc.Errorf(int(resp.StatusCode), "error reading response body for status code %d: %s", resp.StatusCode, err)
+	}
+	if resp.StatusCode/100 != 2 {
+		return promql.Vector{}, httpgrpc.Errorf(int(resp.StatusCode), "unexpected response status code %d: %s", resp.StatusCode, string(body))
 	}
 	level.Debug(logger).Log("msg", "query expression successfully evaluated", "qs", query, "tm", ts)
 
-	contentTypeHeader := getHeader(resp.Headers, "Content-Type")
+	contentTypeHeader := getHeader(resp.Header, "Content-Type")
 	decoder, ok := q.decoders[contentTypeHeader]
 	if !ok {
 		return promql.Vector{}, fmt.Errorf("unknown response content type '%s'", contentTypeHeader)
 	}
 
-	return decoder.Decode(resp.Body)
+	return decoder.Decode(body)
 }
 
-func (q *RemoteQuerier) createRequest(ctx context.Context, query string, ts time.Time) (httpgrpc.HTTPRequest, error) {
+func (q *RemoteQuerier) createRequest(ctx context.Context, query string, ts time.Time) (http.Request, error) {
 	args := make(url.Values)
 	args.Set("query", query)
 	if !ts.IsZero() {
@@ -295,31 +278,31 @@ func (q *RemoteQuerier) createRequest(ctx context.Context, query string, ts time
 	case formatProtobuf:
 		acceptHeader = protobufDecoderInstance.ContentType() + "," + jsonDecoderInstance.ContentType()
 	default:
-		return httpgrpc.HTTPRequest{}, fmt.Errorf("unknown response format '%s'", q.preferredQueryResultResponseFormat)
+		return http.Request{}, fmt.Errorf("unknown response format '%s'", q.preferredQueryResultResponseFormat)
 	}
 
-	req := httpgrpc.HTTPRequest{
+	req := http.Request{
 		Method: http.MethodPost,
-		Url:    q.promHTTPPrefix + queryEndpointPath,
-		Body:   body,
-		Headers: injectHTTPGrpcReadConsistencyHeader(ctx, []*httpgrpc.Header{
-			{Key: textproto.CanonicalMIMEHeaderKey("User-Agent"), Values: []string{version.UserAgent()}},
-			{Key: textproto.CanonicalMIMEHeaderKey("Content-Type"), Values: []string{mimeTypeFormPost}},
-			{Key: textproto.CanonicalMIMEHeaderKey("Content-Length"), Values: []string{strconv.Itoa(len(body))}},
-			{Key: textproto.CanonicalMIMEHeaderKey("Accept"), Values: []string{acceptHeader}},
+		URL:    q.promHTTPUrl.JoinPath(queryEndpointPath),
+		Body:   wrapBuffer(body),
+		Header: injectHTTPGrpcReadConsistencyHeader(ctx, http.Header{
+			textproto.CanonicalMIMEHeaderKey("User-Agent"):     []string{version.UserAgent()},
+			textproto.CanonicalMIMEHeaderKey("Content-Type"):   []string{mimeTypeFormPost},
+			textproto.CanonicalMIMEHeaderKey("Content-Length"): []string{strconv.Itoa(len(body))},
+			textproto.CanonicalMIMEHeaderKey("Accept"):         []string{acceptHeader},
 		}),
 	}
 
 	for _, mdw := range q.middlewares {
 		if err := mdw(ctx, &req); err != nil {
-			return httpgrpc.HTTPRequest{}, err
+			return http.Request{}, err
 		}
 	}
 
 	return req, nil
 }
 
-func (q *RemoteQuerier) sendRequest(ctx context.Context, req *httpgrpc.HTTPRequest, logger log.Logger) (*httpgrpc.HTTPResponse, error) {
+func (q *RemoteQuerier) sendRequest(ctx context.Context, req *http.Request, logger log.Logger) (*http.Response, error) {
 	// Ongoing request may be cancelled during evaluation due to some transient error or server shutdown,
 	// so we'll keep retrying until we get a successful response or backoff is terminated.
 	retryConfig := backoff.Config{
@@ -330,13 +313,18 @@ func (q *RemoteQuerier) sendRequest(ctx context.Context, req *httpgrpc.HTTPReque
 	retry := backoff.New(ctx, retryConfig)
 
 	for {
-		resp, err := q.client.Handle(ctx, req)
+		resp, err := q.client.RoundTrip(req.WithContext(ctx))
 		if err == nil {
 			// Responses with status codes 4xx should always be considered erroneous.
 			// These errors shouldn't be retried because it is expected that
 			// running the same query gives rise to the same 4xx error.
-			if resp.Code/100 == 4 {
-				return nil, httpgrpc.ErrorFromHTTPResponse(resp)
+			if resp.StatusCode/100 == 4 {
+				body, err := readAll(resp.Body)
+				if err != nil {
+					return nil, httpgrpc.Errorf(int(resp.StatusCode), "error reading response body for status code %d: %s", resp.StatusCode, err)
+				}
+
+				return nil, httpgrpc.Error(resp.StatusCode, string(body))
 			}
 			return resp, nil
 		}
@@ -386,23 +374,18 @@ func (q *RemoteQuerier) sendRequest(ctx context.Context, req *httpgrpc.HTTPReque
 // WithOrgIDMiddleware attaches 'X-Scope-OrgID' header value to the outgoing request by inspecting the passed context.
 // In case the expression to evaluate corresponds to a federated rule, the ExtractTenantIDs function will take care
 // of normalizing and concatenating source tenants by separating them with a '|' character.
-func WithOrgIDMiddleware(ctx context.Context, req *httpgrpc.HTTPRequest) error {
+func WithOrgIDMiddleware(ctx context.Context, req *http.Request) error {
 	orgID, err := ExtractTenantIDs(ctx)
 	if err != nil {
 		return err
 	}
-	req.Headers = append(req.Headers, &httpgrpc.Header{
-		Key:    textproto.CanonicalMIMEHeaderKey(user.OrgIDHeaderName),
-		Values: []string{orgID},
-	})
+	req.Header.Set(user.OrgIDHeaderName, orgID)
 	return nil
 }
 
-func getHeader(headers []*httpgrpc.Header, name string) string {
-	for _, h := range headers {
-		if h.Key == name && len(h.Values) > 0 {
-			return h.Values[0]
-		}
+func getHeader(headers http.Header, name string) string {
+	if h, ok := headers[name]; ok && len(h) > 0 {
+		return h[0]
 	}
 
 	return ""
@@ -411,12 +394,9 @@ func getHeader(headers []*httpgrpc.Header, name string) string {
 // injectHTTPGrpcReadConsistencyHeader reads the read consistency level from the ctx and, if defined, injects
 // it as an HTTP header to the list of input headers. This is required to propagate the read consistency
 // through the network when issuing an HTTPgRPC request.
-func injectHTTPGrpcReadConsistencyHeader(ctx context.Context, headers []*httpgrpc.Header) []*httpgrpc.Header {
+func injectHTTPGrpcReadConsistencyHeader(ctx context.Context, headers http.Header) http.Header {
 	if level, ok := api.ReadConsistencyLevelFromContext(ctx); ok {
-		headers = append(headers, &httpgrpc.Header{
-			Key:    textproto.CanonicalMIMEHeaderKey(api.ReadConsistencyHeader),
-			Values: []string{level},
-		})
+		headers[textproto.CanonicalMIMEHeaderKey(api.ReadConsistencyHeader)] = []string{level}
 	}
 
 	return headers

--- a/pkg/ruler/remotequerier_test.go
+++ b/pkg/ruler/remotequerier_test.go
@@ -64,7 +64,7 @@ func TestRemoteQuerier_Read(t *testing.T) {
 	t.Run("should issue a remote read request", func(t *testing.T) {
 		client, inReq := setup()
 
-		q := NewRemoteQuerier(client, time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
+		q := NewRemoteQuerier(newGrpcRoundTripper(client), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
 		_, err := q.Read(context.Background(), &prompb.Query{}, false)
 		require.NoError(t, err)
 
@@ -76,23 +76,23 @@ func TestRemoteQuerier_Read(t *testing.T) {
 	t.Run("should not inject the read consistency header if none is defined in the context", func(t *testing.T) {
 		client, inReq := setup()
 
-		q := NewRemoteQuerier(client, time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
+		q := NewRemoteQuerier(newGrpcRoundTripper(client), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
 		_, err := q.Read(context.Background(), &prompb.Query{}, false)
 		require.NoError(t, err)
 
-		require.Equal(t, "", getHeader(inReq.Headers, api.ReadConsistencyHeader))
+		require.Equal(t, "", getGrpcHeader(inReq.Headers, api.ReadConsistencyHeader))
 	})
 
 	t.Run("should inject the read consistency header if it is defined in the context", func(t *testing.T) {
 		client, inReq := setup()
 
-		q := NewRemoteQuerier(client, time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
+		q := NewRemoteQuerier(newGrpcRoundTripper(client), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
 
 		ctx := api.ContextWithReadConsistencyLevel(context.Background(), api.ReadConsistencyStrong)
 		_, err := q.Read(ctx, &prompb.Query{}, false)
 		require.NoError(t, err)
 
-		require.Equal(t, api.ReadConsistencyStrong, getHeader(inReq.Headers, api.ReadConsistencyHeader))
+		require.Equal(t, api.ReadConsistencyStrong, getGrpcHeader(inReq.Headers, api.ReadConsistencyHeader))
 	})
 }
 
@@ -101,7 +101,7 @@ func TestRemoteQuerier_ReadReqTimeout(t *testing.T) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Second, 1, formatJSON, "/prometheus", log.NewNopLogger())
+	q := NewRemoteQuerier(newGrpcRoundTripper(mockHTTPGRPCClient(mockClientFn)), time.Second, 1, formatJSON, "/prometheus", log.NewNopLogger())
 
 	_, err := q.Read(context.Background(), &prompb.Query{}, false)
 	require.Error(t, err)
@@ -139,7 +139,7 @@ func TestRemoteQuerier_Query(t *testing.T) {
 			t.Run(fmt.Sprintf("format = %s", format), func(t *testing.T) {
 				client, inReq := setup()
 
-				q := NewRemoteQuerier(client, time.Minute, 1, format, "/prometheus", log.NewNopLogger())
+				q := NewRemoteQuerier(newGrpcRoundTripper(client), time.Minute, 1, format, "/prometheus", log.NewNopLogger())
 				_, err := q.Query(context.Background(), "qs", tm)
 				require.NoError(t, err)
 
@@ -148,7 +148,7 @@ func TestRemoteQuerier_Query(t *testing.T) {
 				require.Equal(t, "query=qs&time="+url.QueryEscape(tm.Format(time.RFC3339Nano)), string(inReq.Body))
 				require.Equal(t, "/prometheus/api/v1/query", inReq.Url)
 
-				acceptHeader := getHeader(inReq.Headers, "Accept")
+				acceptHeader := getGrpcHeader(inReq.Headers, "Accept")
 
 				switch format {
 				case formatJSON:
@@ -165,23 +165,23 @@ func TestRemoteQuerier_Query(t *testing.T) {
 	t.Run("should not inject the read consistency header if none is defined in the context", func(t *testing.T) {
 		client, inReq := setup()
 
-		q := NewRemoteQuerier(client, time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
+		q := NewRemoteQuerier(newGrpcRoundTripper(client), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
 		_, err := q.Query(context.Background(), "qs", tm)
 		require.NoError(t, err)
 
-		require.Equal(t, "", getHeader(inReq.Headers, api.ReadConsistencyHeader))
+		require.Equal(t, "", getGrpcHeader(inReq.Headers, api.ReadConsistencyHeader))
 	})
 
 	t.Run("should inject the read consistency header if it is defined in the context", func(t *testing.T) {
 		client, inReq := setup()
 
-		q := NewRemoteQuerier(client, time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
+		q := NewRemoteQuerier(newGrpcRoundTripper(client), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
 
 		ctx := api.ContextWithReadConsistencyLevel(context.Background(), api.ReadConsistencyStrong)
 		_, err := q.Query(ctx, "qs", tm)
 		require.NoError(t, err)
 
-		require.Equal(t, api.ReadConsistencyStrong, getHeader(inReq.Headers, api.ReadConsistencyHeader))
+		require.Equal(t, api.ReadConsistencyStrong, getGrpcHeader(inReq.Headers, api.ReadConsistencyHeader))
 	})
 }
 
@@ -276,7 +276,7 @@ func TestRemoteQuerier_QueryRetryOnFailure(t *testing.T) {
 				}
 				return testCase.response, nil
 			}
-			q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
+			q := NewRemoteQuerier(newGrpcRoundTripper(mockHTTPGRPCClient(mockClientFn)), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
 			require.Equal(t, int64(0), count.Load())
 			_, err := q.Query(ctx, "qs", time.Now())
 			if testCase.err == nil {
@@ -405,7 +405,7 @@ func TestRemoteQuerier_QueryJSONDecoding(t *testing.T) {
 					Body: []byte(scenario.body),
 				}, nil
 			}
-			q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
+			q := NewRemoteQuerier(newGrpcRoundTripper(mockHTTPGRPCClient(mockClientFn)), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
 
 			tm := time.Unix(1649092025, 515834)
 			actual, err := q.Query(context.Background(), "qs", tm)
@@ -678,7 +678,7 @@ func TestRemoteQuerier_QueryProtobufDecoding(t *testing.T) {
 					Body: b,
 				}, nil
 			}
-			q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Minute, 1, formatProtobuf, "/prometheus", log.NewNopLogger())
+			q := NewRemoteQuerier(newGrpcRoundTripper(mockHTTPGRPCClient(mockClientFn)), time.Minute, 1, formatProtobuf, "/prometheus", log.NewNopLogger())
 
 			tm := time.Unix(1649092025, 515834)
 			actual, err := q.Query(context.Background(), "qs", tm)
@@ -701,7 +701,7 @@ func TestRemoteQuerier_QueryUnknownResponseContentType(t *testing.T) {
 			Body: []byte("some body content"),
 		}, nil
 	}
-	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
+	q := NewRemoteQuerier(newGrpcRoundTripper(mockHTTPGRPCClient(mockClientFn)), time.Minute, 1, formatJSON, "/prometheus", log.NewNopLogger())
 
 	tm := time.Unix(1649092025, 515834)
 	_, err := q.Query(context.Background(), "qs", tm)
@@ -713,7 +713,7 @@ func TestRemoteQuerier_QueryReqTimeout(t *testing.T) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Second, 1, formatJSON, "/prometheus", log.NewNopLogger())
+	q := NewRemoteQuerier(newGrpcRoundTripper(mockHTTPGRPCClient(mockClientFn)), time.Second, 1, formatJSON, "/prometheus", log.NewNopLogger())
 
 	tm := time.Unix(1649092025, 515834)
 	_, err := q.Query(context.Background(), "qs", tm)
@@ -771,7 +771,7 @@ func TestRemoteQuerier_StatusErrorResponses(t *testing.T) {
 				return testCase.resp, testCase.err
 			}
 			logger := newLoggerWithCounter()
-			q := NewRemoteQuerier(mockHTTPGRPCClient(mockClientFn), time.Minute, 1, formatJSON, "/prometheus", logger)
+			q := NewRemoteQuerier(newGrpcRoundTripper(mockHTTPGRPCClient(mockClientFn)), time.Minute, 1, formatJSON, "/prometheus", logger)
 
 			tm := time.Unix(1649092025, 515834)
 
@@ -808,4 +808,13 @@ func (l *loggerWithCounter) Log(keyvals ...interface{}) error {
 
 func (l *loggerWithCounter) count() int64 {
 	return l.counter.Load()
+}
+
+func getGrpcHeader(headers []*httpgrpc.Header, name string) string {
+	for _, h := range headers {
+		if h.Key == name && len(h.Values) > 0 {
+			return h.Values[0]
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
In preparation to adding an option to support remote rule evaluation over HTTP.

#### Checklist

- [x] Tests updated.
