### PR TITLE
Make TestingLogger log in logfmt

### DIFF
--- a/pkg/util/test/logger.go
+++ b/pkg/util/test/logger.go
@@ -3,11 +3,14 @@
 package test
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-logfmt/logfmt"
+	"github.com/stretchr/testify/require"
 )
 
 type TestingLogger struct {
@@ -31,11 +34,11 @@ func (l *TestingLogger) WithT(t testing.TB) log.Logger {
 }
 
 func (l *TestingLogger) Log(keyvals ...interface{}) error {
-	// Prepend log with timestamp.
-	keyvals = append([]interface{}{time.Now().String()}, keyvals...)
+	var line strings.Builder
+	require.NoError(l.t, logfmt.NewEncoder(&line).EncodeKeyvals(keyvals...))
 
 	l.mtx.Lock()
-	l.t.Log(keyvals...)
+	l.t.Log(time.Now().Format(time.RFC3339Nano), line.String())
 	l.mtx.Unlock()
 
 	return nil


### PR DESCRIPTION
#### What this PR does

Changes `util/test.TestingLogger` to log in `logfmt` format instead of just throwing kvs separated by spaces.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
