### PR TITLE
rw2: Validate that the first symbol of the RW2 Symbols field is an empty string

### DIFF
--- a/pkg/mimirpb/compat_rw2.go
+++ b/pkg/mimirpb/compat_rw2.go
@@ -57,7 +57,7 @@ func (ps *rw2PagedSymbols) releasePages() {
 }
 
 func (ps *rw2PagedSymbols) get(ref uint32) (string, error) {
-	// The first element of the symbols table MUST be an empty string.
+	// RW2.0 Spec: The first element of the symbols table MUST be an empty string.
 	if ref == 0 {
 		return "", nil
 	}

--- a/pkg/mimirpb/compat_rw2.go
+++ b/pkg/mimirpb/compat_rw2.go
@@ -57,6 +57,11 @@ func (ps *rw2PagedSymbols) releasePages() {
 }
 
 func (ps *rw2PagedSymbols) get(ref uint32) (string, error) {
+	// The first element of the symbols table MUST be an empty string.
+	if ref == 0 {
+		return "", nil
+	}
+
 	if ref < ps.offset {
 		if len(ps.commonSymbols) == 0 {
 			return "", fmt.Errorf("symbol %d is under the offset %d, but no common symbols table was registered", ref, ps.offset)

--- a/pkg/mimirpb/compat_rw2.go
+++ b/pkg/mimirpb/compat_rw2.go
@@ -21,6 +21,7 @@ var (
 	errorInternalRW2                  = errors.New("proto: Remote Write 2.0 internal error")
 	errorInvalidHelpRef               = errors.New("proto: Remote Write 2.0 invalid help reference")
 	errorInvalidUnitRef               = errors.New("proto: Remote Write 2.0 invalid unit reference")
+	errorInvalidFirstSymbol           = errors.New("proto: Remote Write 2.0 symbols must start with empty string")
 )
 
 // rw2SymbolPageSize is the size of each page in bits.

--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -306,6 +306,44 @@ func TestRW2Unmarshal(t *testing.T) {
 		require.ErrorContains(t, err, "invalid")
 	})
 
+	t.Run("zero refs translate to empty string despite offset", func(t *testing.T) {
+		syms := test.NewSymbolTableBuilderWithCommon(nil, 256, nil)
+		writeRequest := &rw2.Request{
+			Timeseries: []rw2.TimeSeries{
+				{
+					LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_total"), syms.GetSymbol("job"), syms.GetSymbol("test_job")},
+					Samples: []rw2.Sample{
+						{
+							Value:     123.456,
+							Timestamp: 1234567890,
+						},
+					},
+					Exemplars: []rw2.Exemplar{
+						{
+							Value:      123.456,
+							Timestamp:  1234567890,
+							LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_total"), syms.GetSymbol("traceID"), syms.GetSymbol("1234567890abcdef")},
+						},
+					},
+					Metadata: rw2.Metadata{
+						Type:    rw2.Metadata_METRIC_TYPE_COUNTER,
+						HelpRef: syms.GetSymbol("test_metric_help"),
+						// UnitRef: left default!
+					},
+				},
+			},
+		}
+		data, err := writeRequest.Marshal()
+		require.NoError(t, err)
+
+		received := PreallocWriteRequest{}
+		received.UnmarshalFromRW2 = true
+		received.RW2SymbolOffset = 256
+		err = received.Unmarshal(data)
+		require.NoError(t, err)
+		require.Equal(t, "", received.Metadata[0].Unit)
+	})
+
 	t.Run("common symbol out of bounds", func(t *testing.T) {
 		commonSyms := []string{"__name__"}
 		syms := test.NewSymbolTableBuilderWithCommon(nil, 256, commonSyms)
@@ -322,66 +360,6 @@ func TestRW2Unmarshal(t *testing.T) {
 		received.RW2CommonSymbols = commonSyms
 		err = received.Unmarshal(data)
 		require.ErrorContains(t, err, "invalid")
-	})
-
-	t.Run("metadata-only RW2 requests are supported", func(t *testing.T) {
-		// Prometheus doesn't send these naturally, but this pattern might
-		// appear in RW2 requests that were translated from RW1.
-		syms := test.NewSymbolTableBuilderWithCommon(nil, 256, nil)
-		wr := &rw2.Request{
-			Timeseries: []rw2.TimeSeries{
-				{
-					LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_1")},
-					Metadata: rw2.Metadata{
-						Type:    rw2.Metadata_METRIC_TYPE_COUNTER,
-						HelpRef: syms.GetSymbol("help text for test_metric_1"),
-					},
-				},
-				{
-					LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_2")},
-					Metadata: rw2.Metadata{
-						Type:    rw2.Metadata_METRIC_TYPE_GAUGE,
-						HelpRef: syms.GetSymbol("help text for test_metric_2"),
-						UnitRef: syms.GetSymbol("bytes"),
-					},
-				},
-			},
-		}
-		data, err := wr.Marshal()
-		require.NoError(t, err)
-
-		require.Equal(t, rw2.Request{}, wr)
-
-		// Unmarshal the data back into Mimir's WriteRequest.
-		received := PreallocWriteRequest{}
-		received.UnmarshalFromRW2 = true
-		received.RW2SymbolOffset = 256
-		err = received.Unmarshal(data)
-		require.NoError(t, err)
-
-		expected := &PreallocWriteRequest{
-			WriteRequest: WriteRequest{
-				Timeseries: []PreallocTimeseries{},
-				Metadata: []*MetricMetadata{
-					{
-						MetricFamilyName: "test_metric_1",
-						Type:             COUNTER,
-						Help:             "help text for test_metric_1",
-					},
-					{
-						MetricFamilyName: "test_metric_2",
-						Type:             GAUGE,
-						Help:             "help text for test_metric_2",
-						Unit:             "bytes",
-					},
-				},
-				unmarshalFromRW2: true,
-				rw2symbols:       rw2PagedSymbols{offset: 256},
-			},
-			UnmarshalFromRW2: true,
-			RW2SymbolOffset:  256,
-		}
-		require.Equal(t, expected, &received)
 	})
 }
 
@@ -412,5 +390,6 @@ func makeTestRW2WriteRequest(syms *test.SymbolTableBuilder) *rw2.Request {
 		},
 	}
 	req.Symbols = syms.GetSymbols()
+
 	return req
 }

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -7321,6 +7321,7 @@ func valueToStringMimir(v interface{}) string {
 }
 func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 	var metadata map[string]*MetricMetadata
+	seenFirstSymbol := false
 
 	l := len(dAtA)
 	iNdEx := 0
@@ -7477,6 +7478,10 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
+			if !seenFirstSymbol && intStringLen > 0 {
+				return errorInvalidFirstSymbol
+			}
+			seenFirstSymbol = true
 			m.rw2symbols.append(yoloString(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		case 5:

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -23,6 +23,7 @@ var (
 	// The first `V2RecordSymbolOffset` symbols are reserved for this table.
 	// Note: V2 is not yet stabilized.
 	V2CommonSymbols = []string{
+		"",
 		// Prometheus/Mimir symbols
 		"__name__",
 		"__aggregation__",

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -17,6 +17,10 @@ func TestV2SymbolsCompat(t *testing.T) {
 	t.Run("v2 symbols cannot be larger than v2 offset", func(t *testing.T) {
 		require.LessOrEqual(t, len(V2CommonSymbols), V2RecordSymbolOffset)
 	})
+
+	t.Run("the first symbol in v2 symbols must be empty string", func(t *testing.T) {
+		require.Empty(t, V2CommonSymbols[0])
+	})
 }
 
 func TestRecordVersionHeader(t *testing.T) {

--- a/pkg/util/test/rw2.go
+++ b/pkg/util/test/rw2.go
@@ -108,6 +108,11 @@ func NewSymbolTableBuilder(symbols []string) *SymbolTableBuilder {
 }
 
 func NewSymbolTableBuilderWithCommon(symbols []string, offset uint32, commonSymbols []string) *SymbolTableBuilder {
+	// RW2.0 Spec: The first element of the symbols table MUST be an empty string.
+	if len(symbols) == 0 || symbols[0] != "" {
+		symbols = append([]string{""}, symbols...)
+	}
+
 	symbolsMap := make(map[string]uint32)
 	for i, sym := range symbols {
 		symbolsMap[sym] = uint32(i) + offset


### PR DESCRIPTION
#### What this PR does

Per the [Remote-Write 2.0 spec](https://prometheus.io/docs/specs/prw/remote_write_spec_2_0/#symbols):

> The first element of the symbols table MUST be an empty string, which is used to represent empty or unspecified values such as when Metadata.unit_ref or Metadata.help_ref are not provided.

Obviously Prometheus [follows its own spec](https://github.com/prometheus/prometheus/blob/74aca682b77d66f5761bd68459f3b570ec34ce2d/prompb/io/prometheus/write/v2/symbols.go#L27-L29), but other clients might send a request that's out of spec. If a client does this, we accept their request, but store garbage. Typically, this looks like mangling their metric metadata into a random label name used elsewhere in the request, possibly for an unrelated series.

We cannot decipher the meaning of such a request. Say a metadata unit has a reference value of 0, we can't tell whether the client intended to set it to the first symbol or to leave it blank. We don't have enough info to try to interpret it, in some cases we will always mangle metadata.

The ingest-storage record format V2 had a compounded version of this bug. In that format, we reserve the first N symbols for common symbols. An unsupplied metadata field serializes as the value `0`, which is in the common symbols space. We add a mandate that common symbols must start with empty string just like regular symbols, for correctness. Even if common symbols are not supplied, we'll still understand the meaning of `0`. It's redundant - in practice, rejecting such requests at the distributor shields this layer from this problem.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
