### PR TITLE
Update IngesterHasNotShippedBlocks to be block-builder aware

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1757,55 +1757,23 @@ How to **fix**:
 
   1. Once ingesters are stable, revert the temporarily config applied in the previous step.
 
-### MimirBlockBuilderNoCycleProcessing
-
-This alert fires when the block-builder stops reporting any processed cycles for an unexpectedly long time.
-
-How it **works**:
-
-- The block-builder periodically consumes a portion of the backlog from Kafka partition, and processes the consumed data into TSDB blocks. The block-builder calls these periods "cycles".
-- If the block-builder doesn't process any cycles for an extended period of time, this could indicate that a block-builder instance is stuck and cannot complete cycle processing.
-
-How to **investigate**:
-
-- Check the block-builder logs to see what its pods have been busy with. The block-builder logs the `start consuming` and `done consuming` log messages, that mark per-partition conume-cycles. These log records include the details about the cycle, the Kafka topic's offsets, etc. Troubleshoot based on that.
-
-Data recovery / temporary mitigation:
-
-While the block builder is still getting mature, ingester is likely still uploading blocks to a backup bucket (if you name your bucket as `*-blocks`, the backup bucket could be `*-ingester-blocks`).
-
-If the block builder permanently missed consuming some portion of the partition, or there is an ongoing issue preventing it from consuming, try the following.
-
-If there is a backup `*-ingester-blocks` bucket
-
-1. Firstly, reconfigure ingesters to upload blocks to the main `*-blocks` bucket.
-2. Use `copyblocks` tool from Mimir to copy over the blocks from the backup bucket `*-ingester-blocks` to the main `*-blocks` bucket for the duration block builder did not produce blocks. It is advised to have the start time for copying blocks to be few hours prior (maybe 4hrs) to when the issue started.
-3. Fix the issue in block builder. Let it catch up with the backlog. Once it catches up, you can switch back ingesters to the backup bucket.
-
-If there is no backup bucket that ingester is uploading to
-
-- Increase the retention of the Kafka topic to buy some time.
-- Spin up a new set of block builder with an older version with a **new kafka topic name**, so that it does not conflict with the existing block builders. Choose the last version where no issue was seen; in most cases it will be the version before the one that caused the alert.
-- If the `block-builder.lookback-on-no-commit` does not cover the time when the issue started, set it long enough so that these new block builders start back far enough to cover the missing data.
-- If there is any corrupt data in the partition that is hard failing the block builder, then this solution will not work. Keep increasing the kafka topic retention until the issue is resolved and block builder has caught up.
-
 ### MimirBlockBuilderLagging
 
-This alert fires when the block-builder instances report a large number of unprocessed records in the Kafka partitions.
+This alert fires when the block-builder reports a large number of unprocessed records in Kafka partitions.
 
 How it **works**:
 
-- When the block-builder starts a new consume cycle, it checks how many records the Kafka partition has in the backlog. This number is tracked in the `cortex_blockbuilder_consumer_lag_records` metric.
-- The block-builder must consume and process these records into TSDB blocks.
-- At the end of the processing, the block-builder commits the offset of the last fully processed record into Kafka.
-- If the block-builder reports high values in the lag, this could indicate that a block-builder instance cannot fully process and commit Kafka record.
+- The block-builder-scheduler watches the Kafka topic backlog. The lag is calculated per-partition as the difference between the partition's end and its last committed offset.
+- The block-builder-scheduler chops the backlog into jobs, and distributes the jobs between the block-builder instances.
+- A block-builder must consume and process the records in a job into TSDB blocks.
+- When the job is processed, the block-builder-scheduler commits the offset of the last record from this job into Kafka.
+
+If the block-builder reports high values in the lag, this could indicate that the block-builder cannot fully process and commit Kafka record.
 
 How to **investigate**:
 
-- Check if the per-partition lag, reported by the `cortex_blockbuilder_consumer_lag_records` metric, has been growing over the past hours.
+- Check if the per-partition lag has been growing over the past hours.
 - Explore the block-builder logs for any errors reported while it processed the partition.
-
-Data recovery / temporary mitigation: Refer the runbook for `MimirBlockBuilderNoCycleProcessing` above.
 
 ### MimirBlockBuilderCompactAndUploadFailed
 
@@ -1820,6 +1788,30 @@ How to **investigate**:
 - Explore the block-builder logs to check what errors are there.
 
 Data recovery / temporary mitigation: Refer the runbook for `MimirBlockBuilderNoCycleProcessing` above.
