### PR TITLE
Added trafficDistribution: PreferClose for same zone communication between remote-writer-agent and mimir (distributor or nginx or gateway)

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -16,6 +16,9 @@ spec:
   {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
   internalTrafficPolicy: {{ .Values.distributor.service.internalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.distributor.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.distributor.service.trafficDistribution }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -22,6 +22,9 @@ spec:
   {{- if and (eq "LoadBalancer" .Values.gateway.service.type) .Values.gateway.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.gateway.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.gateway.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.gateway.service.trafficDistribution }}
+  {{- end }}
   ports:
     - port: {{ .Values.gateway.service.port }}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -25,6 +25,9 @@ spec:
   {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
   internalTrafficPolicy: {{ .Values.ingester.service.internalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.ingester.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.ingester.service.trafficDistribution }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-svc.yaml
@@ -23,6 +23,9 @@ spec:
   {{- if and (eq "LoadBalancer" .Values.nginx.service.type) .Values.nginx.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.nginx.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.nginx.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.nginx.service.trafficDistribution }}
+  {{- end }}
   ports:
     - name: http-metric
       port: {{ .Values.nginx.service.port }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
@@ -16,6 +16,9 @@ spec:
   {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
   internalTrafficPolicy: {{ .Values.querier.service.internalTrafficPolicy }}
   {{- end}}
+  {{- if .Values.querier.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.querier.service.trafficDistribution }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -16,6 +16,9 @@ spec:
   {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
   internalTrafficPolicy: {{ .Values.query_frontend.service.internalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.query_frontend.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.query_frontend.service.trafficDistribution }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
@@ -16,6 +16,9 @@ spec:
   {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
   internalTrafficPolicy: {{ .Values.query_scheduler.service.internalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.query_scheduler.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.query_scheduler.service.trafficDistribution }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -25,6 +25,9 @@ spec:
   {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
   internalTrafficPolicy: {{ .Values.store_gateway.service.internalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.store_gateway.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.store_gateway.service.trafficDistribution }}
+  {{- end }}
   ports:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -908,6 +908,8 @@ distributor:
     internalTrafficPolicy: Cluster
     type: ClusterIP
     extraPorts: []
+    trafficDistribution: ""
+
 
   resources:
     requests:
@@ -1008,6 +1010,7 @@ ingester:
     internalTrafficPolicy: Cluster
     type: ClusterIP
     extraPorts: []
+    trafficDistribution: ""
 
   # -- Optionally set the scheduler for pods of the ingester
   schedulerName: ""
@@ -1855,6 +1858,7 @@ querier:
     internalTrafficPolicy: Cluster
     type: ClusterIP
     extraPorts: []
+    trafficDistribution: ""
 
   resources:
     requests:
@@ -1974,6 +1978,7 @@ query_frontend:
     internalTrafficPolicy: Cluster
     type: ClusterIP
     extraPorts: []
+    trafficDistribution: ""
 
   resources:
     requests:
@@ -2065,6 +2070,7 @@ query_scheduler:
     internalTrafficPolicy: Cluster
     type: ClusterIP
     extraPorts: []
+    trafficDistribution: ""
 
   resources:
     requests:
@@ -2161,6 +2167,7 @@ store_gateway:
     internalTrafficPolicy: Cluster
     type: ClusterIP
     extraPorts: []
+    trafficDistribution: ""
 
   # -- Optionally set the scheduler for pods of the store-gateway
   schedulerName: ""
@@ -3157,6 +3164,8 @@ nginx:
     # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
     internalTrafficPolicy: Cluster
     extraPorts: []
+    # -- https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+    trafficDistribution: ""
   # Ingress configuration
   ingress:
     # -- Specifies whether an ingress for the nginx should be created
@@ -3568,6 +3577,10 @@ gateway:
     # -- https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
     internalTrafficPolicy: Cluster
     extraPorts: []
+    # -- https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+    trafficDistribution: ""
+
+
 
   ingress:
     enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This Pull Request (PR) introduces a significant enhancement for specific use cases where a metrics forwarder and Mimir instances are communicating within the same Kubernetes cluster. Currently, there's no native configuration allowing Mimir distributors and ingesters to prioritise same-Availability Zone (AZ) communication for data ingestion, even when cross-AZ replication is disabled.

This PR aims to enable zone-aware data transfer to optimise data ingestion by leveraging existing Kubernetes kube-proxy features for traffic distribution (as described [here](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution)). By allowing the metrics agent to communicate with same-AZ endpoints of the distributor, NGINX, or gateway (based on configuration), we can achieve more efficient and potentially lower-latency data transfer. This is particularly beneficial for reducing cross-AZ traffic costs and improving overall performance within the cluster

 (I added this in readpath to keep things consistent in the querier or querier_frontend during data reads. In the end, the data will still be fetched from Ingesters across different availability zones.)

#### Which issue(s) this PR fixes or relates to
#10214 

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
