### PR TITLE
mqe: init Subquery childStats in a NewSubquery to avoid panic 

### DIFF
--- a/pkg/streamingpromql/operators/subquery_test.go
+++ b/pkg/streamingpromql/operators/subquery_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package operators
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+	"github.com/grafana/mimir/pkg/util/limiter"
+)
+
+func TestSubquery_CloseWithoutPrepare(t *testing.T) {
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+
+	inner := &TestOperator{
+		Series:                   []labels.Labels{},
+		Data:                     []types.InstantVectorSeriesData{},
+		MemoryConsumptionTracker: memoryConsumptionTracker,
+	}
+
+	// Create time ranges
+	parentQueryTimeRange := types.NewInstantQueryTimeRange(timestamp.Time(0))
+
+	subqueryTimeRange := types.NewRangeQueryTimeRange(timestamp.Time(0), timestamp.Time(0).Add(2*time.Minute), time.Minute)
+
+	subquery, err := NewSubquery(
+		inner,
+		parentQueryTimeRange,
+		subqueryTimeRange,
+		nil,
+		0,
+		time.Minute,
+		posrange.PositionRange{Start: 0, End: 10},
+		memoryConsumptionTracker,
+	)
+	require.NoError(t, err)
+
+	// Call Close() twice without calling Prepare() first
+	// This should not panic or cause any issues
+	subquery.Close()
+	subquery.Close()
+}

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -133,7 +133,10 @@ func (s *Subquery) OperatorFactory(children []types.Operator, timeRange types.Qu
 	if !ok {
 		return nil, fmt.Errorf("expected InstantVectorOperator as child of Subquery, got %T", children[0])
 	}
-	o := operators.NewSubquery(inner, timeRange, s.ChildrenTimeRange(timeRange), TimestampFromTime(s.Timestamp), s.Offset, s.Range, s.ExpressionPosition.ToPrometheusType(), params.MemoryConsumptionTracker)
+	o, err := operators.NewSubquery(inner, timeRange, s.ChildrenTimeRange(timeRange), TimestampFromTime(s.Timestamp), s.Offset, s.Range, s.ExpressionPosition.ToPrometheusType(), params.MemoryConsumptionTracker)
+	if err != nil {
+		return nil, err
+	}
 
 	return planning.NewSingleUseOperatorFactory(o), nil
 }


### PR DESCRIPTION
Fixes a panic in the Subquery operator that could occur if `Close() `is invoked after a failed` Prepare()` call:
1. subqueryStats is initialized during Prepare()
2. if `Prepare()` fails, subqueryStats remains nil.
3. calling `Close()` result in a nil pointer dereference when attempting to call `subqueryStats.Close()`.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
4. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [N/A] Documentation added.
- [N/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
