### PR TITLE
Remove broken target from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -764,9 +764,6 @@ integration-tests-race: export MIMIR_IMAGE=$(IMAGE_PREFIX)mimir:$(IMAGE_TAG_RACE
 integration-tests-race: cmd/mimir/$(UPTODATE_RACE)
 	go test -timeout 30m -tags=requires_docker,stringlabels ./integration/...
 
-web-serve:
-	cd website && hugo --config config.toml --minify -v server
-
 # Those vars are needed for packages target
 export VERSION
 


### PR DESCRIPTION
#### What this PR does

As far as I can tell `make web-serve` never worked. I'm not sure if the piece was copied from somewhere, but Mimir doesn't have a `website` directory for target to work on.