### PR TITLE
Add MimirGoThreadsTooHigh alert 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@
 * [ENHANCEMENT] Alerts: Add alerts for invalid cluster validation labels. #11255 #11282 #11413
 * [ENHANCEMENT] Dashboards: Improve "Kafka 100th percentile end-to-end latency when ingesters are running (outliers)" panel, computing the baseline latency on `max(10, 10%)` of ingesters instead of a fixed 10 replicas. #11581
 * [ENHANCEMENT] Dashboards: Add "per-query memory consumption" and "fallback to Prometheus' query engine" panels to the Queries dashboard. #11626
+* [ENHANCEMENT] Alerts: add `MimirGoThreadsTooHigh` alert. #11836
 * [CHANGE] Alerts: Update query for `MimirBucketIndexNotUpdated`. Use `max_over_time` to prevent alert firing when pods rotate. #11311, #11426
 * [CHANGE] Alerts: Make alerting threshold for `DistributorGcUsesTooMuchCpu` configurable. #11508.
 * [BUGFIX] Dashboards: fix "Mimir / Tenants" legends for non-Kubernetes deployments. #10891

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1817,6 +1817,25 @@ How to **investigate**:
 
 Query for the client side metric `cortex_client_invalid_cluster_validation_label_requests_total`, to determine which clients are sending the mislabeled requests.
 
