### PR TITLE
MQE: change log message to disambiguate from query-frontend query stats log messages

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1532,13 +1532,13 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 			require.NotEmpty(t, span.Events, "There should be events in the span.")
 
 			logEvents := filter(span.Events, func(e tracesdk.Event) bool {
-				return e.Name == "log" && slices.Contains(e.Attributes, attribute.String("msg", "query stats"))
+				return e.Name == "log" && slices.Contains(e.Attributes, attribute.String("msg", "evaluation stats"))
 			})
 			require.Len(t, logEvents, 1, "There should be exactly one log event in the span.")
 			logEvent := logEvents[0]
 			expectedFields := []attribute.KeyValue{
 				attribute.String("level", "info"),
-				attribute.String("msg", "query stats"),
+				attribute.String("msg", "evaluation stats"),
 				attribute.Int64("estimatedPeakMemoryConsumption", int64(expectedMemoryConsumptionEstimate)),
 				attribute.String("expr", testCase.expr),
 				attribute.String("queryType", queryType),

--- a/pkg/streamingpromql/query.go
+++ b/pkg/streamingpromql/query.go
@@ -55,7 +55,7 @@ func (q *Query) Exec(ctx context.Context) *promql.Result {
 		msg := make([]interface{}, 0, 2*(3+4)) // 3 fields for all query types, plus worst case of 4 fields for range queries
 
 		msg = append(msg,
-			"msg", "query stats",
+			"msg", "evaluation stats",
 			"estimatedPeakMemoryConsumption", int64(q.memoryConsumptionTracker.PeakEstimatedMemoryConsumptionBytes()),
 			"expr", q.originalExpression,
 		)


### PR DESCRIPTION
#### What this PR does

The query-frontend emits a `query stats` log message after each query request is completed. 

MQE also emits a `query stats` log message after evaluation is completed. 

With MQE now running in query-frontends, this is potentially confusing, so I've changed the log message from MQE to `evaluation stats` to make it unambiguous.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/11417

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
