### PR TITLE
Optimise label names API by removing __name__!="" matcher when redundant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@
 * [ENHANCEMENT] `kafkatool`: add `consumer-group delete-offset` command as a way to delete the committed offset for a consumer group. #11988
 * [ENHANCEMENT] Block-builder-scheduler: Detect gaps in scheduled and completed jobs. #11867
 * [ENHANCEMENT] Distributor: Experimental support for Prometheus Remote-Write 2.0 protocol has been updated. Created timestamps are now supported. This feature includes some limitations. If samples in a write request aren't ordered by time, the created timestamp might be dropped. Additionally, per-series metadata is automatically merged on the metric family level. Ingestion might fail if the client sends ProtoBuf fields out-of-order. The label `version` is added to the metric `cortex_distributor_requests_in_total` with a value of either `1.0` or `2.0`, depending on the detected remote-write protocol. #11977
+* [ENHANCEMENT] Query-frontend: Added labels query optimizer that automatically removes redundant `__name__!=""` matchers from label names queries, improving query performance. The optimizer can be enabled per-tenant with the `labels_query_optimizer_enabled` runtime configuration flag. #12054
 * [BUGFIX] Distributor: Validate the RW2 symbols field and reject invalid requests that don't have an empty string as the first symbol. #11953
 * [BUGFIX] Distributor: Check `max_inflight_push_requests_bytes` before decompressing incoming requests. #11967
+* [BUGFIX] Query-frontend: Allow limit parameter to be 0 in label queries to explicitly request unlimited results. #12054
 
 ### Mixin
 

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5025,7 +5025,7 @@
           "kind": "field",
           "name": "labels_query_optimizer_enabled",
           "required": false,
