### PR TITLE
Alertmanager: Add metrics for pre-notification hooks.

### DIFF
--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -580,7 +580,7 @@ func (am *Alertmanager) getFullState() (*clusterpb.FullState, error) {
 
 func (am *Alertmanager) wrapNotifier(integrationName string, notifier notify.Notifier) notify.Notifier {
 	if am.cfg.EnableNotifyHooks {
-		n, err := newNotifyHooksNotifier(notifier, am.cfg.Limits, am.cfg.UserID, am.logger)
+		n, err := newNotifyHooksNotifier(notifier, am.cfg.Limits, am.cfg.UserID, am.logger, am.registry)
 		if err != nil {
 			// It's rare an error is returned, but in theory it can happen.
 			level.Error(am.logger).Log("msg", "Failed to setup notify hooks", "err", err)

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -68,6 +68,9 @@ type alertmanagerMetrics struct {
 	initialSyncDuration     *prometheus.Desc
 	persistTotal            *prometheus.Desc
 	persistFailed           *prometheus.Desc
+	notifyHookTotal         *prometheus.Desc
+	notifyHookNoop          *prometheus.Desc
+	notifyHookFailed        *prometheus.Desc
 
 	// exported metrics, gathered from Alertmanager Dispatcher
 	dispatcherAggrGroups                    *prometheus.Desc
@@ -243,6 +246,18 @@ func newAlertmanagerMetrics(logger log.Logger) *alertmanagerMetrics {
 			"cortex_alertmanager_state_persist_failed_total",
 			"Number of times we have failed to persist the running state to storage.",
 			nil, nil),
+		notifyHookTotal: prometheus.NewDesc(
+			"cortex_alertmanager_notify_hook_total",
+			"Number of times a pre-notify hook was invoked.",
+			nil, nil),
+		notifyHookNoop: prometheus.NewDesc(
+			"cortex_alertmanager_notify_hook_noop_total",
+			"Number of times a pre-notify hook was invoked successfully but did nothing.",
+			nil, nil),
+		notifyHookFailed: prometheus.NewDesc(
+			"cortex_alertmanager_notify_hook_failed_total",
+			"Number of times a pre-notify was attempted but failed.",
+			nil, nil),
 		dispatcherAggrGroups: prometheus.NewDesc(
 			"cortex_alertmanager_dispatcher_aggregation_groups",
 			"Number of active aggregation groups",
@@ -325,6 +340,9 @@ func (m *alertmanagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.initialSyncDuration
 	out <- m.persistTotal
 	out <- m.persistFailed
+	out <- m.notifyHookTotal
+	out <- m.notifyHookNoop
+	out <- m.notifyHookFailed
 	out <- m.dispatcherAggrGroups
 	out <- m.dispatcherProcessingDuration
 	out <- m.dispatcherAggregationGroupsLimitReached
@@ -382,6 +400,10 @@ func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfHistograms(out, m.initialSyncDuration, "alertmanager_state_initial_sync_duration_seconds")
 	data.SendSumOfCounters(out, m.persistTotal, "alertmanager_state_persist_total")
 	data.SendSumOfCounters(out, m.persistFailed, "alertmanager_state_persist_failed_total")
+
+	data.SendSumOfCounters(out, m.notifyHookTotal, "alertmanager_notify_hook_total")
+	data.SendSumOfCounters(out, m.notifyHookNoop, "alertmanager_notify_hook_noop_total")
+	data.SendSumOfCounters(out, m.notifyHookFailed, "alertmanager_notify_hook_failed_total")
 
 	data.SendSumOfGauges(out, m.dispatcherAggrGroups, "alertmanager_dispatcher_aggregation_groups")
 	data.SendSumOfSummaries(out, m.dispatcherProcessingDuration, "alertmanager_dispatcher_alert_processing_duration_seconds")

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -319,6 +319,15 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		# HELP cortex_alertmanager_state_persist_total Number of times we have tried to persist the running state to storage.
 		# TYPE cortex_alertmanager_state_persist_total counter
 		cortex_alertmanager_state_persist_total 0
+		# HELP cortex_alertmanager_notify_hook_failed_total Number of times a pre-notify was attempted but failed.
+		# TYPE cortex_alertmanager_notify_hook_failed_total counter
+		cortex_alertmanager_notify_hook_failed_total 0
+		# HELP cortex_alertmanager_notify_hook_noop_total Number of times a pre-notify hook was invoked successfully but did nothing.
+		# TYPE cortex_alertmanager_notify_hook_noop_total counter
+		cortex_alertmanager_notify_hook_noop_total 0
+		# HELP cortex_alertmanager_notify_hook_total Number of times a pre-notify hook was invoked.
+		# TYPE cortex_alertmanager_notify_hook_total counter
+		cortex_alertmanager_notify_hook_total 0
 
 		# HELP cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total Number of times when dispatcher failed to create new aggregation group due to limit.
 		# TYPE cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total counter
@@ -666,6 +675,15 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 						# HELP cortex_alertmanager_state_persist_total Number of times we have tried to persist the running state to storage.
 						# TYPE cortex_alertmanager_state_persist_total counter
 						cortex_alertmanager_state_persist_total 0
+						# HELP cortex_alertmanager_notify_hook_failed_total Number of times a pre-notify was attempted but failed.
+						# TYPE cortex_alertmanager_notify_hook_failed_total counter
+						cortex_alertmanager_notify_hook_failed_total 0
+						# HELP cortex_alertmanager_notify_hook_noop_total Number of times a pre-notify hook was invoked successfully but did nothing.
+						# TYPE cortex_alertmanager_notify_hook_noop_total counter
+						cortex_alertmanager_notify_hook_noop_total 0
+				 		# HELP cortex_alertmanager_notify_hook_total Number of times a pre-notify hook was invoked.
+						# TYPE cortex_alertmanager_notify_hook_total counter
+						cortex_alertmanager_notify_hook_total 0
 
 						# HELP cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total Number of times when dispatcher failed to create new aggregation group due to limit.
 						# TYPE cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total counter
@@ -954,6 +972,15 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 			# HELP cortex_alertmanager_state_persist_total Number of times we have tried to persist the running state to storage.
 			# TYPE cortex_alertmanager_state_persist_total counter
 			cortex_alertmanager_state_persist_total 0
+			# HELP cortex_alertmanager_notify_hook_failed_total Number of times a pre-notify was attempted but failed.
+			# TYPE cortex_alertmanager_notify_hook_failed_total counter
+			cortex_alertmanager_notify_hook_failed_total 0
+			# HELP cortex_alertmanager_notify_hook_noop_total Number of times a pre-notify hook was invoked successfully but did nothing.
+			# TYPE cortex_alertmanager_notify_hook_noop_total counter
+			cortex_alertmanager_notify_hook_noop_total 0
+			# HELP cortex_alertmanager_notify_hook_total Number of times a pre-notify hook was invoked.
+	  		# TYPE cortex_alertmanager_notify_hook_total counter
+			cortex_alertmanager_notify_hook_total 0
 
 			# HELP cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total Number of times when dispatcher failed to create new aggregation group due to limit.
 			# TYPE cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total counter

--- a/pkg/alertmanager/notify_hooks_notifier_test.go
+++ b/pkg/alertmanager/notify_hooks_notifier_test.go
@@ -4,16 +4,20 @@ package alertmanager
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,8 +54,25 @@ type testHooksFixture struct {
 	limits   *fakeHookLimits
 	server   *httptest.Server
 	upstream *fakeNotifier
+	reg      *prometheus.Registry
 
 	notifier *notifyHooksNotifier
+}
+
+func (f *testHooksFixture) assertMetrics(t *testing.T, total, noop, failed int) {
+	t.Helper()
+
+	assert.NoError(t, testutil.GatherAndCompare(f.reg, strings.NewReader(fmt.Sprintf(`
+		# HELP alertmanager_notify_hook_total Number of times a pre-notify hook was invoked.
+		# TYPE alertmanager_notify_hook_total counter
+		alertmanager_notify_hook_total %d
+		# HELP alertmanager_notify_hook_noop_total Number of times a pre-notify hook was invoked successfully but did nothing.
+		# TYPE alertmanager_notify_hook_noop_total counter
+		alertmanager_notify_hook_noop_total %d
+		# HELP alertmanager_notify_hook_failed_total Number of times a pre-notify was attempted but failed.
+		# TYPE alertmanager_notify_hook_failed_total counter
+		alertmanager_notify_hook_failed_total %d
+	`, total, noop, failed))))
 }
 
 func newTestHooksFixture(t *testing.T, handlerStatus int, handlerResponse string) *testHooksFixture {
@@ -96,13 +117,15 @@ func newTestHooksFixture(t *testing.T, handlerStatus int, handlerResponse string
 
 	upstream := &fakeNotifier{}
 
-	notifier, err := newNotifyHooksNotifier(upstream, limits, "user", log.NewLogfmtLogger(os.Stdout))
+	reg := prometheus.NewPedanticRegistry()
+	notifier, err := newNotifyHooksNotifier(upstream, limits, "user", log.NewLogfmtLogger(os.Stdout), reg)
 	require.NoError(t, err)
 
 	return &testHooksFixture{
 		limits:   limits,
 		server:   server,
 		upstream: upstream,
+		reg:      reg,
 		notifier: notifier,
 	}
 }
@@ -145,6 +168,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("changed")}, f.upstream.calls)
+		f.assertMetrics(t, 1, 0, 0)
 	})
 	t.Run("hook not invoked when empty url configured", func(t *testing.T) {
 		f := newTestHooksFixture(t, http.StatusOK, okResponse)
@@ -154,6 +178,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
+		f.assertMetrics(t, 0, 0, 0)
 	})
 	t.Run("hook not invoked when matching receiver name configured ", func(t *testing.T) {
 		f := newTestHooksFixture(t, http.StatusOK, okResponse)
@@ -163,6 +188,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
+		f.assertMetrics(t, 0, 0, 0)
 	})
 	t.Run("hook invoked when matching receiver name configured ", func(t *testing.T) {
 		f := newTestHooksFixture(t, http.StatusOK, okResponse)
@@ -172,6 +198,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("changed")}, f.upstream.calls)
+		f.assertMetrics(t, 1, 0, 0)
 	})
 
 	t.Run("hook failing with 500 does not modify alerts", func(t *testing.T) {
@@ -182,6 +209,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
+		f.assertMetrics(t, 1, 0, 1)
 	})
 	t.Run("hook failing with 500 but returning data does not modify alerts", func(t *testing.T) {
 		f := newTestHooksFixture(t, http.StatusInternalServerError, okResponse)
@@ -191,6 +219,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
+		f.assertMetrics(t, 1, 0, 1)
 	})
 	t.Run("hook yielding 204 with empty response does not modify alerts", func(t *testing.T) {
 		f := newTestHooksFixture(t, http.StatusNoContent, ``)
@@ -200,5 +229,6 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
+		f.assertMetrics(t, 1, 1, 0)
 	})
 }


### PR DESCRIPTION
Also extend logging to show the duration of the hook, as an aggregated metric
for this would not be very valuable and we avoid per-tenant histograms.
