### PR TITLE
ingest-storage: Avoid mutating RW2 timeseries when resymbolizing them for better memory safety

### DIFF
--- a/pkg/mimirpb/split.go
+++ b/pkg/mimirpb/split.go
@@ -89,7 +89,6 @@ func SplitWriteRequestByMaxMarshalSizeRW2(req *WriteRequest, reqSize, maxSize in
 		// if a single timeseries is bigger than the limit.
 		if nextReqSize+seriesSize+symbolsSize > maxSize && len(nextReq.TimeseriesRW2) > 0 {
 			// Finalize the next partial request.
-			// nextReq.TimeseriesRW2 = req.TimeseriesRW2[nextReqTimeseriesStart : nextReqTimeseriesStart+nextReqTimeseriesLength]
 			nextReq.SymbolsRW2 = nextReqSymbols.Symbols()
 			partialReqs = append(partialReqs, nextReq)
 


### PR DESCRIPTION
#### What this PR does

This PR addresses a [comment](https://github.com/grafana/mimir/pull/12166#pullrequestreview-3068093028) from @pracucci on https://github.com/grafana/mimir/pull/12166.

That PR, as an optimization, resymbolizes RW2 requests in-place when splitting in order to minimize allocations. It works, but it's difficult to maintain - as editing the request in place means that the input labels references are mutated.

Request splits are exceedingly uncommon in practice. And, since RW2 shrinks the ingest-storage record size by well over half, they become even more rare going forward. The consensus was that we can relax the performance constraint (and afford a few allocations) in favor of safety.

This PR moves to allocating fresh LabelsRef slices when we're about to mutate them, plus a fresh slice of timeseries per sub-request rather than slicing up the input request. Anything that's mutated is copied, everything else is shallow-copied.

`resymbolizeTimeSeriesRW2` now returns the resymbolized request instead of a size delta. We then can simply compare the size delta after the fact, by comparing the new and old timeseries, meaning we can eliminate a good chunk of copied proto math as well :smile: 

#### Which issue(s) this PR fixes or relates to

contrib https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
