### PR TITLE
Reduce TestConcurrentFetchers flakyness likelihood

### DIFF
--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -141,6 +141,9 @@ type KafkaConfig struct {
 	// The fetch backoff config to use in the concurrent fetchers (when enabled). This setting
 	// is just used to change the default backoff in tests.
 	concurrentFetchersFetchBackoffConfig backoff.Config `yaml:"-"`
+
+	// Disable producer linger. This setting is just used in tests.
+	disableLinger bool `yaml:"-"`
 }
 
 func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -310,13 +310,18 @@ func TestConcurrentFetchers(t *testing.T) {
 	)
 
 	waitForStableBufferedRecords := func(t *testing.T, f fetcher) {
-		previousBufferedRecords := int64(0)
-		assert.Eventually(t, func() bool {
+		// Initialise the previous buffered records with an invalid value, so that at least
+		// we wait 1 tick before comparing values. If we would have initialised this value to 0
+		// and the first reading is 0, this function would return immediately without doing
+		// any real comparison.
+		previousBufferedRecords := int64(-1)
+
+		require.Eventually(t, func() bool {
 			bufferedRecords := f.BufferedRecords()
 			stabilized := bufferedRecords == previousBufferedRecords
 			previousBufferedRecords = bufferedRecords
 			return stabilized
-		}, 2*time.Second, 100*time.Millisecond)
+		}, 5*time.Second, 100*time.Millisecond)
 	}
 
 	t.Run("respect context cancellation", func(t *testing.T) {
@@ -793,7 +798,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("respect maximum buffered bytes limit", func(t *testing.T) {
-		t.Parallel()
+		// This test produces a large number of large records. Do NOT run it concurrently because it may cause
+		// some flakyness, due to assertion timeouts being hit, if slowed down excessively.
 
 		const (
 			topicName        = "test-topic"
@@ -801,8 +807,14 @@ func TestConcurrentFetchers(t *testing.T) {
 			concurrency      = 3
 			maxInflightBytes = 10_000_000
 
-			recordSizeBytes      = 100_000 // sizable records so that our lower limit of 1MB per fetch request doesn't just include all records
-			totalProducedRecords = 6000    // produce a lot of records so that the client is forced to split them into multiple fetches
+			// Create records with a size equal to the initial estimation, to get predictable concurrency.
+			recordSizeBytes = initialBytesPerRecord
+
+			// Produce a lot of records so that the client is forced to split them into multiple fetches.
+			totalProducedRecords = 6000
+
+			// produce records in batches to simulate a real world case.
+			produceRecordsBatchSize = forcedMinValueForMaxBytes / recordSizeBytes
 		)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -811,11 +823,21 @@ func TestConcurrentFetchers(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 		client := newKafkaProduceClient(t, clusterAddr)
 
-		// Produce records
+		// Produce records in batches.
+		t.Logf("Producing %d records", totalProducedRecords)
+
 		recordValue := bytes.Repeat([]byte{'a'}, recordSizeBytes)
-		for i := 0; i < totalProducedRecords; i++ {
-			produceRecord(ctx, t, client, topicName, partitionID, recordValue)
+		for i := 0; i < totalProducedRecords; i += produceRecordsBatchSize {
+			batchSize := min(totalProducedRecords-i, produceRecordsBatchSize)
+			records := make([]*kgo.Record, 0, batchSize)
+			for r := 0; r < batchSize; r++ {
+				records = append(records, createRecord(topicName, partitionID, recordValue, 0))
+			}
+
+			client.ProduceSync(ctx, records...)
 		}
+
+		t.Logf("Produced %d records", totalProducedRecords)
 
 		// Create fetchers with tracking of uncompressed bytes
 		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, maxInflightBytes, true)
@@ -916,7 +938,6 @@ func TestConcurrentFetchers(t *testing.T) {
 		assert.GreaterOrEqual(t, fetchers.BufferedBytes(), int64(maxInflightBytes/2), "Should still buffer a decent number of records")
 
 		// Consume the rest of the small records.
-		// Consume half of the small records. This should be enough to stabilize the records size estimation.
 		fetches = longPollFetches(fetchers, smallRecordsCount/2, 10*time.Second)
 		consumedRecords += fetches.NumRecords()
 		t.Log("Consumed rest of the small records")


### PR DESCRIPTION
#### What this PR does

In this PR I'm (hopefully) reducing the likehood of `TestConcurrentFetchers` flakyness, in particular focusing on `respect maximum buffered bytes limit` case, which is the most flaky one. I'm not calling it a fix because, as usual, I haven't been able to reproduce it locally, but the changes have been originated from the behaviour I've observed in CI execution logs. Here you can see the [logs of a failed execution](https://github.com/grafana/mimir/issues/11859#issuecomment-3052493066).

In this PR:

- Do not run the `respect maximum buffered bytes limit` concurrently. I've seen in logs that there's essentially nothing wrong, but it takes longer than 2s to reach stabilization (and from logs I can see it was still fetching records).
- Increase `waitForStableBufferedRecords()` timeout from 2s to 5s.
- Improve `waitForStableBufferedRecords()` for the case when the buffered records is 0 when it gets called. Previously there was no comparison, now it waits 1 tick (100ms) and then run the comparison.
- Produce records in batches, like in a real world scenario. Previously in the test records were produced in individual batches, which means kfake was actually returning 1 record at a time, regardless how many we requested (behaviour is clearly visible in logs). This also makes the consumption (fetcher) much faster because it fetches 1 batch at a time, instead of 1 record at a time from kfake.
- To produce records, use the real kafka client config we use in distributors, but without lingering (to have tests run faster).

Time will tell if this helps.

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/11859

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
