### PR TITLE
Chore: remove unused block stats in compactor's GatherBlockHealthStats()

### DIFF
--- a/pkg/storage/tsdb/block/index.go
+++ b/pkg/storage/tsdb/block/index.go
@@ -148,7 +148,6 @@ func (i HealthStats) AnyErr() error {
 	return nil
 }
 
-
 // GatherBlockHealthStats returns useful counters as well as outsider chunks (chunks outside of block time range) that
 // helps to assess index and optionally chunk health.
 // It considers https://github.com/prometheus/tsdb/issues/347 as something that Thanos can handle.

--- a/pkg/storage/tsdb/block/index.go
+++ b/pkg/storage/tsdb/block/index.go
@@ -148,38 +148,6 @@ func (i HealthStats) AnyErr() error {
 	return nil
 }
 
-type minMaxSumInt64 struct {
-	sum int64
-	min int64
-	max int64
-
-	cnt int64
-}
-
-func newMinMaxSumInt64() minMaxSumInt64 {
-	return minMaxSumInt64{
-		min: math.MaxInt64,
-		max: math.MinInt64,
-	}
-}
-
-func (n *minMaxSumInt64) Add(v int64) {
-	n.cnt++
-	n.sum += v
-	if n.min > v {
-		n.min = v
-	}
-	if n.max < v {
-		n.max = v
-	}
-}
-
-func (n *minMaxSumInt64) Avg() int64 {
-	if n.cnt == 0 {
-		return 0
-	}
-	return n.sum / n.cnt
-}
 
 // GatherBlockHealthStats returns useful counters as well as outsider chunks (chunks outside of block time range) that
 // helps to assess index and optionally chunk health.
@@ -253,7 +221,6 @@ func GatherBlockHealthStats(ctx context.Context, logger log.Logger, blockDir str
 		}
 
 		ooo := 0
-		seriesLifeTimeMs := int64(0)
 		// Per chunk in series.
 		for i, c := range chks {
 			// Check if chunk data is valid.
@@ -263,9 +230,6 @@ func GatherBlockHealthStats(ctx context.Context, logger log.Logger, blockDir str
 					return stats, errors.Wrapf(err, "verify chunk %d of series %d", i, id)
 				}
 			}
-
-			chkDur := c.MaxTime - c.MinTime
-			seriesLifeTimeMs += chkDur
 
 			// Chunk vs the block ranges.
 			if c.MinTime < minTime || c.MaxTime > maxTime {

--- a/tools/tsdb-index-health/main_test.go
+++ b/tools/tsdb-index-health/main_test.go
@@ -53,12 +53,6 @@ func TestGatherIndexHealthStats(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, int64(2), stats.TotalSeries)
-	require.Equal(t, int64(1), stats.SeriesMinChunks)
-	require.Equal(t, int64(1), stats.SeriesAvgChunks)
-	require.Equal(t, int64(2), stats.SeriesMaxChunks)
-	require.Equal(t, int64(3), stats.TotalChunks)
-	require.Equal(t, int64(2), stats.LabelNamesCount)
-	require.Equal(t, int64(2), stats.MetricLabelValuesCount)
 }
 
 func must[T any](v T, err error) T {


### PR DESCRIPTION
#### What this PR does

The compactor's `GatherBlockHealthStats()` gather several stats. We never read many of them. We can clean them up.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
