### PR TITLE
Remove unsafe from mimirpb.CopyLabels

### DIFF
--- a/pkg/mimirpb/compat_slice_test.go
+++ b/pkg/mimirpb/compat_slice_test.go
@@ -1,0 +1,37 @@
+package mimirpb
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyLabels(t *testing.T) {
+	t.Parallel()
+
+	expected := []labels.Label{
+		{Name: "name1", Value: "value1"},
+		{Name: "name2", Value: "value2"},
+	}
+	got := []labels.Label(CopyLabels(expected))
+	require.Equal(t, expected, got)
+
+	// Check that all strings share the same underlying buffer
+	var base uintptr
+	var offset int
+	for i, label := range got {
+		name := unsafe.StringData(label.Name)
+		value := unsafe.StringData(label.Value)
+
+		if i == 0 {
+			base = uintptr(unsafe.Pointer(name))
+		}
+
+		require.Equal(t, base+uintptr(offset), uintptr(unsafe.Pointer(name)))
+		offset += len(label.Name)
+		require.Equal(t, base+uintptr(offset), uintptr(unsafe.Pointer(value)))
+		offset += len(label.Value)
+	}
+}


### PR DESCRIPTION
#### What this PR does

Part of a bigger effort to contain the unsafety within mimirpb.

`CopyLabels` can be implemented in a safe manner with the same memory optimization by using a StringBuilder rather than a `[]byte` and `yoloString`.

#### Which issue(s) this PR fixes or relates to

https://grafana.com/blog/2025/08/03/grafana-cloud-metrics-memory-corruption-issue-resolved/

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
