### PR TITLE
Block-Builder: Add Graceful Shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [CHANGE] Memcached: Remove experimental `-<prefix>.memcached.addresses-provider` flag to use alternate DNS service discovery backends. The more reliable backend introduced in 2.16.0 (#10895) is now the default. As a result of this change, DNS-based cache service discovery no longer supports search domains. #12175
 * [CHANGE] Query-frontend: Remove the CLI flag `-query-frontend.downstream-url` and corresponding YAML configuration and the ability to use the query-frontend to proxy arbitrary Prometheus backends. #12191
 * [CHANGE] Query-frontend: Remove experimental instant query splitting feature. #12267
+* [CHANGE] Block-builder: Add experimental `-block-builder.shutdown-grace-period` option to delay shutdown after last compaction. #12314
 * [FEATURE] Distributor, ruler: Add experimental `-validation.name-validation-scheme` flag to specify the validation scheme for metric and label names. #12215
 * [FEATURE] Distributor: Add experimental `-distributor.otel-enable-unescaped-names` flag to support disabling escaping of metric and label names in the OTLP endpoint. To use this, you also have to configure `-validation.name-validation-scheme=utf8`. #12284
 * [ENHANCEMENT] Compactor: Add `-compactor.update-blocks-concurrency` flag to control concurrency for updating block metadata during bucket index updates, separate from deletion marker concurrency. #12117

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -160,8 +160,8 @@ func (b *BlockBuilder) stopping(_ error) error {
 		ctx, cancel := context.WithTimeout(context.Background(), gracePeriod)
 		defer cancel()
 
-		lastUpd := b.lastCompactAndUploadTime.Load()
-		deadline := time.Unix(0, lastUpd).Add(gracePeriod)
+		lastJob := b.lastCompactAndUploadTime.Load()
+		deadline := time.Unix(0, lastJob).Add(gracePeriod)
 
 		if wait := time.Until(deadline); wait > 0 {
 			timer := time.NewTimer(wait)
@@ -348,7 +348,7 @@ consumerLoop:
 
 	var err error
 	blockMetas, err = builder.CompactAndUpload(ctx, b.uploadBlocks)
-	b.lastCompactAndUploadTime.Store(time.Now().Unix())
+	b.lastCompactAndUploadTime.Store(time.Now().UnixNano())
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -156,12 +156,12 @@ func (b *BlockBuilder) starting(context.Context) (err error) {
 
 func (b *BlockBuilder) stopping(_ error) error {
 
-	if delay := b.cfg.shutdownGracePeriod; delay > 0 {
-		ctx, cancel := context.WithTimeout(context.Background(), delay)
+	if gracePeriod := b.cfg.shutdownGracePeriod; gracePeriod > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), gracePeriod)
 		defer cancel()
 
 		lastUpd := b.lastCompactAndUploadTime.Load()
-		deadline := time.Unix(0, lastUpd).Add(delay)
+		deadline := time.Unix(0, lastUpd).Add(gracePeriod)
 
 		if wait := time.Until(deadline); wait > 0 {
 			timer := time.NewTimer(wait)


### PR DESCRIPTION
#### What this PR does

Block-Builder will attempt to complete a job it even if the service context is cancelled. In some cases, when the service processes a job right before shutdown, the metrics emitted for that job are never scraped. This PR adds `block-builder.shutdown-grace-period`, which blocks the `Service.stopping()`. This option should be configured long enough so that any pull-based metric collector can observe data related to the recently-completed job.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
