### PR TITLE
Autoscaling: Extract memory HPA queries into configurable constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [ENHANCEMENT] Add assertion to ensure ingester ScaledObject has minimum and maximum replicas set to a value greater than 0. #11979
 * [ENHANCEMENT] Add `ingest_storage_migration_ignore_ingest_storage_errors` and `ingest_storage_migration_ingest_storage_max_wait_time` configs to control error handling of the partition ingesters during ingest storage migrations. #12105
 * [ENHANCEMENT] Add block-builder job processing duration timings and offset-skipped errors to the Block-builder dashboard. #12118
+* [ENHANCEMENT] Autoscaling: Extract memory HPA queries into configurable constants. #12176
 
 ### Documentation
 


### PR DESCRIPTION
## Summary
Extracts the three hardcoded queries from the `memoryHPAQuery` function into configuration constants to improve maintainability and customizability.

## Test plan
- [x] `make build-jsonnet-tests` passes
- [x] `make check-jsonnet-tests` passes (confirms this is a no-op change functionally)