### PR TITLE
chore: Autofix to make #nosec suppressions also legible to semgrep

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -922,7 +922,7 @@ func (f amConfig) fingerprint() model.Fingerprint {
 			writeBytes(nil)
 			return
 		}
-		// #nosec G103
+		// #nosec G103 -- nosemgrep: use-of-unsafe-block
 		// avoid allocation when converting string to byte slice
 		writeBytes(unsafe.Slice(unsafe.StringData(s), len(s)))
 	}


### PR DESCRIPTION
#### What this PR does
Security is working on rolling out semgrep across our codebase. Because of some parser deficiencies in semgrep (the user-configurable rule engine runs after AST parsing, which discards comments), we can't just force it to respect #nosec, so this PR converts lines with valid gosec suppression directives into lines that also contain a valid equivalent semgrep suppression. I know it's ugly, sorry.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [NA] Tests updated.
- [NA] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [NA] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
