### PR TITLE
Update requestAddedLatencyPanelNativeHistogram to use histogram_avg

### DIFF
--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes.json
@@ -2539,7 +2539,7 @@
                         "legendLink": null
                      },
                      {
-                        "expr": "sum(histogram_sum(sum(rate(cortex_request_added_latency_seconds{cluster=~\"$cluster\", job=~\"($namespace)/((gateway|cortex-gw.*))\"}[$__rate_interval])))) / sum(histogram_count(sum(rate(cortex_request_added_latency_seconds{cluster=~\"$cluster\", job=~\"($namespace)/((gateway|cortex-gw.*))\"}[$__rate_interval])))) * 1e3",
+                        "expr": "histogram_avg(sum(rate(cortex_request_added_latency_seconds{cluster=~\"$cluster\", job=~\"($namespace)/((gateway|cortex-gw.*))\"}[$__rate_interval]))) * 1e3",
                         "format": "time_series",
                         "legendFormat": "Average",
                         "legendLink": null

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -1355,7 +1355,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
         'histogram_quantile(0.99, sum(rate(%s{%s}[$__rate_interval]))) * 1e3' % [metric, selector],
         'histogram_quantile(0.50, sum(rate(%s{%s}[$__rate_interval]))) * 1e3' % [metric, selector],
         'histogram_quantile(0.01, sum(rate(%s{%s}[$__rate_interval]))) * 1e3' % [metric, selector],
-        'sum(histogram_sum(sum(rate(%s{%s}[$__rate_interval])))) / sum(histogram_count(sum(rate(%s{%s}[$__rate_interval])))) * 1e3' % [metric, selector, metric, selector],
+        'histogram_avg(sum(rate(%s{%s}[$__rate_interval]))) * 1e3' % [metric, selector],
       ],
       [
         '99th percentile',


### PR DESCRIPTION
#### What this PR does

Simplify a dashboard query by using `histogram_avg`. Tested in ops and the [results](https://admin-ops-eu-south-0.grafana-ops.net/stable-grafana/explore?schemaVersion=1&panes=%7B%22i1g%22:%7B%22datasource%22:%22mimir-ops-03%22,%22queries%22:%5B%7B%22expr%22:%22sum%28histogram_sum%28sum%28rate%28cortex_request_added_latency_seconds%7Bcluster%3D~%5C%22prod-eu-west-0%5C%22,%20job%3D~%5C%22%28cortex-prod-01%29%2F%28%28gateway%7Ccortex-gw.%2A%29%29%5C%22%7D%5B$__rate_interval%5D%29%29%29%29%20%2F%20sum%28histogram_count%28sum%28rate%28cortex_request_added_latency_seconds%7Bcluster%3D~%5C%22prod-eu-west-0%5C%22,%20job%3D~%5C%22%28cortex-prod-01%29%2F%28%28gateway%7Ccortex-gw.%2A%29%29%5C%22%7D%5B$__rate_interval%5D%29%29%29%29%20%2A%201e3%22,%22format%22:%22time_series%22,%22legendFormat%22:%22old%22,%22legendLink%22:null,%22refId%22:%22D%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22mimir-ops-03%22%7D,%22adhocFilters%22:%5B%5D,%22interval%22:%22%22,%22editorMode%22:%22code%22,%22range%22:true,%22instant%22:true%7D,%7B%22refId%22:%22A%22,%22expr%22:%22histogram_avg%28sum%28rate%28cortex_request_added_latency_seconds%7Bcluster%3D~%5C%22prod-eu-west-0%5C%22,%20job%3D~%5C%22%28cortex-prod-01%29%2F%28%28gateway%7Ccortex-gw.%2A%29%29%5C%22%7D%5B$__rate_interval%5D%29%29%29%20%2A%201e3%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22mimir-ops-03%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22new%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1) are identical.

Didn't update `ncHistogramAverageRate` as it can involve recording rules so it could be more complicated.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Not sure if this needs a changelog as it's very minor.