### PR TITLE
Trigger request buffer reuse in distributor validation tests

### DIFF
--- a/pkg/costattribution/testutils/test_utils.go
+++ b/pkg/costattribution/testutils/test_utils.go
@@ -25,10 +25,10 @@ func NewMockCostAttributionOverrides(limits validation.Limits, overrides map[str
 		// user6 has opted to rename team to eng_team.
 		"user6": {MaxCostAttributionCardinality: 5, CostAttributionLabelsStructured: []costattributionmodel.Label{{Input: "team", Output: "eng_team"}}},
 	}
-	for _, ul := range userLabels {
-		baseLimits[ul[0]] = &validation.Limits{
+	for _, uls := range userLabels {
+		baseLimits[uls[0]] = &validation.Limits{
 			MaxCostAttributionCardinality: 10,
-			CostAttributionLabels:         ul[1:],
+			CostAttributionLabels:         uls[1:],
 		}
 	}
 	for userID, l := range baseLimits {

--- a/pkg/costattribution/testutils/test_utils.go
+++ b/pkg/costattribution/testutils/test_utils.go
@@ -8,7 +8,14 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
-func NewMockCostAttributionLimits(idx int, lvs ...string) *validation.Overrides {
+func NewMockCostAttributionLimits(idx int, userLabels ...[]string) *validation.Overrides {
+	return NewMockCostAttributionOverrides(validation.Limits{}, nil, idx, userLabels...)
+}
+
+func NewMockCostAttributionOverrides(limits validation.Limits, overrides map[string]*validation.Limits, idx int, userLabels ...[]string) *validation.Overrides {
+	if overrides == nil {
+		overrides = map[string]*validation.Limits{}
+	}
 	baseLimits := map[string]*validation.Limits{
 		"user1": {MaxCostAttributionCardinality: 5, CostAttributionLabels: []string{"team"}},
 		"user2": {MaxCostAttributionCardinality: 2, CostAttributionLabels: []string{}},
@@ -18,26 +25,35 @@ func NewMockCostAttributionLimits(idx int, lvs ...string) *validation.Overrides 
 		// user6 has opted to rename team to eng_team.
 		"user6": {MaxCostAttributionCardinality: 5, CostAttributionLabelsStructured: []costattributionmodel.Label{{Input: "team", Output: "eng_team"}}},
 	}
-	if len(lvs) > 0 {
-		baseLimits[lvs[0]] = &validation.Limits{
+	for _, ul := range userLabels {
+		baseLimits[ul[0]] = &validation.Limits{
 			MaxCostAttributionCardinality: 10,
-			CostAttributionLabels:         lvs[1:],
+			CostAttributionLabels:         ul[1:],
+		}
+	}
+	for userID, l := range baseLimits {
+		if overrides[userID] == nil {
+			overrides[userID] = l
+		} else {
+			overrides[userID].MaxCostAttributionCardinality = l.MaxCostAttributionCardinality
+			overrides[userID].CostAttributionLabels = l.CostAttributionLabels
+			overrides[userID].CostAttributionLabelsStructured = l.CostAttributionLabelsStructured
 		}
 	}
 	switch idx {
 	case 1:
-		baseLimits["user1"].CostAttributionLabels = []string{}
+		overrides["user1"].CostAttributionLabels = []string{}
 	case 2:
-		baseLimits["user3"].CostAttributionLabels = []string{"team", "feature"}
+		overrides["user3"].CostAttributionLabels = []string{"team", "feature"}
 	case 3:
-		baseLimits["user3"].MaxCostAttributionCardinality = 3
+		overrides["user3"].MaxCostAttributionCardinality = 3
 	case 4:
-		baseLimits["user1"].MaxCostAttributionCardinality = 2
+		overrides["user1"].MaxCostAttributionCardinality = 2
 	case 5:
-		baseLimits["user1"].CostAttributionLabels = []string{"department"}
+		overrides["user1"].CostAttributionLabels = []string{"department"}
 	}
 
-	return validation.NewOverrides(validation.Limits{}, validation.NewMockTenantLimits(baseLimits))
+	return validation.NewOverrides(limits, validation.NewMockTenantLimits(overrides))
 }
 
 type Series struct {

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -86,7 +86,7 @@ func (cfg *RetryConfig) Validate() error {
 // Handler is a http.Handler which accepts WriteRequests.
 func Handler(
 	maxRecvMsgSize int,
-	requestBufferPool util.Pool,
+	newRequestBuffers func() *util.RequestBuffers,
 	sourceIPs *middleware.SourceIPExtractor,
 	allowSkipLabelNameValidation bool,
 	allowSkipLabelCountValidation bool,
@@ -96,7 +96,7 @@ func Handler(
 	pushMetrics *PushMetrics,
 	logger log.Logger,
 ) http.Handler {
-	return handler(maxRecvMsgSize, requestBufferPool, sourceIPs, allowSkipLabelNameValidation, allowSkipLabelCountValidation, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, _ log.Logger) error {
+	return handler(maxRecvMsgSize, newRequestBuffers, sourceIPs, allowSkipLabelNameValidation, allowSkipLabelCountValidation, limits, retryCfg, push, logger, func(ctx context.Context, r *http.Request, maxRecvMsgSize int, buffers *util.RequestBuffers, req *mimirpb.PreallocWriteRequest, _ log.Logger) error {
 		protoBodySize, err := util.ParseProtoReader(ctx, r.Body, int(r.ContentLength), maxRecvMsgSize, buffers, req, util.RawSnappy)
 		if errors.Is(err, util.MsgSizeTooLargeErr{}) {
 			err = distributorMaxWriteMessageSizeErr{actual: int(r.ContentLength), limit: maxRecvMsgSize}
@@ -140,7 +140,7 @@ func (e distributorMaxOTLPRequestSizeErr) Error() string {
 
 func handler(
 	maxRecvMsgSize int,
-	requestBufferPool util.Pool,
+	newRequestBuffers func() *util.RequestBuffers,
 	sourceIPs *middleware.SourceIPExtractor,
 	allowSkipLabelNameValidation bool,
 	allowSkipLabelCountValidation bool,
@@ -165,7 +165,12 @@ func handler(
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 		supplier := func() (*mimirpb.WriteRequest, func(), error) {
-			rb := util.NewRequestBuffers(requestBufferPool)
+			var rb *util.RequestBuffers
+			if newRequestBuffers != nil {
+				rb = newRequestBuffers()
+			} else {
+				rb = util.NewRequestBuffers(nil)
+			}
 			var req mimirpb.PreallocWriteRequest
 
 			req.UnmarshalFromRW2 = isRW2

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -6,11 +6,13 @@
 package distributor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -19,17 +21,20 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
+	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	grpcstatus "google.golang.org/grpc/status"
 	golangproto "google.golang.org/protobuf/proto"
 
 	"github.com/grafana/mimir/pkg/costattribution"
-	catestutils "github.com/grafana/mimir/pkg/costattribution/testutils"
+	"github.com/grafana/mimir/pkg/costattribution/testutils"
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/globalerror"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -76,22 +81,54 @@ func (vm validateMetadataCfg) MaxMetadataLength(_ string) int {
 }
 
 func TestValidateLabels(t *testing.T) {
-	ts := time.Now()
+	t.Parallel()
+
+	const repeatsPerCase = 100
+
+	defaultUserID := "testUserDefault"
+	utf8UserID := "testUserUTF8"
+
+	limits := prepareDefaultLimits()
+	limits.MaxLabelValueLength = 25
+	limits.MaxLabelNameLength = 25
+	limits.MaxLabelNamesPerSeries = 4
+	limits.MaxLabelNamesPerInfoSeries = 5
+	limits.SeparateMetricsGroupLabel = "group"
+
+	perTenant := map[string]*validation.Limits{}
+	for _, userID := range []string{defaultUserID, utf8UserID} {
+		limits := *limits
+		perTenant[userID] = &limits
+	}
+	perTenant[defaultUserID].NameValidationScheme = validation.ValidationSchemeValue(model.LegacyValidation)
+	perTenant[utf8UserID].NameValidationScheme = validation.ValidationSchemeValue(model.UTF8Validation)
+
+	overrides := func(limits *validation.Limits) *validation.Overrides {
+		return testutils.NewMockCostAttributionOverrides(*limits, perTenant, 0,
+			[]string{defaultUserID, "team"},
+			[]string{utf8UserID, "team"},
+		)
+	}
+
 	reg := prometheus.NewPedanticRegistry()
-	s := newSampleValidationMetrics(reg)
-
-	var cfg validateLabelsCfg
-	userID := "testUser"
-
-	cfg.maxLabelValueLength = 25
-	cfg.maxLabelNameLength = 25
-	cfg.maxLabelNamesPerSeries = 3
-	cfg.maxLabelNamesPerInfoSeries = 4
-	limits := catestutils.NewMockCostAttributionLimits(0, userID, "team")
 	careg := prometheus.NewRegistry()
-	manager, err := costattribution.NewManager(5*time.Second, 10*time.Second, log.NewNopLogger(), limits, reg, careg)
+	manager, err := costattribution.NewManager(5*time.Second, 10*time.Second, log.NewNopLogger(), overrides(limits), reg, careg)
 	require.NoError(t, err)
-	cast := manager.SampleTracker(userID)
+
+	ds, _, _, _ := prepare(t, prepConfig{
+		numIngesters:       2,
+		happyIngesters:     2,
+		numDistributors:    1,
+		limits:             limits,
+		overrides:          overrides,
+		reg:                reg,
+		costAttributionMgr: manager,
+	})
+	d := ds[0]
+
+	newRequestBuffers := func() *util.RequestBuffers {
+		return util.NewRequestBuffers(d.RequestBufferPool, util.TaintBuffersOnCleanUp([]byte("The beef is dead.")))
+	}
 
 	validationSchemes := []model.ValidationScheme{
 		model.LegacyValidation,
@@ -116,24 +153,28 @@ func TestValidateLabels(t *testing.T) {
 	}
 
 	testCases := []struct {
+		name                     string
 		metric                   model.Metric
 		skipLabelNameValidation  bool
 		skipLabelCountValidation bool
 		wantErr                  func(model.ValidationScheme) error
 	}{
 		{
+			name:                     "missing metric name",
 			metric:                   map[model.LabelName]model.LabelValue{"team": "a"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
 			wantErr:                  alwaysErr(errors.New(noMetricNameMsgFormat)),
 		},
 		{
+			name:                     "blank metric name",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: " ", "team": "a"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
 			wantErr:                  legacyErr(fmt.Errorf(invalidMetricNameMsgFormat, " ")),
 		},
 		{
+			name:                     "metric name with invalid utf8",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "metric_name_with_\xb0_invalid_utf8_\xb0", "team": "a"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
@@ -142,6 +183,7 @@ func TestValidateLabels(t *testing.T) {
 			),
 		},
 		{
+			name:                     "invalid label name with space",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "valid", "foo ": "bar", "team": "a"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
@@ -152,17 +194,20 @@ func TestValidateLabels(t *testing.T) {
 					[]mimirpb.LabelAdapter{
 						{Name: model.MetricNameLabel, Value: "valid"},
 						{Name: "foo ", Value: "bar"},
+						{Name: "group", Value: "custom label"},
 						{Name: "team", Value: "a"},
 					},
 				),
 			)),
 		},
 		{
+			name:                     "valid metric",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "valid", "team": "c"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
 		},
 		{
+			name:                     "label name too long",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "badLabelName", "this_is_a_really_really_long_name_that_should_cause_an_error": "test_value_please_ignore", "team": "biz"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
@@ -171,6 +216,7 @@ func TestValidateLabels(t *testing.T) {
 				"this_is_a_really_really_long_name_that_should_cause_an_error",
 				mimirpb.FromLabelAdaptersToString(
 					[]mimirpb.LabelAdapter{
+						{Name: "group", Value: "custom label"},
 						{Name: "team", Value: "biz"},
 						{Name: model.MetricNameLabel, Value: "badLabelName"},
 						{Name: "this_is_a_really_really_long_name_that_should_cause_an_error", Value: "test_value_please_ignore"},
@@ -179,6 +225,7 @@ func TestValidateLabels(t *testing.T) {
 			)),
 		},
 		{
+			name:                     "label value too long",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "badLabelValue", "much_shorter_name": "test_value_please_ignore_no_really_nothing_to_see_here", "team": "biz"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
@@ -189,6 +236,7 @@ func TestValidateLabels(t *testing.T) {
 				mimirpb.FromLabelAdaptersToString(
 					[]mimirpb.LabelAdapter{
 						{Name: model.MetricNameLabel, Value: "badLabelValue"},
+						{Name: "group", Value: "custom label"},
 						{Name: "much_shorter_name", Value: "test_value_please_ignore_no_really_nothing_to_see_here"},
 						{Name: "team", Value: "biz"},
 					},
@@ -196,6 +244,7 @@ func TestValidateLabels(t *testing.T) {
 			)),
 		},
 		{
+			name:                     "too many labels",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo", "bar": "baz", "blip": "blop", "team": "plof"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
@@ -204,21 +253,24 @@ func TestValidateLabels(t *testing.T) {
 				tooManyLabelsArgs(
 					[]mimirpb.LabelAdapter{
 						{Name: model.MetricNameLabel, Value: "foo"},
+						{Name: "group", Value: "custom label"},
 						{Name: "bar", Value: "baz"},
 						{Name: "blip", Value: "blop"},
 						{Name: "team", Value: "plof"},
 					},
-					3,
+					limits.MaxLabelNamesPerSeries,
 				)...,
 			)),
 		},
 		{
+			name: "valid info metric within limits",
 			// *_info metrics have higher label limits.
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo_info", "bar": "baz", "blip": "blop", "team": "a"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
 		},
 		{
+			name: "info metric too many labels",
 			// *_info metrics have higher label limits.
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo_info", "bar": "baz", "blip": "blop", "blap": "blup", "team": "a"},
 			skipLabelNameValidation:  false,
@@ -228,31 +280,36 @@ func TestValidateLabels(t *testing.T) {
 				tooManyLabelsArgs(
 					[]mimirpb.LabelAdapter{
 						{Name: model.MetricNameLabel, Value: "foo_info"},
+						{Name: "group", Value: "custom label"},
 						{Name: "bar", Value: "baz"},
 						{Name: "blip", Value: "blop"},
 						{Name: "blap", Value: "blup"},
 						{Name: "team", Value: "a"},
 					},
-					4,
+					limits.MaxLabelNamesPerInfoSeries,
 				)...,
 			)),
 		},
 		{
+			name:                     "skip label count validation",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo", "bar": "baz", "blip": "blop", "team": "a"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: true,
 		},
 		{
+			name:                     "skip label name validation",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo", "invalid%label&name": "bar", "team": "biz"},
 			skipLabelNameValidation:  true,
 			skipLabelCountValidation: false,
 		},
 		{
+			name:                     "valid unicode label value",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo", "label1": "你好", "team": "plof"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
 		},
 		{
+			name:                     "invalid utf8 label value",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo", "label1": "abc\xfe\xfddef", "team": "plof"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
@@ -262,11 +319,13 @@ func TestValidateLabels(t *testing.T) {
 			)),
 		},
 		{
+			name:                     "invalid utf8 label value with name validation skipped",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo", "label1": "abc\xfe\xfddef"},
 			skipLabelNameValidation:  true,
 			skipLabelCountValidation: false,
 		},
 		{
+			name:                     "emoji in label name",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "foo", "name😀": "value", "team": "b"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
@@ -276,6 +335,7 @@ func TestValidateLabels(t *testing.T) {
 				mimirpb.FromLabelAdaptersToString(
 					[]mimirpb.LabelAdapter{
 						{Name: model.MetricNameLabel, Value: "foo"},
+						{Name: "group", Value: "custom label"},
 						{Name: "name😀", Value: "value"},
 						{Name: "team", Value: "b"},
 					},
@@ -283,6 +343,7 @@ func TestValidateLabels(t *testing.T) {
 			)),
 		},
 		{
+			name:                     "emoji in metric name",
 			metric:                   map[model.LabelName]model.LabelValue{model.MetricNameLabel: "name😀", "team": "b"},
 			skipLabelNameValidation:  false,
 			skipLabelCountValidation: false,
@@ -292,92 +353,179 @@ func TestValidateLabels(t *testing.T) {
 		},
 	}
 
-	for i, c := range testCases {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			for _, scheme := range validationSchemes {
-				t.Run(scheme.String(), func(t *testing.T) {
-					testConfig := cfg
-					testConfig.validationScheme = scheme
-					var wantErr error
-					if c.wantErr != nil {
-						wantErr = c.wantErr(scheme)
-					}
-					err := validateLabels(s, testConfig, userID, "custom label", mimirpb.FromMetricsToLabelAdapters(c.metric), c.skipLabelNameValidation, c.skipLabelCountValidation, cast, ts)
-					assert.Equal(t, wantErr, err, "wrong error")
-				})
+	// We want to check those after all subtests are done, but parent tests
+	// cannot wait for subtests. So we're going to run this in the last subtest
+	// that finishes instead.
+	finalChecks := func(t *testing.T) {
+		// [labelValue][userID][team] -> expected discarded samples
+		discardedSamplesValues := map[string]map[string]map[string]int{}
+		for _, c := range testCases {
+			if c.wantErr == nil {
+				continue
 			}
-		})
-	}
-
-	discardedSamplesValues := map[string]map[string]int{}
-	for _, c := range testCases {
-		if c.wantErr == nil {
-			continue
-		}
-		for _, scheme := range validationSchemes {
-			if err := c.wantErr(scheme); err != nil {
-				for _, id := range []globalerror.ID{
-					globalerror.SeriesInvalidLabel,
-					globalerror.SeriesInvalidLabelValue,
-					globalerror.SeriesLabelNameTooLong,
-					globalerror.SeriesLabelValueTooLong,
-					globalerror.MaxLabelNamesPerSeries,
-					globalerror.MaxLabelNamesPerInfoSeries,
-					globalerror.InvalidMetricName,
-					globalerror.MissingMetricName,
-				} {
-					if strings.Contains(err.Error(), string(id)) {
-						if discardedSamplesValues[id.LabelValue()] == nil {
-							discardedSamplesValues[id.LabelValue()] = map[string]int{}
+			for _, scheme := range validationSchemes {
+				if err := c.wantErr(scheme); err != nil {
+					for _, id := range []globalerror.ID{
+						globalerror.SeriesInvalidLabel,
+						globalerror.SeriesInvalidLabelValue,
+						globalerror.SeriesLabelNameTooLong,
+						globalerror.SeriesLabelValueTooLong,
+						globalerror.MaxLabelNamesPerSeries,
+						globalerror.MaxLabelNamesPerInfoSeries,
+						globalerror.InvalidMetricName,
+						globalerror.MissingMetricName,
+					} {
+						if strings.Contains(err.Error(), string(id)) {
+							if discardedSamplesValues[id.LabelValue()] == nil {
+								discardedSamplesValues[id.LabelValue()] = map[string]map[string]int{}
+							}
+							var userID string
+							switch scheme {
+							case model.LegacyValidation:
+								userID = defaultUserID
+							case model.UTF8Validation:
+								userID = utf8UserID
+							}
+							if discardedSamplesValues[id.LabelValue()][userID] == nil {
+								discardedSamplesValues[id.LabelValue()][userID] = map[string]int{}
+							}
+							team := string(c.metric["team"])
+							discardedSamplesValues[id.LabelValue()][userID][team] += repeatsPerCase
 						}
-						team := string(c.metric["team"])
-						discardedSamplesValues[id.LabelValue()][team]++
 					}
 				}
 			}
 		}
-	}
 
-	randomReason := validation.DiscardedSamplesCounter(reg, "random reason")
-	randomReason.WithLabelValues("different user", "custom label").Inc()
+		// Get metrics from the distributor's registry
+		randomReason := validation.DiscardedSamplesCounter(reg, "random reason")
+		randomReason.WithLabelValues("different user", "custom label").Inc()
 
-	wantDiscardedSamples := `
-		# HELP cortex_discarded_samples_total The total number of samples that were discarded.
-		# TYPE cortex_discarded_samples_total counter
-		cortex_discarded_samples_total{group="custom label",reason="random reason",user="different user"} 1
-	`
-	wantDiscardedAttrSamples := `
-		# HELP cortex_discarded_attributed_samples_total The total number of samples that were discarded per attribution.
-		# TYPE cortex_discarded_attributed_samples_total counter
-	`
+		wantDiscardedSamples := `
+			# HELP cortex_discarded_samples_total The total number of samples that were discarded.
+			# TYPE cortex_discarded_samples_total counter
+			cortex_discarded_samples_total{group="custom label",reason="random reason",user="different user"} 1
+		`
+		wantDiscardedAttrSamples := `
+			# HELP cortex_discarded_attributed_samples_total The total number of samples that were discarded per attribution.
+			# TYPE cortex_discarded_attributed_samples_total counter
+		`
 
-	sumSamples := func(m map[string]int) (sum int) {
-		for _, v := range m {
-			sum += v
+		sumSamples := func(m map[string]int) (sum int) {
+			for _, v := range m {
+				sum += v
+			}
+			return
 		}
-		return
-	}
 
-	for reason, countByTeam := range discardedSamplesValues {
-		wantDiscardedSamples += fmt.Sprintf(
-			`cortex_discarded_samples_total{group="custom label",reason="%s",user="testUser"} %d`+"\n",
-			reason,
-			sumSamples(countByTeam),
-		)
-		for team, count := range countByTeam {
-			wantDiscardedAttrSamples += fmt.Sprintf(
-				`cortex_discarded_attributed_samples_total{reason="%s",team="%s",tenant="testUser",tracker="cost-attribution"} %d`+"\n",
-				reason,
-				team,
-				count,
-			)
+		for reason, byUser := range discardedSamplesValues {
+			for userID, countByTeam := range byUser {
+				wantDiscardedSamples += fmt.Sprintf(
+					`cortex_discarded_samples_total{group="custom label",reason="%s",user="%s"} %d`+"\n",
+					reason,
+					userID,
+					sumSamples(countByTeam),
+				)
+				for team, count := range countByTeam {
+					wantDiscardedAttrSamples += fmt.Sprintf(
+						`cortex_discarded_attributed_samples_total{reason="%s",team="%s",tenant="%s",tracker="cost-attribution"} %d`+"\n",
+						reason,
+						team,
+						userID,
+						count,
+					)
+				}
+			}
 		}
+
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(wantDiscardedSamples), "cortex_discarded_samples_total"))
+		require.NoError(t, testutil.GatherAndCompare(careg, strings.NewReader(wantDiscardedAttrSamples), "cortex_discarded_attributed_samples_total"))
+
+		d.sampleValidationMetrics.deleteUserMetrics(defaultUserID)
+		d.sampleValidationMetrics.deleteUserMetrics(utf8UserID)
 	}
 
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(wantDiscardedSamples), "cortex_discarded_samples_total"))
-	require.NoError(t, testutil.GatherAndCompare(careg, strings.NewReader(wantDiscardedAttrSamples), "cortex_discarded_attributed_samples_total"))
+	var inFlightSubsets atomic.Int64
+	inFlightSubsets.Store(int64(len(testCases) * len(validationSchemes)))
 
-	s.deleteUserMetrics(userID)
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			for _, scheme := range validationSchemes {
+				t.Run(scheme.String(), func(t *testing.T) {
+					t.Parallel()
+
+					defer func() {
+						if inFlightSubsets.Add(-1) == 0 {
+							finalChecks(t)
+						}
+					}()
+
+					var userID string
+					switch scheme {
+					case model.LegacyValidation:
+						userID = defaultUserID
+					case model.UTF8Validation:
+						userID = utf8UserID
+					}
+
+					handler := Handler(100000, newRequestBuffers, nil, true, true, d.limits, RetryConfig{},
+						d.PushWithMiddlewares,
+						nil, log.NewNopLogger(),
+					)
+
+					var wantErr error
+					if c.wantErr != nil {
+						wantErr = c.wantErr(scheme)
+					}
+
+					ts := mimirpb.PreallocTimeseries{
+						TimeSeries: &mimirpb.TimeSeries{
+							Labels: []mimirpb.LabelAdapter{{Name: "group", Value: "custom label"}},
+							Samples: []mimirpb.Sample{
+								{Value: 1, TimestampMs: time.Now().UnixMilli()},
+							},
+						},
+					}
+					for name, value := range c.metric {
+						ts.TimeSeries.Labels = append(ts.TimeSeries.Labels, mimirpb.LabelAdapter{Name: string(name), Value: string(value)})
+					}
+
+					var wg sync.WaitGroup
+					wg.Add(repeatsPerCase)
+
+					for range repeatsPerCase {
+						go func() {
+							defer wg.Done()
+
+							req := createRequest(t, createMimirWriteRequestProtobuf(t, c.skipLabelNameValidation, c.skipLabelCountValidation, ts))
+							if c.skipLabelNameValidation {
+								req.Header.Set(SkipLabelNameValidationHeader, "true")
+							}
+							if c.skipLabelCountValidation {
+								req.Header.Set(SkipLabelCountValidationHeader, "true")
+							}
+							req.Header.Set("X-Scope-OrgID", userID)
+							ctx := user.InjectOrgID(context.Background(), userID)
+							req = req.WithContext(ctx)
+
+							resp := httptest.NewRecorder()
+							handler.ServeHTTP(resp, req)
+
+							if wantErr != nil {
+								assert.Equal(t, 400, resp.Code, resp.Body.String())
+								assert.Contains(t, resp.Body.String(), wantErr.Error())
+							} else {
+								assert.Equal(t, 200, resp.Code, resp.Body.String())
+							}
+						}()
+					}
+
+					wg.Wait()
+				})
+			}
+		})
+	}
 }
 
 func TestValidateExemplars(t *testing.T) {

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -85,8 +85,8 @@ func TestValidateLabels(t *testing.T) {
 
 	const repeatsPerCase = 100
 
-	defaultUserID := "testUserDefault"
-	utf8UserID := "testUserUTF8"
+	const defaultUserID = "testUserDefault"
+	const utf8UserID = "testUserUTF8"
 
 	limits := prepareDefaultLimits()
 	limits.MaxLabelValueLength = 25
@@ -385,6 +385,8 @@ func TestValidateLabels(t *testing.T) {
 								userID = defaultUserID
 							case model.UTF8Validation:
 								userID = utf8UserID
+							default:
+								panic(fmt.Errorf("unhandled name validation scheme: %s", scheme))
 							}
 							if discardedSamplesValues[id.LabelValue()][userID] == nil {
 								discardedSamplesValues[id.LabelValue()][userID] = map[string]int{}
@@ -467,6 +469,8 @@ func TestValidateLabels(t *testing.T) {
 						userID = defaultUserID
 					case model.UTF8Validation:
 						userID = utf8UserID
+					default:
+						panic(fmt.Errorf("unhandled name validation scheme: %s", scheme))
 					}
 
 					handler := Handler(100000, newRequestBuffers, nil, true, true, d.limits, RetryConfig{},

--- a/pkg/util/active_groups.go
+++ b/pkg/util/active_groups.go
@@ -139,7 +139,7 @@ func (ag *ActiveGroups) ActiveGroupLimitExceeded(userID, group string) bool {
 
 func (s *ActiveGroupsCleanupService) UpdateActiveGroupTimestamp(user, group string, now time.Time) string {
 	// Does not track empty label
-	if group == "" {
+	if s == nil || s.activeGroups == nil || group == "" {
 		return group
 	}
 


### PR DESCRIPTION
#### What this PR does

The [recent incident](https://grafana.com/blog/2025/08/03/grafana-cloud-metrics-memory-corruption-issue-resolved/) introduced by https://github.com/grafana/mimir/pull/11889 would have been caught with a sufficiently exhaustive test suite.

* Change the distributor validation tests so that they submit actual gRPC write requests, which use the request buffer pool.
* Repeat each test a number of times to increase the likelihood of triggering use-after-release issues.
* Taint the buffers before returning them to the pool, so that even if the buffer isn't reused, lingering references still point to unexpected contents to make tests fail.

To demonstrate that these changes are enough to catch the issue, the original PR has been resubmitted (as a draft) on top of this branch, and [tests do fail](https://github.com/grafana/mimir/actions/runs/16779690455/job/47514746172?pr=12273).

#### Which issue(s) this PR fixes or relates to

https://grafana.com/blog/2025/08/03/grafana-cloud-metrics-memory-corruption-issue-resolved/

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
