### PR TITLE
MQE: fix issue where a query with a common subexpression could return incorrect results

### DIFF
--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/series_data_ring_buffer.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/series_data_ring_buffer.go
@@ -38,29 +38,32 @@ func (b *SeriesDataRingBuffer) Append(d types.InstantVectorSeriesData, seriesInd
 	b.seriesCount++
 }
 
+// Remove removes and returns the first series in the buffer, and panics if that is not the series with index seriesIndex.
 func (b *SeriesDataRingBuffer) Remove(seriesIndex int) types.InstantVectorSeriesData {
 	if b.seriesCount == 0 {
 		panic(fmt.Sprintf("attempted to remove series at index %v, but buffer is empty", seriesIndex))
 	}
 
-	if seriesIndex < b.firstSeriesIndex || seriesIndex >= (b.firstSeriesIndex+b.seriesCount) {
+	if seriesIndex != b.firstSeriesIndex {
 		panic(fmt.Sprintf("attempted to remove series at index %v, but have series from index %v to %v", seriesIndex, b.firstSeriesIndex, b.firstSeriesIndex+b.seriesCount-1))
 	}
 
 	idx := b.startIndex % len(b.data)
 	d := b.data[idx]
 	b.data[idx] = types.InstantVectorSeriesData{} // Clear the slot.
-	b.startIndex++
+	b.startIndex = (b.startIndex + 1) % len(b.data)
 	b.firstSeriesIndex++
 	b.seriesCount--
 
-	if b.startIndex > len(b.data) || b.seriesCount == 0 {
+	if b.seriesCount == 0 {
 		b.startIndex = 0
 	}
 
 	return d
 }
 
+// RemoveFirst removes and returns the first series in the buffer.
+// Calling RemoveFirst on an empty buffer panics.
 func (b *SeriesDataRingBuffer) RemoveFirst() types.InstantVectorSeriesData {
 	if b.seriesCount == 0 {
 		panic("attempted to remove first series of empty buffer")


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where common subexpression elimination (CSE) can cause a query to return incorrect query results.

The issue would occur if the ring buffer used to buffer data was in a state where the head of the buffer is at the end of the slice, and the tail was at the beginning of the slice. In this case, calling `Remove` for the item at the end of the slice would return the correct value, as would the subsequent call for the item at the beginning of the slice, but all following calls would return incorrect values.

#### Which issue(s) this PR fixes or relates to

#11189 

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [covered by #10067] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
