### PR TITLE
Inject push workers as a dependency to distributors

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -784,6 +784,7 @@ type Mimir struct {
 	Overrides                        *validation.Overrides
 	ActiveGroupsCleanup              *util.ActiveGroupsCleanupService
 	Distributor                      *distributor.Distributor
+	DistributorPushWorkers           func(func())
 	Ingester                         *ingester.Ingester
 	Flusher                          *flusher.Flusher
 	FrontendV1                       *frontendv1.Frontend

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -238,7 +238,7 @@ func createIngesterQueryable(t testing.TB, address string) storage.Queryable {
 
 	overrides := validation.NewOverrides(limits, nil)
 
-	d, err := distributor.New(distributorCfg, clientCfg, overrides, nil, nil, ingestersRing, nil, false, nil, logger)
+	d, err := distributor.New(distributorCfg, clientCfg, overrides, nil, nil, ingestersRing, nil, false, nil, nil, logger)
 	require.NoError(t, err)
 
 	queryMetrics := stats.NewQueryMetrics(nil)


### PR DESCRIPTION
#### What this PR does

Instead of making all instances of distributor.New() create push workers, init them as a dependency when running a distributor or a ruler, but not when a Queryable instantiates a DistributorService.

This will prevent workers from starting in the querier, which doesn't push to ingesters at all.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
