### PR TITLE
Fix misleading "production-ready" description of small.yaml

### DIFF
--- a/docs/sources/mimir/set-up/helm-chart.md
+++ b/docs/sources/mimir/set-up/helm-chart.md
@@ -15,11 +15,11 @@ The [`mimir-distributed` Helm chart](https://github.com/grafana/mimir/blob/main/
 
 The mimir-distributed Helm chart includes the following example values files:
 
-| File name                                                                                                        | Description                                                                                                              |
-| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| [`values.yaml`](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml) | Contains default values for testing GEM in non-production environments using a test MinIO deployment for object storage. |
-| [`small.yaml`](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/small.yaml)   | Contains values for production use for ingestion up to approximately one million series.                                 |
-| [`large.yaml`](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/large.yaml)   | Contains values for production use for ingestion up to approximately ten million series.                                 |
+| File name                                                                                                        | Description                                                                                                                                                                                       |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`values.yaml`](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/values.yaml) | Contains default values for testing GEM in non-production environments using a test MinIO deployment for object storage.                                                                          |
+| [`small.yaml`](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/small.yaml)   | Contains values for higher scale than defaults, for ingestion up to approximately one million series. Not suitable for high-availability production use due to single replicas of key components. |
+| [`large.yaml`](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/large.yaml)   | Contains values for production use for ingestion up to approximately ten million series.                                                                                                          |
 
 ## See also
 

--- a/operations/helm/charts/mimir-distributed/small.yaml
+++ b/operations/helm/charts/mimir-distributed/small.yaml
@@ -1,5 +1,6 @@
 # These values configure the Grafana Mimir or Grafana Enterprise Metrics cluster
-# for a more production-ready setup. The setup targets 70% CPU and memory utilization
+# for higher scale than the default values, but not for high-availability production use.
+# The setup targets 70% CPU and memory utilization
 # so that the cluster has room to grow. The resource requests reflect 70% utilization
 # and the limits reflect 100% utilization. The values do not set CPU limits,
 # because CPU limits have caused severe issues elsewhere, so we don't apply any in our helm chart:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3,8 +3,8 @@
 # The default values specified in this file are enough to deploy all of the
 # Grafana Mimir or Grafana Enterprise Metrics microservices but are not suitable for
 # production load.
-# To configure the resources for production load, refer to the small.yaml or
-# large.yaml values files.
+# To configure the resources for higher scale, refer to the small.yaml file.
+# For production load with high availability, refer to the large.yaml values file.
 
 # Note: The values in this file are not backward compatible. Copying and pasting the values is discouraged, but if you do so,
 # make sure to use the values.yaml from the branch or tag that matches the mimir-distributed Helm chart version that you


### PR DESCRIPTION
## Summary
- Fixed misleading "production-ready" description in small.yaml and related documentation
- Clarified that small.yaml is for higher scale than defaults but not suitable for high-availability production use
- Updated documentation to distinguish between small.yaml (higher scale) and large.yaml (production HA)

## Test plan
- Review documentation changes for accuracy
- Verify small.yaml comment reflects actual configuration (single replicas of key components)