### PR TITLE
blockbuilder: add cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds

### DIFF
--- a/pkg/blockbuilder/metrics.go
+++ b/pkg/blockbuilder/metrics.go
@@ -52,9 +52,10 @@ func newBlockBuilderMetrics(reg prometheus.Registerer) blockBuilderMetrics {
 }
 
 type tsdbBuilderMetrics struct {
-	processSamplesDiscarded  *prometheus.CounterVec
-	compactAndUploadDuration *prometheus.HistogramVec
-	compactAndUploadFailed   *prometheus.CounterVec
+	processSamplesDiscarded            *prometheus.CounterVec
+	compactAndUploadDuration           *prometheus.HistogramVec
+	compactAndUploadFailed             *prometheus.CounterVec
+	lastSuccessfulCompactAndUploadTime *prometheus.GaugeVec
 }
 
 func newTSDBBBuilderMetrics(reg prometheus.Registerer) tsdbBuilderMetrics {
@@ -74,6 +75,11 @@ func newTSDBBBuilderMetrics(reg prometheus.Registerer) tsdbBuilderMetrics {
 	m.compactAndUploadFailed = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_blockbuilder_tsdb_compact_and_upload_failed_total",
 		Help: "Total number of failures compacting and uploading a tsdb of one partition.",
+	}, []string{"partition"})
+
+	m.lastSuccessfulCompactAndUploadTime = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds",
+		Help: "Unix timestamp (in seconds) of the last successful tsdb block compacted and uploaded to the object storage on a partition.",
 	}, []string{"partition"})
 
 	return m

--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -365,12 +365,13 @@ func (b *TSDBBuilder) CompactAndUpload(ctx context.Context, uploadBlocks blockUp
 					// Don't track any metrics if context was cancelled. Otherwise, it might be misleading.
 					return
 				}
-				partitionStr := fmt.Sprintf("%d", tenant.partitionID)
+				partitionStr := strconv.Itoa(int(tenant.partitionID))
 				if err != nil {
 					b.metrics.compactAndUploadFailed.WithLabelValues(partitionStr).Inc()
 					return
 				}
 				b.metrics.compactAndUploadDuration.WithLabelValues(partitionStr).Observe(time.Since(t).Seconds())
+				b.metrics.lastSuccessfulCompactAndUploadTime.WithLabelValues(partitionStr).SetToCurrentTime()
 			}(time.Now())
 
 			if err := db.compactEverything(ctx); err != nil {


### PR DESCRIPTION
#### What this PR does

This PR adds a new metric to the `blockbuilder`: 
* `cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds` — tracks the per-partition timestamps of the last successful block uploading

The idea behind the metric is that we could fire an alert if the block-builder stopped shipping blocks for an extended period of time.