### PR TITLE
Alertmanager: Improve metrics and add tracing for pre-notify hooks.

### DIFF
--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -260,7 +260,7 @@ func newAlertmanagerMetrics(logger log.Logger) *alertmanagerMetrics {
 			"Number of times a pre-notify was attempted but failed.",
 			[]string{"status_code"}, nil),
 		notifyHookDuration: prometheus.NewDesc(
-			"alertmanager_notify_hook_duration_seconds",
+			"cortex_alertmanager_notify_hook_duration_seconds",
 			"Time spent invoking pre-notify hooks.",
 			nil, nil),
 		dispatcherAggrGroups: prometheus.NewDesc(
@@ -409,8 +409,8 @@ func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
 
 	data.SendSumOfCounters(out, m.notifyHookTotal, "alertmanager_notify_hook_total")
 	data.SendSumOfCounters(out, m.notifyHookNoop, "alertmanager_notify_hook_noop_total")
-	data.SendSumOfCounters(out, m.notifyHookFailed, "alertmanager_notify_hook_failed_total")
-	data.SendSumOfCounters(out, m.notifyHookDuration, "alertmanager_notify_hook_duration_seconds")
+	data.SendSumOfCountersWithLabels(out, m.notifyHookFailed, "alertmanager_notify_hook_failed_total", "status_code")
+	data.SendSumOfHistograms(out, m.notifyHookDuration, "alertmanager_notify_hook_duration_seconds")
 
 	data.SendSumOfGauges(out, m.dispatcherAggrGroups, "alertmanager_dispatcher_aggregation_groups")
 	data.SendSumOfSummaries(out, m.dispatcherProcessingDuration, "alertmanager_dispatcher_alert_processing_duration_seconds")

--- a/pkg/alertmanager/alertmanager_metrics.go
+++ b/pkg/alertmanager/alertmanager_metrics.go
@@ -71,6 +71,7 @@ type alertmanagerMetrics struct {
 	notifyHookTotal         *prometheus.Desc
 	notifyHookNoop          *prometheus.Desc
 	notifyHookFailed        *prometheus.Desc
+	notifyHookDuration      *prometheus.Desc
 
 	// exported metrics, gathered from Alertmanager Dispatcher
 	dispatcherAggrGroups                    *prometheus.Desc
@@ -257,6 +258,10 @@ func newAlertmanagerMetrics(logger log.Logger) *alertmanagerMetrics {
 		notifyHookFailed: prometheus.NewDesc(
 			"cortex_alertmanager_notify_hook_failed_total",
 			"Number of times a pre-notify was attempted but failed.",
+			[]string{"status_code"}, nil),
+		notifyHookDuration: prometheus.NewDesc(
+			"alertmanager_notify_hook_duration_seconds",
+			"Time spent invoking pre-notify hooks.",
 			nil, nil),
 		dispatcherAggrGroups: prometheus.NewDesc(
 			"cortex_alertmanager_dispatcher_aggregation_groups",
@@ -343,6 +348,7 @@ func (m *alertmanagerMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- m.notifyHookTotal
 	out <- m.notifyHookNoop
 	out <- m.notifyHookFailed
+	out <- m.notifyHookDuration
 	out <- m.dispatcherAggrGroups
 	out <- m.dispatcherProcessingDuration
 	out <- m.dispatcherAggregationGroupsLimitReached
@@ -404,6 +410,7 @@ func (m *alertmanagerMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, m.notifyHookTotal, "alertmanager_notify_hook_total")
 	data.SendSumOfCounters(out, m.notifyHookNoop, "alertmanager_notify_hook_noop_total")
 	data.SendSumOfCounters(out, m.notifyHookFailed, "alertmanager_notify_hook_failed_total")
+	data.SendSumOfCounters(out, m.notifyHookDuration, "alertmanager_notify_hook_duration_seconds")
 
 	data.SendSumOfGauges(out, m.dispatcherAggrGroups, "alertmanager_dispatcher_aggregation_groups")
 	data.SendSumOfSummaries(out, m.dispatcherProcessingDuration, "alertmanager_dispatcher_alert_processing_duration_seconds")

--- a/pkg/alertmanager/alertmanager_metrics_test.go
+++ b/pkg/alertmanager/alertmanager_metrics_test.go
@@ -319,15 +319,17 @@ func TestAlertmanagerMetricsStore(t *testing.T) {
 		# HELP cortex_alertmanager_state_persist_total Number of times we have tried to persist the running state to storage.
 		# TYPE cortex_alertmanager_state_persist_total counter
 		cortex_alertmanager_state_persist_total 0
-		# HELP cortex_alertmanager_notify_hook_failed_total Number of times a pre-notify was attempted but failed.
-		# TYPE cortex_alertmanager_notify_hook_failed_total counter
-		cortex_alertmanager_notify_hook_failed_total 0
 		# HELP cortex_alertmanager_notify_hook_noop_total Number of times a pre-notify hook was invoked successfully but did nothing.
 		# TYPE cortex_alertmanager_notify_hook_noop_total counter
 		cortex_alertmanager_notify_hook_noop_total 0
 		# HELP cortex_alertmanager_notify_hook_total Number of times a pre-notify hook was invoked.
 		# TYPE cortex_alertmanager_notify_hook_total counter
 		cortex_alertmanager_notify_hook_total 0
+		# HELP cortex_alertmanager_notify_hook_duration_seconds Time spent invoking pre-notify hooks.
+		# TYPE cortex_alertmanager_notify_hook_duration_seconds histogram
+		cortex_alertmanager_notify_hook_duration_seconds_bucket{le="+Inf"} 0
+		cortex_alertmanager_notify_hook_duration_seconds_sum 0
+		cortex_alertmanager_notify_hook_duration_seconds_count 0
 
 		# HELP cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total Number of times when dispatcher failed to create new aggregation group due to limit.
 		# TYPE cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total counter
@@ -675,15 +677,17 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 						# HELP cortex_alertmanager_state_persist_total Number of times we have tried to persist the running state to storage.
 						# TYPE cortex_alertmanager_state_persist_total counter
 						cortex_alertmanager_state_persist_total 0
-						# HELP cortex_alertmanager_notify_hook_failed_total Number of times a pre-notify was attempted but failed.
-						# TYPE cortex_alertmanager_notify_hook_failed_total counter
-						cortex_alertmanager_notify_hook_failed_total 0
 						# HELP cortex_alertmanager_notify_hook_noop_total Number of times a pre-notify hook was invoked successfully but did nothing.
 						# TYPE cortex_alertmanager_notify_hook_noop_total counter
 						cortex_alertmanager_notify_hook_noop_total 0
-				 		# HELP cortex_alertmanager_notify_hook_total Number of times a pre-notify hook was invoked.
+						# HELP cortex_alertmanager_notify_hook_total Number of times a pre-notify hook was invoked.
 						# TYPE cortex_alertmanager_notify_hook_total counter
 						cortex_alertmanager_notify_hook_total 0
+						# HELP cortex_alertmanager_notify_hook_duration_seconds Time spent invoking pre-notify hooks.
+						# TYPE cortex_alertmanager_notify_hook_duration_seconds histogram
+						cortex_alertmanager_notify_hook_duration_seconds_bucket{le="+Inf"} 0
+						cortex_alertmanager_notify_hook_duration_seconds_sum 0
+						cortex_alertmanager_notify_hook_duration_seconds_count 0
 
 						# HELP cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total Number of times when dispatcher failed to create new aggregation group due to limit.
 						# TYPE cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total counter
@@ -972,15 +976,17 @@ func TestAlertmanagerMetricsRemoval(t *testing.T) {
 			# HELP cortex_alertmanager_state_persist_total Number of times we have tried to persist the running state to storage.
 			# TYPE cortex_alertmanager_state_persist_total counter
 			cortex_alertmanager_state_persist_total 0
-			# HELP cortex_alertmanager_notify_hook_failed_total Number of times a pre-notify was attempted but failed.
-			# TYPE cortex_alertmanager_notify_hook_failed_total counter
-			cortex_alertmanager_notify_hook_failed_total 0
 			# HELP cortex_alertmanager_notify_hook_noop_total Number of times a pre-notify hook was invoked successfully but did nothing.
 			# TYPE cortex_alertmanager_notify_hook_noop_total counter
 			cortex_alertmanager_notify_hook_noop_total 0
 			# HELP cortex_alertmanager_notify_hook_total Number of times a pre-notify hook was invoked.
 	  		# TYPE cortex_alertmanager_notify_hook_total counter
 			cortex_alertmanager_notify_hook_total 0
+			# HELP cortex_alertmanager_notify_hook_duration_seconds Time spent invoking pre-notify hooks.
+			# TYPE cortex_alertmanager_notify_hook_duration_seconds histogram
+			cortex_alertmanager_notify_hook_duration_seconds_bucket{le="+Inf"} 0
+			cortex_alertmanager_notify_hook_duration_seconds_sum 0
+			cortex_alertmanager_notify_hook_duration_seconds_count 0
 
 			# HELP cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total Number of times when dispatcher failed to create new aggregation group due to limit.
 			# TYPE cortex_alertmanager_dispatcher_aggregation_group_limit_reached_total counter

--- a/pkg/alertmanager/notify_hooks_notifier.go
+++ b/pkg/alertmanager/notify_hooks_notifier.go
@@ -16,13 +16,14 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/user"
-	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
 var (

--- a/pkg/alertmanager/notify_hooks_notifier.go
+++ b/pkg/alertmanager/notify_hooks_notifier.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/user"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/client_golang/prometheus"
@@ -41,9 +42,10 @@ type notifyHooksNotifier struct {
 	logger   log.Logger
 	client   *http.Client
 
-	hookTotal  prometheus.Counter
-	hookNoop   prometheus.Counter
-	hookFailed prometheus.Counter
+	hookTotal    prometheus.Counter
+	hookNoop     prometheus.Counter
+	hookFailed   *prometheus.CounterVec
+	hookDuration prometheus.Histogram
 }
 
 func newNotifyHooksNotifier(upstream notify.Notifier, limits notifyHooksLimits, userID string, logger log.Logger, reg prometheus.Registerer) (*notifyHooksNotifier, error) {
@@ -78,9 +80,14 @@ func newNotifyHooksNotifier(upstream notify.Notifier, limits notifyHooksLimits, 
 			Name: "alertmanager_notify_hook_noop_total",
 			Help: "Number of times a pre-notify hook was invoked successfully but did nothing.",
 		}),
-		hookFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		hookFailed: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "alertmanager_notify_hook_failed_total",
 			Help: "Number of times a pre-notify was attempted but failed.",
+		}, []string{"status_code"}),
+		hookDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:    "alertmanager_notify_hook_duration_seconds",
+			Help:    "Time spent invoking pre-notify hooks.",
+			Buckets: prometheus.DefBuckets,
 		}),
 	}, nil
 }
@@ -115,8 +122,11 @@ func (n *notifyHooksNotifier) apply(ctx context.Context, alerts []*types.Alert) 
 	timeout := n.limits.AlertmanagerNotifyHookTimeout(n.user)
 
 	start := time.Now()
-	newAlerts, err := n.invoke(ctx, l, url, timeout, alerts)
-	l = log.With(l, "duration", time.Since(start))
+	newAlerts, code, err := n.invoke(ctx, l, url, timeout, alerts)
+
+	duration := time.Since(start)
+	n.hookDuration.Observe(float64(duration))
+	l = log.With(l, "duration", duration)
 
 	n.hookTotal.Inc()
 	if err != nil {
@@ -124,7 +134,14 @@ func (n *notifyHooksNotifier) apply(ctx context.Context, alerts []*types.Alert) 
 			n.hookNoop.Inc()
 			level.Debug(l).Log("msg", "Notify hooks applied but returned no content")
 		} else {
-			n.hookFailed.Inc()
+			status := "error"
+			if errors.Is(err, context.DeadlineExceeded) {
+				status = "timeout"
+			}
+			if code > 0 {
+				status = fmt.Sprint(code)
+			}
+			n.hookFailed.WithLabelValues(status).Inc()
 			level.Error(l).Log("msg", "Notify hooks failed", "err", err)
 		}
 		return alerts
@@ -161,12 +178,15 @@ func (n *notifyHooksNotifier) getData(ctx context.Context, l log.Logger, alerts 
 	}
 }
 
-func (n *notifyHooksNotifier) invoke(ctx context.Context, l log.Logger, url string, timeout time.Duration, alerts []*types.Alert) ([]*types.Alert, error) {
+func (n *notifyHooksNotifier) invoke(ctx context.Context, l log.Logger, url string, timeout time.Duration, alerts []*types.Alert) ([]*types.Alert, int, error) {
+	logger, ctx := spanlogger.New(ctx, l, tracer, "NotifyHooksNotifier.Invoke")
+	defer logger.Finish()
+
 	dat := n.getData(ctx, l, alerts)
 
 	var reqBuf bytes.Buffer
 	if err := json.NewEncoder(&reqBuf).Encode(dat); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if timeout > 0 {
@@ -183,30 +203,30 @@ func (n *notifyHooksNotifier) invoke(ctx context.Context, l log.Logger, url stri
 		if ctx.Err() != nil {
 			err = fmt.Errorf("%w: %w", err, context.Cause(ctx))
 		}
-		return nil, notify.RedactURL(err)
+		return nil, 0, notify.RedactURL(err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode/100 != 2 {
 		errBuf, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("unexpected response code=%d body=\"%q\"", resp.StatusCode, string(errBuf))
+		return nil, resp.StatusCode, fmt.Errorf("unexpected response code=%d body=\"%q\"", resp.StatusCode, string(errBuf))
 	}
 
 	if resp.StatusCode == http.StatusNoContent {
 		// If the response indicates there's content, then ignore the response.
-		return nil, ErrNoContent
+		return nil, 0, ErrNoContent
 	}
 
 	respBuf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	var result hookData
 	err = json.Unmarshal(respBuf, &result)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return result.Alerts, nil
+	return result.Alerts, 0, nil
 }

--- a/pkg/alertmanager/notify_hooks_notifier_test.go
+++ b/pkg/alertmanager/notify_hooks_notifier_test.go
@@ -59,7 +59,25 @@ type testHooksFixture struct {
 	notifier *notifyHooksNotifier
 }
 
-func (f *testHooksFixture) assertMetrics(t *testing.T, total, noop, failed int) {
+func (f *testHooksFixture) assertMetricsSuccess(t *testing.T, total, noop int) {
+	t.Helper()
+
+	assert.NoError(t, testutil.GatherAndCompare(f.reg, strings.NewReader(fmt.Sprintf(`
+		# HELP alertmanager_notify_hook_total Number of times a pre-notify hook was invoked.
+		# TYPE alertmanager_notify_hook_total counter
+		alertmanager_notify_hook_total %d
+		# HELP alertmanager_notify_hook_noop_total Number of times a pre-notify hook was invoked successfully but did nothing.
+		# TYPE alertmanager_notify_hook_noop_total counter
+		alertmanager_notify_hook_noop_total %d
+	`, total, noop)),
+		"alertmanager_notify_hook_total",
+		"alertmanager_notify_hook_noop_total",
+		"alertmanager_notify_hook_failed_total",
+		// Don't check duration.
+	))
+}
+
+func (f *testHooksFixture) assertMetricsFailed(t *testing.T, code string, failed int) {
 	t.Helper()
 
 	assert.NoError(t, testutil.GatherAndCompare(f.reg, strings.NewReader(fmt.Sprintf(`
@@ -71,8 +89,13 @@ func (f *testHooksFixture) assertMetrics(t *testing.T, total, noop, failed int) 
 		alertmanager_notify_hook_noop_total %d
 		# HELP alertmanager_notify_hook_failed_total Number of times a pre-notify was attempted but failed.
 		# TYPE alertmanager_notify_hook_failed_total counter
-		alertmanager_notify_hook_failed_total %d
-	`, total, noop, failed))))
+		alertmanager_notify_hook_failed_total{status_code="%s"} %d
+	`, failed, 0, code, failed)),
+		"alertmanager_notify_hook_total",
+		"alertmanager_notify_hook_noop_total",
+		"alertmanager_notify_hook_failed_total",
+		// Don't check duration.
+	))
 }
 
 func newTestHooksFixture(t *testing.T, handlerStatus int, handlerResponse string) *testHooksFixture {
@@ -168,7 +191,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("changed")}, f.upstream.calls)
-		f.assertMetrics(t, 1, 0, 0)
+		f.assertMetricsSuccess(t, 1, 0)
 	})
 	t.Run("hook not invoked when empty url configured", func(t *testing.T) {
 		f := newTestHooksFixture(t, http.StatusOK, okResponse)
@@ -178,7 +201,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
-		f.assertMetrics(t, 0, 0, 0)
+		f.assertMetricsSuccess(t, 0, 0)
 	})
 	t.Run("hook not invoked when matching receiver name configured ", func(t *testing.T) {
 		f := newTestHooksFixture(t, http.StatusOK, okResponse)
@@ -188,7 +211,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
-		f.assertMetrics(t, 0, 0, 0)
+		f.assertMetricsSuccess(t, 0, 0)
 	})
 	t.Run("hook invoked when matching receiver name configured ", func(t *testing.T) {
 		f := newTestHooksFixture(t, http.StatusOK, okResponse)
@@ -198,7 +221,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("changed")}, f.upstream.calls)
-		f.assertMetrics(t, 1, 0, 0)
+		f.assertMetricsSuccess(t, 1, 0)
 	})
 
 	t.Run("hook failing with 500 does not modify alerts", func(t *testing.T) {
@@ -209,7 +232,7 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
-		f.assertMetrics(t, 1, 0, 1)
+		f.assertMetricsFailed(t, "500", 1)
 	})
 	t.Run("hook failing with 500 but returning data does not modify alerts", func(t *testing.T) {
 		f := newTestHooksFixture(t, http.StatusInternalServerError, okResponse)
@@ -219,7 +242,17 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
-		f.assertMetrics(t, 1, 0, 1)
+		f.assertMetricsFailed(t, "500", 1)
+	})
+	t.Run("hook failing with 422 does not modify alerts", func(t *testing.T) {
+		f := newTestHooksFixture(t, http.StatusUnprocessableEntity, ``)
+		f.limits.receivers = []string{"recv"}
+
+		_, err := f.notifier.Notify(makeContext(), makeAlert("foo")...)
+		require.NoError(t, err)
+
+		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
+		f.assertMetricsFailed(t, "422", 1)
 	})
 	t.Run("hook yielding 204 with empty response does not modify alerts", func(t *testing.T) {
 		f := newTestHooksFixture(t, http.StatusNoContent, ``)
@@ -229,6 +262,6 @@ func TestNotifyHooksNotifier(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, [][]*types.Alert{makeAlert("foo")}, f.upstream.calls)
-		f.assertMetrics(t, 1, 1, 0)
+		f.assertMetricsSuccess(t, 1, 1)
 	})
 }


### PR DESCRIPTION
Adds duration metric, and adds status_code to the failed metric.
