### PR TITLE
MQE: simplify logic for "selectors eliminated" metric in CSE, and add "selectors inspected" metric

### DIFF
--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass.go
@@ -31,6 +31,7 @@ import (
 type OptimizationPass struct {
 	duplicationNodesIntroduced prometheus.Counter
 	selectorsEliminated        prometheus.Counter
+	selectorsInspected         prometheus.Counter
 }
 
 func NewOptimizationPass(reg prometheus.Registerer) *OptimizationPass {
@@ -42,6 +43,10 @@ func NewOptimizationPass(reg prometheus.Registerer) *OptimizationPass {
 		selectorsEliminated: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_mimir_query_engine_common_subexpression_elimination_selectors_eliminated",
 			Help: "Number of selectors eliminated by the common subexpression elimination optimization pass.",
+		}),
+		selectorsInspected: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_mimir_query_engine_common_subexpression_elimination_selectors_inspected",
+			Help: "Number of selectors inspected by the common subexpression elimination optimization pass, before elimination.",
 		}),
 	}
 }
@@ -60,6 +65,7 @@ func (e *OptimizationPass) Apply(_ context.Context, plan *planning.QueryPlan) (*
 		return nil, err
 	}
 
+	e.selectorsInspected.Add(float64(len(paths)))
 	e.selectorsEliminated.Add(float64(selectorsEliminated))
 
 	return plan, nil

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass.go
@@ -55,10 +55,12 @@ func (e *OptimizationPass) Apply(_ context.Context, plan *planning.QueryPlan) (*
 	paths := e.accumulatePaths(plan)
 
 	// For each path: find all the other paths that terminate in the same selector, then inject a duplication node
-	err := e.groupAndApplyDeduplication(paths, 0, false)
+	selectorsEliminated, err := e.groupAndApplyDeduplication(paths, 0)
 	if err != nil {
 		return nil, err
 	}
+
+	e.selectorsEliminated.Add(float64(selectorsEliminated))
 
 	return plan, nil
 }
@@ -109,16 +111,20 @@ func (e *OptimizationPass) accumulatePath(soFar *path) []*path {
 	return paths
 }
 
-func (e *OptimizationPass) groupAndApplyDeduplication(paths []*path, offset int, haveAlreadyEliminatedSelectors bool) error {
+func (e *OptimizationPass) groupAndApplyDeduplication(paths []*path, offset int) (int, error) {
 	groups := e.groupPaths(paths, offset)
+	totalPathsEliminated := 0
 
 	for _, group := range groups {
-		if err := e.applyDeduplication(group, offset, haveAlreadyEliminatedSelectors); err != nil {
-			return err
+		pathsEliminated, err := e.applyDeduplication(group, offset)
+		if err != nil {
+			return 0, err
 		}
+
+		totalPathsEliminated += pathsEliminated
 	}
 
-	return nil
+	return totalPathsEliminated, nil
 }
 
 // groupPaths returns paths grouped by the node at offset from the leaf.
@@ -176,7 +182,9 @@ func (e *OptimizationPass) groupPaths(paths []*path, offset int) [][]*path {
 	return groups
 }
 
-func (e *OptimizationPass) applyDeduplication(group []*path, offset int, haveAlreadyEliminatedSelectors bool) error {
+// applyDuplication replaces duplicate expressions at the tails of paths in group with a single expression.
+// It searches for duplicate expressions from offset, and returns the number of duplicates eliminated.
+func (e *OptimizationPass) applyDeduplication(group []*path, offset int) (int, error) {
 	duplicatePathLength := e.findCommonSubexpressionLength(group, offset+1)
 
 	firstPath := group[0]
@@ -184,11 +192,11 @@ func (e *OptimizationPass) applyDeduplication(group []*path, offset int, haveAlr
 	resultType, err := duplicatedExpression.ResultType()
 
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	var skipLongerExpressions bool
-	eliminatedSelectors := !haveAlreadyEliminatedSelectors
+	pathsEliminated := len(group) - 1
 
 	// We only want to deduplicate instant vectors.
 	if resultType == parser.ValueTypeVector {
@@ -198,25 +206,21 @@ func (e *OptimizationPass) applyDeduplication(group []*path, offset int, haveAlr
 		// the subquery itself, but we do want to deduplicate the inner expression of the subquery.
 		skipLongerExpressions, err = e.introduceDuplicateNode(group, duplicatePathLength-1)
 	} else {
-		// Duplicated subquery, but the function that encloses each instance isn't the same (or isn't the same on all paths).
-		eliminatedSelectors = false
+		// Duplicated range vector selector, but the function that encloses each instance isn't the same (or isn't the same on all paths).
+		pathsEliminated = 0
 	}
 
 	if err != nil {
-		return nil
-	}
-
-	if eliminatedSelectors {
-		e.selectorsEliminated.Add(float64(len(group) - 1))
+		return 0, nil
 	}
 
 	if skipLongerExpressions {
-		return nil
+		return pathsEliminated, nil
 	}
 
 	if len(group) <= 2 {
 		// Can't possibly have any more common subexpressions. We're done.
-		return nil
+		return pathsEliminated, nil
 	}
 
 	// Check if a subset of the paths we just examined share an even longer common subexpression.
@@ -225,11 +229,15 @@ func (e *OptimizationPass) applyDeduplication(group []*path, offset int, haveAlr
 	// This applies even if we just saw a common subexpression that returned something other than an instant vector
 	// eg. in "rate(foo[5m]) + rate(foo[5m]) + increase(foo[5m])", we may have just identified the "foo[5m]" expression,
 	// but we can also deduplicate the "rate(foo[5m])" expressions.
-	if err := e.groupAndApplyDeduplication(group, duplicatePathLength, haveAlreadyEliminatedSelectors || eliminatedSelectors); err != nil {
-		return err
+	if nextLevelPathsEliminated, err := e.groupAndApplyDeduplication(group, duplicatePathLength); err != nil {
+		return 0, err
+	} else if pathsEliminated == 0 {
+		// If we didn't eliminate any paths at this level (because the duplicate expression was a range vector selector),
+		// return the number returned by the next level.
+		pathsEliminated = nextLevelPathsEliminated
 	}
 
-	return nil
+	return pathsEliminated, nil
 }
 
 // introduceDuplicateNode introduces a Duplicate node for each path in the group and returns false.


### PR DESCRIPTION
#### What this PR does

This PR builds on https://github.com/grafana/mimir/pull/11879, addressing https://github.com/grafana/mimir/pull/11879#discussion_r2172182055 and adding an additional "selectors inspected" metric.

#### Which issue(s) this PR fixes or relates to

#11879

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
