### PR TITLE
querier: add native histogram definition to cortex_bucket_index_load_duration_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [FEATURE] MQE: Add support for experimental `sort_by_label` and `sort_by_label_desc` PromQL functions. #11930
 * [FEATURE] Ingester/Block-builder: Handle the created timestamp field for remote-write requests. #11977
 * [FEATURE] Cost attribution: Labels specified in the limit configuration may specify an output label in order to override emitted label names. #12035
+* [ENHANCEMENT] Querier: Add native histogram definition to `cortex_bucket_index_load_duration_seconds`. #12094
 * [ENHANCEMENT] Ingester: Display user grace interval in the tenant list obtained through the `/ingester/tenants` endpoint. #11961
 * [ENHANCEMENT] `kafkatool`: add `consumer-group delete-offset` command as a way to delete the committed offset for a consumer group. #11988
 * [ENHANCEMENT] Block-builder-scheduler: Detect gaps in scheduled and completed jobs. #11867

--- a/pkg/storage/tsdb/bucketindex/loader.go
+++ b/pkg/storage/tsdb/bucketindex/loader.go
@@ -69,9 +69,12 @@ func NewLoader(cfg LoaderConfig, bucketClient objstore.Bucket, cfgProvider bucke
 			Help: "Total number of bucket index loading failures.",
 		}),
 		loadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name:    "cortex_bucket_index_load_duration_seconds",
-			Help:    "Duration of the a single bucket index loading operation in seconds.",
-			Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 1, 10},
+			Name:                            "cortex_bucket_index_load_duration_seconds",
+			Help:                            "Duration of the a single bucket index loading operation in seconds.",
+			Buckets:                         []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 1, 10},
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}),
 	}
 

--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	mimir_testutil "github.com/grafana/mimir/pkg/storage/tsdb/testutil"
+	"github.com/grafana/mimir/pkg/util/promtest"
 )
 
 func TestLoader_GetIndex_ShouldLazyLoadBucketIndex(t *testing.T) {
@@ -88,6 +89,9 @@ func TestLoader_GetIndex_ShouldLazyLoadBucketIndex(t *testing.T) {
 		"cortex_bucket_index_load_failures_total",
 		"cortex_bucket_index_loaded",
 	))
+
+	assert.NoError(t, promtest.HasNativeHistogram(reg, "cortex_bucket_index_load_duration_seconds"))
+	assert.NoError(t, promtest.HasSampleCount(reg, "cortex_bucket_index_load_duration_seconds", 1))
 }
 
 func TestLoader_GetIndex_ShouldCacheError(t *testing.T) {

--- a/pkg/util/promtest/histogram.go
+++ b/pkg/util/promtest/histogram.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package promtest
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// HasNativeHistogram checks if a gathered metric has a native histogram.
+//
+// A histogram uses native format if it uses negative/positive span or zero_count > 0.
+// If zero_count is 0, positive span always contains a no-op span.
+func HasNativeHistogram(g prometheus.Gatherer, metricName string) error {
+	family, err := gatherMetricFamily(g, metricName)
+	if err != nil {
+		return err
+	}
+	histograms, err := getHistograms(family)
+	if err != nil {
+		return err
+	}
+	if len(histograms) == 0 {
+		return fmt.Errorf("metric family %s has no histograms", metricName)
+	}
+	for i, h := range histograms {
+		switch {
+		case h.ZeroCount != nil && *h.ZeroCount > 0:
+		case h.ZeroCountFloat != nil && *h.ZeroCountFloat > 0:
+		case len(h.PositiveSpan) > 0:
+		case len(h.NegativeSpan) > 0:
+		default:
+			return fmt.Errorf("metric %d is not a native histogram", i)
+		}
+	}
+	return nil
+}
+
+// HasSampleCount checks if a gathered metric has a specific sample count.
+func HasSampleCount(g prometheus.Gatherer, metricName string, wantCount float64) error {
+	family, err := gatherMetricFamily(g, metricName)
+	if err != nil {
+		return err
+	}
+	histograms, err := getHistograms(family)
+	if err != nil {
+		return err
+	}
+	for i, h := range histograms {
+		var sampleCount float64
+		switch {
+		case h.SampleCount != nil:
+			sampleCount = float64(*h.SampleCount)
+		case h.SampleCountFloat != nil:
+			sampleCount = *h.SampleCountFloat
+		default:
+			return fmt.Errorf("histogram %d with missing sample count", i)
+		}
+		if sampleCount != wantCount {
+			return fmt.Errorf("histogram %d should have %f samples but got %f", i, wantCount, sampleCount)
+		}
+	}
+	return nil
+}
+
+func getHistograms(family *dto.MetricFamily) ([]*dto.Histogram, error) {
+	feType := family.Type
+	if feType == nil || (*feType != dto.MetricType_HISTOGRAM && (*feType != dto.MetricType_GAUGE_HISTOGRAM)) {
+		return nil, fmt.Errorf("family is not a histogram")
+	}
+	if len(family.Metric) == 0 {
+		return nil, fmt.Errorf("family has no metrics")
+	}
+	out := make([]*dto.Histogram, len(family.Metric))
+	for i, m := range family.Metric {
+		if m.Histogram == nil {
+			return nil, fmt.Errorf("metric %d has no histogram", i)
+		}
+		out[i] = m.Histogram
+	}
+	return out, nil
+}
+
+func gatherMetricFamily(g prometheus.Gatherer, metricName string) (*dto.MetricFamily, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	index := slices.IndexFunc(got, func(mf *dto.MetricFamily) bool {
+		return mf.GetName() == metricName
+	})
+	if index == -1 {
+		return nil, fmt.Errorf("metric family %s not found", metricName)
+	}
+	return got[index], nil
+}


### PR DESCRIPTION
#### What this PR does

- Adds native histogram definition to `cortex_bucket_index_load_duration_seconds`, uses standard parameters:
  - BucketFactor: 1.1
  - MaxBuckets: 100
  - MinResetDuration: 1h
- adds new `promtest` package with helpers to check if
  -  a metric is native histogram
  - a histogram has correct amount of samples


#### Which issue(s) this PR fixes or relates to

Part of: https://github.com/grafana/mimir-squad/issues/3077

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
