### PR TITLE
Operations: Allow configuring Querier ScaledObject scaleUp/scaleDown percentages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@
 * [FEATURE] Allow configuring tracing with OTel environment variables through `$._config.otlp_traces_endpoint`. When configured, the `$.jaeger_mixin` is no longer available for use.
 * [FEATURE] Updated rollout-operator to support `OTEL_` environment variables for tracing. #11787
 * [ENHANCEMENT] Add `query_frontend_only_args` option to specify CLI flags that apply only to query-frontends but not ruler-query-frontends. #11799
+* [ENHANCEMENT] Make querier scale up (`$_config.autoscaling_querier_scaleup_percent_cap`) and scale down rates (`$_config.autoscaling_querier_scaledown_percent_cap`) configurable. #11862
 
 ### Mimirtool
 

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -227,7 +227,7 @@
               // policy which is selected by default.
               policies: [
                 {
-                  // Allow to scale up at most autoscaling_querier_scaledown_percent_cap perecent of pods every 2m. Why 2m?
+                  // Allow to scale up at most autoscaling_querier_scaledown_percent_cap percent of pods every 2m. Why 2m?
                   // Because the metric looks back 1m and we give another 1m to let new queriers to start and process some
                   // backlog.
                   //

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -9,8 +9,8 @@
     autoscaling_querier_predictive_scaling_enabled: false,  // Use inflight queries from the past to predict the number of queriers needed.
     autoscaling_querier_predictive_scaling_period: '6d23h30m',  // The period to consider when considering scheduler metrics for predictive scaling. This is usually slightly lower than the period of the repeating query events to give scaling up lead time.
     autoscaling_querier_predictive_scaling_lookback: '30m',  // The time range to consider when considering scheduler metrics for predictive scaling. For example: if lookback is 30m and period is 6d23h30m, the querier will scale based on the maximum inflight queries between 6d23h30m and 7d0h0m ago.
-    autoscaling_querier_scaleup_percent_cap: 50, // The maximum percent a querier deployment may scale up every 2m.
-    autoscaling_querier_scaledown_percent_cap: 10, // The maximum percent a querier deployment may scale down every 2m.
+    autoscaling_querier_scaleup_percent_cap: 50,  // The maximum percent a querier deployment may scale up every 2m.
+    autoscaling_querier_scaledown_percent_cap: 10,  // The maximum percent a querier deployment may scale down every 2m.
 
     autoscaling_ruler_querier_enabled: false,
     autoscaling_ruler_querier_min_replicas: error 'you must set autoscaling_ruler_querier_min_replicas in the _config',
@@ -227,8 +227,8 @@
               // policy which is selected by default.
               policies: [
                 {
-                  // Allow to scale up at most autoscaling_querier_scaledown_percent_cap perecent of pods every 2m. Why 2m? 
-                  // Because the metric looks back 1m and we give another 1m to let new queriers to start and process some 
+                  // Allow to scale up at most autoscaling_querier_scaledown_percent_cap perecent of pods every 2m. Why 2m?
+                  // Because the metric looks back 1m and we give another 1m to let new queriers to start and process some
                   // backlog.
                   //
                   // This policy covers the case we already have an high number of queriers running and adding +50%
@@ -257,7 +257,7 @@
                 // Allow to scale down up to autoscaling_querier_scaledown_percent_cap percent of pods every 2m.
                 // A higher configured value leads to faster scale down.
                 type: 'Percent',
-                value: $._config.autoscaling_querier_scaledown_percent_cap, 
+                value: $._config.autoscaling_querier_scaledown_percent_cap,
                 periodSeconds: 120,
               }],
               // Reduce the likelihood of flapping replicas. When the metrics indicate that the target should be scaled

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -9,6 +9,8 @@
     autoscaling_querier_predictive_scaling_enabled: false,  // Use inflight queries from the past to predict the number of queriers needed.
     autoscaling_querier_predictive_scaling_period: '6d23h30m',  // The period to consider when considering scheduler metrics for predictive scaling. This is usually slightly lower than the period of the repeating query events to give scaling up lead time.
     autoscaling_querier_predictive_scaling_lookback: '30m',  // The time range to consider when considering scheduler metrics for predictive scaling. For example: if lookback is 30m and period is 6d23h30m, the querier will scale based on the maximum inflight queries between 6d23h30m and 7d0h0m ago.
+    autoscaling_querier_scaleup_percent_cap: 50, // The maximum percent a querier deployment may scale up every 2m.
+    autoscaling_querier_scaledown_percent_cap: 10, // The maximum percent a querier deployment may scale down every 2m.
 
     autoscaling_ruler_querier_enabled: false,
     autoscaling_ruler_querier_min_replicas: error 'you must set autoscaling_ruler_querier_min_replicas in the _config',
@@ -225,13 +227,14 @@
               // policy which is selected by default.
               policies: [
                 {
-                  // Allow to scale up at most 50% of pods every 2m. Why 2m? Because the metric looks back 1m and we
-                  // give another 1m to let new queriers to start and process some backlog.
+                  // Allow to scale up at most autoscaling_querier_scaledown_percent_cap perecent of pods every 2m. Why 2m? 
+                  // Because the metric looks back 1m and we give another 1m to let new queriers to start and process some 
+                  // backlog.
                   //
                   // This policy covers the case we already have an high number of queriers running and adding +50%
-                  // in the span of 2m means adding a significative number of pods.
+                  // in the span of 2m means adding a significant number of pods.
                   type: 'Percent',
-                  value: 50,
+                  value: $._config.autoscaling_querier_scaleup_percent_cap,
                   periodSeconds: 120,
                 },
                 {
@@ -251,9 +254,10 @@
             },
             scaleDown: {
               policies: [{
-                // Allow to scale down up to 10% of pods every 2m.
+                // Allow to scale down up to autoscaling_querier_scaledown_percent_cap percent of pods every 2m.
+                // A higher configured value leads to faster scale down.
                 type: 'Percent',
-                value: 10,
+                value: $._config.autoscaling_querier_scaledown_percent_cap, 
                 periodSeconds: 120,
               }],
               // Reduce the likelihood of flapping replicas. When the metrics indicate that the target should be scaled
@@ -573,7 +577,7 @@
                       // pods to be handling load and counted in the 15min lookback window.
                       //
                       // This policy covers the case we already have a high number of pods running and adding +50%
-                      // in the span of 2m means adding a significative number of pods.
+                      // in the span of 2m means adding a significant number of pods.
                       type: 'Percent',
                       value: 50,
                       periodSeconds: 60 * 2,


### PR DESCRIPTION
#### What this PR does

At Grafana Labs, we've noticed that querier deployments scale up and down asymmetrically.  Specifically, brief increases in read traffic, inflight requests, etc. can trigger the querier deployment to scale very quickly and then not scale down for some time even after the scaling metric has returned to baseline levels. In some cases, it’s helpful to be able to control the rate at which queriers scale up or down.

This PR introduces two new configurable options: `$_config.autoscaling_querier_scaleup_percent_cap` for the scale-up rate, and `$_config.autoscaling_querier_scaledown_percent_cap` for the scale-down rate. For example, setting `autoscaling_querier_scaleup_percent_cap` to 50 would allow a querier deployment to scale up by at most 50% of its pods every 2m. The 2m interval is fixed because the scaling metrics look back 1 minute, and we allow an additional 1 minute for new queriers to come online and begin processing some of the backlog.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
