### PR TITLE
mimirpb: Optimize RW2 Marshalling

### DIFF
--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -296,7 +296,7 @@ func TestRW2Unmarshal(t *testing.T) {
 		syms := test.NewSymbolTableBuilderWithCommon(nil, 256, nil)
 		// Create a new WriteRequest with some sample data.
 		writeRequest := makeTestRW2WriteRequest(syms)
-		writeRequest.Timeseries[0].LabelsRefs[0] = 128 // In the reserved space
+		writeRequest.TimeseriesRW2[0].LabelsRefs[0] = 128 // In the reserved space
 		data, err := writeRequest.Marshal()
 		require.NoError(t, err)
 
@@ -353,7 +353,7 @@ func TestRW2Unmarshal(t *testing.T) {
 		syms := test.NewSymbolTableBuilderWithCommon(nil, 256, commonSyms)
 		// Create a new WriteRequest with some sample data.
 		writeRequest := makeTestRW2WriteRequest(syms)
-		writeRequest.Timeseries[0].LabelsRefs[0] = 1 // Out of bounds common symbol.
+		writeRequest.TimeseriesRW2[0].LabelsRefs[0] = 1 // Out of bounds common symbol.
 		data, err := writeRequest.Marshal()
 		require.NoError(t, err)
 
@@ -398,33 +398,33 @@ func TestRW2Unmarshal(t *testing.T) {
 			syms := test.NewSymbolTableBuilder(nil)
 			// Create a new WriteRequest with some sample data.
 			writeRequest := makeTestRW2WriteRequest(syms)
-			writeRequest.Timeseries = []rw2.TimeSeries{
+			writeRequest.TimeseriesRW2 = []TimeSeriesRW2{
 				// Keep the one we already built
-				writeRequest.Timeseries[0],
+				writeRequest.TimeseriesRW2[0],
 				{
 					LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("metric_2")},
-					Metadata: rw2.Metadata{
-						Type:    rw2.Metadata_METRIC_TYPE_COUNTER,
+					Metadata: MetadataRW2{
+						Type:    METRIC_TYPE_COUNTER,
 						HelpRef: syms.GetSymbol("metric_2 help text."),
 					},
 				},
 				{
 					LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("metric_3")},
-					Metadata: rw2.Metadata{
-						Type:    rw2.Metadata_METRIC_TYPE_COUNTER,
+					Metadata: MetadataRW2{
+						Type:    METRIC_TYPE_COUNTER,
 						HelpRef: syms.GetSymbol("metric_3 help text."),
 					},
 				},
 				// Duplicate, should be filtered out.
 				{
 					LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("metric_2")},
-					Metadata: rw2.Metadata{
-						Type:    rw2.Metadata_METRIC_TYPE_COUNTER,
+					Metadata: MetadataRW2{
+						Type:    METRIC_TYPE_COUNTER,
 						HelpRef: syms.GetSymbol("duplicated metric_2 help text, but different."),
 					},
 				},
 			}
-			writeRequest.Symbols = syms.GetSymbols()
+			writeRequest.SymbolsRW2 = syms.GetSymbols()
 			data, err := writeRequest.Marshal()
 			require.NoError(t, err)
 
@@ -444,33 +444,33 @@ func TestRW2Unmarshal(t *testing.T) {
 	})
 }
 
-func makeTestRW2WriteRequest(syms *test.SymbolTableBuilder) *rw2.Request {
-	req := &rw2.Request{
-		Timeseries: []rw2.TimeSeries{
+func makeTestRW2WriteRequest(syms *test.SymbolTableBuilder) *WriteRequest {
+	req := &WriteRequest{
+		TimeseriesRW2: []TimeSeriesRW2{
 			{
 				LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_total"), syms.GetSymbol("job"), syms.GetSymbol("test_job")},
-				Samples: []rw2.Sample{
+				Samples: []Sample{
 					{
-						Value:     123.456,
-						Timestamp: 1234567890,
+						Value:       123.456,
+						TimestampMs: 1234567890,
 					},
 				},
-				Exemplars: []rw2.Exemplar{
+				Exemplars: []ExemplarRW2{
 					{
 						Value:      123.456,
 						Timestamp:  1234567890,
 						LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_total"), syms.GetSymbol("traceID"), syms.GetSymbol("1234567890abcdef")},
 					},
 				},
-				Metadata: rw2.Metadata{
-					Type:    rw2.Metadata_METRIC_TYPE_COUNTER,
+				Metadata: MetadataRW2{
+					Type:    METRIC_TYPE_COUNTER,
 					HelpRef: syms.GetSymbol("test_metric_help"),
 					UnitRef: syms.GetSymbol("test_metric_unit"),
 				},
 			},
 		},
 	}
-	req.Symbols = syms.GetSymbols()
+	req.SymbolsRW2 = syms.GetSymbols()
 
 	return req
 }

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -14,6 +14,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	strconv "strconv"
 	strings "strings"
 )
@@ -5912,19 +5913,25 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		}
 	}
 	if len(m.LabelsRefs) > 0 {
-		dAtA22 := make([]byte, len(m.LabelsRefs)*10)
+		// Modified code.
+		// Normally we move backward through the message, but varint encoding requires moving forward, due to the bit math/continuation bits.
+		// The generator normally allocates a new buffer for the varint slice, moves foward, and copies it into dAtA.
+		// We optimize it by instead encoding the value in-place, but backward, and then reversing the bits at the end.
 		var j21 int
+		start := i
 		for _, num := range m.LabelsRefs {
 			for num >= 1<<7 {
-				dAtA22[j21] = uint8(uint64(num)&0x7f | 0x80)
+				dAtA[i-1] = uint8(uint64(num)&0x7f | 0x80)
 				num >>= 7
+				i--
 				j21++
 			}
-			dAtA22[j21] = uint8(num)
+			dAtA[i-1] = uint8(num)
+			i--
 			j21++
 		}
-		i -= j21
-		copy(dAtA[i:], dAtA22[:j21])
+		slices.Reverse(dAtA[i:start])
+		// End modified code.
 		i = encodeVarintMimir(dAtA, i, uint64(j21))
 		i--
 		dAtA[i] = 0xa
@@ -5964,19 +5971,25 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		dAtA[i] = 0x11
 	}
 	if len(m.LabelsRefs) > 0 {
-		dAtA24 := make([]byte, len(m.LabelsRefs)*10)
+		// Modified code.
+		// Normally we move backward through the message, but varint encoding requires moving forward, due to the bit math/continuation bits.
+		// The generator normally allocates a new buffer for the varint slice, moves foward, and copies it into dAtA.
+		// We optimize it by instead encoding the value in-place, but backward, and then reversing the bits at the end.
 		var j23 int
+		start := i
 		for _, num := range m.LabelsRefs {
 			for num >= 1<<7 {
-				dAtA24[j23] = uint8(uint64(num)&0x7f | 0x80)
+				dAtA[i-1] = uint8(uint64(num)&0x7f | 0x80)
 				num >>= 7
+				i--
 				j23++
 			}
-			dAtA24[j23] = uint8(num)
+			dAtA[i-1] = uint8(num)
+			i--
 			j23++
 		}
-		i -= j23
-		copy(dAtA[i:], dAtA24[:j23])
+		slices.Reverse(dAtA[i:start])
+		// End modified code.
 		i = encodeVarintMimir(dAtA, i, uint64(j23))
 		i--
 		dAtA[i] = 0xa

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -5915,8 +5915,8 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	if len(m.LabelsRefs) > 0 {
 		// Modified code.
 		// Normally we move backward through the message, but varint encoding requires moving forward, due to the bit math/continuation bits.
-		// The generator normally allocates a new buffer for the varint slice, moves foward, and copies it into dAtA.
-		// We optimize it by instead encoding the value in-place, but backward, and then reversing the bits at the end.
+		// The generator normally allocates a new buffer for the varint slice, moves foward through it, and copies it into dAtA at the end.
+		// We avoid the buffer allocation by instead encoding the value in-place, but backward, and then reversing the bits at the end.
 		var j21 int
 		start := i
 		for _, num := range m.LabelsRefs {
@@ -5973,8 +5973,8 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	if len(m.LabelsRefs) > 0 {
 		// Modified code.
 		// Normally we move backward through the message, but varint encoding requires moving forward, due to the bit math/continuation bits.
-		// The generator normally allocates a new buffer for the varint slice, moves foward, and copies it into dAtA.
-		// We optimize it by instead encoding the value in-place, but backward, and then reversing the bits at the end.
+		// The generator normally allocates a new buffer for the varint slice, moves foward through it, and copies it into dAtA at the end.
+		// We avoid the buffer allocation by instead encoding the value in-place, but backward, and then reversing the bits at the end.
 		var j23 int
 		start := i
 		for _, num := range m.LabelsRefs {

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -14,6 +14,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	strconv "strconv"
 	strings "strings"
 )
@@ -5916,7 +5917,7 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		// Normally we move backward through the message, but varint encoding requires moving forward, due to the bit math/continuation bits.
 		// The generator normally allocates a new buffer for the varint slice, moves foward through it, and copies it into dAtA at the end.
 		// We avoid the buffer allocation by instead encoding the value in-place, but backward, and then reversing the bits at the end.
-		/*var j21 int
+		var j21 int
 		start := i
 		for _, num := range m.LabelsRefs {
 			for num >= 1<<7 {
@@ -5929,22 +5930,7 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 			i--
 			j21++
 		}
-		slices.Reverse(dAtA[i:start])*/
-		var num uint32
-		var offset, size, j21 int
-		for j := len(m.LabelsRefs)-1; j >= 0; j-- {
-			num = m.LabelsRefs[j]
-			size = (math_bits.Len64(uint64(num)|1) + 6) / 7  // inlined sovMimir
-			offset = i - size
-			for num >= 1<<7 {
-				dAtA[offset] = uint8(num&0x7f | 0x80)
-				num >>= 7
-				offset++
-			}
-			dAtA[offset] = uint8(num)
-			i -= size
-			j21 += size
-		}
+		slices.Reverse(dAtA[i:start])
 		// End modified code.
 		i = encodeVarintMimir(dAtA, i, uint64(j21))
 		i--
@@ -5989,7 +5975,7 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		// Normally we move backward through the message, but varint encoding requires moving forward, due to the bit math/continuation bits.
 		// The generator normally allocates a new buffer for the varint slice, moves foward through it, and copies it into dAtA at the end.
 		// We avoid the buffer allocation by instead encoding the value in-place, but backward, and then reversing the bits at the end.
-		/*var j23 int
+		var j23 int
 		start := i
 		for _, num := range m.LabelsRefs {
 			for num >= 1<<7 {
@@ -6002,22 +5988,7 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 			i--
 			j23++
 		}
-		slices.Reverse(dAtA[i:start])*/
-		var num uint32
-		var offset, size, j23 int
-		for j := len(m.LabelsRefs)-1; j >= 0; j-- {
-			num = m.LabelsRefs[j]
-			size = (math_bits.Len64(uint64(num)|1) + 6) / 7  // inlined sovMimir
-			offset = i - size
-			for num >= 1<<7 {
-				dAtA[offset] = uint8(num&0x7f | 0x80)
-				num >>= 7
-				offset++
-			}
-			dAtA[offset] = uint8(num)
-			i -= size
-			j23 += size
-		}
+		slices.Reverse(dAtA[i:start])
 		// End modified code.
 		i = encodeVarintMimir(dAtA, i, uint64(j23))
 		i--

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -14,7 +14,6 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
-	slices "slices"
 	strconv "strconv"
 	strings "strings"
 )
@@ -5917,7 +5916,7 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		// Normally we move backward through the message, but varint encoding requires moving forward, due to the bit math/continuation bits.
 		// The generator normally allocates a new buffer for the varint slice, moves foward through it, and copies it into dAtA at the end.
 		// We avoid the buffer allocation by instead encoding the value in-place, but backward, and then reversing the bits at the end.
-		var j21 int
+		/*var j21 int
 		start := i
 		for _, num := range m.LabelsRefs {
 			for num >= 1<<7 {
@@ -5930,7 +5929,22 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 			i--
 			j21++
 		}
-		slices.Reverse(dAtA[i:start])
+		slices.Reverse(dAtA[i:start])*/
+		var num uint32
+		var offset, size, j21 int
+		for j := len(m.LabelsRefs)-1; j >= 0; j-- {
+			num = m.LabelsRefs[j]
+			size = (math_bits.Len64(uint64(num)|1) + 6) / 7  // inlined sovMimir
+			offset = i - size
+			for num >= 1<<7 {
+				dAtA[offset] = uint8(num&0x7f | 0x80)
+				num >>= 7
+				offset++
+			}
+			dAtA[offset] = uint8(num)
+			i -= size
+			j21 += size
+		}
 		// End modified code.
 		i = encodeVarintMimir(dAtA, i, uint64(j21))
 		i--
@@ -5975,7 +5989,7 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		// Normally we move backward through the message, but varint encoding requires moving forward, due to the bit math/continuation bits.
 		// The generator normally allocates a new buffer for the varint slice, moves foward through it, and copies it into dAtA at the end.
 		// We avoid the buffer allocation by instead encoding the value in-place, but backward, and then reversing the bits at the end.
-		var j23 int
+		/*var j23 int
 		start := i
 		for _, num := range m.LabelsRefs {
 			for num >= 1<<7 {
@@ -5988,7 +6002,22 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 			i--
 			j23++
 		}
-		slices.Reverse(dAtA[i:start])
+		slices.Reverse(dAtA[i:start])*/
+		var num uint32
+		var offset, size, j23 int
+		for j := len(m.LabelsRefs)-1; j >= 0; j-- {
+			num = m.LabelsRefs[j]
+			size = (math_bits.Len64(uint64(num)|1) + 6) / 7  // inlined sovMimir
+			offset = i - size
+			for num >= 1<<7 {
+				dAtA[offset] = uint8(num&0x7f | 0x80)
+				num >>= 7
+				offset++
+			}
+			dAtA[offset] = uint8(num)
+			i -= size
+			j23 += size
+		}
 		// End modified code.
 		i = encodeVarintMimir(dAtA, i, uint64(j23))
 		i--

--- a/pkg/mimirpb/mimir.pb.go.expdiff
+++ b/pkg/mimirpb/mimir.pb.go.expdiff
@@ -1,8 +1,16 @@
 diff --git a/pkg/mimirpb/mimir.pb.go b/pkg/mimirpb/mimir.pb.go
-index 406e4d2ac..de8364cdb 100644
+index b2bbe2099..de8364cdb 100644
 --- a/pkg/mimirpb/mimir.pb.go
 +++ b/pkg/mimirpb/mimir.pb.go
-@@ -275,9 +275,6 @@ func (MetadataRW2_MetricType) EnumDescriptor() ([]byte, []int) {
+@@ -14,7 +14,6 @@ import (
+ 	math "math"
+ 	math_bits "math/bits"
+ 	reflect "reflect"
+-	slices "slices"
+ 	strconv "strconv"
+ 	strings "strings"
+ )
+@@ -276,9 +275,6 @@ func (MetadataRW2_MetricType) EnumDescriptor() ([]byte, []int) {
  }
  
  type WriteRequest struct {
@@ -12,7 +20,7 @@ index 406e4d2ac..de8364cdb 100644
  	Timeseries []PreallocTimeseries    `protobuf:"bytes,1,rep,name=timeseries,proto3,customtype=PreallocTimeseries" json:"timeseries"`
  	Source     WriteRequest_SourceEnum `protobuf:"varint,2,opt,name=Source,proto3,enum=cortexpb.WriteRequest_SourceEnum" json:"Source,omitempty"`
  	Metadata   []*MetricMetadata       `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty"`
-@@ -289,12 +286,6 @@ type WriteRequest struct {
+@@ -290,12 +286,6 @@ type WriteRequest struct {
  	SkipLabelValidation bool `protobuf:"varint,1000,opt,name=skip_label_validation,json=skipLabelValidation,proto3" json:"skip_label_validation,omitempty"`
  	// Skip label count validation.
  	SkipLabelCountValidation bool `protobuf:"varint,1001,opt,name=skip_label_count_validation,json=skipLabelCountValidation,proto3" json:"skip_label_count_validation,omitempty"`
@@ -25,7 +33,7 @@ index 406e4d2ac..de8364cdb 100644
  }
  
  func (m *WriteRequest) Reset()      { *m = WriteRequest{} }
-@@ -461,9 +452,6 @@ type TimeSeries struct {
+@@ -462,9 +452,6 @@ type TimeSeries struct {
  	// Zero value means value not set. If you need to use exactly zero value for
  	// the timestamp, use 1 millisecond before or after.
  	CreatedTimestamp int64 `protobuf:"varint,6,opt,name=created_timestamp,json=createdTimestamp,proto3" json:"created_timestamp,omitempty"`
@@ -35,7 +43,69 @@ index 406e4d2ac..de8364cdb 100644
  }
  
  func (m *TimeSeries) Reset()      { *m = TimeSeries{} }
-@@ -7320,9 +7308,6 @@ func valueToStringMimir(v interface{}) string {
+@@ -5913,25 +5900,19 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+ 		}
+ 	}
+ 	if len(m.LabelsRefs) > 0 {
+-		// Modified code.
+-		// Normally we move backward through the message, but varint encoding requires moving forward, due to the bit math/continuation bits.
+-		// The generator normally allocates a new buffer for the varint slice, moves foward through it, and copies it into dAtA at the end.
+-		// We avoid the buffer allocation by instead encoding the value in-place, but backward, and then reversing the bits at the end.
++		dAtA22 := make([]byte, len(m.LabelsRefs)*10)
+ 		var j21 int
+-		start := i
+ 		for _, num := range m.LabelsRefs {
+ 			for num >= 1<<7 {
+-				dAtA[i-1] = uint8(uint64(num)&0x7f | 0x80)
++				dAtA22[j21] = uint8(uint64(num)&0x7f | 0x80)
+ 				num >>= 7
+-				i--
+ 				j21++
+ 			}
+-			dAtA[i-1] = uint8(num)
+-			i--
++			dAtA22[j21] = uint8(num)
+ 			j21++
+ 		}
+-		slices.Reverse(dAtA[i:start])
+-		// End modified code.
++		i -= j21
++		copy(dAtA[i:], dAtA22[:j21])
+ 		i = encodeVarintMimir(dAtA, i, uint64(j21))
+ 		i--
+ 		dAtA[i] = 0xa
+@@ -5971,25 +5952,19 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+ 		dAtA[i] = 0x11
+ 	}
+ 	if len(m.LabelsRefs) > 0 {
+-		// Modified code.
+-		// Normally we move backward through the message, but varint encoding requires moving forward, due to the bit math/continuation bits.
+-		// The generator normally allocates a new buffer for the varint slice, moves foward through it, and copies it into dAtA at the end.
+-		// We avoid the buffer allocation by instead encoding the value in-place, but backward, and then reversing the bits at the end.
++		dAtA24 := make([]byte, len(m.LabelsRefs)*10)
+ 		var j23 int
+-		start := i
+ 		for _, num := range m.LabelsRefs {
+ 			for num >= 1<<7 {
+-				dAtA[i-1] = uint8(uint64(num)&0x7f | 0x80)
++				dAtA24[j23] = uint8(uint64(num)&0x7f | 0x80)
+ 				num >>= 7
+-				i--
+ 				j23++
+ 			}
+-			dAtA[i-1] = uint8(num)
+-			i--
++			dAtA24[j23] = uint8(num)
+ 			j23++
+ 		}
+-		slices.Reverse(dAtA[i:start])
+-		// End modified code.
++		i -= j23
++		copy(dAtA[i:], dAtA24[:j23])
+ 		i = encodeVarintMimir(dAtA, i, uint64(j23))
+ 		i--
+ 		dAtA[i] = 0xa
+@@ -7333,9 +7308,6 @@ func valueToStringMimir(v interface{}) string {
  	return fmt.Sprintf("*%v", pv)
  }
  func (m *WriteRequest) Unmarshal(dAtA []byte) error {
@@ -45,7 +115,7 @@ index 406e4d2ac..de8364cdb 100644
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -7352,9 +7337,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7365,9 +7337,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  		}
  		switch fieldNum {
  		case 1:
@@ -55,7 +125,7 @@ index 406e4d2ac..de8364cdb 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Timeseries", wireType)
  			}
-@@ -7384,8 +7366,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7397,8 +7366,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  				return io.ErrUnexpectedEOF
  			}
  			m.Timeseries = append(m.Timeseries, PreallocTimeseries{})
@@ -65,7 +135,7 @@ index 406e4d2ac..de8364cdb 100644
  				return err
  			}
  			iNdEx = postIndex
-@@ -7409,9 +7390,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7422,9 +7390,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  				}
  			}
  		case 3:
@@ -75,7 +145,7 @@ index 406e4d2ac..de8364cdb 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
  			}
-@@ -7446,9 +7424,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7459,9 +7424,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  			}
  			iNdEx = postIndex
  		case 4:
@@ -85,7 +155,7 @@ index 406e4d2ac..de8364cdb 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field SymbolsRW2", wireType)
  			}
-@@ -7478,16 +7453,9 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7491,16 +7453,9 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -103,7 +173,7 @@ index 406e4d2ac..de8364cdb 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field TimeseriesRW2", wireType)
  			}
-@@ -7516,12 +7484,8 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7529,12 +7484,8 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -118,7 +188,7 @@ index 406e4d2ac..de8364cdb 100644
  				return err
  			}
  			iNdEx = postIndex
-@@ -7584,15 +7548,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7597,15 +7548,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  	if iNdEx > l {
  		return io.ErrUnexpectedEOF
  	}
@@ -134,7 +204,7 @@ index 406e4d2ac..de8364cdb 100644
  	return nil
  }
  func (m *WriteResponse) Unmarshal(dAtA []byte) error {
-@@ -7840,11 +7795,9 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
+@@ -7853,11 +7795,9 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -149,7 +219,7 @@ index 406e4d2ac..de8364cdb 100644
  			}
  			iNdEx = postIndex
  		case 4:
-@@ -11153,10 +11106,6 @@ func (m *WriteRequestRW2) Unmarshal(dAtA []byte) error {
+@@ -11166,10 +11106,6 @@ func (m *WriteRequestRW2) Unmarshal(dAtA []byte) error {
  	return nil
  }
  func (m *TimeSeriesRW2) Unmarshal(dAtA []byte) error {
@@ -160,7 +230,7 @@ index 406e4d2ac..de8364cdb 100644
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -11187,7 +11136,22 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11200,7 +11136,22 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  		switch fieldNum {
  		case 1:
  			if wireType == 0 {
@@ -184,24 +254,24 @@ index 406e4d2ac..de8364cdb 100644
  			} else if wireType == 2 {
  				var packedLen int
  				for shift := uint(0); ; shift += 7 {
-@@ -11222,14 +11186,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11235,14 +11186,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  					}
  				}
  				elementCount = count
 -				if elementCount%2 != 0 {
 -					return errorOddNumberOfLabelRefs
--				}
--				if elementCount != 0 && len(m.Labels) == 0 {
--					m.Labels = make([]LabelAdapter, 0, elementCount/2)
 +				if elementCount != 0 && len(m.LabelsRefs) == 0 {
 +					m.LabelsRefs = make([]uint32, 0, elementCount)
  				}
+-				if elementCount != 0 && len(m.Labels) == 0 {
+-					m.Labels = make([]LabelAdapter, 0, elementCount/2)
+-				}
 -				idx := 0
 -				metricNameLabel := false
  				for iNdEx < postIndex {
  					var v uint32
  					for shift := uint(0); ; shift += 7 {
-@@ -11246,27 +11205,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11259,27 +11205,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  							break
  						}
  					}
@@ -230,7 +300,7 @@ index 406e4d2ac..de8364cdb 100644
  				}
  			} else {
  				return fmt.Errorf("proto: wrong wireType = %d for field LabelsRefs", wireType)
-@@ -11368,11 +11307,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11381,11 +11307,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -245,7 +315,7 @@ index 406e4d2ac..de8364cdb 100644
  			}
  			iNdEx = postIndex
  		case 5:
-@@ -11404,7 +11341,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11417,7 +11341,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -254,7 +324,7 @@ index 406e4d2ac..de8364cdb 100644
  				return err
  			}
  			iNdEx = postIndex
-@@ -11449,10 +11386,6 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11462,10 +11386,6 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  	return nil
  }
  func (m *ExemplarRW2) Unmarshal(dAtA []byte) error {
@@ -265,7 +335,7 @@ index 406e4d2ac..de8364cdb 100644
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -11483,7 +11416,22 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11496,7 +11416,22 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  		switch fieldNum {
  		case 1:
  			if wireType == 0 {
@@ -289,7 +359,7 @@ index 406e4d2ac..de8364cdb 100644
  			} else if wireType == 2 {
  				var packedLen int
  				for shift := uint(0); ; shift += 7 {
-@@ -11518,13 +11466,9 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11531,13 +11466,9 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  					}
  				}
  				elementCount = count
@@ -305,7 +375,7 @@ index 406e4d2ac..de8364cdb 100644
  				for iNdEx < postIndex {
  					var v uint32
  					for shift := uint(0); ; shift += 7 {
-@@ -11541,20 +11485,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11554,20 +11485,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  							break
  						}
  					}
@@ -327,7 +397,7 @@ index 406e4d2ac..de8364cdb 100644
  				}
  			} else {
  				return fmt.Errorf("proto: wrong wireType = %d for field LabelsRefs", wireType)
-@@ -11574,7 +11505,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11587,7 +11505,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  			if wireType != 0 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
  			}
@@ -336,7 +406,7 @@ index 406e4d2ac..de8364cdb 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11584,7 +11515,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11597,7 +11515,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -345,7 +415,7 @@ index 406e4d2ac..de8364cdb 100644
  				if b < 0x80 {
  					break
  				}
-@@ -11611,16 +11542,6 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11624,16 +11542,6 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  	return nil
  }
  func (m *MetadataRW2) Unmarshal(dAtA []byte) error {
@@ -362,7 +432,7 @@ index 406e4d2ac..de8364cdb 100644
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -11653,7 +11574,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11666,7 +11574,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  			if wireType != 0 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
  			}
@@ -371,7 +441,7 @@ index 406e4d2ac..de8364cdb 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11663,23 +11584,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11676,23 +11584,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -397,7 +467,7 @@ index 406e4d2ac..de8364cdb 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11689,20 +11603,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11702,20 +11603,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -420,7 +490,7 @@ index 406e4d2ac..de8364cdb 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11712,15 +11622,11 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11725,15 +11622,11 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -437,7 +507,7 @@ index 406e4d2ac..de8364cdb 100644
  		default:
  			iNdEx = preIndex
  			skippy, err := skipMimir(dAtA[iNdEx:])
-@@ -11740,21 +11646,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11753,21 +11646,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  	if iNdEx > l {
  		return io.ErrUnexpectedEOF
  	}

--- a/pkg/mimirpb/unmarshal_bench_test.go
+++ b/pkg/mimirpb/unmarshal_bench_test.go
@@ -7,8 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	rw1 "github.com/prometheus/prometheus/prompb"
-	rw2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	rw2util "github.com/grafana/mimir/pkg/util/test"
@@ -31,47 +30,49 @@ func BenchmarkUnMarshal(b *testing.B) {
 	const numExemplarLabels = 5
 
 	// Generate a random series in Remote Write 1.0 format.
-	rw1Request := &rw1.WriteRequest{
-		Timeseries: make([]rw1.TimeSeries, numSeries),
-		Metadata:   make([]rw1.MetricMetadata, numFamilies),
+	rw1Request := &WriteRequest{
+		Timeseries: make([]PreallocTimeseries, numSeries),
+		Metadata:   make([]*MetricMetadata, numFamilies),
 	}
 
 	for i := 0; i < numSeries; i++ {
+		rw1Request.Timeseries[i] = PreallocTimeseries{TimeSeries: &TimeSeries{}}
 		rw1Request.Timeseries[i].Labels = generateLabels("", i, numCommonLabels, numUniqueLabels)
 
-		rw1Request.Timeseries[i].Samples = make([]rw1.Sample, 1)
+		rw1Request.Timeseries[i].Samples = make([]Sample, 1)
 		// Histograms are the same in both formats so we skip them.
 		rw1Request.Timeseries[i].Samples[0].Value = 1.0
 
-		rw1Request.Timeseries[i].Exemplars = make([]rw1.Exemplar, numExemplars)
+		rw1Request.Timeseries[i].Exemplars = make([]Exemplar, numExemplars)
 		for j := 0; j < numExemplars; j++ {
 			rw1Request.Timeseries[i].Exemplars[j].Labels = generateLabels("exemplar_", i, 0, numExemplarLabels)
 			rw1Request.Timeseries[i].Exemplars[j].Value = 2.0
 		}
 	}
 	for i := 0; i < numFamilies; i++ {
+		rw1Request.Metadata[i] = &MetricMetadata{}
 		rw1Request.Metadata[i].MetricFamilyName = fmt.Sprintf("metric_%d", i)
 		rw1Request.Metadata[i].Help = fmt.Sprintf("help_%d", i)
 		rw1Request.Metadata[i].Unit = fmt.Sprintf("unit_%d", i)
-		rw1Request.Metadata[i].Type = rw1.MetricMetadata_COUNTER
+		rw1Request.Metadata[i].Type = COUNTER
 	}
 
 	// Convert RW1 to RW2.
-	rw2Request := &rw2.Request{}
+	rw2Request := &WriteRequest{}
 	symBuilder := rw2util.NewSymbolTableBuilder(nil)
 
 	for i, ts := range rw1Request.Timeseries {
-		rw2Ts := rw2.TimeSeries{}
+		rw2Ts := TimeSeriesRW2{}
 		for _, label := range ts.Labels {
 			rw2Ts.LabelsRefs = append(rw2Ts.LabelsRefs, symBuilder.GetSymbol(label.Name))
 			rw2Ts.LabelsRefs = append(rw2Ts.LabelsRefs, symBuilder.GetSymbol(label.Value))
 		}
 		for _, sample := range ts.Samples {
-			rw2Ts.Samples = append(rw2Ts.Samples, rw2.Sample{Value: sample.Value})
+			rw2Ts.Samples = append(rw2Ts.Samples, Sample{Value: sample.Value})
 		}
 		// Histograms are the same in both formats so we skip them.
 		for _, exemplar := range ts.Exemplars {
-			rw2Exemplar := rw2.Exemplar{
+			rw2Exemplar := ExemplarRW2{
 				Value: exemplar.Value,
 			}
 			for _, label := range exemplar.Labels {
@@ -80,14 +81,32 @@ func BenchmarkUnMarshal(b *testing.B) {
 			}
 			rw2Ts.Exemplars = append(rw2Ts.Exemplars, rw2Exemplar)
 		}
-		rw2Ts.Metadata.Type = rw2.Metadata_METRIC_TYPE_COUNTER
+		rw2Ts.Metadata.Type = METRIC_TYPE_COUNTER
 		rw2Ts.Metadata.HelpRef = symBuilder.GetSymbol(rw1Request.Metadata[i%numFamilies].Help)
 		rw2Ts.Metadata.UnitRef = symBuilder.GetSymbol(rw1Request.Metadata[i%numFamilies].Unit)
 
-		rw2Request.Timeseries = append(rw2Request.Timeseries, rw2Ts)
+		rw2Request.TimeseriesRW2 = append(rw2Request.TimeseriesRW2, rw2Ts)
 	}
-	rw2Request.Symbols = symBuilder.GetSymbols()
-	require.Len(b, rw2Request.Symbols, numCommonLabels*2+numSeries*numUniqueLabels*2+numFamilies*2+numExemplarLabels*numSeries*numExemplars*2)
+	rw2Request.SymbolsRW2 = symBuilder.GetSymbols()
+	require.Len(b, rw2Request.SymbolsRW2, 1+numCommonLabels*2+numSeries*numUniqueLabels*2+numFamilies*2+numExemplarLabels*numSeries*numExemplars*2)
+
+	b.Run("Marshal/RW1", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			data, err := rw1Request.Marshal()
+			require.NoError(b, err)
+			require.NotEmpty(b, data)
+		}
+	})
+
+	b.Run("Marshal/RW2", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			data, err := rw2Request.Marshal()
+			require.NoError(b, err)
+			require.NotEmpty(b, data)
+		}
+	})
 
 	rw1Data, err := rw1Request.Marshal()
 	require.NoError(b, err)
@@ -98,7 +117,7 @@ func BenchmarkUnMarshal(b *testing.B) {
 	require.NotEmpty(b, rw2Data)
 
 	for _, skipExemplars := range []bool{true, false} {
-		b.Run(fmt.Sprintf("RW1/skipExemplars=%v", skipExemplars), func(b *testing.B) {
+		b.Run(fmt.Sprintf("Unmarshal/RW1/skipExemplars=%v", skipExemplars), func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				pw := PreallocWriteRequest{}
@@ -108,7 +127,7 @@ func BenchmarkUnMarshal(b *testing.B) {
 			}
 		})
 
-		b.Run(fmt.Sprintf("RW2/skipExemplars=%v", skipExemplars), func(b *testing.B) {
+		b.Run(fmt.Sprintf("Unmarshal/RW2/skipExemplars=%v", skipExemplars), func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				pw := PreallocWriteRequest{}
@@ -121,8 +140,8 @@ func BenchmarkUnMarshal(b *testing.B) {
 	}
 }
 
-func generateLabels(prefix string, seriesNumber, numCommonLabels, numUniqueLabels int) []rw1.Label {
-	labels := make([]rw1.Label, numCommonLabels+numUniqueLabels)
+func generateLabels(prefix string, seriesNumber, numCommonLabels, numUniqueLabels int) []LabelAdapter {
+	labels := make([]labels.Label, numCommonLabels+numUniqueLabels)
 	for i := 0; i < numCommonLabels; i++ {
 		labels[i].Name = prefix + "common_label_" + strconv.Itoa(i)
 		labels[i].Value = prefix + "common_value_" + strconv.Itoa(i)
@@ -133,5 +152,5 @@ func generateLabels(prefix string, seriesNumber, numCommonLabels, numUniqueLabel
 		labels[idx].Name = prefix + "unique_label_" + strconv.Itoa(uid)
 		labels[idx].Value = prefix + "unique_value_" + strconv.Itoa(uid)
 	}
-	return labels
+	return FromLabelsToLabelAdapters(labels)
 }


### PR DESCRIPTION
#### What this PR does

This PR optimizes marshalling of RW2. Benchmark shows a `-17.06%` change to CPU, `-43.14%` change to memory, and removal of nearly all allocations (previously scaled based on series count; now fixed at 2, 99.99% reduction in the benchmark).

<details>
<summary>Full benchstat results (only "Marshal/RW2" benchmarks affected)</summary>

```
pkg: github.com/grafana/mimir/pkg/mimirpb
cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics
                                               │ before.txt  │          after-reverse.txt          │
                                               │   sec/op    │   sec/op     vs base                │
UnMarshal/Marshal/RW1-16                         34.21m ± 1%   35.27m ± 1%   +3.09% (p=0.002 n=10)
UnMarshal/Marshal/RW2-16                         20.99m ± 1%   17.41m ± 1%  -17.06% (p=0.000 n=10)
UnMarshal/Unmarshal/RW1/skipExemplars=true-16    20.63m ± 3%   21.89m ± 3%   +6.11% (p=0.000 n=10)
UnMarshal/Unmarshal/RW2/skipExemplars=true-16    24.22m ± 1%   25.52m ± 1%   +5.33% (p=0.000 n=10)
UnMarshal/Unmarshal/RW1/skipExemplars=false-16   23.63m ± 2%   24.77m ± 1%   +4.84% (p=0.000 n=10)
UnMarshal/Unmarshal/RW2/skipExemplars=false-16   25.98m ± 1%   27.90m ± 3%   +7.42% (p=0.000 n=10)
geomean                                          24.57m        24.88m        +1.23%

                                               │  before.txt  │          after-reverse.txt           │
                                               │     B/op     │     B/op      vs base                │
UnMarshal/Marshal/RW1-16                         25.58Mi ± 0%   25.58Mi ± 0%   -0.00% (p=0.025 n=10)
UnMarshal/Marshal/RW2-16                         30.78Mi ± 0%   17.50Mi ± 0%  -43.14% (p=0.000 n=10)
UnMarshal/Unmarshal/RW1/skipExemplars=true-16    54.48Mi ± 0%   54.48Mi ± 0%        ~ (p=0.739 n=10)
UnMarshal/Unmarshal/RW2/skipExemplars=true-16    31.29Mi ± 0%   31.29Mi ± 0%        ~ (p=0.218 n=10)
UnMarshal/Unmarshal/RW1/skipExemplars=false-16   59.05Mi ± 0%   59.05Mi ± 0%        ~ (p=0.289 n=10)
UnMarshal/Unmarshal/RW2/skipExemplars=false-16   32.82Mi ± 0%   32.82Mi ± 0%        ~ (p=0.739 n=10)
geomean                                          37.08Mi        33.75Mi        -8.98%

                                               │   before.txt   │           after-reverse.txt           │
                                               │   allocs/op    │  allocs/op   vs base                  │
UnMarshal/Marshal/RW1-16                             2.000 ± 0%    2.000 ± 0%        ~ (p=1.000 n=10) ¹
UnMarshal/Marshal/RW2-16                         20002.000 ± 0%    2.000 ± 0%  -99.99% (p=0.000 n=10)
UnMarshal/Unmarshal/RW1/skipExemplars=true-16       60.43k ± 0%   60.43k ± 0%        ~ (p=1.000 n=10) ¹
UnMarshal/Unmarshal/RW2/skipExemplars=true-16       50.03k ± 0%   50.03k ± 0%        ~ (p=1.000 n=10) ¹
UnMarshal/Unmarshal/RW1/skipExemplars=false-16      100.4k ± 0%   100.4k ± 0%        ~ (p=1.000 n=10) ¹
UnMarshal/Unmarshal/RW2/skipExemplars=false-16      60.03k ± 0%   60.03k ± 0%        ~ (p=1.000 n=10)
geomean                                             9.487k        2.044k       -78.46%
```

</details>

Namely we focus on marshalling labels references, removing the need for a memory buffer in the generated code.
It's not an original optimization. Upstream Prometheus does the same, as added in [this commit](https://github.com/prometheus/prometheus/pull/14395/commits/5dbe3c191961b228c3eae08a5d827271d590c745) by @npazosmendez.

[I've also included an alternative implementation in this commit](https://github.com/grafana/mimir/commit/4934c540710788066ae9eddb76b4ff078159fa38), that builds on the Prometheus version. It just marshalls the references completely inplace without the need for reversing anything. It's about 5% faster in the benchmark (no change to memory or allocations). But, the tradeoff is that it's completely custom logic written from scratch - the `reverse` algorithm retains some of the generated code, and is easier to diff/understand without needing a deep understanding of protobuf encoding.

#### Which issue(s) this PR fixes or relates to

Contrib https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
