### PR TITLE
Alertmanager: Rename and move newMimirAmConfigFromDesc

### DIFF
--- a/pkg/alertmanager/config.go
+++ b/pkg/alertmanager/config.go
@@ -148,6 +148,16 @@ func createUsableGrafanaConfig(logger log.Logger, gCfg alertspb.GrafanaAlertConf
 	}, nil
 }
 
+func amConfigFromMimirConfig(dec alertspb.AlertConfigDesc, url *url.URL) amConfig {
+	return amConfig{
+		User:               dec.User,
+		RawConfig:          dec.RawConfig,
+		Templates:          templateDescToPostableApiTemplate(dec.Templates, definition.MimirTemplateKind),
+		TmplExternalURL:    url,
+		UsingGrafanaConfig: false,
+	}
+}
+
 func templateDescToPostableApiTemplate(t []*alertspb.TemplateDesc, kind definition.TemplateKind) []definition.PostableApiTemplate {
 	result := make([]definition.PostableApiTemplate, 0, len(t))
 	for _, desc := range t {

--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -764,7 +764,7 @@ func (am *MultitenantAlertmanager) syncConfigs(ctx context.Context, cfgMap map[s
 // It returns the final configuration and a bool indicating whether the Alertmanager should be started for the tenant.
 func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs) (amConfig, bool, error) {
 	userID := cfgs.Mimir.User
-	cfg := newMimirAmConfigFromDesc(cfgs.Mimir, am.cfg.ExternalURL.URL)
+	cfg := amConfigFromMimirConfig(cfgs.Mimir, am.cfg.ExternalURL.URL)
 
 	// Check if tenants can be skipped (strict initialization enabled).
 	skippable := am.cfg.StrictInitializationEnabled
@@ -898,16 +898,6 @@ type amConfig struct {
 	TmplExternalURL    *url.URL
 	UsingGrafanaConfig bool
 	EmailConfig        alertingReceivers.EmailSenderConfig
-}
-
-func newMimirAmConfigFromDesc(dec alertspb.AlertConfigDesc, url *url.URL) amConfig {
-	return amConfig{
-		User:               dec.User,
-		RawConfig:          dec.RawConfig,
-		Templates:          templateDescToPostableApiTemplate(dec.Templates, definition.MimirTemplateKind),
-		TmplExternalURL:    url,
-		UsingGrafanaConfig: false,
-	}
 }
 
 func (f amConfig) fingerprint() model.Fingerprint {
@@ -1278,7 +1268,7 @@ func (am *MultitenantAlertmanager) alertmanagerFromFallbackConfig(ctx context.Co
 	}
 
 	// Calling setConfig with an empty configuration will use the fallback config.
-	amConfig := newMimirAmConfigFromDesc(cfgDesc, am.cfg.ExternalURL.URL)
+	amConfig := amConfigFromMimirConfig(cfgDesc, am.cfg.ExternalURL.URL)
 	err = am.setConfig(amConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -319,7 +319,7 @@ func TestMultitenantAlertmanager_loadAndSyncConfigs(t *testing.T) {
 
 	currentConfigFp, cfgExists := am.cfgs["user1"]
 	require.True(t, cfgExists)
-	require.Equal(t, newMimirAmConfigFromDesc(user1Cfg, cfg.ExternalURL.URL).fingerprint(), currentConfigFp)
+	require.Equal(t, amConfigFromMimirConfig(user1Cfg, cfg.ExternalURL.URL).fingerprint(), currentConfigFp)
 
 	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 		# HELP cortex_alertmanager_config_last_reload_successful Boolean set to 1 whenever the last configuration reload attempt was successful.
@@ -359,7 +359,7 @@ templates:
 	require.True(t, dirExists(t, user3Dir))
 	finalUserCfgFp, ok := am.cfgs["user3"]
 	require.True(t, ok)
-	require.Equal(t, newMimirAmConfigFromDesc(user3Cfg, cfg.ExternalURL.URL).fingerprint(), finalUserCfgFp)
+	require.Equal(t, amConfigFromMimirConfig(user3Cfg, cfg.ExternalURL.URL).fingerprint(), finalUserCfgFp)
 	user3Am, ok := am.alertmanagers["user3"]
 	require.True(t, ok)
 	require.Len(t, user3Am.templates, 2)
@@ -387,7 +387,7 @@ templates:
 
 	currentConfigFp, cfgExists = am.cfgs["user1"]
 	require.True(t, cfgExists)
-	expectedFp := newMimirAmConfigFromDesc(user1Cfg, cfg.ExternalURL.URL).fingerprint()
+	expectedFp := amConfigFromMimirConfig(user1Cfg, cfg.ExternalURL.URL).fingerprint()
 	require.Equal(t, expectedFp, currentConfigFp)
 
 	// Ensure the config is reloaded if only templates changed
@@ -411,7 +411,7 @@ templates:
 
 	currentConfigFp, cfgExists = am.cfgs["user1"]
 	require.True(t, cfgExists)
-	expectedFp = newMimirAmConfigFromDesc(user1Cfg, cfg.ExternalURL.URL).fingerprint()
+	expectedFp = amConfigFromMimirConfig(user1Cfg, cfg.ExternalURL.URL).fingerprint()
 	require.Equal(t, expectedFp, currentConfigFp)
 	user1Am, ok := am.alertmanagers["user1"]
 	require.True(t, ok)
@@ -587,7 +587,7 @@ templates:
 
 	currentConfigFp, cfgExists = am.cfgs["user3"]
 	require.True(t, cfgExists)
-	expectedFp = newMimirAmConfigFromDesc(user3Cfg, cfg.ExternalURL.URL).fingerprint()
+	expectedFp = amConfigFromMimirConfig(user3Cfg, cfg.ExternalURL.URL).fingerprint()
 	require.Equal(t, expectedFp, currentConfigFp)
 
 	_, cfgExists = am.alertmanagers["user3"]


### PR DESCRIPTION
This PR renames newMimirAmConfigFromDesc to amConfigFromMimirConfig (similar to https://github.com/grafana/mimir/pull/12289) and moves it to `config.go`.