### PR TITLE
TestValidateLabels: run finalChecks from the cleanup

### DIFF
--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 	grpcstatus "google.golang.org/grpc/status"
 	golangproto "google.golang.org/protobuf/proto"
 
@@ -447,8 +446,8 @@ func TestValidateLabels(t *testing.T) {
 		d.sampleValidationMetrics.deleteUserMetrics(utf8UserID)
 	}
 
-	var inFlightSubsets atomic.Int64
-	inFlightSubsets.Store(int64(len(testCases) * len(validationSchemes)))
+	// Run final checks after all subtests are done.
+	t.Cleanup(func() { finalChecks(t) })
 
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
@@ -456,12 +455,6 @@ func TestValidateLabels(t *testing.T) {
 			for _, scheme := range validationSchemes {
 				t.Run(scheme.String(), func(t *testing.T) {
 					t.Parallel()
-
-					defer func() {
-						if inFlightSubsets.Add(-1) == 0 {
-							finalChecks(t)
-						}
-					}()
 
 					var userID string
 					switch scheme {


### PR DESCRIPTION
Instead of doing the unnecessary atomic logic, we can just register a cleanup function: that runs after all subtests are finished.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
