### PR TITLE
Chore: instruct claude to end comments with a period

### DIFF
--- a/docs/internal/contributing/design-patterns-and-conventions.md
+++ b/docs/internal/contributing/design-patterns-and-conventions.md
@@ -4,7 +4,9 @@ Grafana Mimir adopts some design patterns and code conventions that we ask you t
 
 ## Go coding style
 
-Grafana Mimir follows the [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments) styleguide and the [Formatting and style](https://peter.bourgon.org/go-in-production/#formatting-and-style) section of Peter Bourgon's [Go: Best Practices for Production Environments](https://peter.bourgon.org/go-in-production/).
+Grafana Mimir follows the [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments) styleguide and the [Formatting and style](https://peter.bourgon.org/go-in-production/#formatting-and-style) section of Peter Bourgon's [Go: Best Practices for Production Environments](https://peter.bourgon.org/go-in-production/).
+
+Comment sentences should begin with the name of the thing being described and end in a period.
 
 ## No global variables
 


### PR DESCRIPTION
#### What this PR does

The fact that claude doesn't end comments with a period is driving me crazy 😄 It's part of the go styling guide, but looks ignoring it. Let's make it explicit, copying the sentence from the styleguide.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
