### PR TITLE
WIP: OTLP: Record in-flight push request before decompression

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -283,12 +283,9 @@ func (a *API) RegisterDistributor(d *distributor.Distributor, pushConfig distrib
 		), true, false, "POST")
 	}
 
-	a.RegisterRoute(OTLPPushEndpoint, distributor.OTLPHandler(
-		pushConfig.MaxOTLPRequestSize, d.RequestBufferPool, a.sourceIPs, limits,
-		pushConfig.OTelResourceAttributePromotionConfig,
-		pushConfig.KeepIdentifyingOTelResourceAttributesConfig,
-		pushConfig.RetryConfig, pushConfig.OTLPPushMiddlewares,
-		d.PushWithMiddlewares, d.PushMetrics, reg, a.logger,
+	a.RegisterRoute(OTLPPushEndpoint, d.OTLPHandler(
+		pushConfig.MaxOTLPRequestSize, d.RequestBufferPool, a.sourceIPs, limits, pushConfig.OTelResourceAttributePromotionConfig,
+		pushConfig.RetryConfig, pushConfig.OTLPPushMiddlewares, d.PushWithMiddlewares, d.PushMetrics, reg, a.logger,
 	), true, false, "POST")
 
 	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Modify the distributor OTLP endpoint so that before decompressing a request, record an in-flight push request with the detected payload size. This is to prevent going over the `max_inflight_push_requests_bytes` limit during request decompression.

#### Which issue(s) this PR fixes or relates to

Part of #11558.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
