### PR TITLE
Alertmanager: Refactor createUsableGrafanaConfig

### DIFF
--- a/pkg/alertmanager/api_grafana.go
+++ b/pkg/alertmanager/api_grafana.go
@@ -537,7 +537,7 @@ func validateUserGrafanaConfig(logger log.Logger, cfg alertspb.GrafanaAlertConfi
 	}
 
 	// Perform a similar flow of transformations that would happen in the Alertmanager on Sync & Apply.
-	grafanaConfig, err := createUsableGrafanaConfig(logger, cfg, "")
+	grafanaConfig, err := amConfigFromGrafanaConfig(logger, cfg, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/alertmanager/api_grafana.go
+++ b/pkg/alertmanager/api_grafana.go
@@ -453,7 +453,7 @@ func (am *MultitenantAlertmanager) SetUserGrafanaConfig(w http.ResponseWriter, r
 	}
 
 	cfgDesc := alertspb.ToGrafanaProto(cfg.GrafanaAlertmanagerConfig.original, userID, cfg.Hash, cfg.CreatedAt, cfg.Default, cfg.Promoted, cfg.ExternalURL, cfg.SmtpFrom, cfg.StaticHeaders, smtpConfig)
-	if err := validateUserGrafanaConfig(logger, cfgDesc, am.limits, userID); err != nil {
+	if err := am.validateUserGrafanaConfig(logger, cfgDesc, am.limits, userID); err != nil {
 		level.Error(logger).Log("msg", errValidatingConfig, "err", err.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		util.WriteJSONResponse(w, errorResult{Status: statusError, Error: fmt.Sprintf("%s: %s", errValidatingConfig, err.Error())})
@@ -527,7 +527,7 @@ func (am *MultitenantAlertmanager) GetGrafanaConfigStatus(w http.ResponseWriter,
 }
 
 // ValidateUserGrafanaConfig validates the Grafana Alertmanager configuration.
-func validateUserGrafanaConfig(logger log.Logger, cfg alertspb.GrafanaAlertConfigDesc, limits Limits, user string) error {
+func (am *MultitenantAlertmanager) validateUserGrafanaConfig(logger log.Logger, cfg alertspb.GrafanaAlertConfigDesc, limits Limits, user string) error {
 	// We don't have a valid use case for empty configurations. If a tenant does not have a
 	// configuration set and issue a request to the Alertmanager, we'll a) upload an empty
 	// config and b) start an Alertmanager instance for them if a fallback
@@ -537,7 +537,7 @@ func validateUserGrafanaConfig(logger log.Logger, cfg alertspb.GrafanaAlertConfi
 	}
 
 	// Perform a similar flow of transformations that would happen in the Alertmanager on Sync & Apply.
-	grafanaConfig, err := amConfigFromGrafanaConfig(logger, cfg, "")
+	grafanaConfig, err := am.amConfigFromGrafanaConfig(cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/alerting/definition"
 	alertingReceivers "github.com/grafana/alerting/receivers"
@@ -24,7 +23,7 @@ import (
 // amConfigFromGrafanaConfig creates an amConfig from a GrafanaAlertConfigDesc.
 // If provided, it assigns the global section from the Mimir config to the Grafana config.
 // The amConfig.EmailConfig field can be used to create Grafana email integrations.
-func amConfigFromGrafanaConfig(logger log.Logger, gCfg alertspb.GrafanaAlertConfigDesc, rawMimirConfig string) (amConfig, error) {
+func (am *MultitenantAlertmanager) amConfigFromGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc) (amConfig, error) {
 	externalURL, err := url.Parse(gCfg.ExternalUrl)
 	if err != nil {
 		return amConfig{}, err
@@ -35,8 +34,8 @@ func amConfigFromGrafanaConfig(logger log.Logger, gCfg alertspb.GrafanaAlertConf
 		return amConfig{}, fmt.Errorf("failed to unmarshal Grafana Alertmanager configuration: %w", err)
 	}
 
-	if rawMimirConfig != "" {
-		cfg, err := definition.LoadCompat([]byte(rawMimirConfig))
+	if am.fallbackConfig != "" {
+		cfg, err := definition.LoadCompat([]byte(am.fallbackConfig))
 		if err != nil {
 			return amConfig{}, fmt.Errorf("failed to unmarshal Mimir Alertmanager configuration: %w", err)
 		}
@@ -68,7 +67,7 @@ func amConfigFromGrafanaConfig(logger log.Logger, gCfg alertspb.GrafanaAlertConf
 			for _, integration := range rcv.GrafanaManagedReceivers {
 				itypes = append(itypes, integration.Type)
 			}
-			level.Debug(logger).Log("msg", "receiver with same name is defined multiple times. Only the last one will be used", "receiver_name", rcv.Name, "overwritten_integrations", strings.Join(itypes, ","))
+			level.Debug(am.logger).Log("msg", "receiver with same name is defined multiple times. Only the last one will be used", "receiver_name", rcv.Name, "overwritten_integrations", strings.Join(itypes, ","))
 			continue
 		}
 		rcvs = append(rcvs, rcv)

--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -21,7 +21,7 @@ import (
 )
 
 // amConfigFromGrafanaConfig creates an amConfig from a GrafanaAlertConfigDesc.
-// If provided, it assigns the global section from the Mimir config to the Grafana config.
+// It uses the 'global' section from the Alertmanager's fallback config (if any) in the final config.
 // The amConfig.EmailConfig field can be used to create Grafana email integrations.
 func (am *MultitenantAlertmanager) amConfigFromGrafanaConfig(gCfg alertspb.GrafanaAlertConfigDesc) (amConfig, error) {
 	externalURL, err := url.Parse(gCfg.ExternalUrl)

--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -21,10 +21,10 @@ import (
 	"github.com/grafana/mimir/pkg/util/version"
 )
 
-// createUsableGrafanaConfig creates an amConfig from a GrafanaAlertConfigDesc.
+// amConfigFromGrafanaConfig creates an amConfig from a GrafanaAlertConfigDesc.
 // If provided, it assigns the global section from the Mimir config to the Grafana config.
 // The amConfig.EmailConfig field can be used to create Grafana email integrations.
-func createUsableGrafanaConfig(logger log.Logger, gCfg alertspb.GrafanaAlertConfigDesc, rawMimirConfig string) (amConfig, error) {
+func amConfigFromGrafanaConfig(logger log.Logger, gCfg alertspb.GrafanaAlertConfigDesc, rawMimirConfig string) (amConfig, error) {
 	externalURL, err := url.Parse(gCfg.ExternalUrl)
 	if err != nil {
 		return amConfig{}, err

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -290,7 +290,7 @@ receivers:
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			am := MultitenantAlertmanager{logger: log.NewNopLogger()}
-			cfg, err := createUsableGrafanaConfig(am.logger, test.grafanaConfig, test.mimirConfig)
+			cfg, err := amConfigFromGrafanaConfig(am.logger, test.grafanaConfig, test.mimirConfig)
 			if test.expErr != "" {
 				require.Error(t, err)
 				require.Equal(t, test.expErr, err.Error())
@@ -326,7 +326,7 @@ receivers:
 
 			// Ensure that configuration is deterministic. For example, ordering of receivers.
 			// This is important for change detection.
-			cfg2, err := createUsableGrafanaConfig(am.logger, test.grafanaConfig, test.mimirConfig)
+			cfg2, err := amConfigFromGrafanaConfig(am.logger, test.grafanaConfig, test.mimirConfig)
 			require.NoError(t, err)
 
 			require.Equal(t, cfg.RawConfig, cfg2.RawConfig)

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -290,7 +290,7 @@ receivers:
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			am := MultitenantAlertmanager{logger: log.NewNopLogger()}
-			cfg, err := amConfigFromGrafanaConfig(am.logger, test.grafanaConfig, test.mimirConfig)
+			cfg, err := am.amConfigFromGrafanaConfig(test.grafanaConfig)
 			if test.expErr != "" {
 				require.Error(t, err)
 				require.Equal(t, test.expErr, err.Error())
@@ -326,7 +326,7 @@ receivers:
 
 			// Ensure that configuration is deterministic. For example, ordering of receivers.
 			// This is important for change detection.
-			cfg2, err := amConfigFromGrafanaConfig(am.logger, test.grafanaConfig, test.mimirConfig)
+			cfg2, err := am.amConfigFromGrafanaConfig(test.grafanaConfig)
 			require.NoError(t, err)
 
 			require.Equal(t, cfg.RawConfig, cfg2.RawConfig)

--- a/pkg/alertmanager/config_test.go
+++ b/pkg/alertmanager/config_test.go
@@ -78,7 +78,7 @@ const grafanaConfigWithDuplicateReceiverName = `{
 
 var grafanaConfigWithTemplates = `{"template_files":{"first.tpl":"{{ define \"t1\" }}Gra-gra{{end}}"},"templates":[{"name":"def.tpl","kind":"mimir","content":"{{ define \"t1\" }}Mimi-mi{{end}}"}],"alertmanager_config":{"route":{"receiver":"default","group_by":["grafana_folder","alertname"]},"receivers":[{"name":"default","grafana_managed_receiver_configs":[{"name":"WH","type":"webhook","settings":{"url":"http://localhost:8080"}}],"webhook_configs":[{"url":"http://localhost:8081"}]}]}}`
 
-func TestCreateUsableGrafanaConfig(t *testing.T) {
+func TestAmConfigFromGrafanaConfig(t *testing.T) {
 	defaultFromAddress := "grafana@example.com"
 	mimirConfig := fmt.Sprintf(`
 global:
@@ -108,7 +108,7 @@ receivers:
 	tests := []struct {
 		name                 string
 		grafanaConfig        alertspb.GrafanaAlertConfigDesc
-		mimirConfig          string
+		fallbackConfig       string
 		expEmailSenderConfig receivers.EmailSenderConfig
 		expErr               string
 		expTemplates         []definition.PostableApiTemplate
@@ -119,8 +119,8 @@ receivers:
 				ExternalUrl: externalURL,
 				RawConfig:   "",
 			},
-			mimirConfig: mimirConfig,
-			expErr:      "failed to unmarshal Grafana Alertmanager configuration: unexpected end of JSON input",
+			fallbackConfig: mimirConfig,
+			expErr:         "failed to unmarshal Grafana Alertmanager configuration: unexpected end of JSON input",
 		},
 		{
 			name: "invalid grafana config",
@@ -129,11 +129,11 @@ receivers:
 				RawConfig:   "invalid",
 				SmtpConfig:  smtpConfig,
 			},
-			mimirConfig: mimirConfig,
-			expErr:      "failed to unmarshal Grafana Alertmanager configuration: invalid character 'i' looking for beginning of value",
+			fallbackConfig: mimirConfig,
+			expErr:         "failed to unmarshal Grafana Alertmanager configuration: invalid character 'i' looking for beginning of value",
 		},
 		{
-			name: "no mimir config",
+			name: "no fallback config",
 			grafanaConfig: alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl: externalURL,
 				RawConfig:   grafanaConfig,
@@ -142,7 +142,7 @@ receivers:
 			expEmailSenderConfig: baseEmailSenderConfig,
 		},
 		{
-			name: "no mimir config, custom SMTP config",
+			name: "no fallback config, custom SMTP config",
 			grafanaConfig: alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl: externalURL,
 				RawConfig:   grafanaConfig,
@@ -183,17 +183,17 @@ receivers:
 			expEmailSenderConfig: baseEmailSenderConfig,
 		},
 		{
-			name: "non-empty mimir config",
+			name: "non-empty fallback config",
 			grafanaConfig: alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl: externalURL,
 				RawConfig:   grafanaConfig,
 				SmtpConfig:  smtpConfig,
 			},
-			mimirConfig:          mimirConfig,
+			fallbackConfig:       mimirConfig,
 			expEmailSenderConfig: baseEmailSenderConfig,
 		},
 		{
-			name: "non-empty mimir config, empty SMTP from address",
+			name: "non-empty fallback config, empty SMTP from address",
 			grafanaConfig: alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl: externalURL,
 				RawConfig:   grafanaConfig,
@@ -201,7 +201,7 @@ receivers:
 					StaticHeaders: staticHeaders,
 				},
 			},
-			mimirConfig: mimirConfig,
+			fallbackConfig: mimirConfig,
 			expEmailSenderConfig: receivers.EmailSenderConfig{
 				ContentTypes:  baseEmailSenderConfig.ContentTypes,
 				EhloIdentity:  baseEmailSenderConfig.EhloIdentity,
@@ -213,14 +213,14 @@ receivers:
 			},
 		},
 		{
-			name: "non-empty mimir config, SmtpFrom and StaticHeaders fields",
+			name: "non-empty fallback config, SmtpFrom and StaticHeaders fields",
 			grafanaConfig: alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl:   externalURL,
 				RawConfig:     grafanaConfig,
 				SmtpFrom:      "custom@example.com",
 				StaticHeaders: map[string]string{"test": "test"},
 			},
-			mimirConfig: mimirConfig,
+			fallbackConfig: mimirConfig,
 			expEmailSenderConfig: receivers.EmailSenderConfig{
 				ContentTypes:  baseEmailSenderConfig.ContentTypes,
 				EhloIdentity:  baseEmailSenderConfig.EhloIdentity,
@@ -232,7 +232,7 @@ receivers:
 			},
 		},
 		{
-			name: "non-empty mimir config, custom SMTP config",
+			name: "non-empty fallback config, custom SMTP config",
 			grafanaConfig: alertspb.GrafanaAlertConfigDesc{
 				ExternalUrl: externalURL,
 				RawConfig:   grafanaConfig,
@@ -248,7 +248,7 @@ receivers:
 					User:           "custom-user",
 				},
 			},
-			mimirConfig: mimirConfig,
+			fallbackConfig: mimirConfig,
 			expEmailSenderConfig: receivers.EmailSenderConfig{
 				AuthPassword:   "custom-password",
 				AuthUser:       "custom-user",
@@ -289,7 +289,10 @@ receivers:
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			am := MultitenantAlertmanager{logger: log.NewNopLogger()}
+			am := MultitenantAlertmanager{
+				logger:         log.NewNopLogger(),
+				fallbackConfig: test.fallbackConfig,
+			}
 			cfg, err := am.amConfigFromGrafanaConfig(test.grafanaConfig)
 			if test.expErr != "" {
 				require.Error(t, err)

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -805,7 +805,7 @@ func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs)
 
 	if !isMimirConfigCustom {
 		level.Debug(am.logger).Log("msg", "using grafana config with the default globals", "user", userID)
-		cfg, err := amConfigFromGrafanaConfig(am.logger, cfgs.Grafana, am.fallbackConfig)
+		cfg, err := am.amConfigFromGrafanaConfig(cfgs.Grafana)
 		return cfg, true, err
 	}
 

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -805,7 +805,7 @@ func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs)
 
 	if !isMimirConfigCustom {
 		level.Debug(am.logger).Log("msg", "using grafana config with the default globals", "user", userID)
-		cfg, err := createUsableGrafanaConfig(am.logger, cfgs.Grafana, am.fallbackConfig)
+		cfg, err := amConfigFromGrafanaConfig(am.logger, cfgs.Grafana, am.fallbackConfig)
 		return cfg, true, err
 	}
 

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -455,7 +455,7 @@ templates:
 	require.Len(t, am.alertmanagers, 4)
 
 	// The Mimir configuration was empty, so the Grafana configuration should be chosen for user 4.
-	amCfg, err := createUsableGrafanaConfig(am.logger, userGrafanaCfg, am.fallbackConfig)
+	amCfg, err := amConfigFromGrafanaConfig(am.logger, userGrafanaCfg, am.fallbackConfig)
 	require.NoError(t, err)
 	grafanaAlertConfigDesc := amCfg
 	require.Equal(t, grafanaAlertConfigDesc.fingerprint(), am.cfgs["user4"])

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -455,7 +455,7 @@ templates:
 	require.Len(t, am.alertmanagers, 4)
 
 	// The Mimir configuration was empty, so the Grafana configuration should be chosen for user 4.
-	amCfg, err := amConfigFromGrafanaConfig(am.logger, userGrafanaCfg, am.fallbackConfig)
+	amCfg, err := am.amConfigFromGrafanaConfig(userGrafanaCfg)
 	require.NoError(t, err)
 	grafanaAlertConfigDesc := amCfg
 	require.Equal(t, grafanaAlertConfigDesc.fingerprint(), am.cfgs["user4"])


### PR DESCRIPTION
This PR refactors the `createUsableGrafanaConfig` function.

Three changes:
- Rename to `amConfigFromGrafanaConfig`: It's not clear what "usable" means. The name `amConfigFromGrafanaConfig` implies we're creating an `amConfig` from a Grafana configuration.
- Make it a method in the `MultitenantAlertmanager`: we can use the logger and fallback configs in the struct instead of always passing them as arguments
- Remove logger and config arguments: we're always using the same config and loggers, it's unnecessary for the caller to always pass these

Part of https://github.com/grafana/mimir/pull/12272