### PR TITLE
Update dskit to skip tracing configuration when no env is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [BUGFIX] Distributor: Check `max_inflight_push_requests_bytes` before decompressing incoming requests. #11967
 * [BUGFIX] Query-frontend: Allow limit parameter to be 0 in label queries to explicitly request unlimited results. #12054
 * [BUGFIX] Distributor: Fix a possible panic in the OTLP push path while handling a gRPC status error. #12072
+* [BUGFIX] Tracing: Skip tracing configuration when no tracing environment variables were provided. #12074
 
 ### Mixin
 

--- a/docs/sources/mimir/configure/configure-tracing.md
+++ b/docs/sources/mimir/configure/configure-tracing.md
@@ -48,8 +48,8 @@ OpenTelemetry configuration follows the standard documentation from [OpenTelemet
 
 The `OTEL_TRACES_EXPORTER` environment variable specifies which trace exporter to use:
 
-- `otlp` (default): OpenTelemetry Protocol exporter
-- `none`: No trace exporter
+- `otlp` (default): OpenTelemetry Protocol exporter.
+- `none`: No trace exporter. You can set this value if you want to configure the tracing library to propagate trace context without exporting traces.
 
 {{< admonition type="note" >}}
 The `jaeger` exporter option is not available, as it was deprecated by the OpenTelemetry project in 2023. Instead, use the `otlp` exporter, since Jaeger supports OTLP ingestion natively.

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20250703125411-00229f5b510c
+	github.com/grafana/dskit v0.0.0-20250714110327-9c6da3f1e284
 	github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.7.12

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20250709204613-c5c6f9c1653d h1:rtlYpwsE3KDWWCg2kytDw3s5qgpDjG87qh1IixAyNz4=
 github.com/grafana/alerting v0.0.0-20250709204613-c5c6f9c1653d/go.mod h1:gtR7agmxVfJOmNKV/n2ZULgOYTYNL+PDKYB5N48tQ7Q=
-github.com/grafana/dskit v0.0.0-20250703125411-00229f5b510c h1:m5O2Oj755FlFhKSuQB1KwcFZZRVijZWYU7u34dhS88M=
-github.com/grafana/dskit v0.0.0-20250703125411-00229f5b510c/go.mod h1:gVg14WngG7SMnJ/5mZGNFAs31+7BhspoWfmZ/U4rb90=
+github.com/grafana/dskit v0.0.0-20250714110327-9c6da3f1e284 h1:sJhf9j1smHbBZS7EXiPoRZVxawTNDqT7wzWPtWmxvnY=
+github.com/grafana/dskit v0.0.0-20250714110327-9c6da3f1e284/go.mod h1:gVg14WngG7SMnJ/5mZGNFAs31+7BhspoWfmZ/U4rb90=
 github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673 h1:Va04sDlP33f1SFUHRTho4QJfDlGTz+/HnBIpYwlqV9Q=
 github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/pkg/frontend/v1/frontend_test.go
+++ b/pkg/frontend/v1/frontend_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -42,6 +43,7 @@ import (
 
 func init() {
 	// Install OTel tracing, we need it for the tests.
+	os.Setenv("OTEL_TRACES_EXPORTER", "none")
 	_, err := tracing.NewOTelFromEnv("test", log.NewNopLogger())
 	if err != nil {
 		panic(err)

--- a/pkg/querier/engine/query_tracker_test.go
+++ b/pkg/querier/engine/query_tracker_test.go
@@ -4,6 +4,7 @@ package engine
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -15,6 +16,7 @@ import (
 
 func init() {
 	// Install OTel tracing, we need it for the tests.
+	os.Setenv("OTEL_TRACES_EXPORTER", "none")
 	_, err := tracing.NewOTelFromEnv("test", log.NewNopLogger())
 	if err != nil {
 		panic(err)

--- a/vendor/github.com/grafana/dskit/tracing/otel.go
+++ b/vendor/github.com/grafana/dskit/tracing/otel.go
@@ -35,6 +35,11 @@ var tracer = otel.Tracer("dskit/tracing")
 // Refer to official OTel SDK configuration docs to see the available options.
 // https://opentelemetry.io/docs/languages/sdk-configuration/general/
 func NewOTelFromEnv(serviceName string, logger log.Logger, opts ...OTelOption) (io.Closer, error) {
+	if os.Getenv("OTEL_TRACES_EXPORTER") == "" && os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") == "" && os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") == "" {
+		// No tracing is configured, so don't initialize the tracer as it would complain on every span about localhost:4718 not accepting traces.
+		return ioCloser(func() error { return nil }), nil
+	}
+
 	level.Info(logger).Log("msg", "initialising OpenTelemetry tracer")
 
 	exp, err := autoexport.NewSpanExporter(context.Background())

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -734,7 +734,7 @@ github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
 github.com/grafana/alerting/templates/gomplate
 github.com/grafana/alerting/templates/mimir
-# github.com/grafana/dskit v0.0.0-20250703125411-00229f5b510c
+# github.com/grafana/dskit v0.0.0-20250714110327-9c6da3f1e284
 ## explicit; go 1.23.0
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
#### What this PR does

This updates dskit to include https://github.com/grafana/dskit/pull/723

This will stop configuring the tracing libraries when no tracing environment variables were provided, as by default OTel libraries will try to export spans to `localhost` and complain because it would reject them.

#### Which issue(s) this PR fixes or relates to

Related to the migration to OTel tracing.

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
