### PR TITLE
blockbuilder: refactor TSDBBuilder.Process

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -305,8 +305,7 @@ consumerLoop:
 				break consumerLoop
 			}
 
-			// Process everything in this record.
-			_, err := builder.Process(ctx, rec, 0, 0, false, true)
+			err := builder.Process(ctx, rec)
 			if err != nil {
 				// All "non-terminal" errors are handled by the TSDBBuilder.
 				return 0, fmt.Errorf("process record in partition %d at offset %d: %w", rec.Partition, rec.Offset, err)


### PR DESCRIPTION
#### What this PR does

Here is the follow-up to the #11643

The PR is a part of a refactoring in the block-builder's internals. Here I update the `TSDBBuilder.Process`, removing the legacy handling of stand-alone cases.