### PR TITLE
querier: limit remote read parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 * [FEATURE] OTLP: Add experimental support for promoting OTel scope metadata (name, version, schema URL, attributes) to metric labels, prefixed with `otel_scope_`. Enable via the `-distributor.otel-promote-scope-metadata` flag. #11795
 * [ENHANCEMENT] Dashboards: Add "Influx write requests" row to Writes Dashboard. #11731
 * [ENHANCEMENT] Querier: Make the maximum series limit for cardinality API requests configurable on a per-tenant basis with the `cardinality_analysis_max_results` option. #11456
-* [ENHANCEMENT] Querier: Add configurable concurrency limit for remote read queries with `--querier.max-concurrent-remote-read-queries` flag (default: 2). Set to 0 for unlimited concurrency. #11892
+* [ENHANCEMENT] Querier: Add configurable concurrency limit for remote read queries with the `--querier.max-concurrent-remote-read-queries` flag. Defaults to 2. Set to 0 for unlimited concurrency. #11892
 * [ENHANCEMENT] Dashboards: Add "Queries / sec by read path" to Queries Dashboard. #11640
 * [ENHANCEMENT] Dashboards: Add "Added Latency" row to Writes Dashboard. #11579
 * [ENHANCEMENT] Ingester: Add support for exporting native histogram cost attribution metrics (`cortex_ingester_attributed_active_native_histogram_series` and `cortex_ingester_attributed_active_native_histogram_buckets`) with labels specified by customers to a custom Prometheus registry. #10892

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [FEATURE] OTLP: Add experimental support for promoting OTel scope metadata (name, version, schema URL, attributes) to metric labels, prefixed with `otel_scope_`. Enable via the `-distributor.otel-promote-scope-metadata` flag. #11795
 * [ENHANCEMENT] Dashboards: Add "Influx write requests" row to Writes Dashboard. #11731
 * [ENHANCEMENT] Querier: Make the maximum series limit for cardinality API requests configurable on a per-tenant basis with the `cardinality_analysis_max_results` option. #11456
+* [ENHANCEMENT] Querier: Add configurable concurrency limit for remote read queries with `--querier.max-concurrent-remote-read-queries` flag (default: 2). Set to 0 for unlimited concurrency. #11892
 * [ENHANCEMENT] Dashboards: Add "Queries / sec by read path" to Queries Dashboard. #11640
 * [ENHANCEMENT] Dashboards: Add "Added Latency" row to Writes Dashboard. #11579
 * [ENHANCEMENT] Ingester: Add support for exporting native histogram cost attribution metrics (`cortex_ingester_attributed_active_native_histogram_series` and `cortex_ingester_attributed_active_native_histogram_buckets`) with labels specified by customers to a custom Prometheus registry. #10892

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2220,7 +2220,7 @@
           "kind": "field",
           "name": "max_concurrent_remote_read_queries",
           "required": false,
