### PR TITLE
Compactor: Keep bucket index update progress across failed cleanUser() runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [ENHANCEMENT] Query-frontend: Added labels query optimizer that automatically removes redundant `__name__!=""` matchers from label names and label values queries, improving query performance. You can enable the optimizer per-tenant with the `labels_query_optimizer_enabled` runtime configuration flag. #12054 #12066 #12076 #12080
 * [ENHANCEMENT] Query-frontend: Standardise non-regex patterns in query blocking upon loading of config. #12102
 * [ENHANCEMENT] Ruler: Propagate GCS object mutation rate limit for rule group uploads. #12086
+* [ENHANCEMENT] Compactor: Keep bucket index update progress across failed cleanUser() runs to reduce duplicated work when cleanup jobs fail and retry. The compactor now caches the in-progress bucket index in memory and reuses it in subsequent runs if the stored bucket index hasn't been updated by other compactors. #<PR>
 * [BUGFIX] Distributor: Validate the RW2 symbols field and reject invalid requests that don't have an empty string as the first symbol. #11953
 * [BUGFIX] Distributor: Check `max_inflight_push_requests_bytes` before decompressing incoming requests. #11967
 * [BUGFIX] Query-frontend: Allow limit parameter to be 0 in label queries to explicitly request unlimited results. #12054


### PR DESCRIPTION
## Summary

This PR addresses the post-incident action from https://github.com/grafana/pir-actions/issues/402 to improve the compactor's BlocksCleaner component.

The compactor's BlocksCleaner now caches the in-progress bucket index in memory to avoid duplicated work when cleanup jobs fail and retry. This allows long-running cleanup jobs to pick up where previous runs left off instead of starting the entire bucket index update from scratch.

## Key Changes

- **In-progress index caching**: Added thread-safe in-memory cache for partially updated bucket indexes
- **Resume functionality**: Modified `cleanUser()` to check for and reuse cached progress on subsequent runs  
- **Concurrent safety**: Handle edge case where multiple compactors update the same tenant by validating index timestamps
- **Memory management**: Clear cache on successful completion to free memory
- **Comprehensive testing**: Added unit and integration tests for cache behavior and edge cases

## How It Works

1. **Cache Check**: `cleanUser()` first checks if there's a valid cached in-progress index
2. **Resume**: If found, uses the cached index to continue from where the previous run left off
3. **Cache Save**: After successful `UpdateIndex()` but before other operations, saves the updated index to cache
4. **Cache Clear**: Clears cache on successful completion or when bucket index in storage is newer (concurrent compactor scenario)

## Benefits

- **Reduces duplicate work**: Eliminates re-listing deletion markers and block metadata on retry
- **Improves success rate**: Long-running cleanup jobs have better chance to complete since each run builds on previous progress
- **Memory efficient**: Only caches in memory, no disk persistence overhead  
- **Safe**: Handles concurrent compactor scenarios by validating index timestamps
- **Backward compatible**: No configuration changes required, works transparently

## Test Plan

- [x] Unit tests for in-progress index management methods
- [x] Integration tests for cache behavior during failed/successful cleanup runs
- [x] Tests for concurrent compactor edge cases
- [x] All existing compactor tests pass
- [x] Package builds successfully

The implementation directly addresses the issue described in the post-incident action by reducing duplicated work between failed cleanup runs, giving long-running jobs a greater chance to eventually complete successfully.