### PR TITLE
CI: don't re-run unit tests that have already passed when retrying

### DIFF
--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -47,4 +47,4 @@ echo "$GROUP_TESTS"
 echo ""
 
 # shellcheck disable=SC2086 # we *want* word splitting of GROUP_TESTS.
-exec go test -tags=netgo,stringlabels -timeout 30m -race -count 1 ${GROUP_TESTS}
+exec go test -tags=netgo,stringlabels -timeout 30m -race ${GROUP_TESTS}


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where the second attempt to run unit tests would re-run all unit tests, including those that already passed.

This isn't necessary, and introduces the risk that a test that previously passed will flake and fail.

#### Which issue(s) this PR fixes or relates to

#11300

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
