### PR TITLE
MQE: Fix estimations in TestMemoryConsumptionLimit_SingleQueries

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1593,9 +1593,10 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 						assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(rejectedMetrics(1)), "cortex_querier_queries_rejected_total"))
 					}
 
-					spanStubs := spanExporter.GetSpans()
-					assert.Len(t, spanStubs, 1)
-					spanStub := spanStubs[0]
+					var spanStub tracetest.SpanStub
+					if spanStubs := spanExporter.GetSpans(); assert.Len(t, spanStubs, 1) {
+						spanStub = spanStubs[0]
+					}
 					assertEstimatedPeakMemoryConsumption(t, reg, spanStub, expectedPeakMemoryConsumption, queryType)
 				})
 			}

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
 	promstats "github.com/prometheus/prometheus/util/stats"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -1438,9 +1439,28 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			expr:          "sum(some_metric)",
 			shouldSucceed: true,
 
-			rangeQueryExpectedPeak: 8*types.FPointSize + 16*types.Float64Size + 8*types.BoolSize + types.SeriesMetadataSize,
-			rangeQueryLimit:        8*types.FPointSize + 16*types.Float64Size + 8*types.BoolSize + types.SeriesMetadataSize + 1,
+			// There are two stages to processing the query. They take different memory depending on whether we're running with stringlabels or not.
+			// At peak we'll hold in memory either A) or B)
+			rangeQueryExpectedPeak: max(
+				// A)
+				//   - 5 input series labels (8 series metadata because of bucketed pool rounding to a power of 2)
+				//   - 1 output series metadata (no labels)
+				8*types.SeriesMetadataSize+5*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize())+types.SeriesMetadataSize,
+				// B)
+				//   - the running total for the sum() (two floats (due to kahan) and a bool at each step, with the number of steps rounded to the nearest power of 2),
+				//   - the next series from the selector
+				//   - the series metadata for the output series (no labels)
+				8*(2*types.Float64Size+types.BoolSize)+8*types.FPointSize+types.SeriesMetadataSize,
+			),
+			rangeQueryLimit: max(
+				// A)
+				8*types.SeriesMetadataSize+5*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize())+types.SeriesMetadataSize,
+				// B)
+				8*(2*types.Float64Size+types.BoolSize)+8*types.FPointSize+types.SeriesMetadataSize,
+			),
 
+			// Each series has one sample, which is already a power of two.
+			// At peak we'll hold in memory 9 SeriesMetadata.
 			instantQueryExpectedPeak: 9*types.SeriesMetadataSize + 5*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize()),
 			instantQueryLimit:        9*types.SeriesMetadataSize + 5*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize()),
 		},
@@ -1448,11 +1468,14 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			expr:          "sum(some_metric)",
 			shouldSucceed: false,
 
+			// At peak we'll hold in memory
+			//   - 5 input series labels (8 series metadata because of bucketed pool rounding to a power of 2)
+			//   - 1 output series metadata (no labels). This will tip over the limit and we won't allocate it, so the peak calculations don't include it.
 			rangeQueryExpectedPeak: 8*types.SeriesMetadataSize + 5*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize()),
-			rangeQueryLimit:        8*types.SeriesMetadataSize + 5*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize()),
+			rangeQueryLimit:        9*types.SeriesMetadataSize + 5*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize()) - 1,
 
 			instantQueryExpectedPeak: 8*types.SeriesMetadataSize + 5*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize()),
-			instantQueryLimit:        8*types.SeriesMetadataSize + 5*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize()),
+			instantQueryLimit:        9*types.SeriesMetadataSize + 5*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize()) - 1,
 		},
 		"histogram: limit enabled, but query does not exceed limit": {
 			expr:          "sum(some_histogram)",
@@ -1563,15 +1586,15 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 					span.End()
 
 					if testCase.shouldSucceed {
-						require.NoError(t, res.Err)
-						require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(rejectedMetrics(0)), "cortex_querier_queries_rejected_total"))
+						assert.NoError(t, res.Err)
+						assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(rejectedMetrics(0)), "cortex_querier_queries_rejected_total"))
 					} else {
-						require.ErrorContains(t, res.Err, globalerror.MaxEstimatedMemoryConsumptionPerQuery.Error())
-						require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(rejectedMetrics(1)), "cortex_querier_queries_rejected_total"))
+						assert.ErrorContains(t, res.Err, globalerror.MaxEstimatedMemoryConsumptionPerQuery.Error())
+						assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(rejectedMetrics(1)), "cortex_querier_queries_rejected_total"))
 					}
 
 					spanStubs := spanExporter.GetSpans()
-					require.Len(t, spanStubs, 1)
+					assert.Len(t, spanStubs, 1)
 					spanStub := spanStubs[0]
 					assertEstimatedPeakMemoryConsumption(t, reg, spanStub, expectedPeakMemoryConsumption, queryType)
 				})


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

follow-up of #11683

The memory estimations have peaks during different stages of query processing when running with `-tags stringlabels` and when running without.

When running without `stringlabels`, strings appear cheaper (because the plain `ByteSize()` doesn't account for slice overhead). Because of this, the peak is during floating point processing.

When running with `stringlabels`, strings appear more expensive. Then the peak is during labels processing.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
