### PR TITLE
Fix issues with `mimirtool remote-read export` and long time ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,10 @@
 ### Mimirtool
 
 * [FEATURE] Add `--enable-experimental-functions` flag to commands that parse PromQL to allow parsing experimental functions such as `sort_by_label()`.
+* [ENHANCEMENT] Add `--block-size` CLI flag to `remote-read export` that allows setting the output block size. #12025
 * [BUGFIX] Fix issue where `remote-read` doesn't behave like other mimirtool commands for authentication. #11402
+* [BUGFIX] Fix issue where `remote-read export` could omit some samples if the query time range spanned multiple blocks. #12025
+* [BUGFIX] Fix issue where `remote-read export` could omit some output blocks in the list printed to the console, or fail with `read/write on closed pipe`. #12025
 
 ### Mimir Continuous Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,8 +185,8 @@
 * [FEATURE] Add `--enable-experimental-functions` flag to commands that parse PromQL to allow parsing experimental functions such as `sort_by_label()`.
 * [ENHANCEMENT] Add `--block-size` CLI flag to `remote-read export` that allows setting the output block size. #12025
 * [BUGFIX] Fix issue where `remote-read` doesn't behave like other mimirtool commands for authentication. #11402
-* [BUGFIX] Fix issue where `remote-read export` could omit some samples if the query time range spanned multiple blocks. #12025
-* [BUGFIX] Fix issue where `remote-read export` could omit some output blocks in the list printed to the console, or fail with `read/write on closed pipe`. #12025
+* [BUGFIX] Fix issue where `remote-read export` could omit some samples if the query time range spans multiple blocks. #12025
+* [BUGFIX] Fix issue where `remote-read export` could omit some output blocks in the list printed to the console or fail with `read/write on closed pipe`. #12025
 
 ### Mimir Continuous Test
 

--- a/pkg/mimirtool/backfill/backfill.go
+++ b/pkg/mimirtool/backfill/backfill.go
@@ -8,176 +8,108 @@ package backfill
 import (
 	"context"
 	"fmt"
-	"io"
-	"strconv"
-	"strings"
-	"text/tabwriter"
 	"time"
 
-	"github.com/alecthomas/units"
+	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
-	"github.com/prometheus/prometheus/model/histogram"
-	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 )
 
-// copied from https://github.com/prometheus/prometheus/blob/2f54aa060484a9a221eb227e1fb917ae66051c76/cmd/promtool/tsdb.go#L361-L398
-
-func printBlocks(blocks []tsdb.BlockReader, writeHeader, humanReadable bool, output io.Writer) {
-	tw := tabwriter.NewWriter(output, 13, 0, 2, ' ', 0)
-	defer tw.Flush()
-
-	if writeHeader {
-		fmt.Fprintln(tw, "BLOCK ULID\tMIN TIME\tMAX TIME\tDURATION\tNUM SAMPLES\tNUM CHUNKS\tNUM SERIES\tSIZE")
-	}
-
-	for _, b := range blocks {
-		meta := b.Meta()
-
-		fmt.Fprintf(tw,
-			"%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-			meta.ULID,
-			getFormattedTime(meta.MinTime, humanReadable),
-			getFormattedTime(meta.MaxTime, humanReadable),
-			time.Duration(meta.MaxTime-meta.MinTime)*time.Millisecond,
-			meta.Stats.NumSamples,
-			meta.Stats.NumChunks,
-			meta.Stats.NumSeries,
-			getFormattedBytes(b.Size(), humanReadable),
-		)
-	}
-}
-
-func getFormattedTime(timestamp int64, humanReadable bool) string {
-	if humanReadable {
-		return time.Unix(timestamp/1000, 0).UTC().String()
-	}
-	return strconv.FormatInt(timestamp, 10)
-}
-
-func getFormattedBytes(bytes int64, humanReadable bool) string {
-	if humanReadable {
-		return units.Base2Bytes(bytes).String()
-	}
-	return strconv.FormatInt(bytes, 10)
-}
-
-type Iterator interface {
-	Next() error
-	Sample() (ts int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram)
-	Labels() (l labels.Labels)
-}
-
-type IteratorCreator func() Iterator
-
 // this is adapted from  https://github.com/prometheus/prometheus/blob/2f54aa060484a9a221eb227e1fb917ae66051c76/cmd/promtool/backfill.go#L68-L171
