### PR TITLE
Bring BufferHolder back to PrometheusResponse

### DIFF
--- a/pkg/frontend/querymiddleware/model.pb.go
+++ b/pkg/frontend/querymiddleware/model.pb.go
@@ -83,6 +83,9 @@ func (m *PrometheusHeader) GetValues() []string {
 }
 
 type PrometheusResponse struct {
+	// Keep reference to buffer for unsafe references.
+	github_com_grafana_mimir_pkg_mimirpb.BufferHolder
+
 	Status    string              `protobuf:"bytes,1,opt,name=Status,proto3" json:"status"`
 	Data      *PrometheusData     `protobuf:"bytes,2,opt,name=Data,proto3" json:"data,omitempty"`
 	ErrorType string              `protobuf:"bytes,3,opt,name=ErrorType,proto3" json:"errorType,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

BufferHolder was added in this [PR](https://github.com/grafana/mimir/pull/11136) and mistakenly removed  later ina different [PR](https://github.com/grafana/mimir/pull/11568/files#diff-f460500f40606393884c046e42540c09ff5c7cd6146d2b1f59c6b3d7f2b320e6R85). I confirmed with @aknuds1 that it should be there.

#### Checklist

- [N/A] Tests updated.
- [N/A] Documentation added.
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
