### PR TITLE
Alertmanager: Add an endpoint to get the full state

### DIFF
--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -646,6 +646,15 @@ func TestAlertmanagerSharding(t *testing.T) {
 				}
 			}
 
+			// Endpoint: GET /api/v1/grafana/full_state
+			{
+				for _, c := range clients {
+					fs, err := c.GetFullState(context.Background())
+					assert.NoError(t, err)
+					assert.NotEmpty(t, fs.State)
+				}
+			}
+
 			// Endpoint: GET /api/v1/grafana/receivers
 			{
 				for _, c := range clients {

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -1225,8 +1225,16 @@ func (c *Client) DeleteGrafanaAlertmanagerConfig(ctx context.Context) error {
 	return nil
 }
 
+func (c *Client) GetFullState(ctx context.Context) (*alertmanager.UserGrafanaState, error) {
+	return c.getState(ctx, "/api/v1/grafana/full_state")
+}
+
 func (c *Client) GetGrafanaAlertmanagerState(ctx context.Context) (*alertmanager.UserGrafanaState, error) {
-	u := c.alertmanagerClient.URL("/api/v1/grafana/state", nil)
+	return c.getState(ctx, "/api/v1/grafana/state")
+}
+
+func (c *Client) getState(ctx context.Context, path string) (*alertmanager.UserGrafanaState, error) {
+	u := c.alertmanagerClient.URL(path, nil)
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -8,6 +8,7 @@ package alertmanager
 import (
 	"context"
 	"crypto/md5"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -326,6 +327,7 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 	// This route is an experimental Mimir extension to the receivers API, so we put
 	// it under an additional prefix to avoid any confusion with upstream Alertmanager.
 	if cfg.GrafanaAlertmanagerCompatibility {
+		am.mux.Handle("/api/v1/grafana/full_state", http.HandlerFunc(am.GetFullStateHandler))
 		am.mux.Handle("/api/v1/grafana/receivers", http.HandlerFunc(am.GetReceiversHandler))
 		am.mux.Handle("/api/v1/grafana/templates/test", http.HandlerFunc(am.TestTemplatesHandler))
 		am.mux.Handle("/api/v1/grafana/receivers/test", http.HandlerFunc(am.TestReceiversHandler))
@@ -335,6 +337,37 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 
 	// TODO: From this point onward, the alertmanager _might_ receive requests - we need to make sure we've settled and are ready.
 	return am, nil
+}
+
+func (am *Alertmanager) GetFullStateHandler(w http.ResponseWriter, _ *http.Request) {
+	st, err := am.state.GetFullState()
+	if err != nil {
+		level.Error(am.logger).Log("msg", "error getting full state", "err", err)
+		http.Error(w,
+			fmt.Sprintf("error getting full state: %s", err.Error()),
+			http.StatusInternalServerError)
+		return
+	}
+
+	bytes, err := st.Marshal()
+	if err != nil {
+		level.Error(am.logger).Log("msg", "error marshalling full state", "err", err)
+		http.Error(w,
+			fmt.Sprintf("error marshalling full state: %s", err.Error()),
+			http.StatusInternalServerError)
+		return
+	}
+
+	d, err := json.Marshal(successResult{
+		Status: statusSuccess,
+		Data:   &UserGrafanaState{State: base64.StdEncoding.EncodeToString(bytes)},
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(d); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }
 
 func (am *Alertmanager) GetReceiversHandler(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/alertmanager/distributor_test.go
+++ b/pkg/alertmanager/distributor_test.go
@@ -221,6 +221,24 @@ func TestDistributor_DistributeRequest(t *testing.T) {
 			expectedTotalCalls:  0,
 			headersNotPreserved: true,
 			route:               "/receivers",
+		}, {
+			name:               "Read /api/v1/grafana/full_state is sent to only 1 AM",
+			numAM:              5,
+			numHappyAM:         5,
+			replicationFactor:  3,
+			isRead:             true,
+			expStatusCode:      http.StatusOK,
+			expectedTotalCalls: 1,
+			route:              "/api/v1/grafana/full_state",
+		}, {
+			name:                "Write /api/v1/grafana/full_state not supported",
+			numAM:               5,
+			numHappyAM:          5,
+			replicationFactor:   3,
+			expStatusCode:       http.StatusNotFound,
+			expectedTotalCalls:  0,
+			headersNotPreserved: true,
+			route:               "/api/v1/grafana/full_state",
 		},
 	}
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -216,13 +216,12 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, api
 			a.RegisterRoute("/api/v1/grafana/config", http.HandlerFunc(am.SetUserGrafanaConfig), true, true, http.MethodPost)
 			a.RegisterRoute("/api/v1/grafana/config", http.HandlerFunc(am.DeleteUserGrafanaConfig), true, true, http.MethodDelete)
 
-			a.RegisterRoute("/api/v1/grafana/full_state", http.HandlerFunc(am.GetUserState), true, true, http.MethodGet)
-
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.GetUserGrafanaState), true, true, http.MethodGet)
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.SetUserGrafanaState), true, true, http.MethodPost)
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.DeleteUserGrafanaState), true, true, http.MethodDelete)
 
 			// These APIs are handled by the per-tenant Alertmanager, so they are handled by the distributor.
+			a.RegisterRoute("/api/v1/grafana/full_state", am, true, true, http.MethodGet)
 			a.RegisterRoute("/api/v1/grafana/receivers", am, true, true, http.MethodGet)
 			a.RegisterRoute("/api/v1/grafana/receivers/test", am, true, true, http.MethodPost)
 			a.RegisterRoute("/api/v1/grafana/templates/test", am, true, true, http.MethodPost)


### PR DESCRIPTION
### Description

This PR adds an endpoint through which Grafana can retrieve the Alertmanager's current state.

As the state is not immediately persisted in the database, we attempt to fetch the state from the running Alertmanager. This way we return the latest nflog entries and silences (at least from a specific Alertmanager's perspective, there's still the chance that some entries have not yet been received via gossip).

The remote Alertmanager feature can use this to roll back to _remote secondary_ mode using the latest Alertmanager state, thus avoiding duplicate notifications and missing silences.

### How to test it

You can spin up Mimir in read-write mode to test this PR.
1. Go to `development/mimir-read-write-mode`
2. In `config/mimir.yaml`, set `grafana_alertmanager_compatibility_enabled: true` under the `alertmanager` section
3. Run `./compose-up`
4. (Optional) Create some silences and alerts to populate the state
6. Get the full state using `curl http://localhost:8780/api/v1/grafana/full_state`