### PR TITLE
MQE: alternative way to ensure pooled slices are not reused

### DIFF
--- a/pkg/streamingpromql/operators/aggregations/aggregation.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation.go
@@ -124,7 +124,7 @@ func (a *Aggregation) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadat
 		return nil, err
 	}
 
-	defer types.SeriesMetadataSlicePool.Put(innerSeries, a.MemoryConsumptionTracker)
+	defer types.SeriesMetadataSlicePool.Put(&innerSeries, a.MemoryConsumptionTracker)
 
 	if len(innerSeries) == 0 {
 		// No input series == no output series.

--- a/pkg/streamingpromql/operators/aggregations/aggregation_test.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation_test.go
@@ -383,7 +383,7 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 			} else {
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedSeries), series)
 			}
-			types.SeriesMetadataSlicePool.Put(series, memoryConsumptionTracker)
+			types.SeriesMetadataSlicePool.Put(&series, memoryConsumptionTracker)
 
 			// Read the first output series to force the creation of incomplete groups.
 			seriesData, err := o.NextSeries(ctx)

--- a/pkg/streamingpromql/operators/aggregations/avg.go
+++ b/pkg/streamingpromql/operators/aggregations/avg.go
@@ -303,24 +303,11 @@ func (g *AvgAggregationGroup) ComputeOutputSeries(_ types.ScalarData, timeRange 
 }
 
 func (g *AvgAggregationGroup) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
-	types.Float64SlicePool.Put(g.floats, memoryConsumptionTracker)
-	g.floats = nil
-
-	types.Float64SlicePool.Put(g.floatMeans, memoryConsumptionTracker)
-	g.floatMeans = nil
-
-	types.Float64SlicePool.Put(g.floatCompensatingMeans, memoryConsumptionTracker)
-	g.floatCompensatingMeans = nil
-
-	types.BoolSlicePool.Put(g.incrementalMeans, memoryConsumptionTracker)
-	g.incrementalMeans = nil
-
-	types.BoolSlicePool.Put(g.floatPresent, memoryConsumptionTracker)
-	g.floatPresent = nil
-
-	types.HistogramSlicePool.Put(g.histograms, memoryConsumptionTracker)
-	g.histograms = nil
-
-	types.Float64SlicePool.Put(g.groupSeriesCounts, memoryConsumptionTracker)
-	g.groupSeriesCounts = nil
+	types.Float64SlicePool.Put(&g.floats, memoryConsumptionTracker)
+	types.Float64SlicePool.Put(&g.floatMeans, memoryConsumptionTracker)
+	types.Float64SlicePool.Put(&g.floatCompensatingMeans, memoryConsumptionTracker)
+	types.BoolSlicePool.Put(&g.incrementalMeans, memoryConsumptionTracker)
+	types.BoolSlicePool.Put(&g.floatPresent, memoryConsumptionTracker)
+	types.HistogramSlicePool.Put(&g.histograms, memoryConsumptionTracker)
+	types.Float64SlicePool.Put(&g.groupSeriesCounts, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/aggregations/count.go
+++ b/pkg/streamingpromql/operators/aggregations/count.go
@@ -87,6 +87,5 @@ func (g *CountGroupAggregationGroup) ComputeOutputSeries(_ types.ScalarData, tim
 }
 
 func (g *CountGroupAggregationGroup) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
-	types.Float64SlicePool.Put(g.values, memoryConsumptionTracker)
-	g.values = nil
+	types.Float64SlicePool.Put(&g.values, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/aggregations/count_values.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values.go
@@ -91,7 +91,7 @@ func (c *CountValues) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadat
 		return nil, err
 	}
 
-	defer types.SeriesMetadataSlicePool.Put(innerMetadata, c.MemoryConsumptionTracker)
+	defer types.SeriesMetadataSlicePool.Put(&innerMetadata, c.MemoryConsumptionTracker)
 
 	c.labelsBuilder = labels.NewBuilder(labels.EmptyLabels())
 	c.labelsBytesBuffer = make([]byte, 0, 1024) // Why 1024 bytes? It's what labels.Labels.String() uses as a buffer size, so we use that as a sensible starting point too.
@@ -142,8 +142,7 @@ func (c *CountValues) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadat
 
 		c.series = append(c.series, points)
 
-		types.IntSlicePool.Put(s.count, c.MemoryConsumptionTracker)
-		s.count = nil
+		types.IntSlicePool.Put(&s.count, c.MemoryConsumptionTracker)
 		countValuesSeriesPool.Put(s)
 	}
 
