### PR TITLE
Test potential fix for HA tracker failovers on r348

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4367,6 +4367,17 @@
         },
         {
           "kind": "field",
+          "name": "ha_tracker_use_sample_time_for_failover",
+          "required": false,
+          "desc": "Use the sample time for failover instead of the current time. This is useful to prevent samples being too close together during failover when write requests are delayed such that the sample time is earlier than the current time.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "distributor.ha-tracker.use-sample-time-for-failover",
+          "fieldType": "boolean",
+          "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
           "name": "drop_labels",
           "required": false,
           "desc": "This flag can be used to specify label names that to drop during sample ingestion within the distributor and can be repeated in order to drop multiple labels.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1389,6 +1389,8 @@ Usage of ./cmd/mimir/mimir:
     	Update the timestamp in the KV store for a given cluster/replica only after this amount of time has passed since the current stored timestamp. (default 15s)
   -distributor.ha-tracker.update-timeout-jitter-max duration
     	Maximum jitter applied to the update timeout, in order to spread the HA heartbeats over time. (default 5s)
+  -distributor.ha-tracker.use-sample-time-for-failover
+    	Use the sample time for failover instead of the current time. This is useful to prevent samples being too close together during failover when write requests are delayed such that the sample time is earlier than the current time.
   -distributor.health-check-ingesters
     	Run a health check on each ingester client during periodic cleanup. (default true)
   -distributor.ingestion-burst-factor float

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3347,6 +3347,13 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -distributor.ha-tracker.failover-timeout
 [ha_tracker_failover_timeout: <duration> | default = 30s]
 
+# (advanced) Use the sample time for failover instead of the current time. This
+# is useful to prevent samples being too close together during failover when
+# write requests are delayed such that the sample time is earlier than the
+# current time.
+# CLI flag: -distributor.ha-tracker.use-sample-time-for-failover
+[ha_tracker_use_sample_time_for_failover: <boolean> | default = false]
+
 # (advanced) This flag can be used to specify label names that to drop during
 # sample ingestion within the distributor and can be repeated in order to drop
 # multiple labels.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -41,6 +41,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"go.opentelemetry.io/otel"
@@ -785,7 +786,7 @@ func (d *Distributor) stopping(_ error) error {
 // Returns a boolean that indicates whether or not we want to remove the replica label going forward,
 // and an error that indicates whether we want to accept samples based on the cluster/replica found in ts.
 // nil for the error means accept the sample.
-func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica string) (removeReplicaLabel bool, _ error) {
+func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica string, ts int64) (removeReplicaLabel bool, _ error) {
 	// If the sample doesn't have either HA label, accept it.
 	// At the moment we want to accept these samples by default.
 	if cluster == "" || replica == "" {
@@ -799,7 +800,9 @@ func (d *Distributor) checkSample(ctx context.Context, userID, cluster, replica 
 
 	// At this point we know we have both HA labels, we should lookup
 	// the cluster/instance here to see if we want to accept this sample.
-	err := d.HATracker.checkReplica(ctx, userID, cluster, replica, time.Now())
+	// Convert the timestamp to a time.Time for checking the replica
+	sampleTime := timestamp.Time(ts)
+	err := d.HATracker.checkReplica(ctx, userID, cluster, replica, time.Now(), sampleTime)
 	// checkReplica would have returned an error if there was a real error talking to Consul,
 	// or if the replica is not the currently elected replica.
 	if err != nil { // Don't accept the sample.
@@ -1042,11 +1045,33 @@ func (d *Distributor) prePushHaDedupeMiddleware(next PushFunc) PushFunc {
 		numSamples := 0
 		now := time.Now()
 		group := d.activeGroups.UpdateActiveGroupTimestamp(userID, validation.GroupLabel(d.limits, userID, req.Timeseries), now)
+		sampleTimestamp := timestamp.FromTime(now)
+		if d.limits.HATrackerUseSampleTimeForFailover(userID) {
+			earliestSampleTimestamp := sampleTimestamp
+			latestSampleTimestamp := sampleTimestamp
+			for _, ts := range req.Timeseries {
+				if len(ts.Samples) > 0 {
+					tsms := ts.Samples[0].TimestampMs
+					if tsms < earliestSampleTimestamp {
+						earliestSampleTimestamp = tsms
+					} else if tsms > latestSampleTimestamp {
+						latestSampleTimestamp = tsms
+					}
+				}
+			}
+			delta := now.UnixMilli() - earliestSampleTimestamp
+			if delta > 10000 {
+				delta2 := sampleTimestamp - earliestSampleTimestamp
+				delta3 := latestSampleTimestamp - now.UnixMilli()
+				level.Warn(d.log).Log("msg", "earliest sample timestamp is a lot earlier than now", "delta", delta, "delta2", delta2, "delta3", delta3, "user", userID, "cluster", cluster, "replica", replica, "earliestSampleTime", timestamp.Time(earliestSampleTimestamp), "sampleTime", timestamp.Time(sampleTimestamp), "latestSampleTime", timestamp.Time(latestSampleTimestamp), "now", now)
+			}
+			sampleTimestamp = earliestSampleTimestamp
+		}
 		for _, ts := range req.Timeseries {
 			numSamples += len(ts.Samples) + len(ts.Histograms)
 		}
 
-		removeReplica, err := d.checkSample(ctx, userID, cluster, replica)
+		removeReplica, err := d.checkSample(ctx, userID, cluster, replica, sampleTimestamp)
 		if err != nil {
 			if errors.As(err, &replicasDidNotMatchError{}) {
 				// These samples have been deduped.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -999,7 +999,7 @@ func TestDistributor_PushHAInstances(t *testing.T) {
 
 			userID, err := tenant.TenantID(ctx)
 			assert.NoError(t, err)
-			err = d.HATracker.checkReplica(ctx, userID, tc.cluster, tc.acceptedReplica, time.Now())
+			err = d.HATracker.checkReplica(ctx, userID, tc.cluster, tc.acceptedReplica, time.Now(), time.Now())
 			assert.NoError(t, err)
 
 			request := makeWriteRequestForGenerators(tc.samples, labelSetGenWithReplicaAndCluster(tc.testReplica, tc.cluster), nil, nil)

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -38,13 +38,14 @@ type haTrackerLimits interface {
 	// HATrackerTimeouts returns timeouts that may be specific for the user.
 	HATrackerTimeouts(user string) (update time.Duration, updateJitterMax time.Duration, failover time.Duration)
 	DefaultHATrackerUpdateTimeout() time.Duration
+	HATrackerUseSampleTimeForFailover(user string) bool
 }
 
 type haTracker interface {
 	services.Service
 	http.Handler
 
-	checkReplica(ctx context.Context, userID, cluster, replica string, now time.Time) error
+	checkReplica(ctx context.Context, userID, cluster, replica string, now, sampleTime time.Time) error
 	cleanupHATrackerMetricsForUser(userID string)
 }
 
@@ -207,10 +208,11 @@ type defaultHaTracker struct {
 
 // For one cluster, the information we need to do ha-tracking.
 type haClusterInfo struct {
-	elected                     ReplicaDesc // latest info from KVStore
-	electedLastSeenTimestamp    int64       // timestamp in milliseconds
-	nonElectedLastSeenReplica   string
-	nonElectedLastSeenTimestamp int64 // timestamp in milliseconds
+	elected                      ReplicaDesc // latest info from KVStore
+	electedLastSeenTimestamp     int64       // timestamp in milliseconds
+	nonElectedLastSeenReplica    string
+	nonElectedLastSeenTimestamp  int64 // timestamp in milliseconds
+	nonElectedLastSeenSampleTime int64 // last seen earliest sample time in milliseconds
 }
 
 // newHaTracker returns a new HA cluster tracker using either Consul,
@@ -453,20 +455,27 @@ func (h *defaultHaTracker) updateKVStoreAll(ctx context.Context, now time.Time) 
 			}
 			var replica string
 			var receivedAt int64
+			var sampleTime time.Time
 			if uh.withinUpdateTimeout(now, entry.electedLastSeenTimestamp) {
 				// We have seen the elected replica recently; carry on with that choice.
 				replica = entry.elected.Replica
 				receivedAt = entry.electedLastSeenTimestamp
+				sampleTime = now
 			} else if uh.withinUpdateTimeout(now, entry.nonElectedLastSeenTimestamp) {
 				// Not seen elected but have seen another: attempt to fail over.
 				replica = entry.nonElectedLastSeenReplica
 				receivedAt = entry.nonElectedLastSeenTimestamp
+				if uh.useSampleTimeForFailover {
+					sampleTime = timestamp.Time(entry.nonElectedLastSeenSampleTime)
+				} else {
+					sampleTime = now
+				}
 			} else {
 				continue // we don't have any recent timestamps
 			}
 			// Release lock while we talk to KVStore, which could take a while.
 			h.electedLock.RUnlock()
-			err := uh.updateKVStore(ctx, cluster, replica, now, receivedAt)
+			err := uh.updateKVStore(ctx, cluster, replica, now, sampleTime, receivedAt, true)
 			h.electedLock.RLock()
 			if err != nil {
 				// Failed to store - log it but carry on
@@ -556,7 +565,7 @@ func (h *defaultHaTracker) cleanupOldReplicas(ctx context.Context, deadline time
 // Updates to and from the KV store are handled in the background, except
 // if we have no cached data for this cluster in which case we create the
 // record and store it in-band.
-func (h *defaultHaTracker) checkReplica(ctx context.Context, userID, cluster, replica string, now time.Time) error {
+func (h *defaultHaTracker) checkReplica(ctx context.Context, userID, cluster, replica string, now, sampleTime time.Time) error {
 	h.electedLock.Lock()
 	if entry := h.clusters[userID][cluster]; entry != nil {
 		var err error
@@ -567,6 +576,7 @@ func (h *defaultHaTracker) checkReplica(ctx context.Context, userID, cluster, re
 			// Sample received is from non-elected replica: record details and reject.
 			entry.nonElectedLastSeenReplica = replica
 			entry.nonElectedLastSeenTimestamp = timestamp.FromTime(now)
+			entry.nonElectedLastSeenSampleTime = timestamp.FromTime(sampleTime)
 			err = newReplicasDidNotMatchError(replica, entry.elected.Replica)
 		}
 		h.electedLock.Unlock()
@@ -582,21 +592,22 @@ func (h *defaultHaTracker) checkReplica(ctx context.Context, userID, cluster, re
 	}
 
 	uh := h.forUser(userID)
-	err := uh.updateKVStore(ctx, cluster, replica, now, now.UnixMilli())
+	err := uh.updateKVStore(ctx, cluster, replica, now, sampleTime, now.UnixMilli(), false)
 	if err != nil {
 		level.Error(h.logger).Log("msg", "failed to update KVStore - rejecting sample", "err", err)
 		return err
 	}
 	// Cache will now have the value - recurse to check it again.
-	return h.checkReplica(ctx, userID, cluster, replica, now)
+	return h.checkReplica(ctx, userID, cluster, replica, now, sampleTime)
 }
 
 type defaultHaTrackerForUser struct {
 	*defaultHaTracker
-	userID              string
-	updateTimeout       time.Duration
-	updateTimeoutJitter time.Duration
-	failoverTimeout     time.Duration
+	userID                   string
+	updateTimeout            time.Duration
+	updateTimeoutJitter      time.Duration
+	failoverTimeout          time.Duration
+	useSampleTimeForFailover bool
 }
 
 func (h *defaultHaTracker) forUser(userID string) defaultHaTrackerForUser {
@@ -613,6 +624,8 @@ func (h *defaultHaTracker) forUser(userID string) defaultHaTrackerForUser {
 		computeJitter = computeUpdateTimeoutJitter
 	}
 	uh.updateTimeoutJitter = computeJitter(updateJitterMax)
+
+	uh.useSampleTimeForFailover = h.limits.HATrackerUseSampleTimeForFailover(userID)
 
 	return uh
 }
@@ -653,7 +666,7 @@ func (h *defaultHaTracker) updateCache(userID, cluster string, desc *ReplicaDesc
 
 // If we do set the value then err will be nil and desc will contain the value we set.
 // If there is already a valid value in the store, return nil, nil.
-func (h *defaultHaTrackerForUser) updateKVStore(ctx context.Context, cluster, replica string, now time.Time, receivedAt int64) error {
+func (h *defaultHaTrackerForUser) updateKVStore(ctx context.Context, cluster, replica string, now, sampleTime time.Time, receivedAt int64, fromAll bool) error {
 	key := fmt.Sprintf("%s/%s", h.userID, cluster)
 	var desc *ReplicaDesc
 	var electedAtTime, electedChanges int64
@@ -676,11 +689,17 @@ func (h *defaultHaTrackerForUser) updateKVStore(ctx context.Context, cluster, re
 
 			// If our replica is different, wait until the failover time
 			if desc.Replica != replica {
-				if now.Sub(timestamp.Time(desc.ReceivedAt)) < h.failoverTimeout {
-					level.Info(h.logger).Log("msg", "replica differs, but it's too early to failover", "user", h.userID, "cluster", cluster, "replica", replica, "elected", desc.Replica, "received_at", timestamp.Time(desc.ReceivedAt))
+				var currentTime time.Time
+				if h.useSampleTimeForFailover {
+					currentTime = sampleTime
+				} else {
+					currentTime = now
+				}
+				if currentTime.Sub(timestamp.Time(desc.ReceivedAt)) < h.failoverTimeout {
+					level.Info(h.logger).Log("msg", "replica differs, but it's too early to failover", "user", h.userID, "cluster", cluster, "replica", replica, "elected", desc.Replica, "received_at", timestamp.Time(desc.ReceivedAt), "current_time", currentTime, "use_sample_time_for_failover", h.useSampleTimeForFailover, "from_all", fromAll)
 					return nil, false, nil
 				}
-				level.Info(h.logger).Log("msg", "replica differs, attempting to update kv", "user", h.userID, "cluster", cluster, "replica", replica, "elected", desc.Replica, "received_at", timestamp.Time(desc.ReceivedAt))
+				level.Info(h.logger).Log("msg", "replica differs, attempting to update kv", "user", h.userID, "cluster", cluster, "replica", replica, "elected", desc.Replica, "received_at", timestamp.Time(desc.ReceivedAt), "current_time", currentTime, "use_sample_time_for_failover", h.useSampleTimeForFailover, "from_all", fromAll)
 				electedAtTime = timestamp.FromTime(now)
 				electedChanges = desc.ElectedChanges + 1
 			}

--- a/pkg/distributor/ha_tracker_nop.go
+++ b/pkg/distributor/ha_tracker_nop.go
@@ -22,7 +22,7 @@ func newNopHaTracker() *nopHaTracker {
 	return tracker
 }
 
-func (n nopHaTracker) checkReplica(context.Context, string, string, string, time.Time) error {
+func (n nopHaTracker) checkReplica(context.Context, string, string, string, time.Time, time.Time) error {
 	return nil
 }
 

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -303,18 +303,18 @@ func TestHaTrackerWithMemberList(t *testing.T) {
 	now := time.Now()
 
 	// Write the first time.
-	err = tracker.checkReplica(context.Background(), "user", cluster, replica1, now)
+	err = tracker.checkReplica(context.Background(), "user", cluster, replica1, now, now)
 	assert.NoError(t, err)
 
 	// Throw away a sample from replica2.
-	err = tracker.checkReplica(context.Background(), "user", cluster, replica2, now)
+	err = tracker.checkReplica(context.Background(), "user", cluster, replica2, now, now)
 	assert.Error(t, err)
 
 	// Wait more than the overwrite timeout.
 	now = now.Add(failoverTimeoutPlus100ms)
 
 	// Another sample from replica2 to update its timestamp.
-	err = tracker.checkReplica(context.Background(), "user", cluster, replica2, now)
+	err = tracker.checkReplica(context.Background(), "user", cluster, replica2, now, now)
 	assert.Error(t, err)
 
 	// Update KVStore - this should elect replica 2.
@@ -323,11 +323,11 @@ func TestHaTrackerWithMemberList(t *testing.T) {
 	checkReplicaTimestamp(t, 100*time.Millisecond, tracker, "user", cluster, replica2, now, now)
 
 	// Now we should accept from replica 2.
-	err = tracker.checkReplica(context.Background(), "user", cluster, replica2, now)
+	err = tracker.checkReplica(context.Background(), "user", cluster, replica2, now, now)
 	assert.NoError(t, err)
 
 	// We timed out accepting samples from replica 1 and should now reject them.
-	err = tracker.checkReplica(context.Background(), "user", cluster, replica1, now)
+	err = tracker.checkReplica(context.Background(), "user", cluster, replica1, now, now)
 	assert.Error(t, err)
 }
 
@@ -386,7 +386,7 @@ func TestHaTrackerWithMemberlistWhenReplicaDescIsMarkedDeletedThenKVStoreUpdateI
 	now := time.Now()
 
 	// Write the first time.
-	err = tracker.checkReplica(context.Background(), tenant, cluster, replica1, now)
+	err = tracker.checkReplica(context.Background(), tenant, cluster, replica1, now, now)
 	assert.NoError(t, err)
 
 	key := fmt.Sprintf("%s/%s", tenant, cluster)
@@ -407,11 +407,11 @@ func TestHaTrackerWithMemberlistWhenReplicaDescIsMarkedDeletedThenKVStoreUpdateI
 
 	now = now.Add(failoverTimeoutPlus100ms)
 	// check replica2
-	err = tracker.checkReplica(context.Background(), tenant, cluster, replica2, now)
+	err = tracker.checkReplica(context.Background(), tenant, cluster, replica2, now, now)
 	assert.NoError(t, err)
 
 	// check replica1
-	assert.ErrorAs(t, tracker.checkReplica(context.Background(), tenant, cluster, replica1, now), &replicasDidNotMatchError{})
+	assert.ErrorAs(t, tracker.checkReplica(context.Background(), tenant, cluster, replica1, now, now), &replicasDidNotMatchError{})
 }
 
 func TestHATrackerCacheSyncOnStart(t *testing.T) {
@@ -447,7 +447,7 @@ func TestHATrackerCacheSyncOnStart(t *testing.T) {
 	assert.Equal(t, 0, int(mockCountingClient.GetCalls.Load()))
 
 	now = time.Now()
-	err = c.checkReplica(context.Background(), "user", cluster, replicaOne, now)
+	err = c.checkReplica(context.Background(), "user", cluster, replicaOne, now, now)
 	assert.NoError(t, err)
 
 	err = services.StopAndAwaitTerminated(context.Background(), c)
@@ -475,7 +475,7 @@ func TestHATrackerCacheSyncOnStart(t *testing.T) {
 	assert.Equal(t, 1, int(mockCountingClient.GetCalls.Load()))
 
 	now = time.Now()
-	err = c.checkReplica(context.Background(), "user", cluster, replicaTwo, now)
+	err = c.checkReplica(context.Background(), "user", cluster, replicaTwo, now, now)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, replicasDidNotMatchError{replica: "r2", elected: "r1"})
 }
@@ -506,7 +506,7 @@ func TestHATrackerWatchPrefixAssignment(t *testing.T) {
 	// Write the first time.
 	now := time.Now()
 
-	err = c.checkReplica(context.Background(), "user", cluster, replica, now)
+	err = c.checkReplica(context.Background(), "user", cluster, replica, now, now)
 	assert.NoError(t, err)
 
 	// Check to see if the value in the trackers cache is correct.
@@ -533,18 +533,18 @@ func TestHATrackerCheckReplicaOverwriteTimeout(t *testing.T) {
 	now := time.Now()
 
 	// Write the first time.
-	err = c.checkReplica(context.Background(), "user", "test", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "test", replica1, now, now)
 	assert.NoError(t, err)
 
 	// Throw away a sample from replica2.
-	err = c.checkReplica(context.Background(), "user", "test", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "test", replica2, now, now)
 	assert.Error(t, err)
 
 	// Wait more than the overwrite timeout.
 	now = now.Add(1100 * time.Millisecond)
 
 	// Another sample from replica2 to update its timestamp.
-	err = c.checkReplica(context.Background(), "user", "test", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "test", replica2, now, now)
 	assert.Error(t, err)
 
 	// Update KVStore - this should elect replica 2.
@@ -554,11 +554,11 @@ func TestHATrackerCheckReplicaOverwriteTimeout(t *testing.T) {
 	checkReplicaTimestamp(t, 100*time.Millisecond, c, "user", "test", replica2, now, now)
 
 	// Now we should accept from replica 2.
-	err = c.checkReplica(context.Background(), "user", "test", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "test", replica2, now, now)
 	assert.NoError(t, err)
 
 	// We timed out accepting samples from replica 1 and should now reject them.
-	err = c.checkReplica(context.Background(), "user", "test", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "test", replica1, now, now)
 	assert.Error(t, err)
 }
 
@@ -583,21 +583,21 @@ func TestHATrackerCheckReplicaMultiCluster(t *testing.T) {
 	now := time.Now()
 
 	// Write the first time.
-	err = c.checkReplica(context.Background(), "user", "c1", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "c1", replica1, now, now)
 	assert.NoError(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "c2", replica1, now, now)
 	assert.NoError(t, err)
 
 	// Reject samples from replica 2 in each cluster.
-	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "c1", replica2, now, now)
 	assert.Error(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "c2", replica2, now, now)
 	assert.Error(t, err)
 
 	// We should still accept from replica 1.
-	err = c.checkReplica(context.Background(), "user", "c1", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "c1", replica1, now, now)
 	assert.NoError(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "c2", replica1, now, now)
 	assert.NoError(t, err)
 
 	// We expect no CAS operation failures.
@@ -635,46 +635,46 @@ func TestHATrackerCheckReplicaMultiClusterTimeout(t *testing.T) {
 	now := time.Now()
 
 	// Write the first time.
-	err = c.checkReplica(context.Background(), "user", "c1", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "c1", replica1, now, now)
 	assert.NoError(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "c2", replica1, now, now)
 	assert.NoError(t, err)
 
 	// Reject samples from replica 2 in each cluster.
-	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "c1", replica2, now, now)
 	assert.Error(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "c2", replica2, now, now)
 	assert.Error(t, err)
 
 	// Accept a sample for replica1 in C2.
 	now = now.Add(500 * time.Millisecond)
-	err = c.checkReplica(context.Background(), "user", "c2", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "c2", replica1, now, now)
 	assert.NoError(t, err)
 
 	// Reject samples from replica 2 in each cluster.
-	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "c1", replica2, now, now)
 	assert.Error(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "c2", replica2, now, now)
 	assert.Error(t, err)
 
 	// Wait more than the failover timeout.
 	now = now.Add(1100 * time.Millisecond)
 
 	// Another sample from c1/replica2 to update its timestamp.
-	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "c1", replica2, now, now)
 	assert.Error(t, err)
 	c.updateKVStoreAll(context.Background(), now)
 
 	checkReplicaTimestamp(t, 100*time.Millisecond, c, "user", "c1", replica2, now, now)
 
 	// Accept a sample from c1/replica2.
-	err = c.checkReplica(context.Background(), "user", "c1", replica2, now)
+	err = c.checkReplica(context.Background(), "user", "c1", replica2, now, now)
 	assert.NoError(t, err)
 
 	// We should still accept from c2/replica1 but reject from c1/replica1.
-	err = c.checkReplica(context.Background(), "user", "c1", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "c1", replica1, now, now)
 	assert.Error(t, err)
-	err = c.checkReplica(context.Background(), "user", "c2", replica1, now)
+	err = c.checkReplica(context.Background(), "user", "c2", replica1, now, now)
 	assert.NoError(t, err)
 
 	// We expect no CAS operation failures.
@@ -717,13 +717,13 @@ func TestHATrackerCheckReplicaUpdateTimeout(t *testing.T) {
 
 	// Write the first time.
 	startTime := time.Now()
-	err = c.checkReplica(context.Background(), user, cluster, replica, startTime)
+	err = c.checkReplica(context.Background(), user, cluster, replica, startTime, startTime)
 	assert.NoError(t, err)
 
 	checkReplicaTimestamp(t, 2*time.Second, c, user, cluster, replica, startTime, startTime)
 
 	// Timestamp should not update here, since time has not advanced.
-	err = c.checkReplica(context.Background(), user, cluster, replica, startTime)
+	err = c.checkReplica(context.Background(), user, cluster, replica, startTime, startTime)
 	assert.NoError(t, err)
 
 	checkReplicaTimestamp(t, 2*time.Second, c, user, cluster, replica, startTime, startTime)
@@ -732,7 +732,7 @@ func TestHATrackerCheckReplicaUpdateTimeout(t *testing.T) {
 	updateTime := time.Unix(0, startTime.UnixNano()).Add(500 * time.Millisecond)
 	c.updateKVStoreAll(context.Background(), updateTime)
 
-	err = c.checkReplica(context.Background(), user, cluster, replica, updateTime)
+	err = c.checkReplica(context.Background(), user, cluster, replica, updateTime, updateTime)
 	assert.NoError(t, err)
 	checkReplicaTimestamp(t, 2*time.Second, c, user, cluster, replica, startTime, startTime)
 
@@ -745,7 +745,7 @@ func TestHATrackerCheckReplicaUpdateTimeout(t *testing.T) {
 	// Timestamp stored in KV should be time when we have received a request (called "checkReplica"), not current time (updateTime).
 	checkReplicaTimestamp(t, 2*time.Second, c, user, cluster, replica, receivedAt, receivedAt)
 
-	err = c.checkReplica(context.Background(), user, cluster, replica, updateTime)
+	err = c.checkReplica(context.Background(), user, cluster, replica, updateTime, updateTime)
 	assert.NoError(t, err)
 }
 
@@ -797,7 +797,7 @@ func TestHATrackerCheckReplicaShouldFixZeroElectedAtTimestamp(t *testing.T) {
 
 	// Advance time and replica timestamp. This should fix the ElectedAt timestamp too.
 	updatedReceivedAt := initialReceivedAt.Add(2 * time.Second)
-	require.NoError(t, c.checkReplica(context.Background(), userID, cluster, replica, updatedReceivedAt))
+	require.NoError(t, c.checkReplica(context.Background(), userID, cluster, replica, updatedReceivedAt, updatedReceivedAt))
 	checkReplicaTimestamp(t, 2*time.Second, c, userID, cluster, replica, updatedReceivedAt, updatedReceivedAt)
 }
 
@@ -827,18 +827,18 @@ func TestHATrackerCheckReplicaMultiUser(t *testing.T) {
 	now := time.Now()
 
 	// Write the first time for user 1.
-	err = c.checkReplica(context.Background(), "user1", cluster, replica, now)
+	err = c.checkReplica(context.Background(), "user1", cluster, replica, now, now)
 	assert.NoError(t, err)
 	checkReplicaTimestamp(t, 2*time.Second, c, "user1", cluster, replica, now, now)
 
 	// Write the first time for user 2.
-	err = c.checkReplica(context.Background(), "user2", cluster, replica, now)
+	err = c.checkReplica(context.Background(), "user2", cluster, replica, now, now)
 	assert.NoError(t, err)
 	checkReplicaTimestamp(t, 2*time.Second, c, "user2", cluster, replica, now, now)
 
 	// Now we've waited > 1s, so the timestamp should update.
 	updated := now.Add(1100 * time.Millisecond)
-	err = c.checkReplica(context.Background(), "user1", cluster, replica, updated)
+	err = c.checkReplica(context.Background(), "user1", cluster, replica, updated, updated)
 	assert.NoError(t, err)
 	c.updateKVStoreAll(context.Background(), updated)
 
@@ -919,12 +919,12 @@ func TestHATrackerCheckReplicaUpdateTimeoutJitter(t *testing.T) {
 			}
 
 			// Init the replica in the KV Store
-			err = c.checkReplica(ctx, "user1", "cluster", "replica-1", testData.startTime)
+			err = c.checkReplica(ctx, "user1", "cluster", "replica-1", testData.startTime, testData.startTime)
 			require.NoError(t, err)
 			checkReplicaTimestamp(t, 2*time.Second, c, "user1", "cluster", "replica-1", testData.startTime, testData.startTime)
 
 			// Refresh the replica in the KV Store
-			err = c.checkReplica(ctx, "user1", "cluster", "replica-1", testData.updateTime)
+			err = c.checkReplica(ctx, "user1", "cluster", "replica-1", testData.updateTime, testData.updateTime)
 			require.NoError(t, err)
 			c.updateKVStoreAll(context.Background(), testData.updateTime)
 
@@ -1017,26 +1017,26 @@ func TestHATrackerClustersLimit(t *testing.T) {
 
 	now := time.Now()
 
-	assert.NoError(t, t1.checkReplica(context.Background(), userID, "a", "a1", now))
+	assert.NoError(t, t1.checkReplica(context.Background(), userID, "a", "a1", now, now))
 	waitForClustersUpdate(t, 1, t1, userID)
 
-	assert.NoError(t, t1.checkReplica(context.Background(), userID, "b", "b1", now))
+	assert.NoError(t, t1.checkReplica(context.Background(), userID, "b", "b1", now, now))
 	waitForClustersUpdate(t, 2, t1, userID)
 
 	expectedErr := newTooManyClustersError(2)
-	assert.EqualError(t, t1.checkReplica(context.Background(), userID, "c", "c1", now), expectedErr.Error())
+	assert.EqualError(t, t1.checkReplica(context.Background(), userID, "c", "c1", now, now), expectedErr.Error())
 
 	// Move time forward, and make sure that checkReplica for existing cluster works fine.
 	now = now.Add(5 * time.Second) // higher than "update timeout"
 
 	// Another sample to update internal timestamp.
-	err = t1.checkReplica(context.Background(), userID, "b", "b2", now)
+	err = t1.checkReplica(context.Background(), userID, "b", "b2", now, now)
 	assert.Error(t, err)
 	// Update KVStore.
 	t1.updateKVStoreAll(context.Background(), now)
 	checkReplicaTimestamp(t, 2*time.Second, t1, userID, "b", "b2", now, now)
 
-	assert.NoError(t, t1.checkReplica(context.Background(), userID, "b", "b2", now))
+	assert.NoError(t, t1.checkReplica(context.Background(), userID, "b", "b2", now, now))
 	waitForClustersUpdate(t, 2, t1, userID)
 
 	// Mark cluster "a" for deletion (it was last updated 5 seconds ago)
@@ -1045,12 +1045,12 @@ func TestHATrackerClustersLimit(t *testing.T) {
 	waitForClustersUpdate(t, 1, t1, userID)
 
 	// Now adding cluster "c" works.
-	assert.NoError(t, t1.checkReplica(context.Background(), userID, "c", "c1", now))
+	assert.NoError(t, t1.checkReplica(context.Background(), userID, "c", "c1", now, now))
 	waitForClustersUpdate(t, 2, t1, userID)
 
 	// But yet another cluster doesn't.
 	expectedErr = newTooManyClustersError(2)
-	assert.EqualError(t, t1.checkReplica(context.Background(), userID, "a", "a2", now), expectedErr.Error())
+	assert.EqualError(t, t1.checkReplica(context.Background(), userID, "a", "a2", now, now), expectedErr.Error())
 
 	now = now.Add(5 * time.Second)
 
@@ -1059,7 +1059,7 @@ func TestHATrackerClustersLimit(t *testing.T) {
 	waitForClustersUpdate(t, 0, t1, userID)
 
 	// Now "a" works again.
-	assert.NoError(t, t1.checkReplica(context.Background(), userID, "a", "a1", now))
+	assert.NoError(t, t1.checkReplica(context.Background(), userID, "a", "a1", now, now))
 	waitForClustersUpdate(t, 1, t1, userID)
 }
 
@@ -1074,10 +1074,11 @@ func waitForClustersUpdate(t *testing.T, expected int, tr *defaultHaTracker, use
 }
 
 type trackerLimits struct {
-	maxClusters            int
-	updateTimeout          time.Duration
-	updateTimeoutJitterMax time.Duration
-	failoverTimeout        time.Duration
+	maxClusters              int
+	updateTimeout            time.Duration
+	updateTimeoutJitterMax   time.Duration
+	failoverTimeout          time.Duration
+	useSampleTimeForFailover bool
 
 	forUser map[string]trackerLimits
 }
@@ -1098,6 +1099,13 @@ func (l trackerLimits) HATrackerTimeouts(userID string) (update time.Duration, u
 
 func (l trackerLimits) DefaultHATrackerUpdateTimeout() time.Duration {
 	return l.updateTimeout
+}
+
+func (l trackerLimits) HATrackerUseSampleTimeForFailover(userID string) bool {
+	if ul, ok := l.forUser[userID]; ok {
+		l = ul
+	}
+	return l.useSampleTimeForFailover
 }
 
 func TestHATracker_MetricsCleanup(t *testing.T) {
@@ -1260,7 +1268,7 @@ func TestHATrackerCheckReplicaCleanup(t *testing.T) {
 
 	now := time.Now()
 
-	err = c.checkReplica(context.Background(), userID, cluster, replica, now)
+	err = c.checkReplica(context.Background(), userID, cluster, replica, now, now)
 	assert.NoError(t, err)
 	checkReplicaTimestamp(t, 2*time.Second, c, userID, cluster, replica, now, now)
 
@@ -1277,7 +1285,7 @@ func TestHATrackerCheckReplicaCleanup(t *testing.T) {
 
 	// This will "revive" the replica.
 	now = time.Now()
-	err = c.checkReplica(context.Background(), userID, cluster, replica, now)
+	err = c.checkReplica(context.Background(), userID, cluster, replica, now, now)
 	assert.NoError(t, err)
 	checkReplicaTimestamp(t, 2*time.Second, c, userID, cluster, replica, now, now) // This also checks that entry is not marked for deletion.
 	checkUserClusters(t, time.Second, c, userID, 1)
@@ -1433,17 +1441,17 @@ func TestHATrackerChangeInElectedReplicaClearsLastSeenTimestamp(t *testing.T) {
 	const firstReplica = "first"
 	const secondReplica = "second"
 
-	assert.NoError(t, t1.checkReplica(context.Background(), userID, cluster, firstReplica, now))
+	assert.NoError(t, t1.checkReplica(context.Background(), userID, cluster, firstReplica, now, now))
 	// Both trackers will see "first" replica as current.
 	checkReplicaTimestamp(t, 2*time.Second, t1, userID, cluster, firstReplica, now, now)
 	checkReplicaTimestamp(t, 2*time.Second, t2, userID, cluster, firstReplica, now, now)
 
 	// Ten seconds later, t1 receives request from first replica again
 	now = now.Add(10 * time.Second)
-	assert.NoError(t, t1.checkReplica(context.Background(), userID, cluster, firstReplica, now))
+	assert.NoError(t, t1.checkReplica(context.Background(), userID, cluster, firstReplica, now, now))
 
 	// And t2 receives request from second replica.
-	assert.Error(t, t2.checkReplica(context.Background(), userID, cluster, secondReplica, now))
+	assert.Error(t, t2.checkReplica(context.Background(), userID, cluster, secondReplica, now, now))
 	secondReplicaReceivedAtT2 := now
 
 	// Now t2 updates the KV store... and overwrite elected replica.
@@ -1465,10 +1473,10 @@ func TestHATrackerChangeInElectedReplicaClearsLastSeenTimestamp(t *testing.T) {
 	// They both reject it.
 	now = now.Add(9 * time.Second)
 	firstReceivedAtT1 := now
-	assert.Error(t, t1.checkReplica(context.Background(), userID, cluster, firstReplica, now))
+	assert.Error(t, t1.checkReplica(context.Background(), userID, cluster, firstReplica, now, now))
 	now = now.Add(1 * time.Second)
 	firstReceivedAtT2 := now
-	assert.Error(t, t2.checkReplica(context.Background(), userID, cluster, firstReplica, now))
+	assert.Error(t, t2.checkReplica(context.Background(), userID, cluster, firstReplica, now, now))
 
 	// Now t1 updates the KV Store.
 	t1.updateKVStoreAll(context.Background(), now)
@@ -1531,7 +1539,7 @@ func TestHATracker_UserSpecificTimeouts(t *testing.T) {
 	now := time.Now()
 
 	// First request should succeed (establishes the replica as elected)
-	err = userTracker.updateKVStore(context.Background(), cluster, replica, now, now.UnixMilli())
+	err = userTracker.updateKVStore(context.Background(), cluster, replica, now, now, now.UnixMilli(), false)
 	assert.NoError(t, err)
 	tracker.electedLock.Lock()
 	assert.Equal(t, replica, tracker.clusters[userID][cluster].elected.Replica)
@@ -1541,7 +1549,7 @@ func TestHATracker_UserSpecificTimeouts(t *testing.T) {
 
 	// Second request within user-specific timeout should not update KV store
 	now = now.Add(2 * time.Second)
-	err = userTracker.updateKVStore(context.Background(), cluster, replica, now, now.UnixMilli())
+	err = userTracker.updateKVStore(context.Background(), cluster, replica, now, now, now.UnixMilli(), false)
 	assert.NoError(t, err)
 	tracker.electedLock.Lock()
 	assert.Equal(t, replica, tracker.clusters[userID][cluster].elected.Replica)
@@ -1550,7 +1558,7 @@ func TestHATracker_UserSpecificTimeouts(t *testing.T) {
 
 	// Request after user-specific timeout should trigger an update
 	now = now.Add(userSpecificUpdateTimeout) // Beyond user-specific timeout
-	err = userTracker.updateKVStore(context.Background(), cluster, replica, now, now.UnixMilli())
+	err = userTracker.updateKVStore(context.Background(), cluster, replica, now, now, now.UnixMilli(), false)
 	assert.NoError(t, err)
 	tracker.electedLock.Lock()
 	assert.Equal(t, replica, tracker.clusters[userID][cluster].elected.Replica)
@@ -1558,7 +1566,7 @@ func TestHATracker_UserSpecificTimeouts(t *testing.T) {
 	tracker.electedLock.Unlock()
 
 	// Failover shouldn't happen before FailoverTimeout
-	err = userTracker.updateKVStore(context.Background(), cluster, otherReplica, now, now.UnixMilli())
+	err = userTracker.updateKVStore(context.Background(), cluster, otherReplica, now, now, now.UnixMilli(), false)
 	assert.NoError(t, err)
 	tracker.electedLock.Lock()
 	assert.Equal(t, replica, tracker.clusters[userID][cluster].elected.Replica)
@@ -1566,7 +1574,7 @@ func TestHATracker_UserSpecificTimeouts(t *testing.T) {
 
 	// After FailoverTimeout, new value should be set
 	now = now.Add(userSpecificFailoverTimeout)
-	err = userTracker.updateKVStore(context.Background(), cluster, otherReplica, now, now.UnixMilli())
+	err = userTracker.updateKVStore(context.Background(), cluster, otherReplica, now, now, now.UnixMilli(), false)
 	assert.NoError(t, err)
 	tracker.electedLock.Lock()
 	assert.Equal(t, otherReplica, tracker.clusters[userID][cluster].elected.Replica)

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -128,6 +128,7 @@ type Limits struct {
 	// between the stored timestamp and the time we received a sample is
 	// more than this duration
 	HATrackerFailoverTimeout                    model.Duration      `yaml:"ha_tracker_failover_timeout" json:"ha_tracker_failover_timeout" category:"advanced" doc:"description=If we don't receive any samples from the accepted replica for a cluster in this amount of time we will failover to the next replica we receive a sample from. This value must be greater than the update timeout."`
+	HATrackerUseSampleTimeForFailover           bool                `yaml:"ha_tracker_use_sample_time_for_failover" json:"ha_tracker_use_sample_time_for_failover" category:"advanced" doc:"description=Use the sample time for failover instead of the current time. This is useful to prevent samples being too close together during failover when write requests are delayed such that the sample time is earlier than the current time."`
 	DropLabels                                  flagext.StringSlice `yaml:"drop_labels" json:"drop_labels" category:"advanced"`
 	MaxLabelNameLength                          int                 `yaml:"max_label_name_length" json:"max_label_name_length"`
 	MaxLabelValueLength                         int                 `yaml:"max_label_value_length" json:"max_label_value_length"`
@@ -314,6 +315,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.HATrackerUpdateTimeoutJitterMax, "distributor.ha-tracker.update-timeout-jitter-max", "Maximum jitter applied to the update timeout, in order to spread the HA heartbeats over time.")
 	l.HATrackerFailoverTimeout = model.Duration(30 * time.Second)
 	f.Var(&l.HATrackerFailoverTimeout, "distributor.ha-tracker.failover-timeout", "If we don't receive any samples from the accepted replica for a cluster in this amount of time we will failover to the next replica we receive a sample from. This value must be greater than the update timeout.")
+	f.BoolVar(&l.HATrackerUseSampleTimeForFailover, "distributor.ha-tracker.use-sample-time-for-failover", false, "Use the sample time for failover instead of the current time. This is useful to prevent samples being too close together during failover when write requests are delayed such that the sample time is earlier than the current time.")
 	f.IntVar(&l.HAMaxClusters, HATrackerMaxClustersFlag, 100, "Maximum number of clusters that HA tracker will keep track of for a single tenant. 0 to disable the limit.")
 	f.Var(&l.DropLabels, "distributor.drop-label", "This flag can be used to specify label names that to drop during sample ingestion within the distributor and can be repeated in order to drop multiple labels.")
 	f.IntVar(&l.MaxLabelNameLength, MaxLabelNameLengthFlag, 1024, "Maximum length accepted for label names")
@@ -1142,6 +1144,11 @@ func (o *Overrides) HATrackerTimeouts(user string) (update time.Duration, update
 
 func (o *Overrides) DefaultHATrackerUpdateTimeout() time.Duration {
 	return time.Duration(o.defaultLimits.HATrackerUpdateTimeout)
+}
+
+// See distributor.haTrackerLimits.HATrackerUseSampleTimeForFailover
+func (o *Overrides) HATrackerUseSampleTimeForFailover(user string) bool {
+	return o.getOverridesForUser(user).HATrackerUseSampleTimeForFailover
 }
 
 // S3SSEType returns the per-tenant S3 SSE type.


### PR DESCRIPTION
Not to be merged, just running tests in CI, using it as a base for vendoring and getting feedback.