### PR TITLE
Move streamingpromql engine opts into its own package

### DIFF
--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/series"
 	"github.com/grafana/mimir/pkg/storage/sharding"
 	"github.com/grafana/mimir/pkg/streamingpromql"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
@@ -306,16 +306,16 @@ func TestNewMockShardedQueryable(t *testing.T) {
 	}
 }
 
-type engineOpt func(o *opts.EngineOpts)
+type engineOpt func(o *engineopts.EngineOpts)
 
 func withTimeout(timeout time.Duration) engineOpt {
-	return func(o *opts.EngineOpts) {
+	return func(o *engineopts.EngineOpts) {
 		o.CommonOpts.Timeout = timeout
 	}
 }
 
 func withMaxSamples(samples int) engineOpt {
-	return func(o *opts.EngineOpts) {
+	return func(o *engineopts.EngineOpts) {
 		o.CommonOpts.MaxSamples = samples
 	}
 }
@@ -323,7 +323,7 @@ func withMaxSamples(samples int) engineOpt {
 func newEngineForTesting(t *testing.T, engine string, opts ...engineOpt) (promql.EngineOpts, promql.QueryEngine) {
 	t.Helper()
 
-	mqeOpts := opts.NewTestEngineOpts()
+	mqeOpts := engineopts.NewTestEngineOpts()
 	for _, o := range opts {
 		o(&mqeOpts)
 	}

--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/series"
 	"github.com/grafana/mimir/pkg/storage/sharding"
 	"github.com/grafana/mimir/pkg/streamingpromql"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
@@ -305,16 +306,16 @@ func TestNewMockShardedQueryable(t *testing.T) {
 	}
 }
 
-type engineOpt func(o *streamingpromql.EngineOpts)
+type engineOpt func(o *opts.EngineOpts)
 
 func withTimeout(timeout time.Duration) engineOpt {
-	return func(o *streamingpromql.EngineOpts) {
+	return func(o *opts.EngineOpts) {
 		o.CommonOpts.Timeout = timeout
 	}
 }
 
 func withMaxSamples(samples int) engineOpt {
-	return func(o *streamingpromql.EngineOpts) {
+	return func(o *opts.EngineOpts) {
 		o.CommonOpts.MaxSamples = samples
 	}
 }
@@ -322,7 +323,7 @@ func withMaxSamples(samples int) engineOpt {
 func newEngineForTesting(t *testing.T, engine string, opts ...engineOpt) (promql.EngineOpts, promql.QueryEngine) {
 	t.Helper()
 
-	mqeOpts := streamingpromql.NewTestEngineOpts()
+	mqeOpts := opts.NewTestEngineOpts()
 	for _, o := range opts {
 		o(&mqeOpts)
 	}

--- a/pkg/querier/engine/config.go
+++ b/pkg/querier/engine/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/promql"
 
-	"github.com/grafana/mimir/pkg/streamingpromql"      //lint:ignore faillint streamingpromql is fine
+	"github.com/grafana/mimir/pkg/streamingpromql/opts" //lint:ignore faillint opts is fine
 	"github.com/grafana/mimir/pkg/util/activitytracker" //lint:ignore faillint activitytracker is fine
 	util_log "github.com/grafana/mimir/pkg/util/log"    //lint:ignore faillint log is fine
 )
@@ -31,7 +31,7 @@ type Config struct {
 	// series is considered stale.
 	LookbackDelta time.Duration `yaml:"lookback_delta" category:"advanced"`
 
-	MimirQueryEngine streamingpromql.EngineOpts `yaml:"mimir_query_engine" category:"experimental"`
+	MimirQueryEngine opts.EngineOpts `yaml:"mimir_query_engine" category:"experimental"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
@@ -53,7 +53,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 // NewPromQLEngineOptions returns the PromQL engine options based on the provided config.
-func NewPromQLEngineOptions(cfg Config, activityTracker *activitytracker.ActivityTracker, logger log.Logger, reg prometheus.Registerer) (promql.EngineOpts, streamingpromql.EngineOpts) {
+func NewPromQLEngineOptions(cfg Config, activityTracker *activitytracker.ActivityTracker, logger log.Logger, reg prometheus.Registerer) (promql.EngineOpts, opts.EngineOpts) {
 	commonOpts := promql.EngineOpts{
 		Logger:               util_log.SlogFromGoKit(logger),
 		Reg:                  reg,

--- a/pkg/querier/engine/config.go
+++ b/pkg/querier/engine/config.go
@@ -11,9 +11,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/promql"
 
-	"github.com/grafana/mimir/pkg/streamingpromql/opts" //lint:ignore faillint opts is fine
-	"github.com/grafana/mimir/pkg/util/activitytracker" //lint:ignore faillint activitytracker is fine
-	util_log "github.com/grafana/mimir/pkg/util/log"    //lint:ignore faillint log is fine
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts" //lint:ignore faillint engineopts is fine
+	"github.com/grafana/mimir/pkg/util/activitytracker"       //lint:ignore faillint activitytracker is fine
+	util_log "github.com/grafana/mimir/pkg/util/log"          //lint:ignore faillint log is fine
 )
 
 // Config holds the PromQL engine config exposed by Mimir.
@@ -31,7 +31,7 @@ type Config struct {
 	// series is considered stale.
 	LookbackDelta time.Duration `yaml:"lookback_delta" category:"advanced"`
 
-	MimirQueryEngine opts.EngineOpts `yaml:"mimir_query_engine" category:"experimental"`
+	MimirQueryEngine engineopts.EngineOpts `yaml:"mimir_query_engine" category:"experimental"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
@@ -53,7 +53,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 // NewPromQLEngineOptions returns the PromQL engine options based on the provided config.
-func NewPromQLEngineOptions(cfg Config, activityTracker *activitytracker.ActivityTracker, logger log.Logger, reg prometheus.Registerer) (promql.EngineOpts, opts.EngineOpts) {
+func NewPromQLEngineOptions(cfg Config, activityTracker *activitytracker.ActivityTracker, logger log.Logger, reg prometheus.Registerer) (promql.EngineOpts, engineopts.EngineOpts) {
 	commonOpts := promql.EngineOpts{
 		Logger:               util_log.SlogFromGoKit(logger),
 		Reg:                  reg,

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -41,7 +42,7 @@ func BenchmarkQuery(b *testing.B) {
 	q := createBenchmarkQueryable(b, MetricSizes)
 	cases := TestCases(MetricSizes)
 
-	opts := streamingpromql.NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), streamingpromql.NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(b, err)
@@ -93,7 +94,7 @@ func TestBothEnginesReturnSameResultsForBenchmarkQueries(t *testing.T) {
 	q := createBenchmarkQueryable(t, metricSizes)
 	cases := TestCases(metricSizes)
 
-	opts := streamingpromql.NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	limitsProvider := streamingpromql.NewStaticQueryLimitsProvider(0)
 	queryMetrics := stats.NewQueryMetrics(nil)
@@ -123,7 +124,7 @@ func TestBothEnginesReturnSameResultsForBenchmarkQueries(t *testing.T) {
 func TestBenchmarkSetup(t *testing.T) {
 	q := createBenchmarkQueryable(t, []int{1})
 
-	opts := streamingpromql.NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), streamingpromql.NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -42,7 +42,7 @@ func BenchmarkQuery(b *testing.B) {
 	q := createBenchmarkQueryable(b, MetricSizes)
 	cases := TestCases(MetricSizes)
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), streamingpromql.NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(b, err)
@@ -94,7 +94,7 @@ func TestBothEnginesReturnSameResultsForBenchmarkQueries(t *testing.T) {
 	q := createBenchmarkQueryable(t, metricSizes)
 	cases := TestCases(metricSizes)
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	limitsProvider := streamingpromql.NewStaticQueryLimitsProvider(0)
 	queryMetrics := stats.NewQueryMetrics(nil)
@@ -124,7 +124,7 @@ func TestBothEnginesReturnSameResultsForBenchmarkQueries(t *testing.T) {
 func TestBenchmarkSetup(t *testing.T) {
 	q := createBenchmarkQueryable(t, []int{1})
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), streamingpromql.NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/limiter"
@@ -37,7 +38,7 @@ var tracer = otel.Tracer("pkg/streamingpromql")
 
 const defaultLookbackDelta = 5 * time.Minute // This should be the same value as github.com/prometheus/prometheus/promql.defaultLookbackDelta.
 
-func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *stats.QueryMetrics, planner *QueryPlanner, logger log.Logger) (*Engine, error) {
+func NewEngine(opts opts.EngineOpts, limitsProvider QueryLimitsProvider, metrics *stats.QueryMetrics, planner *QueryPlanner, logger log.Logger) (*Engine, error) {
 	if !opts.CommonOpts.EnableAtModifier {
 		return nil, errors.New("disabling @ modifier not supported by Mimir query engine")
 	}

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/grafana/mimir/pkg/querier/stats"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/limiter"
@@ -38,7 +38,7 @@ var tracer = otel.Tracer("pkg/streamingpromql")
 
 const defaultLookbackDelta = 5 * time.Minute // This should be the same value as github.com/prometheus/prometheus/promql.defaultLookbackDelta.
 
-func NewEngine(opts opts.EngineOpts, limitsProvider QueryLimitsProvider, metrics *stats.QueryMetrics, planner *QueryPlanner, logger log.Logger) (*Engine, error) {
+func NewEngine(opts engineopts.EngineOpts, limitsProvider QueryLimitsProvider, metrics *stats.QueryMetrics, planner *QueryPlanner, logger log.Logger) (*Engine, error) {
 	if !opts.CommonOpts.EnableAtModifier {
 		return nil, errors.New("disabling @ modifier not supported by Mimir query engine")
 	}

--- a/pkg/streamingpromql/engine_concurrency_test.go
+++ b/pkg/streamingpromql/engine_concurrency_test.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 )
 
 func TestConcurrentQueries(t *testing.T) {
@@ -186,7 +187,7 @@ func TestConcurrentQueries(t *testing.T) {
 	storage := promqltest.LoadedStorage(t, data)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 

--- a/pkg/streamingpromql/engine_concurrency_test.go
+++ b/pkg/streamingpromql/engine_concurrency_test.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/mimir/pkg/querier/stats"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 )
 
 func TestConcurrentQueries(t *testing.T) {
@@ -187,7 +187,7 @@ func TestConcurrentQueries(t *testing.T) {
 	storage := promqltest.LoadedStorage(t, data)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/storage/lazyquery"
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/globalerror"
@@ -94,7 +94,7 @@ func requireQueryIsUnsupported(t *testing.T, expression string, expectedError st
 }
 
 func requireRangeQueryIsUnsupported(t *testing.T, expression string, expectedError string) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -105,7 +105,7 @@ func requireRangeQueryIsUnsupported(t *testing.T, expression string, expectedErr
 }
 
 func requireInstantQueryIsUnsupported(t *testing.T, expression string, expectedError string) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -117,7 +117,7 @@ func requireInstantQueryIsUnsupported(t *testing.T, expression string, expectedE
 }
 
 func TestNewRangeQuery_InvalidQueryTime(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -131,7 +131,7 @@ func TestNewRangeQuery_InvalidQueryTime(t *testing.T) {
 }
 
 func TestNewRangeQuery_InvalidExpressionTypes(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -145,7 +145,7 @@ func TestNewRangeQuery_InvalidExpressionTypes(t *testing.T) {
 
 func TestNewInstantQuery_Strings(t *testing.T) {
 	ctx := context.Background()
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
@@ -171,7 +171,7 @@ func TestNewInstantQuery_Strings(t *testing.T) {
 // Test cases that are not supported by the streaming engine are commented out (or, if the entire file is not supported, .disabled is appended to the file name).
 // Once the streaming engine supports all PromQL features exercised by Prometheus' test cases, we can remove these files and instead call promql.RunBuiltinTests here instead.
 func TestUpstreamTestCases(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -195,7 +195,7 @@ func TestUpstreamTestCases(t *testing.T) {
 }
 
 func TestOurTestCases(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -237,7 +237,7 @@ func TestOurTestCases(t *testing.T) {
 //
 // So instead, we test these few cases here instead.
 func TestRangeVectorSelectors(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
@@ -782,7 +782,7 @@ func TestSubqueries(t *testing.T) {
 	           other_metric{type="mixed"} 0 4 3 6 {{count:-1}} {{count:10}}
 	`
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	opts.CommonOpts.EnablePerStepStats = true
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
@@ -1208,7 +1208,7 @@ func TestSubqueries(t *testing.T) {
 }
 
 func TestQueryCancellation(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -1235,7 +1235,7 @@ func TestQueryCancellation(t *testing.T) {
 }
 
 func TestQueryTimeout(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	opts.CommonOpts.Timeout = 20 * time.Millisecond
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
@@ -1302,7 +1302,7 @@ func (w cancellationQuerier) waitForCancellation(ctx context.Context) error {
 }
 
 func TestQueryContextCancelledOnceQueryFinished(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -1510,7 +1510,7 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 
 	createEngine := func(t *testing.T, limit uint64) (promql.QueryEngine, *prometheus.Registry, trace.Span, context.Context) {
 		reg := prometheus.NewPedanticRegistry()
-		opts := opts.NewTestEngineOpts()
+		opts := engineopts.NewTestEngineOpts()
 		opts.CommonOpts.Reg = reg
 
 		engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(limit), stats.NewQueryMetrics(reg), NewQueryPlanner(opts), log.NewNopLogger())
@@ -1628,7 +1628,7 @@ func TestMemoryConsumptionLimit_MultipleQueries(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
 	reg := prometheus.NewPedanticRegistry()
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	opts.CommonOpts.Reg = reg
 
 	limit := 32*types.FPointSize + 4*types.SeriesMetadataSize + 3*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize())
@@ -1699,7 +1699,7 @@ func getHistogram(t *testing.T, reg *prometheus.Registry, name string) *dto.Hist
 }
 
 func TestActiveQueryTracker_SuccessfulQuery(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	tracker := &testQueryTracker{}
 	opts.CommonOpts.ActiveQueryTracker = tracker
 	planner := NewQueryPlanner(opts)
@@ -1762,7 +1762,7 @@ func testActiveQueryTracker(t *testing.T, engine *Engine, tracker *testQueryTrac
 }
 
 func TestActiveQueryTracker_FailedQuery(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	tracker := &testQueryTracker{}
 	opts.CommonOpts.ActiveQueryTracker = tracker
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
@@ -1853,7 +1853,7 @@ func (a *activeQueryTrackerQueryable) Querier(mint, maxt int64) (storage.Querier
 
 func TestActiveQueryTracker_WaitingForTrackerIncludesQueryTimeout(t *testing.T) {
 	tracker := &timeoutTestingQueryTracker{}
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	opts.CommonOpts.Timeout = 10 * time.Millisecond
 	opts.CommonOpts.ActiveQueryTracker = tracker
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
@@ -1932,7 +1932,7 @@ func runAnnotationTests(t *testing.T, testCases map[string]annotationTestCase) {
 	step := time.Minute
 	endT := startT.Add(2 * step)
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
@@ -2947,7 +2947,7 @@ func runMixedMetricsTests(t *testing.T, expressions []string, pointsPerSeries in
 	// - Stale markers
 	// - Look backs
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
@@ -3184,7 +3184,7 @@ func TestCompareVariousMixedMetricsComparisonOps(t *testing.T) {
 }
 
 func TestQueryStats(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	opts.CommonOpts.EnablePerStepStats = true
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
@@ -3488,7 +3488,7 @@ func TestQueryStats(t *testing.T) {
 
 func TestQueryStatsUpstreamTestCases(t *testing.T) {
 	// TestCases are taken from Prometheus' TestQueryStatistics.
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	opts.CommonOpts.EnablePerStepStats = true
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
@@ -3884,7 +3884,7 @@ func TestQueryStatementLookbackDelta(t *testing.T) {
 	}
 
 	t.Run("engine with no lookback delta configured", func(t *testing.T) {
-		engineOpts := opts.NewTestEngineOpts()
+		engineOpts := engineopts.NewTestEngineOpts()
 		engine, err := NewEngine(engineOpts, limitsProvider, stats, NewQueryPlanner(engineOpts), logger)
 		require.NoError(t, err)
 
@@ -3904,7 +3904,7 @@ func TestQueryStatementLookbackDelta(t *testing.T) {
 	})
 
 	t.Run("engine with lookback delta configured", func(t *testing.T) {
-		engineOpts := opts.NewTestEngineOpts()
+		engineOpts := engineopts.NewTestEngineOpts()
 		engineOpts.CommonOpts.LookbackDelta = 12 * time.Minute
 		engine, err := NewEngine(engineOpts, limitsProvider, stats, NewQueryPlanner(engineOpts), logger)
 		require.NoError(t, err)
@@ -3938,7 +3938,7 @@ func TestQueryClose(t *testing.T) {
 	`)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -3974,11 +3974,11 @@ func TestEagerLoadSelectors(t *testing.T) {
 	limitsProvider := NewStaticQueryLimitsProvider(0)
 	metrics := stats.NewQueryMetrics(nil)
 	logger := log.NewNopLogger()
-	optsWithoutEagerLoading := opts.NewTestEngineOpts()
+	optsWithoutEagerLoading := engineopts.NewTestEngineOpts()
 	engineWithoutEagerLoading, err := NewEngine(optsWithoutEagerLoading, limitsProvider, metrics, NewQueryPlanner(optsWithoutEagerLoading), logger)
 	require.NoError(t, err)
 
-	optsWithEagerLoading := opts.NewTestEngineOpts()
+	optsWithEagerLoading := engineopts.NewTestEngineOpts()
 	optsWithEagerLoading.EagerLoadSelectors = true
 	engineWithEagerLoading, err := NewEngine(optsWithEagerLoading, limitsProvider, metrics, NewQueryPlanner(optsWithEagerLoading), logger)
 	require.NoError(t, err)
@@ -4094,7 +4094,7 @@ func TestInstantQueryDurationExpression(t *testing.T) {
 	`)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/storage/lazyquery"
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/globalerror"
@@ -93,7 +94,7 @@ func requireQueryIsUnsupported(t *testing.T, expression string, expectedError st
 }
 
 func requireRangeQueryIsUnsupported(t *testing.T, expression string, expectedError string) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -104,7 +105,7 @@ func requireRangeQueryIsUnsupported(t *testing.T, expression string, expectedErr
 }
 
 func requireInstantQueryIsUnsupported(t *testing.T, expression string, expectedError string) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -116,7 +117,7 @@ func requireInstantQueryIsUnsupported(t *testing.T, expression string, expectedE
 }
 
 func TestNewRangeQuery_InvalidQueryTime(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -130,7 +131,7 @@ func TestNewRangeQuery_InvalidQueryTime(t *testing.T) {
 }
 
 func TestNewRangeQuery_InvalidExpressionTypes(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -144,7 +145,7 @@ func TestNewRangeQuery_InvalidExpressionTypes(t *testing.T) {
 
 func TestNewInstantQuery_Strings(t *testing.T) {
 	ctx := context.Background()
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
@@ -170,7 +171,7 @@ func TestNewInstantQuery_Strings(t *testing.T) {
 // Test cases that are not supported by the streaming engine are commented out (or, if the entire file is not supported, .disabled is appended to the file name).
 // Once the streaming engine supports all PromQL features exercised by Prometheus' test cases, we can remove these files and instead call promql.RunBuiltinTests here instead.
 func TestUpstreamTestCases(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -194,7 +195,7 @@ func TestUpstreamTestCases(t *testing.T) {
 }
 
 func TestOurTestCases(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -236,7 +237,7 @@ func TestOurTestCases(t *testing.T) {
 //
 // So instead, we test these few cases here instead.
 func TestRangeVectorSelectors(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
@@ -781,7 +782,7 @@ func TestSubqueries(t *testing.T) {
 	           other_metric{type="mixed"} 0 4 3 6 {{count:-1}} {{count:10}}
 	`
 
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	opts.CommonOpts.EnablePerStepStats = true
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
@@ -1207,7 +1208,7 @@ func TestSubqueries(t *testing.T) {
 }
 
 func TestQueryCancellation(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -1234,7 +1235,7 @@ func TestQueryCancellation(t *testing.T) {
 }
 
 func TestQueryTimeout(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	opts.CommonOpts.Timeout = 20 * time.Millisecond
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
@@ -1301,7 +1302,7 @@ func (w cancellationQuerier) waitForCancellation(ctx context.Context) error {
 }
 
 func TestQueryContextCancelledOnceQueryFinished(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -1509,7 +1510,7 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 
 	createEngine := func(t *testing.T, limit uint64) (promql.QueryEngine, *prometheus.Registry, trace.Span, context.Context) {
 		reg := prometheus.NewPedanticRegistry()
-		opts := NewTestEngineOpts()
+		opts := opts.NewTestEngineOpts()
 		opts.CommonOpts.Reg = reg
 
 		engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(limit), stats.NewQueryMetrics(reg), NewQueryPlanner(opts), log.NewNopLogger())
@@ -1627,7 +1628,7 @@ func TestMemoryConsumptionLimit_MultipleQueries(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
 	reg := prometheus.NewPedanticRegistry()
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	opts.CommonOpts.Reg = reg
 
 	limit := 32*types.FPointSize + 4*types.SeriesMetadataSize + 3*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize())
@@ -1698,7 +1699,7 @@ func getHistogram(t *testing.T, reg *prometheus.Registry, name string) *dto.Hist
 }
 
 func TestActiveQueryTracker_SuccessfulQuery(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	tracker := &testQueryTracker{}
 	opts.CommonOpts.ActiveQueryTracker = tracker
 	planner := NewQueryPlanner(opts)
@@ -1761,7 +1762,7 @@ func testActiveQueryTracker(t *testing.T, engine *Engine, tracker *testQueryTrac
 }
 
 func TestActiveQueryTracker_FailedQuery(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	tracker := &testQueryTracker{}
 	opts.CommonOpts.ActiveQueryTracker = tracker
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
@@ -1852,7 +1853,7 @@ func (a *activeQueryTrackerQueryable) Querier(mint, maxt int64) (storage.Querier
 
 func TestActiveQueryTracker_WaitingForTrackerIncludesQueryTimeout(t *testing.T) {
 	tracker := &timeoutTestingQueryTracker{}
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	opts.CommonOpts.Timeout = 10 * time.Millisecond
 	opts.CommonOpts.ActiveQueryTracker = tracker
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
@@ -1931,7 +1932,7 @@ func runAnnotationTests(t *testing.T, testCases map[string]annotationTestCase) {
 	step := time.Minute
 	endT := startT.Add(2 * step)
 
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
@@ -2946,7 +2947,7 @@ func runMixedMetricsTests(t *testing.T, expressions []string, pointsPerSeries in
 	// - Stale markers
 	// - Look backs
 
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
@@ -3183,7 +3184,7 @@ func TestCompareVariousMixedMetricsComparisonOps(t *testing.T) {
 }
 
 func TestQueryStats(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	opts.CommonOpts.EnablePerStepStats = true
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
@@ -3487,7 +3488,7 @@ func TestQueryStats(t *testing.T) {
 
 func TestQueryStatsUpstreamTestCases(t *testing.T) {
 	// TestCases are taken from Prometheus' TestQueryStatistics.
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	opts.CommonOpts.EnablePerStepStats = true
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
@@ -3883,7 +3884,7 @@ func TestQueryStatementLookbackDelta(t *testing.T) {
 	}
 
 	t.Run("engine with no lookback delta configured", func(t *testing.T) {
-		engineOpts := NewTestEngineOpts()
+		engineOpts := opts.NewTestEngineOpts()
 		engine, err := NewEngine(engineOpts, limitsProvider, stats, NewQueryPlanner(engineOpts), logger)
 		require.NoError(t, err)
 
@@ -3903,7 +3904,7 @@ func TestQueryStatementLookbackDelta(t *testing.T) {
 	})
 
 	t.Run("engine with lookback delta configured", func(t *testing.T) {
-		engineOpts := NewTestEngineOpts()
+		engineOpts := opts.NewTestEngineOpts()
 		engineOpts.CommonOpts.LookbackDelta = 12 * time.Minute
 		engine, err := NewEngine(engineOpts, limitsProvider, stats, NewQueryPlanner(engineOpts), logger)
 		require.NoError(t, err)
@@ -3937,7 +3938,7 @@ func TestQueryClose(t *testing.T) {
 	`)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 
@@ -3973,11 +3974,11 @@ func TestEagerLoadSelectors(t *testing.T) {
 	limitsProvider := NewStaticQueryLimitsProvider(0)
 	metrics := stats.NewQueryMetrics(nil)
 	logger := log.NewNopLogger()
-	optsWithoutEagerLoading := NewTestEngineOpts()
+	optsWithoutEagerLoading := opts.NewTestEngineOpts()
 	engineWithoutEagerLoading, err := NewEngine(optsWithoutEagerLoading, limitsProvider, metrics, NewQueryPlanner(optsWithoutEagerLoading), logger)
 	require.NoError(t, err)
 
-	optsWithEagerLoading := NewTestEngineOpts()
+	optsWithEagerLoading := opts.NewTestEngineOpts()
 	optsWithEagerLoading.EagerLoadSelectors = true
 	engineWithEagerLoading, err := NewEngine(optsWithEagerLoading, limitsProvider, metrics, NewQueryPlanner(optsWithEagerLoading), logger)
 	require.NoError(t, err)
@@ -4093,7 +4094,7 @@ func TestInstantQueryDurationExpression(t *testing.T) {
 	`)
 	t.Cleanup(func() { require.NoError(t, storage.Close()) })
 
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)

--- a/pkg/streamingpromql/engineopts/config.go
+++ b/pkg/streamingpromql/engineopts/config.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package opts
+package engineopts
 
 import (
 	"flag"

--- a/pkg/streamingpromql/functions_test.go
+++ b/pkg/streamingpromql/functions_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 )
 
 // This test ensures that all functions correctly merge series after dropping the metric name.
@@ -29,7 +29,7 @@ func TestFunctionDeduplicateAndMerge(t *testing.T) {
 	`
 
 	storage := promqltest.LoadedStorage(t, data)
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 

--- a/pkg/streamingpromql/functions_test.go
+++ b/pkg/streamingpromql/functions_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 )
 
 // This test ensures that all functions correctly merge series after dropping the metric name.
@@ -28,7 +29,7 @@ func TestFunctionDeduplicateAndMerge(t *testing.T) {
 	`
 
 	storage := promqltest.LoadedStorage(t, data)
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
 	require.NoError(t, err)
 

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql"
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/ast"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
@@ -503,7 +503,7 @@ func TestOptimizationPass(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			opts := opts.NewTestEngineOpts()
+			opts := engineopts.NewTestEngineOpts()
 			plannerWithoutOptimizationPass := streamingpromql.NewQueryPlannerWithoutOptimizationPasses(opts)
 			plannerWithoutOptimizationPass.RegisterASTOptimizationPass(&ast.CollapseConstants{})
 

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/ast"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
@@ -502,7 +503,7 @@ func TestOptimizationPass(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			opts := streamingpromql.NewTestEngineOpts()
+			opts := opts.NewTestEngineOpts()
 			plannerWithoutOptimizationPass := streamingpromql.NewQueryPlannerWithoutOptimizationPasses(opts)
 			plannerWithoutOptimizationPass.RegisterASTOptimizationPass(&ast.CollapseConstants{})
 

--- a/pkg/streamingpromql/optimize/plan/skip_histogram_decoding_test.go
+++ b/pkg/streamingpromql/optimize/plan/skip_histogram_decoding_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
@@ -370,7 +371,7 @@ func TestSkipHistogramDecodingOptimizationPass(t *testing.T) {
 	timeRange := types.NewInstantQueryTimeRange(time.Now())
 	observer := streamingpromql.NoopPlanningObserver{}
 
-	opts := streamingpromql.NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	planner := streamingpromql.NewQueryPlannerWithoutOptimizationPasses(opts)
 	planner.RegisterQueryPlanOptimizationPass(commonsubexpressionelimination.NewOptimizationPass(true, nil))
 	planner.RegisterQueryPlanOptimizationPass(plan.NewSkipHistogramDecodingOptimizationPass())

--- a/pkg/streamingpromql/optimize/plan/skip_histogram_decoding_test.go
+++ b/pkg/streamingpromql/optimize/plan/skip_histogram_decoding_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql"
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
@@ -371,7 +371,7 @@ func TestSkipHistogramDecodingOptimizationPass(t *testing.T) {
 	timeRange := types.NewInstantQueryTimeRange(time.Now())
 	observer := streamingpromql.NoopPlanningObserver{}
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	planner := streamingpromql.NewQueryPlannerWithoutOptimizationPasses(opts)
 	planner.RegisterQueryPlanOptimizationPass(commonsubexpressionelimination.NewOptimizationPass(true, nil))
 	planner.RegisterQueryPlanOptimizationPass(plan.NewSkipHistogramDecodingOptimizationPass())

--- a/pkg/streamingpromql/opts/config.go
+++ b/pkg/streamingpromql/opts/config.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package streamingpromql
+package opts
 
 import (
 	"flag"

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/ast"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
@@ -43,7 +43,7 @@ type QueryPlanner struct {
 	planStageLatency         *prometheus.HistogramVec
 }
 
-func NewQueryPlanner(opts opts.EngineOpts) *QueryPlanner {
+func NewQueryPlanner(opts engineopts.EngineOpts) *QueryPlanner {
 	planner := NewQueryPlannerWithoutOptimizationPasses(opts)
 
 	// FIXME: it makes sense to register these common optimization passes here, but we'll likely need to rework this once
@@ -68,7 +68,7 @@ func NewQueryPlanner(opts opts.EngineOpts) *QueryPlanner {
 // NewQueryPlannerWithoutOptimizationPasses creates a new query planner without any optimization passes registered.
 //
 // This is intended for use in tests only.
-func NewQueryPlannerWithoutOptimizationPasses(opts opts.EngineOpts) *QueryPlanner {
+func NewQueryPlannerWithoutOptimizationPasses(opts engineopts.EngineOpts) *QueryPlanner {
 	activeQueryTracker := opts.CommonOpts.ActiveQueryTracker
 	if activeQueryTracker == nil {
 		activeQueryTracker = &NoopQueryTracker{}

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/ast"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
@@ -42,7 +43,7 @@ type QueryPlanner struct {
 	planStageLatency         *prometheus.HistogramVec
 }
 
-func NewQueryPlanner(opts EngineOpts) *QueryPlanner {
+func NewQueryPlanner(opts opts.EngineOpts) *QueryPlanner {
 	planner := NewQueryPlannerWithoutOptimizationPasses(opts)
 
 	// FIXME: it makes sense to register these common optimization passes here, but we'll likely need to rework this once
@@ -67,7 +68,7 @@ func NewQueryPlanner(opts EngineOpts) *QueryPlanner {
 // NewQueryPlannerWithoutOptimizationPasses creates a new query planner without any optimization passes registered.
 //
 // This is intended for use in tests only.
-func NewQueryPlannerWithoutOptimizationPasses(opts EngineOpts) *QueryPlanner {
+func NewQueryPlannerWithoutOptimizationPasses(opts opts.EngineOpts) *QueryPlanner {
 	activeQueryTracker := opts.CommonOpts.ActiveQueryTracker
 	if activeQueryTracker == nil {
 		activeQueryTracker = &NoopQueryTracker{}

--- a/pkg/streamingpromql/planning_test.go
+++ b/pkg/streamingpromql/planning_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
@@ -1082,7 +1083,7 @@ func TestPlanCreationEncodingAndDecoding(t *testing.T) {
 			testCase.expectedPlan.OriginalExpression = testCase.expr
 
 			reg := prometheus.NewPedanticRegistry()
-			opts := NewTestEngineOpts()
+			opts := opts.NewTestEngineOpts()
 			opts.CommonOpts.NoStepSubqueryIntervalFn = func(_ int64) int64 {
 				return (23 * time.Second).Milliseconds()
 			}
@@ -1132,7 +1133,7 @@ func BenchmarkPlanEncodingAndDecoding(b *testing.B) {
 		`label_join(foo, "abc", "-") + label_join(bar, "def", ",")`,
 	}
 
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	planner := NewQueryPlanner(opts)
 	ctx := context.Background()
 
@@ -1184,7 +1185,7 @@ func BenchmarkPlanEncodingAndDecoding(b *testing.B) {
 }
 
 func TestQueryPlanner_ActivityTracking(t *testing.T) {
-	opts := NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	tracker := &testQueryTracker{}
 	opts.CommonOpts.ActiveQueryTracker = tracker
 	planner := NewQueryPlanner(opts)
@@ -1440,7 +1441,7 @@ func TestAnalysisHandler(t *testing.T) {
 		},
 	}
 
-	planner := NewQueryPlannerWithoutOptimizationPasses(NewTestEngineOpts())
+	planner := NewQueryPlannerWithoutOptimizationPasses(opts.NewTestEngineOpts())
 	handler := AnalysisHandler(planner)
 
 	for name, testCase := range testCases {

--- a/pkg/streamingpromql/planning_test.go
+++ b/pkg/streamingpromql/planning_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
@@ -1083,7 +1083,7 @@ func TestPlanCreationEncodingAndDecoding(t *testing.T) {
 			testCase.expectedPlan.OriginalExpression = testCase.expr
 
 			reg := prometheus.NewPedanticRegistry()
-			opts := opts.NewTestEngineOpts()
+			opts := engineopts.NewTestEngineOpts()
 			opts.CommonOpts.NoStepSubqueryIntervalFn = func(_ int64) int64 {
 				return (23 * time.Second).Milliseconds()
 			}
@@ -1133,7 +1133,7 @@ func BenchmarkPlanEncodingAndDecoding(b *testing.B) {
 		`label_join(foo, "abc", "-") + label_join(bar, "def", ",")`,
 	}
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	planner := NewQueryPlanner(opts)
 	ctx := context.Background()
 
@@ -1185,7 +1185,7 @@ func BenchmarkPlanEncodingAndDecoding(b *testing.B) {
 }
 
 func TestQueryPlanner_ActivityTracking(t *testing.T) {
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	tracker := &testQueryTracker{}
 	opts.CommonOpts.ActiveQueryTracker = tracker
 	planner := NewQueryPlanner(opts)
@@ -1441,7 +1441,7 @@ func TestAnalysisHandler(t *testing.T) {
 		},
 	}
 
-	planner := NewQueryPlannerWithoutOptimizationPasses(opts.NewTestEngineOpts())
+	planner := NewQueryPlannerWithoutOptimizationPasses(engineopts.NewTestEngineOpts())
 	handler := AnalysisHandler(planner)
 
 	for name, testCase := range testCases {

--- a/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
+++ b/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
-	"github.com/grafana/mimir/pkg/streamingpromql/opts"
+	"github.com/grafana/mimir/pkg/streamingpromql/engineopts"
 	"github.com/grafana/mimir/pkg/util/fs"
 )
 
@@ -58,7 +58,7 @@ func run() error {
 		return fmt.Errorf("could not list test files in '%v': %w", testsDir, err)
 	}
 
-	opts := opts.NewTestEngineOpts()
+	opts := engineopts.NewTestEngineOpts()
 	engine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), streamingpromql.NewQueryPlanner(opts), log.NewNopLogger())
 	if err != nil {
 		return fmt.Errorf("could not create engine: %w", err)

--- a/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
+++ b/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
+	"github.com/grafana/mimir/pkg/streamingpromql/opts"
 	"github.com/grafana/mimir/pkg/util/fs"
 )
 
@@ -57,7 +58,7 @@ func run() error {
 		return fmt.Errorf("could not list test files in '%v': %w", testsDir, err)
 	}
 
-	opts := streamingpromql.NewTestEngineOpts()
+	opts := opts.NewTestEngineOpts()
 	engine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), streamingpromql.NewQueryPlanner(opts), log.NewNopLogger())
 	if err != nil {
 		return fmt.Errorf("could not create engine: %w", err)


### PR DESCRIPTION
#### What this PR does

Move streamingpromql engine opts into its own package so it can be imported into other packages like `ast` without causing a cycle. Not sure if this is the best approach or if there's a better package name, please let me know.

#### Which issue(s) this PR fixes or relates to

Will unblock https://github.com/grafana/mimir/pull/12303

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Not a user-facing change, more like a refactor.