### PR TITLE
feature(parquet): Implement store-gateway limits

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -11215,6 +11215,39 @@
               "fieldFlag": "blocks-storage.bucket-store.series-fetch-preference",
               "fieldType": "float",
               "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "parquet_max_row_count",
+              "required": false,
+              "desc": "Maximum number of rows in a parquet file. If the number of rows exceeds this value the query will stop with limit error.",
+              "fieldValue": null,
+              "fieldDefaultValue": 0,
+              "fieldFlag": "blocks-storage.bucket-store.parquet-max-row-count",
+              "fieldType": "int",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "parquet_max_chunk_size_bytes",
+              "required": false,
+              "desc": "Maximum size in bytes that can be fetched from the parquet chunks file. If the size exceeds this value the query will stop with limit error.",
+              "fieldValue": null,
+              "fieldDefaultValue": 0,
+              "fieldFlag": "blocks-storage.bucket-store.parquet-max-chunk-size-bytes",
+              "fieldType": "int",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
+              "name": "parquet_max_data_size_bytes",
+              "required": false,
+              "desc": "Maximum size in bytes that can be fetched from the parquet labels and chunks data files combined in a single query. If the size exceeds this value the query will stop with limit error.",
+              "fieldValue": null,
+              "fieldDefaultValue": 0,
+              "fieldFlag": "blocks-storage.bucket-store.parquet-max-data-size-bytes",
+              "fieldType": "int",
+              "fieldCategory": "advanced"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -771,6 +771,12 @@ Usage of ./cmd/mimir/mimir:
     	How long to cache list of blocks for each tenant. (default 5m0s)
   -blocks-storage.bucket-store.metadata-cache.tenants-list-ttl duration
     	How long to cache list of tenants in the bucket. (default 15m0s)
+  -blocks-storage.bucket-store.parquet-max-chunk-size-bytes uint
+    	Maximum size in bytes that can be fetched from the parquet chunks file. If the size exceeds this value the query will stop with limit error.
+  -blocks-storage.bucket-store.parquet-max-data-size-bytes uint
+    	Maximum size in bytes that can be fetched from the parquet labels and chunks data files combined in a single query. If the size exceeds this value the query will stop with limit error.
+  -blocks-storage.bucket-store.parquet-max-row-count uint
+    	Maximum number of rows in a parquet file. If the number of rows exceeds this value the query will stop with limit error.
   -blocks-storage.bucket-store.partitioner-max-gap-bytes uint
     	Max size - in bytes - of a gap for which the partitioner aggregates together two bucket GET object requests. (default 524288)
   -blocks-storage.bucket-store.posting-offsets-in-mem-sampling int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4864,6 +4864,22 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.series-fetch-preference
   [series_fetch_preference: <float> | default = 0.75]
 
+  # (advanced) Maximum number of rows in a parquet file. If the number of rows
+  # exceeds this value the query will stop with limit error.
+  # CLI flag: -blocks-storage.bucket-store.parquet-max-row-count
+  [parquet_max_row_count: <int> | default = 0]
+
+  # (advanced) Maximum size in bytes that can be fetched from the parquet chunks
+  # file. If the size exceeds this value the query will stop with limit error.
+  # CLI flag: -blocks-storage.bucket-store.parquet-max-chunk-size-bytes
+  [parquet_max_chunk_size_bytes: <int> | default = 0]
+
+  # (advanced) Maximum size in bytes that can be fetched from the parquet labels
+  # and chunks data files combined in a single query. If the size exceeds this
+  # value the query will stop with limit error.
+  # CLI flag: -blocks-storage.bucket-store.parquet-max-data-size-bytes
+  [parquet_max_data_size_bytes: <int> | default = 0]
+
 tsdb:
   # Directory to store TSDBs (including WAL) in the ingesters. This directory is
   # required to be persisted between restarts.

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/opentracing-contrib/go-stdlib v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus-community/parquet-common v0.0.0-20250710090957-8fdc99f06643
+	github.com/prometheus-community/parquet-common v0.0.0-20250714085052-3b8805a2f9ad
 	github.com/prometheus/alertmanager v0.28.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/opentracing-contrib/go-stdlib v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus-community/parquet-common v0.0.0-20250708150752-0811a700a852
+	github.com/prometheus-community/parquet-common v0.0.0-20250710090957-8fdc99f06643
 	github.com/prometheus/alertmanager v0.28.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -905,8 +905,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
