### PR TITLE
ingest-storage: Split very large RW2.0 requests into multiple Kafka records

### DIFF
--- a/pkg/mimirpb/custom.go
+++ b/pkg/mimirpb/custom.go
@@ -228,6 +228,33 @@ func (m *WriteRequest) TimeseriesSize() int {
 	return n
 }
 
+// TimeseriesSize is like Size() but returns only the marshalled size of TimeseriesRW2 field.
+func (m *WriteRequest) TimeseriesRW2Size() int {
+	var n, l int
+
+	for _, e := range m.TimeseriesRW2 {
+		l = e.Size()
+		n += 1 + l + sovMimir(uint64(l))
+	}
+
+	return n
+}
+
+// TimeseriesSize is like Size() but returns only the marshalled size of SymbolsRW2 field.
+func (m *WriteRequest) SymbolsRW2Size() int {
+	if len(m.SymbolsRW2) == 0 {
+		return 0
+	}
+
+	var n, l int
+	for _, s := range m.SymbolsRW2 {
+		l = len(s)
+		n += 1 + l + sovMimir(uint64(l))
+	}
+
+	return n
+}
+
 func (h Histogram) IsFloatHistogram() bool {
 	_, ok := h.GetCount().(*Histogram_CountFloat)
 	return ok

--- a/pkg/mimirpb/custom.go
+++ b/pkg/mimirpb/custom.go
@@ -228,7 +228,7 @@ func (m *WriteRequest) TimeseriesSize() int {
 	return n
 }
 
-// TimeseriesSize is like Size() but returns only the marshalled size of TimeseriesRW2 field.
+// TimeseriesRW2Size is like Size() but returns only the marshalled size of TimeseriesRW2 field.
 func (m *WriteRequest) TimeseriesRW2Size() int {
 	var n, l int
 
@@ -240,12 +240,8 @@ func (m *WriteRequest) TimeseriesRW2Size() int {
 	return n
 }
 
-// TimeseriesSize is like Size() but returns only the marshalled size of SymbolsRW2 field.
+// SymbolsRW2Size is like Size() but returns only the marshalled size of SymbolsRW2 field.
 func (m *WriteRequest) SymbolsRW2Size() int {
-	if len(m.SymbolsRW2) == 0 {
-		return 0
-	}
-
 	var n, l int
 	for _, s := range m.SymbolsRW2 {
 		l = len(s)

--- a/pkg/mimirpb/prealloc_rw2.go
+++ b/pkg/mimirpb/prealloc_rw2.go
@@ -50,9 +50,10 @@ func FromWriteRequestToRW2Request(rw1 *WriteRequest, commonSymbols []string, off
 	// Represent metadata as extra, empty timeseries rather than attaching it to existing series.
 	// We never replicate metadata if there are multiple series with the same name, and it removes the requirement to match up the metadata to the right series.
 	for _, meta := range rw1.Metadata {
+		labelsRefs := []uint32{symbols.Symbolize("__name__"), symbols.Symbolize(meta.MetricFamilyName)}
 		rw2meta := FromMetricMetadataToMetadataRW2(meta, symbols)
 		rw2Timeseries = append(rw2Timeseries, TimeSeriesRW2{
-			LabelsRefs: []uint32{symbols.Symbolize("__name__"), symbols.Symbolize(meta.MetricFamilyName)},
+			LabelsRefs: labelsRefs,
 			Metadata:   rw2meta,
 		})
 	}

--- a/pkg/mimirpb/prealloc_rw2_test.go
+++ b/pkg/mimirpb/prealloc_rw2_test.go
@@ -296,14 +296,14 @@ func TestWriteRequestRW2Conversion(t *testing.T) {
 
 		rw2, err := FromWriteRequestToRW2Request(req, nil, 0)
 
-		expSymbols := []string{"", "It's a cool series.", "megawatts", "__name__", "my_cool_series"}
+		expSymbols := []string{"", "__name__", "my_cool_series", "It's a cool series.", "megawatts"}
 		expTimeseries := []TimeSeriesRW2{
 			{
-				LabelsRefs: []uint32{3, 4},
+				LabelsRefs: []uint32{1, 2},
 				Metadata: MetadataRW2{
 					Type:    METRIC_TYPE_COUNTER,
-					HelpRef: 1,
-					UnitRef: 2,
+					HelpRef: 3,
+					UnitRef: 4,
 				},
 			},
 		}

--- a/pkg/mimirpb/split.go
+++ b/pkg/mimirpb/split.go
@@ -51,7 +51,7 @@ func SplitWriteRequestByMaxMarshalSize(req *WriteRequest, reqSize, maxSize int) 
 //
 // The request will split the RW2 symbols among the various sub-requests. The original symbols table will no longer be valid for the individual timeseries.
 // Timeseries are re-symbolized in place, so this function mutates the input.
-func SplitWriteRequestByMaxMarshalSizeRW2(req *WriteRequest, reqSize, maxSize int) []*WriteRequest {
+func SplitWriteRequestByMaxMarshalSizeRW2(req *WriteRequest, reqSize, maxSize int, offset uint32, commonSymbols []string) []*WriteRequest {
 	if reqSize <= maxSize {
 		return []*WriteRequest{req}
 	}
@@ -75,7 +75,7 @@ func SplitWriteRequestByMaxMarshalSizeRW2(req *WriteRequest, reqSize, maxSize in
 
 	// Split timeseries into partial write requests, and resymbolize each batch.
 	nextReqSymbols := symbolsTableFromPool()
-	// TODO: Common Symbols...
+	nextReqSymbols.ConfigureCommonSymbols(offset, commonSymbols)
 	defer reuseSymbolsTable(nextReqSymbols)
 	nextReq, nextReqSize := newPartialReq()
 	nextReqTimeseriesStart := 0

--- a/pkg/mimirpb/split.go
+++ b/pkg/mimirpb/split.go
@@ -63,7 +63,8 @@ func splitWriteRequestByMaxMarshalSizeRW2(req *WriteRequest, reqSize, maxSize in
 
 	// Naive implementation: send all symbols on all sub-requests.
 	// Skip the work needed to slice up symbols and update references.
-	timeSeriesMaxSize := maxSize - symbolSize
+	const sizeLimitLowerBound = 1
+	timeSeriesMaxSize := max(sizeLimitLowerBound, maxSize-symbolSize)
 
 	// The partial requests returned by this function will not contain any Metadata,
 	// so we first compute the request size without it.

--- a/pkg/mimirpb/split.go
+++ b/pkg/mimirpb/split.go
@@ -236,6 +236,7 @@ func splitMetadataByMaxMarshalSize(req *WriteRequest, reqSize, maxSize int) []*W
 }
 
 // maxSeriesSizeAfterResymbolization calculates an upper bound for the size of the given TimeSeries, and its referenced symbols.
+// It is only an upper bound. The actual series might end up being smaller if it re-uses symbols or has low magnitude references.
 func maxRW2SeriesSizeAfterResymbolization(ts *TimeSeriesRW2, symbols []string, symbolOffset uint32) (seriesSize int, symbolsSize int) {
 	// Symbol references are eventually encoded as protobuf varints which do not have a stable size.
 	// So, resymbolization might alter the size of the timeseries by a few bytes.

--- a/pkg/mimirpb/split.go
+++ b/pkg/mimirpb/split.go
@@ -58,60 +58,50 @@ func splitWriteRequestByMaxMarshalSizeRW2(req *WriteRequest, reqSize, maxSize in
 		return r, r.Size()
 	}
 
-	symbolSize := req.SymbolsRW2Size()
-	timeSeriesSize := req.TimeseriesRW2Size()
-
-	// Naive implementation: send all symbols on all sub-requests.
-	// Skip the work needed to slice up symbols and update references.
-	const sizeLimitLowerBound = 1
-	timeSeriesMaxSize := max(sizeLimitLowerBound, maxSize-symbolSize)
-
-	// The partial requests returned by this function will not contain any Metadata,
-	// so we first compute the request size without it.
-	if timeSeriesSize <= timeSeriesMaxSize {
-		partialReq, _ := newPartialReq()
-		partialReq.TimeseriesRW2 = req.TimeseriesRW2
-		partialReq.SymbolsRW2 = req.SymbolsRW2
-		return []*WriteRequest{partialReq}
-	}
-
-	// We assume that different timeseries roughly have the same size (no huge outliers)
+	// Assume that the distribution of symbols usage is even across all timeseries, and that the timeseries are a roughly even size.
 	// so we preallocate the returned slice just adding 1 extra item (+2 because a +1 is to round up).
-	estimatedPartialReqs := (timeSeriesSize / timeSeriesMaxSize) + 2
+	estimatedPartialReqs := (reqSize / maxSize) + 2
 	partialReqs := make([]*WriteRequest, 0, estimatedPartialReqs)
 
-	// Split timeseries into partial write requests.
+	// Split timeseries into partial write requests, and resymbolize each batch.
+	nextReqSymbols := symbolsTableFromPool()
+	// TODO: Common Symbols...
+	defer reuseSymbolsTable(nextReqSymbols)
 	nextReq, nextReqSize := newPartialReq()
 	nextReqTimeseriesStart := 0
 	nextReqTimeseriesLength := 0
 
 	for i := 0; i < len(req.TimeseriesRW2); i++ {
-		seriesSize := req.TimeseriesRW2[i].Size()
+		// Both are upper bounds. In particular symbolsSize does have knowledge of whether symbols can be re-used.
+		// The actual growth will be less than or equal to these values.
+		seriesSize, symbolsSize := maxRW2SeriesSizeAfterResymbolization(&req.TimeseriesRW2[i], req.SymbolsRW2, req.rw2symbols.offset)
 
 		// Check if the next partial request is full (or close to be full), and so it's time to finalize it and create a new one.
 		// If the next partial request doesn't have any timeseries yet, we add the series anyway, in order to avoid an infinite loop
 		// if a single timeseries is bigger than the limit.
-		if nextReqSize+seriesSize > timeSeriesMaxSize && nextReqTimeseriesLength > 0 {
+		if nextReqSize+seriesSize+symbolsSize > maxSize && nextReqTimeseriesLength > 0 {
 			// Finalize the next partial request.
 			nextReq.TimeseriesRW2 = req.TimeseriesRW2[nextReqTimeseriesStart : nextReqTimeseriesStart+nextReqTimeseriesLength]
-			nextReq.SymbolsRW2 = req.SymbolsRW2
+			nextReq.SymbolsRW2 = nextReqSymbols.Symbols()
 			partialReqs = append(partialReqs, nextReq)
 
 			// Initialize a new partial request.
 			nextReq, nextReqSize = newPartialReq()
 			nextReqTimeseriesStart = i
 			nextReqTimeseriesLength = 0
+			nextReqSymbols.Reset()
 		}
 
 		// Add the current series to next partial request.
-		nextReqSize += seriesSize + 1 + sovMimir(uint64(seriesSize)) // Math copied from Size().
+		deltaSize := resymbolizeTimeSeriesRW2(&req.TimeseriesRW2[i], req.SymbolsRW2, nextReqSymbols)
+		nextReqSize += deltaSize + 1 + sovMimir(uint64(seriesSize)) // Math copied from Size().
 		nextReqTimeseriesLength++
 	}
 
 	if nextReqTimeseriesLength > 0 {
 		// Finalize the last partial request.
 		nextReq.TimeseriesRW2 = req.TimeseriesRW2[nextReqTimeseriesStart : nextReqTimeseriesStart+nextReqTimeseriesLength]
-		nextReq.SymbolsRW2 = req.SymbolsRW2
+		nextReq.SymbolsRW2 = nextReqSymbols.Symbols()
 		partialReqs = append(partialReqs, nextReq)
 	}
 
@@ -243,4 +233,84 @@ func splitMetadataByMaxMarshalSize(req *WriteRequest, reqSize, maxSize int) []*W
 	}
 
 	return partialReqs
+}
+
+// maxSeriesSizeAfterResymbolization calculates an upper bound for the size of the given TimeSeries, and its referenced symbols.
+func maxRW2SeriesSizeAfterResymbolization(ts *TimeSeriesRW2, symbols []string, symbolOffset uint32) (seriesSize int, symbolsSize int) {
+	// Symbol references are eventually encoded as protobuf varints which do not have a stable size.
+	// So, resymbolization might alter the size of the timeseries by a few bytes.
+	highestPossibleSymbol := uint64(len(symbols)) + uint64(symbolOffset)
+	symbolSizeUpperBound := 1 + sovMimir(highestPossibleSymbol)
+	seriesSize = ts.Size()
+	symbolsSize = 0
+
+	var l int
+	for _, e := range ts.LabelsRefs {
+		seriesSize += (symbolSizeUpperBound - sovMimir(uint64(e)))
+		l = len(symbols[e])
+		symbolsSize += 1 + l + sovMimir(uint64(l))
+	}
+	for _, ex := range ts.Exemplars {
+		for _, e := range ex.LabelsRefs {
+			seriesSize += (symbolSizeUpperBound - sovMimir(uint64(e)))
+			l = len(symbols[e])
+			symbolsSize += 1 + l + sovMimir(uint64(l))
+		}
+	}
+	seriesSize += (symbolSizeUpperBound - sovMimir(uint64(ts.Metadata.HelpRef)))
+	l = len(symbols[ts.Metadata.HelpRef])
+	symbolsSize += 1 + l + sovMimir(uint64(l))
+	seriesSize += (symbolSizeUpperBound - sovMimir(uint64(ts.Metadata.UnitRef)))
+	l = len(symbols[ts.Metadata.UnitRef])
+	symbolsSize += 1 + l + sovMimir(uint64(l))
+	return
+}
+
+// resymbolizeTimeSeriesRW2 resolves and re-symbolizes a TimeSeriesRW2 in the context of a new request.
+// Work is done in-place, the provided timeseries is modified.
+// It returns the total size delta (change in the Timeseries + growth in the new symbols table).
+func resymbolizeTimeSeriesRW2(ts *TimeSeriesRW2, origSymbols []string, symbols *FastSymbolsTable) int {
+	delta := 0
+
+	for i := range ts.LabelsRefs {
+		oldRef := ts.LabelsRefs[i]
+		newRef, growth := symbolizeWithDeltaLen(symbols, origSymbols[oldRef])
+		ts.LabelsRefs[i] = newRef
+		delta += growth
+		delta += sovMimir(uint64(newRef)) - sovMimir(uint64(oldRef))
+	}
+
+	for i := range ts.Exemplars {
+		for j := range ts.Exemplars[i].LabelsRefs {
+			oldRef := ts.Exemplars[i].LabelsRefs[j]
+			newRef, growth := symbolizeWithDeltaLen(symbols, origSymbols[oldRef])
+			ts.Exemplars[i].LabelsRefs[j] = newRef
+			delta += growth
+			delta += sovMimir(uint64(ts.Exemplars[i].LabelsRefs[j])) - sovMimir(uint64(oldRef))
+		}
+	}
+
+	oldRef := ts.Metadata.HelpRef
+	newRef, growth := symbolizeWithDeltaLen(symbols, origSymbols[oldRef])
+	delta += growth
+	delta += sovMimir(uint64(ts.Metadata.HelpRef)) - sovMimir(uint64(oldRef))
+	ts.Metadata.HelpRef = newRef
+
+	oldRef = ts.Metadata.UnitRef
+	newRef, growth = symbolizeWithDeltaLen(symbols, origSymbols[oldRef])
+	delta += growth
+	delta += sovMimir(uint64(ts.Metadata.UnitRef)) - sovMimir(uint64(oldRef))
+	ts.Metadata.UnitRef = newRef
+
+	return delta
+}
+
+func symbolizeWithDeltaLen(st *FastSymbolsTable, v string) (ref uint32, growth int) {
+	newRef, isNew := st.SymbolizeCheckNew(v)
+	if isNew {
+		l := len(v)
+		growth = 1 + l + sovMimir(uint64(l))
+	}
+	ref = newRef
+	return
 }

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -402,18 +402,7 @@ func TestSplitWriteRequestByMaxMarshalSize_Fuzzy(t *testing.T) {
 			partials := SplitWriteRequestByMaxMarshalSize(req, req.Size(), maxSize)
 
 			// Ensure the merge of all partial requests is equal to the original one.
-			/*merged := &WriteRequest{
-				Source:              partials[0].Source,
-				SkipLabelValidation: partials[0].SkipLabelValidation,
-				SymbolsRW2:          partials[0].SymbolsRW2,
-				TimeseriesRW2:       []TimeSeriesRW2{},
-			}*/
 			merged := mergeRW2s(partials)
-
-			/*for _, partial := range partials {
-				merged.TimeseriesRW2 = append(merged.TimeseriesRW2, partial.TimeseriesRW2...)
-			}*/
-
 			assert.Equal(t, reqCpy, merged)
 		}
 	})

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -816,7 +816,7 @@ func TestRW2SymbolSplitting(t *testing.T) {
 			require.Equal(t, []uint32{1, 2, 3, 4}, ts.LabelsRefs)
 			require.Equal(t, []uint32{5, 6}, ts.Exemplars[0].LabelsRefs)
 			require.Equal(t, uint32(7), ts.Metadata.HelpRef)
-			require.Equal(t, newTable.SymbolsSizeProto(), delta)
+			require.Equal(t, 0, delta)
 		})
 
 		t.Run("excludes unrelated strings in original symbols", func(t *testing.T) {
@@ -840,7 +840,7 @@ func TestRW2SymbolSplitting(t *testing.T) {
 			require.Equal(t, []uint32{1, 2, 3, 4}, ts.LabelsRefs)
 			require.Equal(t, []uint32{5, 6}, ts.Exemplars[0].LabelsRefs)
 			require.Equal(t, uint32(7), ts.Metadata.HelpRef)
-			require.Equal(t, newTable.SymbolsSizeProto(), delta)
+			require.Equal(t, 0, delta)
 		})
 
 		t.Run("re-uses symbols already loaded in new symbols table", func(t *testing.T) {
@@ -869,7 +869,8 @@ func TestRW2SymbolSplitting(t *testing.T) {
 			require.Equal(t, []uint32{3, 4, 5, 6}, ts.LabelsRefs)
 			require.Equal(t, []uint32{7, 8}, ts.Exemplars[0].LabelsRefs)
 			require.Equal(t, uint32(9), ts.Metadata.HelpRef)
-			require.Equal(t, newTable.SymbolsSizeProto()-prevSize, delta)
+			require.Equal(t, 0, delta)
+			require.Greater(t, newTable.SymbolsSizeProto(), prevSize)
 		})
 
 		t.Run("resymbolize with different symbol magnitudes", func(t *testing.T) {
@@ -896,8 +897,8 @@ func TestRW2SymbolSplitting(t *testing.T) {
 			require.Equal(t, []uint32{10005, 10006}, ts.Exemplars[0].LabelsRefs)
 			require.Equal(t, uint32(10007), ts.Metadata.HelpRef)
 			require.Equal(t, uint32(10008), ts.Metadata.UnitRef)
-			expGrowth := 6
-			require.Equal(t, newTable.SymbolsSizeProto()+expGrowth, delta)
+			const expGrowth = 6
+			require.Equal(t, expGrowth, delta)
 		})
 	})
 }

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -144,8 +144,8 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 	})
 
 	t.Run("should split the input WriteRequest into multiple requests, honoring the size limit, and bin-packing - RW2", func(t *testing.T) {
-		// 200 allows the first and second WriteRequests to fit into one request, but not the third.
-		const limit = 200
+		// 220 allows the first and second WriteRequests to fit into one request, but not the third.
+		const limit = 220
 		reqv2 := testReqV2Static(t)
 
 		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit, 0, nil)

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -51,7 +51,7 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 
 	t.Run("should return the input WriteRequest if its size is less than the size limit - RW2", func(t *testing.T) {
 		reqv2 := testReqV2Static(t)
-		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), 100000)
+		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), 100000, 0, nil)
 		require.Len(t, partials, 1)
 		assert.Equal(t, reqv2, partials[0])
 	})
@@ -90,7 +90,7 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 		const limit = 150
 		reqv2 := testReqV2Static(t)
 
-		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit)
+		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit, 0, nil)
 		assert.Equal(t, []*WriteRequest{
 			{
 				Source:              RULE,
@@ -148,7 +148,7 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 		const limit = 200
 		reqv2 := testReqV2Static(t)
 
-		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit)
+		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit, 0, nil)
 		assert.Equal(t, []*WriteRequest{
 			{
 				Source:              RULE,
@@ -199,7 +199,7 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 		const limit = 50
 		reqv2 := testReqV2Static(t)
 
-		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit)
+		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit, 0, nil)
 		assert.Equal(t, []*WriteRequest{
 			{
 				Source:              RULE,
@@ -289,7 +289,7 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 		const limit = 70
 		reqv2 := testReqV2Static(t)
 
-		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit)
+		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit, 0, nil)
 		assert.Equal(t, []*WriteRequest{
 			{
 				Source:              RULE,
@@ -399,7 +399,7 @@ func TestSplitWriteRequestByMaxMarshalSize_Fuzzy(t *testing.T) {
 			assert.Equal(t, req, reqCpy)
 
 			maxSize := req.Size() / (1 + rnd.Intn(10))
-			partials := SplitWriteRequestByMaxMarshalSizeRW2(req, req.Size(), maxSize)
+			partials := SplitWriteRequestByMaxMarshalSizeRW2(req, req.Size(), maxSize, 0, nil)
 
 			// Ensure the merge of all partial requests is equal to the original one.
 			merged := mergeRW2s(partials)
@@ -450,7 +450,7 @@ func BenchmarkSplitWriteRequestByMaxMarshalSize(b *testing.B) {
 	b.Run("rw2", func(b *testing.B) {
 		benchmarkSplitWriteRequestByMaxMarshalSize(b, generateWriteRequestRW2, func(b *testing.B, req *WriteRequest, maxSize int) {
 			for n := 0; n < b.N; n++ {
-				SplitWriteRequestByMaxMarshalSizeRW2(req, req.Size(), maxSize)
+				SplitWriteRequestByMaxMarshalSizeRW2(req, req.Size(), maxSize, 0, nil)
 			}
 		})
 	})
@@ -506,7 +506,7 @@ func BenchmarkSplitWriteRequestByMaxMarshalSize_WithMarshalling(b *testing.B) {
 				}
 
 				// Split the request.
-				partialReqs := SplitWriteRequestByMaxMarshalSizeRW2(req, req.Size(), maxSize)
+				partialReqs := SplitWriteRequestByMaxMarshalSizeRW2(req, req.Size(), maxSize, 0, nil)
 
 				// Marshal each split request.
 				for _, partialReq := range partialReqs {

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -450,7 +450,7 @@ func TestSplitWriteRequestByMaxMarshalSize_WriteRequestHasChanged(t *testing.T) 
 	}, fieldNames)
 }
 
-/*func BenchmarkSplitWriteRequestByMaxMarshalSize(b *testing.B) {
+func BenchmarkSplitWriteRequestByMaxMarshalSize(b *testing.B) {
 	benchmarkSplitWriteRequestByMaxMarshalSize(b, func(b *testing.B, req *WriteRequest, maxSize int) {
 		for n := 0; n < b.N; n++ {
 			SplitWriteRequestByMaxMarshalSize(req, req.Size(), maxSize)
@@ -491,7 +491,7 @@ func BenchmarkSplitWriteRequestByMaxMarshalSize_WithMarshalling(b *testing.B) {
 			}
 		}
 	})
-}*/
+}
 
 func benchmarkSplitWriteRequestByMaxMarshalSize(b *testing.B, run func(b *testing.B, req *WriteRequest, maxSize int)) {
 	tests := map[string]struct {

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -709,7 +709,9 @@ func mergeRW2s(partials []*WriteRequest) *WriteRequest {
 			}
 
 			helpTxt := partial.SymbolsRW2[ts.Metadata.HelpRef]
+			helpRef := st.Symbolize(helpTxt)
 			unitTxt := partial.SymbolsRW2[ts.Metadata.UnitRef]
+			unitRef := st.Symbolize(unitTxt)
 
 			newTS := TimeSeriesRW2{
 				LabelsRefs:       newLbls,
@@ -719,8 +721,8 @@ func mergeRW2s(partials []*WriteRequest) *WriteRequest {
 				CreatedTimestamp: ts.CreatedTimestamp,
 				Metadata: MetadataRW2{
 					Type:    ts.Metadata.Type,
-					HelpRef: st.Symbolize(helpTxt),
-					UnitRef: st.Symbolize(unitTxt),
+					HelpRef: helpRef,
+					UnitRef: unitRef,
 				},
 			}
 			timeSeries = append(timeSeries, newTS)

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -86,7 +86,7 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 	})
 
 	t.Run("should split the input WriteRequest into multiple requests, honoring the size limit - RW2", func(t *testing.T) {
-		// 150 is small enough to force each WriteRequest into its own sub-request
+		// 150 is small enough to force each timeseries into its own sub-request
 		const limit = 150
 		reqv2 := testReqV2Static(t)
 
@@ -475,7 +475,7 @@ func BenchmarkSplitWriteRequestByMaxMarshalSize_WithMarshalling(b *testing.B) {
 				}
 
 				// Split the request.
-				partialReqs := SplitWriteRequestByMaxMarshalSize(req, req.Size(), maxSize)
+				partialReqs := SplitWriteRequestByMaxMarshalSize(unmarshalledReq, unmarshalledReq.Size(), maxSize)
 
 				// Marshal each split request.
 				for _, partialReq := range partialReqs {
@@ -506,7 +506,7 @@ func BenchmarkSplitWriteRequestByMaxMarshalSize_WithMarshalling(b *testing.B) {
 				}
 
 				// Split the request.
-				partialReqs := SplitWriteRequestByMaxMarshalSizeRW2(req, req.Size(), maxSize, 0, nil)
+				partialReqs := SplitWriteRequestByMaxMarshalSizeRW2(unmarshalledReq, unmarshalledReq.Size(), maxSize, 0, nil)
 
 				// Marshal each split request.
 				for _, partialReq := range partialReqs {

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -143,16 +143,17 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 		}
 	})
 
-	/*t.Run("should split the input WriteRequest into multiple requests, honoring the size limit, and bin-packing - RW2", func(t *testing.T) {
+	t.Run("should split the input WriteRequest into multiple requests, honoring the size limit, and bin-packing - RW2", func(t *testing.T) {
 		// 200 allows the first and second WriteRequests to fit into one request, but not the third.
 		const limit = 200
+		reqv2 := testReqV2Static(t)
 
 		partials := SplitWriteRequestByMaxMarshalSize(reqv2, reqv2.Size(), limit)
 		assert.Equal(t, []*WriteRequest{
 			{
 				Source:              RULE,
 				SkipLabelValidation: true,
-				SymbolsRW2:          []string{"", labels.MetricName, "series_1", "pod", "test-application-123456", "This is the first test metric."},
+				SymbolsRW2:          []string{"", labels.MetricName, "series_1", "pod", "test-application-123456", "This is the first test metric.", "series_2", "This is the second test metric."},
 				TimeseriesRW2: []TimeSeriesRW2{
 					{
 						LabelsRefs: []uint32{1, 2, 3, 4},
@@ -165,11 +166,11 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 						},
 					},
 					{
-						LabelsRefs: []uint32{1, 2, 3, 4},
+						LabelsRefs: []uint32{1, 6, 3, 4},
 						Samples:    []Sample{{TimestampMs: 30}},
 						Metadata: MetadataRW2{
 							Type:    METRIC_TYPE_COUNTER,
-							HelpRef: 5,
+							HelpRef: 7,
 						},
 					},
 				},
@@ -192,7 +193,7 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 		for _, partial := range partials {
 			assert.LessOrEqual(t, partial.Size(), limit)
 		}
-	})*/
+	})
 
 	t.Run("should split the input WriteRequest into multiple requests with size bigger than limit if limit < size(symbols)", func(t *testing.T) {
 		const limit = 50

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -344,7 +344,7 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 }
 
 func TestSplitWriteRequestByMaxMarshalSize_Fuzzy(t *testing.T) {
-	const numRuns = 3
+	const numRuns = 1000
 
 	// Randomise the seed but log it in case we need to reproduce the test on failure.
 	seed := time.Now().UnixNano()

--- a/pkg/mimirpb/symbols.go
+++ b/pkg/mimirpb/symbols.go
@@ -95,21 +95,28 @@ func (t *FastSymbolsTable) ConfigureCommonSymbols(offset uint32, commonSymbols [
 }
 
 func (t *FastSymbolsTable) Symbolize(str string) uint32 {
+	sym, _ := t.SymbolizeCheckNew(str)
+	return sym
+}
+
+// SymbolizeCheckNew symbolizes a string and gives information about the table.
+// It returns the symbol, and an indication of whether the symbol is newly added to the table.
+func (t *FastSymbolsTable) SymbolizeCheckNew(str string) (uint32, bool) {
 	if str == "" {
 		// 0 means empty string, even if an offset is provided.
-		return 0
+		return 0, false
 	}
 	if t.commonSymbols != nil {
 		// TODO: CommonSymbols is bounded size, it small enough to where linear search is faster?
 		for i := range t.commonSymbols {
 			if str == t.commonSymbols[i] {
-				return uint32(i)
+				return uint32(i), false
 			}
 		}
 	}
 
 	if ref, ok := t.symbolsMap[str]; ok {
-		return ref
+		return ref, false
 	}
 	// Symbol indexes in the map start at 1 because 0 is always reserved, and we don't need to use space to store it.
 	symMapLen := len(t.symbolsMap)
@@ -118,7 +125,7 @@ func (t *FastSymbolsTable) Symbolize(str string) uint32 {
 	if symMapLen+1 > t.symbolsMapCapacityLowerBound {
 		t.symbolsMapCapacityLowerBound = symMapLen + 1
 	}
-	return ref
+	return ref, true
 }
 
 func (t *FastSymbolsTable) CountSymbols() int {

--- a/pkg/mimirpb/symbols.go
+++ b/pkg/mimirpb/symbols.go
@@ -155,6 +155,15 @@ func (t *FastSymbolsTable) SymbolsPrealloc(prealloc []string) []string {
 	return prealloc
 }
 
+func (t *FastSymbolsTable) SymbolsSizeProto() int {
+	var l, n int
+	for k := range t.symbolsMap {
+		l = len(k)
+		n += 1 + l + sovMimir(uint64(l))
+	}
+	return n
+}
+
 func (t *FastSymbolsTable) Reset() {
 	clear(t.symbolsMap)
 	// We intentionally don't reset symbolsMapCapacityLowerBound.

--- a/pkg/mimirpb/symbols.go
+++ b/pkg/mimirpb/symbols.go
@@ -95,28 +95,21 @@ func (t *FastSymbolsTable) ConfigureCommonSymbols(offset uint32, commonSymbols [
 }
 
 func (t *FastSymbolsTable) Symbolize(str string) uint32 {
-	sym, _ := t.SymbolizeCheckNew(str)
-	return sym
-}
-
-// SymbolizeCheckNew symbolizes a string and gives information about the table.
-// It returns the symbol, and an indication of whether the symbol is newly added to the table.
-func (t *FastSymbolsTable) SymbolizeCheckNew(str string) (uint32, bool) {
 	if str == "" {
 		// 0 means empty string, even if an offset is provided.
-		return 0, false
+		return 0
 	}
 	if t.commonSymbols != nil {
 		// TODO: CommonSymbols is bounded size, it small enough to where linear search is faster?
 		for i := range t.commonSymbols {
 			if str == t.commonSymbols[i] {
-				return uint32(i), false
+				return uint32(i)
 			}
 		}
 	}
 
 	if ref, ok := t.symbolsMap[str]; ok {
-		return ref, false
+		return ref
 	}
 	// Symbol indexes in the map start at 1 because 0 is always reserved, and we don't need to use space to store it.
 	symMapLen := len(t.symbolsMap)
@@ -125,7 +118,7 @@ func (t *FastSymbolsTable) SymbolizeCheckNew(str string) (uint32, bool) {
 	if symMapLen+1 > t.symbolsMapCapacityLowerBound {
 		t.symbolsMapCapacityLowerBound = symMapLen + 1
 	}
-	return ref, true
+	return ref
 }
 
 func (t *FastSymbolsTable) CountSymbols() int {

--- a/pkg/mimirpb/symbols_test.go
+++ b/pkg/mimirpb/symbols_test.go
@@ -135,6 +135,20 @@ func TestSymbolsTable(t *testing.T) {
 		s.Symbolize("ghi")
 		require.Equal(t, 50, s.CapLowerBound())
 	})
+
+	t.Run("symbols size proto", func(t *testing.T) {
+		s := NewFastSymbolsTable(0)
+
+		wr := &WriteRequest{}
+		require.Equal(t, wr.SymbolsRW2Size(), s.SymbolsSizeProto())
+
+		s.Symbolize("abc")
+		s.Symbolize("def")
+		s.Symbolize("test some other longer one")
+
+		wr = &WriteRequest{SymbolsRW2: []string{"abc", "def", "test some other longer one"}}
+		require.Equal(t, wr.SymbolsRW2Size(), s.SymbolsSizeProto())
+	})
 }
 
 func desymbolizeLabelsDirect(labelRefs []uint32, symbols []string) ([]LabelAdapter, string) {

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -129,6 +129,8 @@ func (m *WriteRequest) ClearTimeseriesUnmarshalData() {
 	for idx := range m.Timeseries {
 		m.Timeseries[idx].clearUnmarshalData()
 	}
+	m.rw2symbols = rw2PagedSymbols{}
+	m.unmarshalFromRW2 = false
 }
 
 // PreallocTimeseries is a TimeSeries which preallocs slices on Unmarshal.

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -153,7 +153,7 @@ func (v versionTwoRecordSerializer) ToRecords(partitionID int32, tenantID string
 		return nil, errors.Wrap(err, "failed to convert RW1 request to RW2")
 	}
 
-	records, err := marshalWriteRequestToRecords(partitionID, tenantID, reqv2, maxSize, mimirpb.SplitWriteRequestByMaxMarshalSize)
+	records, err := marshalWriteRequestToRecords(partitionID, tenantID, reqv2, maxSize, mimirpb.SplitWriteRequestByMaxMarshalSizeRW2)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to serialise write request")
 	}

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -125,7 +125,7 @@ type recordSerializer interface {
 type versionZeroRecordSerializer struct{}
 
 func (v versionZeroRecordSerializer) ToRecords(partitionID int32, tenantID string, req *mimirpb.WriteRequest, maxSize int) ([]*kgo.Record, error) {
-	return marshalWriteRequestToRecords(partitionID, tenantID, req, maxSize)
+	return marshalWriteRequestToRecords(partitionID, tenantID, req, maxSize, mimirpb.SplitWriteRequestByMaxMarshalSize)
 }
 
 // versionOneRecordSerializer produces records of version 1.
@@ -134,7 +134,7 @@ func (v versionZeroRecordSerializer) ToRecords(partitionID int32, tenantID strin
 type versionOneRecordSerializer struct{}
 
 func (v versionOneRecordSerializer) ToRecords(partitionID int32, tenantID string, req *mimirpb.WriteRequest, maxSize int) ([]*kgo.Record, error) {
-	records, err := marshalWriteRequestToRecords(partitionID, tenantID, req, maxSize)
+	records, err := marshalWriteRequestToRecords(partitionID, tenantID, req, maxSize, mimirpb.SplitWriteRequestByMaxMarshalSize)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (v versionTwoRecordSerializer) ToRecords(partitionID int32, tenantID string
 		return nil, errors.Wrap(err, "failed to convert RW1 request to RW2")
 	}
 
-	records, err := marshalWriteRequestToRecords(partitionID, tenantID, reqv2, maxSize)
+	records, err := marshalWriteRequestToRecords(partitionID, tenantID, reqv2, maxSize, mimirpb.SplitWriteRequestByMaxMarshalSize)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to serialise write request")
 	}

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -153,7 +153,7 @@ func (v versionTwoRecordSerializer) ToRecords(partitionID int32, tenantID string
 		return nil, errors.Wrap(err, "failed to convert RW1 request to RW2")
 	}
 
-	records, err := marshalWriteRequestToRecords(partitionID, tenantID, req, maxSize)
+	records, err := marshalWriteRequestToRecords(partitionID, tenantID, reqv2, maxSize)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to serialise write request")
 	}

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -153,10 +153,7 @@ func (v versionTwoRecordSerializer) ToRecords(partitionID int32, tenantID string
 		return nil, errors.Wrap(err, "failed to convert RW1 request to RW2")
 	}
 
-	split := func(wr *mimirpb.WriteRequest, reqSize, maxSize int) []*mimirpb.WriteRequest {
-		return mimirpb.SplitWriteRequestByMaxMarshalSizeRW2(wr, reqSize, maxSize, V2RecordSymbolOffset, V2CommonSymbols)
-	}
-	records, err := marshalWriteRequestToRecords(partitionID, tenantID, reqv2, maxSize, split)
+	records, err := marshalWriteRequestToRecords(partitionID, tenantID, reqv2, maxSize, splitRequestVersionTwo)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to serialise write request")
 	}
@@ -189,4 +186,9 @@ func deserializeRecordContentV2(content []byte, wr *mimirpb.PreallocWriteRequest
 	wr.RW2SymbolOffset = V2RecordSymbolOffset
 	wr.RW2CommonSymbols = V2CommonSymbols
 	return wr.Unmarshal(content)
+}
+
+// splitRequestVersionTwo adapts mimirpb.SplitWriteRequestByMaxMarshalSizeRW2 to requestSplitter
+func splitRequestVersionTwo(wr *mimirpb.WriteRequest, reqSize, maxSize int) []*mimirpb.WriteRequest {
+	return mimirpb.SplitWriteRequestByMaxMarshalSizeRW2(wr, reqSize, maxSize, V2RecordSymbolOffset, V2CommonSymbols)
 }

--- a/pkg/storage/ingest/version.go
+++ b/pkg/storage/ingest/version.go
@@ -153,7 +153,10 @@ func (v versionTwoRecordSerializer) ToRecords(partitionID int32, tenantID string
 		return nil, errors.Wrap(err, "failed to convert RW1 request to RW2")
 	}
 
-	records, err := marshalWriteRequestToRecords(partitionID, tenantID, reqv2, maxSize, mimirpb.SplitWriteRequestByMaxMarshalSizeRW2)
+	split := func(wr *mimirpb.WriteRequest, reqSize, maxSize int) []*mimirpb.WriteRequest {
+		return mimirpb.SplitWriteRequestByMaxMarshalSizeRW2(wr, reqSize, maxSize, V2RecordSymbolOffset, V2CommonSymbols)
+	}
+	records, err := marshalWriteRequestToRecords(partitionID, tenantID, reqv2, maxSize, split)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to serialise write request")
 	}

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -1072,7 +1072,7 @@ func TestMarshalWriteRequestToRecords(t *testing.T) {
 		for _, rec := range records {
 			assert.Equal(t, int32(1), rec.Partition)
 			assert.Equal(t, "user-1", string(rec.Key))
-			assert.Less(t, len(rec.Value), limit)
+			assert.LessOrEqual(t, len(rec.Value), limit)
 
 			actual := &mimirpb.PreallocWriteRequest{
 				UnmarshalFromRW2: true,
@@ -1089,19 +1089,87 @@ func TestMarshalWriteRequestToRecords(t *testing.T) {
 			{
 				Source:              mimirpb.RULE,
 				SkipLabelValidation: true,
-				Timeseries:          []mimirpb.PreallocTimeseries{req.Timeseries[0], req.Timeseries[1]},
+				Timeseries: []mimirpb.PreallocTimeseries{
+					{
+						TimeSeries: &mimirpb.TimeSeries{
+							Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_1")),
+							Samples:   []mimirpb.Sample{{TimestampMs: 1, Value: 2.0}},
+							Exemplars: []mimirpb.Exemplar{},
+						},
+					},
+					{
+						TimeSeries: &mimirpb.TimeSeries{
+							Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_2")),
+							Samples:   []mimirpb.Sample{{TimestampMs: 1, Value: 2.0}},
+							Exemplars: []mimirpb.Exemplar{},
+						},
+					},
+					{
+						TimeSeries: &mimirpb.TimeSeries{
+							Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_3")),
+							Samples:   []mimirpb.Sample{{TimestampMs: 1, Value: 2.0}},
+							Exemplars: []mimirpb.Exemplar{},
+						},
+					},
+				},
+				Metadata: []*mimirpb.MetricMetadata{},
 			}, {
 				Source:              mimirpb.RULE,
 				SkipLabelValidation: true,
-				Timeseries:          []mimirpb.PreallocTimeseries{req.Timeseries[2]},
+				Timeseries: []mimirpb.PreallocTimeseries{
+					{
+						TimeSeries: &mimirpb.TimeSeries{
+							Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_1")),
+							Samples:   []mimirpb.Sample{},
+							Exemplars: []mimirpb.Exemplar{},
+						},
+					},
+				},
+				Metadata: []*mimirpb.MetricMetadata{
+					{
+						MetricFamilyName: "series_1",
+						Type:             mimirpb.COUNTER,
+						Help:             "This is the first test metric.",
+					},
+				},
 			}, {
 				Source:              mimirpb.RULE,
 				SkipLabelValidation: true,
-				Metadata:            []*mimirpb.MetricMetadata{req.Metadata[0], req.Metadata[1]},
+				Timeseries: []mimirpb.PreallocTimeseries{
+					{
+						TimeSeries: &mimirpb.TimeSeries{
+							Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_2")),
+							Samples:   []mimirpb.Sample{},
+							Exemplars: []mimirpb.Exemplar{},
+						},
+					},
+				},
+				Metadata: []*mimirpb.MetricMetadata{
+					{
+						MetricFamilyName: "series_2",
+						Type:             mimirpb.COUNTER,
+						Help:             "This is the second test metric.",
+					},
+				},
 			}, {
 				Source:              mimirpb.RULE,
 				SkipLabelValidation: true,
-				Metadata:            []*mimirpb.MetricMetadata{req.Metadata[2]},
+				Timeseries: []mimirpb.PreallocTimeseries{
+					{
+						TimeSeries: &mimirpb.TimeSeries{
+							Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_3")),
+							Samples:   []mimirpb.Sample{},
+							Exemplars: []mimirpb.Exemplar{},
+						},
+					},
+				},
+				Metadata: []*mimirpb.MetricMetadata{
+					{
+						MetricFamilyName: "series_3",
+						Type:             mimirpb.COUNTER,
+						Help:             "This is the third test metric.",
+					},
+				},
 			},
 		}, partials)
 	})

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -887,28 +888,40 @@ func TestWriter_WriteSync_HighConcurrencyOnKafkaClientBufferFull(t *testing.T) {
 }
 
 func TestMarshalWriteRequestToRecords(t *testing.T) {
-	req := &mimirpb.WriteRequest{
-		Source:              mimirpb.RULE,
-		SkipLabelValidation: true,
-		Timeseries: []mimirpb.PreallocTimeseries{
-			mockPreallocTimeseries("series_1"),
-			mockPreallocTimeseries("series_2"),
-			mockPreallocTimeseries("series_3"),
-		},
-		Metadata: []*mimirpb.MetricMetadata{
-			{Type: mimirpb.COUNTER, MetricFamilyName: "series_1", Help: "This is the first test metric."},
-			{Type: mimirpb.COUNTER, MetricFamilyName: "series_2", Help: "This is the second test metric."},
-			{Type: mimirpb.COUNTER, MetricFamilyName: "series_3", Help: "This is the third test metric."},
-		},
+	testReq := func(t *testing.T) *mimirpb.WriteRequest {
+		t.Helper()
+		req := &mimirpb.WriteRequest{
+			Source:              mimirpb.RULE,
+			SkipLabelValidation: true,
+			Timeseries: []mimirpb.PreallocTimeseries{
+				mockPreallocTimeseries("series_1"),
+				mockPreallocTimeseries("series_2"),
+				mockPreallocTimeseries("series_3"),
+			},
+			Metadata: []*mimirpb.MetricMetadata{
+				{Type: mimirpb.COUNTER, MetricFamilyName: "series_1", Help: "This is the first test metric."},
+				{Type: mimirpb.COUNTER, MetricFamilyName: "series_2", Help: "This is the second test metric."},
+				{Type: mimirpb.COUNTER, MetricFamilyName: "series_3", Help: "This is the third test metric."},
+			},
+		}
+		// Pre-requisite check: WriteRequest fields are set to non-zero values.
+		require.NotZero(t, req.Source)
+		require.NotZero(t, req.SkipLabelValidation)
+		require.NotZero(t, req.Timeseries)
+		require.NotZero(t, req.Metadata)
+		return req
 	}
 
-	// Pre-requisite check: WriteRequest fields are set to non-zero values.
-	require.NotZero(t, req.Source)
-	require.NotZero(t, req.SkipLabelValidation)
-	require.NotZero(t, req.Timeseries)
-	require.NotZero(t, req.Metadata)
+	testReqV2 := func(t *testing.T) *mimirpb.WriteRequest {
+		t.Helper()
+		rw1 := testReq(t)
+		rw2, err := mimirpb.FromWriteRequestToRW2Request(rw1, V2CommonSymbols, V2RecordSymbolOffset)
+		require.NoError(t, err)
+		return rw2
+	}
 
 	t.Run("should return 1 record if the input WriteRequest size is less than the size limit", func(t *testing.T) {
+		req := testReq(t)
 		records, err := marshalWriteRequestToRecords(1, "user-1", req, req.Size()*2, mimirpb.SplitWriteRequestByMaxMarshalSize)
 		require.NoError(t, err)
 		require.Len(t, records, 1)
@@ -920,8 +933,90 @@ func TestMarshalWriteRequestToRecords(t *testing.T) {
 		assert.Equal(t, req, actual)
 	})
 
+	t.Run("should return 1 record if the input WriteRequest in RW2 size is less than the size limit", func(t *testing.T) {
+		req := testReqV2(t)
+		records, err := marshalWriteRequestToRecords(1, "user-1", req, req.Size()*2, splitRequestVersionTwo)
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+
+		actual := &mimirpb.PreallocWriteRequest{
+			UnmarshalFromRW2: true,
+			RW2SymbolOffset:  V2RecordSymbolOffset,
+			RW2CommonSymbols: V2CommonSymbols,
+		}
+		require.NoError(t, actual.Unmarshal(records[0].Value))
+
+		actual.ClearTimeseriesUnmarshalData()
+		assert.Equal(t, mimirpb.RULE, actual.Source)
+		assert.Equal(t, true, actual.SkipLabelValidation)
+		expMetadata := []*mimirpb.MetricMetadata{
+			{
+				Type:             mimirpb.COUNTER,
+				MetricFamilyName: "series_1",
+				Help:             "This is the first test metric.",
+			},
+			{
+				Type:             mimirpb.COUNTER,
+				MetricFamilyName: "series_2",
+				Help:             "This is the second test metric.",
+			},
+			{
+				Type:             mimirpb.COUNTER,
+				MetricFamilyName: "series_3",
+				Help:             "This is the third test metric.",
+			},
+		}
+		assert.ElementsMatch(t, expMetadata, actual.Metadata)
+		expTimeseries := []mimirpb.PreallocTimeseries{
+			{
+				TimeSeries: &mimirpb.TimeSeries{
+					Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_1")),
+					Samples:   []mimirpb.Sample{{TimestampMs: 1, Value: 2.0}},
+					Exemplars: []mimirpb.Exemplar{},
+				},
+			},
+			{
+				TimeSeries: &mimirpb.TimeSeries{
+					Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_2")),
+					Samples:   []mimirpb.Sample{{TimestampMs: 1, Value: 2.0}},
+					Exemplars: []mimirpb.Exemplar{},
+				},
+			},
+			{
+				TimeSeries: &mimirpb.TimeSeries{
+					Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_3")),
+					Samples:   []mimirpb.Sample{{TimestampMs: 1, Value: 2.0}},
+					Exemplars: []mimirpb.Exemplar{},
+				},
+			},
+			{
+				TimeSeries: &mimirpb.TimeSeries{
+					Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_1")),
+					Samples:   []mimirpb.Sample{},
+					Exemplars: []mimirpb.Exemplar{},
+				},
+			},
+			{
+				TimeSeries: &mimirpb.TimeSeries{
+					Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_2")),
+					Samples:   []mimirpb.Sample{},
+					Exemplars: []mimirpb.Exemplar{},
+				},
+			},
+			{
+				TimeSeries: &mimirpb.TimeSeries{
+					Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_3")),
+					Samples:   []mimirpb.Sample{},
+					Exemplars: []mimirpb.Exemplar{},
+				},
+			},
+		}
+		assert.Equal(t, expTimeseries, actual.Timeseries)
+	})
+
 	t.Run("should return multiple records if the input WriteRequest size is bigger than the size limit", func(t *testing.T) {
 		const limit = 100
+		req := testReq(t)
 
 		records, err := marshalWriteRequestToRecords(1, "user-1", req, limit, mimirpb.SplitWriteRequestByMaxMarshalSize)
 		require.NoError(t, err)
@@ -963,8 +1058,57 @@ func TestMarshalWriteRequestToRecords(t *testing.T) {
 		}, partials)
 	})
 
+	t.Run("should return multiple records if the input RW2 WriteRequest size is bigger than the size limit", func(t *testing.T) {
+		const limit = 100
+		req := testReqV2(t)
+
+		records, err := marshalWriteRequestToRecords(1, "user-1", req, limit, splitRequestVersionTwo)
+		require.NoError(t, err)
+		require.Len(t, records, 4)
+
+		// Assert each record, and decode all partial WriteRequests.
+		partials := make([]*mimirpb.WriteRequest, 0, len(records))
+
+		for _, rec := range records {
+			assert.Equal(t, int32(1), rec.Partition)
+			assert.Equal(t, "user-1", string(rec.Key))
+			assert.Less(t, len(rec.Value), limit)
+
+			actual := &mimirpb.PreallocWriteRequest{
+				UnmarshalFromRW2: true,
+				RW2SymbolOffset:  V2RecordSymbolOffset,
+				RW2CommonSymbols: V2CommonSymbols,
+			}
+			require.NoError(t, actual.Unmarshal(rec.Value))
+
+			actual.ClearTimeseriesUnmarshalData()
+			partials = append(partials, &actual.WriteRequest)
+		}
+
+		assert.Equal(t, []*mimirpb.WriteRequest{
+			{
+				Source:              mimirpb.RULE,
+				SkipLabelValidation: true,
+				Timeseries:          []mimirpb.PreallocTimeseries{req.Timeseries[0], req.Timeseries[1]},
+			}, {
+				Source:              mimirpb.RULE,
+				SkipLabelValidation: true,
+				Timeseries:          []mimirpb.PreallocTimeseries{req.Timeseries[2]},
+			}, {
+				Source:              mimirpb.RULE,
+				SkipLabelValidation: true,
+				Metadata:            []*mimirpb.MetricMetadata{req.Metadata[0], req.Metadata[1]},
+			}, {
+				Source:              mimirpb.RULE,
+				SkipLabelValidation: true,
+				Metadata:            []*mimirpb.MetricMetadata{req.Metadata[2]},
+			},
+		}, partials)
+	})
+
 	t.Run("should return multiple records, larger than the limit, if the Timeseries and Metadata entries in the WriteRequest are bigger than limit", func(t *testing.T) {
 		const limit = 1
+		req := testReq(t)
 
 		records, err := marshalWriteRequestToRecords(1, "user-1", req, limit, mimirpb.SplitWriteRequestByMaxMarshalSize)
 		require.NoError(t, err)

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -1104,6 +1104,12 @@ func TestMarshalWriteRequestToRecords(t *testing.T) {
 							Exemplars: []mimirpb.Exemplar{},
 						},
 					},
+				},
+				Metadata: []*mimirpb.MetricMetadata{},
+			}, {
+				Source:              mimirpb.RULE,
+				SkipLabelValidation: true,
+				Timeseries: []mimirpb.PreallocTimeseries{
 					{
 						TimeSeries: &mimirpb.TimeSeries{
 							Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_3")),
@@ -1111,12 +1117,6 @@ func TestMarshalWriteRequestToRecords(t *testing.T) {
 							Exemplars: []mimirpb.Exemplar{},
 						},
 					},
-				},
-				Metadata: []*mimirpb.MetricMetadata{},
-			}, {
-				Source:              mimirpb.RULE,
-				SkipLabelValidation: true,
-				Timeseries: []mimirpb.PreallocTimeseries{
 					{
 						TimeSeries: &mimirpb.TimeSeries{
 							Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("__name__", "series_1")),


### PR DESCRIPTION
#### What this PR does

This is the record format V2 equivalent of https://github.com/grafana/mimir/pull/8077. Kafka has a limit in payload size, here we break down extremely large requests into multiple records to work around it.

RW2 carries some complexity due to the symbols table. When splitting a request, we have to split the symbols as well. It's not reasonable to use all the symbols on each request, because symbols still dominate the overall request size.

This PR uses a similar bin-packing algorithm to RW1, but it also re-symbolizes each Timeseries as we move along, using a separate symbols table per sub-request. That means each Timeseries can re-use symbols from other timeseries in the same request as they're added, up until the point where the request is close to the max.

To determine when to split a request, we calculate an upper bound of the growth that the next timeseries will cause without actually processing any symbols yet. If it's possible that this timeseries can push things over the limit, we split it (preferring splitting early vs breaching the limit).

Addresses this comment: https://github.com/grafana/mimir/pull/12060#discussion_r2221466520

#### Which issue(s) this PR fixes or relates to

contrib https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
