### PR TITLE
Fix possible panic when handling OTLP push errors

### DIFF
--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -145,11 +145,17 @@ func OTLPHandler(
 			errorMsg string
 		)
 		if st, ok := grpcutil.ErrorToStatus(pushErr); ok {
-			// This code is needed for a correct handling of errors returned by the supplier function.
-			// These errors are created by using the httpgrpc package.
-			httpCode = httpRetryableToOTLPRetryable(int(st.Code()))
 			grpcCode = st.Code()
 			errorMsg = st.Message()
+
+			// This code is needed for a correct handling of errors returned by the supplier function.
+			// These errors are usually created by using the httpgrpc package.
+			// However, distributor's write path is complex and has a lot of dependencies, so sometimes it's not.
+			if util.IsHTTPStatusCode(grpcCode) {
+				httpCode = httpRetryableToOTLPRetryable(int(grpcCode))
+			} else {
+				httpCode = http.StatusServiceUnavailable
+			}
 		} else {
 			grpcCode, httpCode = toOtlpGRPCHTTPStatus(pushErr)
 			errorMsg = pushErr.Error()


### PR DESCRIPTION
#### What this PR does

While developing a different feature I encountered a panic when a gRPC status error bubbled up through the middlewares to the OTLP handler, which tried to write the gRPC status code as an HTTP status code.

I can't see how to reproduce this without that feature, but in any case the handler should be prepared to handle a gRPC error from the complex stack of distributor's middlewares.

#### Which issue(s) this PR fixes or relates to

Fixes: https://github.com/grafana/mimir/issues/12019

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
