### PR TITLE
Alertmanager: Fix duplicate registration of notify hooks metrics.

### DIFF
--- a/pkg/alertmanager/notify_hooks_notifier_test.go
+++ b/pkg/alertmanager/notify_hooks_notifier_test.go
@@ -141,7 +141,7 @@ func newTestHooksFixture(t *testing.T, handlerStatus int, handlerResponse string
 	upstream := &fakeNotifier{}
 
 	reg := prometheus.NewPedanticRegistry()
-	notifier, err := newNotifyHooksNotifier(upstream, limits, "user", log.NewLogfmtLogger(os.Stdout), reg)
+	notifier, err := newNotifyHooksNotifier(upstream, limits, "user", log.NewLogfmtLogger(os.Stdout), newNotifyHooksMetrics(reg))
 	require.NoError(t, err)
 
 	return &testHooksFixture{


### PR DESCRIPTION
Creating the metrics for every wrapper has the obvious (in hindsight) problem of
registering the same metrics for each receiver, and every config reload.
