### PR TITLE
Document yoloStrings and buffer pooling in contributing/README.md

### DIFF
--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -119,7 +119,8 @@ There are currently no guardrails around this, beyond tests.
 
 Some (but maybe not all) specific critical areas are:
 
-- In the distributor, such strings must not outlive the `PushFunc` passed to `Handler`.
+- In the distributor, those strings must not outlive the `PushFunc` passed to `Handler`.
+  - The `PushFunc` decompresses an incoming request into a reused buffer, then unmarshals the buffer into a `PreallocWriteRequest` that holds `unsafeMutableString`s (indirectly through `unsafeMutableLabel`) into that same buffer, and then, before returning, returns the buffer to the pool to be reused. If any strings from the `PreallocWriteRequest` are still alive at that point, they will be referring to a buffer that could be reused for a new request at any point.
 
 ## Documentation
 


### PR DESCRIPTION
#### What this PR does

Introduces a section in our contributing guidelines in the hopes of raise awareness of yoloStrings and its perils.

This also updates CLAUDE.md, which is a symlink.

#### Which issue(s) this PR fixes or relates to

https://grafana.com/blog/2025/08/03/grafana-cloud-metrics-memory-corruption-issue-resolved/

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
