### PR TITLE
add note about not using monolithic mode for large-scale deployments

### DIFF
--- a/docs/sources/mimir/references/architecture/deployment-modes/index.md
+++ b/docs/sources/mimir/references/architecture/deployment-modes/index.md
@@ -36,6 +36,10 @@ Monolithic mode can be horizontally scaled out by deploying multiple Grafana Mim
 
 ![Mimir's horizontally scaled monolithic mode](scaled-monolithic-mode.svg)
 
+{{< admonition type="note" >}}
+Because monolithic mode requires scaling all Grafana Mimir components together, this deployment mode isn't recommended for large-scale deployments.
+{{< /admonition >}}
+
 ## Microservices mode
 
 In microservices mode, components are deployed in distinct processes. Scaling is per component, which allows for greater flexibility in scaling and more granular failure domains. Microservices mode is the preferred method for a production deployment, but it is also the most complex.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds a note to https://grafana.com/docs/mimir/latest/references/architecture/deployment-modes/ to caution against using monolithic mode for large-scale deployments.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/2646

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
