### PR TITLE
feat(parquet): Cache get range calls for parquet label and chunks files

### DIFF
--- a/pkg/storage/tsdb/caching_config.go
+++ b/pkg/storage/tsdb/caching_config.go
@@ -143,6 +143,9 @@ func CreateCachingBucket(chunksCache cache.Cache, chunksConfig ChunksCacheConfig
 			}
 		}
 		cfg.CacheGetRange("chunks", chunksCache, isTSDBChunkFile, subrangeSize, attributesCache, chunksConfig.AttributesTTL, chunksConfig.SubrangeTTL, chunksConfig.MaxGetRangeRequests)
+		cfg.CacheGetRange("parquet-chunks", chunksCache, isParquetChunksFile, subrangeSize, attributesCache, chunksConfig.AttributesTTL, chunksConfig.SubrangeTTL, chunksConfig.MaxGetRangeRequests)
+		// TODO Note that the parquet labels should go into a different cache than the chunks. We reuse the same cache to avoid changes across the codebase but if we're going with this implementation we should move it.
+		cfg.CacheGetRange("parquet-labels", chunksCache, isParquetLabelsFile, subrangeSize, attributesCache, chunksConfig.AttributesTTL, chunksConfig.SubrangeTTL, chunksConfig.MaxGetRangeRequests)
 	}
 
 	if !cachingConfigured {


### PR DESCRIPTION
This PR:
- Caches parquet labels and parquet chunks get-range calls
- Modifies parquet bucket store syncBlocks() method to check whether it has been converted or not before adding it to the list of blocks that can be queried. We had too many errors like:
```
code = Unknown desc = error converting parquet series set to labels and chunks slice: get TSDB schema from lazy reader: lazy open parquet labels file: storage: object doesn't exist: googleapi: Error 404: No such object
``` 