-          "desc": "Maximum number of remote read queries that can execute concurrently. 0 or negative values mean unlimited concurrency.",
+          "desc": "Maximum number of remote read queries that can be executed concurrently. 0 or negative values mean unlimited concurrency.",
           "fieldValue": null,
           "fieldDefaultValue": 2,
           "fieldFlag": "querier.max-concurrent-remote-read-queries",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2218,6 +2218,17 @@
         },
         {
           "kind": "field",
+          "name": "max_concurrent_remote_read_queries",
+          "required": false,
+          "desc": "Maximum number of remote read queries that can execute concurrently. 0 or negative values mean unlimited concurrency.",
+          "fieldValue": null,
+          "fieldDefaultValue": 2,
+          "fieldFlag": "querier.max-concurrent-remote-read-queries",
+          "fieldType": "int",
+          "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
           "name": "max_concurrent",
           "required": false,
           "desc": "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2186,7 +2186,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.max-concurrent int
     	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum (default 20)
   -querier.max-concurrent-remote-read-queries int
-    	Maximum number of remote read queries that can execute concurrently. 0 or negative values mean unlimited concurrency. (default 2)
+    	Maximum number of remote read queries that can be executed concurrently. 0 or negative values mean unlimited concurrency. (default 2)
   -querier.max-estimated-fetched-chunks-per-query-multiplier float
     	[experimental] Maximum number of chunks estimated to be fetched in a single query from ingesters and store-gateways, as a multiple of -querier.max-fetched-chunks-per-query. This limit is enforced in the querier. Must be greater than or equal to 1, or 0 to disable.
   -querier.max-estimated-memory-consumption-per-query uint

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2185,6 +2185,8 @@ Usage of ./cmd/mimir/mimir:
     	Time since the last sample after which a time series is considered stale and ignored by expression evaluations. This config option should be set on query-frontend too when query sharding is enabled. (default 5m0s)
   -querier.max-concurrent int
     	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum (default 20)
+  -querier.max-concurrent-remote-read-queries int
+    	Maximum number of remote read queries that can execute concurrently. 0 or negative values mean unlimited concurrency. (default 2)
   -querier.max-estimated-fetched-chunks-per-query-multiplier float
     	[experimental] Maximum number of chunks estimated to be fetched in a single query from ingesters and store-gateways, as a multiple of -querier.max-fetched-chunks-per-query. This limit is enforced in the querier. Must be greater than or equal to 1, or 0 to disable.
   -querier.max-estimated-memory-consumption-per-query uint

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1599,8 +1599,8 @@ The `querier` block configures the querier.
 # CLI flag: -querier.filter-queryables-enabled
 [filter_queryables_enabled: <boolean> | default = false]
 
-# (advanced) Maximum number of remote read queries that can execute
-# concurrently. 0 or negative values mean unlimited concurrency.
+# (advanced) Maximum number of remote read queries that can run
+# concurrently. 0 and negative values indicate unlimited concurrency.
 # CLI flag: -querier.max-concurrent-remote-read-queries
 [max_concurrent_remote_read_queries: <int> | default = 2]
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1599,8 +1599,8 @@ The `querier` block configures the querier.
 # CLI flag: -querier.filter-queryables-enabled
 [filter_queryables_enabled: <boolean> | default = false]
 
-# (advanced) Maximum number of remote read queries that can run
-# concurrently. 0 and negative values indicate unlimited concurrency.
+# (advanced) Maximum number of remote read queries that can be executed
+# concurrently. 0 or negative values mean unlimited concurrency.
 # CLI flag: -querier.max-concurrent-remote-read-queries
 [max_concurrent_remote_read_queries: <int> | default = 2]
 

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1599,6 +1599,11 @@ The `querier` block configures the querier.
 # CLI flag: -querier.filter-queryables-enabled
 [filter_queryables_enabled: <boolean> | default = false]
 
+# (advanced) Maximum number of remote read queries that can execute
+# concurrently. 0 or negative values mean unlimited concurrency.
+# CLI flag: -querier.max-concurrent-remote-read-queries
+[max_concurrent_remote_read_queries: <int> | default = 2]
+
 # The number of workers running in each querier process. This setting limits the
 # maximum number of concurrent queries in each querier. The minimum value is
 # four; lower values are ignored and set to the minimum

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -212,20 +212,6 @@ func (cfg *Config) statusFlagsHandler() http.HandlerFunc {
 // server to fulfill the Prometheus query API.
 func NewQuerierHandler(
 	cfg Config,
-	queryable storage.SampleAndChunkQueryable,
-	exemplarQueryable storage.ExemplarQueryable,
-	metadataSupplier querier.MetadataSupplier,
-	engine promql.QueryEngine,
-	distributor Distributor,
-	reg prometheus.Registerer,
-	logger log.Logger,
-	limits *validation.Overrides,
-) http.Handler {
-	return NewQuerierHandlerWithQuerierConfig(cfg, querier.Config{}, queryable, exemplarQueryable, metadataSupplier, engine, distributor, reg, logger, limits)
-}
-
-func NewQuerierHandlerWithQuerierConfig(
-	cfg Config,
 	querierCfg querier.Config,
 	queryable storage.SampleAndChunkQueryable,
 	exemplarQueryable storage.ExemplarQueryable,
@@ -340,7 +326,7 @@ func NewQuerierHandlerWithQuerierConfig(
 
 	// TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
 	// https://github.com/prometheus/prometheus/pull/7125/files
-	router.Path(path.Join(prefix, "/api/v1/read")).Methods("POST").Handler(remoteReadStats.Wrap(querier.RemoteReadHandlerWithConfig(queryable, logger, querierCfg)))
+	router.Path(path.Join(prefix, "/api/v1/read")).Methods("POST").Handler(remoteReadStats.Wrap(querier.RemoteReadHandler(queryable, logger, querierCfg)))
 	router.Path(path.Join(prefix, "/api/v1/query")).Methods("GET", "POST").Handler(instantQueryStats.Wrap(promRouter))
 	router.Path(path.Join(prefix, "/api/v1/query_range")).Methods("GET", "POST").Handler(rangeQueryStats.Wrap(promRouter))
 	router.Path(path.Join(prefix, "/api/v1/query_exemplars")).Methods("GET", "POST").Handler(exemplarsQueryStats.Wrap(promRouter))

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -623,7 +623,7 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 
 	// Create an internal HTTP handler that is configured with the Prometheus API routes and points
 	// to a Prometheus API struct instantiated with the Mimir Queryable.
-	internalQuerierRouter := api.NewQuerierHandlerWithQuerierConfig(
+	internalQuerierRouter := api.NewQuerierHandler(
 		t.Cfg.API,
 		t.Cfg.Querier,
 		t.QuerierQueryable,

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -623,8 +623,9 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 
 	// Create an internal HTTP handler that is configured with the Prometheus API routes and points
 	// to a Prometheus API struct instantiated with the Mimir Queryable.
-	internalQuerierRouter := api.NewQuerierHandler(
+	internalQuerierRouter := api.NewQuerierHandlerWithQuerierConfig(
 		t.Cfg.API,
+		t.Cfg.Querier,
 		t.QuerierQueryable,
 		t.ExemplarQueryable,
 		t.MetadataSupplier,

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -103,7 +103,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&cfg.FilterQueryablesEnabled, "querier.filter-queryables-enabled", false, "If set to true, the header 'X-Filter-Queryables' can be used to filter down the list of queryables that shall be used. This is useful to test and monitor single queryables in isolation.")
 
-	f.IntVar(&cfg.MaxConcurrentRemoteReadQueries, "querier.max-concurrent-remote-read-queries", 2, "Maximum number of remote read queries that can execute concurrently. 0 or negative values mean unlimited concurrency.")
+	f.IntVar(&cfg.MaxConcurrentRemoteReadQueries, "querier.max-concurrent-remote-read-queries", 2, "Maximum number of remote read queries that can be executed concurrently. 0 or negative values mean unlimited concurrency.")
 
 	cfg.EngineConfig.RegisterFlags(f)
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -66,6 +66,10 @@ type Config struct {
 
 	FilterQueryablesEnabled bool `yaml:"filter_queryables_enabled" category:"advanced"`
 
+	// MaxConcurrentRemoteReadQueries limits the number of remote read queries that execute concurrently.
+	// 0 or negative values mean unlimited concurrency.
+	MaxConcurrentRemoteReadQueries int `yaml:"max_concurrent_remote_read_queries" category:"advanced"`
+
 	// PromQL engine config.
 	EngineConfig engine.Config `yaml:",inline"`
 }
@@ -98,6 +102,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.EnableQueryEngineFallback, "querier.enable-query-engine-fallback", true, "If set to true and the Mimir query engine is in use, fall back to using the Prometheus query engine for any queries not supported by the Mimir query engine.")
 
 	f.BoolVar(&cfg.FilterQueryablesEnabled, "querier.filter-queryables-enabled", false, "If set to true, the header 'X-Filter-Queryables' can be used to filter down the list of queryables that shall be used. This is useful to test and monitor single queryables in isolation.")
+
+	f.IntVar(&cfg.MaxConcurrentRemoteReadQueries, "querier.max-concurrent-remote-read-queries", 2, "Maximum number of remote read queries that can execute concurrently. 0 or negative values mean unlimited concurrency.")
 
 	cfg.EngineConfig.RegisterFlags(f)
 }

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -107,11 +107,6 @@ func remoteReadSamples(
 		}
 	}()
 
-	concurrencyLimit := maxConcurrency
-	if concurrencyLimit <= 0 {
-		concurrencyLimit = len(jobs)
-	}
-
 	run := func(_ context.Context, idx int) error {
 		job := &jobs[idx]
 		start, end, minT, maxT, matchers, hints, err := queryFromRemoteReadQuery(job.query)
@@ -133,7 +128,7 @@ func remoteReadSamples(
 		return err
 	}
 
-	err := concurrency.ForEachJob(ctx, len(jobs), concurrencyLimit, run)
+	err := concurrency.ForEachJob(ctx, len(jobs), maxConcurrency, run)
 	if err != nil {
 		code := remoteReadErrorStatusCode(err)
 		if code/100 != 4 {
@@ -184,11 +179,6 @@ func remoteReadStreamedXORChunks(
 		}
 	}()
 
-	concurrencyLimit := maxConcurrency
-	if concurrencyLimit <= 0 {
-		concurrencyLimit = len(req.Queries)
-	}
-
 	run := func(_ context.Context, idx int) error {
 		qr := req.Queries[idx]
 		start, end, _, _, matchers, hints, err := queryFromRemoteReadQuery(qr)
@@ -209,7 +199,7 @@ func remoteReadStreamedXORChunks(
 		return nil
 	}
 
-	err := concurrency.ForEachJob(ctx, len(req.Queries), concurrencyLimit, run)
+	err := concurrency.ForEachJob(ctx, len(req.Queries), maxConcurrency, run)
 	// If any query failed, return the error
 	if err != nil {
 		code := remoteReadErrorStatusCode(err)

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -100,8 +100,6 @@ func remoteReadSamples(
 		}
 	}
 
-	// Use concurrency.ForEachJob to limit parallel execution
-	// If maxConcurrency is 0 or negative, use unlimited concurrency by setting to len(jobs)
 	concurrencyLimit := maxConcurrency
 	if concurrencyLimit <= 0 {
 		concurrencyLimit = len(jobs)
@@ -168,8 +166,6 @@ func remoteReadStreamedXORChunks(
 
 	results := make([]queryResult, len(req.Queries))
 
-	// Use concurrency.ForEachJob to limit parallel execution
-	// If maxConcurrency is 0 or negative, use unlimited concurrency by setting to len(req.Queries)
 	concurrencyLimit := maxConcurrency
 	if concurrencyLimit <= 0 {
 		concurrencyLimit = len(req.Queries)

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -44,12 +44,7 @@ const (
 )
 
 // RemoteReadHandler handles Prometheus remote read requests.
-func RemoteReadHandler(q storage.SampleAndChunkQueryable, logger log.Logger) http.Handler {
-	return remoteReadHandler(q, maxRemoteReadFrameBytes, 0, logger) // 0 means unlimited concurrency (backward compatibility)
-}
-
-// RemoteReadHandlerWithConfig handles Prometheus remote read requests with configurable concurrency.
-func RemoteReadHandlerWithConfig(q storage.SampleAndChunkQueryable, logger log.Logger, cfg Config) http.Handler {
+func RemoteReadHandler(q storage.SampleAndChunkQueryable, logger log.Logger, cfg Config) http.Handler {
 	return remoteReadHandler(q, maxRemoteReadFrameBytes, cfg.MaxConcurrentRemoteReadQueries, logger)
 }
 

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -1340,9 +1340,7 @@ func TestRemoteReadHandler_ConcurrencyLimit(t *testing.T) {
 			maxObserved := int32(0)
 			require.Eventually(t, func() bool {
 				current := concurrentQueries.Load()
-				if current > maxObserved {
-					maxObserved = current
-				}
+				maxObserved = max(current, maxObserved)
 
 				// Check that we never exceed the expected limit
 				require.LessOrEqual(t, current, tt.expectedMaxConcurrent,

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -81,6 +81,13 @@ func (m mockChunkQuerier) Select(ctx context.Context, sorted bool, hints *storag
 	return storage.ErrChunkSeriesSet(errors.New("the Select() function has not been mocked in the test"))
 }
 
+func (m mockChunkQuerier) Close() error {
+	if m.ChunkQuerier != nil {
+		return m.ChunkQuerier.Close()
+	}
+	return nil
+}
+
 type partiallyFailingSeriesSet struct {
 	ss        storage.SeriesSet
 	failAfter int

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -1299,9 +1299,7 @@ func TestRemoteReadHandler_ConcurrencyLimit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset counters and ensure control channel is empty
 			concurrentQueries.Store(0)
-			for len(controlChan) > 0 {
-				<-controlChan
-			}
+			controlChan = make(chan struct{})
 
 			// Create handler with configurable concurrency
 			handler := RemoteReadHandler(q, log.NewNopLogger(), Config{MaxConcurrentRemoteReadQueries: tt.maxConcurrency})

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -1343,7 +1343,7 @@ func TestRemoteReadHandler_ConcurrencyLimit(t *testing.T) {
 				maxObserved = max(current, maxObserved)
 
 				// Check that we never exceed the expected limit
-				require.LessOrEqual(t, current, tt.expectedMaxConcurrent,
+				require.LessOrEqualf(t, current, tt.expectedMaxConcurrent,
 					"concurrent queries (%d) exceeded limit (%d)", current, tt.expectedMaxConcurrent)
 
 				// Return true when we've reached the expected concurrency

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -830,7 +830,7 @@ func TestRemoteReadHandler_StreamedXORChunks(t *testing.T) {
 			// frame to contain at most 2 chunks.
 			maxBytesInFrame := 10 + 165*2
 
-			handler := remoteReadHandler(q, maxBytesInFrame, log.NewNopLogger())
+			handler := remoteReadHandler(q, maxBytesInFrame, 0, log.NewNopLogger())
 
 			requestBody, err := proto.Marshal(&prompb.ReadRequest{
 				Queries:               testData.query,
@@ -1071,7 +1071,7 @@ func TestRemoteReadErrorParsing(t *testing.T) {
 						}, err
 					},
 				}
-				handler := remoteReadHandler(q, 1024*1024, log.NewNopLogger())
+				handler := remoteReadHandler(q, 1024*1024, 0, log.NewNopLogger())
 
 				// Create queries based on the number of expected errors/series sets
 				var queries []*prompb.Query
@@ -1125,7 +1125,7 @@ func TestRemoteReadErrorParsing(t *testing.T) {
 						}, err
 					},
 				}
-				handler := remoteReadHandler(q, 1024*1024, log.NewNopLogger())
+				handler := remoteReadHandler(q, 1024*1024, 0, log.NewNopLogger())
 
 				// Create queries based on the number of expected errors/series sets
 				var queries []*prompb.Query
@@ -1271,11 +1271,11 @@ func TestRemoteReadHandler_ConcurrencyLimit(t *testing.T) {
 					queryProcessed <- struct{}{}
 
 					// Return a simple series set
-					return series.NewConcreteSeriesSet([]storage.Series{
-						series.NewConcreteSeries(labels.FromStrings("foo", "bar"), []model.SamplePair{
-							{Timestamp: 1, Value: 1.0},
-						}),
-					})
+					return series.NewConcreteSeriesSetFromUnsortedSeries(
+						[]storage.Series{
+							series.NewConcreteSeries(labels.FromStrings("foo", "bar"), []model.SamplePair{{Timestamp: 1, Value: 1.0}}, nil),
+						},
+					)
 				},
 			}, nil
 		},


### PR DESCRIPTION
- Added `-querier.max-concurrent-remote-read-queries` flag (default: 2)
- 0 or negative values mean unlimited concurrency
- Uses `concurrency.ForEachJob` pattern for implementation like @zenador suggested

Addresses discussion in https://github.com/grafana/mimir/pull/11732#discussion_r2148903080 with @charleskorn where unlimited concurrency could hold too much data in memory. Default limit provides safety while allowing GEM to configure unlimited when needed.