### PR TITLE
ingester: provide noop lookup planner

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -58,6 +58,7 @@ import (
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
 	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 	"github.com/grafana/mimir/pkg/ingester/client"
+	"github.com/grafana/mimir/pkg/ingester/lookupplan"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/api"
 	mimir_storage "github.com/grafana/mimir/pkg/storage"
@@ -2863,6 +2864,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 		BlockPostingsForMatchersCacheMetrics:  i.tsdbMetrics.blockPostingsForMatchersCacheMetrics,
 		EnableNativeHistograms:                i.limits.NativeHistogramsIngestionEnabled(userID),
 		SecondaryHashFunction:                 secondaryTSDBHashFunctionForUser(userID),
+		IndexLookupPlanner:                    lookupplan.NoopPlanner{},
 	}, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open TSDB: %s", udir)

--- a/pkg/ingester/lookupplan/planner.go
+++ b/pkg/ingester/lookupplan/planner.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package lookupplan
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/tsdb/index"
+)
+
+type NoopPlanner struct{}
+
+func (i NoopPlanner) PlanIndexLookup(_ context.Context, plan index.LookupPlan, _, _ int64) (index.LookupPlan, error) {
+	return plan, nil
+}


### PR DESCRIPTION

#### What this PR does


i'm not 100% convinced that the naive default planner will always do a good job. That was added as a suggestion upstream

https://github.com/grafana/mimir/blob/b8396cd92300d053a58fd1e0085da98e5f92aee6/vendor/github.com/prometheus/prometheus/tsdb/index/lookup.go#L74-L117

this configurability was added today in https://github.com/grafana/mimir/pull/12237

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
