### PR TITLE
mimirpb: Make RW2 metadata serialization deterministic

### DIFF
--- a/pkg/mimirpb/custom.go
+++ b/pkg/mimirpb/custom.go
@@ -428,3 +428,12 @@ type MarshalerWithSize interface {
 	// MarshalWithSize returns a wire format byte slice of the given size.
 	MarshalWithSize(size int) ([]byte, error)
 }
+
+// orderAwareMetricMetadata is a tuple (index, metadata) that knows its own position in a metadata slice.
+// It's tied to custom logic that unmarshals RW2 metadata into a map, and allows us to
+// remember the order that metadata arrived in when unmarshalling.
+type orderAwareMetricMetadata struct {
+	MetricMetadata
+	// order is the 0-based index of this metadata object in a wider metadata array.
+	order int
+}

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -7,16 +7,15 @@ import (
 	bytes "bytes"
 	encoding_binary "encoding/binary"
 	fmt "fmt"
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	github_com_prometheus_prometheus_model_histogram "github.com/prometheus/prometheus/model/histogram"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strconv "strconv"
 	strings "strings"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
-	github_com_prometheus_prometheus_model_histogram "github.com/prometheus/prometheus/model/histogram"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -11616,11 +11615,11 @@ func (m *MetadataRW2) Unmarshal(dAtA []byte) error {
 }
 func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata map[string]*orderAwareMetricMetadata, metricName string) error {
 	var (
-		err                 error
-		help                string
-		metricType          MetadataRW2_MetricType
+		err error
+		help string
+		metricType MetadataRW2_MetricType
 		normalizeMetricName string
-		unit                string
+		unit string
 	)
 	l := len(dAtA)
 	iNdEx := 0

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -270,7 +270,7 @@ var TimeseriesUnmarshalCachingEnabled = true
 //   - in case 3 the exemplars don't get unmarshaled if
 //     p.skipUnmarshalingExemplars is false,
 //   - is symbols is not nil, we unmarshal from Remote Write 2.0 format.
-func (p *PreallocTimeseries) Unmarshal(dAtA []byte, symbols *rw2PagedSymbols, metadata map[string]*MetricMetadata) error {
+func (p *PreallocTimeseries) Unmarshal(dAtA []byte, symbols *rw2PagedSymbols, metadata map[string]*orderAwareMetricMetadata) error {
 	if TimeseriesUnmarshalCachingEnabled && symbols == nil {
 		// TODO(krajorama): check if it makes sense for RW2 as well.
 		p.marshalledData = dAtA


### PR DESCRIPTION
#### What this PR does

When deserializing RW2 requests, the metadata slice might come back in a different order for the same request.
This doesn't change the meaning of the in practice, so from the user perspective the order has no meaning. However, it makes it hard to compare RW2 requests (e.g. in tests) because serializing the same request repeatedly is not bit-equal.

This happens because the RW2 metadata is stored into a map by family name, which is then iterated through to produce the final slice - the map iteration might yield different orders on different unmarshal passes, for the same request.

This PR fixes it by remembering the order of the metadata as we parse the request, then we populate the metadata field in that order.

#### Which issue(s) this PR fixes or relates to

contrib https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
