### PR TITLE
Move query pruning and experimental functions middlewares earlier in query-frontend pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
   * `memberlist.max-concurrent-writes`: `5`
   * `memberlist.acquire-writer-timeout`: `1s`
     These defaults perform better but may cause long-running packets to be dropped in high-latency networks.
-* [CHANGE] Query-frontend: apply query pruning and check for disabled experimental functions earlier in query processing. #11939
+* [CHANGE] Query-frontend: Apply query pruning and check for disabled experimental functions earlier in query processing. #11939
 * [FEATURE] Distributor: Experimental support for Prometheus Remote-Write 2.0 protocol. Limitations: Created timestamp is ignored, per series metadata is merged on metric family level automatically, ingestion might fail if client sends ProtoBuf fields out of order. The label `version` is added to the metric `cortex_distributor_requests_in_total` with a value of either `1.0` or `2.0` depending on the detected Remote-Write protocol. #11100 #11101 #11192 #11143
 * [FEATURE] Query-frontend: expand `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` configuration options to cache non-transient response failures for instant queries. #11120
 * [FEATURE] Query-frontend: Allow use of Mimir Query Engine (MQE) via the experimental CLI flags `-query-frontend.query-engine` or `-query-frontend.enable-query-engine-fallback` or corresponding YAML. #11417 #11775

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   * `memberlist.max-concurrent-writes`: `5`
   * `memberlist.acquire-writer-timeout`: `1s`
     These defaults perform better but may cause long-running packets to be dropped in high-latency networks.
+* [CHANGE] Query-frontend: apply query pruning and check for disabled experimental functions earlier in query processing. #11939
 * [FEATURE] Distributor: Experimental support for Prometheus Remote-Write 2.0 protocol. Limitations: Created timestamp is ignored, per series metadata is merged on metric family level automatically, ingestion might fail if client sends ProtoBuf fields out of order. The label `version` is added to the metric `cortex_distributor_requests_in_total` with a value of either `1.0` or `2.0` depending on the detected Remote-Write protocol. #11100 #11101 #11192 #11143
 * [FEATURE] Query-frontend: expand `query-frontend.cache-errors` and `query-frontend.results-cache-ttl-for-errors` configuration options to cache non-transient response failures for instant queries. #11120
 * [FEATURE] Query-frontend: Allow use of Mimir Query Engine (MQE) via the experimental CLI flags `-query-frontend.query-engine` or `-query-frontend.enable-query-engine-fallback` or corresponding YAML. #11417 #11775


### PR DESCRIPTION
#### What this PR does

This PR moves the query pruning and experimental functions middlewares earlier in the query-frontend pipeline.

This has a number of benefits:

* these middlewares now run before splitting and sharding, so they are only applied once to the entire query rather than once per split and sharded leg
* these middlewares no longer run after sharding, which will make it easier to migrate sharding to a MQE query planner optimisation pass in the future
* the experimental functions middleware now runs immediately after the error caching middleware, so queries that will be rejected are rejected and cached before doing as much work as possible

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
