### PR TITLE
MQE: remove outdated comments in `mergeOneSideHistograms`

### DIFF
--- a/pkg/streamingpromql/operators/series_merging.go
+++ b/pkg/streamingpromql/operators/series_merging.go
@@ -222,7 +222,6 @@ func mergeOneSideHistograms(data []types.InstantVectorSeriesData, sourceSeriesIn
 		// We're going to create a new slice, so return this one to the pool.
 		// We must defer here, rather than at the end, as the merge loop below reslices Histograms.
 		// We deliberately want this to happen at the end of mergeOneSideHistograms, so calling defer like this in a loop is fine.
-		// FIXME: this isn't correct for many-to-one / one-to-many matching - we'll need the series again (unless we store the result of the merge)
 		defer clearAndReturnHPointSlice(second.Histograms, memoryConsumptionTracker) // We're going to retain all the FloatHistogram instances, so don't leave them in the slice to be reused.
 
 		if len(second.Histograms) == 0 {
@@ -250,7 +249,6 @@ func mergeOneSideHistograms(data []types.InstantVectorSeriesData, sourceSeriesIn
 	// We're going to create a new slice, so return this one to the pool.
 	// We'll return the other slices in the for loop below.
 	// We must defer here, rather than at the end, as the merge loop below reslices Histograms.
-	// FIXME: this isn't correct for many-to-one / one-to-many matching - we'll need the series again (unless we store the result of the merge)
 	defer clearAndReturnHPointSlice(data[0].Histograms, memoryConsumptionTracker) // We're going to retain all the FloatHistogram instances, so don't leave them in the slice to be reused.
 
 	// Re-slice data with just the series with histograms to make the rest of our job easier


### PR DESCRIPTION
#### What this PR does

This PR removes some outdated comments in `mergeOneSideHistograms`.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
