### PR TITLE
Reduce bucket index TTL in development Docker Compose environment

### DIFF
--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -73,6 +73,7 @@ blocks_storage:
       backend: memcached
       memcached:
         addresses: dns+memcached:11211
+      bucket_index_content_ttl: 10s
 
   s3:
     endpoint:          minio:9000


### PR DESCRIPTION
#### What this PR does

This PR fixes a source of friction in the development Docker Compose environment.

After restarting the Docker Compose environment after it has been shut down for at least an hour, if you perform a query that touches data in object storage before the compactor has updated the bucket index in object storage, all queries for the next five minutes fail with `err-mimir-bucket-index-too-old`.

This happens because the first request to the querier causes it to load and cache the old bucket index, and this bucket index remains cached for the value of `-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl`, which defaults to five minutes. This PR reduces the value to 10s.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