-github.com/prometheus-community/parquet-common v0.0.0-20250708150752-0811a700a852 h1:GNUP6g2eSqZbzGTdFK9D1RLQLjZxCkuuA/MkgfB/enQ=
-github.com/prometheus-community/parquet-common v0.0.0-20250708150752-0811a700a852/go.mod h1:zJNGzMKctJoOESjRVaNTlPis3C9VcY3cRzNxj6ll3Is=
+github.com/prometheus-community/parquet-common v0.0.0-20250710090957-8fdc99f06643 h1:XoOXq+q+CcY8MZqAVoPtdG3R6o84aeZpZFDM+C9DJXg=
+github.com/prometheus-community/parquet-common v0.0.0-20250710090957-8fdc99f06643/go.mod h1:zJNGzMKctJoOESjRVaNTlPis3C9VcY3cRzNxj6ll3Is=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=

--- a/go.sum
+++ b/go.sum
@@ -905,8 +905,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
-github.com/prometheus-community/parquet-common v0.0.0-20250710090957-8fdc99f06643 h1:XoOXq+q+CcY8MZqAVoPtdG3R6o84aeZpZFDM+C9DJXg=
-github.com/prometheus-community/parquet-common v0.0.0-20250710090957-8fdc99f06643/go.mod h1:zJNGzMKctJoOESjRVaNTlPis3C9VcY3cRzNxj6ll3Is=
+github.com/prometheus-community/parquet-common v0.0.0-20250714085052-3b8805a2f9ad h1:w3igWmqBUdyOpiKoh8eO1j+Skd/kO+T+sC/OHP0uK6I=
+github.com/prometheus-community/parquet-common v0.0.0-20250714085052-3b8805a2f9ad/go.mod h1:MbAv/yCv9GORLj0XvXgRF913R9Jc04+BvVq4VJpPCi0=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=

--- a/pkg/storage/parquet/queryable_shard.go
+++ b/pkg/storage/parquet/queryable_shard.go
@@ -23,12 +23,12 @@ type queryableShard struct {
 	concurrency int
 }
 
