### PR TITLE
MQE: reduce numerical errors by not inlining `KahanSumInc`

### DIFF
--- a/pkg/streamingpromql/floats/kahan.go
+++ b/pkg/streamingpromql/floats/kahan.go
@@ -7,6 +7,11 @@ package floats
 
 import "math"
 
+// KahanSumInc computes the sum of inc and sum using the Kahan summation algorithm.
+//
+// See https://github.com/prometheus/prometheus/pull/16895 for further explanation of why inlining is disabled here.
+//
+//go:noinline
 func KahanSumInc(inc, sum, c float64) (newSum, newC float64) {
 	t := sum + inc
 	switch {


### PR DESCRIPTION
#### What this PR does

See https://github.com/prometheus/prometheus/pull/16895 for further explanation. We've copied the code into MQE, so we need to apply the same change here as well.

#### Which issue(s) this PR fixes or relates to

https://github.com/prometheus/prometheus/pull/16895

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
