### PR TITLE
Refactoring: move X-Scope-OrgID HTTP header injection into EncodeLabelsSeriesQueryRequest() and EncodeMetricsQueryRequest()

### DIFF
--- a/pkg/frontend/querymiddleware/labels_query_optimizer.go
+++ b/pkg/frontend/querymiddleware/labels_query_optimizer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
-	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
@@ -124,10 +123,6 @@ func (l *labelsQueryOptimizer) optimizeRequest(ctx context.Context, req *http.Re
 		level.Error(l.logger).Log("msg", "failed to encode labels request with optimized matchers", "err", err)
 		l.failedQueries.Inc()
 		return l.next.RoundTrip(req)
-	}
-
-	if err := user.InjectOrgIDIntoHTTPRequest(ctx, optimizedReq); err != nil {
-		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
 	// Track successful optimization.

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/tenant"
-	"github.com/grafana/dskit/user"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/semaphore"
@@ -290,10 +289,6 @@ func (rth roundTripperHandler) Do(ctx context.Context, r MetricsQueryRequest) (R
 	request, err := rth.codec.EncodeMetricsQueryRequest(ctx, r)
 	if err != nil {
 		return nil, err
-	}
-
-	if err := user.InjectOrgIDIntoHTTPRequest(ctx, request); err != nil {
-		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
 	response, err := rth.next.RoundTrip(request)


### PR DESCRIPTION
#### What this PR does

This PR addresses the comment received [here](https://github.com/grafana/mimir/pull/12076#discussion_r2205602043). The idea is to move the X-Scope-OrgID HTTP header injection into `EncodeLabelsSeriesQueryRequest()` and `EncodeMetricsQueryRequest()` instead of doing it in the caller, right after encoding requests. The `EncodeLabelsSeriesQueryRequest()` and `EncodeMetricsQueryRequest()` are only called in places where `user.InjectOrgIDIntoHTTPRequest()` is called right after (and same in GEM, that I will take care of updating if this PR is accepted).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