-func CreateBlocks(input IteratorCreator, mint, maxt int64, maxSamplesInAppender int, outputDir string, humanReadable bool, output io.Writer) (returnErr error) {
-	blockDuration := tsdb.DefaultBlockDuration / 2
-	mint = blockDuration * (mint / blockDuration)
-
-	db, err := tsdb.OpenDBReadOnly(outputDir, "", nil)
+func CreateBlock(input storage.SeriesSet, maxSamplesInAppender int, outputDir string, blockDuration time.Duration) (blockID ulid.ULID, returnErr error) {
+	blockWriter, err := tsdb.NewBlockWriter(promslog.NewNopLogger(), outputDir, blockDuration.Milliseconds()*2) // Multiply by 2 so that we can append samples anywhere in the original time window.
 	if err != nil {
-		return err
+		return ulid.Zero, errors.Wrap(err, "create block writer")
 	}
+
 	defer func() {
 		mErr := tsdb_errors.NewMulti()
 		mErr.Add(returnErr)
-		mErr.Add(db.Close())
+		mErr.Add(blockWriter.Close())
 		returnErr = mErr.Err()
 	}()
 
-	var wroteHeader bool
+	ctx := context.Background()
+	var it chunkenc.Iterator
 
-	for blockMinT := mint; blockMinT <= maxt; blockMinT = blockMinT + blockDuration {
-		blockMaxT := blockMinT + blockDuration
-		err := func() error {
-			w, err := tsdb.NewBlockWriter(promslog.NewNopLogger(), outputDir, blockDuration)
-			if err != nil {
-				return errors.Wrap(err, "block writer")
-			}
-			defer func() {
-				mErr := tsdb_errors.NewMulti()
-				mErr.Add(err)
-				mErr.Add(w.Close())
-				err = mErr.Err()
-			}()
+	for input.Next() {
+		if err := input.Err(); err != nil {
+			return ulid.Zero, errors.Wrap(err, "read next series")
+		}
 
-			ctx := context.Background()
-			app := w.Appender(ctx)
-			i := input()
-			samplesCount := 0
-			for {
-				err := i.Next()
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				if err != nil {
-					return errors.Wrap(err, "input")
-				}
+		series := input.At()
+		it = series.Iterator(it)
+		app := blockWriter.Appender(ctx)
 
-				ts, v, h, fh := i.Sample()
-				if ts < blockMinT || ts >= blockMaxT {
-					continue
-				}
+		var seriesRef storage.SeriesRef
+		samplesCount := 0
 
-				l := i.Labels()
-				if h != nil || fh != nil {
-					_, err = app.AppendHistogram(0, i.Labels(), ts, h, fh)
-				} else {
-					_, err = app.Append(0, i.Labels(), ts, v)
-				}
-				if err != nil {
-					return errors.Wrap(err, fmt.Sprintf("add sample for metric=%s ts=%s value=%f", l, model.Time(ts).Time().Format(time.RFC3339Nano), v))
-				}
-
-				samplesCount++
-				if samplesCount < maxSamplesInAppender {
-					continue
-				}
-
-				// If we arrive here, the samples count is greater than the maxSamplesInAppender.
-				// Therefore the old appender is committed and a new one is created.
-				// This prevents keeping too many samples lined up in an appender and thus in RAM.
-				if err := app.Commit(); err != nil {
-					return errors.Wrap(err, "commit")
-				}
-
-				app = w.Appender(ctx)
-				samplesCount = 0
+		commit := func() error {
+			if samplesCount == 0 {
+				return nil
 			}
 
 			if err := app.Commit(); err != nil {
 				return errors.Wrap(err, "commit")
 			}
 
-			block, err := w.Flush(ctx)
-			if err != nil && !strings.Contains(err.Error(), "no series appended, aborting") {
-				return errors.Wrap(err, "flush")
+			app = blockWriter.Appender(ctx)
+			samplesCount = 0
+			seriesRef = 0
+			return nil
+		}
+
+		for {
+			valueType := it.Next()
+			if valueType == chunkenc.ValNone {
+				break
 			}
 
-			blocks, err := db.Blocks()
-			if err != nil {
-				return errors.Wrap(err, "get blocks")
+			var err error
+
+			switch valueType {
+			case chunkenc.ValFloat:
+				t, v := it.At()
+				seriesRef, err = app.Append(seriesRef, series.Labels(), t, v)
+			case chunkenc.ValFloatHistogram:
+				t, h := it.AtFloatHistogram(nil)
+				seriesRef, err = app.AppendHistogram(seriesRef, series.Labels(), t, nil, h)
+			case chunkenc.ValHistogram:
+				t, h := it.AtHistogram(nil)
+				seriesRef, err = app.AppendHistogram(seriesRef, series.Labels(), t, h, nil)
+			default:
+				return ulid.Zero, fmt.Errorf("unexpected value type: %v", valueType)
 			}
-			for _, b := range blocks {
-				if b.Meta().ULID == block {
-					printBlocks([]tsdb.BlockReader{b}, !wroteHeader, humanReadable, output)
-					wroteHeader = true
-					break
+
+			if err != nil {
+				return ulid.Zero, errors.Wrap(err, "append sample")
+			}
+
+			samplesCount++
+			if samplesCount > maxSamplesInAppender {
+				if err := commit(); err != nil {
+					return ulid.Zero, err
 				}
 			}
+		}
 
-			return nil
-		}()
+		if err := it.Err(); err != nil {
+			return ulid.Zero, errors.Wrap(err, "read series data")
+		}
 
-		if err != nil {
-			return errors.Wrap(err, "process blocks")
+		if err := commit(); err != nil {
+			return ulid.Zero, err
 		}
 	}
-	return nil
 
+	blockID, err = blockWriter.Flush(ctx)
+	if err != nil {
+		return ulid.Zero, errors.Wrap(err, "flush")
+	}
+
+	return blockID, nil
 }

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -429,11 +429,10 @@ func (c *RemoteReadCommand) export(_ *kingpin.ParseContext) error {
 				return err
 			}
 			log.Infof("Created TSDB in path '%s'", c.tsdbPath)
+		} else {
+			log.Infof("Using existing TSDB in path '%s'", c.tsdbPath)
 		}
-		log.Infof("Using existing TSDB in path '%s'", c.tsdbPath)
 	}
-
-	log.Infof("Store TSDB blocks in '%s'", c.tsdbPath)
 
 	ctx := context.Background()
 	var blocks []ulid.ULID

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -472,6 +472,7 @@ func (c *RemoteReadCommand) export(_ *kingpin.ParseContext) error {
 
 	pipeR, pipeW := io.Pipe()
 	go func() {
+		defer pipeR.Close()
 		scanner := bufio.NewScanner(pipeR)
 		for scanner.Scan() {
 			log.Info(scanner.Text())
@@ -480,7 +481,7 @@ func (c *RemoteReadCommand) export(_ *kingpin.ParseContext) error {
 			log.Error("reading block status:", err)
 		}
 	}()
-	defer pipeR.Close()
+	defer pipeW.Close()
 
 	log.Infof("Store TSDB blocks in '%s'", c.tsdbPath)
 	if err := backfill.CreateBlocks(iteratorCreator, int64(mint), int64(maxt), 1000, c.tsdbPath, true, pipeW); err != nil {

--- a/pkg/mimirtool/commands/remote_read.go
+++ b/pkg/mimirtool/commands/remote_read.go
@@ -447,7 +447,7 @@ func (c *RemoteReadCommand) export(_ *kingpin.ParseContext) error {
 			return err
 		}
 
-		block, err := backfill.CreateBlock(timeseries, 1000, c.tsdbPath, c.blockSize)
+		block, err := backfill.CreateBlock(timeseries, c.tsdbPath, c.blockSize)
 		if err != nil {
 			return err
 		}

--- a/pkg/mimirtool/commands/remote_read_test.go
+++ b/pkg/mimirtool/commands/remote_read_test.go
@@ -262,7 +262,7 @@ func TestExport(t *testing.T) {
 						to:            testCase.queryTo.Format(time.RFC3339Nano),
 						readTimeout:   30 * time.Second,
 						readSizeLimit: DefaultChunkedReadLimit,
-						blockSize:     time.Duration(tsdb.DefaultBlockDuration) * time.Millisecond,
+						blockDuration: time.Duration(tsdb.DefaultBlockDuration) * time.Millisecond,
 					}
 
 					require.NoError(t, c.export(nil), "expected export to complete without error")

--- a/pkg/mimirtool/commands/remote_read_test.go
+++ b/pkg/mimirtool/commands/remote_read_test.go
@@ -6,15 +6,27 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
 	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/mimirtool/backfill"
 )
@@ -166,4 +178,247 @@ func TestEarlyCommit(t *testing.T) {
 	}
 	err := backfill.CreateBlocks(iterator, start, end, maxSamplesPerBlock, t.TempDir(), true, io.Discard)
 	assert.NoError(t, err)
+}
+
+type exportTestCase struct {
+	queryFrom time.Time
+	queryTo   time.Time
+	series    []*prompb.TimeSeries
+}
+
+func TestExport(t *testing.T) {
+	start := time.Date(2025, 5, 1, 0, 5, 0, 0, time.UTC)
+	metricName := "some_metric"
+
+	testCases := map[string]exportTestCase{
+		"data entirely within single block": {
+			queryFrom: start,
+			queryTo:   start.Add(5 * time.Minute),
+			series: []*prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{Name: labels.MetricName, Value: metricName},
+						{Name: "idx", Value: "0"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: timestamp.FromTime(start), Value: 0.0},
+						{Timestamp: timestamp.FromTime(start.Add(time.Minute)), Value: 0.1},
+					},
+				},
+				{
+					Labels: []prompb.Label{
+						{Name: labels.MetricName, Value: metricName},
+						{Name: "idx", Value: "1"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: timestamp.FromTime(start), Value: 1.0},
+						{Timestamp: timestamp.FromTime(start.Add(time.Minute)), Value: 1.1},
+					},
+				},
+			},
+		},
+		"data entirely within second half of single block": {
+			queryFrom: start,
+			queryTo:   start.Add(5 * time.Minute),
+			series: []*prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{Name: labels.MetricName, Value: metricName},
+						{Name: "idx", Value: "0"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: timestamp.FromTime(start.Add(time.Hour)), Value: 0.0},
+						{Timestamp: timestamp.FromTime(start.Add(time.Hour).Add(time.Minute)), Value: 0.1},
+					},
+				},
+				{
+					Labels: []prompb.Label{
+						{Name: labels.MetricName, Value: metricName},
+						{Name: "idx", Value: "1"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: timestamp.FromTime(start.Add(time.Hour)), Value: 1.0},
+						{Timestamp: timestamp.FromTime(start.Add(time.Hour).Add(time.Minute)), Value: 1.1},
+					},
+				},
+			},
+		},
+		"data over multiple blocks": {
+			queryFrom: start,
+			queryTo:   start.Add(5 * time.Hour),
+			series: []*prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{Name: labels.MetricName, Value: metricName},
+						{Name: "case", Value: "entirely in first block"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: timestamp.FromTime(start), Value: 0.0},
+						{Timestamp: timestamp.FromTime(start.Add(time.Minute)), Value: 0.1},
+					},
+				},
+				{
+					Labels: []prompb.Label{
+						{Name: labels.MetricName, Value: metricName},
+						{Name: "case", Value: "entirely in second block"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: timestamp.FromTime(start.Add(2 * time.Hour)), Value: 1.0},
+						{Timestamp: timestamp.FromTime(start.Add(2 * time.Hour).Add(time.Minute)), Value: 1.1},
+					},
+				},
+				{
+					Labels: []prompb.Label{
+						{Name: labels.MetricName, Value: metricName},
+						{Name: "case", Value: "across multiple blocks"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: timestamp.FromTime(start), Value: 2.0},
+						{Timestamp: timestamp.FromTime(start.Add(2 * time.Hour)), Value: 2.1},
+					},
+				},
+				{
+					Labels: []prompb.Label{
+						{Name: labels.MetricName, Value: metricName},
+						{Name: "case", Value: "across multiple blocks, with sample on block boundary"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: timestamp.FromTime(start), Value: 3.0},
+						{Timestamp: timestamp.FromTime(start.Add(55 * time.Minute)), Value: 3.1},
+						{Timestamp: timestamp.FromTime(start.Add(2 * time.Hour)), Value: 3.2},
+					},
+				},
+			},
+		},
+	}
+
+	for name, sendChunks := range map[string]bool{"chunks": true, "samples": false} {
+		t.Run(name, func(t *testing.T) {
+
+			for name, testCase := range testCases {
+				t.Run(name, func(t *testing.T) {
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if sendChunks {
+							serveChunks(t, testCase, w)
+						} else {
+							serveSamples(t, testCase, w)
+						}
+					}))
+
+					t.Cleanup(server.Close)
+
+					tsdbPath := t.TempDir()
+
+					c := &RemoteReadCommand{
+						address:       server.URL,
+						tsdbPath:      tsdbPath,
+						selector:      metricName,
+						from:          testCase.queryFrom.Format(time.RFC3339),
+						to:            testCase.queryTo.Format(time.RFC3339),
+						readTimeout:   30 * time.Second,
+						readSizeLimit: DefaultChunkedReadLimit,
+					}
+
+					require.NoError(t, c.export(nil), "expected export to complete without error")
+
+					// Check that the data was written correctly.
+					db, err := tsdb.Open(tsdbPath, nil, nil, nil, nil)
+					require.NoError(t, err)
+					t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+					querier, err := db.Querier(timestamp.FromTime(testCase.queryFrom), timestamp.FromTime(testCase.queryTo))
+					require.NoError(t, err)
+					t.Cleanup(func() { require.NoError(t, querier.Close()) })
+
+					ss := querier.Select(context.Background(), true, nil, labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, metricName))
+					writtenSeries := []*prompb.TimeSeries{}
+					for ss.Next() {
+						series := ss.At()
+						samples := []prompb.Sample{}
+						it := series.Iterator(nil)
+
+						for it.Next() != chunkenc.ValNone {
+							t, v := it.At()
+							samples = append(samples, prompb.Sample{
+								Timestamp: t,
+								Value:     v,
+							})
+						}
+
+						require.NoError(t, it.Err())
+
+						writtenSeries = append(writtenSeries, &prompb.TimeSeries{
+							Labels:  prompb.FromLabels(series.Labels(), nil),
+							Samples: samples,
+						})
+					}
+
+					require.NoError(t, ss.Err())
+					require.ElementsMatch(t, testCase.series, writtenSeries, "expected all samples to be written to TSDB")
+				})
+			}
+		})
+	}
+}
+
+func serveSamples(t *testing.T, testCase exportTestCase, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/x-protobuf")
+
+	resp := &prompb.ReadResponse{
+		Results: []*prompb.QueryResult{
+			{
+				Timeseries: testCase.series,
+			},
+		},
+	}
+	msg, err := proto.Marshal(resp)
+	require.NoError(t, err)
+
+	_, err = w.Write(snappy.Encode(nil, msg))
+	require.NoError(t, err)
+}
+
+func serveChunks(t *testing.T, testCase exportTestCase, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/x-streamed-protobuf; proto=prometheus.ChunkedReadResponse")
+
+	flusher, ok := w.(http.Flusher)
+	require.True(t, ok)
+
+	chunkedWriter := remote.NewChunkedWriter(w, flusher)
+
+	for _, s := range testCase.series {
+		chunk := chunkenc.NewXORChunk()
+		a, err := chunk.Appender()
+		require.NoError(t, err)
+
+		minTime := s.Samples[0].Timestamp
+		maxTime := s.Samples[0].Timestamp
+
+		for _, sample := range s.Samples {
+			a.Append(sample.Timestamp, sample.Value)
+			minTime = min(minTime, sample.Timestamp)
+			maxTime = max(maxTime, sample.Timestamp)
+		}
+
+		resp := prompb.ChunkedReadResponse{
+			ChunkedSeries: []*prompb.ChunkedSeries{
+				{
+					Labels: s.Labels,
+					Chunks: []prompb.Chunk{
+						{
+							MinTimeMs: minTime,
+							MaxTimeMs: maxTime,
+							Type:      prompb.Chunk_XOR,
+							Data:      chunk.Bytes(),
+						},
+					},
+				},
+			},
+		}
+
+		msg, err := proto.Marshal(&resp)
+		require.NoError(t, err)
+		_, err = chunkedWriter.Write(msg)
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes a number of issues in `mimirtool remote-read export` that could occur when querying a range longer than an hour, or that crossed block boundaries (which were hardcoded to 2h in size). In particular, queries that crossed block boundaries could omit some output blocks.

Key changes:

- Output blocks will now be 2h in length, not 1h, and this can be configured with `--block-size`.
- Time ranges that cross block boundaries are now handled correctly, including for cases where some series appear in only some output blocks.
- Long time ranges are now broken up into intervals that match the output block size, reducing the amount of data that must be held in memory by `mimirtool` and simplifying the logic of producing blocks in this case. 
  - An alternative solution would be to create multiple block writers, one for each output block, and append to the correct one based on the samples received, but this would require all received samples to be held in memory until the last one is received.
- Details of blocks are now reliably printed to the console, rather than sometimes being incomplete or omitted entirely, or failing with `read/write on closed pipe`.

#### Which issue(s) this PR fixes or relates to

Related to #11404

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
