### PR TITLE
Build: Include updated Mozilla CA bundle from Debian Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Grafana Mimir
 
-* [CHANGE] Build: Include updated Mozilla CA bundle from Debian Testing
+* [CHANGE] Build: Include updated Mozilla CA bundle from Debian Testing. #12247
 * [CHANGE] Query-frontend: Add support for UTF-8 label and metric names in `/api/v1/cardinality/{label_values|label_values|active_series}` endpoints. #11848.
 * [CHANGE] Querier: Add support for UTF-8 label and metric names in `label_join`, `label_replace` and `count_values` PromQL functions. #11848.
 * [CHANGE] Remove support for Redis as a cache backend. #12163

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Build: Include updated Mozilla CA bundle from Debian Testing
 * [CHANGE] Query-frontend: Add support for UTF-8 label and metric names in `/api/v1/cardinality/{label_values|label_values|active_series}` endpoints. #11848.
 * [CHANGE] Querier: Add support for UTF-8 label and metric names in `label_join`, `label_replace` and `count_values` PromQL functions. #11848.
 * [CHANGE] Remove support for Redis as a cache backend. #12163

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -3,6 +3,10 @@
 # See difference between distroless static and base-nossl at https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md.
 
 ARG        BASEIMG=gcr.io/distroless/static-debian12
+# TODO(rwwiv): Remove once CA bundle is updated upstream.
+FROM debian:testing AS updated-ca-bundle
+RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+
 FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
@@ -11,6 +15,8 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying mimir binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       mimir${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /bin/mimir
+# Copy the updated CA bundle from the updated-ca-bundle stage
+COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE     8080
 ENTRYPOINT [ "/bin/mimir" ]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Debian 12 (which the base Distroless image for Mimir is based on) is using an outdated version version of Mozilla's CA bundle (v2.60) which is missing several root CA's. This change pulls an update bundle from Debian Testing to ensure outgoing requests to trusted domains will not fail during certificate verification.

#### Which issue(s) this PR fixes or relates to

Related to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1108314

#### Checklist

- n/a Tests updated.
- n/a Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- n/a [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
