### PR TITLE
Native histogram definitions for cortex_query_{frontend|scheduler}_queue_duration_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [CHANGE] Query-frontend: Remove experimental instant query splitting feature. #12267
 * [FEATURE] Distributor, ruler: Add experimental `-validation.name-validation-scheme` flag to specify the validation scheme for metric and label names. #12215
 * [FEATURE] Distributor: Add experimental `-distributor.otel-translation-strategy` flag to support configuring the metric and label name translation strategy in the OTLP endpoint. #12284 #12306
+* [ENHANCEMENT] Query-scheduler/query-frontend: Add native histogram definitions to `cortex_query_{scheduler|frontend}_queue_duration_seconds`. #12288
 * [ENHANCEMENT] Compactor: Add `-compactor.update-blocks-concurrency` flag to control concurrency for updating block metadata during bucket index updates, separate from deletion marker concurrency. #12117
 * [ENHANCEMENT] Stagger head compaction intervals across zones to prevent compactions from aligning simultaneously, which could otherwise cause strong consistency queries to fail when experimental ingest storage is enabled. #12090
 * [ENHANCEMENT] Querier: Add native histogram definition to `cortex_bucket_index_load_duration_seconds`. #12094

--- a/pkg/frontend/v1/frontend.go
+++ b/pkg/frontend/v1/frontend.go
@@ -106,9 +106,12 @@ func New(cfg Config, limits Limits, log log.Logger, registerer prometheus.Regist
 			Help: "Total number of query requests discarded.",
 		}, []string{"user"}),
 		queueDuration: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
-			Name:    "cortex_query_frontend_queue_duration_seconds",
-			Help:    "Time spent by requests in queue before getting picked up by a querier.",
-			Buckets: prometheus.DefBuckets,
+			Name:                            "cortex_query_frontend_queue_duration_seconds",
+			Help:                            "Time spent by requests in queue before getting picked up by a querier.",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+			NativeHistogramMaxBucketNumber:  100,
 		}),
 	}
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -178,9 +178,12 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 	}
 
 	s.queueDuration = promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "cortex_query_scheduler_queue_duration_seconds",
-		Help:    "Time spent by requests in queue before getting picked up by a querier.",
-		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120},
+		Name:                            "cortex_query_scheduler_queue_duration_seconds",
+		Help:                            "Time spent by requests in queue before getting picked up by a querier.",
+		Buckets:                         []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120},
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+		NativeHistogramMaxBucketNumber:  100,
 	}, []string{"user", "additional_queue_dimensions"})
 	s.connectedQuerierClients = promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "cortex_query_scheduler_connected_querier_clients",

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/test"
 	"github.com/prometheus/client_golang/prometheus"
-	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	jaegerpropagator "go.opentelemetry.io/contrib/propagators/jaeger"
 	"go.opentelemetry.io/otel"
@@ -38,6 +38,7 @@ import (
 	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/httpgrpcutil"
+	"github.com/grafana/mimir/pkg/util/promtest"
 	util_test "github.com/grafana/mimir/pkg/util/test"
 )
 
