### PR TITLE
Alertmanager: Grafana configuration status API endpoint

### DIFF
--- a/development/common/config/nginx.conf.template
+++ b/development/common/config/nginx.conf.template
@@ -67,6 +67,9 @@ http {
     location = /api/v1/grafana/config {
       proxy_pass      http://${ALERT_MANAGER_HOST}$request_uri;
     }
+    location = /api/v1/grafana/config/status {
+      proxy_pass      http://${ALERT_MANAGER_HOST}$request_uri;
+    }
     location = /api/v1/grafana/full_state {
       proxy_pass      http://${ALERT_MANAGER_HOST}$request_uri;
     }

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -1084,9 +1084,9 @@ func TestAlertmanagerGrafanaAlertmanagerAPI(t *testing.T) {
 			require.EqualError(t, err, e2emimir.ErrNotFound.Error())
 			require.Nil(t, cfg)
 
-			cfg, err = c.GetGrafanaAlertmanagerConfigStatus(context.Background())
+			status, err := c.GetGrafanaAlertmanagerConfigStatus(context.Background())
 			require.EqualError(t, err, e2emimir.ErrNotFound.Error())
-			require.Nil(t, cfg)
+			require.Nil(t, status)
 
 			// Now, let's set a config.
 			now := time.Now().UnixMilli()

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -1084,6 +1084,10 @@ func TestAlertmanagerGrafanaAlertmanagerAPI(t *testing.T) {
 			require.EqualError(t, err, e2emimir.ErrNotFound.Error())
 			require.Nil(t, cfg)
 
+			cfg, err = c.GetGrafanaAlertmanagerConfigStatus(context.Background())
+			require.EqualError(t, err, e2emimir.ErrNotFound.Error())
+			require.Nil(t, cfg)
+
 			// Now, let's set a config.
 			now := time.Now().UnixMilli()
 			err = c.SetGrafanaAlertmanagerConfig(context.Background(), now, testGrafanaConfig, "bb788eaa294c05ec556c1ed87546b7a9", "http://test.com", false, true, staticHeaders, smtpConfig)
@@ -1093,6 +1097,12 @@ func TestAlertmanagerGrafanaAlertmanagerAPI(t *testing.T) {
 			cfg, err = c.GetGrafanaAlertmanagerConfig(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, now, cfg.CreatedAt)
+
+			status, err = c.GetGrafanaAlertmanagerConfigStatus(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, cfg.CreatedAt, status.CreatedAt)
+			require.Equal(t, cfg.Promoted, status.Promoted)
+			require.Equal(t, cfg.Hash, status.Hash)
 		}
 
 		// Let's store config for a different user as well.
@@ -1123,6 +1133,12 @@ func TestAlertmanagerGrafanaAlertmanagerAPI(t *testing.T) {
 			cfg, err = c.GetGrafanaAlertmanagerConfig(context.Background())
 			require.EqualError(t, err, e2emimir.ErrNotFound.Error())
 			require.Nil(t, cfg)
+
+			status, err = c.GetGrafanaAlertmanagerConfigStatus(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, cfg.CreatedAt, status.CreatedAt)
+			require.Equal(t, cfg.Promoted, status.Promoted)
+			require.Equal(t, cfg.Hash, status.Hash)
 		}
 	}
 

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -1134,11 +1134,8 @@ func TestAlertmanagerGrafanaAlertmanagerAPI(t *testing.T) {
 			require.EqualError(t, err, e2emimir.ErrNotFound.Error())
 			require.Nil(t, cfg)
 
-			status, err = c.GetGrafanaAlertmanagerConfigStatus(context.Background())
-			require.NoError(t, err)
-			require.Equal(t, cfg.CreatedAt, status.CreatedAt)
-			require.Equal(t, cfg.Promoted, status.Promoted)
-			require.Equal(t, cfg.Hash, status.Hash)
+			_, err = c.GetGrafanaAlertmanagerConfigStatus(context.Background())
+			require.EqualError(t, err, e2emimir.ErrNotFound.Error())
 		}
 	}
 

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -17,14 +17,15 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/tenant"
-	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
-	"github.com/grafana/mimir/pkg/util"
-	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/template"
 	commoncfg "github.com/prometheus/common/config"
 	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
+	"github.com/grafana/mimir/pkg/util"
+	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
 const (

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -17,15 +17,14 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/tenant"
+	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
+	"github.com/grafana/mimir/pkg/util"
+	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/template"
 	commoncfg "github.com/prometheus/common/config"
 	"gopkg.in/yaml.v3"
-
-	"github.com/grafana/mimir/pkg/alertmanager/alertspb"
-	"github.com/grafana/mimir/pkg/util"
-	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
 const (

--- a/pkg/alertmanager/api_grafana.go
+++ b/pkg/alertmanager/api_grafana.go
@@ -91,6 +91,12 @@ type UserGrafanaConfig struct {
 	StaticHeaders map[string]string `json:"static_headers"`
 }
 
+type UserGrafanaConfigStatus struct {
+	Hash     string `json:"configuration_hash"`
+	CreateAt int64  `json:"created"`
+	Promoted bool   `json:"promoted"`
+}
+
 func (gc *UserGrafanaConfig) Validate() error {
 	if gc.Hash == "" {
 		return errors.New("no hash specified")
@@ -485,6 +491,39 @@ func (am *MultitenantAlertmanager) DeleteUserGrafanaConfig(w http.ResponseWriter
 
 	w.WriteHeader(http.StatusOK)
 	util.WriteJSONResponse(w, successResult{Status: statusSuccess})
+}
+
+func (am *MultitenantAlertmanager) GetGrafanaConfigStatus(w http.ResponseWriter, r *http.Request) {
+	logger := util_log.WithContext(r.Context(), am.logger)
+
+	userID, err := tenant.TenantID(r.Context())
+	if err != nil {
+		level.Error(logger).Log("msg", errNoOrgID, "err", err.Error())
+		w.WriteHeader(http.StatusUnauthorized)
+		util.WriteJSONResponse(w, errorResult{Status: statusError, Error: fmt.Sprintf("%s: %s", errNoOrgID, err.Error())})
+		return
+	}
+
+	cfg, err := am.store.GetGrafanaAlertConfig(r.Context(), userID)
+	if err != nil {
+		if errors.Is(err, alertspb.ErrNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			util.WriteJSONResponse(w, errorResult{Status: statusError, Error: err.Error()})
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+			util.WriteJSONResponse(w, errorResult{Status: statusError, Error: err.Error()})
+		}
+		return
+	}
+
+	util.WriteJSONResponse(w, successResult{
+		Status: statusSuccess,
+		Data: &UserGrafanaConfigStatus{
+			Hash:     cfg.Hash,
+			CreateAt: cfg.CreatedAtTimestamp,
+			Promoted: cfg.Promoted,
+		},
+	})
 }
 
 // ValidateUserGrafanaConfig validates the Grafana Alertmanager configuration.

--- a/pkg/alertmanager/api_grafana.go
+++ b/pkg/alertmanager/api_grafana.go
@@ -92,9 +92,9 @@ type UserGrafanaConfig struct {
 }
 
 type UserGrafanaConfigStatus struct {
-	Hash     string `json:"configuration_hash"`
-	CreateAt int64  `json:"created"`
-	Promoted bool   `json:"promoted"`
+	Hash      string `json:"configuration_hash"`
+	CreatedAt int64  `json:"created"`
+	Promoted  bool   `json:"promoted"`
 }
 
 func (gc *UserGrafanaConfig) Validate() error {
@@ -519,9 +519,9 @@ func (am *MultitenantAlertmanager) GetGrafanaConfigStatus(w http.ResponseWriter,
 	util.WriteJSONResponse(w, successResult{
 		Status: statusSuccess,
 		Data: &UserGrafanaConfigStatus{
-			Hash:     cfg.Hash,
-			CreateAt: cfg.CreatedAtTimestamp,
-			Promoted: cfg.Promoted,
+			Hash:      cfg.Hash,
+			CreatedAt: cfg.CreatedAtTimestamp,
+			Promoted:  cfg.Promoted,
 		},
 	})
 }

--- a/pkg/alertmanager/api_grafana_test.go
+++ b/pkg/alertmanager/api_grafana_test.go
@@ -312,6 +312,30 @@ func TestMultitenantAlertmanager_GetUserGrafanaConfig(t *testing.T) {
 		require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
 		require.Len(t, storage.Objects(), 1)
 	}
+	t.Run("should return correct config status", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/grafana/config/status", nil)
+		req = req.WithContext(user.InjectOrgID(context.Background(), "test_user"))
+
+		rec := httptest.NewRecorder()
+		am.GetGrafanaConfigStatus(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+		body, err := io.ReadAll(rec.Body)
+		require.NoError(t, err)
+		json := fmt.Sprintf(`
+		{
+			"data": {
+				 "configuration_hash": "bb788eaa294c05ec556c1ed87546b7a9",
+				 "created": %d,
+				 "promoted": true
+			},
+			"status": "success"
+		}
+		`, now)
+
+		require.JSONEq(t, json, string(body))
+		require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+		require.Len(t, storage.Objects(), 1)
+	})
 }
 
 func TestMultitenantAlertmanager_GetUserGrafanaState(t *testing.T) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -215,11 +215,12 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, api
 			a.RegisterRoute("/api/v1/grafana/config", http.HandlerFunc(am.GetUserGrafanaConfig), true, true, http.MethodGet)
 			a.RegisterRoute("/api/v1/grafana/config", http.HandlerFunc(am.SetUserGrafanaConfig), true, true, http.MethodPost)
 			a.RegisterRoute("/api/v1/grafana/config", http.HandlerFunc(am.DeleteUserGrafanaConfig), true, true, http.MethodDelete)
+			a.RegisterRoute("/api/v1/grafana/config/status", http.HandlerFunc(am.GetGrafanaConfigStatus), true, true, http.MethodGet)
 
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.GetUserGrafanaState), true, true, http.MethodGet)
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.SetUserGrafanaState), true, true, http.MethodPost)
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.DeleteUserGrafanaState), true, true, http.MethodDelete)
-
+			
 			// These APIs are handled by the per-tenant Alertmanager, so they are handled by the distributor.
 			a.RegisterRoute("/api/v1/grafana/full_state", am, true, true, http.MethodGet)
 			a.RegisterRoute("/api/v1/grafana/receivers", am, true, true, http.MethodGet)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -220,7 +220,7 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, api
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.GetUserGrafanaState), true, true, http.MethodGet)
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.SetUserGrafanaState), true, true, http.MethodPost)
 			a.RegisterRoute("/api/v1/grafana/state", http.HandlerFunc(am.DeleteUserGrafanaState), true, true, http.MethodDelete)
-			
+
 			// These APIs are handled by the per-tenant Alertmanager, so they are handled by the distributor.
 			a.RegisterRoute("/api/v1/grafana/full_state", am, true, true, http.MethodGet)
 			a.RegisterRoute("/api/v1/grafana/receivers", am, true, true, http.MethodGet)


### PR DESCRIPTION
#### What this PR does
Currently, Grafana fetches entire configuration from the Mimir just to compare the currently active configuration with the desired one. The configuration could be large, which will take some resources from Grafana to unmarshall and compare it again. Instead alerting team decided to rely on the hash that Grafana will calculate and then compare. 
This pull request introduces a new endpoint `/api/v1/grafana/config/status` that returns just the bare minimum information needed to determine whether desired configuration needs to be pushed from Grafana to Mimir Alertmanager.

This PR does not affect the base Mimir Alertmanager functionality and exposes the new endpoint only if Grafana compatibility is enabled.

