### PR TITLE
helm-chart: Dynamic downscaleLeader and alertmanager prepareDownscale cleanup

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -39,6 +39,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] KEDA Autoscaling: Resolved an issue where the authModes field was missing from the ScaledObject definition for the querier when authentication was enabled. #11709
 * [BUGFIX] Fix indentation in the templates that resolve `extraVolumes` values. #11202
 * [BUGFIX] Added extraVolumes to provisioner to support mounting TLS certificates. #11400
+* [ENHANCEMENT] Add values for setting annotations and labels for rollout-operator. #6733 #11924
 
 ## 5.7.0
 
@@ -58,7 +59,6 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add extra values for KEDA autoscaling to support authentication, `ignoreNullValues`, `unsafeSsl`, and `PromQLLabelSelector`. #10265
 * [BUGFIX] Create proper in-cluster remote URLs when gateway and nginx are disabled. #10625
 * [BUGFIX] Fix calculation of `mimir.siToBytes` and use floating point arithmetics. #10044
-* [ENHANCEMENT] Add values for setting annotations and labels for rollout-operator. #6733 #11924
 
 ## 5.6.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -58,7 +58,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add extra values for KEDA autoscaling to support authentication, `ignoreNullValues`, `unsafeSsl`, and `PromQLLabelSelector`. #10265
 * [BUGFIX] Create proper in-cluster remote URLs when gateway and nginx are disabled. #10625
 * [BUGFIX] Fix calculation of `mimir.siToBytes` and use floating point arithmetics. #10044
-* [ENHANCEMENT] Add values for setting annotations and labels for rollout-operator. #6733
+* [ENHANCEMENT] Add values for setting annotations and labels for rollout-operator. #6733 #11924
 
 ## 5.6.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -39,7 +39,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] KEDA Autoscaling: Resolved an issue where the authModes field was missing from the ScaledObject definition for the querier when authentication was enabled. #11709
 * [BUGFIX] Fix indentation in the templates that resolve `extraVolumes` values. #11202
 * [BUGFIX] Added extraVolumes to provisioner to support mounting TLS certificates. #11400
