### PR TITLE
Remove deprecated HA tracker timeout configs

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1284,36 +1284,6 @@
               ],
               "fieldValue": null,
               "fieldDefaultValue": null
-            },
-            {
-              "kind": "field",
-              "name": "ha_tracker_update_timeout",
-              "required": false,
-              "desc": "Deprecated. Use limits.ha_tracker_update_timeout.",
-              "fieldValue": null,
-              "fieldDefaultValue": null,
-              "fieldType": "duration",
-              "fieldCategory": "advanced"
-            },
-            {
-              "kind": "field",
-              "name": "ha_tracker_update_timeout_jitter_max",
-              "required": false,
-              "desc": "Deprecated. Use limits.ha_tracker_update_timeout_jitter_max.",
-              "fieldValue": null,
-              "fieldDefaultValue": null,
-              "fieldType": "duration",
-              "fieldCategory": "advanced"
-            },
-            {
-              "kind": "field",
-              "name": "ha_tracker_failover_timeout",
-              "required": false,
-              "desc": "Deprecated. Use limits.ha_tracker_failover_timeout.",
-              "fieldValue": null,
-              "fieldDefaultValue": null,
-              "fieldType": "duration",
-              "fieldCategory": "advanced"
             }
           ],
           "fieldValue": null,

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -907,15 +907,6 @@ ha_tracker:
       # CLI flag: -distributor.ha-tracker.multi.mirror-timeout
       [mirror_timeout: <duration> | default = 2s]
 
-  # (advanced) Deprecated. Use limits.ha_tracker_update_timeout.
-  [ha_tracker_update_timeout: <duration> | default = ]
-
-  # (advanced) Deprecated. Use limits.ha_tracker_update_timeout_jitter_max.
-  [ha_tracker_update_timeout_jitter_max: <duration> | default = ]
-
-  # (advanced) Deprecated. Use limits.ha_tracker_failover_timeout.
-  [ha_tracker_failover_timeout: <duration> | default = ]
-
 # (advanced) Max message size in bytes that the distributors will accept for
 # incoming push requests to the remote write API. If exceeded, the request will
 # be rejected.

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -143,8 +143,6 @@ type HATrackerConfig struct {
 	EnableElectedReplicaMetric bool `yaml:"enable_elected_replica_metric"`
 
 	KVStore kv.Config `yaml:"kvstore" doc:"description=Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. Note that etcd is deprecated."`
-
-	DeprecatedHATrackerTimeoutsConfig `yaml:",inline"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -157,16 +155,6 @@ func (cfg *HATrackerConfig) RegisterFlags(f *flag.FlagSet) {
 	// order to not clash with the ring key if they both share the same KVStore
 	// backend (i.e. run on the same Consul cluster).
 	cfg.KVStore.RegisterFlagsWithPrefix("distributor.ha-tracker.", "ha-tracker/", f)
-}
-
-// DeprecatedHATrackerTimeoutsConfig is kept for backwards-compatibility in the
-// YAML config files. Values are copied to limits config, and must be accesed
-// through haTrackerLimits.HATrackerTimeouts.
-// TODO: Remove in Mimir 2.18.0
-type DeprecatedHATrackerTimeoutsConfig struct {
-	DeprecatedUpdateTimeout          time.Duration `yaml:"ha_tracker_update_timeout" category:"advanced" doc:"nocli|description=Deprecated. Use limits.ha_tracker_update_timeout."`
-	DeprecatedUpdateTimeoutJitterMax time.Duration `yaml:"ha_tracker_update_timeout_jitter_max" category:"advanced" doc:"nocli|description=Deprecated. Use limits.ha_tracker_update_timeout_jitter_max."`
-	DeprecatedFailoverTimeout        time.Duration `yaml:"ha_tracker_failover_timeout" category:"advanced" doc:"nocli|description=Deprecated. Use limits.ha_tracker_failover_timeout."`
 }
 
 func GetReplicaDescCodec() codec.Proto {

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -35,7 +35,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql"
 	prom_storage "github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
@@ -334,18 +333,6 @@ func (c *Config) Validate(log log.Logger) error {
 		return errors.Wrap(err, "invalid overrides-exporter config")
 	}
 
-	if c.Distributor.HATrackerConfig.DeprecatedUpdateTimeout > 0 {
-		c.LimitsConfig.HATrackerUpdateTimeout = model.Duration(c.Distributor.HATrackerConfig.DeprecatedUpdateTimeout)
-		level.Warn(log).Log("msg", "using deprecated config parameter distributor.ha_tracker.ha_tracker_update_timeout; use limits.ha_tracker_update_timeout instead")
-	}
-	if c.Distributor.HATrackerConfig.DeprecatedUpdateTimeoutJitterMax > 0 {
-		c.LimitsConfig.HATrackerUpdateTimeoutJitterMax = model.Duration(c.Distributor.HATrackerConfig.DeprecatedUpdateTimeoutJitterMax)
-		level.Warn(log).Log("msg", "using deprecated config parameter distributor.ha_tracker.ha_tracker_update_timeout_jitter_max; use limits.ha_tracker_update_timeout_jitter_max instead")
-	}
-	if c.Distributor.HATrackerConfig.DeprecatedFailoverTimeout > 0 {
-		c.LimitsConfig.HATrackerFailoverTimeout = model.Duration(c.Distributor.HATrackerConfig.DeprecatedFailoverTimeout)
-		level.Warn(log).Log("msg", "using deprecated config parameter distributor.ha_tracker.ha_tracker_failover_timeout; use limits.ha_tracker_failover_timeout instead")
-	}
 	// validate the default limits
 	if err := c.ValidateLimits(&c.LimitsConfig); err != nil {
 		return err


### PR DESCRIPTION
#### What this PR does

Remove the deprecated global HA tracker timeout configs (they are now per-tenant instead of global).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