@@ -218,7 +219,7 @@ func TestSchedulerEnqueueWithFrontendDisconnect(t *testing.T) {
 
 	// Wait until the frontend has connected to the scheduler.
 	test.Poll(t, time.Second, float64(1), func() interface{} {
-		return promtest.ToFloat64(scheduler.connectedFrontendClients)
+		return testutil.ToFloat64(scheduler.connectedFrontendClients)
 	})
 
 	// Disconnect frontend.
@@ -226,7 +227,7 @@ func TestSchedulerEnqueueWithFrontendDisconnect(t *testing.T) {
 
 	// Wait until the frontend has disconnected.
 	test.Poll(t, time.Second, float64(0), func() interface{} {
-		return promtest.ToFloat64(scheduler.connectedFrontendClients)
+		return testutil.ToFloat64(scheduler.connectedFrontendClients)
 	})
 
 	querierLoop := initQuerierLoop(t, querierClient, "querier-1")
@@ -511,7 +512,7 @@ func TestSchedulerQueueMetrics(t *testing.T) {
 		HttpRequest: &httpgrpc.HTTPRequest{Method: "GET", Url: "/hello"},
 	})
 
-	require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_query_scheduler_queue_length Number of queries in the queue.
 		# TYPE cortex_query_scheduler_queue_length gauge
 		cortex_query_scheduler_queue_length{user="another"} 1
@@ -520,7 +521,7 @@ func TestSchedulerQueueMetrics(t *testing.T) {
 
 	scheduler.cleanupMetricsForInactiveUser("test")
 
-	require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_query_scheduler_queue_length Number of queries in the queue.
 		# TYPE cortex_query_scheduler_queue_length gauge
 		cortex_query_scheduler_queue_length{user="another"} 1
@@ -529,7 +530,16 @@ func TestSchedulerQueueMetrics(t *testing.T) {
 
 func TestSchedulerQuerierMetrics(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-	_, _, querierClient := setupScheduler(t, reg)
+	_, frontendClient, querierClient := setupScheduler(t, reg)
+
+	frontendLoop := initFrontendLoop(t, frontendClient, "frontend-12345")
+	frontendToScheduler(t, frontendLoop, &schedulerpb.FrontendToScheduler{
+		Type:         schedulerpb.ENQUEUE,
+		QueryID:      1,
+		UserID:       "test",
+		HttpRequest:  &httpgrpc.HTTPRequest{Method: "GET", Url: "/hello"},
+		StatsEnabled: true,
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	querierLoop, err := querierClient.QuerierLoop(ctx)
@@ -537,7 +547,7 @@ func TestSchedulerQuerierMetrics(t *testing.T) {
 	require.NoError(t, querierLoop.Send(&schedulerpb.QuerierToScheduler{QuerierID: "querier-1"}))
 
 	require.Eventually(t, func() bool {
-		err := promtest.GatherAndCompare(reg, strings.NewReader(`
+		err := testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_query_scheduler_connected_querier_clients Number of querier worker clients currently connected to the query-scheduler.
 			# TYPE cortex_query_scheduler_connected_querier_clients gauge
 			cortex_query_scheduler_connected_querier_clients 1
@@ -550,7 +560,7 @@ func TestSchedulerQuerierMetrics(t *testing.T) {
 	require.NoError(t, util.CloseAndExhaust[*schedulerpb.SchedulerToQuerier](querierLoop))
 
 	require.Eventually(t, func() bool {
-		err := promtest.GatherAndCompare(reg, strings.NewReader(`
+		err := testutil.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_query_scheduler_connected_querier_clients Number of querier worker clients currently connected to the query-scheduler.
 			# TYPE cortex_query_scheduler_connected_querier_clients gauge
 			cortex_query_scheduler_connected_querier_clients 0
@@ -558,6 +568,9 @@ func TestSchedulerQuerierMetrics(t *testing.T) {
 
 		return err == nil
 	}, time.Second, 10*time.Millisecond, "expected cortex_query_scheduler_connected_querier_clients metric to be decremented after querier disconnected")
+
+	require.NoError(t, promtest.HasNativeHistogram(reg, "cortex_query_scheduler_queue_duration_seconds"))
+	require.NoError(t, promtest.HasSampleCount(reg, "cortex_query_scheduler_queue_duration_seconds", 1))
 }
 
 func initFrontendLoop(t *testing.T, client schedulerpb.SchedulerForFrontendClient, frontendAddr string) schedulerpb.SchedulerForFrontend_FrontendLoopClient {


### PR DESCRIPTION

#### What this PR does
Add native histogram definitions to
- `cortex_query_scheduler_queue_duration_seconds`
- `cortex_query_frontend_queue_duration_seconds`

with the following parameters:
```go
	NativeHistogramBucketFactor:     1.1,
	NativeHistogramMinResetDuration: 1 * time.Hour,
	NativeHistogramMaxBucketNumber:  100,
```


#### Which issue(s) this PR fixes or relates to

Part of: https://github.com/grafana/mimir-squad/issues/3077

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