@@ -255,7 +254,7 @@ func (c *CountValues) Close() {
 	c.LabelName.Close()
 
 	for _, d := range c.series {
-		types.FPointSlicePool.Put(d, c.MemoryConsumptionTracker)
+		types.FPointSlicePool.Put(&d, c.MemoryConsumptionTracker)
 	}
 
 	c.series = nil

--- a/pkg/streamingpromql/operators/aggregations/min_max.go
+++ b/pkg/streamingpromql/operators/aggregations/min_max.go
@@ -118,9 +118,6 @@ func (g *MinMaxAggregationGroup) ComputeOutputSeries(_ types.ScalarData, timeRan
 }
 
 func (g *MinMaxAggregationGroup) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
-	types.Float64SlicePool.Put(g.floatValues, memoryConsumptionTracker)
-	g.floatValues = nil
-
-	types.BoolSlicePool.Put(g.floatPresent, memoryConsumptionTracker)
-	g.floatPresent = nil
+	types.Float64SlicePool.Put(&g.floatValues, memoryConsumptionTracker)
+	types.BoolSlicePool.Put(&g.floatPresent, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/aggregations/quantile.go
+++ b/pkg/streamingpromql/operators/aggregations/quantile.go
@@ -96,8 +96,7 @@ func (q *QuantileAggregation) Prepare(ctx context.Context, params *types.Prepare
 
 func (q *QuantileAggregation) Close() {
 	if q.Aggregation.ParamData.Samples != nil {
-		types.FPointSlicePool.Put(q.Aggregation.ParamData.Samples, q.MemoryConsumptionTracker)
-		q.Aggregation.ParamData.Samples = nil
+		types.FPointSlicePool.Put(&q.Aggregation.ParamData.Samples, q.MemoryConsumptionTracker)
 	}
 
 	if q.Param != nil {
@@ -190,11 +189,9 @@ func (q *QuantileAggregationGroup) ComputeOutputSeries(param types.ScalarData, t
 }
 
 func (q *QuantileAggregationGroup) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
-	for i, qGroup := range q.qGroups {
-		types.Float64SlicePool.Put(qGroup.points, memoryConsumptionTracker)
-		q.qGroups[i].points = nil
+	for i := range q.qGroups {
+		types.Float64SlicePool.Put(&q.qGroups[i].points, memoryConsumptionTracker)
 	}
 
-	qGroupPool.Put(q.qGroups, memoryConsumptionTracker)
-	q.qGroups = nil
+	qGroupPool.Put(&q.qGroups, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/aggregations/stddev_stdvar.go
+++ b/pkg/streamingpromql/operators/aggregations/stddev_stdvar.go
@@ -119,12 +119,7 @@ func (g *StddevStdvarAggregationGroup) ComputeOutputSeries(_ types.ScalarData, t
 }
 
 func (g *StddevStdvarAggregationGroup) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
-	types.Float64SlicePool.Put(g.floats, memoryConsumptionTracker)
-	g.floats = nil
-
-	types.Float64SlicePool.Put(g.floatMeans, memoryConsumptionTracker)
-	g.floatMeans = nil
-
-	types.Float64SlicePool.Put(g.groupSeriesCounts, memoryConsumptionTracker)
-	g.groupSeriesCounts = nil
+	types.Float64SlicePool.Put(&g.floats, memoryConsumptionTracker)
+	types.Float64SlicePool.Put(&g.floatMeans, memoryConsumptionTracker)
+	types.Float64SlicePool.Put(&g.groupSeriesCounts, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/aggregations/sum.go
+++ b/pkg/streamingpromql/operators/aggregations/sum.go
@@ -205,15 +205,8 @@ func (g *SumAggregationGroup) ComputeOutputSeries(_ types.ScalarData, timeRange 
 }
 
 func (g *SumAggregationGroup) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
-	types.Float64SlicePool.Put(g.floatSums, memoryConsumptionTracker)
-	g.floatSums = nil
-
-	types.Float64SlicePool.Put(g.floatCompensatingValues, memoryConsumptionTracker)
-	g.floatCompensatingValues = nil
-
-	types.BoolSlicePool.Put(g.floatPresent, memoryConsumptionTracker)
-	g.floatPresent = nil
-
-	types.HistogramSlicePool.Put(g.histogramSums, memoryConsumptionTracker)
-	g.histogramSums = nil
+	types.Float64SlicePool.Put(&g.floatSums, memoryConsumptionTracker)
+	types.Float64SlicePool.Put(&g.floatCompensatingValues, memoryConsumptionTracker)
+	types.BoolSlicePool.Put(&g.floatPresent, memoryConsumptionTracker)
+	types.HistogramSlicePool.Put(&g.histogramSums, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
@@ -62,7 +62,7 @@ func (t *InstantQuery) SeriesMetadata(ctx context.Context) ([]types.SeriesMetada
 		return nil, err
 	}
 
-	defer types.SeriesMetadataSlicePool.Put(innerSeries, t.MemoryConsumptionTracker)
+	defer types.SeriesMetadataSlicePool.Put(&innerSeries, t.MemoryConsumptionTracker)
 
 	groupLabelsBytesFunc := aggregations.GroupLabelsBytesFunc(t.Grouping, t.Without)
 	groups := map[string]*instantQueryGroup{}
@@ -154,7 +154,7 @@ func (t *InstantQuery) SeriesMetadata(ctx context.Context) ([]types.SeriesMetada
 			}
 		}
 
-		instantQuerySeriesSlicePool.Put(g.series, t.MemoryConsumptionTracker)
+		instantQuerySeriesSlicePool.Put(&g.series, t.MemoryConsumptionTracker)
 	}
 
 	return outputSeries, nil
@@ -166,7 +166,7 @@ func (t *InstantQuery) getK(ctx context.Context) error {
 		return err
 	}
 
-	defer types.FPointSlicePool.Put(paramValues.Samples, t.MemoryConsumptionTracker)
+	defer types.FPointSlicePool.Put(&paramValues.Samples, t.MemoryConsumptionTracker)
 
 	v := paramValues.Samples[0].F // There will always be exactly one value for an instant query: scalars always produce values at every step.
 
@@ -297,8 +297,7 @@ func (t *InstantQuery) Close() {
 	t.Inner.Close()
 	t.Param.Close()
 
-	types.Float64SlicePool.Put(t.values, t.MemoryConsumptionTracker)
-	t.values = nil
+	types.Float64SlicePool.Put(&t.values, t.MemoryConsumptionTracker)
 }
 
 type instantQueryGroup struct {

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
@@ -79,7 +79,7 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 								// Range queries will return all input series, but those with histograms will return no data from NextSeries() below.
 								require.ElementsMatch(t, testutils.LabelsToSeriesMetadata(inputSeries), series)
 							}
-							types.SeriesMetadataSlicePool.Put(series, memoryConsumptionTracker)
+							types.SeriesMetadataSlicePool.Put(&series, memoryConsumptionTracker)
 
 							if readSeries {
 								seriesData, err := o.NextSeries(ctx)

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
@@ -75,7 +75,7 @@ func (a *AndUnlessBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.
 
 	if len(leftMetadata) == 0 {
 		// We can't produce any series, we are done.
-		types.SeriesMetadataSlicePool.Put(leftMetadata, a.MemoryConsumptionTracker)
+		types.SeriesMetadataSlicePool.Put(&leftMetadata, a.MemoryConsumptionTracker)
 		return nil, nil
 	}
 
@@ -84,11 +84,11 @@ func (a *AndUnlessBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.
 		return nil, err
 	}
 
-	defer types.SeriesMetadataSlicePool.Put(rightMetadata, a.MemoryConsumptionTracker)
+	defer types.SeriesMetadataSlicePool.Put(&rightMetadata, a.MemoryConsumptionTracker)
 
 	if len(rightMetadata) == 0 && !a.IsUnless {
 		// We can't produce any series, we are done.
-		types.SeriesMetadataSlicePool.Put(leftMetadata, a.MemoryConsumptionTracker)
+		types.SeriesMetadataSlicePool.Put(&leftMetadata, a.MemoryConsumptionTracker)
 		return nil, nil
 	}
 
@@ -327,6 +327,5 @@ func (g *andGroup) FilterLeftSeries(leftData types.InstantVectorSeriesData, memo
 }
 
 func (g *andGroup) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
-	types.BoolSlicePool.Put(g.rightSamplePresence, memoryConsumptionTracker)
-	g.rightSamplePresence = nil
+	types.BoolSlicePool.Put(&g.rightSamplePresence, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -325,7 +325,6 @@ func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testin
 			} else {
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
@@ -355,6 +354,8 @@ func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testin
 					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}
+
+			types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
 
 			_, err = o.NextSeries(ctx)
 			require.Equal(t, types.EOS, err)
@@ -447,7 +448,7 @@ func TestAndUnlessBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *test
 					} else {
 						require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedAndOutputSeries), outputSeries)
 					}
-					types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
+					types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
 
 					// Read the first output series to trigger the loading of some intermediate state for at least one of the output groups.
 					_, err = o.NextSeries(ctx)

--- a/pkg/streamingpromql/operators/binops/binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation.go
@@ -146,7 +146,7 @@ func filterSeries(data types.InstantVectorSeriesData, mask []bool, desiredMaskVa
 		filteredData.Floats = data.Floats[:nextOutputFloatIndex]
 	} else {
 		// We don't have any float points to return, return the original slice to the pool.
-		types.FPointSlicePool.Put(data.Floats, memoryConsumptionTracker)
+		types.FPointSlicePool.Put(&data.Floats, memoryConsumptionTracker)
 	}
 
 	nextOutputHistogramIndex := 0
@@ -171,7 +171,7 @@ func filterSeries(data types.InstantVectorSeriesData, mask []bool, desiredMaskVa
 		filteredData.Histograms = data.Histograms[:nextOutputHistogramIndex]
 	} else {
 		// We don't have any histogram points to return, return the original slice to the pool.
-		types.HPointSlicePool.Put(data.Histograms, memoryConsumptionTracker)
+		types.HPointSlicePool.Put(&data.Histograms, memoryConsumptionTracker)
 	}
 
 	return filteredData, nil
@@ -418,16 +418,16 @@ func (e *vectorVectorBinaryOperationEvaluator) computeResult(left types.InstantV
 
 	// Cleanup the unused slices.
 	if canReturnLeftFPointSlice {
-		types.FPointSlicePool.Put(left.Floats, e.memoryConsumptionTracker)
+		types.FPointSlicePool.Put(&left.Floats, e.memoryConsumptionTracker)
 	}
 	if canReturnLeftHPointSlice {
-		types.HPointSlicePool.Put(left.Histograms, e.memoryConsumptionTracker)
+		types.HPointSlicePool.Put(&left.Histograms, e.memoryConsumptionTracker)
 	}
 	if canReturnRightFPointSlice {
-		types.FPointSlicePool.Put(right.Floats, e.memoryConsumptionTracker)
+		types.FPointSlicePool.Put(&right.Floats, e.memoryConsumptionTracker)
 	}
 	if canReturnRightHPointSlice {
-		types.HPointSlicePool.Put(right.Histograms, e.memoryConsumptionTracker)
+		types.HPointSlicePool.Put(&right.Histograms, e.memoryConsumptionTracker)
 	}
 
 	return types.InstantVectorSeriesData{

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -115,8 +115,7 @@ func (s *oneSide) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTrack
 	s.mergedData = types.InstantVectorSeriesData{}
 
 	if s.matchGroup != nil {
-		types.IntSlicePool.Put(s.matchGroup.presence, memoryConsumptionTracker)
-		s.matchGroup.presence = nil
+		types.IntSlicePool.Put(&s.matchGroup.presence, memoryConsumptionTracker)
 	}
 }
 
@@ -214,9 +213,9 @@ func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context)
 	}
 
 	if len(allMetadata) == 0 {
-		types.SeriesMetadataSlicePool.Put(allMetadata, g.MemoryConsumptionTracker)
-		types.BoolSlicePool.Put(oneSideSeriesUsed, g.MemoryConsumptionTracker)
-		types.BoolSlicePool.Put(manySideSeriesUsed, g.MemoryConsumptionTracker)
+		types.SeriesMetadataSlicePool.Put(&allMetadata, g.MemoryConsumptionTracker)
+		types.BoolSlicePool.Put(&oneSideSeriesUsed, g.MemoryConsumptionTracker)
+		types.BoolSlicePool.Put(&manySideSeriesUsed, g.MemoryConsumptionTracker)
 		g.Close()
 		return nil, nil
 	}
@@ -682,8 +681,7 @@ func (g *GroupedVectorVectorBinaryOperation) updateOneSidePresence(side *oneSide
 	matchGroup.oneSideCount--
 
 	if matchGroup.oneSideCount == 0 {
-		types.IntSlicePool.Put(matchGroup.presence, g.MemoryConsumptionTracker)
-		matchGroup.presence = nil
+		types.IntSlicePool.Put(&matchGroup.presence, g.MemoryConsumptionTracker)
 	}
 
 	return nil
@@ -769,11 +767,8 @@ func (g *GroupedVectorVectorBinaryOperation) Close() {
 	g.Right.Close()
 	// We don't need to close g.oneSide or g.manySide, as these are either g.Left or g.Right and so have been closed above.
 
-	types.SeriesMetadataSlicePool.Put(g.oneSideMetadata, g.MemoryConsumptionTracker)
-	g.oneSideMetadata = nil
-
-	types.SeriesMetadataSlicePool.Put(g.manySideMetadata, g.MemoryConsumptionTracker)
-	g.manySideMetadata = nil
+	types.SeriesMetadataSlicePool.Put(&g.oneSideMetadata, g.MemoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&g.manySideMetadata, g.MemoryConsumptionTracker)
 
 	if g.oneSideBuffer != nil {
 		g.oneSideBuffer.Close()

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -483,7 +483,6 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 			} else {
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
@@ -513,6 +512,8 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}
+
+			types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
 
 			_, err = o.NextSeries(ctx)
 			require.Equal(t, types.EOS, err)
@@ -651,7 +652,7 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 			outputSeries, err := o.SeriesMetadata(ctx)
 			require.NoError(t, err)
 			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
+			types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
 
 			for range testCase.seriesToRead {
 				d, err := o.NextSeries(ctx)

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -105,8 +105,7 @@ func (g *oneToOneBinaryOperationRightSide) latestRightSeriesIndex() int {
 }
 
 func (g *oneToOneBinaryOperationRightSide) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
-	types.IntSlicePool.Put(g.leftSidePresence, memoryConsumptionTracker)
-	g.leftSidePresence = nil
+	types.IntSlicePool.Put(&g.leftSidePresence, memoryConsumptionTracker)
 
 	// If this right side was used for all of its corresponding output series, then mergedData will have already been returned to the pool by the evaluator's computeResult.
 	// However, if the operator is being closed early, then we need to return mergedData to the pool.
@@ -185,9 +184,9 @@ func (b *OneToOneVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context
 	}
 
 	if len(allMetadata) == 0 {
-		types.SeriesMetadataSlicePool.Put(allMetadata, b.MemoryConsumptionTracker)
-		types.BoolSlicePool.Put(leftSeriesUsed, b.MemoryConsumptionTracker)
-		types.BoolSlicePool.Put(rightSeriesUsed, b.MemoryConsumptionTracker)
+		types.SeriesMetadataSlicePool.Put(&allMetadata, b.MemoryConsumptionTracker)
+		types.BoolSlicePool.Put(&leftSeriesUsed, b.MemoryConsumptionTracker)
+		types.BoolSlicePool.Put(&rightSeriesUsed, b.MemoryConsumptionTracker)
 		b.Close()
 		return nil, nil
 	}
@@ -597,11 +596,8 @@ func (b *OneToOneVectorVectorBinaryOperation) Close() {
 	b.Left.Close()
 	b.Right.Close()
 
-	types.SeriesMetadataSlicePool.Put(b.leftMetadata, b.MemoryConsumptionTracker)
-	b.leftMetadata = nil
-
-	types.SeriesMetadataSlicePool.Put(b.rightMetadata, b.MemoryConsumptionTracker)
-	b.rightMetadata = nil
+	types.SeriesMetadataSlicePool.Put(&b.leftMetadata, b.MemoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&b.rightMetadata, b.MemoryConsumptionTracker)
 
 	if b.leftBuffer != nil {
 		b.leftBuffer.Close()

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -636,7 +636,6 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 			} else {
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
@@ -666,6 +665,8 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}
+
+			types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
 
 			_, err = o.NextSeries(ctx)
 			require.Equal(t, types.EOS, err)
@@ -719,7 +720,7 @@ func TestOneToOneVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEa
 			metadata, err := o.SeriesMetadata(ctx)
 			require.NoError(t, err)
 			require.Equal(t, testutils.LabelsToSeriesMetadata(leftSeries), metadata)
-			types.SeriesMetadataSlicePool.Put(metadata, memoryConsumptionTracker)
+			types.SeriesMetadataSlicePool.Put(&metadata, memoryConsumptionTracker)
 
 			// Read the first series.
 			d, err := o.NextSeries(ctx)

--- a/pkg/streamingpromql/operators/binops/or_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation.go
@@ -73,8 +73,8 @@ func (o *OrBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesM
 
 	if len(leftMetadata) == 0 && len(rightMetadata) == 0 {
 		// Nothing to return.
-		types.SeriesMetadataSlicePool.Put(leftMetadata, o.MemoryConsumptionTracker)
-		types.SeriesMetadataSlicePool.Put(rightMetadata, o.MemoryConsumptionTracker)
+		types.SeriesMetadataSlicePool.Put(&leftMetadata, o.MemoryConsumptionTracker)
+		types.SeriesMetadataSlicePool.Put(&rightMetadata, o.MemoryConsumptionTracker)
 
 		o.Left.Close()
 		o.Right.Close()
@@ -86,7 +86,7 @@ func (o *OrBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesM
 		// We can just return everything from the right side.
 		o.nextSeriesIsFromLeft = false
 		o.rightSeriesCount = []int{len(rightMetadata)}
-		types.SeriesMetadataSlicePool.Put(leftMetadata, o.MemoryConsumptionTracker)
+		types.SeriesMetadataSlicePool.Put(&leftMetadata, o.MemoryConsumptionTracker)
 
 		o.Left.Close()
 
@@ -97,15 +97,15 @@ func (o *OrBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesM
 		// We can just return everything from the left side.
 		o.nextSeriesIsFromLeft = true
 		o.leftSeriesCount = []int{len(leftMetadata)}
-		types.SeriesMetadataSlicePool.Put(rightMetadata, o.MemoryConsumptionTracker)
+		types.SeriesMetadataSlicePool.Put(&rightMetadata, o.MemoryConsumptionTracker)
 
 		o.Right.Close()
 
 		return leftMetadata, nil
 	}
 
-	defer types.SeriesMetadataSlicePool.Put(leftMetadata, o.MemoryConsumptionTracker)
-	defer types.SeriesMetadataSlicePool.Put(rightMetadata, o.MemoryConsumptionTracker)
+	defer types.SeriesMetadataSlicePool.Put(&leftMetadata, o.MemoryConsumptionTracker)
+	defer types.SeriesMetadataSlicePool.Put(&rightMetadata, o.MemoryConsumptionTracker)
 
 	o.computeGroups(leftMetadata, rightMetadata)
 
@@ -388,6 +388,5 @@ func (g *orGroup) FilterRightSeries(rightData types.InstantVectorSeriesData, mem
 }
 
 func (g *orGroup) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
-	types.BoolSlicePool.Put(g.leftSamplePresence, memoryConsumptionTracker)
-	g.leftSamplePresence = nil
+	types.BoolSlicePool.Put(&g.leftSamplePresence, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
@@ -546,7 +546,6 @@ func TestOrBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
 			} else {
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
@@ -576,6 +575,8 @@ func TestOrBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
 					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}
+
+			types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
 
 			_, err = o.NextSeries(ctx)
 			require.Equal(t, types.EOS, err)
@@ -686,7 +687,7 @@ func TestOrBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *testing.T) 
 			outputSeries, err := o.SeriesMetadata(ctx)
 			require.NoError(t, err)
 			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
-			types.SeriesMetadataSlicePool.Put(outputSeries, memoryConsumptionTracker)
+			types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
 			// Read the output series to trigger the loading of some intermediate state for at least one of the output groups.
 			for range testCase.closeAfterReadingIndex + 1 {
 				_, err := o.NextSeries(ctx)

--- a/pkg/streamingpromql/operators/binops/scalar_scalar_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/scalar_scalar_binary_operation.go
@@ -96,7 +96,7 @@ func (s *ScalarScalarBinaryOperation) GetValues(ctx context.Context) (types.Scal
 		leftValues.Samples[i].F = f
 	}
 
-	types.FPointSlicePool.Put(rightValues.Samples, s.MemoryConsumptionTracker)
+	types.FPointSlicePool.Put(&rightValues.Samples, s.MemoryConsumptionTracker)
 
 	return leftValues, nil
 }

--- a/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
@@ -235,11 +235,11 @@ func (v *VectorScalarBinaryOperation) NextSeries(ctx context.Context) (types.Ins
 	}
 
 	if returnInputFPointSlice {
-		types.FPointSlicePool.Put(series.Floats, v.MemoryConsumptionTracker)
+		types.FPointSlicePool.Put(&series.Floats, v.MemoryConsumptionTracker)
 	}
 
 	if returnInputHPointSlice {
-		types.HPointSlicePool.Put(series.Histograms, v.MemoryConsumptionTracker)
+		types.HPointSlicePool.Put(&series.Histograms, v.MemoryConsumptionTracker)
 	}
 
 	return types.InstantVectorSeriesData{
@@ -264,8 +264,7 @@ func (v *VectorScalarBinaryOperation) Close() {
 	v.Scalar.Close()
 	v.Vector.Close()
 
-	types.FPointSlicePool.Put(v.scalarData.Samples, v.MemoryConsumptionTracker)
-	v.scalarData.Samples = nil
+	types.FPointSlicePool.Put(&v.scalarData.Samples, v.MemoryConsumptionTracker)
 }
 
 func (v *VectorScalarBinaryOperation) emitAnnotation(generator types.AnnotationGenerator) {

--- a/pkg/streamingpromql/operators/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge.go
@@ -57,7 +57,7 @@ func (d *DeduplicateAndMerge) SeriesMetadata(ctx context.Context) ([]types.Serie
 
 	d.groups = groups
 	d.buffer = NewInstantVectorOperatorBuffer(d.Inner, nil, len(innerMetadata), d.MemoryConsumptionTracker)
-	types.SeriesMetadataSlicePool.Put(innerMetadata, d.MemoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&innerMetadata, d.MemoryConsumptionTracker)
 
 	return outputMetadata, nil
 }

--- a/pkg/streamingpromql/operators/functions/absent.go
+++ b/pkg/streamingpromql/operators/functions/absent.go
@@ -47,7 +47,7 @@ func (a *Absent) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, er
 	if err != nil {
 		return nil, err
 	}
-	defer types.SeriesMetadataSlicePool.Put(innerMetadata, a.MemoryConsumptionTracker)
+	defer types.SeriesMetadataSlicePool.Put(&innerMetadata, a.MemoryConsumptionTracker)
 
 	a.presence, err = types.BoolSlicePool.Get(a.TimeRange.StepCount, a.MemoryConsumptionTracker)
 	if err != nil {
@@ -119,8 +119,7 @@ func (a *Absent) Prepare(ctx context.Context, params *types.PrepareParams) error
 func (a *Absent) Close() {
 	a.Inner.Close()
 
-	types.BoolSlicePool.Put(a.presence, a.MemoryConsumptionTracker)
-	a.presence = nil
+	types.BoolSlicePool.Put(&a.presence, a.MemoryConsumptionTracker)
 }
 
 // CreateLabelsForAbsentFunction returns the labels that are uniquely and exactly matched

--- a/pkg/streamingpromql/operators/functions/absent_over_time.go
+++ b/pkg/streamingpromql/operators/functions/absent_over_time.go
@@ -51,7 +51,7 @@ func (a *AbsentOverTime) SeriesMetadata(ctx context.Context) ([]types.SeriesMeta
 	if err != nil {
 		return nil, err
 	}
-	defer types.SeriesMetadataSlicePool.Put(innerMetadata, a.MemoryConsumptionTracker)
+	defer types.SeriesMetadataSlicePool.Put(&innerMetadata, a.MemoryConsumptionTracker)
 
 	a.presence, err = types.BoolSlicePool.Get(a.TimeRange.StepCount, a.MemoryConsumptionTracker)
 	if err != nil {
@@ -125,6 +125,5 @@ func (a *AbsentOverTime) Prepare(ctx context.Context, params *types.PrepareParam
 func (a *AbsentOverTime) Close() {
 	a.Inner.Close()
 
-	types.BoolSlicePool.Put(a.presence, a.MemoryConsumptionTracker)
-	a.presence = nil
+	types.BoolSlicePool.Put(&a.presence, a.MemoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/functions/absent_test.go
+++ b/pkg/streamingpromql/operators/functions/absent_test.go
@@ -29,10 +29,7 @@ func TestAbsent_NextSeries_ExhaustedCondition(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result1.Floats)
 	require.Len(t, result1.Floats, 1)
-
-	if result1.Floats != nil {
-		types.FPointSlicePool.Put(result1.Floats, memTracker)
-	}
+	types.FPointSlicePool.Put(&result1.Floats, memTracker)
 
 	// Second call should return EOS.
 	result2, err := a.NextSeries(ctx)

--- a/pkg/streamingpromql/operators/functions/common.go
+++ b/pkg/streamingpromql/operators/functions/common.go
@@ -42,15 +42,13 @@ func FloatTransformationDropHistogramsFunc(transform func(f float64) float64) In
 	return func(seriesData types.InstantVectorSeriesData, _ []types.ScalarData, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) (types.InstantVectorSeriesData, error) {
 		// Functions that do not explicitly mention native histograms in their documentation will ignore histogram samples.
 		// https://prometheus.io/docs/prometheus/latest/querying/functions
-		types.HPointSlicePool.Put(seriesData.Histograms, memoryConsumptionTracker)
-		seriesData.Histograms = nil
+		types.HPointSlicePool.Put(&seriesData.Histograms, memoryConsumptionTracker)
 		return ft(seriesData, nil, timeRange, memoryConsumptionTracker)
 	}
 }
 
 func DropHistograms(seriesData types.InstantVectorSeriesData, _ []types.ScalarData, _ types.QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) (types.InstantVectorSeriesData, error) {
-	types.HPointSlicePool.Put(seriesData.Histograms, memoryConsumptionTracker)
-	seriesData.Histograms = nil
+	types.HPointSlicePool.Put(&seriesData.Histograms, memoryConsumptionTracker)
 	return seriesData, nil
 }
 

--- a/pkg/streamingpromql/operators/functions/function_over_instant_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_instant_vector.go
@@ -121,7 +121,7 @@ func (m *FunctionOverInstantVector) Close() {
 	m.Inner.Close()
 
 	for _, sd := range m.scalarArgsData {
-		types.FPointSlicePool.Put(sd.Samples, m.MemoryConsumptionTracker)
+		types.FPointSlicePool.Put(&sd.Samples, m.MemoryConsumptionTracker)
 	}
 
 	m.scalarArgsData = nil

--- a/pkg/streamingpromql/operators/functions/function_over_range_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_range_vector.go
@@ -208,7 +208,7 @@ func (m *FunctionOverRangeVector) Close() {
 	m.Inner.Close()
 
 	for _, d := range m.scalarArgsData {
-		types.FPointSlicePool.Put(d.Samples, m.MemoryConsumptionTracker)
+		types.FPointSlicePool.Put(&d.Samples, m.MemoryConsumptionTracker)
 	}
 
 	m.scalarArgsData = nil

--- a/pkg/streamingpromql/operators/functions/math.go
+++ b/pkg/streamingpromql/operators/functions/math.go
@@ -86,8 +86,7 @@ var Clamp InstantVectorSeriesFunction = func(seriesData types.InstantVectorSerie
 	}
 	seriesData.Floats = seriesData.Floats[:outputIdx]
 	// Histograms are dropped from clamp
-	types.HPointSlicePool.Put(seriesData.Histograms, memoryConsumptionTracker)
-	seriesData.Histograms = nil
+	types.HPointSlicePool.Put(&seriesData.Histograms, memoryConsumptionTracker)
 	return seriesData, nil
 }
 
@@ -113,8 +112,7 @@ func ClampMinMaxFactory(isMin bool) InstantVectorSeriesFunction {
 			seriesData.Floats[step].F = clampFunc(val, data.F)
 		}
 		// Histograms are dropped from clamp
-		types.HPointSlicePool.Put(seriesData.Histograms, memoryConsumptionTracker)
-		seriesData.Histograms = nil
+		types.HPointSlicePool.Put(&seriesData.Histograms, memoryConsumptionTracker)
 		return seriesData, nil
 	}
 }
@@ -135,7 +133,6 @@ var Round InstantVectorSeriesFunction = func(seriesData types.InstantVectorSerie
 		seriesData.Floats[step].F = math.Floor(data.F*toNearestInverse+0.5) / toNearestInverse
 	}
 	// Histograms are dropped from Round
-	types.HPointSlicePool.Put(seriesData.Histograms, memoryConsumptionTracker)
-	seriesData.Histograms = nil
+	types.HPointSlicePool.Put(&seriesData.Histograms, memoryConsumptionTracker)
 	return seriesData, nil
 }

--- a/pkg/streamingpromql/operators/functions/range_vectors.go
+++ b/pkg/streamingpromql/operators/functions/range_vectors.go
@@ -804,7 +804,7 @@ func quantileOverTime(step *types.RangeVectorStepData, _ float64, args []types.S
 		return 0, false, nil, err
 	}
 
-	defer types.Float64SlicePool.Put(values, memoryConsumptionTracker)
+	defer types.Float64SlicePool.Put(&values, memoryConsumptionTracker)
 
 	for _, p := range head {
 		values = append(values, p.F)

--- a/pkg/streamingpromql/operators/functions/sort.go
+++ b/pkg/streamingpromql/operators/functions/sort.go
@@ -56,8 +56,7 @@ func (s *Sort) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, erro
 		}
 
 		// sort() and sort_desc() ignore histograms.
-		types.HPointSlicePool.Put(d.Histograms, s.MemoryConsumptionTracker)
-		d.Histograms = nil
+		types.HPointSlicePool.Put(&d.Histograms, s.MemoryConsumptionTracker)
 
 		pointCount := len(d.Floats)
 

--- a/pkg/streamingpromql/operators/functions/times.go
+++ b/pkg/streamingpromql/operators/functions/times.go
@@ -45,8 +45,7 @@ func timeWrapperFunc(f func(t time.Time) float64) InstantVectorSeriesFunction {
 	return func(seriesData types.InstantVectorSeriesData, _ []types.ScalarData, _ types.QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) (types.InstantVectorSeriesData, error) {
 
 		// we don't do time based function on histograms
-		types.HPointSlicePool.Put(seriesData.Histograms, memoryConsumptionTracker)
-		seriesData.Histograms = nil
+		types.HPointSlicePool.Put(&seriesData.Histograms, memoryConsumptionTracker)
 
 		for i := range seriesData.Floats {
 			t := time.Unix(int64(seriesData.Floats[i].F), 0).UTC()

--- a/pkg/streamingpromql/operators/functions/timestamp.go
+++ b/pkg/streamingpromql/operators/functions/timestamp.go
@@ -21,10 +21,10 @@ var Timestamp = FunctionOverInstantVectorDefinition{
 func timestamp(data types.InstantVectorSeriesData, _ []types.ScalarData, _ types.QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) (types.InstantVectorSeriesData, error) {
 	output := types.InstantVectorSeriesData{}
 
-	defer types.HPointSlicePool.Put(data.Histograms, memoryConsumptionTracker)
+	defer types.HPointSlicePool.Put(&data.Histograms, memoryConsumptionTracker)
 
 	if len(data.Histograms) > 0 {
-		defer types.FPointSlicePool.Put(data.Floats, memoryConsumptionTracker)
+		defer types.FPointSlicePool.Put(&data.Floats, memoryConsumptionTracker)
 
 		var err error
 		output.Floats, err = types.FPointSlicePool.Get(len(data.Floats)+len(data.Histograms), memoryConsumptionTracker)

--- a/pkg/streamingpromql/operators/operator_buffer.go
+++ b/pkg/streamingpromql/operators/operator_buffer.go
@@ -117,6 +117,5 @@ func (b *InstantVectorOperatorBuffer) Close() {
 	b.buffer = nil
 	b.output = nil
 
-	types.BoolSlicePool.Put(b.seriesUsed, b.memoryConsumptionTracker)
-	b.seriesUsed = nil
+	types.BoolSlicePool.Put(&b.seriesUsed, b.memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/scalars/instant_vector_to_scalar.go
+++ b/pkg/streamingpromql/operators/scalars/instant_vector_to_scalar.go
@@ -49,7 +49,7 @@ func (i *InstantVectorToScalar) GetValues(ctx context.Context) (types.ScalarData
 		return types.ScalarData{}, err
 	}
 
-	defer types.BoolSlicePool.Put(seenPoint, i.MemoryConsumptionTracker)
+	defer types.BoolSlicePool.Put(&seenPoint, i.MemoryConsumptionTracker)
 	seenPoint = seenPoint[:i.TimeRange.StepCount]
 
 	output, err := types.FPointSlicePool.Get(i.TimeRange.StepCount, i.MemoryConsumptionTracker)
@@ -96,7 +96,7 @@ func (i *InstantVectorToScalar) getInnerSeriesCount(ctx context.Context) (int, e
 		return 0, err
 	}
 
-	defer types.SeriesMetadataSlicePool.Put(metadata, i.MemoryConsumptionTracker)
+	defer types.SeriesMetadataSlicePool.Put(&metadata, i.MemoryConsumptionTracker)
 
 	seriesCount := len(metadata)
 

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator.go
@@ -187,8 +187,7 @@ func (b *DuplicationBuffer) Prepare(ctx context.Context, params *types.PreparePa
 }
 
 func (b *DuplicationBuffer) close() {
-	types.SeriesMetadataSlicePool.Put(b.seriesMetadata, b.MemoryConsumptionTracker)
-	b.seriesMetadata = nil
+	types.SeriesMetadataSlicePool.Put(&b.seriesMetadata, b.MemoryConsumptionTracker)
 
 	for b.buffer.Size() > 0 {
 		types.PutInstantVectorSeriesData(b.buffer.RemoveFirst(), b.MemoryConsumptionTracker)

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operator_test.go
@@ -36,8 +36,8 @@ func TestOperator_Buffering(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testutils.LabelsToSeriesMetadata(inner.Series), metadata1, "first consumer should get expected series metadata")
 	require.Equal(t, testutils.LabelsToSeriesMetadata(inner.Series), metadata2, "second consumer should get expected series metadata")
-	types.SeriesMetadataSlicePool.Put(metadata1, memoryConsumptionTracker)
-	types.SeriesMetadataSlicePool.Put(metadata2, memoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&metadata1, memoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&metadata2, memoryConsumptionTracker)
 
 	// Read some data from the first consumer and ensure that it was buffered for the second consumer.
 	d, err := consumer1.NextSeries(ctx)
@@ -127,8 +127,8 @@ func TestOperator_ClosedWithBufferedData(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testutils.LabelsToSeriesMetadata(inner.Series), metadata1, "first consumer should get expected series metadata")
 	require.Equal(t, testutils.LabelsToSeriesMetadata(inner.Series), metadata2, "second consumer should get expected series metadata")
-	types.SeriesMetadataSlicePool.Put(metadata1, memoryConsumptionTracker)
-	types.SeriesMetadataSlicePool.Put(metadata2, memoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&metadata2, memoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&metadata1, memoryConsumptionTracker)
 
 	// Read some data for the first consumer and ensure that it was buffered for the second consumer.
 	d, err := consumer1.NextSeries(ctx)
@@ -203,8 +203,8 @@ func TestOperator_Cloning(t *testing.T) {
 	require.Equal(t, testutils.LabelsToSeriesMetadata(inner.Series), metadata1, "first consumer should get expected series metadata")
 	require.Equal(t, testutils.LabelsToSeriesMetadata(inner.Series), metadata2, "second consumer should get expected series metadata")
 	require.NotSame(t, &metadata1[0], &metadata2[0], "consumers should not share series metadata slices")
-	types.SeriesMetadataSlicePool.Put(metadata1, memoryConsumptionTracker)
-	types.SeriesMetadataSlicePool.Put(metadata2, memoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&metadata1, memoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&metadata2, memoryConsumptionTracker)
 
 	// Both consumers should get the same data, but not the same slice, and not the same histogram instances.
 	d1, err := consumer1.NextSeries(ctx)
@@ -269,7 +269,7 @@ func TestOperator_ClosingAfterFirstReadFails(t *testing.T) {
 	metadata1, err := consumer1.SeriesMetadata(ctx)
 	require.NoError(t, err)
 	require.Equal(t, series, metadata1, "first consumer should get expected series metadata")
-	types.SeriesMetadataSlicePool.Put(metadata1, memoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&metadata1, memoryConsumptionTracker)
 
 	data, err := consumer1.NextSeries(ctx)
 	require.EqualError(t, err, "something went wrong reading data")
@@ -296,7 +296,7 @@ func TestOperator_ClosingAfterSubsequentReadFails(t *testing.T) {
 	metadata1, err := consumer1.SeriesMetadata(ctx)
 	require.NoError(t, err)
 	require.Equal(t, series, metadata1, "first consumer should get expected series metadata")
-	types.SeriesMetadataSlicePool.Put(metadata1, memoryConsumptionTracker)
+	types.SeriesMetadataSlicePool.Put(&metadata1, memoryConsumptionTracker)
 
 	data, err := consumer1.NextSeries(ctx)
 	require.NoError(t, err)

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -193,7 +193,7 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 		if err != nil {
 			return &promql.Result{Err: err}
 		}
-		defer types.SeriesMetadataSlicePool.Put(series, q.memoryConsumptionTracker)
+		defer types.SeriesMetadataSlicePool.Put(&series, q.memoryConsumptionTracker)
 
 		v, err := q.populateMatrixFromRangeVectorOperator(ctx, root, series)
 		if err != nil {
@@ -206,7 +206,7 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 		if err != nil {
 			return &promql.Result{Err: err}
 		}
-		defer types.SeriesMetadataSlicePool.Put(series, q.memoryConsumptionTracker)
+		defer types.SeriesMetadataSlicePool.Put(&series, q.memoryConsumptionTracker)
 
 		if q.topLevelQueryTimeRange.IsInstant {
 			v, err := q.populateVectorFromInstantVectorOperator(ctx, root, series)
@@ -368,8 +368,8 @@ func (q *Query) populateMatrixFromRangeVectorOperator(ctx context.Context, o typ
 		}
 
 		if len(floats) == 0 && len(histograms) == 0 {
-			types.FPointSlicePool.Put(floats, q.memoryConsumptionTracker)
-			types.HPointSlicePool.Put(histograms, q.memoryConsumptionTracker)
+			types.FPointSlicePool.Put(&floats, q.memoryConsumptionTracker)
+			types.HPointSlicePool.Put(&histograms, q.memoryConsumptionTracker)
 			continue
 		}
 
@@ -397,7 +397,7 @@ func (q *Query) populateMatrixFromScalarOperator(d types.ScalarData) promql.Matr
 }
 
 func (q *Query) populateScalarFromScalarOperator(d types.ScalarData) promql.Scalar {
-	defer types.FPointSlicePool.Put(d.Samples, q.memoryConsumptionTracker)
+	defer types.FPointSlicePool.Put(&d.Samples, q.memoryConsumptionTracker)
 
 	p := d.Samples[0]
 
@@ -420,13 +420,13 @@ func (q *Query) Close() {
 	switch v := q.result.Value.(type) {
 	case promql.Matrix:
 		for _, s := range v {
-			types.FPointSlicePool.Put(s.Floats, q.memoryConsumptionTracker)
-			types.HPointSlicePool.Put(s.Histograms, q.memoryConsumptionTracker)
+			types.FPointSlicePool.Put(&s.Floats, q.memoryConsumptionTracker)
+			types.HPointSlicePool.Put(&s.Histograms, q.memoryConsumptionTracker)
 		}
 
 		types.PutMatrix(v)
 	case promql.Vector:
-		types.VectorPool.Put(v, q.memoryConsumptionTracker)
+		types.VectorPool.Put(&v, q.memoryConsumptionTracker)
 	case promql.Scalar:
 		// Nothing to do, we already returned the slice in populateScalarFromScalarOperator.
 	case promql.String:

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -73,7 +73,7 @@ func (b *FPointRingBuffer) Append(p promql.FPoint) error {
 		copy(newSlice, b.points[b.firstIndex:])
 		copy(newSlice[pointsAtEnd:], b.points[:b.firstIndex])
 
-		putFPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+		putFPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 		b.points = newSlice
 		b.firstIndex = 0
 		b.pointsIndexMask = cap(newSlice) - 1
@@ -138,7 +138,7 @@ func (b *FPointRingBuffer) Reset() {
 // The buffer can be used again and will acquire a new slice when required.
 func (b *FPointRingBuffer) Release() {
 	b.Reset()
-	putFPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+	putFPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 	b.points = nil
 }
 
@@ -154,7 +154,7 @@ func (b *FPointRingBuffer) Use(s []promql.FPoint) error {
 		return fmt.Errorf("slice capacity must be a power of two, but is %v", cap(s))
 	}
 
-	putFPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+	putFPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 
 	b.points = s[:cap(s)]
 	b.firstIndex = 0
@@ -165,7 +165,7 @@ func (b *FPointRingBuffer) Use(s []promql.FPoint) error {
 
 // Close releases any resources associated with this buffer.
 func (b *FPointRingBuffer) Close() {
-	putFPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+	putFPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 	b.points = nil
 }
 

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -138,7 +138,7 @@ func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, error) {
 		// those instances instead of creating new FloatHistograms.
 		clear(b.points)
 
-		putHPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+		putHPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 		b.points = newSlice
 		b.firstIndex = 0
 		b.pointsIndexMask = cap(newSlice) - 1
@@ -175,7 +175,7 @@ func (b *HPointRingBuffer) Reset() {
 // The buffer can be used again and will acquire a new slice when required.
 func (b *HPointRingBuffer) Release() {
 	b.Reset()
-	putHPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+	putHPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 	b.points = nil
 }
 
@@ -191,7 +191,7 @@ func (b *HPointRingBuffer) Use(s []promql.HPoint) error {
 		return fmt.Errorf("slice capacity must be a power of two, but is %v", cap(s))
 	}
 
-	putHPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+	putHPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 
 	b.points = s[:cap(s)]
 	b.firstIndex = 0
@@ -202,7 +202,7 @@ func (b *HPointRingBuffer) Use(s []promql.HPoint) error {
 
 // Close releases any resources associated with this buffer.
 func (b *HPointRingBuffer) Close() {
-	putHPointSliceForRingBuffer(b.points, b.memoryConsumptionTracker)
+	putHPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 	b.points = nil
 }
 

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -48,7 +48,7 @@ func TestLimitingBucketedPool_Unlimited(t *testing.T) {
 	require.Equal(t, 130*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 
 	// Put a slice back into the pool, the current stat should be updated but peak should be unchanged.
-	p.Put(s100, tracker)
+	p.Put(&s100, tracker)
 	require.Equal(t, 2*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, 130*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 
@@ -104,7 +104,7 @@ func TestLimitingPool_Limited(t *testing.T) {
 	assertRejectedQueryCount(t, reg, 0)
 
 	// Return a slice to the pool.
-	p.Put(s1, tracker)
+	p.Put(&s1, tracker)
 	require.Equal(t, 8*FPointSize, tracker.CurrentEstimatedMemoryConsumptionBytes())
 	require.Equal(t, 9*FPointSize, tracker.PeakEstimatedMemoryConsumptionBytes())
 	assertRejectedQueryCount(t, reg, 0)
@@ -156,7 +156,8 @@ func TestLimitingPool_ClearsReturnedSlices(t *testing.T) {
 		s[0] = 123
 		s[1] = 456
 
-		Float64SlicePool.Put(s, tracker)
+		Float64SlicePool.Put(&s, tracker)
+		require.Nil(t, s, "reference to slice should be cleared on Put")
 
 		s, err = Float64SlicePool.Get(2, tracker)
 		require.NoError(t, err)
@@ -171,7 +172,8 @@ func TestLimitingPool_ClearsReturnedSlices(t *testing.T) {
 		s[0] = false
 		s[1] = true
 
-		BoolSlicePool.Put(s, tracker)
+		BoolSlicePool.Put(&s, tracker)
+		require.Nil(t, s, "reference to slice should be cleared on Put")
 
 		s, err = BoolSlicePool.Get(2, tracker)
 		require.NoError(t, err)
@@ -186,7 +188,8 @@ func TestLimitingPool_ClearsReturnedSlices(t *testing.T) {
 		s[0] = &histogram.FloatHistogram{Count: 1}
 		s[1] = &histogram.FloatHistogram{Count: 2}
 
-		HistogramSlicePool.Put(s, tracker)
+		HistogramSlicePool.Put(&s, tracker)
+		require.Nil(t, s, "reference to slice should be cleared on Put")
 
 		s, err = HistogramSlicePool.Get(2, tracker)
 		require.NoError(t, err)
@@ -218,18 +221,20 @@ func TestLimitingPool_Mangling(t *testing.T) {
 	s, err := p.Get(4, tracker)
 	require.NoError(t, err)
 	s = append(s, 1000, 2000, 3000, 4000)
+	sCopy := s // Take another reference to s, so that we can check that it was mangled. (Put will set s to nil when it is called below, so we need to take a copy.)
 
-	p.Put(s, tracker)
-	require.Equal(t, []int{1000, 2000, 3000, 4000}, s, "returned slice should not be mangled when mangling is disabled")
+	p.Put(&s, tracker)
+	require.Equal(t, []int{1000, 2000, 3000, 4000}, sCopy, "returned slice should not be mangled when mangling is disabled")
 
 	// Test with mangling enabled.
 	EnableManglingReturnedSlices = true
 	s, err = p.Get(4, tracker)
 	require.NoError(t, err)
 	s = append(s, 1000, 2000, 3000, 4000)
+	sCopy = s
 
-	p.Put(s, tracker)
-	require.Equal(t, []int{123, 123, 123, 123}, s, "returned slice should be mangled when mangling is enabled")
+	p.Put(&s, tracker)
+	require.Equal(t, []int{123, 123, 123, 123}, sCopy, "returned slice should be mangled when mangling is enabled")
 }
 
 func TestLimitingBucketedPool_MaxExpectedPointsPerSeriesConstantIsPowerOfTwo(t *testing.T) {

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -499,13 +499,13 @@ func setupRingBufferTestingPools(t *testing.T) {
 		return make([]promql.FPoint, 0, size), nil
 	}
 
-	putFPointSliceForRingBuffer = func(_ []promql.FPoint, _ *limiter.MemoryConsumptionTracker) {}
+	putFPointSliceForRingBuffer = func(_ *[]promql.FPoint, _ *limiter.MemoryConsumptionTracker) {}
 
 	getHPointSliceForRingBuffer = func(size int, _ *limiter.MemoryConsumptionTracker) ([]promql.HPoint, error) {
 		return make([]promql.HPoint, 0, size), nil
 	}
 
-	putHPointSliceForRingBuffer = func(_ []promql.HPoint, _ *limiter.MemoryConsumptionTracker) {}
+	putHPointSliceForRingBuffer = func(_ *[]promql.HPoint, _ *limiter.MemoryConsumptionTracker) {}
 
 	t.Cleanup(func() {
 		getFPointSliceForRingBuffer = originalGetFPointSlice

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -87,7 +87,7 @@ func (qs *QueryStats) Clear() {
 
 func (qs *QueryStats) Close() {
 	if qs.TotalSamplesPerStep != nil {
-		Int64SlicePool.Put(qs.TotalSamplesPerStep, qs.memoryConsumptionTracker)
+		Int64SlicePool.Put(&qs.TotalSamplesPerStep, qs.memoryConsumptionTracker)
 		qs.TotalSamplesPerStep = nil
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR is an alternative to #11741, which implements an idea from @bboreham [here](https://github.com/grafana/mimir/pull/11690#issuecomment-2999379812).

Compared to #11741, this avoids a need for a linter, at the cost of a slightly less obvious behaviour and slightly uglier code.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/11690

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
