### PR TITLE
Prevent renovate from updating flaky tests workflow dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -50,6 +50,11 @@
           "docker",
         ],
         "enabled": false
+      },
+      {
+        "description": "Prevent renovate from updating dependencies in flaky tests workflow",
+        "matchFileNames": [".github/workflows/flaky-tests.yml"],
+        "enabled": false
       }
     ],
     "branchPrefix": "deps-update/",


### PR DESCRIPTION
Add a package rule to prevent renovate from updating dependencies in the flaky tests workflow. I'm running from a branch's fork because merging to main is take a long time. 

will be undone once https://github.com/grafana/mimir-squad/issues/2944 is closed