### PR TITLE
test(otlp): make benchmark more realistic

### DIFF
--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -629,8 +629,8 @@ func TimeseriesToOTLPRequest(timeseries []prompb.TimeSeries, metadata []mimirpb.
 				if i == 0 {
 					for _, tsEx := range ts.Exemplars {
 						ex := datapoint.Exemplars().AppendEmpty()
-						ex.SetDoubleValue(sample.Value)
-						ex.SetTimestamp(pcommon.Timestamp(sample.Timestamp * time.Millisecond.Nanoseconds()))
+						ex.SetDoubleValue(tsEx.Value)
+						ex.SetTimestamp(pcommon.Timestamp(tsEx.Timestamp * time.Millisecond.Nanoseconds()))
 						ex.FilteredAttributes().EnsureCapacity(len(tsEx.Labels))
 						for _, label := range tsEx.Labels {
 							ex.FilteredAttributes().PutStr(label.Name, label.Value)

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -706,7 +706,7 @@ func TestOTelDeltaIngestion(t *testing.T) {
 }
 
 // Extra labels to make a more realistic workload - taken from Kubernetes' embedded cAdvisor metrics.
-var extraLabels []labels.Label = []labels.Label{
+var extraLabels = []labels.Label{
 	{Name: "kubernetes_io_arch", Value: "amd64"},
 	{Name: "kubernetes_io_instance_type", Value: "c3.somesize"},
 	{Name: "kubernetes_io_os", Value: "linux"},
@@ -757,7 +757,8 @@ func BenchmarkOTLPHandler(b *testing.B) {
 				Labels:    make([]prompb.Label, 0, len(extraLabels)),
 			})
 			for _, lbl := range extraLabels {
-				histogramExemplars[len(histogramExemplars)-1].Labels = append(histogramExemplars[len(histogramExemplars)-1].Labels, prompb.Label{Name: lbl.Name, Value: lbl.Value})
+				lastExemplar := &histogramExemplars[len(histogramExemplars)-1]
+				lastExemplar.Labels = append(lastExemplar.Labels, prompb.Label{Name: lbl.Name, Value: lbl.Value})
 			}
 		}
 	}


### PR DESCRIPTION
Change the test to exercise labels much more.

Use 2000 series instead of 1.
Use 1 sample per series instead of 1000.
Use more realistic number of labels per series.
Make 10% of series use exponential histograms and let those have 10 exemplars per series instead of 1 per series.
Add exemplars to the first sample for each series.

Related to #12152 