### PR TITLE
Chore: let claude to figure out the PR number itself

### DIFF
--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -18,7 +18,7 @@ Before a piece of work is finished:
 - Each commit should build towards the whole - don't leave in back-tracks and mistakes that you later corrected.
 - Have unit and/or [integration](./how-integration-tests-work.md) tests for new functionality or tests that would have caught the bug being fixed.
 - Include a [CHANGELOG](#changelog) message if users of Grafana Mimir need to hear about what you did.
-- If you have made any changes to flags or config, run `make doc` and commit the changed files to update the config file documentation.
+- If you have made any changes to flags or config, run `make reference-help doc` and commit the changed files to update the config file documentation.
 
 ## Grafana Mimir Helm chart
 
@@ -124,6 +124,8 @@ To add a new error:
 
 ## Changelog
 
+### Changelog scope
+
 When appending to the changelog, the changes must be listed with a corresponding scope. A scope denotes the type of change that has occurred.
 
 The ordering of entries in the changelog should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
@@ -146,3 +148,7 @@ The ENHANCEMENT scope denotes a change that improves upon the current functional
 #### [BUGFIX]
 
 The BUGFIX scope denotes a change that fixes an issue with the project in question. A BUGFIX should align the behaviour of the service with the current expected behaviour of the service. If a BUGFIX introduces new unexpected behaviour to ameliorate the issue, a corresponding FEATURE or ENHANCEMENT scope should also be added to the changelog.
+
+### Referencing the PR number in the changelog entry
+
+When adding an entry to the changelog, the first line of the entry must end with `#<PR>` where `<PR>` is the GitHub pull request ID. You get get the next `<PR>` ID right before opening the PR by executing the script `./tools/hub-next-pr-number.sh`.

--- a/tools/hub-next-pr-number.sh
+++ b/tools/hub-next-pr-number.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+LAST_PR=$(hub pr list --state all -L 1 --format '%I')
+LAST_ISSUE=$(hub issue --format '%I' -L 1)
+
+if [ "$LAST_PR" == "" ] && [ "$LAST_ISSUE" == "" ]; then
+  echo "Unable to get last PR and/or Issue number. Is your current working directory a public GitHub repository?"
+  exit 1
+elif [ "$LAST_PR" -gt "$LAST_ISSUE" ]; then
+  echo $((LAST_PR + 1))
+else
+  echo $((LAST_ISSUE + 1))
+fi


### PR DESCRIPTION
#### What this PR does

Let claude to figure out the PR number itself. The CHANGELOG PR number in https://github.com/grafana/mimir/pull/12066 was referenced automatically by Claude by using these instructions.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