+### MimirGoThreadsTooHigh
+
+This alert fires when a Mimir instance is running a very high number of Go threads.
+
+How it **works**:
+
+- In Go, concurrency is handled via goroutines, which are lightweight threads managed by the Go runtime.
+- Goroutines are multiplexed onto a small number of actual OS threads by the Go scheduler.
+- Go threads are limited to 10K. When this limit is reached, the application panics with error like `runtime: program exceeds 10000-thread limit`.
+- If a goroutine makes a syscall that blocks (e.g. network I/O, disk I/O, ...), the Go runtime will try to schedule other goroutines on other OS threads, starting new threads on-demand.
+- Idle go threads are never terminated ([issue](https://github.com/golang/go/issues/14592)), so once an application has a spike in the number of go threads, the process needs to be restarted to get back to a low number of threads.
+
+How to **investigate**:
+
+- Check the process stack trace to find common patterns in where the goroutines were blocked (typically a syscall):
+  - If the application panicked with error like `runtime: program exceeds 10000-thread limit`, check the panic stack trace
+  - If the application has not panicked yet, issue `kill -QUIT <pid>` to dump the current stack trace of the process
+
+
 ## Errors catalog
 
 Mimir has some codified error IDs that you might see in HTTP responses or logs.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -704,6 +704,36 @@ spec:
             for: 15m
             labels:
               severity: critical
+      - name: golang_alerts
+        rules:
+          - alert: MimirGoThreadsTooHigh
+            annotations:
+              message: |
+                  Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+            expr: |
+              # We filter by the namespace because go_threads can be very high cardinality in a large organization.
+              max by(cluster, namespace, pod) (go_threads{namespace=~".*(cortex|mimir).*"} > 5000)
+  
+              # Further filter on namespaces actually running Mimir.
+              and on (cluster, namespace) (count by (cluster, namespace) (cortex_build_info))
+            for: 15m
+            labels:
+              severity: warning
+          - alert: MimirGoThreadsTooHigh
+            annotations:
+              message: |
+                  Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+            expr: |
+              # We filter by the namespace because go_threads can be very high cardinality in a large organization.
+              max by(cluster, namespace, pod) (go_threads{namespace=~".*(cortex|mimir).*"} > 8000)
+  
+              # Further filter on namespaces actually running Mimir.
+              and on (cluster, namespace) (count by (cluster, namespace) (cortex_build_info))
+            for: 15m
+            labels:
+              severity: critical
       - name: alertmanager_alerts
         rules:
           - alert: MimirAlertmanagerSyncConfigsFailing

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -682,6 +682,36 @@ groups:
           for: 15m
           labels:
             severity: critical
+    - name: golang_alerts
+      rules:
+        - alert: MimirGoThreadsTooHigh
+          annotations:
+            message: |
+                Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+          expr: |
+            # We filter by the namespace because go_threads can be very high cardinality in a large organization.
+            max by(cluster, namespace, instance) (go_threads{namespace=~".*(cortex|mimir).*"} > 5000)
+
+            # Further filter on namespaces actually running Mimir.
+            and on (cluster, namespace) (count by (cluster, namespace) (cortex_build_info))
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MimirGoThreadsTooHigh
+          annotations:
+            message: |
+                Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+          expr: |
+            # We filter by the namespace because go_threads can be very high cardinality in a large organization.
+            max by(cluster, namespace, instance) (go_threads{namespace=~".*(cortex|mimir).*"} > 8000)
+
+            # Further filter on namespaces actually running Mimir.
+            and on (cluster, namespace) (count by (cluster, namespace) (cortex_build_info))
+          for: 15m
+          labels:
+            severity: critical
     - name: alertmanager_alerts
       rules:
         - alert: MimirAlertmanagerSyncConfigsFailing

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -692,6 +692,36 @@ groups:
           for: 15m
           labels:
             severity: critical
+    - name: golang_alerts
+      rules:
+        - alert: MimirGoThreadsTooHigh
+          annotations:
+            message: |
+                GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+          expr: |
+            # We filter by the namespace because go_threads can be very high cardinality in a large organization.
+            max by(cluster, namespace, pod) (go_threads{namespace=~".*(cortex|mimir).*"} > 5000)
+
+            # Further filter on namespaces actually running Mimir.
+            and on (cluster, namespace) (count by (cluster, namespace) (cortex_build_info))
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MimirGoThreadsTooHigh
+          annotations:
+            message: |
+                GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+          expr: |
+            # We filter by the namespace because go_threads can be very high cardinality in a large organization.
+            max by(cluster, namespace, pod) (go_threads{namespace=~".*(cortex|mimir).*"} > 8000)
+
+            # Further filter on namespaces actually running Mimir.
+            and on (cluster, namespace) (count by (cluster, namespace) (cortex_build_info))
+          for: 15m
+          labels:
+            severity: critical
     - name: alertmanager_alerts
       rules:
         - alert: MimirAlertmanagerSyncConfigsFailing

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -692,6 +692,36 @@ groups:
           for: 15m
           labels:
             severity: critical
+    - name: golang_alerts
+      rules:
+        - alert: MimirGoThreadsTooHigh
+          annotations:
+            message: |
+                Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+          expr: |
+            # We filter by the namespace because go_threads can be very high cardinality in a large organization.
+            max by(cluster, namespace, pod) (go_threads{namespace=~".*(cortex|mimir).*"} > 5000)
+
+            # Further filter on namespaces actually running Mimir.
+            and on (cluster, namespace) (count by (cluster, namespace) (cortex_build_info))
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MimirGoThreadsTooHigh
+          annotations:
+            message: |
+                Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+          expr: |
+            # We filter by the namespace because go_threads can be very high cardinality in a large organization.
+            max by(cluster, namespace, pod) (go_threads{namespace=~".*(cortex|mimir).*"} > 8000)
+
+            # Further filter on namespaces actually running Mimir.
+            and on (cluster, namespace) (count by (cluster, namespace) (cortex_build_info))
+          for: 15m
+          labels:
+            severity: critical
     - name: alertmanager_alerts
       rules:
         - alert: MimirAlertmanagerSyncConfigsFailing


### PR DESCRIPTION
#### What this PR does

Add MimirGoThreadsTooHigh alert , firing when a Mimir instance is running a very high number of Go threads.

I backtested it at Grafana Labs and both the warning and critical alert would have just fired in 1 cell over the last 30d, the one where we had the incident that pushed me to add this new alert.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