+
+#### MimirBlockBuilderHasNotShippedBlocks
+
+Similar to [`MimirIngesterHasNotShippedBlocks`](#MimirIngesterHasNotShippedBlocks) but for block-builder.
+
+This alert fires when the block-builder stops shipping any blocks for an unexpectedly long time.
+
+How it **works**:
+
+- The block-builder periodically consumes a portion of the backlog from Kafka partition, and processes the consumed data into TSDB blocks.
+- It then sends the TSDB blocks to the object storage.
+
+How to **investigate**:
+
+- Check the block-builder logs to see what its pods have been busy with. The block-builder logs the `start consuming` and `done consuming` log messages, that mark per-partition jobs. These log records include the details about the Kafka topic's offsets, etc. Troubleshoot based on that.
+
+Data recovery / temporary mitigation:
+
+If the block-builder permanently missed consuming some portion of the partition, or there is an ongoing issue preventing it from consuming, try the following:
+
+- Increase the retention of the Kafka topic to buy some time.
+- Spin up a new set of block-builders and block-builder-scheduler with an older version and a **new kafka consumer group**. The latter is so it didn't conflict with the existing block-builders. Choose the last version where no issue was seen; in most cases it will be the version before the one that caused the alert.
+- If the `block-builder-scheduler.lookback-on-no-commit` does not cover the time when the issue started, set it long enough so that these new block-builders start back far enough to cover the missing data.
+- Investigate why the block-builder fails, while the ingesters, who consumed the same data, don't.
 
 ### MimirServerInvalidClusterValidationLabelRequests
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1381,7 +1381,6 @@ spec:
               (min by(cluster, namespace, pod) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
               and
               (max by(cluster, namespace, pod) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
-              and
               # Only if blocks aren't shipped by ingesters.
               unless on (cluster, namespace)
               (max by (cluster, namespace) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -851,6 +851,9 @@ spec:
               # receiving samples again. Without this check, the alert would fire as soon as it gets back receiving
               # samples, while the a block shipping is expected within the next 4h.
               (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[1h] offset 4h)) > 0)
+              # And only if blocks aren't shipped by the block-builder.
+              unless on (cluster, namespace)
+              (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
             for: 15m
             labels:
               severity: critical
@@ -862,6 +865,9 @@ spec:
               (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
               and
               (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
+              # Only if blocks aren't shipped by the block-builder.
+              unless on (cluster, namespace)
+              (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
             for: 4h
             labels:
               severity: critical
@@ -873,6 +879,9 @@ spec:
               (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
               and
               (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)
+              # Only if blocks aren't shipped by the block-builder.
+              unless on (cluster, namespace)
+              (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
             for: 15m
             labels:
               severity: critical
@@ -1362,6 +1371,21 @@ spec:
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
             expr: |
               sum by (cluster, namespace, pod) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
+            labels:
+              severity: critical
+          - alert: MimirBlockBuilderHasNotShippedBlocks
+            annotations:
+              message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderhasnotshippedblocks
+            expr: |
+              (min by(cluster, namespace, pod) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
+              and
+              (max by(cluster, namespace, pod) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+              and
+              # Only if blocks aren't shipped by ingesters.
+              unless on (cluster, namespace)
+              (max by (cluster, namespace) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)
+            for: 15m
             labels:
               severity: critical
       - name: mimir_continuous_test

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1355,7 +1355,6 @@ groups:
             (min by(cluster, namespace, instance) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
             and
             (max by(cluster, namespace, instance) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
-            and
             # Only if blocks aren't shipped by ingesters.
             unless on (cluster, namespace)
             (max by (cluster, namespace) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -825,6 +825,9 @@ groups:
             # receiving samples again. Without this check, the alert would fire as soon as it gets back receiving
             # samples, while the a block shipping is expected within the next 4h.
             (max by(cluster, namespace, instance) (max_over_time(cluster_namespace_instance:cortex_ingester_ingested_samples_total:rate1m[1h] offset 4h)) > 0)
+            # And only if blocks aren't shipped by the block-builder.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           for: 15m
           labels:
             severity: critical
@@ -836,6 +839,9 @@ groups:
             (max by(cluster, namespace, instance) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
             and
             (max by(cluster, namespace, instance) (max_over_time(cluster_namespace_instance:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
+            # Only if blocks aren't shipped by the block-builder.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           for: 4h
           labels:
             severity: critical
@@ -847,6 +853,9 @@ groups:
             (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
             and
             (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)
+            # Only if blocks aren't shipped by the block-builder.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           for: 15m
           labels:
             severity: critical
@@ -1336,6 +1345,21 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
           expr: |
             sum by (cluster, namespace, instance) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
+          labels:
+            severity: critical
+        - alert: MimirBlockBuilderHasNotShippedBlocks
+          annotations:
+            message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderhasnotshippedblocks
+          expr: |
+            (min by(cluster, namespace, instance) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
+            and
+            (max by(cluster, namespace, instance) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            and
+            # Only if blocks aren't shipped by ingesters.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)
+          for: 15m
           labels:
             severity: critical
     - name: mimir_continuous_test

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -1369,7 +1369,6 @@ groups:
             (min by(cluster, namespace, pod) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
             and
             (max by(cluster, namespace, pod) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
-            and
             # Only if blocks aren't shipped by ingesters.
             unless on (cluster, namespace)
             (max by (cluster, namespace) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -839,6 +839,9 @@ groups:
             # receiving samples again. Without this check, the alert would fire as soon as it gets back receiving
             # samples, while the a block shipping is expected within the next 4h.
             (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[1h] offset 4h)) > 0)
+            # And only if blocks aren't shipped by the block-builder.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           for: 15m
           labels:
             severity: critical
@@ -850,6 +853,9 @@ groups:
             (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
             and
             (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
+            # Only if blocks aren't shipped by the block-builder.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           for: 4h
           labels:
             severity: critical
@@ -861,6 +867,9 @@ groups:
             (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
             and
             (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)
+            # Only if blocks aren't shipped by the block-builder.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           for: 15m
           labels:
             severity: critical
@@ -1350,6 +1359,21 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
           expr: |
             sum by (cluster, namespace, pod) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
+          labels:
+            severity: critical
+        - alert: MimirBlockBuilderHasNotShippedBlocks
+          annotations:
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderhasnotshippedblocks
+          expr: |
+            (min by(cluster, namespace, pod) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
+            and
+            (max by(cluster, namespace, pod) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            and
+            # Only if blocks aren't shipped by ingesters.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)
+          for: 15m
           labels:
             severity: critical
     - name: mimir_continuous_test

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1369,7 +1369,6 @@ groups:
             (min by(cluster, namespace, pod) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
             and
             (max by(cluster, namespace, pod) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
-            and
             # Only if blocks aren't shipped by ingesters.
             unless on (cluster, namespace)
             (max by (cluster, namespace) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -839,6 +839,9 @@ groups:
             # receiving samples again. Without this check, the alert would fire as soon as it gets back receiving
             # samples, while the a block shipping is expected within the next 4h.
             (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[1h] offset 4h)) > 0)
+            # And only if blocks aren't shipped by the block-builder.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           for: 15m
           labels:
             severity: critical
@@ -850,6 +853,9 @@ groups:
             (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
             and
             (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
+            # Only if blocks aren't shipped by the block-builder.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           for: 4h
           labels:
             severity: critical
@@ -861,6 +867,9 @@ groups:
             (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
             and
             (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)
+            # Only if blocks aren't shipped by the block-builder.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           for: 15m
           labels:
             severity: critical
@@ -1350,6 +1359,21 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
           expr: |
             sum by (cluster, namespace, pod) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[1m])) > 0
+          labels:
+            severity: critical
+        - alert: MimirBlockBuilderHasNotShippedBlocks
+          annotations:
+            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderhasnotshippedblocks
+          expr: |
+            (min by(cluster, namespace, pod) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
+            and
+            (max by(cluster, namespace, pod) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            and
+            # Only if blocks aren't shipped by ingesters.
+            unless on (cluster, namespace)
+            (max by (cluster, namespace) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)
+          for: 15m
           labels:
             severity: critical
     - name: mimir_continuous_test

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -21,6 +21,9 @@
             # receiving samples again. Without this check, the alert would fire as soon as it gets back receiving
             # samples, while the a block shipping is expected within the next 4h.
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate%(recording_rules_range_interval)s[1h] offset 4h)) > 0)
+            # And only if blocks aren't shipped by the block-builder.
+            unless on (%(alert_aggregation_labels)s)
+            (max by (%(alert_aggregation_labels)s) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
@@ -43,6 +46,9 @@
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
             and
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate%(recording_rules_range_interval)s[4h])) > 0)
+            # Only if blocks aren't shipped by the block-builder.
+            unless on (%(alert_aggregation_labels)s)
+            (max by (%(alert_aggregation_labels)s) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
@@ -66,7 +72,12 @@
             (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
             and
             (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)
-          |||,
+            # Only if blocks aren't shipped by the block-builder.
+            unless on (%(alert_aggregation_labels)s)
+            (max by (%(alert_aggregation_labels)s) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+          ||| % {
+            alert_aggregation_labels: $._config.alert_aggregation_labels,
+          },
           labels: {
             severity: 'critical',
           },

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -288,6 +288,28 @@
             message: '%(product)s {{ $labels.%(per_instance_label)s }} in %(alert_aggregation_variables)s fails to compact and upload blocks.' % $._config,
           },
         },
+
+        // Alert if block-builder didn't ship blocks in the past hours.
+        // This is similar to the blocks shipment alerts from the ingesters.
+        {
+          alert: $.alertName('BlockBuilderHasNotShippedBlocks'),
+          'for': '15m',
+          expr: |||
+            (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
+            and
+            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            and
+            # Only if blocks aren't shipped by ingesters.
+            unless on (%(alert_aggregation_labels)s)
+            (max by (%(alert_aggregation_labels)s) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)
+          ||| % $._config,
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: '%(product)s {{ $labels.%(per_instance_label)s }} in %(alert_aggregation_variables)s has not shipped any block in the last 4 hours.' % $._config,
+          },
+        },
       ],
     },
   ],

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -298,7 +298,6 @@
             (min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
             and
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
-            and
             # Only if blocks aren't shipped by ingesters.
             unless on (%(alert_aggregation_labels)s)
             (max by (%(alert_aggregation_labels)s) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)


### PR DESCRIPTION
#### What this PR does

In #11872 we added the `cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds` metric, that the block-builder exposes to track its shipment of blocks.

In this PR we update the ingester alerts to not trigger if the mentioned metric exists. This is so we could safely stop the ingesters from uploading the blocks to the object store, while the block-builder is doing that.

Also, the PR updates related runbooks. It removes the references to alerts and metrics of the legacy stand-alone mode, and adds the new one.