### PR TITLE
parquet converter: include user id in converter counter metrics

### DIFF
--- a/pkg/parquetconverter/metrics.go
+++ b/pkg/parquetconverter/metrics.go
@@ -10,32 +10,32 @@ import (
 )
 
 type parquetConverterMetrics struct {
-	blocksConverted       prometheus.Counter
-	blocksConvertedFailed prometheus.Counter
-	conversionDuration    prometheus.Histogram
+	blocksConverted       *prometheus.CounterVec
+	blocksConvertedFailed *prometheus.CounterVec
+	conversionDuration    *prometheus.HistogramVec
 	tenantsDiscovered     prometheus.Gauge
 }
 
 func newParquetConverterMetrics(reg prometheus.Registerer) parquetConverterMetrics {
 	var m parquetConverterMetrics
 
-	m.blocksConverted = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+	m.blocksConverted = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_parquet_converter_blocks_converted_total",
 		Help: "Total number of blocks converted to parquet format",
-	})
+	}, []string{"user"})
 
-	m.blocksConvertedFailed = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+	m.blocksConvertedFailed = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_parquet_converter_blocks_converted_failed_total",
 		Help: "Total number of blocks that failed to convert to parquet format",
-	})
+	}, []string{"user"})
 
-	m.conversionDuration = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+	m.conversionDuration = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            "cortex_parquet_converter_conversion_duration_seconds",
 		Help:                            "Time taken to convert a block to parquet format",
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,
-	})
+	}, []string{"user"})
 
 	m.tenantsDiscovered = promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 		Name: "cortex_parquet_converter_tenants_discovered",

--- a/pkg/parquetconverter/parquet_converter.go
+++ b/pkg/parquetconverter/parquet_converter.go
@@ -304,11 +304,11 @@ func (c *ParquetConverter) processBlock(ctx context.Context, userID string, meta
 	var skipped bool
 	defer func() {
 		duration := time.Since(start)
-		c.metrics.conversionDuration.Observe(duration.Seconds())
+		c.metrics.conversionDuration.WithLabelValues(userID).Observe(duration.Seconds())
 		if err != nil {
-			c.metrics.blocksConvertedFailed.Inc()
+			c.metrics.blocksConvertedFailed.WithLabelValues(userID).Inc()
 		} else if !skipped {
-			c.metrics.blocksConverted.Inc()
+			c.metrics.blocksConverted.WithLabelValues(userID).Inc()
 		}
 	}()
 


### PR DESCRIPTION
Adding user id to the converter metrics to better track converter progress through tenants.