### PR TITLE
Add weekly flaky tests detection workflow

### DIFF
--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -1,0 +1,49 @@
+name: Flaky Tests Detection
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Run every Monday at 9 AM
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  id-token: write
+
+jobs:
+  analyze-flaky-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve Secrets from Vault
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b
+        with:
+          repo_secrets: |
+            LOKI_URL=ci/repo/grafana/mimir/flaky-tests-bot:loki-url
+            LOKI_USERNAME=ci/repo/grafana/mimir/flaky-tests-bot:loki-username
+            LOKI_PASSWORD=ci/repo/grafana/mimir/flaky-tests-bot:loki-password
+            APP_ID=mimir-github-bot:app_id
+            PRIVATE_KEY=mimir-github-bot:private_key
+
+      - name: Generate GitHub App Token
+        id: github-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Run Flaky Tests Analysis
+        uses: dimitarvdimitrov/shared-workflows/actions/go-flaky-tests@dimitar/analyze-test-failures/github-issues
+        with:
+          loki-url: ${{ env.LOKI_URL }}
+          loki-username: ${{ env.LOKI_USERNAME }}
+          loki-password: ${{ env.LOKI_PASSWORD }}
+          repository: ${{ github.repository }}
+          time-range: "7d"
+          top-k: "3"
+        env:
+          GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}


### PR DESCRIPTION
## Summary

Adds automated flaky test detection to help identify and resolve unreliable tests that cause CI noise and developer frustration.

## What it does

- Runs weekly (Mondays at 9 AM) and can be triggered manually
- Analyzes the last 7 days of test failure logs from Loki  
- Identifies the top 3 most problematic flaky tests
- Automatically creates GitHub issues with author mentions for faster resolution
- Uses existing mimir-github-bot for secure authentication

## Why now

Flaky tests slow down development by requiring re-runs and creating false alerts. This automation helps us proactively identify and fix the most impactful ones before they become bigger problems.

## Testing

The action was tested locally with production Loki credentials and works correctly. The workflow will use vault secrets at ci/repo/grafana/mimir/flaky-tests-bot for Loki access.