### PR TITLE
helm: deprecate metaMonitoring.grafanaAgent

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,9 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [CHANGE] Grafana Agent: Depreate `metaMonitoring.grafanaAgent` values. #12307
+  * Grafana Agent has been deprecated in earlier 2024, and will reach End-of-Support by the end of 2025.
+  * Instead of provisioning agent's Kubernetes resources with the chart's `metaMonitoring.grafanaAgent.enabled`, users are recommended to collect Mimir's meta-monitoring data with an external collector. We recommend Grafana k8s-monitoring, that manages the creation and lifecycle of Alloy instances, and has built-in support for collecting telemetry from Grafana LGTM stacks.
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to closer to the requested number of CPUs. #12150
 * [CHANGE] Query-scheduler: The query-scheduler is now a required component that is always used by queriers and query-frontends. #12188
 * [ENHANCEMENT] Gateway ingress: Support labels for gateway ingress. #11964

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,8 +30,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 ## main / unreleased
 
 * [CHANGE] Grafana Agent: Depreate `metaMonitoring.grafanaAgent` values. #12307
-  * Grafana Agent has been deprecated in earlier 2024, and will reach End-of-Support by the end of 2025.
-  * Instead of provisioning agent's Kubernetes resources with the chart's `metaMonitoring.grafanaAgent.enabled`, users are recommended to collect Mimir's meta-monitoring data with an external collector. We recommend Grafana k8s-monitoring, that manages the creation and lifecycle of Alloy instances, and has built-in support for collecting telemetry from Grafana LGTM stacks.
+  * Grafana Agent was deprecated in early 2024 and reaches End-of-Support at the end of 2025.
+  * Instead of provisioning agent's Kubernetes resources with the chart's `metaMonitoring.grafanaAgent.enabled`, collect Mimir's meta-monitoring data with an external collector. It's recommended to use Grafana k8s-monitoring, which manages the creation and lifecycle of Alloy instances and has built-in support for collecting telemetry from Grafana LGTM stacks.
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to closer to the requested number of CPUs. #12150
 * [CHANGE] Query-scheduler: The query-scheduler is now a required component that is always used by queriers and query-frontends. #12188
 * [ENHANCEMENT] Gateway ingress: Support labels for gateway ingress. #11964

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,7 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [CHANGE] Grafana Agent: Depreate `metaMonitoring.grafanaAgent` values. #12307
+* [CHANGE] Grafana Agent: Deprecate `metaMonitoring.grafanaAgent` values. #12307
   * Grafana Agent was deprecated in early 2024 and reaches End-of-Support at the end of 2025.
   * Instead of provisioning agent's Kubernetes resources with the chart's `metaMonitoring.grafanaAgent.enabled`, collect Mimir's meta-monitoring data with an external collector. It's recommended to use Grafana k8s-monitoring, which manages the creation and lifecycle of Alloy instances and has built-in support for collecting telemetry from Grafana LGTM stacks.
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to closer to the requested number of CPUs. #12150

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -31,7 +31,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [CHANGE] Grafana Agent: Deprecate `metaMonitoring.grafanaAgent` values. #12307
   * Grafana Agent was deprecated in early 2024 and reaches End-of-Support at the end of 2025.
-  * Instead of provisioning agent's Kubernetes resources with the chart's `metaMonitoring.grafanaAgent.enabled`, collect Mimir's meta-monitoring data with an external collector. It's recommended to use Grafana k8s-monitoring, which manages the creation and lifecycle of Alloy instances and has built-in support for collecting telemetry from Grafana LGTM stacks.
+  * Instead of provisioning the agent's Kubernetes resources with the chart's `metaMonitoring.grafanaAgent.enabled`, collect Mimir's meta-monitoring data with an external collector. It's recommended to use Grafana k8s-monitoring, which manages the creation and lifecycle of Alloy instances and has built-in support for collecting telemetry from Grafana LGTM stacks.
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to closer to the requested number of CPUs. #12150
 * [CHANGE] Query-scheduler: The query-scheduler is now a required component that is always used by queriers and query-frontends. #12188
 * [ENHANCEMENT] Gateway ingress: Support labels for gateway ingress. #11964

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3847,7 +3847,7 @@ metaMonitoring:
     labels:
       grafana_dashboard: "1"
 
-  # ServiceMonitor configuration for monitoring Kubernetes Services with Prometheus Operator and/or Grafana Agent
+  # ServiceMonitor configuration for monitoring Kubernetes Services with Prometheus Operator, Grafana Agent (deprecated), and/or Grafana Alloy
   serviceMonitor:
     # -- If enabled, ServiceMonitor resources for Prometheus Operator are created
     enabled: false
@@ -3916,7 +3916,9 @@ metaMonitoring:
   #    - expr: sum(rate(cortex_request_duration_seconds_count[1m])) by (cluster, job)
   #      record: cluster_job:cortex_request_duration_seconds_count:sum_rate
 
-  # metaMonitoringAgent configures the built in Grafana Agent that can scrape metrics and logs and send them to a local or remote destination
+  # -- DEPRECATED: Grafana Agent is deprecated and will reach the End-of-Support in the end of 2025.
+  # Users are recommended to switch to Grafana k8s-monitoring, that orchestrates the lifecycle of Grafana Alloy instances, and comes with built-in support for monitoring Grafana LGTM stacks (https://github.com/grafana/k8s-monitoring-helm/tree/k8s-monitoring-3.2.2/charts/k8s-monitoring)
+  # metaMonitoring.grafanaAgent configures the built in Grafana Agent that can scrape metrics and logs and send them to a local or remote destination
   grafanaAgent:
     # -- Controls whether to create PodLogs, MetricsInstance, LogsInstance, and GrafanaAgent CRs to scrape the
     # ServiceMonitors of the chart and ship metrics and logs to the remote endpoints below.
@@ -4114,6 +4116,8 @@ metaMonitoring:
         # matchLabelKeys:
         #   - pod-template-hash
 
+# -- DEPRECATED: Grafana Agent is deprecated and will reach the End-of-Support in the end of 2025.
+# Users are recommended to switch to Grafana k8s-monitoring (https://github.com/grafana/k8s-monitoring-helm/tree/k8s-monitoring-3.2.2/charts/k8s-monitoring)
 # -- Values exposed by the [Grafana agent-operator chart](https://github.com/grafana/helm-charts/blob/main/charts/agent-operator/values.yaml)
 grafana-agent-operator:
   podSecurityContext:


### PR DESCRIPTION
#### What this PR does

This PR marks `metaMonitoring.grafanaAgent` as deprecated, and suggests users to switch to external system, that can capture meta-monitoring telemetry.

Ref to a detailed explanation in the comment https://github.com/grafana/mimir/issues/5860#issuecomment-3035319639

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/5860