### PR TITLE
[HELM] Add labels configuration for gateway ingress

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to closer to the requested number of CPUs. #12150
+* [ENHANCEMENT] Gateway ingress: Support labels for gateway ingress. #11964
 
 ## 5.8.0-rc.0
 

--- a/operations/helm/charts/mimir-distributed/ci/offline/test-enterprise-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/test-enterprise-values.yaml
@@ -9,11 +9,13 @@ enterprise:
 gateway:
   ingress:
     enabled: true
+    labels:
+      foo: bar
 
 provisioner:
   enabled: true
   additionalTenants:
     - name: team-a
-      secretNamespace: '{{ .Release.Namespace }}'
+      secretNamespace: "{{ .Release.Namespace }}"
     - name: team-b
-      secretNamespace: '{{ .Release.Namespace }}'
+      secretNamespace: "{{ .Release.Namespace }}"

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-ingress.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-ingress.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ .Values.gateway.ingress.nameOverride | default (include "mimir.resourceName" (dict "ctx" . "component" "gateway") ) }}
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
+    {{- with .Values.gateway.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.gateway.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3579,6 +3579,8 @@ gateway:
     nameOverride: ""
     # -- Ingress Class Name. MAY be required for Kubernetes versions >= 1.18
     ingressClassName: ""
+    # -- Labels for the Ingress
+    labels: {}
     # -- Annotations for the Ingress
     annotations: {}
     # -- Hosts configuration for the Ingress

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-ingress.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/gateway/gateway-ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: gateway
     app.kubernetes.io/managed-by: Helm
+    foo: bar
   namespace: "citestns"
 spec:
   tls:


### PR DESCRIPTION
This update introduces a new `labels` field under the `gateway.ingress` section in the `values.yaml` file, allowing users to specify custom labels for the Ingress resource. The corresponding template in `gateway-ingress.yaml` has been updated to include these labels in the metadata.

- Added `labels: {}` to `values.yaml`
- Updated `gateway-ingress.yaml` to render labels if provided

This enhancement improves the flexibility of the Ingress configuration for users deploying the Mimir distributed system.

Checklist

- [X]  Tests updated
- [X]  Documentation added
- [X]  CHANGELOG.md updated - the order of entries should be [CHANGE], [FEATURE], [ENHANCEMENT], [BUGFIX]