### PR TITLE
MQE: adjust behaviour of binary operations with `on (__name__)` to match Prometheus

### DIFF
--- a/pkg/streamingpromql/operators/binops/binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation.go
@@ -64,6 +64,7 @@ func groupLabelsFunc(vectorMatching parser.VectorMatching, op parser.ItemType, r
 		return func(l labels.Labels) labels.Labels {
 			lb.Reset(l)
 			lb.Keep(vectorMatching.MatchingLabels...)
+			lb.Del(labels.MetricName)
 			return lb.Labels()
 		}
 	}

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1785,3 +1785,27 @@ load 1m
 
 eval instant at 0m left_side{pod="pod-1"} * on(pod) group_left(base_name, region, system_name) right_side{pod="pod-1"}
   {base_name="base-1", region="region-1", system_name="system-1", pod="pod-1"} 1
+
+clear
+
+# Test the behaviour of 'on (__name__)', which is not as expected in Prometheus:
+# https://github.com/prometheus/prometheus/issues/16631
+load 1m
+  a{env="prod"} 10
+  a{env="test"} 12
+  b{env="prod"} 20
+  b{env="test"} 25
+
+eval instant at 0 a + on (__name__, env) a
+  {env="prod"} 20
+  {env="test"} 24
+
+eval_fail instant at 0 {__name__=~"a|b"} + on (__name__, env) {__name__=~"a|b"}
+  expected_fail_regexp (vector cannot contain metrics with the same labelset|found duplicate series for the match group \{env="prod"\} on the left side of the operation.*)
+
+eval instant at 0 a + on (__name__, env) group_left a
+  {env="prod"} 20
+  {env="test"} 24
+
+eval_fail instant at 0 {__name__=~"a|b"} + on (__name__, env) group_left {__name__=~"a|b"}
+  expected_fail_regexp (vector cannot contain metrics with the same labelset|multiple matches for labels: grouping labels must ensure unique matches)


### PR DESCRIPTION
#### What this PR does

This PR changes the behaviour of MQE's implementation of binary operations to match Prometheus' query engine.

Specifically, it changes MQE to match how Prometheus handles binary operations with `on (__name__)`. Prometheus always drops the metric name label, even if it is listed in `on`, as discussed in https://github.com/prometheus/prometheus/issues/16631. Changing this in Prometheus is considered a breaking change, so [I've updated the Prometheus documentation](https://github.com/prometheus/prometheus/pull/16716) to explicitly state that the current behaviour is expected, and in this PR I'm updating MQE to match.

#### Which issue(s) this PR fixes or relates to

https://github.com/prometheus/prometheus/issues/16631

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
