### PR TITLE
Change level 0 blocks to be reported as 'unknown/old_block' in metrics

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1211,7 +1211,7 @@ func (s *BucketStore) recordSeriesCallResult(safeStats *safeQueryStats) {
 	s.metrics.seriesDataSizeFetched.WithLabelValues("chunks", "refetched").Observe(float64(stats.chunksRefetchedSizeSum))
 
 	for m, count := range stats.blocksQueriedByBlockMeta {
-		s.metrics.seriesBlocksQueried.WithLabelValues(string(m.source), strconv.Itoa(m.level), strconv.FormatBool(m.outOfOrder)).Observe(float64(count))
+		s.metrics.seriesBlocksQueried.WithLabelValues(string(m.source), m.level, strconv.FormatBool(m.outOfOrder)).Observe(float64(count))
 	}
 
 	s.metrics.seriesDataTouched.WithLabelValues("chunks", "processed").Observe(float64(stats.chunksTouched))
@@ -1232,7 +1232,7 @@ func (s *BucketStore) recordLabelNamesCallResult(safeStats *safeQueryStats) {
 	s.recordStreamingSeriesStats(stats)
 
 	for m, count := range stats.blocksQueriedByBlockMeta {
-		s.metrics.seriesBlocksQueried.WithLabelValues(string(m.source), strconv.Itoa(m.level), strconv.FormatBool(m.outOfOrder)).Observe(float64(count))
+		s.metrics.seriesBlocksQueried.WithLabelValues(string(m.source), m.level, strconv.FormatBool(m.outOfOrder)).Observe(float64(count))
 	}
 }
 


### PR DESCRIPTION
Level 0 blocks in metrics indicate metadata from before we started tracking compaction levels in bucket index (pre-January 2024). This change improves metric clarity by labeling them as 'unknown/old_block' instead of '0'.

**Background:**
- Blocks are correctly created with level 1 in Prometheus compactor:
  - [Out-of-order blocks](https://github.com/grafana/mimir/blob/ad510f2b5f/vendor/github.com/prometheus/prometheus/tsdb/compact.go#L686): `meta.Compaction.Level = 1`
  - [Regular head blocks](https://github.com/grafana/mimir/blob/ad510f2b5f/vendor/github.com/prometheus/prometheus/tsdb/compact.go#L759): `meta.Compaction.Level = 1`

- CompactionLevel field was added to bucket index in [dcc2d9bb](https://github.com/grafana/mimir/commit/dcc2d9bbbed4873e62a9685c04349150ff354564) (January 2024)

- The [`updateBlockIndexEntry`](https://github.com/grafana/mimir/blob/ad510f2b5f/pkg/storage/tsdb/bucketindex/updater.go#L350) function only runs for new blocks, which explains why existing blocks had zero-valued compaction level.

Discovered while working on #11803.