-          "desc": "Enable labels query optimizations. When enabled, the query-frontend rewrites labels queries in an idempotent way to improve their performance.",
+          "desc": "Enable labels query optimizations. When enabled, the query-frontend may rewrite labels queries to improve their performance.",
           "fieldValue": null,
           "fieldDefaultValue": false,
           "fieldFlag": "query-frontend.labels-query-optimizer-enabled",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5023,6 +5023,17 @@
         },
         {
           "kind": "field",
+          "name": "labels_query_optimizer_enabled",
+          "required": false,
+          "desc": "Enable labels query optimizations. When enabled, the query-frontend rewrites labels queries in an idempotent way to improve their performance.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-frontend.labels-query-optimizer-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "cardinality_analysis_enabled",
           "required": false,
           "desc": "Enables endpoints used for cardinality analysis.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2409,6 +2409,8 @@ Usage of ./cmd/mimir/mimir:
     	List of network interface names to look up when finding the instance IP address. This address is sent to query-scheduler and querier, which uses it to send the query response back to query-frontend. (default [<private network interfaces>])
   -query-frontend.instance-port int
     	Port to advertise to querier (via scheduler) (defaults to server.grpc-listen-port).
+  -query-frontend.labels-query-optimizer-enabled
+    	[experimental] Enable labels query optimizations. When enabled, the query-frontend rewrites labels queries in an idempotent way to improve their performance.
   -query-frontend.log-queries-longer-than duration
     	Log queries that are slower than the specified duration. Set to 0 to disable. Set to < 0 to enable on all queries.
   -query-frontend.log-query-request-headers comma-separated-list-of-strings

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2410,7 +2410,7 @@ Usage of ./cmd/mimir/mimir:
   -query-frontend.instance-port int
     	Port to advertise to querier (via scheduler) (defaults to server.grpc-listen-port).
   -query-frontend.labels-query-optimizer-enabled
-    	[experimental] Enable labels query optimizations. When enabled, the query-frontend rewrites labels queries in an idempotent way to improve their performance.
+    	[experimental] Enable labels query optimizations. When enabled, the query-frontend may rewrite labels queries to improve their performance.
   -query-frontend.log-queries-longer-than duration
     	Log queries that are slower than the specified duration. Set to 0 to disable. Set to < 0 to enable on all queries.
   -query-frontend.log-query-request-headers comma-separated-list-of-strings

--- a/development/mimir-ingest-storage/config/runtime.yaml
+++ b/development/mimir-ingest-storage/config/runtime.yaml
@@ -6,4 +6,4 @@ overrides:
       base_mimir_read:  '{job="mimir-read-write-mode/mimir-read"}'
     active_series_additional_custom_trackers:
       additional_mimir_backend: '{job="mimir-read-write-mode/mimir-backend"}'
-    labels_query_optimizer_enabled: false
+    labels_query_optimizer_enabled: true

--- a/development/mimir-ingest-storage/config/runtime.yaml
+++ b/development/mimir-ingest-storage/config/runtime.yaml
@@ -6,3 +6,4 @@ overrides:
       base_mimir_read:  '{job="mimir-read-write-mode/mimir-read"}'
     active_series_additional_custom_trackers:
       additional_mimir_backend: '{job="mimir-read-write-mode/mimir-backend"}'
+    labels_query_optimizer_enabled: false

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -225,6 +225,7 @@ The following features are currently experimental:
   - Support for duration expressions in PromQL, which are simple arithmetics on numbers in offset and range specification.
   - Support for configuring the maximum series limit for cardinality API requests on a per-tenant basis via `cardinality_analysis_max_results`.
   - [Mimir query engine](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/mimir-query-engine) (`-query-frontend.query-engine` and `-query-frontend.enable-query-engine-fallback`)
+  - Labels query optimizer (`-query-frontend.labels-query-optimizer-enabled`)
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
 - Store-gateway

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3758,6 +3758,12 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -query-frontend.subquery-spin-off-enabled
 [subquery_spin_off_enabled: <boolean> | default = false]
 
+# (experimental) Enable labels query optimizations. When enabled, the
+# query-frontend rewrites labels queries in an idempotent way to improve their
+# performance.
+# CLI flag: -query-frontend.labels-query-optimizer-enabled
+[labels_query_optimizer_enabled: <boolean> | default = false]
+
 # Enables endpoints used for cardinality analysis.
 # CLI flag: -querier.cardinality-analysis-enabled
 [cardinality_analysis_enabled: <boolean> | default = false]

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3759,8 +3759,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 [subquery_spin_off_enabled: <boolean> | default = false]
 
 # (experimental) Enable labels query optimizations. When enabled, the
-# query-frontend rewrites labels queries in an idempotent way to improve their
-# performance.
+# query-frontend may rewrite labels queries to improve their performance.
 # CLI flag: -query-frontend.labels-query-optimizer-enabled
 [labels_query_optimizer_enabled: <boolean> | default = false]
 

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -442,8 +442,8 @@ func (prometheusCodec) DecodeLabelsSeriesQueryRequest(_ context.Context, r *http
 	limit := uint64(0) // 0 means unlimited
 	if limitStr := reqValues.Get("limit"); limitStr != "" {
 		limit, err = strconv.ParseUint(limitStr, 10, 64)
-		if err != nil || limit == 0 {
-			return nil, apierror.New(apierror.TypeBadData, fmt.Sprintf("limit parameter must be a positive number: %s", limitStr))
+		if err != nil {
+			return nil, apierror.New(apierror.TypeBadData, fmt.Sprintf("limit parameter must be greater or equal to 0: %s", limitStr))
 		}
 	}
 	headers := httpHeadersToProm(r.Header)

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -443,7 +443,7 @@ func (prometheusCodec) DecodeLabelsSeriesQueryRequest(_ context.Context, r *http
 	if limitStr := reqValues.Get("limit"); limitStr != "" {
 		limit, err = strconv.ParseUint(limitStr, 10, 64)
 		if err != nil {
-			return nil, apierror.New(apierror.TypeBadData, fmt.Sprintf("limit parameter must be greater or equal to 0: %s", limitStr))
+			return nil, apierror.New(apierror.TypeBadData, fmt.Sprintf("limit parameter must be greater than or equal to 0, got %s", limitStr))
 		}
 	}
 	headers := httpHeadersToProm(r.Header)

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -505,6 +505,7 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 		propagateHeaders          []string
 		url                       string
 		headers                   http.Header
+		expectedURL               string
 		expectedStruct            LabelsSeriesQueryRequest
 		expectedGetLabelName      string
 		expectedGetStartOrDefault int64
@@ -513,8 +514,9 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 		expectedLimit             uint64
 	}{
 		{
-			name: "label names with start and end timestamps, no matcher sets",
-			url:  "/api/v1/labels?end=1708588800&start=1708502400",
+			name:        "label names with start and end timestamps, no matcher sets",
+			url:         "/api/v1/labels?end=1708588800&start=1708502400",
+			expectedURL: "/api/v1/labels?end=1708588800&start=1708502400",
 			expectedStruct: &PrometheusLabelNamesQueryRequest{
 				Path:             "/api/v1/labels",
 				Start:            1708502400 * 1e3,
@@ -526,8 +528,9 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetEndOrDefault:   1708588800 * 1e3,
 		},
 		{
-			name: "label values with start and end timestamps, no matcher sets",
-			url:  "/api/v1/label/job/values?end=1708588800&start=1708502400",
+			name:        "label values with start and end timestamps, no matcher sets",
+			url:         "/api/v1/label/job/values?end=1708588800&start=1708502400",
+			expectedURL: "/api/v1/label/job/values?end=1708588800&start=1708502400",
 			expectedStruct: &PrometheusLabelValuesQueryRequest{
 				Path:             "/api/v1/label/job/values",
 				LabelName:        "job",
@@ -540,8 +543,9 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetEndOrDefault:   1708588800 * 1e3,
 		},
 		{
-			name: "label names with start timestamp, no end timestamp, no matcher sets",
-			url:  "/api/v1/labels?start=1708502400",
+			name:        "label names with start timestamp, no end timestamp, no matcher sets",
+			url:         "/api/v1/labels?start=1708502400",
+			expectedURL: "/api/v1/labels?start=1708502400",
 			expectedStruct: &PrometheusLabelNamesQueryRequest{
 				Path:             "/api/v1/labels",
 				Start:            1708502400 * 1e3,
@@ -553,8 +557,9 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetEndOrDefault:   v1API.MaxTime.UnixMilli(),
 		},
 		{
-			name: "label values with start timestamp, no end timestamp, no matcher sets",
-			url:  "/api/v1/label/job/values?start=1708502400",
+			name:        "label values with start timestamp, no end timestamp, no matcher sets",
+			url:         "/api/v1/label/job/values?start=1708502400",
+			expectedURL: "/api/v1/label/job/values?start=1708502400",
 			expectedStruct: &PrometheusLabelValuesQueryRequest{
 				Path:             "/api/v1/label/job/values",
 				LabelName:        "job",
@@ -567,8 +572,9 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetEndOrDefault:   v1API.MaxTime.UnixMilli(),
 		},
 		{
-			name: "label names with end timestamp, no start timestamp, no matcher sets",
-			url:  "/api/v1/labels?end=1708588800",
+			name:        "label names with end timestamp, no start timestamp, no matcher sets",
+			url:         "/api/v1/labels?end=1708588800",
+			expectedURL: "/api/v1/labels?end=1708588800",
 			expectedStruct: &PrometheusLabelNamesQueryRequest{
 				Path:             "/api/v1/labels",
 				Start:            0,
@@ -580,8 +586,9 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetEndOrDefault:   1708588800 * 1e3,
 		},
 		{
-			name: "label values with end timestamp, no start timestamp, no matcher sets",
-			url:  "/api/v1/label/job/values?end=1708588800",
+			name:        "label values with end timestamp, no start timestamp, no matcher sets",
+			url:         "/api/v1/label/job/values?end=1708588800",
+			expectedURL: "/api/v1/label/job/values?end=1708588800",
 			expectedStruct: &PrometheusLabelValuesQueryRequest{
 				Path:             "/api/v1/label/job/values",
 				LabelName:        "job",
@@ -594,8 +601,9 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetEndOrDefault:   1708588800 * 1e3,
 		},
 		{
-			name: "label names with start and end timestamp, multiple matcher sets",
-			url:  "/api/v1/labels?end=1708588800&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+			name:        "label names with start and end timestamp, multiple matcher sets",
+			url:         "/api/v1/labels?end=1708588800&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+			expectedURL: "/api/v1/labels?end=1708588800&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
 			expectedStruct: &PrometheusLabelNamesQueryRequest{
 				Path:  "/api/v1/labels",
 				Start: 1708502400 * 1e3,
@@ -610,8 +618,9 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetEndOrDefault:   1708588800 * 1e3,
 		},
 		{
-			name: "label values with start and end timestamp, multiple matcher sets",
-			url:  "/api/v1/label/job/values?end=1708588800&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+			name:        "label values with start and end timestamp, multiple matcher sets",
+			url:         "/api/v1/label/job/values?end=1708588800&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+			expectedURL: "/api/v1/label/job/values?end=1708588800&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
 			expectedStruct: &PrometheusLabelValuesQueryRequest{
 				Path:      "/api/v1/label/job/values",
 				LabelName: "job",
@@ -627,8 +636,9 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetEndOrDefault:   1708588800 * 1e3,
 		},
 		{
-			name: "label names with start and end timestamp, multiple matcher sets, limit",
-			url:  "/api/v1/labels?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+			name:        "label names with start and end timestamp, multiple matcher sets, limit",
+			url:         "/api/v1/labels?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+			expectedURL: "/api/v1/labels?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
 			expectedStruct: &PrometheusLabelNamesQueryRequest{
 				Path:  "/api/v1/labels",
 				Start: 1708502400 * 1e3,
@@ -645,8 +655,9 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetEndOrDefault:   1708588800 * 1e3,
 		},
 		{
-			name: "label values with start and end timestamp, multiple matcher sets, limit",
-			url:  "/api/v1/label/job/values?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+			name:        "label values with start and end timestamp, multiple matcher sets, limit",
+			url:         "/api/v1/label/job/values?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
+			expectedURL: "/api/v1/label/job/values?end=1708588800&limit=10&match%5B%5D=go_goroutines%7Bcontainer%3D~%22quer.%2A%22%7D&match%5B%5D=go_goroutines%7Bcontainer%21%3D%22query-scheduler%22%7D&start=1708502400",
 			expectedStruct: &PrometheusLabelValuesQueryRequest{
 				Path:      "/api/v1/label/job/values",
 				LabelName: "job",
@@ -664,14 +675,26 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetEndOrDefault:   1708588800 * 1e3,
 		},
 		{
-			name:        "zero limit is not allowed",
-			url:         "/api/v1/label/job/values?limit=0",
-			expectedErr: "limit parameter must be a positive number: 0",
+			name:        "zero limit is allowed",
+			url:         "/api/v1/label/job/values?limit=0&start=1708502400&end=1708588800",
+			expectedURL: "/api/v1/label/job/values?end=1708588800&start=1708502400", // Zero limit is omitted (it's the default).
+			expectedStruct: &PrometheusLabelValuesQueryRequest{
+				Path:      "/api/v1/label/job/values",
+				LabelName: "job",
+				Start:     1708502400 * 1e3,
+				End:       1708588800 * 1e3,
+				Limit:     0,
+			},
+			expectedGetLabelName:      "job",
+			expectedLimit:             0,
+			expectedGetStartOrDefault: 1708502400 * 1e3,
+			expectedGetEndOrDefault:   1708588800 * 1e3,
 		},
 		{
 			name:        "negative limit is not allowed",
 			url:         "/api/v1/label/job/values?limit=-1",
-			expectedErr: "limit parameter must be a positive number: -1",
+			expectedURL: "/api/v1/label/job/values?limit=-1",
+			expectedErr: "limit parameter must be greater than or equal to 0, got -1",
 		},
 		{
 			name: "propagates headers",
@@ -679,6 +702,7 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 				"X-Special-Header": []string{"some-value"},
 			},
 			url:              "/api/v1/labels?end=1708588800&start=1708502400",
+			expectedURL:      "/api/v1/labels?end=1708588800&start=1708502400",
 			propagateHeaders: []string{"X-Special-Header"},
 			expectedStruct: &PrometheusLabelNamesQueryRequest{
 				Path:  "/api/v1/labels",
@@ -746,7 +770,7 @@ func TestPrometheusCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 
 					reqEncoded, err := codec.EncodeLabelsSeriesQueryRequest(context.Background(), reqDecoded)
 					require.NoError(t, err)
-					require.EqualValues(t, testCase.url, reqEncoded.RequestURI)
+					require.EqualValues(t, testCase.expectedURL, reqEncoded.RequestURI)
 				})
 			}
 		})

--- a/pkg/frontend/querymiddleware/labels_query_optimizer.go
+++ b/pkg/frontend/querymiddleware/labels_query_optimizer.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/tenant"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	apierror "github.com/grafana/mimir/pkg/api/error"
+	"github.com/grafana/mimir/pkg/util"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+	"github.com/grafana/mimir/pkg/util/validation"
+)
+
+type labelsQueryOptimizer struct {
+	next   http.RoundTripper
+	codec  Codec
+	limits Limits
+	logger log.Logger
+}
+
+func newLabelsQueryOptimizer(codec Codec, limits Limits, next http.RoundTripper, logger log.Logger) http.RoundTripper {
+	return &labelsQueryOptimizer{
+		next:   next,
+		codec:  codec,
+		limits: limits,
+		logger: logger,
+	}
+}
+
+func (l *labelsQueryOptimizer) RoundTrip(req *http.Request) (*http.Response, error) {
+	spanLog, ctx := spanlogger.New(req.Context(), l.logger, tracer, "labelsQueryOptimizer")
+	defer spanLog.Finish()
+
+	tenantIDs, err := tenant.TenantIDs(ctx)
+	if err != nil {
+		return nil, apierror.New(apierror.TypeBadData, err.Error())
+	}
+
+	// Check if the optimization is enabled for this tenant.
+	if !validation.AllTrueBooleansPerTenant(tenantIDs, l.limits.LabelsQueryOptimizerEnabled) {
+		return l.next.RoundTrip(req)
+	}
+
+	// Decode the request. If decoding fails, pass through the original request to ensure the client
+	// will get a proper error message.
+	parsedReq, err := l.codec.DecodeLabelsSeriesQueryRequest(ctx, req)
+	if err != nil {
+		return l.next.RoundTrip(req)
+	}
+
+	switch parsedReq.(type) {
+	case *PrometheusLabelNamesQueryRequest:
+		return l.optimizeLabelNamesRequest(ctx, req, parsedReq.(*PrometheusLabelNamesQueryRequest))
+	default:
+		return l.next.RoundTrip(req)
+	}
+}
+
+func (l *labelsQueryOptimizer) optimizeLabelNamesRequest(ctx context.Context, req *http.Request, parsedReq *PrometheusLabelNamesQueryRequest) (*http.Response, error) {
+	// Check if there are any matchers to optimize.
+	rawMatchers := parsedReq.GetLabelMatcherSets()
+	if len(rawMatchers) == 0 {
+		return l.next.RoundTrip(req)
+	}
+
+	// Optimize the matchers.
+	optimizedMatchers, optimized, err := optimizeLabelNamesRequestMatchers(rawMatchers)
+	if err != nil {
+		// Do not log any error because this error is typically caused by a malformed request, which wouldn't be actionable.
+		// TODO track a metric with reason "skipped"
+		return l.next.RoundTrip(req)
+	}
+
+	if !optimized {
+		return l.next.RoundTrip(req)
+	}
+
+	// Create a new request with optimized matchers.
+	optimizedParsedReq, err := parsedReq.WithLabelMatcherSets(optimizedMatchers)
+	if err != nil {
+		level.Error(l.logger).Log("msg", "failed to clone label names request with optimized matchers", "err", err)
+		// TODO track a metric to count the number of failures
+		return l.next.RoundTrip(req)
+	}
+
+	// Encode the optimized request back to HTTP.
+	optimizedReq, err := l.codec.EncodeLabelsSeriesQueryRequest(ctx, optimizedParsedReq)
+	if err != nil {
+		level.Error(l.logger).Log("msg", "failed to encode label names request with optimized matchers", "err", err)
+		// TODO track a metric to count the number of failures
+		return l.next.RoundTrip(req)
+	}
+
+	return l.next.RoundTrip(optimizedReq)
+}
+
+func optimizeLabelNamesRequestMatchers(rawMatcherSets []string) (_ []string, optimized bool, _ error) {
+	matcherSets, err := parser.ParseMetricSelectors(rawMatcherSets)
+	if err != nil {
+		return nil, false, err
+	}
+
+	optimizedRawMatcherSets := make([]string, 0, len(rawMatcherSets))
+
+	for _, matchers := range matcherSets {
+		optimizedMatchers := make([]*labels.Matcher, 0, len(matchers))
+
+		for _, matcher := range matchers {
+			// Filter out __name__!="" matchers because all series in Mimir have a metric name
+			// so this matcher is redundant (but very expensive to run).
+			if matcher.Name == labels.MetricName && matcher.Type == labels.MatchNotEqual && matcher.Value == "" {
+				optimized = true
+				continue
+			}
+
+			// Keep the matcher as is.
+			optimizedMatchers = append(optimizedMatchers, matcher)
+		}
+
+		if len(optimizedMatchers) > 0 {
+			optimizedRawMatcherSets = append(optimizedRawMatcherSets, util.LabelMatchersToString(optimizedMatchers))
+		}
+	}
+
+	return optimizedRawMatcherSets, optimized, nil
+}

--- a/pkg/frontend/querymiddleware/labels_query_optimizer.go
+++ b/pkg/frontend/querymiddleware/labels_query_optimizer.go
@@ -146,7 +146,7 @@ func optimizeLabelNamesRequestMatchers(rawMatcherSets []string) (_ []string, opt
 		// for the labels API, but we want to get the actual error from downstream. In this case we just
 		// don't optimize any matchers set.
 		if len(matchers) == 0 {
-			return nil, false, nil
+			return rawMatcherSets, false, nil
 		}
 
 		optimizedMatchers := make([]*labels.Matcher, 0, len(matchers))

--- a/pkg/frontend/querymiddleware/labels_query_optimizer.go
+++ b/pkg/frontend/querymiddleware/labels_query_optimizer.go
@@ -111,7 +111,6 @@ func (l *labelsQueryOptimizer) optimizeLabelNamesRequest(ctx context.Context, re
 	optimizedParsedReq, err := parsedReq.WithLabelMatcherSets(optimizedMatchers)
 	if err != nil {
 		level.Error(l.logger).Log("msg", "failed to clone label names request with optimized matchers", "err", err)
-		// Track failed optimization attempts.
 		l.failedQueries.Inc()
 		return l.next.RoundTrip(req)
 	}
@@ -120,7 +119,6 @@ func (l *labelsQueryOptimizer) optimizeLabelNamesRequest(ctx context.Context, re
 	optimizedReq, err := l.codec.EncodeLabelsSeriesQueryRequest(ctx, optimizedParsedReq)
 	if err != nil {
 		level.Error(l.logger).Log("msg", "failed to encode label names request with optimized matchers", "err", err)
-		// Track failed optimization attempts.
 		l.failedQueries.Inc()
 		return l.next.RoundTrip(req)
 	}

--- a/pkg/frontend/querymiddleware/labels_query_optimizer.go
+++ b/pkg/frontend/querymiddleware/labels_query_optimizer.go
@@ -5,6 +5,7 @@ package querymiddleware
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -124,12 +125,9 @@ func (l *labelsQueryOptimizer) optimizeLabelNamesRequest(ctx context.Context, re
 		return l.next.RoundTrip(req)
 	}
 
-	// TODO DEBUG
-	level.Info(l.logger).Log("msg", "optimized label names query", "original_matchers", parsedReq.LabelMatcherSets, "optimized_matchers", optimizedParsedReq.GetLabelMatcherSets())
-
 	// Track successful optimization.
 	l.rewrittenQueries.Inc()
-	spanLog.DebugLog("msg", "optimized label names query", "original_matchers", parsedReq.LabelMatcherSets, "optimized_matchers", optimizedParsedReq.GetLabelMatcherSets())
+	spanLog.DebugLog("msg", "optimized label names query", "original_matchers", strings.Join(parsedReq.LabelMatcherSets, " "), "optimized_matchers", strings.Join(optimizedParsedReq.GetLabelMatcherSets(), " "))
 	return l.next.RoundTrip(optimizedReq)
 }
 

--- a/pkg/frontend/querymiddleware/labels_query_optimizer_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_optimizer_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querymiddleware
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mimirtest "github.com/grafana/mimir/pkg/util/test"
+)
+
+func TestLabelsQueryOptimizer_RoundTrip(t *testing.T) {
+	const userID = "user-1"
+
+	tests := map[string]struct {
+		optimizerEnabled         bool
+		reqPath                  string
+		reqData                  url.Values
+		expectedDownstreamParams url.Values
+	}{
+		"should optimize labels request when enabled": {
+			optimizerEnabled:         true,
+			reqPath:                  "/api/v1/labels",
+			reqData:                  url.Values{"match[]": []string{`{__name__!="", job="prometheus"}`}},
+			expectedDownstreamParams: url.Values{"match[]": []string{`{job="prometheus"}`}},
+		},
+		"should optimize multiple matchers": {
+			optimizerEnabled:         true,
+			reqPath:                  "/api/v1/labels",
+			reqData:                  url.Values{"match[]": []string{`{__name__!="", job="prometheus"}`, `{__name__!="", instance="localhost"}`}},
+			expectedDownstreamParams: url.Values{"match[]": []string{`{job="prometheus"}`, `{instance="localhost"}`}},
+		},
+		"should handle mixed optimizable and non-optimizable matchers": {
+			optimizerEnabled:         true,
+			reqPath:                  "/api/v1/labels",
+			reqData:                  url.Values{"match[]": []string{`{job="test"}`, `{__name__!="", env="prod"}`}},
+			expectedDownstreamParams: url.Values{"match[]": []string{`{job="test"}`, `{env="prod"}`}},
+		},
+		"should pass through when optimization disabled": {
+			optimizerEnabled:         false,
+			reqPath:                  "/api/v1/labels",
+			reqData:                  url.Values{"match[]": []string{`{__name__!="", job="prometheus"}`}},
+			expectedDownstreamParams: url.Values{"match[]": []string{`{__name__!="", job="prometheus"}`}},
+		},
+		"should pass through when no optimization needed": {
+			optimizerEnabled:         true,
+			reqPath:                  "/api/v1/labels",
+			reqData:                  url.Values{"match[]": []string{`{job="prometheus"}`}},
+			expectedDownstreamParams: url.Values{"match[]": []string{`{job="prometheus"}`}},
+		},
+		"should pass through non-labels requests": {
+			optimizerEnabled:         true,
+			reqPath:                  "/api/v1/query",
+			reqData:                  url.Values{"query": []string{"up"}},
+			expectedDownstreamParams: url.Values{"query": []string{"up"}},
+		},
+		"should pass through when no matchers": {
+			optimizerEnabled:         true,
+			reqPath:                  "/api/v1/labels",
+			reqData:                  url.Values{},
+			expectedDownstreamParams: url.Values{},
+		},
+		"should pass through when malformed matchers": {
+			optimizerEnabled:         true,
+			reqPath:                  "/api/v1/labels",
+			reqData:                  url.Values{"match[]": []string{"{invalid syntax"}},
+			expectedDownstreamParams: url.Values{"match[]": []string{"{invalid syntax"}},
+		},
+		// TODO another path
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			for _, reqMethod := range []string{http.MethodGet, http.MethodPost} {
+				t.Run(reqMethod, func(t *testing.T) {
+					// Mock the limits.
+					limits := multiTenantMockLimits{
+						byTenant: map[string]mockLimits{
+							userID: {
+								labelsQueryOptimizerEnabled: testData.optimizerEnabled,
+							},
+						},
+					}
+
+					var (
+						req                 *http.Request
+						downstreamCalled    = false
+						downstreamReqParams url.Values
+						err                 error
+					)
+
+					// Mock the downstream and capture the request.
+					downstream := RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+						downstreamCalled = true
+
+						// Parse the request form to capture parameters.
+						require.NoError(t, req.ParseForm())
+						downstreamReqParams = req.Form
+
+						return &http.Response{StatusCode: http.StatusOK}, nil
+					})
+
+					// Create the request.
+					switch reqMethod {
+					case http.MethodGet:
+						req, err = http.NewRequest(reqMethod, testData.reqPath+"?"+testData.reqData.Encode(), nil)
+						require.NoError(t, err)
+					case http.MethodPost:
+						req, err = http.NewRequest(reqMethod, testData.reqPath, strings.NewReader(testData.reqData.Encode()))
+						req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+						require.NoError(t, err)
+					default:
+						t.Fatalf("unsupported HTTP method %q", reqMethod)
+					}
+
+					// Inject the tenant ID in the request
+					req = req.WithContext(user.InjectOrgID(context.Background(), userID))
+
+					// Create the labels query optimizer
+					codec := NewPrometheusCodec(prometheus.NewRegistry(), 0*time.Minute, formatJSON, nil)
+					optimizer := newLabelsQueryOptimizer(codec, limits, downstream, mimirtest.NewTestingLogger(t))
+
+					// Execute the request
+					_, err = optimizer.RoundTrip(req)
+					require.NoError(t, err)
+
+					// Ensure the downstream has been called with the expected params.
+					require.True(t, downstreamCalled)
+					require.Equal(t, testData.expectedDownstreamParams, downstreamReqParams)
+				})
+			}
+		})
+	}
+}
+
+func TestOptimizeLabelNamesRequestMatchers(t *testing.T) {
+	tests := map[string]struct {
+		inputMatchers     []string
+		expectedMatchers  []string
+		expectedOptimized bool
+		expectedError     bool
+	}{
+		"empty matchers": {
+			inputMatchers:     []string{},
+			expectedMatchers:  []string{},
+			expectedOptimized: false,
+			expectedError:     false,
+		},
+		`single __name__!="" matcher`: {
+			inputMatchers:     []string{`{__name__!=""}`},
+			expectedMatchers:  []string{},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		`single __name__!="" matcher with job label`: {
+			inputMatchers:     []string{`{__name__!="", job="prometheus"}`},
+			expectedMatchers:  []string{`{job="prometheus"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		`multiple labels with __name__!=""`: {
+			inputMatchers:     []string{`{__name__!="", job="prometheus", instance="localhost:9090"}`},
+			expectedMatchers:  []string{`{job="prometheus",instance="localhost:9090"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		`no __name__!="" matcher`: {
+			inputMatchers:     []string{`{job="prometheus"}`},
+			expectedMatchers:  []string{`{job="prometheus"}`},
+			expectedOptimized: false,
+			expectedError:     false,
+		},
+		"__name__ equal matcher": {
+			inputMatchers:     []string{`{__name__="up"}`},
+			expectedMatchers:  []string{`{__name__="up"}`},
+			expectedOptimized: false,
+			expectedError:     false,
+		},
+		"__name__ regex matchers": {
+			inputMatchers:     []string{`{__name__=~"up.*"}`, `{__name__!~"down.*"}`},
+			expectedMatchers:  []string{`{__name__=~"up.*"}`, `{__name__!~"down.*"}`},
+			expectedOptimized: false,
+			expectedError:     false,
+		},
+		"__name__ not equal with value": {
+			inputMatchers:     []string{`{__name__!="up"}`},
+			expectedMatchers:  []string{`{__name__!="up"}`},
+			expectedOptimized: false,
+			expectedError:     false,
+		},
+		"multiple matchers with mixed __name__ conditions": {
+			inputMatchers:     []string{`{__name__!="", job="prometheus"}`, `{__name__="up"}`, `{__name__!=""}`, `{instance="localhost"}`},
+			expectedMatchers:  []string{`{job="prometheus"}`, `{__name__="up"}`, `{instance="localhost"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		`multiple __name__!="" matchers in different sets`: {
+			inputMatchers:     []string{`{__name__!="", job="prometheus"}`, `{__name__!="", instance="localhost"}`},
+			expectedMatchers:  []string{`{job="prometheus"}`, `{instance="localhost"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		"complex matchers with special characters": {
+			inputMatchers:     []string{`{__name__!="", job=~"prometheus.*", instance!="bad-host"}`},
+			expectedMatchers:  []string{`{job=~"prometheus.*",instance!="bad-host"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		"quoted label names": {
+			inputMatchers:     []string{`{__name__!="", "strange-label"="value"}`},
+			expectedMatchers:  []string{`{"strange-label"="value"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		"label values with special characters": {
+			inputMatchers:     []string{`{__name__!="", job="prometheus:9090", path="/metrics"}`},
+			expectedMatchers:  []string{`{job="prometheus:9090",path="/metrics"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		"empty selector - no matchers inside braces": {
+			inputMatchers:     []string{`{}`},
+			expectedMatchers:  []string{`{}`},
+			expectedOptimized: false,
+			expectedError:     false,
+		},
+		"invalid matcher syntax": {
+			inputMatchers: []string{`{invalid syntax`},
+			expectedError: true,
+		},
+		"malformed regex": {
+			inputMatchers: []string{`{job=~"[invalid"}`},
+			expectedError: true,
+		},
+		"mixed valid and optimizable matchers": {
+			inputMatchers:     []string{`{job="test"}`, `{__name__!="", env="prod"}`, `{instance=~".*:9090"}`},
+			expectedMatchers:  []string{`{job="test"}`, `{env="prod"}`, `{instance=~".*:9090"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		"unicode label values": {
+			inputMatchers:     []string{`{__name__!="", job="测试", env="🚀"}`},
+			expectedMatchers:  []string{`{job="测试",env="🚀"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		"large number of labels": {
+			inputMatchers:     []string{`{__name__!="", label1="val1", label2="val2", label3="val3", label4="val4", label5="val5"}`},
+			expectedMatchers:  []string{`{label1="val1",label2="val2",label3="val3",label4="val4",label5="val5"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+		"matcher with escaped quotes": {
+			inputMatchers:     []string{`{__name__!="", job="test\"with\"quotes"}`},
+			expectedMatchers:  []string{`{job="test\"with\"quotes"}`},
+			expectedOptimized: true,
+			expectedError:     false,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			actualMatchers, actualOptimized, err := optimizeLabelNamesRequestMatchers(testData.inputMatchers)
+
+			if testData.expectedError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testData.expectedOptimized, actualOptimized)
+			assert.Equal(t, testData.expectedMatchers, actualMatchers)
+
+			// Ensure the optimized matchers are still valid.
+			_, err = parser.ParseMetricSelectors(actualMatchers)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/labels_query_optimizer_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_optimizer_test.go
@@ -305,8 +305,8 @@ func TestOptimizeLabelNamesRequestMatchers(t *testing.T) {
 			// The empty matcher must be preserved because it's an invalid matcher, and we
 			// want the downstream to generate the proper validation error.
 			inputMatchers:     []string{`{}`, `{__name__!="", job="prometheus:9090"}`},
-			expectedMatchers:  []string{`{}`, `{job="prometheus:9090"}`},
-			expectedOptimized: true,
+			expectedMatchers:  []string{`{}`, `{__name__!="", job="prometheus:9090"}`},
+			expectedOptimized: false,
 			expectedError:     false,
 		},
 		"quoted label names": {

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -123,6 +123,9 @@ type Limits interface {
 
 	// SubquerySpinOffEnabled returns if the feature of spinning off subqueries from instant queries as range queries is enabled.
 	SubquerySpinOffEnabled(userID string) bool
+
+	// LabelsQueryOptimizerEnabled returns whether labels query optimizations are enabled.
+	LabelsQueryOptimizerEnabled(userID string) bool
 }
 
 type limitsMiddleware struct {

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -708,6 +708,10 @@ func (m multiTenantMockLimits) SubquerySpinOffEnabled(userID string) bool {
 	return m.byTenant[userID].subquerySpinOffEnabled
 }
 
+func (m multiTenantMockLimits) LabelsQueryOptimizerEnabled(userID string) bool {
+	return m.byTenant[userID].labelsQueryOptimizerEnabled
+}
+
 type mockLimits struct {
 	maxQueryLookback                     time.Duration
 	maxQueryLength                       time.Duration
@@ -739,6 +743,7 @@ type mockLimits struct {
 	queryIngestersWithin                 time.Duration
 	ingestStorageReadConsistency         string
 	subquerySpinOffEnabled               bool
+	labelsQueryOptimizerEnabled          bool
 }
 
 func (m mockLimits) MaxQueryLookback(string) time.Duration {
@@ -861,6 +866,10 @@ func (m mockLimits) BlockedRequests(string) []*validation.BlockedRequest {
 
 func (m mockLimits) SubquerySpinOffEnabled(string) bool {
 	return m.subquerySpinOffEnabled
+}
+
+func (m mockLimits) LabelsQueryOptimizerEnabled(string) bool {
+	return m.labelsQueryOptimizerEnabled
 }
 
 type mockHandler struct {

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -328,7 +328,7 @@ func newQueryTripperware(
 		}
 
 		// Optimize labels queries after validation.
-		labels = newLabelsQueryOptimizer(codec, limits, labels, log)
+		labels = newLabelsQueryOptimizer(codec, limits, labels, log, registerer)
 
 		// Validate the request before any processing.
 		queryrange = NewMetricsQueryRequestValidationRoundTripper(codec, queryrange)

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -327,6 +327,9 @@ func newQueryTripperware(
 			labels = newLabelsQueryCacheRoundTripper(c, cacheKeyGenerator, limits, labels, log, registerer)
 		}
 
+		// Optimize labels queries after validation.
+		labels = newLabelsQueryOptimizer(codec, limits, labels, log)
+
 		// Validate the request before any processing.
 		queryrange = NewMetricsQueryRequestValidationRoundTripper(codec, queryrange)
 		instant = NewMetricsQueryRequestValidationRoundTripper(codec, instant)

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -448,7 +448,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.EnabledPromQLExperimentalFunctions, "query-frontend.enabled-promql-experimental-functions", "Enable certain experimental PromQL functions, which are subject to being changed or removed at any time, on a per-tenant basis. Defaults to empty which means all experimental functions are disabled. Set to 'all' to enable all experimental functions.")
 	f.BoolVar(&l.Prom2RangeCompat, "query-frontend.prom2-range-compat", false, "Rewrite queries using the same range selector and resolution [X:X] which don't work in Prometheus 3.0 to a nearly identical form that works with Prometheus 3.0 semantics")
 	f.BoolVar(&l.SubquerySpinOffEnabled, "query-frontend.subquery-spin-off-enabled", false, "Enable spinning off subqueries from instant queries as range queries to optimize their performance.")
-	f.BoolVar(&l.LabelsQueryOptimizerEnabled, "query-frontend.labels-query-optimizer-enabled", false, "Enable labels query optimizations. When enabled, the query-frontend rewrites labels queries in an idempotent way to improve their performance.")
+	f.BoolVar(&l.LabelsQueryOptimizerEnabled, "query-frontend.labels-query-optimizer-enabled", false, "Enable labels query optimizations. When enabled, the query-frontend may rewrite labels queries to improve their performance.")
 
 	// Store-gateway.
 	f.IntVar(&l.StoreGatewayTenantShardSize, "store-gateway.tenant-shard-size", 0, "The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.")

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -211,6 +211,7 @@ type Limits struct {
 	EnabledPromQLExperimentalFunctions     flagext.StringSliceCSV `yaml:"enabled_promql_experimental_functions" json:"enabled_promql_experimental_functions" category:"experimental"`
 	Prom2RangeCompat                       bool                   `yaml:"prom2_range_compat" json:"prom2_range_compat" category:"experimental"`
 	SubquerySpinOffEnabled                 bool                   `yaml:"subquery_spin_off_enabled" json:"subquery_spin_off_enabled" category:"experimental"`
+	LabelsQueryOptimizerEnabled            bool                   `yaml:"labels_query_optimizer_enabled" json:"labels_query_optimizer_enabled" category:"experimental"`
 
 	// Cardinality
 	CardinalityAnalysisEnabled                    bool `yaml:"cardinality_analysis_enabled" json:"cardinality_analysis_enabled"`
@@ -447,6 +448,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.EnabledPromQLExperimentalFunctions, "query-frontend.enabled-promql-experimental-functions", "Enable certain experimental PromQL functions, which are subject to being changed or removed at any time, on a per-tenant basis. Defaults to empty which means all experimental functions are disabled. Set to 'all' to enable all experimental functions.")
 	f.BoolVar(&l.Prom2RangeCompat, "query-frontend.prom2-range-compat", false, "Rewrite queries using the same range selector and resolution [X:X] which don't work in Prometheus 3.0 to a nearly identical form that works with Prometheus 3.0 semantics")
 	f.BoolVar(&l.SubquerySpinOffEnabled, "query-frontend.subquery-spin-off-enabled", false, "Enable spinning off subqueries from instant queries as range queries to optimize their performance.")
+	f.BoolVar(&l.LabelsQueryOptimizerEnabled, "query-frontend.labels-query-optimizer-enabled", false, "Enable labels query optimizations. When enabled, the query-frontend rewrites labels queries in an idempotent way to improve their performance.")
 
 	// Store-gateway.
 	f.IntVar(&l.StoreGatewayTenantShardSize, "store-gateway.tenant-shard-size", 0, "The tenant's shard size, used when store-gateway sharding is enabled. Value of 0 disables shuffle sharding for the tenant, that is all tenant blocks are sharded across all store-gateway replicas.")
@@ -1375,6 +1377,11 @@ func (o *Overrides) IngestionPartitionsTenantShardSize(userID string) int {
 
 func (o *Overrides) SubquerySpinOffEnabled(userID string) bool {
 	return o.getOverridesForUser(userID).SubquerySpinOffEnabled
+}
+
+// LabelsQueryOptimizerEnabled returns whether labels query optimizations are enabled.
+func (o *Overrides) LabelsQueryOptimizerEnabled(userID string) bool {
+	return o.getOverridesForUser(userID).LabelsQueryOptimizerEnabled
 }
 
 // CardinalityAnalysisMaxResults returns the maximum number of results that


### PR DESCRIPTION
#### What this PR does

This PR introduces a new labels query optimizer middleware for the query-frontend that automatically removes
the ` __name__!=""` matcher from label names queries when the matcher is redundant. The PR also includes a bug
  fix for the limit parameter validation in label queries: the value 0 was not supported previously, but it's actually a valid parameter in Prometheus (means unlimited).

I've tested the following matchers, comparing the result with and without the optimizer enabled and I've got the same exact results:
- No matchers
- With `{}` matcher (invalid)
- With `{__name__!=""}` matcher
- With `{__name__!="", container="mimir-write"}` matcher
- With `{__name__!="", __name__="up"}` matcher
- With `{__name__!=""}` and `{__name__=~"a.*"}` matchers
- With `{__name__!="", __name__=~"a.*"}` matcher

This PR only address the label names API. I will then open a PR for the label values.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
