### PR TITLE
Add cluster role to allow rollout-operator to watch for webhook confi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to be closer to the requested number of CPUs. #12150
 * [CHANGE] Query-scheduler: The query-scheduler is now a required component that is always used by queriers and query-frontends. #12187
+* [CHANGE] Rollout-operator: Add `watch` permission to the rollout-operators's cluster role. #12360
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to be closer to the requested number of CPUs. #12150
 * [CHANGE] Query-scheduler: The query-scheduler is now a required component that is always used by queriers and query-frontends. #12187
-* [CHANGE] Rollout-operator: Add `watch` permission to the rollout-operators's cluster role. #12360
+* [CHANGE] Rollout-operator: Add `watch` permission to the rollout-operators's cluster role. #12360. See [rollout-operator#262](https://github.com/grafana/rollout-operator/pull/262)
 
 ### Documentation
 

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -213,6 +213,7 @@ rules:
   verbs:
   - list
   - patch
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/operations/mimir/rollout-operator.libsonnet
+++ b/operations/mimir/rollout-operator.libsonnet
@@ -152,7 +152,7 @@
     clusterRole.withRulesMixin([
       policyRule.withApiGroups('admissionregistration.k8s.io')
       + policyRule.withResources(['validatingwebhookconfigurations', 'mutatingwebhookconfigurations'])
-      + policyRule.withVerbs(['list', 'patch']),
+      + policyRule.withVerbs(['list', 'patch', 'watch']),
     ]),
 
   rollout_operator_webhook_cert_update_clusterrolebinding: if !rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else


### PR DESCRIPTION
#### What this PR does

Adds the watch permission to the rollout-operator cluster role. 

#### Which issue(s) this PR fixes or relates to

This is required for https://github.com/grafana/rollout-operator/pull/262

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [X ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
