### PR TITLE
fix(ingester): Keep read only when any number of compactions in progress (#12128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 * [BUGFIX] Ruler: Fix rare panic when the ruler is shutting down. #11781
 * [BUGFIX] Block-builder-scheduler: Fix data loss bug in job assignment. #11785
 * [BUGFIX] Compactor: start tracking `-compactor.max-compaction-time` after the initial compaction planning phase, to avoid rare cases where planning takes longer than `-compactor.max-compaction-time` and so actual compaction never runs for a tenant. #11834
+* [BUGFIX] Ingester: Fix issue where ingesters can exit read-only mode during idle compactions, resulting in write errors. #12128
 
 ### Mixin
 

--- a/pkg/ingester/downscale.go
+++ b/pkg/ingester/downscale.go
@@ -52,9 +52,9 @@ func (i *Ingester) PrepareInstanceRingDownscaleHandler(w http.ResponseWriter, r 
 		i.circuitBreaker.push.deactivate()
 
 	case http.MethodDelete:
-		// Don't leave read-only mode if there's a forced compaction pending or in progress.
-		if len(i.forceCompactTrigger) > 0 || i.forcedCompactionInProgress.Load() {
-			msg := "cannot clear read-only mode while forced compaction is in progress"
+		// Don't leave read-only mode if there is any compaction pending or in progress.
+		if i.numCompactionsInProgress.Load() != 0 {
+			msg := "cannot clear read-only mode while forced compaction is pending or in progress"
 			level.Warn(i.logger).Log("msg", msg)
 			http.Error(w, msg, http.StatusConflict)
 			return

--- a/pkg/ingester/downscale_test.go
+++ b/pkg/ingester/downscale_test.go
@@ -155,7 +155,7 @@ func TestIngester_PrepareInstanceRingDownscaleHandler(t *testing.T) {
 		require.Equal(t, http.StatusMethodNotAllowed, res.Code)
 	})
 
-	t.Run("should return Conflict when forced compaction is in progress", func(t *testing.T) {
+	t.Run("should return Conflict when any compaction is in progress", func(t *testing.T) {
 		t.Parallel()
 
 		ingester, r := setup(true)
@@ -170,7 +170,9 @@ func TestIngester_PrepareInstanceRingDownscaleHandler(t *testing.T) {
 			return inst.ReadOnly
 		})
 
-		ingester.forcedCompactionInProgress.Store(true)
+		// Simulate a compation in progress.
+		ingester.numCompactionsInProgress.Inc()
+		defer ingester.numCompactionsInProgress.Dec()
 
 		// Try to switch back to read-write while compaction is in progress
 		res = httptest.NewRecorder()


### PR DESCRIPTION
#### What this PR does

Backporting https://github.com/grafana/mimir/pull/12128 to release 2.17. The only merge conflict was in the changelog.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