-* [ENHANCEMENT] Add values for setting annotations and labels for rollout-operator. #6733 #11924
+* [ENHANCEMENT] Add values for setting annotations and labels for the rollout-operator. #6733 #11924
 
 ## 5.7.0
 

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     {{- include "mimir.componentAnnotations" $args | nindent 4 }}
     {{- if $rolloutZone.downscaleLeader }}
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: {{ $rolloutZone.downscaleLeader }}
     {{- end }}
   namespace: {{ .Release.Namespace | quote }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -25,7 +25,7 @@ metadata:
     grafana.com/prepare-downscale-http-port: {{ include "mimir.serverHttpListenPort" . | quote }}
     {{- end -}}
     {{- if $rolloutZone.downscaleLeader }}
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: {{ $rolloutZone.downscaleLeader }}
     {{- end }}
   namespace: {{ .Release.Namespace | quote }}
 spec:

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -25,7 +25,7 @@ metadata:
     grafana.com/prepare-downscale-http-port: {{ include "mimir.serverHttpListenPort" . | quote }}
     {{- end -}}
     {{- if $rolloutZone.downscaleLeader }}
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: {{ $rolloutZone.downscaleLeader }}
     {{- end }}
   namespace: {{ .Release.Namespace | quote }}
 spec:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -816,12 +816,14 @@ alertmanager:
         storageClass: null
         # -- noDownscale adds a label that can be used by the rollout-operator as documented in the rollout-operator repo: https://github.com/grafana/rollout-operator#webhooks
         noDownscale: false
-        # -- downscaleLeader is an Annotation used by the rollout-operator
-        # If defined, downscaleLeader: <downscaleLeader>
-        # If undefined or set to null (the default), no Annotation is set
+        # -- downscaleLeader is an Annotation used by the rollout-operator to coordinate downscaling across zones.
+        # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
+        # Example: "mimir-alertmanager-zone-a" for zone-b, "mimir-alertmanager-zone-b" for zone-c.
+        # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
         downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        prepareDownscale: true
+        # NOTE: Alertmanager does not support prepared downscale functionality
+        prepareDownscale: false
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
       - name: zone-b
         # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -837,12 +839,14 @@ alertmanager:
         storageClass: null
         # -- noDownscale adds a label that can be used by the rollout-operator as documented in the rollout-operator repo: https://github.com/grafana/rollout-operator#webhooks
         noDownscale: false
-        # -- downscaleLeader is an Annotation used by the rollout-operator
-        # If defined, downscaleLeader: <downscaleLeader>
-        # If undefined or set to null (the default), no Annotation is set
-        downscaleLeader: null
+        # -- downscaleLeader is an Annotation used by the rollout-operator to coordinate downscaling across zones.
+        # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
+        # Example: "mimir-alertmanager-zone-a" for zone-b, "mimir-alertmanager-zone-b" for zone-c.
+        # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
+        downscaleLeader: mimir-alertmanager-zone-a
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        prepareDownscale: true
+        # NOTE: Alertmanager does not support prepared downscale functionality
+        prepareDownscale: false
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
       - name: zone-c
         # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -858,12 +862,14 @@ alertmanager:
         storageClass: null
         # -- noDownscale adds a label that can be used by the rollout-operator as documented in the rollout-operator repo: https://github.com/grafana/rollout-operator#webhooks
         noDownscale: false
-        # -- downscaleLeader is an Annotation used by the rollout-operator
-        # If defined, downscaleLeader: <downscaleLeader>
-        # If undefined or set to null (the default), no Annotation is set
-        downscaleLeader: null
+        # -- downscaleLeader is an Annotation used by the rollout-operator to coordinate downscaling across zones.
+        # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
+        # Example: "mimir-alertmanager-zone-a" for zone-b, "mimir-alertmanager-zone-b" for zone-c.
+        # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
+        downscaleLeader: mimir-alertmanager-zone-b
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        prepareDownscale: true
+        # NOTE: Alertmanager does not support prepared downscale functionality
+        prepareDownscale: false
 
 distributor:
   # -- Whether to render the manifests related to the distributor component.
@@ -1194,9 +1200,10 @@ ingester:
         storageClass: null
         # -- noDownscale adds a label that can be used by the rollout-operator as documented in the rollout-operator repo: https://github.com/grafana/rollout-operator#webhooks
         noDownscale: false
-        # -- downscaleLeader is an Annotation used by the rollout-operator
-        # If defined, downscaleLeader: <downscaleLeader>
-        # If undefined or set to null (the default), no Annotation is set
+        # -- downscaleLeader is an Annotation used by the rollout-operator to coordinate downscaling across zones.
+        # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
+        # Example: "mimir-ingester-zone-a" for zone-b, "mimir-ingester-zone-b" for zone-c.
+        # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
         downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
         prepareDownscale: true
@@ -1215,9 +1222,10 @@ ingester:
         storageClass: null
         # -- noDownscale adds a label that can be used by the rollout-operator as documented in the rollout-operator repo: https://github.com/grafana/rollout-operator#webhooks
         noDownscale: false
-        # -- downscaleLeader is an Annotation used by the rollout-operator
-        # If defined, downscaleLeader: <downscaleLeader>
-        # If undefined or set to null (the default), no Annotation is set
+        # -- downscaleLeader is an Annotation used by the rollout-operator to coordinate downscaling across zones.
+        # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
+        # Example: "mimir-ingester-zone-a" for zone-b, "mimir-ingester-zone-b" for zone-c.
+        # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
         downscaleLeader: mimir-ingester-zone-a
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
         prepareDownscale: true
@@ -1236,9 +1244,10 @@ ingester:
         storageClass: null
         # -- noDownscale adds a label that can be used by the rollout-operator as documented in the rollout-operator repo: https://github.com/grafana/rollout-operator#webhooks
         noDownscale: false
-        # -- downscaleLeader is an Annotation used by the rollout-operator
-        # If defined, downscaleLeader: <downscaleLeader>
-        # If undefined or set to null (the default), no Annotation is set
+        # -- downscaleLeader is an Annotation used by the rollout-operator to coordinate downscaling across zones.
+        # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
+        # Example: "mimir-ingester-zone-a" for zone-b, "mimir-ingester-zone-b" for zone-c.
+        # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
         downscaleLeader: mimir-ingester-zone-b
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
         prepareDownscale: true
@@ -2337,9 +2346,10 @@ store_gateway:
         storageClass: null
         # -- noDownscale adds a label that can be used by the rollout-operator as documented in the rollout-operator repo: https://github.com/grafana/rollout-operator#webhooks
         noDownscale: false
-        # -- downscaleLeader is an Annotation used by the rollout-operator
-        # If defined, downscaleLeader: <downscaleLeader>
-        # If undefined or set to null (the default), no Annotation is set
+        # -- downscaleLeader is an Annotation used by the rollout-operator to coordinate downscaling across zones.
+        # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
+        # Example: "mimir-store-gateway-zone-a" for zone-b, "mimir-store-gateway-zone-b" for zone-c.
+        # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
         downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
         prepareDownscale: true
@@ -2358,10 +2368,11 @@ store_gateway:
         storageClass: null
         # -- noDownscale adds a label that can be used by the rollout-operator as documented in the rollout-operator repo: https://github.com/grafana/rollout-operator#webhooks
         noDownscale: false
-        # -- downscaleLeader is an Annotation used by the rollout-operator
-        # If defined, downscaleLeader: <downscaleLeader>
-        # If undefined or set to null (the default), no Annotation is set
-        downscaleLeader: null
+        # -- downscaleLeader is an Annotation used by the rollout-operator to coordinate downscaling across zones.
+        # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
+        # Example: "mimir-store-gateway-zone-a" for zone-b, "mimir-store-gateway-zone-b" for zone-c.
+        # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
+        downscaleLeader: mimir-store-gateway-zone-a
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
         prepareDownscale: true
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -2379,10 +2390,11 @@ store_gateway:
         storageClass: null
         # -- noDownscale adds a label that can be used by the rollout-operator as documented in the rollout-operator repo: https://github.com/grafana/rollout-operator#webhooks
         noDownscale: false
-        # -- downscaleLeader is an Annotation used by the rollout-operator
-        # If defined, downscaleLeader: <downscaleLeader>
-        # If undefined or set to null (the default), no Annotation is set
-        downscaleLeader: null
+        # -- downscaleLeader is an Annotation used by the rollout-operator to coordinate downscaling across zones.
+        # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
+        # Example: "mimir-store-gateway-zone-a" for zone-b, "mimir-store-gateway-zone-b" for zone-c.
+        # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
+        downscaleLeader: mimir-store-gateway-zone-b
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
         prepareDownscale: true
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -821,9 +821,6 @@ alertmanager:
         # Example: "mimir-alertmanager-zone-a" for zone-b, "mimir-alertmanager-zone-b" for zone-c.
         # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
         downscaleLeader: null
-        # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        # NOTE: Alertmanager does not support prepared downscale functionality
-        prepareDownscale: false
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
       - name: zone-b
         # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -843,10 +840,7 @@ alertmanager:
         # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
         # Example: "mimir-alertmanager-zone-a" for zone-b, "mimir-alertmanager-zone-b" for zone-c.
         # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
-        downscaleLeader: mimir-alertmanager-zone-a
-        # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        # NOTE: Alertmanager does not support prepared downscale functionality
-        prepareDownscale: false
+        downscaleLeader: null
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
       - name: zone-c
         # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -866,10 +860,7 @@ alertmanager:
         # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
         # Example: "mimir-alertmanager-zone-a" for zone-b, "mimir-alertmanager-zone-b" for zone-c.
         # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
-        downscaleLeader: mimir-alertmanager-zone-b
-        # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        # NOTE: Alertmanager does not support prepared downscale functionality
-        prepareDownscale: false
+        downscaleLeader: null
 
 distributor:
   # -- Whether to render the manifests related to the distributor component.
@@ -1226,7 +1217,7 @@ ingester:
         # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
         # Example: "mimir-ingester-zone-a" for zone-b, "mimir-ingester-zone-b" for zone-c.
         # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
-        downscaleLeader: mimir-ingester-zone-a
+        downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
         prepareDownscale: true
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -1248,7 +1239,7 @@ ingester:
         # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
         # Example: "mimir-ingester-zone-a" for zone-b, "mimir-ingester-zone-b" for zone-c.
         # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
-        downscaleLeader: mimir-ingester-zone-b
+        downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
         prepareDownscale: true
 
@@ -2372,7 +2363,7 @@ store_gateway:
         # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
         # Example: "mimir-store-gateway-zone-a" for zone-b, "mimir-store-gateway-zone-b" for zone-c.
         # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
-        downscaleLeader: mimir-store-gateway-zone-a
+        downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
         prepareDownscale: true
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -2394,7 +2385,7 @@ store_gateway:
         # Set to the StatefulSet name that should lead downscaling for this component (typically the previous zone).
         # Example: "mimir-store-gateway-zone-a" for zone-b, "mimir-store-gateway-zone-b" for zone-c.
         # If undefined or set to null (the default), this zone won't be designated as a downscale leader.
-        downscaleLeader: mimir-store-gateway-zone-b
+        downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
         prepareDownscale: true
 

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -170,7 +170,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -322,7 +322,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -170,7 +170,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: enterprise-https-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -322,7 +322,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: enterprise-https-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -172,7 +172,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: enterprise-https-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -326,7 +326,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: enterprise-https-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -172,6 +172,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -325,6 +326,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -161,7 +161,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -304,7 +304,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -161,7 +161,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: gateway-enterprise-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -304,7 +304,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: gateway-enterprise-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -163,6 +163,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -307,6 +308,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -163,7 +163,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: gateway-enterprise-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -308,7 +308,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: gateway-enterprise-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: gateway-nginx-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: gateway-nginx-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: gateway-nginx-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: gateway-nginx-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,6 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,6 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: keda-autoscaling-global-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: keda-autoscaling-global-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: keda-autoscaling-global-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: keda-autoscaling-global-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,6 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,6 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: keda-autoscaling-metamonitoring-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: keda-autoscaling-metamonitoring-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: keda-autoscaling-metamonitoring-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: keda-autoscaling-metamonitoring-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,6 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,6 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: keda-autoscaling-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: keda-autoscaling-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: keda-autoscaling-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: keda-autoscaling-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,6 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,6 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -172,7 +172,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: large-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -326,7 +326,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: large-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -172,7 +172,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -326,7 +326,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -174,6 +174,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -329,6 +330,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -174,7 +174,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: large-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -330,7 +330,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: large-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: openshift-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: openshift-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -160,7 +160,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: openshift-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -302,7 +302,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: openshift-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -160,6 +160,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -301,6 +302,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -157,7 +157,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: scheduler-name-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -296,7 +296,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: scheduler-name-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -157,7 +157,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -296,7 +296,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -159,6 +159,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -299,6 +300,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -159,7 +159,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: scheduler-name-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -300,7 +300,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: scheduler-name-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -172,7 +172,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -326,7 +326,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -172,7 +172,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: small-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -326,7 +326,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: small-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -174,6 +174,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -329,6 +330,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -174,7 +174,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: small-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -330,7 +330,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: small-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -162,7 +162,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-enterprise-component-image-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -306,7 +306,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-enterprise-component-image-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -162,7 +162,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -306,7 +306,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -164,6 +164,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -309,6 +310,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -164,7 +164,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-enterprise-component-image-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -310,7 +310,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-enterprise-component-image-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -161,7 +161,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -304,7 +304,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -161,7 +161,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-enterprise-k8s-1.25-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -304,7 +304,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-enterprise-k8s-1.25-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -163,7 +163,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-enterprise-k8s-1.25-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -308,7 +308,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-enterprise-k8s-1.25-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -163,6 +163,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -307,6 +308,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -151,7 +151,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-enterprise-legacy-label-values-enterprise-metrics-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -286,7 +286,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-enterprise-legacy-label-values-enterprise-metrics-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -151,7 +151,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -286,7 +286,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -153,7 +153,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -290,7 +290,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-enterprise-legacy-label-values-enterprise-metrics-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -153,6 +153,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -289,6 +290,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-enterprise-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-enterprise-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -160,7 +160,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-enterprise-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -302,7 +302,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-enterprise-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -160,6 +160,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -301,6 +302,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-extra-args-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-extra-args-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -165,7 +165,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-extra-args-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -312,7 +312,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-extra-args-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -165,6 +165,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -311,6 +312,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-extra-objects-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-extra-objects-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-extra-objects-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-extra-objects-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,6 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,6 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-ingress-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-ingress-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-ingress-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-ingress-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,6 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,6 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -157,7 +157,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -296,7 +296,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -157,7 +157,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-oss-component-image-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -296,7 +296,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-oss-component-image-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -159,6 +159,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -299,6 +300,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -159,7 +159,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-oss-component-image-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -300,7 +300,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-oss-component-image-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-oss-k8s-1.25-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-oss-k8s-1.25-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,6 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,6 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-oss-k8s-1.25-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-oss-k8s-1.25-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -13,7 +13,6 @@ metadata:
     name: "alertmanager-zone-a"
     rollout-group: alertmanager
     zone: zone-a
-    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"
@@ -145,7 +144,6 @@ metadata:
     name: "alertmanager-zone-b"
     rollout-group: alertmanager
     zone: zone-b
-    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"
@@ -277,7 +275,6 @@ metadata:
     name: "alertmanager-zone-c"
     rollout-group: alertmanager
     zone: zone-c
-    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -142,7 +142,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-oss-logical-multizone-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -266,7 +266,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-oss-logical-multizone-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -142,7 +142,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -266,7 +266,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -142,7 +142,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-oss-logical-multizone-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -266,7 +266,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-oss-logical-multizone-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -142,6 +142,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -265,6 +266,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -13,7 +13,6 @@ metadata:
     name: "alertmanager-zone-a"
     rollout-group: alertmanager
     zone: zone-a
-    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"
@@ -170,7 +169,6 @@ metadata:
     name: "alertmanager-zone-b"
     rollout-group: alertmanager
     zone: zone-b
-    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"
@@ -327,7 +325,6 @@ metadata:
     name: "alertmanager-zone-c"
     rollout-group: alertmanager
     zone: zone-c
-    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -171,7 +171,7 @@ metadata:
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-oss-multizone-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -328,7 +328,7 @@ metadata:
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-oss-multizone-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -171,6 +171,7 @@ metadata:
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -327,6 +328,7 @@ metadata:
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -166,7 +166,7 @@ metadata:
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-oss-multizone-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -318,7 +318,7 @@ metadata:
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-oss-multizone-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -166,6 +166,7 @@ metadata:
     zone: zone-b
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -317,6 +318,7 @@ metadata:
     zone: zone-c
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -177,7 +177,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-oss-topology-spread-constraints-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -336,7 +336,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-oss-topology-spread-constraints-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -177,7 +177,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -336,7 +336,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -168,7 +168,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-oss-topology-spread-constraints-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -318,7 +318,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-oss-topology-spread-constraints-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -168,6 +168,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -317,6 +318,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-requests-and-limits-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-requests-and-limits-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-requests-and-limits-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-requests-and-limits-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,6 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,6 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-ruler-dedicated-query-path-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-ruler-dedicated-query-path-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -156,7 +156,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -294,7 +294,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,7 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-ruler-dedicated-query-path-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -298,7 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-ruler-dedicated-query-path-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -158,6 +158,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,6 +298,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -163,7 +163,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -308,7 +308,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
+    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -163,7 +163,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-a
+    grafana.com/rollout-downscale-leader: test-vault-agent-values-mimir-ingester-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -308,7 +308,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-ingester-zone-b
+    grafana.com/rollout-downscale-leader: test-vault-agent-values-mimir-ingester-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -165,6 +165,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -311,6 +312,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -165,7 +165,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-a
+    grafana.com/rollout-downscale-leader: test-vault-agent-values-mimir-store-gateway-zone-a
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -312,7 +312,7 @@ metadata:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "8080"
-    grafana.com/rollout-downscale-leader: mimir-store-gateway-zone-b
+    grafana.com/rollout-downscale-leader: test-vault-agent-values-mimir-store-gateway-zone-b
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady


### PR DESCRIPTION
Follow-up of PR #6733.


### Dynamic downscaleLeader
- **Removed hardcoded values**: Reset all downscaleLeader values to `null` in values.yaml
- **Added smart logic in _helpers.tpl** to set the downscale leader to be the "previous zone" in the list of zones
  - Automatically sorts zone names alphabetically  
  - Computes `downscaleLeader` as `mimir-<component>-<previous-zone>` for each zone
  - Only applies to ingester and store-gateway (excludes alertmanager)
  - First zone (zone-a) gets no downscaleLeader annotation

### Cleaned up alertmanager configuration
- **Removed prepareDownscale**: Completely removed from alertmanager zones since it's not supported
