### PR TITLE
Improve docs for blocked requests, blocked queries and limited queries config options

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4975,7 +4975,7 @@
                 "kind": "field",
                 "name": "regex",
                 "required": false,
-                "desc": "If true, pattern is treated as a regular expression. If false, pattern is treated as a literal match.",
+                "desc": "If true, the pattern is treated as a regular expression. If false, the pattern is treated as a literal match.",
                 "fieldValue": null,
                 "fieldDefaultValue": false,
                 "fieldType": "boolean"
@@ -5090,7 +5090,7 @@
                       "kind": "field",
                       "name": "is_regexp",
                       "required": false,
-                      "desc": "If true, value is treated as a regexp pattern. If false, value is treated as a literal match.",
+                      "desc": "If true, the value is treated as a regular expression. If false, the value is treated as a literal match.",
                       "fieldValue": null,
                       "fieldDefaultValue": false,
                       "fieldType": "boolean"

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4966,7 +4966,7 @@
                 "kind": "field",
                 "name": "pattern",
                 "required": false,
-                "desc": "",
+                "desc": "PromQL expression pattern to match.",
                 "fieldValue": null,
                 "fieldDefaultValue": "",
                 "fieldType": "string"
@@ -4975,7 +4975,7 @@
                 "kind": "field",
                 "name": "regex",
                 "required": false,
-                "desc": "",
+                "desc": "If true, pattern is treated as a regular expression. If false, pattern is treated as a literal match.",
                 "fieldValue": null,
                 "fieldDefaultValue": false,
                 "fieldType": "boolean"
@@ -4984,7 +4984,7 @@
                 "kind": "field",
                 "name": "reason",
                 "required": false,
-                "desc": "",
+                "desc": "Reason returned to clients when rejecting matching queries.",
                 "fieldValue": null,
                 "fieldDefaultValue": "",
                 "fieldType": "string"
@@ -5012,7 +5012,7 @@
                 "kind": "field",
                 "name": "query",
                 "required": false,
-                "desc": "",
+                "desc": "Literal PromQL expression to match.",
                 "fieldValue": null,
                 "fieldDefaultValue": "",
                 "fieldType": "string"
@@ -5021,7 +5021,7 @@
                 "kind": "field",
                 "name": "allowed_frequency",
                 "required": false,
-                "desc": "",
+                "desc": "Minimum duration between matching queries. If a matching query arrives more often than this, it is rejected.",
                 "fieldValue": null,
                 "fieldDefaultValue": null,
                 "fieldType": "duration"
@@ -5035,7 +5035,7 @@
           "kind": "field",
           "name": "blocked_requests",
           "required": false,
-          "desc": "List of http requests to block.",
+          "desc": "List of HTTP requests to block.",
           "fieldValue": null,
           "fieldDefaultValue": null,
           "fieldType": "slice",
@@ -5049,7 +5049,7 @@
                 "kind": "field",
                 "name": "path",
                 "required": false,
-                "desc": "",
+                "desc": "Path to match, including leading slash (/). Leave blank to match all paths.",
                 "fieldValue": null,
                 "fieldDefaultValue": "",
                 "fieldType": "string"
@@ -5058,7 +5058,7 @@
                 "kind": "field",
                 "name": "method",
                 "required": false,
-                "desc": "",
+                "desc": "HTTP method to match. Leave blank to match all methods.",
                 "fieldValue": null,
                 "fieldDefaultValue": "",
                 "fieldType": "string"
@@ -5067,7 +5067,7 @@
                 "kind": "map",
                 "name": "query_params",
                 "required": false,
-                "desc": "",
+                "desc": "Query parameters to match. Requests must have all of the provided query parameters to be considered a match.",
                 "fieldValue": null,
                 "fieldDefaultValue": null,
                 "fieldType": "string",
@@ -5081,7 +5081,7 @@
                       "kind": "field",
                       "name": "value",
                       "required": false,
-                      "desc": "",
+                      "desc": "Value to match.",
                       "fieldValue": null,
                       "fieldDefaultValue": "",
                       "fieldType": "string"
@@ -5090,7 +5090,7 @@
                       "kind": "field",
                       "name": "is_regexp",
                       "required": false,
-                      "desc": "",
+                      "desc": "If true, value is treated as a regexp pattern. If false, value is treated as a literal match.",
                       "fieldValue": null,
                       "fieldDefaultValue": false,
                       "fieldType": "boolean"

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4954,9 +4954,45 @@
           "required": false,
           "desc": "List of queries to block.",
           "fieldValue": null,