-func newQueryableShard(opts *querierOpts, block storage.ParquetShard, d *schema.PrometheusParquetChunksDecoder) (*queryableShard, error) {
+func newQueryableShard(opts *querierOpts, block storage.ParquetShard, d *schema.PrometheusParquetChunksDecoder, rowCountQuota *search.Quota, chunkBytesQuota *search.Quota, dataBytesQuota *search.Quota) (*queryableShard, error) {
 	s, err := block.TSDBSchema()
 	if err != nil {
 		return nil, err
 	}
-	m, err := search.NewMaterializer(s, d, block, opts.concurrency)
+	m, err := search.NewMaterializer(s, d, block, opts.concurrency, rowCountQuota, chunkBytesQuota, dataBytesQuota, opts.materializedSeriesCallback)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -434,6 +434,11 @@ type BucketStoreConfig struct {
 
 	StreamingBatchSize    int     `yaml:"streaming_series_batch_size" category:"advanced"`
 	SeriesFetchPreference float64 `yaml:"series_fetch_preference" category:"advanced"`
+
+	// Options for the parquet store
+	ParquetMaxRowCount       uint64 `yaml:"parquet_max_row_count" category:"advanced"`
+	ParquetMaxChunkSizeBytes uint64 `yaml:"parquet_max_chunk_size_bytes" category:"advanced"`
+	ParquetMaxDataSizeBytes  uint64 `yaml:"parquet_max_data_size_bytes" category:"advanced"`
 }
 
 // RegisterFlags registers the BucketStore flags
@@ -461,6 +466,11 @@ func (cfg *BucketStoreConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Uint64Var(&cfg.PartitionerMaxGapBytes, "blocks-storage.bucket-store.partitioner-max-gap-bytes", DefaultPartitionerMaxGapSize, "Max size - in bytes - of a gap for which the partitioner aggregates together two bucket GET object requests.")
 	f.IntVar(&cfg.StreamingBatchSize, "blocks-storage.bucket-store.batch-series-size", 5000, "This option controls how many series to fetch per batch. The batch size must be greater than 0.")
 	f.Float64Var(&cfg.SeriesFetchPreference, "blocks-storage.bucket-store.series-fetch-preference", 0.75, "This parameter controls the trade-off in fetching series versus fetching postings to fulfill a series request. Increasing the series preference results in fetching more series and reducing the volume of postings fetched. Reducing the series preference results in the opposite. Increase this parameter to reduce the rate of fetched series bytes (see \"Mimir / Queries\" dashboard) or API calls to the object store. Must be a positive floating point number.")
+
+	// Parquet flags separated from the rest to avoid confusion on rebases with main
+	f.Uint64Var(&cfg.ParquetMaxRowCount, "blocks-storage.bucket-store.parquet-max-row-count", 0, "Maximum number of rows in a parquet file. If the number of rows exceeds this value the query will stop with limit error.")
+	f.Uint64Var(&cfg.ParquetMaxChunkSizeBytes, "blocks-storage.bucket-store.parquet-max-chunk-size-bytes", 0, "Maximum size in bytes that can be fetched from the parquet chunks file. If the size exceeds this value the query will stop with limit error.")
+	f.Uint64Var(&cfg.ParquetMaxDataSizeBytes, "blocks-storage.bucket-store.parquet-max-data-size-bytes", 0, "Maximum size in bytes that can be fetched from the parquet labels and chunks data files combined in a single query. If the size exceeds this value the query will stop with limit error.")
 }
 
 // Validate the config.

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -670,40 +670,6 @@ func generateStorageBlock(t *testing.T, storageDir, userID string, metricName st
 	require.NoError(t, db.Snapshot(userDir, true))
 }
 
-func generateStorageBlockWithMultipleSeries(t *testing.T, storageDir, userID string, metricName string, numSeries int, minT, maxT int64, step int) {
-	// Create a directory for the user (if doesn't already exist).
-	userDir := filepath.Join(storageDir, userID)
-	if _, err := os.Stat(userDir); err != nil {
-		require.NoError(t, os.Mkdir(userDir, os.ModePerm))
-	}
-
-	// Create a temporary directory where the TSDB is opened,
-	// then it will be snapshotted to the storage directory.
-	tmpDir := t.TempDir()
-
-	db, err := tsdb.Open(tmpDir, promslog.NewNopLogger(), nil, tsdb.DefaultOptions(), nil)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, db.Close())
-	}()
-
-	app := db.Appender(context.Background())
-
-	// Generate multiple series with the specified numSeries
-	for seriesIdx := 0; seriesIdx < numSeries; seriesIdx++ {
-		series := labels.FromStrings(labels.MetricName, metricName, "series_id", fmt.Sprintf("%d", seriesIdx))
-
-		for ts := minT; ts < maxT; ts += int64(step) {
-			_, err = app.Append(0, series, ts, 1)
-			require.NoError(t, err)
-		}
-	}
-	require.NoError(t, app.Commit())
-
-	// Snapshot TSDB to the storage directory.
-	require.NoError(t, db.Snapshot(userDir, true))
-}
-
 func querySeries(t *testing.T, stores *BucketStores, userID, metricName string, minT, maxT int64) ([]*storepb.Series, annotations.Annotations, error) {
 	req := &storepb.SeriesRequest{
 		MinTime: minT,

--- a/pkg/storegateway/parquet_bucket_store.go
+++ b/pkg/storegateway/parquet_bucket_store.go
@@ -129,23 +129,23 @@ func NewParquetBucketStore(
 		maxSeriesPerBatch:    bucketStoreConfig.StreamingBatchSize,
 	}
 
-	var pOpts []parquet.QuerierOpts
+	var querierOpts []parquet.QuerierOpts
 	if bucketStoreConfig.ParquetMaxRowCount > 0 {
-		pOpts = append(pOpts, parquet.WithRowCountLimitFunc(func(ctx context.Context) int64 {
+		querierOpts = append(querierOpts, parquet.WithRowCountLimitFunc(func(ctx context.Context) int64 {
 			return int64(bucketStoreConfig.ParquetMaxRowCount)
 		}))
 	}
 	if bucketStoreConfig.ParquetMaxChunkSizeBytes > 0 {
-		pOpts = append(pOpts, parquet.WithChunkBytesLimitFunc(func(ctx context.Context) int64 {
+		querierOpts = append(querierOpts, parquet.WithChunkBytesLimitFunc(func(ctx context.Context) int64 {
 			return int64(bucketStoreConfig.ParquetMaxChunkSizeBytes)
 		}))
 	}
 	if bucketStoreConfig.ParquetMaxDataSizeBytes > 0 {
-		pOpts = append(pOpts, parquet.WithDataBytesLimitFunc(func(ctx context.Context) int64 {
+		querierOpts = append(querierOpts, parquet.WithDataBytesLimitFunc(func(ctx context.Context) int64 {
 			return int64(bucketStoreConfig.ParquetMaxDataSizeBytes)
 		}))
 	}
-	s.querierOpts = pOpts
+	s.querierOpts = querierOpts
 
 	s.readerPool = parquetBlock.NewReaderPool(
 		bucketStoreConfig.IndexHeader,

--- a/pkg/storegateway/parquet_bucket_stores.go
+++ b/pkg/storegateway/parquet_bucket_stores.go
@@ -427,31 +427,7 @@ func (ss *ParquetBucketStores) getOrCreateStore(ctx context.Context, userID stri
 		fetcherReg,
 		filters,
 	)
-	//bucketStoreOpts := []BucketStoreOption{
-	//	WithLogger(userLogger),
-	//	//WithIndexCache(ss.indexCache),
-	//	WithQueryGate(ss.queryGate),
-	//	WithLazyLoadingGate(ss.lazyLoadingGate),
-	//}
 
-	//bs, err := NewBucketStore(
-	//	userID,
-	//	userBkt,
-	//	fetcher,
-	//	ss.syncDirForUser(userID),
-	//	ss.cfg.BucketStore,
-	//	worstCaseFetchedDataStrategy{postingListActualSizeFactor: ss.cfg.BucketStore.SeriesFetchPreference},
-	//	NewChunksLimiterFactory(func() uint64 {
-	//		return uint64(ss.limits.MaxChunksPerQuery(userID))
-	//	}),
-	//	NewSeriesLimiterFactory(func() uint64 {
-	//		return uint64(ss.limits.MaxFetchedSeriesPerQuery(userID))
-	//	}),
-	//	ss.partitioners,
-	//	ss.seriesHashCache,
-	//	ss.bucketStoreMetrics,
-	//	bucketStoreOpts...,
-	//)
 	bs, err := NewParquetBucketStore(
 		userID,
 		ss.syncDirForUser(userID),

--- a/pkg/storegateway/parquet_bucket_stores_test.go
+++ b/pkg/storegateway/parquet_bucket_stores_test.go
@@ -44,7 +44,7 @@ func TestParquetBucketStores_InitialSync(t *testing.T) {
 	require.NoError(t, err)
 
 	for userID, metricName := range userToMetric {
-		generateParquetStorageBlock(t, storageDir, bucket, userID, metricName, 10, 100, 15)
+		generateParquetStorageBlock(t, storageDir, bucket, userID, metricName, 1, 10, 100, 15)
 	}
 
 	var allowedTenants *util.AllowList
@@ -106,7 +106,7 @@ func TestParquetBucketStores_SyncBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run an initial sync to discover 1 block.
-	generateParquetStorageBlock(t, storageDir, bucket, userID, metricName, 10, 100, 15)
+	generateParquetStorageBlock(t, storageDir, bucket, userID, metricName, 1, 10, 100, 15)
 	createBucketIndex(t, bucket, userID)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, stores))
 	t.Cleanup(func() {
@@ -120,7 +120,7 @@ func TestParquetBucketStores_SyncBlocks(t *testing.T) {
 	assert.Empty(t, seriesSet)
 
 	// Generate another block and sync blocks again.
-	generateParquetStorageBlock(t, storageDir, bucket, userID, metricName, 100, 200, 15)
+	generateParquetStorageBlock(t, storageDir, bucket, userID, metricName, 1, 100, 200, 15)
 	createBucketIndex(t, bucket, userID)
 	require.NoError(t, stores.SyncBlocks(ctx))
 
@@ -140,8 +140,8 @@ func prepareParquetStorageConfig(t *testing.T) mimir_tsdb.BlocksStorageConfig {
 	return cfg
 }
 
-func generateParquetStorageBlock(t *testing.T, storageDir string, bkt objstore.Bucket, userID string, metricName string, minT, maxT int64, step int) {
-	generateStorageBlock(t, storageDir, userID, metricName, minT, maxT, step)
+func generateParquetStorageBlock(t *testing.T, storageDir string, bkt objstore.Bucket, userID string, metricName string, numSeries int, minT, maxT int64, step int) {
+	generateStorageBlockWithMultipleSeries(t, storageDir, userID, metricName, numSeries, minT, maxT, step)
 	userDir := filepath.Join(storageDir, userID)
 	bkt = bucket.NewPrefixedBucketClient(bkt, userID)
 	entries, err := os.ReadDir(userDir)

--- a/vendor/github.com/prometheus-community/parquet-common/convert/convert.go
+++ b/vendor/github.com/prometheus-community/parquet-common/convert/convert.go
@@ -226,25 +226,25 @@ func NewTsdbRowReader(ctx context.Context, mint, maxt, colDuration int64, blks [
 	for _, blk := range blks {
 		indexr, err := blk.Index()
 		if err != nil {
-			return nil, fmt.Errorf("unable to get index reader from block: %s", err)
+			return nil, fmt.Errorf("unable to get index reader from block: %w", err)
 		}
 		closers = append(closers, indexr)
 
 		chunkr, err := blk.Chunks()
 		if err != nil {
-			return nil, fmt.Errorf("unable to get chunk reader from block: %s", err)
+			return nil, fmt.Errorf("unable to get chunk reader from block: %w", err)
 		}
 		closers = append(closers, chunkr)
 
 		tombsr, err := blk.Tombstones()
 		if err != nil {
-			return nil, fmt.Errorf("unable to get tombstone reader from block: %s", err)
+			return nil, fmt.Errorf("unable to get tombstone reader from block: %w", err)
 		}
 		closers = append(closers, tombsr)
 
 		lblns, err := indexr.LabelNames(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("unable to get label names from block: %s", err)
+			return nil, fmt.Errorf("unable to get label names from block: %w", err)
 		}
 
 		postings := sortedPostings(ctx, indexr, compareFunc, ops.sortedLabels...)
@@ -258,7 +258,7 @@ func NewTsdbRowReader(ctx context.Context, mint, maxt, colDuration int64, blks [
 
 	s, err := b.Build()
 	if err != nil {
-		return nil, fmt.Errorf("unable to build index reader from block: %s", err)
+		return nil, fmt.Errorf("unable to build index reader from block: %w", err)
 	}
 
 	return &TsdbRowReader{

--- a/vendor/github.com/prometheus-community/parquet-common/convert/writer.go
+++ b/vendor/github.com/prometheus-community/parquet-common/convert/writer.go
@@ -77,7 +77,7 @@ func (c *ShardedWriter) Write(ctx context.Context) error {
 func (c *ShardedWriter) convertShards(ctx context.Context) error {
 	for {
 		if ok, err := c.convertShard(ctx); err != nil {
-			return fmt.Errorf("unable to convert shard: %s", err)
+			return fmt.Errorf("unable to convert shard: %w", err)
 		} else if !ok {
 			break
 		}
@@ -125,17 +125,17 @@ func (c *ShardedWriter) writeFile(ctx context.Context, schema *schema.TSDBSchema
 		ctx, schema.Schema, c.outSchemasForCurrentShard(), c.pipeReaderWriter, fileOpts...,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("unable to create row writer: %s", err)
+		return 0, fmt.Errorf("unable to create row writer: %w", err)
 	}
 
 	n, err := parquet.CopyRows(writer, newBufferedReader(ctx, newLimitReader(c.rr, rowsToWrite)))
 	if err != nil {
-		return 0, fmt.Errorf("unable to copy rows: %s", err)
+		return 0, fmt.Errorf("unable to copy rows: %w", err)
 	}
 
 	err = writer.Close()
 	if err != nil {
-		return 0, fmt.Errorf("unable to close writer: %s", err)
+		return 0, fmt.Errorf("unable to close writer: %w", err)
 	}
 
 	return n, nil
@@ -261,11 +261,11 @@ func (s *splitPipeFileWriter) WriteRows(rows []parquet.Row) (int, error) {
 			convertedRows := util.CloneRows(rows)
 			_, err := writer.conv.Convert(convertedRows)
 			if err != nil {
-				return fmt.Errorf("unable to convert rows: %d", err)
+				return fmt.Errorf("unable to convert rows: %w", err)
 			}
 			n, err := writer.pw.WriteRows(convertedRows)
 			if err != nil {
-				return fmt.Errorf("unable to write rows: %d", err)
+				return fmt.Errorf("unable to write rows: %w", err)
 			}
 			if n != len(rows) {
 				return fmt.Errorf("unable to write rows: %d != %d", n, len(rows))

--- a/vendor/github.com/prometheus-community/parquet-common/queryable/parquet_queryable.go
+++ b/vendor/github.com/prometheus-community/parquet-common/queryable/parquet_queryable.go
@@ -34,11 +34,19 @@ import (
 type ShardsFinderFunction func(ctx context.Context, mint, maxt int64) ([]storage.ParquetShard, error)
 
 type queryableOpts struct {
-	concurrency int
+	concurrency                int
+	rowCountLimitFunc          search.QuotaLimitFunc
+	chunkBytesLimitFunc        search.QuotaLimitFunc
+	dataBytesLimitFunc         search.QuotaLimitFunc
+	materializedSeriesCallback search.MaterializedSeriesFunc
 }
 
 var DefaultQueryableOpts = queryableOpts{
-	concurrency: runtime.GOMAXPROCS(0),
+	concurrency:                runtime.GOMAXPROCS(0),
+	rowCountLimitFunc:          search.NoopQuotaLimitFunc,
+	chunkBytesLimitFunc:        search.NoopQuotaLimitFunc,
+	dataBytesLimitFunc:         search.NoopQuotaLimitFunc,
+	materializedSeriesCallback: search.NoopMaterializedSeriesFunc,
 }
 
 type QueryableOpts func(*queryableOpts)
@@ -47,6 +55,35 @@ type QueryableOpts func(*queryableOpts)
 func WithConcurrency(concurrency int) QueryableOpts {
 	return func(opts *queryableOpts) {
 		opts.concurrency = concurrency
+	}
+}
+
+// WithRowCountLimitFunc sets a callback function to get limit for matched row count.
+func WithRowCountLimitFunc(fn search.QuotaLimitFunc) QueryableOpts {
+	return func(opts *queryableOpts) {
+		opts.rowCountLimitFunc = fn
+	}
+}
+
+// WithChunkBytesLimitFunc sets a callback function to get limit for chunk column page bytes fetched.
+func WithChunkBytesLimitFunc(fn search.QuotaLimitFunc) QueryableOpts {
+	return func(opts *queryableOpts) {
+		opts.chunkBytesLimitFunc = fn
+	}
+}
+
+// WithDataBytesLimitFunc sets a callback function to get limit for data (including label and chunk)
+// column page bytes fetched.
+func WithDataBytesLimitFunc(fn search.QuotaLimitFunc) QueryableOpts {
+	return func(opts *queryableOpts) {
+		opts.dataBytesLimitFunc = fn
+	}
+}
+
+// WithMaterializedSeriesCallback sets a callback function to process the materialized series.
+func WithMaterializedSeriesCallback(fn search.MaterializedSeriesFunc) QueryableOpts {
+	return func(opts *queryableOpts) {
+		opts.materializedSeriesCallback = fn
 	}
 }
 
@@ -191,8 +228,11 @@ func (p parquetQuerier) queryableShards(ctx context.Context, mint, maxt int64) (
 		return nil, err
 	}
 	qBlocks := make([]*queryableShard, len(shards))
+	rowCountQuota := search.NewQuota(p.opts.rowCountLimitFunc(ctx))
+	chunkBytesQuota := search.NewQuota(p.opts.chunkBytesLimitFunc(ctx))
+	dataBytesQuota := search.NewQuota(p.opts.dataBytesLimitFunc(ctx))
 	for i, shard := range shards {
-		qb, err := newQueryableShard(p.opts, shard, p.d)
+		qb, err := newQueryableShard(p.opts, shard, p.d, rowCountQuota, chunkBytesQuota, dataBytesQuota)
 		if err != nil {
 			return nil, err
 		}
@@ -207,12 +247,12 @@ type queryableShard struct {
 	concurrency int
 }
 
-func newQueryableShard(opts *queryableOpts, block storage.ParquetShard, d *schema.PrometheusParquetChunksDecoder) (*queryableShard, error) {
+func newQueryableShard(opts *queryableOpts, block storage.ParquetShard, d *schema.PrometheusParquetChunksDecoder, rowCountQuota *search.Quota, chunkBytesQuota *search.Quota, dataBytesQuota *search.Quota) (*queryableShard, error) {
 	s, err := block.TSDBSchema()
 	if err != nil {
 		return nil, err
 	}
-	m, err := search.NewMaterializer(s, d, block, opts.concurrency)
+	m, err := search.NewMaterializer(s, d, block, opts.concurrency, rowCountQuota, chunkBytesQuota, dataBytesQuota, opts.materializedSeriesCallback)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/prometheus-community/parquet-common/search/limits.go
+++ b/vendor/github.com/prometheus-community/parquet-common/search/limits.go
@@ -1,0 +1,82 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+// This package is a modified copy from
+// https://github.com/thanos-io/thanos-parquet-gateway/blob/cfc1279f605d1c629c4afe8b1e2a340e8b15ecdc/internal/limits/limit.go.
+
+package search
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+type resourceExhausted struct {
+	used int64
+}
+
+func (re *resourceExhausted) Error() string {
+	return fmt.Sprintf("resource exhausted (used %d)", re.used)
+}
+
+// IsResourceExhausted checks if the error is a resource exhausted error.
+func IsResourceExhausted(err error) bool {
+	var re *resourceExhausted
+	return errors.As(err, &re)
+}
+
+// Quota is a limiter for a resource.
+type Quota struct {
+	mu sync.Mutex
+	q  int64
+	u  int64
+}
+
+// NewQuota creates a new quota with the given limit.
+func NewQuota(n int64) *Quota {
+	return &Quota{q: n, u: n}
+}
+
+// UnlimitedQuota creates a new quota with no limit.
+func UnlimitedQuota() *Quota {
+	return NewQuota(0)
+}
+
+func (q *Quota) Reserve(n int64) error {
+	if q.q == 0 {
+		return nil
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.u-n < 0 {
+		return &resourceExhausted{used: q.q}
+	}
+	q.u -= n
+	return nil
+}
+
+// QuotaLimitFunc is a function that returns the limit value.
+type QuotaLimitFunc func(ctx context.Context) int64
+
+// NoopQuotaLimitFunc returns 0 which means no limit.
+func NoopQuotaLimitFunc(ctx context.Context) int64 {
+	return 0
+}

--- a/vendor/github.com/prometheus-community/parquet-common/search/materialize.go
+++ b/vendor/github.com/prometheus-community/parquet-common/search/materialize.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"iter"
 	"maps"
 	"slices"
 	"sync"
@@ -43,12 +44,31 @@ type Materializer struct {
 	concurrency int
 
 	dataColToIndex []int
+
+	rowCountQuota   *Quota
+	chunkBytesQuota *Quota
+	dataBytesQuota  *Quota
+
+	materializedSeriesCallback MaterializedSeriesFunc
+}
+
+// MaterializedSeriesFunc is a callback function that can be used to add limiter or statistic logics for
+// materialized series.
+type MaterializedSeriesFunc func(ctx context.Context, series []prom_storage.ChunkSeries) error
+
+// NoopMaterializedSeriesFunc is a noop callback function that does nothing.
+func NoopMaterializedSeriesFunc(_ context.Context, _ []prom_storage.ChunkSeries) error {
+	return nil
 }
 
 func NewMaterializer(s *schema.TSDBSchema,
 	d *schema.PrometheusParquetChunksDecoder,
 	block storage.ParquetShard,
 	concurrency int,
+	rowCountQuota *Quota,
+	chunkBytesQuota *Quota,
+	dataBytesQuota *Quota,
+	materializeSeriesCallback MaterializedSeriesFunc,
 ) (*Materializer, error) {
 	colIdx, ok := block.LabelsFile().Schema().Lookup(schema.ColIndexes)
 	if !ok {
@@ -66,19 +86,26 @@ func NewMaterializer(s *schema.TSDBSchema,
 	}
 
 	return &Materializer{
-		s:              s,
-		d:              d,
-		b:              block,
-		colIdx:         colIdx.ColumnIndex,
-		concurrency:    concurrency,
-		partitioner:    util.NewGapBasedPartitioner(block.ChunksFile().Cfg.PagePartitioningMaxGapSize),
-		dataColToIndex: dataColToIndex,
+		s:                          s,
+		d:                          d,
+		b:                          block,
+		colIdx:                     colIdx.ColumnIndex,
+		concurrency:                concurrency,
+		partitioner:                util.NewGapBasedPartitioner(block.ChunksFile().Cfg.PagePartitioningMaxGapSize),
+		dataColToIndex:             dataColToIndex,
+		rowCountQuota:              rowCountQuota,
+		chunkBytesQuota:            chunkBytesQuota,
+		dataBytesQuota:             dataBytesQuota,
+		materializedSeriesCallback: materializeSeriesCallback,
 	}, nil
 }
 
 // Materialize reconstructs the ChunkSeries that belong to the specified row ranges (rr).
 // It uses the row group index (rgi) and time bounds (mint, maxt) to filter and decode the series.
 func (m *Materializer) Materialize(ctx context.Context, rgi int, mint, maxt int64, skipChunks bool, rr []RowRange) ([]prom_storage.ChunkSeries, error) {
+	if err := m.checkRowCountQuota(rr); err != nil {
+		return nil, err
+	}
 	sLbls, err := m.materializeAllLabels(ctx, rgi, rr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error materializing labels")
@@ -106,6 +133,10 @@ func (m *Materializer) Materialize(ctx context.Context, rgi int, mint, maxt int6
 			return len(cs.(*concreteChunksSeries).chks) == 0
 		})
 	}
+
+	if err := m.materializedSeriesCallback(ctx, results); err != nil {
+		return nil, err
+	}
 	return results, err
 }
 
@@ -125,7 +156,7 @@ func (m *Materializer) MaterializeAllLabelNames() []string {
 func (m *Materializer) MaterializeLabelNames(ctx context.Context, rgi int, rr []RowRange) ([]string, error) {
 	labelsRg := m.b.LabelsFile().RowGroups()[rgi]
 	cc := labelsRg.ColumnChunks()[m.colIdx]
-	colsIdxs, err := m.materializeColumn(ctx, m.b.LabelsFile(), rgi, cc, rr)
+	colsIdxs, err := m.materializeColumn(ctx, m.b.LabelsFile(), rgi, cc, rr, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "materializer failed to materialize columns")
 	}
@@ -164,7 +195,7 @@ func (m *Materializer) MaterializeLabelValues(ctx context.Context, name string, 
 		return []string{}, nil
 	}
 	cc := labelsRg.ColumnChunks()[cIdx.ColumnIndex]
-	values, err := m.materializeColumn(ctx, m.b.LabelsFile(), rgi, cc, rr)
+	values, err := m.materializeColumn(ctx, m.b.LabelsFile(), rgi, cc, rr, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "materializer failed to materialize columns")
 	}
@@ -208,7 +239,7 @@ func (m *Materializer) MaterializeAllLabelValues(ctx context.Context, name strin
 func (m *Materializer) materializeAllLabels(ctx context.Context, rgi int, rr []RowRange) ([][]labels.Label, error) {
 	labelsRg := m.b.LabelsFile().RowGroups()[rgi]
 	cc := labelsRg.ColumnChunks()[m.colIdx]
-	colsIdxs, err := m.materializeColumn(ctx, m.b.LabelsFile(), rgi, cc, rr)
+	colsIdxs, err := m.materializeColumn(ctx, m.b.LabelsFile(), rgi, cc, rr, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "materializer failed to materialize columns")
 	}
@@ -232,7 +263,7 @@ func (m *Materializer) materializeAllLabels(ctx context.Context, rgi int, rr []R
 	for cIdx, v := range colsMap {
 		errGroup.Go(func() error {
 			cc := labelsRg.ColumnChunks()[cIdx]
-			values, err := m.materializeColumn(ctx, m.b.LabelsFile(), rgi, cc, rr)
+			values, err := m.materializeColumn(ctx, m.b.LabelsFile(), rgi, cc, rr, false)
 			if err != nil {
 				return errors.Wrap(err, "failed to materialize labels values")
 			}
@@ -279,7 +310,7 @@ func (m *Materializer) materializeChunks(ctx context.Context, rgi int, mint, max
 	r := make([][]chunks.Meta, totalRows(rr))
 
 	for i := minDataCol; i <= min(maxDataCol, len(m.dataColToIndex)-1); i++ {
-		values, err := m.materializeColumn(ctx, m.b.ChunksFile(), rgi, rg.ColumnChunks()[m.dataColToIndex[i]], rr)
+		values, err := m.materializeColumn(ctx, m.b.ChunksFile(), rgi, rg.ColumnChunks()[m.dataColToIndex[i]], rr, true)
 		if err != nil {
 			return r, err
 		}
@@ -296,7 +327,7 @@ func (m *Materializer) materializeChunks(ctx context.Context, rgi int, mint, max
 	return r, nil
 }
 
-func (m *Materializer) materializeColumn(ctx context.Context, file *storage.ParquetFile, rgi int, cc parquet.ColumnChunk, rr []RowRange) ([]parquet.Value, error) {
+func (m *Materializer) materializeColumn(ctx context.Context, file *storage.ParquetFile, rgi int, cc parquet.ColumnChunk, rr []RowRange, chunkColumn bool) ([]parquet.Value, error) {
 	if len(rr) == 0 {
 		return nil, nil
 	}
@@ -330,6 +361,9 @@ func (m *Materializer) materializeColumn(ctx context.Context, file *storage.Parq
 				pagesToRowsMap[i] = append(pagesToRowsMap[i], pageRowRange.Intersection(r))
 			}
 		}
+	}
+	if err := m.checkBytesQuota(maps.Keys(pagesToRowsMap), oidx, chunkColumn); err != nil {
+		return nil, err
 	}
 
 	pageRanges := m.coalescePageRanges(pagesToRowsMap, oidx)
@@ -462,6 +496,34 @@ func (m *Materializer) coalescePageRanges(pagedIdx map[int][]RowRange, offset pa
 	}
 
 	return r
+}
+
+func (m *Materializer) checkRowCountQuota(rr []RowRange) error {
+	if err := m.rowCountQuota.Reserve(totalRows(rr)); err != nil {
+		return fmt.Errorf("would fetch too many rows: %w", err)
+	}
+	return nil
+}
+
+func (m *Materializer) checkBytesQuota(pages iter.Seq[int], oidx parquet.OffsetIndex, chunkColumn bool) error {
+	total := totalBytes(pages, oidx)
+	if chunkColumn {
+		if err := m.chunkBytesQuota.Reserve(total); err != nil {
+			return fmt.Errorf("would fetch too many chunk bytes: %w", err)
+		}
+	}
+	if err := m.dataBytesQuota.Reserve(total); err != nil {
+		return fmt.Errorf("would fetch too many data bytes: %w", err)
+	}
+	return nil
+}
+
+func totalBytes(pages iter.Seq[int], oidx parquet.OffsetIndex) int64 {
+	res := int64(0)
+	for i := range pages {
+		res += oidx.CompressedPageSize(i)
+	}
+	return res
 }
 
 type valuesIterator struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1147,7 +1147,7 @@ github.com/pmezard/go-difflib/difflib
 # github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c
 ## explicit; go 1.14
 github.com/power-devops/perfstat
-# github.com/prometheus-community/parquet-common v0.0.0-20250708150752-0811a700a852
+# github.com/prometheus-community/parquet-common v0.0.0-20250710090957-8fdc99f06643
 ## explicit; go 1.23.4
 github.com/prometheus-community/parquet-common/convert
 github.com/prometheus-community/parquet-common/queryable

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1147,7 +1147,7 @@ github.com/pmezard/go-difflib/difflib
 # github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c
 ## explicit; go 1.14
 github.com/power-devops/perfstat
-# github.com/prometheus-community/parquet-common v0.0.0-20250710090957-8fdc99f06643
+# github.com/prometheus-community/parquet-common v0.0.0-20250714085052-3b8805a2f9ad
 ## explicit; go 1.23.4
 github.com/prometheus-community/parquet-common/convert
 github.com/prometheus-community/parquet-common/queryable


### PR DESCRIPTION
This PR is based on the upstream work https://github.com/prometheus-community/parquet-common/pull/81

The idea is to implement a set of basic quota limiters that can protect us against potential bad queries for the gateways.

Note we had to bring bits of the code available in the querier in upstream because we have our own chunk querier in Mimir.