### PR TITLE
docs: Add influx section to HTTP api reference

### DIFF
--- a/docs/sources/mimir/references/http-api/_index.md
+++ b/docs/sources/mimir/references/http-api/_index.md
@@ -352,7 +352,7 @@ Entry point for the [Influx HTTP](https://docs.influxdata.com/influxdb/v1/tools/
 This endpoint accepts an HTTP POST request with a body that contains a request encoded in `text/plain` and is optionally compressed with [GZIP](https://www.gnu.org/software/gzip/).
 You can find more information on the protocol in [InfluxDB line protocol](https://docs.influxdata.com/influxdb/v1/write_protocols/line_protocol_tutorial/).
 
-Requires [authentication](#authentication).
+This endpoint requires [authentication](#authentication).
 
 ### Distributor ring status
 

--- a/docs/sources/mimir/references/http-api/_index.md
+++ b/docs/sources/mimir/references/http-api/_index.md
@@ -347,7 +347,7 @@ POST /api/v1/push/influx/write
 To send Influx data to Grafana Cloud, refer to [Send or visualize InfluxDB metrics](https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-influxdb/).
 {{% /admonition %}}
 
-Entrypoint for the [Influx HTTP](https://docs.influxdata.com/influxdb/v1/tools/api/#write-http-endpoint).
+Entry point for the [Influx HTTP](https://docs.influxdata.com/influxdb/v1/tools/api/#write-http-endpoint).
 
 This endpoint accepts an HTTP POST request with a body that contains a request encoded in `text/plain` and optionally compressed with [GZIP](https://www.gnu.org/software/gzip/).
 You can find more information on the protocol in [InfluxDB line protocol](https://docs.influxdata.com/influxdb/v1/write_protocols/line_protocol_tutorial/).

--- a/docs/sources/mimir/references/http-api/_index.md
+++ b/docs/sources/mimir/references/http-api/_index.md
@@ -349,7 +349,7 @@ To send Influx data to Grafana Cloud, refer to [Send or visualize InfluxDB metri
 
 Entry point for the [Influx HTTP](https://docs.influxdata.com/influxdb/v1/tools/api/#write-http-endpoint).
 
-This endpoint accepts an HTTP POST request with a body that contains a request encoded in `text/plain` and optionally compressed with [GZIP](https://www.gnu.org/software/gzip/).
+This endpoint accepts an HTTP POST request with a body that contains a request encoded in `text/plain` and is optionally compressed with [GZIP](https://www.gnu.org/software/gzip/).
 You can find more information on the protocol in [InfluxDB line protocol](https://docs.influxdata.com/influxdb/v1/write_protocols/line_protocol_tutorial/).
 
 Requires [authentication](#authentication).

--- a/docs/sources/mimir/references/http-api/_index.md
+++ b/docs/sources/mimir/references/http-api/_index.md
@@ -44,6 +44,7 @@ This document groups API endpoints by service. Note that the API endpoints are e
 | [Get tenant limits](#get-tenant-limits) | _All services_ | `GET /api/v1/user_limits` |
 | [Remote write](#remote-write) | Distributor | `POST /api/v1/push` |
 | [OTLP](#otlp) | Distributor | `POST /otlp/v1/metrics` |
+| [Influx](#influx) | Distributor | `POST /api/v1/push/influx/write` |
 | [Tenants stats](#tenants-stats) | Distributor | `GET /distributor/all_user_stats` |
 | [HA tracker status](#ha-tracker-status) | Distributor | `GET /distributor/ha_tracker` |
 | [Flush chunks / blocks](#flush-chunks--blocks) | Ingester | `GET,POST /ingester/flush` |
@@ -333,6 +334,23 @@ Entrypoint for the [OTLP HTTP](https://github.com/open-telemetry/opentelemetry-p
 
 This endpoint accepts an HTTP POST request with a body that contains a request encoded with [Protocol Buffers](https://developers.google.com/protocol-buffers) and optionally compressed with [GZIP](https://www.gnu.org/software/gzip/).
 You can find the definition of the protobuf message in [metrics.proto](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto).
+
+Requires [authentication](#authentication).
+
+### Influx
+
+```
+POST /api/v1/push/influx/write
+```
+
+{{% admonition type="note" %}}
+To send Influx data to Grafana Cloud, refer to [Send or visualize InfluxDB metrics](https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-influxdb/).
+{{% /admonition %}}
+
+Entrypoint for the [Influx HTTP](https://docs.influxdata.com/influxdb/v1/tools/api/#write-http-endpoint).
+
+This endpoint accepts an HTTP POST request with a body that contains a request encoded in `text/plain` and optionally compressed with [GZIP](https://www.gnu.org/software/gzip/).
+You can find more information on the protocol in [InfluxDB line protocol](https://docs.influxdata.com/influxdb/v1/write_protocols/line_protocol_tutorial/).
 
 Requires [authentication](#authentication).
 


### PR DESCRIPTION
#### What this PR does

Adds documentation for the Influx endpoint (similar to that of the OTLP endpoint).

#### Which issue(s) this PR fixes or relates to

* https://github.com/grafana/mimir/pull/10153 (main PR for Influx endpoint)
* https://github.com/grafana/mimir/pull/10505 (fix to path)

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
