### PR TITLE
generate-otlp: run in build image

### DIFF
--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -144,7 +144,7 @@ jobs:
           echo "Dependencies updated successfully"
 
       - name: Regenerate OTLP files
-        run: go install golang.org/x/tools/cmd/goimports@v0.34.0 && go install github.com/uber-go/gopatch@v0.4.0 && make generate-otlp
+        run: make generate-otlp
 
       - name: Create Pull Request
         id: create_pull_request

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ GOVOLUMES=	-v mimir-go-cache:/go/cache \
 # Mount local ssh credentials to be able to clone private repos when doing `mod-check`
 SSHVOLUME=  -v ~/.ssh/:/root/.ssh:$(CONTAINER_MOUNT_OPTIONS)
 
-exes $(EXES) $(EXES_RACE) protos $(PROTO_GOS) lint lint-gh-action lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests print-go-version format-promql-tests check-promql-tests: fetch-build-image
+exes $(EXES) $(EXES_RACE) protos $(PROTO_GOS) lint lint-gh-action lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests print-go-version format-promql-tests check-promql-tests generate-otlp: fetch-build-image
 	@echo ">>>> Entering build container: $@"
 	$(SUDO) time docker run --rm $(TTY) -i $(SSHVOLUME) $(GOVOLUMES) $(BUILD_IMAGE) GOOS=$(GOOS) GOARCH=$(GOARCH) BINARY_SUFFIX=$(BINARY_SUFFIX) $@;
 

--- a/Makefile
+++ b/Makefile
@@ -620,6 +620,14 @@ check-helm-tests: ## Check the helm golden records.
 check-helm-tests: build-helm-tests helm-conftest-test
 	@./tools/find-diff-or-untracked.sh $(HELM_REFERENCE_MANIFESTS) || (echo "Rebuild the Helm tests output by running 'make build-helm-tests' and commit the changes" && false)
 
+.PHONY: generate-otlp
+generate-otlp:
+	cd pkg/distributor/otlp && rm -f *_generated.go && go generate
+
+.PHONY: check-generated-otlp-code
+check-generated-otlp-code: generate-otlp
+	@./tools/find-diff-or-untracked.sh $(OTLP_GOS) || (echo "Please rebuild OTLP code by running 'make generate-otlp'" && false)
+
 endif
 
 .PHONY: check-makefiles
@@ -790,11 +798,3 @@ test-packages: packages packaging/rpm/centos-systemd/$(UPTODATE) packaging/deb/d
 
 docs: doc
 	cd docs && $(MAKE) docs
-
-.PHONY: generate-otlp
-generate-otlp:
-	cd pkg/distributor/otlp && rm -f *_generated.go && go generate
-
-.PHONY: check-generated-otlp-code
-check-generated-otlp-code: generate-otlp
-	@./tools/find-diff-or-untracked.sh $(OTLP_GOS) || (echo "Please rebuild OTLP code by running 'make generate-otlp'" && false)


### PR DESCRIPTION
This makes it easier to manage the dependencies of the script and upgrade them only in a single place. The build image already contains these dependencies. For this I also had to move the target into the targets that run in a build image.

example run https://github.com/grafana/mimir/actions/runs/15878851471/job/44773419103 and PR https://github.com/grafana/mimir/pull/11860 (the point is that the PR's CI passes and that the GH action completes)
