### PR TITLE
Add reordering of histogram aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [FEATURE] Distributor, ruler: Add experimental `-validation.name-validation-scheme` flag to specify the validation scheme for metric and label names. #12215
 * [FEATURE] Distributor: Add experimental `-distributor.otel-translation-strategy` flag to support configuring the metric and label name translation strategy in the OTLP endpoint. #12284 #12306 #12369
 * [FEATURE] Query-frontend: Add `query-frontend.rewrite-propagate-matchers` flag that enables a new MQE AST optimization pass that copies relevant label matchers across binary operations. #12304
+* [FEATURE] Query-frontend: Add `query-frontend.rewrite-histogram-queries` flag that enables a new MQE AST optimization pass that rewrites histogram queries for a more efficient order of execution. #12305
 * [FEATURE] Usage-tracker: Introduce a new experimental service to enforce active series limits before Kafka ingestion. #12358
 * [FEATURE] Ingester: Add experimental `-include-tenant-id-in-profile-labels` flag to include tenant ID in pprof profiling labels for sampled traces. Currently only supported by the ingester. This can help debug performance issues for specific tenants. #12404
 * [FEATURE] Alertmanager: Add experimental `-alertmanager.storage.state-read-timeout` flag to configure the timeout for reading the Alertmanager state (notification log, silences) from object storage during the initial sync. #12425

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7817,6 +7817,17 @@
         },
         {
           "kind": "field",
+          "name": "rewrite_histogram_queries",
+          "required": false,
+          "desc": "Set to true to enable rewriting histogram queries for a more efficient order of execution.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-frontend.rewrite-histogram-queries",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "rewrite_propagate_matchers",
           "required": false,
           "desc": "Set to true to enable rewriting queries to propagate label matchers across binary expressions.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2409,6 +2409,8 @@ Usage of ./cmd/mimir/mimir:
     	Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
   -query-frontend.results-cache.memcached.tls-server-name string
     	Override the expected name on the server certificate.
+  -query-frontend.rewrite-histogram-queries
+    	[experimental] Set to true to enable rewriting histogram queries for a more efficient order of execution.
   -query-frontend.rewrite-propagate-matchers
     	[experimental] Set to true to enable rewriting queries to propagate label matchers across binary expressions.
   -query-frontend.scheduler-address string

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2845,6 +2845,11 @@ results_cache:
 # CLI flag: -query-frontend.parallelize-shardable-queries
 [parallelize_shardable_queries: <boolean> | default = false]
 
+# (experimental) Set to true to enable rewriting histogram queries for a more
+# efficient order of execution.
+# CLI flag: -query-frontend.rewrite-histogram-queries
+[rewrite_histogram_queries: <boolean> | default = false]
+
 # (experimental) Set to true to enable rewriting queries to propagate label
 # matchers across binary expressions.
 # CLI flag: -query-frontend.rewrite-propagate-matchers

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -66,6 +66,7 @@ type Config struct {
 	MaxRetries                      int                `yaml:"max_retries" category:"advanced"`
 	NotRunningTimeout               time.Duration      `yaml:"not_running_timeout" category:"advanced"`
 	ShardedQueries                  bool               `yaml:"parallelize_shardable_queries"`
+	RewriteQueriesHistogram         bool               `yaml:"rewrite_histogram_queries" category:"experimental"`
 	RewriteQueriesPropagateMatchers bool               `yaml:"rewrite_propagate_matchers" category:"experimental"`
 	TargetSeriesPerShard            uint64             `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
 	ShardActiveSeriesQueries        bool               `yaml:"shard_active_series_queries" category:"experimental"`
@@ -98,6 +99,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.CacheResults, "query-frontend.cache-results", false, "Cache query results.")
 	f.BoolVar(&cfg.CacheErrors, "query-frontend.cache-errors", false, "Cache non-transient errors from queries.")
 	f.BoolVar(&cfg.ShardedQueries, "query-frontend.parallelize-shardable-queries", false, "True to enable query sharding.")
+	f.BoolVar(&cfg.RewriteQueriesHistogram, "query-frontend.rewrite-histogram-queries", false, "Set to true to enable rewriting histogram queries for a more efficient order of execution.")
 	f.BoolVar(&cfg.RewriteQueriesPropagateMatchers, "query-frontend.rewrite-propagate-matchers", false, "Set to true to enable rewriting queries to propagate label matchers across binary expressions.")
 	f.Uint64Var(&cfg.TargetSeriesPerShard, "query-frontend.query-sharding-target-series-per-shard", 0, "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.")
 	f.Var(&cfg.ExtraPropagateHeaders, "query-frontend.extra-propagated-headers", "Comma-separated list of request header names to allow to pass through to the rest of the query path. This is in addition to a list of required headers that the read path needs.")
@@ -130,6 +132,10 @@ func (cfg *Config) Validate() error {
 
 func (cfg *Config) cardinalityBasedShardingEnabled() bool {
 	return cfg.TargetSeriesPerShard > 0
+}
+
+func (cfg *Config) isPruningQueriesEnabled() bool {
+	return cfg.RewriteQueriesHistogram || cfg.RewriteQueriesPropagateMatchers
 }
 
 // HandlerFunc is like http.HandlerFunc, but for MetricsQueryHandler.
@@ -466,7 +472,7 @@ func newQueryMiddlewares(
 	)
 
 	// This is here for now as we need to run it before query sharding, but we plan to make it an AST optimization pass later.
-	if cfg.RewriteQueriesPropagateMatchers {
+	if cfg.isPruningQueriesEnabled() {
 		rewriteMiddleware := newRewriteMiddleware(log, cfg, registerer)
 		queryRangeMiddleware = append(
 			queryRangeMiddleware,

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -573,11 +573,13 @@ func TestMiddlewaresConsistency(t *testing.T) {
 	cfg := makeTestConfig()
 	cfg.CacheResults = true
 	cfg.ShardedQueries = true
+	cfg.RewriteQueriesHistogram = true
 	cfg.RewriteQueriesPropagateMatchers = true
 
 	// Ensure all features are enabled, so that we assert on all middlewares.
 	require.NotZero(t, cfg.CacheResults)
 	require.NotZero(t, cfg.ShardedQueries)
+	require.NotZero(t, cfg.RewriteQueriesHistogram)
 	require.NotZero(t, cfg.RewriteQueriesPropagateMatchers)
 	require.NotZero(t, cfg.SplitQueriesByInterval)
 	require.NotZero(t, cfg.MaxRetries)

--- a/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation.go
+++ b/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ast
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
+)
+
+// NewReorderHistogramAggregationMapper optimizes queries by reordering histogram functions and aggregations
+// for more efficient execution.
+func NewReorderHistogramAggregationMapper() *astmapper.ASTExprMapperWithState {
+	mapper := &reorderHistogramAggregation{}
+	return astmapper.NewASTExprMapperWithState(mapper)
+}
+
+type reorderHistogramAggregation struct {
+	changed bool
+}
+
+func (mapper *reorderHistogramAggregation) HasChanged() bool {
+	return mapper.changed
+}
+
+func (mapper *reorderHistogramAggregation) MapExpr(ctx context.Context, expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
+	call, ok := expr.(*parser.Call)
+	if !ok || !mapper.isSwitchableCall(call.Func) {
+		return expr, false, nil
+	}
+
+	if len(call.Args) != 1 {
+		return expr, false, nil
+	}
+
+	agg, ok := call.Args[0].(*parser.AggregateExpr)
+	if !ok || !mapper.isSwitchableAgg(agg.Op) {
+		return expr, false, nil
+	}
+
+	for _, label := range agg.Grouping {
+		if label == labels.MetricName {
+			// Do not reorder if __name__ is used in grouping, as it can lead to incorrect aggregations.
+			return expr, false, nil
+		}
+	}
+
+	if vectorSelectorContainsNonExactMetricNameMatcher(agg.Expr) {
+		// Do not reorder if any vector selector matcher specifies __name__, as it can lead to errors due to duplicate label sets.
+		return expr, false, nil
+	}
+
+	newExpr := &parser.AggregateExpr{
+		Op: agg.Op,
+		Expr: &parser.Call{
+			Func:     call.Func,
+			Args:     []parser.Expr{agg.Expr},
+			PosRange: call.PosRange,
+		},
+		Param:    agg.Param,
+		Grouping: agg.Grouping,
+		Without:  agg.Without,
+		PosRange: agg.PosRange,
+	}
+
+	mapper.changed = true
+
+	return newExpr, false, nil
+}
+
+func (*reorderHistogramAggregation) isSwitchableCall(callFunc *parser.Function) bool {
+	return callFunc.Name == "histogram_sum" || callFunc.Name == "histogram_count"
+}
+
+func (*reorderHistogramAggregation) isSwitchableAgg(op parser.ItemType) bool {
+	return op == parser.SUM || op == parser.AVG
+}
+
+func vectorSelectorContainsNonExactMetricNameMatcher(expr parser.Expr) bool {
+	switch e := expr.(type) {
+	case *parser.VectorSelector:
+		for _, matcher := range e.LabelMatchers {
+			if matcher.Name == labels.MetricName && matcher.Type != labels.MatchEqual {
+				return true
+			}
+		}
+		return false
+	case *parser.MatrixSelector:
+		return vectorSelectorContainsNonExactMetricNameMatcher(e.VectorSelector)
+	case *parser.ParenExpr:
+		return vectorSelectorContainsNonExactMetricNameMatcher(e.Expr)
+	case *parser.UnaryExpr:
+		return vectorSelectorContainsNonExactMetricNameMatcher(e.Expr)
+	case *parser.Call:
+		// TODO: Handle more cases in this function and check if we need a separate one for this pass.
+		if i, _ := VectorSelectorArgumentIndex(e.Func.Name); i >= 0 {
+			if len(e.Args) <= i {
+				return false
+			}
+			return vectorSelectorContainsNonExactMetricNameMatcher(e.Args[i])
+		}
+		// If unsure, don't reorder.
+		return true
+	case *parser.AggregateExpr:
+		return vectorSelectorContainsNonExactMetricNameMatcher(e.Expr)
+	case *parser.BinaryExpr:
+		if vectorSelectorContainsNonExactMetricNameMatcher(e.LHS) {
+			return true
+		}
+		return vectorSelectorContainsNonExactMetricNameMatcher(e.RHS)
+	default:
+		// If unsure, don't reorder.
+		return true
+	}
+}

--- a/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation_test.go
+++ b/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ast_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/optimize/ast"
+)
+
+var testCasesReorderHistogramAggregation = map[string]string{
+	`histogram_sum(sum(foo))`:                   `sum(histogram_sum(foo))`,
+	`sum(histogram_sum(foo))`:                   `sum(histogram_sum(foo))`,
+	`histogram_sum(avg(foo))`:                   `avg(histogram_sum(foo))`,
+	`avg(histogram_sum(foo))`:                   `avg(histogram_sum(foo))`,
+	`histogram_sum(sum(rate(foo[2m])))`:         `sum(histogram_sum(rate(foo[2m])))`,
+	`sum(histogram_sum(rate(foo[2m])))`:         `sum(histogram_sum(rate(foo[2m])))`,
+	`histogram_sum(avg(rate(foo[2m])))`:         `avg(histogram_sum(rate(foo[2m])))`,
+	`avg(histogram_sum(rate(foo[2m])))`:         `avg(histogram_sum(rate(foo[2m])))`,
+	`histogram_count(sum(foo))`:                 `sum(histogram_count(foo))`,
+	`sum(histogram_count(foo))`:                 `sum(histogram_count(foo))`,
+	`histogram_count(avg(foo))`:                 `avg(histogram_count(foo))`,
+	`avg(histogram_count(foo))`:                 `avg(histogram_count(foo))`,
+	`histogram_count(sum(rate(foo[2m])))`:       `sum(histogram_count(rate(foo[2m])))`,
+	`sum(histogram_count(rate(foo[2m])))`:       `sum(histogram_count(rate(foo[2m])))`,
+	`histogram_count(avg(rate(foo[2m])))`:       `avg(histogram_count(rate(foo[2m])))`,
+	`avg(histogram_count(rate(foo[2m])))`:       `avg(histogram_count(rate(foo[2m])))`,
+	`(((histogram_sum(sum(foo)))))`:             `(((sum(histogram_sum(foo)))))`,
+	`histogram_sum(sum(foo+bar))`:               `sum(histogram_sum(foo+bar))`,
+	`histogram_sum(sum(foo)+sum(bar))`:          `histogram_sum(sum(foo)+sum(bar))`,
+	"histogram_sum(sum by (job) (foo))":         "sum by (job) (histogram_sum(foo))",
+	"histogram_sum(sum without (job) (foo))":    "sum without (job) (histogram_sum(foo))",
+	"histogram_sum(rate(foo[2m]))":              "histogram_sum(rate(foo[2m]))",
+	`3 + (((histogram_sum(sum(foo)))))`:         `3 + (((sum(histogram_sum(foo)))))`,
+	`vector(3) + (((histogram_sum(sum(foo)))))`: `vector(3) + (((sum(histogram_sum(foo)))))`,
+
+	// Do not reorder when __name__ is used in grouping or matcher as the histogram function drops the metric name which will cause incorrect aggregations or vector cannot contain metrics with the same labelset error.
+	`histogram_sum(sum by (__name__) (foo))`:            `histogram_sum(sum by (__name__) (foo))`,
+	`histogram_sum(sum({__name__=~"foo.*"}))`:           `histogram_sum(sum({__name__=~"foo.*"}))`,
+	`histogram_sum(sum(rate({__name__=~"foo.*"}[2m])))`: `histogram_sum(sum(rate({__name__=~"foo.*"}[2m])))`,
+}
+
+func TestReorderHistogramAggregation(t *testing.T) {
+	ctx := context.Background()
+
+	for input, expected := range testCasesReorderHistogramAggregation {
+		t.Run(input, func(t *testing.T) {
+			expectedExpr, err := parser.ParseExpr(expected)
+			require.NoError(t, err)
+
+			inputExpr, err := parser.ParseExpr(input)
+			require.NoError(t, err)
+			optimizer := ast.NewReorderHistogramAggregationMapper()
+			outputExpr, err := optimizer.Map(ctx, inputExpr)
+			require.NoError(t, err)
+
+			require.Equal(t, expectedExpr.String(), outputExpr.String())
+			require.Equal(t, input != expected, optimizer.HasChanged())
+		})
+	}
+}
+
+func TestReorderHistogramAggregationWithData(t *testing.T) {
+	testASTOptimizationPassWithData(t, `
+		load 1m
+			foo	{{schema:0 sum:4 count:4 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x<num samples>
+			bar	{{schema:0 sum:4 count:4 buckets:[1 2 1]}}+{{sum:4 count:2 buckets:[1 2] offset:1}}x<num samples>
+	`, testCasesReorderHistogramAggregation)
+}

--- a/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation_test.go
+++ b/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation_test.go
@@ -38,6 +38,16 @@ var testCasesReorderHistogramAggregation = map[string]string{
 	`3 + (((histogram_sum(sum(foo)))))`:         `3 + (((sum(histogram_sum(foo)))))`,
 	`vector(3) + (((histogram_sum(sum(foo)))))`: `vector(3) + (((sum(histogram_sum(foo)))))`,
 
+	// Unsupported aggregations
+	`histogram_sum(max(foo))`:     `histogram_sum(max(foo))`,
+	`max(histogram_sum(foo))`:     `max(histogram_sum(foo))`,
+	`histogram_count(max(foo))`:   `histogram_count(max(foo))`,
+	`max(histogram_count(foo))`:   `max(histogram_count(foo))`,
+	`histogram_sum(count(foo))`:   `histogram_sum(count(foo))`,
+	`count(histogram_sum(foo))`:   `count(histogram_sum(foo))`,
+	`histogram_count(group(foo))`: `histogram_count(group(foo))`,
+	`group(histogram_count(foo))`: `group(histogram_count(foo))`,
+
 	// Do not reorder when __name__ is used in grouping or matcher as the histogram function drops the metric name which will cause incorrect aggregations or vector cannot contain metrics with the same labelset error.
 	`histogram_sum(sum by (__name__) (foo))`:            `histogram_sum(sum by (__name__) (foo))`,
 	`histogram_sum(sum({__name__=~"foo.*"}))`:           `histogram_sum(sum({__name__=~"foo.*"}))`,

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -54,7 +54,7 @@ func NewQueryPlanner(opts EngineOpts) *QueryPlanner {
 		planner.RegisterASTOptimizationPass(ast.NewPruneToggles(opts.CommonOpts.Reg)) // Do this next to ensure that toggled off expressions are removed before the other optimization passes are applied.
 	}
 	planner.RegisterASTOptimizationPass(&ast.SortLabelsAndMatchers{}) // This is a prerequisite for other optimization passes such as common subexpression elimination.
-	// After query sharding is moved here, we want to move propagate matchers here as well before query sharding.
+	// After query sharding is moved here, we want to move propagate matchers and reorder histogram aggregation here as well before query sharding.
 
 	if opts.EnableCommonSubexpressionElimination {
 		planner.RegisterQueryPlanOptimizationPass(commonsubexpressionelimination.NewOptimizationPass(opts.EnableCommonSubexpressionEliminationForRangeVectorExpressionsInInstantQueries, opts.CommonOpts.Reg))


### PR DESCRIPTION
#### What this PR does

Add reordering of histogram aggregations as an AST optimisation pass but run in query frontend rewrite middleware (so that it can be run before query sharding).

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/3027

Split from https://github.com/grafana/mimir/pull/11971

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
