### PR TITLE
Replace sort.SliceIsSorted with slices.IsSortedFunc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,6 +418,11 @@ lint: check-makefiles
 		"sort.{Strings,Ints}=slices.Sort" \
 		./pkg/... ./cmd/... ./tools/... ./integration/...
 
+	# Use the faster slices.IsSortedFunc where we can.
+	faillint -paths \
+		"sort.{SliceIsSorted}=slices.IsSortedFunc" \
+		./pkg/... ./cmd/... ./tools/... ./integration/...
+
 	# Don't use generic ring.Read operation.
 	# ring.Read usually isn't the right choice, and we prefer that each component define its operations explicitly.
 	faillint -paths \

--- a/pkg/ingester/shipper_test.go
+++ b/pkg/ingester/shipper_test.go
@@ -6,13 +6,14 @@
 package ingester
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -259,8 +260,8 @@ func TestIterBlockMetas(t *testing.T) {
 	shipper := newShipper(nil, overrides, "", newShipperMetrics(nil), dir, nil, block.TestSource)
 	metas, err := shipper.blockMetasFromOldest()
 	require.NoError(t, err)
-	require.Equal(t, sort.SliceIsSorted(metas, func(i, j int) bool {
-		return metas[i].MinTime < metas[j].MinTime
+	require.Equal(t, slices.IsSortedFunc(metas, func(a, b *block.Meta) int {
+		return cmp.Compare(a.MinTime, b.MinTime)
 	}), true)
 }
 

--- a/pkg/ingester/shipper_test.go
+++ b/pkg/ingester/shipper_test.go
@@ -260,9 +260,9 @@ func TestIterBlockMetas(t *testing.T) {
 	shipper := newShipper(nil, overrides, "", newShipperMetrics(nil), dir, nil, block.TestSource)
 	metas, err := shipper.blockMetasFromOldest()
 	require.NoError(t, err)
-	require.Equal(t, slices.IsSortedFunc(metas, func(a, b *block.Meta) int {
+	require.True(t, slices.IsSortedFunc(metas, func(a, b *block.Meta) int {
 		return cmp.Compare(a.MinTime, b.MinTime)
-	}), true)
+	}))
 }
 
 func TestShipperAddsSegmentFiles(t *testing.T) {

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -6,11 +6,11 @@
 package mimirpb
 
 import (
+	"cmp"
 	"crypto/rand"
 	"fmt"
 	"reflect"
 	"slices"
-	"sort"
 	"testing"
 	"time"
 	"unsafe"
@@ -411,8 +411,8 @@ func TestPreallocTimeseries_SortLabelsIfNeeded(t *testing.T) {
 
 		unsorted.SortLabelsIfNeeded()
 
-		require.True(t, sort.SliceIsSorted(unsorted.Labels, func(i, j int) bool {
-			return unsorted.Labels[i].Name < unsorted.Labels[j].Name
+		require.True(t, slices.IsSortedFunc(unsorted.Labels, func(a, b LabelAdapter) int {
+			return cmp.Compare(a.Name, b.Name)
 		}))
 		require.Nil(t, unsorted.marshalledData)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Replace [sort.SliceIsSorted](https://pkg.go.dev/sort#SliceIsSorted) with [slices.IsSortedFunc](https://pkg.go.dev/slices#IsSortedFunc). `slices.IsSortedFunc` is generic instead of reflection based, and should generally be more performant.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
