### PR TITLE
test(otlp): test start time handling end 2 end

### DIFF
--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -408,7 +408,7 @@ func testStartTimeHandling(t *testing.T, enableCTzero bool) {
 			expectCTzero: false,
 		},
 		"start time ok": {
-			startTs:      now.Add(-2 * time.Minute),
+			startTs:      now.Add(-30 * time.Second),
 			expectCTzero: true,
 		},
 		"start time equal to sample timestamp": {
@@ -416,7 +416,7 @@ func testStartTimeHandling(t *testing.T, enableCTzero bool) {
 			expectCTzero: false,
 		},
 		"start time in the future": {
-			startTs:      now.Add(2 * time.Minute),
+			startTs:      now.Add(30 * time.Second),
 			expectCTzero: false,
 		},
 	}


### PR DESCRIPTION
Prepare for the rewrite of the OTLP translator upstream in https://github.com/prometheus/prometheus/pull/16951 by adding an end-to-end test to check for regressions.

Related to https://github.com/grafana/mimir/pull/12152.

Also switch from raw JSON in the test to building the payload in code and marshaling to protobuf.
