### PR TITLE
mimir-mixin: relax the guard in IngesterHasUnshippedBlocks when block-builder is running

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -853,7 +853,7 @@ spec:
               (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[1h] offset 4h)) > 0)
               # And only if blocks aren't shipped by the block-builder.
               unless on (cluster, namespace)
-              (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+              (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
             for: 15m
             labels:
               severity: critical
@@ -867,7 +867,7 @@ spec:
               (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
               # Only if blocks aren't shipped by the block-builder.
               unless on (cluster, namespace)
-              (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+              (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
             for: 4h
             labels:
               severity: critical
@@ -881,7 +881,7 @@ spec:
               (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)
               # Only if blocks aren't shipped by the block-builder.
               unless on (cluster, namespace)
-              (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+              (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
             for: 15m
             labels:
               severity: critical

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -827,7 +827,7 @@ groups:
             (max by(cluster, namespace, instance) (max_over_time(cluster_namespace_instance:cortex_ingester_ingested_samples_total:rate1m[1h] offset 4h)) > 0)
             # And only if blocks aren't shipped by the block-builder.
             unless on (cluster, namespace)
-            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           for: 15m
           labels:
             severity: critical
@@ -841,7 +841,7 @@ groups:
             (max by(cluster, namespace, instance) (max_over_time(cluster_namespace_instance:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
             # Only if blocks aren't shipped by the block-builder.
             unless on (cluster, namespace)
-            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           for: 4h
           labels:
             severity: critical
@@ -855,7 +855,7 @@ groups:
             (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)
             # Only if blocks aren't shipped by the block-builder.
             unless on (cluster, namespace)
-            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           for: 15m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -841,7 +841,7 @@ groups:
             (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[1h] offset 4h)) > 0)
             # And only if blocks aren't shipped by the block-builder.
             unless on (cluster, namespace)
-            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           for: 15m
           labels:
             severity: critical
@@ -855,7 +855,7 @@ groups:
             (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
             # Only if blocks aren't shipped by the block-builder.
             unless on (cluster, namespace)
-            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           for: 4h
           labels:
             severity: critical
@@ -869,7 +869,7 @@ groups:
             (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)
             # Only if blocks aren't shipped by the block-builder.
             unless on (cluster, namespace)
-            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           for: 15m
           labels:
             severity: critical

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -841,7 +841,7 @@ groups:
             (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[1h] offset 4h)) > 0)
             # And only if blocks aren't shipped by the block-builder.
             unless on (cluster, namespace)
-            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           for: 15m
           labels:
             severity: critical
@@ -855,7 +855,7 @@ groups:
             (max by(cluster, namespace, pod) (max_over_time(cluster_namespace_pod:cortex_ingester_ingested_samples_total:rate1m[4h])) > 0)
             # Only if blocks aren't shipped by the block-builder.
             unless on (cluster, namespace)
-            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           for: 4h
           labels:
             severity: critical
@@ -869,7 +869,7 @@ groups:
             (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)
             # Only if blocks aren't shipped by the block-builder.
             unless on (cluster, namespace)
-            (max by (cluster, namespace) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (cluster, namespace) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           for: 15m
           labels:
             severity: critical

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -23,7 +23,7 @@
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate%(recording_rules_range_interval)s[1h] offset 4h)) > 0)
             # And only if blocks aren't shipped by the block-builder.
             unless on (%(alert_aggregation_labels)s)
-            (max by (%(alert_aggregation_labels)s) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (%(alert_aggregation_labels)s) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
@@ -48,7 +48,7 @@
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate%(recording_rules_range_interval)s[4h])) > 0)
             # Only if blocks aren't shipped by the block-builder.
             unless on (%(alert_aggregation_labels)s)
-            (max by (%(alert_aggregation_labels)s) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (%(alert_aggregation_labels)s) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
@@ -74,7 +74,7 @@
             (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)
             # Only if blocks aren't shipped by the block-builder.
             unless on (%(alert_aggregation_labels)s)
-            (max by (%(alert_aggregation_labels)s) (cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 0)
+            (max by (%(alert_aggregation_labels)s) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
           },


### PR DESCRIPTION
#### What this PR does

This is an alternative fix for the issue, https://github.com/grafana/mimir/pull/12314 wanted to address (_providing I understood the motivation for later_).

We observed a couple of cases, where the block-builder deployment was restarted right around the end of its hourly cycle. This reset its `successful_compact_and_upload_timestamp_seconds`, and delays the next update of the metric, until the updated block-builders catch up. In turn, this caused the `MimirIngesterHasUnshippedBlocks` to fire, because the mentioned metric wasn't set.

This PR updates the `MimirIngesterHasUnshippedBlocks` (and related) alerts, relaxing the `unless ...` hand, so it looked it for the past N minutes, when it checked for block-builder's `successful_compact_and_upload_timestamp_seconds`.