-          "fieldDefaultValue": [],
-          "fieldType": "list of pattern (string), regex (bool), and, optionally, reason (string)",
-          "fieldCategory": "experimental"
+          "fieldDefaultValue": null,
+          "fieldType": "slice",
+          "fieldElement": {
+            "kind": "block",
+            "name": "blocked_queries",
+            "required": false,
+            "desc": "",
+            "blockEntries": [
+              {
+                "kind": "field",
+                "name": "pattern",
+                "required": false,
+                "desc": "",
+                "fieldValue": null,
+                "fieldDefaultValue": "",
+                "fieldType": "string"
+              },
+              {
+                "kind": "field",
+                "name": "regex",
+                "required": false,
+                "desc": "",
+                "fieldValue": null,
+                "fieldDefaultValue": false,
+                "fieldType": "boolean"
+              },
+              {
+                "kind": "field",
+                "name": "reason",
+                "required": false,
+                "desc": "",
+                "fieldValue": null,
+                "fieldDefaultValue": "",
+                "fieldType": "string"
+              }
+            ],
+            "fieldValue": null,
+            "fieldDefaultValue": null
+          }
         },
         {
           "kind": "field",
@@ -4964,9 +5000,36 @@
           "required": false,
           "desc": "List of queries to limit and duration to limit them for.",
           "fieldValue": null,
-          "fieldDefaultValue": [],
-          "fieldType": "list of query (string) and allowed_frequency (duration)",
-          "fieldCategory": "experimental"
+          "fieldDefaultValue": null,
+          "fieldType": "slice",
+          "fieldElement": {
+            "kind": "block",
+            "name": "limited_queries",
+            "required": false,
+            "desc": "",
+            "blockEntries": [
+              {
+                "kind": "field",
+                "name": "query",
+                "required": false,
+                "desc": "",
+                "fieldValue": null,
+                "fieldDefaultValue": "",
+                "fieldType": "string"
+              },
+              {
+                "kind": "field",
+                "name": "allowed_frequency",
+                "required": false,
+                "desc": "",
+                "fieldValue": null,
+                "fieldDefaultValue": null,
+                "fieldType": "duration"
+              }
+            ],
+            "fieldValue": null,
+            "fieldDefaultValue": null
+          }
         },
         {
           "kind": "field",
@@ -4975,8 +5038,72 @@
           "desc": "List of http requests to block.",
           "fieldValue": null,
           "fieldDefaultValue": null,
-          "fieldType": "blocked_requests_config...",
-          "fieldCategory": "experimental"
+          "fieldType": "slice",
+          "fieldElement": {
+            "kind": "block",
+            "name": "blocked_requests",
+            "required": false,
+            "desc": "",
+            "blockEntries": [
+              {
+                "kind": "field",
+                "name": "path",
+                "required": false,
+                "desc": "",
+                "fieldValue": null,
+                "fieldDefaultValue": "",
+                "fieldType": "string"
+              },
+              {
+                "kind": "field",
+                "name": "method",
+                "required": false,
+                "desc": "",
+                "fieldValue": null,
+                "fieldDefaultValue": "",
+                "fieldType": "string"
+              },
+              {
+                "kind": "map",
+                "name": "query_params",
+                "required": false,
+                "desc": "",
+                "fieldValue": null,
+                "fieldDefaultValue": null,
+                "fieldType": "string",
+                "fieldElement": {
+                  "kind": "block",
+                  "name": "query_params",
+                  "required": false,
+                  "desc": "",
+                  "blockEntries": [
+                    {
+                      "kind": "field",
+                      "name": "value",
+                      "required": false,
+                      "desc": "",
+                      "fieldValue": null,
+                      "fieldDefaultValue": "",
+                      "fieldType": "string"
+                    },
+                    {
+                      "kind": "field",
+                      "name": "is_regexp",
+                      "required": false,
+                      "desc": "",
+                      "fieldValue": null,
+                      "fieldDefaultValue": false,
+                      "fieldType": "boolean"
+                    }
+                  ],
+                  "fieldValue": null,
+                  "fieldDefaultValue": null
+                }
+              }
+            ],
+            "fieldValue": null,
+            "fieldDefaultValue": null
+          }
         },
         {
           "kind": "field",

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3759,6 +3759,12 @@ blocked_requests:
 
     [method: <string> | default = ""]
 
+    [query_params:]
+      <string>:
+        [value: <string> | default = ""]
+
+        [is_regexp: <boolean> | default = ]
+
 # Mutate incoming queries to align their start and end with their step to
 # improve result caching.
 # CLI flag: -query-frontend.align-queries-with-step

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3720,20 +3720,44 @@ The `limits` block configures default and per-tenant limits imposed by component
 #   Setting the pattern to ".*" and regex to true blocks all queries.
 #   blocked_queries:
 #       - pattern: rate(metric_counter[5m])
+#         regex: false
 #         reason: because the query is misconfigured
-[blocked_queries: <list of pattern (string), regex (bool), and, optionally, reason (string)> | default = ]
+blocked_queries:
+  -
+    [pattern: <string> | default = ""]
+
+    [regex: <boolean> | default = ]
+
+    [reason: <string> | default = ""]
 
 # (experimental) List of queries to limit and duration to limit them for.
 # Example:
 #   The following configuration limits the query "rate(metric_counter[5m])" to
 #   running, at most, every minute.
 #   limited_queries:
-#       - allowed_frequency: 1m
-#         query: rate(metric_counter[5m])
-[limited_queries: <list of query (string) and allowed_frequency (duration)> | default = ]
+#       - query: rate(metric_counter[5m])
+#         allowed_frequency: 1m0s
+limited_queries:
+  -
+    [query: <string> | default = ""]
+
+    [allowed_frequency: <duration> | default = ]
 
 # (experimental) List of http requests to block.
-[blocked_requests: <blocked_requests_config...> | default = ]
+# Example:
+#   The following configuration blocks all GET requests to /foo when the "limit"
+#   parameter is set to 100.
+#   blocked_requests:
+#       - path: /foo
+#         method: GET
+#         query_params:
+#           limit:
+#               value: "100"
+blocked_requests:
+  -
+    [path: <string> | default = ""]
+
+    [method: <string> | default = ""]
 
 # Mutate incoming queries to align their start and end with their step to
 # improve result caching.

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3723,8 +3723,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 #         regex: false
 #         reason: because the query is misconfigured
 blocked_queries:
-  -
-    # PromQL expression pattern to match.
+  - # PromQL expression pattern to match.
     [pattern: <string> | default = ""]
 
     # If true, pattern is treated as a regular expression. If false, pattern is
@@ -3742,8 +3741,7 @@ blocked_queries:
 #       - query: rate(metric_counter[5m])
 #         allowed_frequency: 1m0s
 limited_queries:
-  -
-    # Literal PromQL expression to match.
+  - # Literal PromQL expression to match.
     [query: <string> | default = ""]
 
     # Minimum duration between matching queries. If a matching query arrives
@@ -3761,9 +3759,7 @@ limited_queries:
 #           limit:
 #               value: "100"
 blocked_requests:
-  -
-    # Path to match, including leading slash (/). Leave blank to match all
-    # paths.
+  - # Path to match, including leading slash (/). Leave blank to match all paths.
     [path: <string> | default = ""]
 
     # HTTP method to match. Leave blank to match all methods.

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3724,10 +3724,14 @@ The `limits` block configures default and per-tenant limits imposed by component
 #         reason: because the query is misconfigured
 blocked_queries:
   -
+    # PromQL expression pattern to match.
     [pattern: <string> | default = ""]
 
+    # If true, pattern is treated as a regular expression. If false, pattern is
+    # treated as a literal match.
     [regex: <boolean> | default = ]
 
+    # Reason returned to clients when rejecting matching queries.
     [reason: <string> | default = ""]
 
 # (experimental) List of queries to limit and duration to limit them for.
@@ -3739,11 +3743,14 @@ blocked_queries:
 #         allowed_frequency: 1m0s
 limited_queries:
   -
+    # Literal PromQL expression to match.
     [query: <string> | default = ""]
 
+    # Minimum duration between matching queries. If a matching query arrives
+    # more often than this, it is rejected.
     [allowed_frequency: <duration> | default = ]
 
-# (experimental) List of http requests to block.
+# (experimental) List of HTTP requests to block.
 # Example:
 #   The following configuration blocks all GET requests to /foo when the "limit"
 #   parameter is set to 100.
@@ -3755,14 +3762,22 @@ limited_queries:
 #               value: "100"
 blocked_requests:
   -
+    # Path to match, including leading slash (/). Leave blank to match all
+    # paths.
     [path: <string> | default = ""]
 
+    # HTTP method to match. Leave blank to match all methods.
     [method: <string> | default = ""]
 
+    # Query parameters to match. Requests must have all of the provided query
+    # parameters to be considered a match.
     [query_params:]
       <string>:
+        # Value to match.
         [value: <string> | default = ""]
 
+        # If true, value is treated as a regexp pattern. If false, value is
+        # treated as a literal match.
         [is_regexp: <boolean> | default = ]
 
 # Mutate incoming queries to align their start and end with their step to

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3726,8 +3726,8 @@ blocked_queries:
   - # PromQL expression pattern to match.
     [pattern: <string> | default = ""]
 
-    # If true, pattern is treated as a regular expression. If false, pattern is
-    # treated as a literal match.
+    # If true, the pattern is treated as a regular expression. If false, the
+    # pattern is treated as a literal match.
     [regex: <boolean> | default = ]
 
     # Reason returned to clients when rejecting matching queries.
@@ -3772,8 +3772,8 @@ blocked_requests:
         # Value to match.
         [value: <string> | default = ""]
 
-        # If true, value is treated as a regexp pattern. If false, value is
-        # treated as a literal match.
+        # If true, the value is treated as a regular expression. If false, the
+        # value is treated as a literal match.
         [is_regexp: <boolean> | default = ]
 
 # Mutate incoming queries to align their start and end with their step to

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -104,13 +104,13 @@ type Limits interface {
 	Prom2RangeCompat(userID string) bool
 
 	// BlockedQueries returns the blocked queries.
-	BlockedQueries(userID string) []*validation.BlockedQuery
+	BlockedQueries(userID string) []validation.BlockedQuery
 
 	// BlockedRequests returns the blocked http requests.
-	BlockedRequests(userID string) []*validation.BlockedRequest
+	BlockedRequests(userID string) []validation.BlockedRequest
 
 	// LimitedQueries returns the limited queries.
-	LimitedQueries(userID string) []*validation.LimitedQuery
+	LimitedQueries(userID string) []validation.LimitedQuery
 
 	// AlignQueriesWithStep returns if queries should be adjusted to be step-aligned
 	AlignQueriesWithStep(userID string) bool

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -672,11 +672,11 @@ func (m multiTenantMockLimits) Prom2RangeCompat(userID string) bool {
 	return m.byTenant[userID].prom2RangeCompat
 }
 
-func (m multiTenantMockLimits) BlockedQueries(userID string) []*validation.BlockedQuery {
+func (m multiTenantMockLimits) BlockedQueries(userID string) []validation.BlockedQuery {
 	return m.byTenant[userID].blockedQueries
 }
 
-func (m multiTenantMockLimits) LimitedQueries(userID string) []*validation.LimitedQuery {
+func (m multiTenantMockLimits) LimitedQueries(userID string) []validation.LimitedQuery {
 	return m.byTenant[userID].limitedQueries
 }
 
@@ -700,7 +700,7 @@ func (m multiTenantMockLimits) IngestStorageReadConsistency(userID string) strin
 	return m.byTenant[userID].ingestStorageReadConsistency
 }
 
-func (m multiTenantMockLimits) BlockedRequests(userID string) []*validation.BlockedRequest {
+func (m multiTenantMockLimits) BlockedRequests(userID string) []validation.BlockedRequest {
 	return m.byTenant[userID].blockedRequests
 }
 
@@ -732,9 +732,9 @@ type mockLimits struct {
 	resultsCacheForUnalignedQueryEnabled bool
 	enabledPromQLExperimentalFunctions   []string
 	prom2RangeCompat                     bool
-	blockedQueries                       []*validation.BlockedQuery
-	limitedQueries                       []*validation.LimitedQuery
-	blockedRequests                      []*validation.BlockedRequest
+	blockedQueries                       []validation.BlockedQuery
+	limitedQueries                       []validation.LimitedQuery
+	blockedRequests                      []validation.BlockedRequest
 	alignQueriesWithStep                 bool
 	queryIngestersWithin                 time.Duration
 	ingestStorageReadConsistency         string
@@ -811,11 +811,11 @@ func (m mockLimits) ResultsCacheTTLForCardinalityQuery(string) time.Duration {
 	return m.resultsCacheTTLForCardinalityQuery
 }
 
-func (m mockLimits) BlockedQueries(string) []*validation.BlockedQuery {
+func (m mockLimits) BlockedQueries(string) []validation.BlockedQuery {
 	return m.blockedQueries
 }
 
-func (m mockLimits) LimitedQueries(userID string) []*validation.LimitedQuery {
+func (m mockLimits) LimitedQueries(userID string) []validation.LimitedQuery {
 	return m.limitedQueries
 }
 
@@ -855,7 +855,7 @@ func (m mockLimits) IngestStorageReadConsistency(string) string {
 	return m.ingestStorageReadConsistency
 }
 
-func (m mockLimits) BlockedRequests(string) []*validation.BlockedRequest {
+func (m mockLimits) BlockedRequests(string) []validation.BlockedRequest {
 	return m.blockedRequests
 }
 

--- a/pkg/frontend/querymiddleware/query_blocker_test.go
+++ b/pkg/frontend/querymiddleware/query_blocker_test.go
@@ -35,7 +35,7 @@ func TestQueryBlockerMiddleware_RangeAndInstantQuery(t *testing.T) {
 		{
 			name: "blocks single line query non regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: "rate(metric_counter[5m])", Regex: false},
 				},
 			},
@@ -45,7 +45,7 @@ func TestQueryBlockerMiddleware_RangeAndInstantQuery(t *testing.T) {
 		{
 			name: "not blocks single line query non regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: "rate(metric_counter[5m])", Regex: false},
 				},
 			},
@@ -54,7 +54,7 @@ func TestQueryBlockerMiddleware_RangeAndInstantQuery(t *testing.T) {
 		{
 			name: "blocks multiple line query non regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: `rate(metric_counter[5m]) / rate(other_counter[5m])`, Regex: false},
 				},
 			},
@@ -68,7 +68,7 @@ func TestQueryBlockerMiddleware_RangeAndInstantQuery(t *testing.T) {
 		{
 			name: "not blocks multiple line query non regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: "rate(metric_counter[5m])", Regex: false},
 				},
 			},
@@ -81,7 +81,7 @@ func TestQueryBlockerMiddleware_RangeAndInstantQuery(t *testing.T) {
 		{
 			name: "blocks single line query regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: ".*metric_counter.*", Regex: true},
 				},
 			},
@@ -91,7 +91,7 @@ func TestQueryBlockerMiddleware_RangeAndInstantQuery(t *testing.T) {
 		{
 			name: "blocks multiple line query regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					// We need to turn on the s flag to allow dot matches newlines.
 					{Pattern: "(?s).*metric_counter.*", Regex: true},
 				},
@@ -106,7 +106,7 @@ func TestQueryBlockerMiddleware_RangeAndInstantQuery(t *testing.T) {
 		{
 			name: "invalid regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: "[a-9}", Regex: true},
 				},
 			},
@@ -175,7 +175,7 @@ func TestQueryBlockerMiddleware_RemoteRead(t *testing.T) {
 		{
 			name: "blocks query via non regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: `{__name__="metric_counter",pod=~"app-.*"}`, Regex: false},
 				},
 			},
@@ -184,7 +184,7 @@ func TestQueryBlockerMiddleware_RemoteRead(t *testing.T) {
 		{
 			name: "not blocks query via non regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: `{__name__="another_metric",pod=~"app-.*"}`, Regex: false},
 				},
 			},
@@ -192,7 +192,7 @@ func TestQueryBlockerMiddleware_RemoteRead(t *testing.T) {
 		{
 			name: "blocks query via regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: ".*metric_counter.*", Regex: true},
 				},
 			},
@@ -201,7 +201,7 @@ func TestQueryBlockerMiddleware_RemoteRead(t *testing.T) {
 		{
 			name: "blocks query via regex pattern, with begin/end curly brackets used as a trick to match only remote read requests",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: "\\{.*metric_counter.*\\}", Regex: true},
 				},
 			},
@@ -210,7 +210,7 @@ func TestQueryBlockerMiddleware_RemoteRead(t *testing.T) {
 		{
 			name: "not blocks query via regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: ".*another_metric.*", Regex: true},
 				},
 			},
@@ -218,7 +218,7 @@ func TestQueryBlockerMiddleware_RemoteRead(t *testing.T) {
 		{
 			name: "invalid regex pattern",
 			limits: mockLimits{
-				blockedQueries: []*validation.BlockedQuery{
+				blockedQueries: []validation.BlockedQuery{
 					{Pattern: "[a-9}", Regex: true},
 				},
 			},

--- a/pkg/frontend/querymiddleware/query_limiter_test.go
+++ b/pkg/frontend/querymiddleware/query_limiter_test.go
@@ -37,20 +37,20 @@ func TestQueryLimiterMiddleware_RangeAndInstantQuery(t *testing.T) {
 		},
 		{
 			name: "non-empty limit should block",
-			limits: mockLimits{limitedQueries: []*validation.LimitedQuery{
+			limits: mockLimits{limitedQueries: []validation.LimitedQuery{
 				{Query: query, AllowedFrequency: time.Minute},
 			}},
 			expectSecondQueryBlocked: true,
 		},
 		{
 			name: "short max frequency should not block",
-			limits: mockLimits{limitedQueries: []*validation.LimitedQuery{
+			limits: mockLimits{limitedQueries: []validation.LimitedQuery{
 				{Query: query, AllowedFrequency: time.Second},
 			}},
 		},
 		{
 			name: "non-matching pattern should not block",
-			limits: mockLimits{limitedQueries: []*validation.LimitedQuery{
+			limits: mockLimits{limitedQueries: []validation.LimitedQuery{
 				{Query: "increase(metric_counter[5m])", AllowedFrequency: time.Minute},
 			}},
 		},
@@ -121,7 +121,7 @@ func TestQueryLimiterMiddleware_MultipleUsers_RangeAndInstantQuery(t *testing.T)
 		{
 			name: "limit matching for one tenant but not other should block",
 			limits: &multiTenantMockLimits{byTenant: map[string]mockLimits{
-				"test2": {limitedQueries: []*validation.LimitedQuery{
+				"test2": {limitedQueries: []validation.LimitedQuery{
 					{
 						Query: query, AllowedFrequency: time.Minute,
 					}},
@@ -132,7 +132,7 @@ func TestQueryLimiterMiddleware_MultipleUsers_RangeAndInstantQuery(t *testing.T)
 		{
 			name: "limit does not exist for queried tenants should not block",
 			limits: &multiTenantMockLimits{byTenant: map[string]mockLimits{
-				"test3": {limitedQueries: []*validation.LimitedQuery{
+				"test3": {limitedQueries: []validation.LimitedQuery{
 					{
 						Query: query, AllowedFrequency: time.Minute,
 					}},
@@ -142,12 +142,12 @@ func TestQueryLimiterMiddleware_MultipleUsers_RangeAndInstantQuery(t *testing.T)
 		{
 			name: "tenants with different limit frequencies (one long) should block",
 			limits: &multiTenantMockLimits{byTenant: map[string]mockLimits{
-				"test1": {limitedQueries: []*validation.LimitedQuery{
+				"test1": {limitedQueries: []validation.LimitedQuery{
 					{
 						Query: query, AllowedFrequency: time.Second,
 					}},
 				},
-				"test2": {limitedQueries: []*validation.LimitedQuery{
+				"test2": {limitedQueries: []validation.LimitedQuery{
 					{
 						Query: query, AllowedFrequency: time.Minute,
 					}},
@@ -224,20 +224,20 @@ func TestQueryLimiterMiddleware_RemoteRead(t *testing.T) {
 		},
 		{
 			name: "matching query should block",
-			limits: mockLimits{limitedQueries: []*validation.LimitedQuery{
+			limits: mockLimits{limitedQueries: []validation.LimitedQuery{
 				{Query: queryString, AllowedFrequency: time.Minute},
 			}},
 			expectSecondQueryBlocked: true,
 		},
 		{
 			name: "non-matching query should not block",
-			limits: mockLimits{limitedQueries: []*validation.LimitedQuery{
+			limits: mockLimits{limitedQueries: []validation.LimitedQuery{
 				{Query: `{__name__="sample_counter",pod=~"app-.*"}`, AllowedFrequency: time.Minute},
 			}},
 		},
 		{
 			name: "short max frequency should not block",
-			limits: mockLimits{limitedQueries: []*validation.LimitedQuery{
+			limits: mockLimits{limitedQueries: []validation.LimitedQuery{
 				{Query: queryString, AllowedFrequency: time.Second},
 			}},
 		},
@@ -300,7 +300,7 @@ func TestQueryLimiterMiddleware_MultipleUsers_RemoteRead(t *testing.T) {
 		{
 			name: "limit matching for one tenant but not other should block",
 			limits: &multiTenantMockLimits{byTenant: map[string]mockLimits{
-				"test2": {limitedQueries: []*validation.LimitedQuery{
+				"test2": {limitedQueries: []validation.LimitedQuery{
 					{
 						Query:            queryString,
 						AllowedFrequency: time.Minute,
@@ -312,7 +312,7 @@ func TestQueryLimiterMiddleware_MultipleUsers_RemoteRead(t *testing.T) {
 		{
 			name: "limit does not exist for queried tenants should not block",
 			limits: &multiTenantMockLimits{byTenant: map[string]mockLimits{
-				"test3": {limitedQueries: []*validation.LimitedQuery{
+				"test3": {limitedQueries: []validation.LimitedQuery{
 					{
 						Query:            queryString,
 						AllowedFrequency: time.Minute,
@@ -323,13 +323,13 @@ func TestQueryLimiterMiddleware_MultipleUsers_RemoteRead(t *testing.T) {
 		{
 			name: "tenants with different limit frequencies (one long) should block",
 			limits: &multiTenantMockLimits{byTenant: map[string]mockLimits{
-				"test1": {limitedQueries: []*validation.LimitedQuery{
+				"test1": {limitedQueries: []validation.LimitedQuery{
 					{
 						Query:            queryString,
 						AllowedFrequency: time.Second,
 					}},
 				},
-				"test2": {limitedQueries: []*validation.LimitedQuery{
+				"test2": {limitedQueries: []validation.LimitedQuery{
 					{
 						Query:            queryString,
 						AllowedFrequency: time.Minute,

--- a/pkg/frontend/querymiddleware/request_blocker_test.go
+++ b/pkg/frontend/querymiddleware/request_blocker_test.go
@@ -22,7 +22,7 @@ func TestRequestBlocker_IsBlocked(t *testing.T) {
 	limits := multiTenantMockLimits{
 		byTenant: map[string]mockLimits{
 			userID: {
-				blockedRequests: []*validation.BlockedRequest{
+				blockedRequests: []validation.BlockedRequest{
 					{Path: "/blocked-by-path"},
 					{Method: "POST"},
 					{

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -507,7 +507,7 @@ func TestTripperware_BlockedRequests(t *testing.T) {
 		multiTenantMockLimits{
 			byTenant: map[string]mockLimits{
 				"user-1": {
-					blockedRequests: []*validation.BlockedRequest{
+					blockedRequests: []validation.BlockedRequest{
 						{
 							Path: "/api/v1/series",
 							QueryParams: map[string]validation.BlockedRequestQueryParam{

--- a/pkg/mimirtool/config/inspect.go
+++ b/pkg/mimirtool/config/inspect.go
@@ -36,6 +36,7 @@ type EntryKind string
 const (
 	KindBlock EntryKind = "block"
 	KindField EntryKind = "field"
+	KindMap   EntryKind = "map"
 )
 
 type InspectedEntry struct {
@@ -524,6 +525,12 @@ func convertEntryToEntry(entry *parse.ConfigEntry) *InspectedEntry {
 		e.FieldType = entry.FieldType
 		e.FieldCategory = entry.FieldCategory
 		e.FieldDefaultValue = parseDefaultValue(e, entry.FieldDefault)
+	case parse.KindMap:
+		e.Kind = KindMap
+		e.FieldType = entry.FieldType
+		e.FieldCategory = entry.FieldCategory
+		element := convertBlockToEntry(entry.Element)
+		e.FieldElement = element
 	default:
 		panic(fmt.Sprintf("cannot handle parse kind %q, entry name: %s", entry.Kind, entry.Name))
 	}

--- a/pkg/util/validation/blocked_query.go
+++ b/pkg/util/validation/blocked_query.go
@@ -8,14 +8,14 @@ type BlockedQuery struct {
 	Reason  string `yaml:"reason"`
 }
 
-type BlockedQueriesConfig []*BlockedQuery
+type BlockedQueriesConfig []BlockedQuery
 
 func (lq *BlockedQueriesConfig) ExampleDoc() (comment string, yaml interface{}) {
 	return `The following configuration blocks the query "rate(metric_counter[5m])". Setting the pattern to ".*" and regex to true blocks all queries.`,
-		[]map[string]string{
+		[]BlockedQuery{
 			{
-				"pattern": "rate(metric_counter[5m])",
-				"reason":  "because the query is misconfigured",
+				Pattern: "rate(metric_counter[5m])",
+				Reason:  "because the query is misconfigured",
 			},
 		}
 }

--- a/pkg/util/validation/blocked_query.go
+++ b/pkg/util/validation/blocked_query.go
@@ -4,7 +4,7 @@ package validation
 
 type BlockedQuery struct {
 	Pattern string `yaml:"pattern" doc:"description=PromQL expression pattern to match."`
-	Regex   bool   `yaml:"regex" doc:"description=If true, pattern is treated as a regular expression. If false, pattern is treated as a literal match."`
+	Regex   bool   `yaml:"regex" doc:"description=If true, the pattern is treated as a regular expression. If false, the pattern is treated as a literal match."`
 	Reason  string `yaml:"reason" doc:"description=Reason returned to clients when rejecting matching queries."`
 }
 

--- a/pkg/util/validation/blocked_query.go
+++ b/pkg/util/validation/blocked_query.go
@@ -3,9 +3,9 @@
 package validation
 
 type BlockedQuery struct {
-	Pattern string `yaml:"pattern"`
-	Regex   bool   `yaml:"regex"`
-	Reason  string `yaml:"reason"`
+	Pattern string `yaml:"pattern" doc:"description=PromQL expression pattern to match."`
+	Regex   bool   `yaml:"regex" doc:"description=If true, pattern is treated as a regular expression. If false, pattern is treated as a literal match."`
+	Reason  string `yaml:"reason" doc:"description=Reason returned to clients when rejecting matching queries."`
 }
 
 type BlockedQueriesConfig []BlockedQuery

--- a/pkg/util/validation/blocked_request.go
+++ b/pkg/util/validation/blocked_request.go
@@ -10,7 +10,7 @@ type BlockedRequest struct {
 
 type BlockedRequestQueryParam struct {
 	Value    string `yaml:"value" doc:"description=Value to match."`
-	IsRegexp bool   `yaml:"is_regexp,omitempty" doc:"description=If true, value is treated as a regexp pattern. If false, value is treated as a literal match."`
+	IsRegexp bool   `yaml:"is_regexp,omitempty" doc:"description=If true, the value is treated as a regular expression. If false, the value is treated as a literal match."`
 }
 
 type BlockedRequestsConfig []BlockedRequest

--- a/pkg/util/validation/blocked_request.go
+++ b/pkg/util/validation/blocked_request.go
@@ -12,3 +12,20 @@ type BlockedRequestQueryParam struct {
 	Value    string `yaml:"value"`
 	IsRegexp bool   `yaml:"is_regexp,omitempty"`
 }
+
+type BlockedRequestsConfig []BlockedRequest
+
+func (lq *BlockedRequestsConfig) ExampleDoc() (comment string, yaml interface{}) {
+	return `The following configuration blocks all GET requests to /foo when the "limit" parameter is set to 100.`,
+		[]BlockedRequest{
+			{
+				Path:   "/foo",
+				Method: "GET",
+				QueryParams: map[string]BlockedRequestQueryParam{
+					"limit": {
+						Value: "100",
+					},
+				},
+			},
+		}
+}

--- a/pkg/util/validation/blocked_request.go
+++ b/pkg/util/validation/blocked_request.go
@@ -3,14 +3,14 @@
 package validation
 
 type BlockedRequest struct {
-	Path        string                              `yaml:"path,omitempty"`
-	Method      string                              `yaml:"method,omitempty"`
-	QueryParams map[string]BlockedRequestQueryParam `yaml:"query_params,omitempty"`
+	Path        string                              `yaml:"path,omitempty" doc:"description=Path to match, including leading slash (/). Leave blank to match all paths."`
+	Method      string                              `yaml:"method,omitempty" doc:"description=HTTP method to match. Leave blank to match all methods."`
+	QueryParams map[string]BlockedRequestQueryParam `yaml:"query_params,omitempty" doc:"description=Query parameters to match. Requests must have all of the provided query parameters to be considered a match."`
 }
 
 type BlockedRequestQueryParam struct {
-	Value    string `yaml:"value"`
-	IsRegexp bool   `yaml:"is_regexp,omitempty"`
+	Value    string `yaml:"value" doc:"description=Value to match."`
+	IsRegexp bool   `yaml:"is_regexp,omitempty" doc:"description=If true, value is treated as a regexp pattern. If false, value is treated as a literal match."`
 }
 
 type BlockedRequestsConfig []BlockedRequest

--- a/pkg/util/validation/limited_query.go
+++ b/pkg/util/validation/limited_query.go
@@ -9,14 +9,14 @@ type LimitedQuery struct {
 	AllowedFrequency time.Duration `yaml:"allowed_frequency"` // query may only be run once per this duration
 }
 
-type LimitedQueriesConfig []*LimitedQuery
+type LimitedQueriesConfig []LimitedQuery
 
 func (lq *LimitedQueriesConfig) ExampleDoc() (comment string, yaml interface{}) {
 	return `The following configuration limits the query "rate(metric_counter[5m])" to running, at most, every minute.`,
-		[]map[string]string{
+		[]LimitedQuery{
 			{
-				"query":             "rate(metric_counter[5m])",
-				"allowed_frequency": "1m",
+				Query:            "rate(metric_counter[5m])",
+				AllowedFrequency: time.Minute,
 			},
 		}
 }

--- a/pkg/util/validation/limited_query.go
+++ b/pkg/util/validation/limited_query.go
@@ -5,8 +5,8 @@ package validation
 import "time"
 
 type LimitedQuery struct {
-	Query            string        `yaml:"query"`
-	AllowedFrequency time.Duration `yaml:"allowed_frequency"` // query may only be run once per this duration
+	Query            string        `yaml:"query" doc:"description=Literal PromQL expression to match."`
+	AllowedFrequency time.Duration `yaml:"allowed_frequency" doc:"description=Minimum duration between matching queries. If a matching query arrives more often than this, it is rejected."`
 }
 
 type LimitedQueriesConfig []LimitedQuery

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -206,7 +206,7 @@ type Limits struct {
 	MaxQueryExpressionSizeBytes            int                    `yaml:"max_query_expression_size_bytes" json:"max_query_expression_size_bytes"`
 	BlockedQueries                         BlockedQueriesConfig   `yaml:"blocked_queries,omitempty" json:"blocked_queries,omitempty" doc:"nocli|description=List of queries to block." category:"experimental"`
 	LimitedQueries                         LimitedQueriesConfig   `yaml:"limited_queries,omitempty" json:"limited_queries,omitempty" doc:"nocli|description=List of queries to limit and duration to limit them for." category:"experimental"`
-	BlockedRequests                        BlockedRequestsConfig  `yaml:"blocked_requests,omitempty" json:"blocked_requests,omitempty" doc:"nocli|description=List of http requests to block." category:"experimental"`
+	BlockedRequests                        BlockedRequestsConfig  `yaml:"blocked_requests,omitempty" json:"blocked_requests,omitempty" doc:"nocli|description=List of HTTP requests to block." category:"experimental"`
 	AlignQueriesWithStep                   bool                   `yaml:"align_queries_with_step" json:"align_queries_with_step"`
 	EnabledPromQLExperimentalFunctions     flagext.StringSliceCSV `yaml:"enabled_promql_experimental_functions" json:"enabled_promql_experimental_functions" category:"experimental"`
 	Prom2RangeCompat                       bool                   `yaml:"prom2_range_compat" json:"prom2_range_compat" category:"experimental"`

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -206,7 +206,7 @@ type Limits struct {
 	MaxQueryExpressionSizeBytes            int                    `yaml:"max_query_expression_size_bytes" json:"max_query_expression_size_bytes"`
 	BlockedQueries                         BlockedQueriesConfig   `yaml:"blocked_queries,omitempty" json:"blocked_queries,omitempty" doc:"nocli|description=List of queries to block." category:"experimental"`
 	LimitedQueries                         LimitedQueriesConfig   `yaml:"limited_queries,omitempty" json:"limited_queries,omitempty" doc:"nocli|description=List of queries to limit and duration to limit them for." category:"experimental"`
-	BlockedRequests                        []*BlockedRequest      `yaml:"blocked_requests,omitempty" json:"blocked_requests,omitempty" doc:"nocli|description=List of http requests to block." category:"experimental"`
+	BlockedRequests                        BlockedRequestsConfig  `yaml:"blocked_requests,omitempty" json:"blocked_requests,omitempty" doc:"nocli|description=List of http requests to block." category:"experimental"`
 	AlignQueriesWithStep                   bool                   `yaml:"align_queries_with_step" json:"align_queries_with_step"`
 	EnabledPromQLExperimentalFunctions     flagext.StringSliceCSV `yaml:"enabled_promql_experimental_functions" json:"enabled_promql_experimental_functions" category:"experimental"`
 	Prom2RangeCompat                       bool                   `yaml:"prom2_range_compat" json:"prom2_range_compat" category:"experimental"`
@@ -793,16 +793,16 @@ func (o *Overrides) MaxQueryExpressionSizeBytes(userID string) int {
 }
 
 // BlockedQueries returns the blocked queries.
-func (o *Overrides) BlockedQueries(userID string) []*BlockedQuery {
+func (o *Overrides) BlockedQueries(userID string) []BlockedQuery {
 	return o.getOverridesForUser(userID).BlockedQueries
 }
 
-func (o *Overrides) LimitedQueries(userID string) []*LimitedQuery {
+func (o *Overrides) LimitedQueries(userID string) []LimitedQuery {
 	return o.getOverridesForUser(userID).LimitedQueries
 }
 
 // BlockedRequests returns the blocked http requests.
-func (o *Overrides) BlockedRequests(userID string) []*BlockedRequest {
+func (o *Overrides) BlockedRequests(userID string) []BlockedRequest {
 	return o.getOverridesForUser(userID).BlockedRequests
 }
 

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -1836,7 +1836,7 @@ user1:
 
 	blockedRequests := ov.BlockedRequests("user1")
 	require.Len(t, blockedRequests, 2)
-	require.Equal(t, &BlockedRequest{
+	require.Equal(t, BlockedRequest{
 		Path:   "/api/v1/query",
 		Method: "POST",
 		QueryParams: map[string]BlockedRequestQueryParam{
@@ -1845,7 +1845,7 @@ user1:
 			},
 		},
 	}, blockedRequests[0])
-	require.Equal(t, &BlockedRequest{
+	require.Equal(t, BlockedRequest{
 		QueryParams: map[string]BlockedRequestQueryParam{
 			"first": {
 				Value:    "bar.*",

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -27,7 +27,6 @@ import (
 	"github.com/grafana/mimir/pkg/ruler/notifier"
 	"github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/util/configdoc"
-	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 var (
@@ -366,12 +365,6 @@ func getFieldCustomType(t reflect.Type) (string, bool) {
 		return "string", true
 	case reflect.TypeOf([]*relabel.Config{}).String():
 		return "relabel_config...", true
-	case reflect.TypeOf(validation.BlockedQueriesConfig{}).String():
-		return "list of pattern (string), regex (bool), and, optionally, reason (string)", true
-	case reflect.TypeOf(validation.LimitedQueriesConfig{}).String():
-		return "list of query (string) and allowed_frequency (duration)", true
-	case reflect.TypeOf([]*validation.BlockedRequest{}).String():
-		return "blocked_requests_config...", true
 	case reflect.TypeOf(asmodel.CustomTrackersConfig{}).String():
 		return "map of tracker name (string) to matcher (string)", true
 	default:
@@ -458,12 +451,6 @@ func getCustomFieldType(t reflect.Type) (string, bool) {
 		return "string", true
 	case reflect.TypeOf([]*relabel.Config{}).String():
 		return "relabel_config...", true
-	case reflect.TypeOf([]*validation.BlockedQueriesConfig{}).String():
-		return "list of pattern (string), regex (bool), and, optionally, reason (string)", true
-	case reflect.TypeOf(validation.LimitedQueriesConfig{}).String():
-		return "list of query (string) and allowed_frequency (duration)", true
-	case reflect.TypeOf([]*validation.BlockedRequest{}).String():
-		return "blocked_requests_config...", true
 	case reflect.TypeOf(asmodel.CustomTrackersConfig{}).String():
 		return "map of tracker name (string) to matcher (string)", true
 	default:
@@ -495,12 +482,6 @@ func ReflectType(typ string) reflect.Type {
 		return reflect.TypeOf(map[string]string{})
 	case "relabel_config...":
 		return reflect.TypeOf([]*relabel.Config{})
-	case "list of pattern (string), regex (bool), and, optionally, reason (string)":
-		return reflect.TypeOf([]*validation.BlockedQueriesConfig{})
-	case "list of query (string) and allowed_frequency (duration)":
-		return reflect.TypeOf(validation.LimitedQueriesConfig{})
-	case "blocked_requests_config...":
-		return reflect.TypeOf([]*validation.BlockedRequest{})
 	case "ruler_alertmanager_client_config...":
 		return reflect.TypeOf(notifier.AlertmanagerClientConfig{})
 	case "map of string to float64":

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -247,6 +247,11 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 			continue
 		}
 
+		fieldType, err := getFieldType(field.Type)
+		if err != nil {
+			return nil, errors.Wrapf(err, "config=%s.%s", t.PkgPath(), t.Name())
+		}
+
 		var (
 			element *ConfigBlock
 			kind    = KindField
@@ -268,11 +273,23 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 					return nil, errors.Wrapf(err, "couldn't inspect slice, element_type=%s", field.Type.Elem())
 				}
 			}
-		}
+			isMapOfStructs := field.Type.Kind() == reflect.Map && (field.Type.Elem().Kind() == reflect.Struct || field.Type.Elem().Kind() == reflect.Ptr)
+			if !isCustomType && isMapOfStructs {
+				element = &ConfigBlock{
+					Name: fieldName,
+					Desc: getFieldDescription(cfg, field, ""),
+				}
+				kind = KindMap
+				fieldType, err = getFieldType(field.Type.Key())
+				if err != nil {
+					return nil, errors.Wrapf(err, "couldn't inspect map, key_type=%s", field.Type.Key())
+				}
 
-		fieldType, err := getFieldType(field.Type)
-		if err != nil {
-			return nil, errors.Wrapf(err, "config=%s.%s", t.PkgPath(), t.Name())
+				_, err = config(element, reflect.New(field.Type.Elem()).Interface(), flags, rootBlocks)
+				if err != nil {
+					return nil, errors.Wrapf(err, "couldn't inspect map, element_type=%s", field.Type.Elem())
+				}
+			}
 		}
 
 		fieldFlag, err := getFieldFlag(field, fieldValue, flags)

--- a/tools/doc-generator/write/writer.go
+++ b/tools/doc-generator/write/writer.go
@@ -71,7 +71,7 @@ func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 			w.writeConfigBlock(e.Block, indent+tabWidth)
 		}
 
-	case parse.KindField, parse.KindMap:
+	case parse.KindField:
 		// Description
 		w.writeComment(w.modifyDescriptions(e.Description()), indent, 0)
 		w.writeExample(e.FieldExample, indent)
@@ -91,6 +91,22 @@ func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 		} else {
 			w.out.WriteString(pad(indent) + "[" + e.Name + ": <" + e.FieldType + "> | default = " + fieldDefault + "]\n")
 		}
+
+	case parse.KindMap:
+		// Description
+		w.writeComment(w.modifyDescriptions(e.Description()), indent, 0)
+		w.writeExample(e.FieldExample, indent)
+		w.writeFlag(e.FieldFlag, indent)
+
+		// Specification
+		if e.Required {
+			w.out.WriteString(pad(indent) + e.Name + ":\n")
+		} else {
+			w.out.WriteString(pad(indent) + "[" + e.Name + ":]\n")
+		}
+
+		w.out.WriteString(pad(indent+tabWidth) + "<" + e.FieldType + ">:\n")
+		w.writeConfigBlock(e.Element, indent+(2*tabWidth))
 
 	case parse.KindSlice:
 		// Description

--- a/tools/doc-generator/write/writer.go
+++ b/tools/doc-generator/write/writer.go
@@ -51,6 +51,8 @@ func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 		if e.Root {
 			// Description
 			w.writeComment(w.modifyDescriptions(e.BlockDesc), indent, 0)
+			w.writeExample(e.FieldExample, indent)
+
 			if e.Block.FlagsPrefix != "" {
 				w.writeComment(fmt.Sprintf("The CLI flags prefix for this block configuration is: %s", e.Block.FlagsPrefix), indent, 0)
 			}
@@ -60,6 +62,7 @@ func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 		} else {
 			// Description
 			w.writeComment(w.modifyDescriptions(e.BlockDesc), indent, 0)
+			w.writeExample(e.FieldExample, indent)
 
 			// Name
 			w.out.WriteString(pad(indent) + e.Name + ":\n")
@@ -92,6 +95,7 @@ func (w *specWriter) writeConfigEntry(e *parse.ConfigEntry, indent int) {
 	case parse.KindSlice:
 		// Description
 		w.writeComment(w.modifyDescriptions(e.Description()), indent, 0)
+		w.writeExample(e.FieldExample, indent)
 
 		// Name
 		w.out.WriteString(pad(indent) + e.Name + ":\n")

--- a/tools/doc-generator/write/writer_test.go
+++ b/tools/doc-generator/write/writer_test.go
@@ -41,8 +41,7 @@ nested_struct:
 
 # The nested list
 nested_slice:
-  -
-    # The username
+  - # The username
     [username: <string> | default = ""]
 
     # The password


### PR DESCRIPTION
#### What this PR does

This PR improves how the configuration of blocked requests, blocked queries and limited queries is displayed in the docs.

In particular:

* all fields are now shown as they would be for any other config block, rather than relying on a comment
* an example has been added for how to configure a blocked request

To achieve this, I've made two changes to the config doc generator:

* maps of structs are now shown expanded, instead of as `map of string to package.SomeStruct`
* examples (if available) are now shown for all types of fields

I've also changed the implementation of `ExampleDoc` for each type to use the Go type rather than a generic map, so these should stay in-sync with the actual configuration fields. I changed the blocked requests, blocked queries and limited queries slices to not use pointers, as the pointers seemed unnecessary and keeping them would have required further changes to the config doc generator.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [x] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
