### PR TITLE
operations: Allow ingest-storage record version to be increased to v2

### DIFF
--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -11,8 +11,10 @@
     // How many zones ingesters should be deployed to.
     ingest_storage_ingester_zones: 3,
 
-    // The version of the Kafka record wire format.
+    // The version of the Kafka record wire format. Versions 0 and 1 are stable, version 2 is experimental.
     ingest_storage_kafka_producer_record_version: 1,
+    // Opt-in to allowing experimental record formats that may not be stable between builds.
+    ingest_storage_allow_experimental_record_formats: false,
 
     commonConfig+:: if !$._config.ingest_storage_enabled then {} else
       $.ingest_storage_args +
@@ -211,6 +213,7 @@
       // Explicitly use null so that the CLI flag will not be set at all (instead of getting set to an empty string).
       null,
 
-  assert $._config.ingest_storage_kafka_producer_record_version >= 0 && $._config.ingest_storage_kafka_producer_record_version <= 1
-         : 'the Kafka record version must be in the range [0, 1]',
+  local max_producer_record_version = if $._config.ingest_storage_allow_experimental_record_formats then 2 else 1,
+  assert $._config.ingest_storage_kafka_producer_record_version >= 0 && $._config.ingest_storage_kafka_producer_record_version <= max_producer_record_version
+         : 'the Kafka record version must be in the range [0, %s]' % max_producer_record_version,
 }


### PR DESCRIPTION
#### What this PR does

Allows V2 as a producer record version as of https://github.com/grafana/mimir/pull/12060.
V2 is still considered unstable at the time of writing. We might make breaking changes to the format.

Thus, we include a guard where you have to explicitly opt-in to experimental formats before setting v2.

#### Which issue(s) this PR fixes or relates to

Contrib https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
