### PR TITLE
Silence false-positive Zizmor warnings

### DIFF
--- a/.github/workflows/compare-helm-with-jsonnet.yml
+++ b/.github/workflows/compare-helm-with-jsonnet.yml
@@ -29,8 +29,8 @@ jobs:
   goversion:
     runs-on: ubuntu-latest
     needs: prepare
-    container: 
-      image: ${{ needs.prepare.outputs.build_image }}
+    container:
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
+++ b/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
@@ -35,7 +35,7 @@ jobs:
     needs:
       - prepare
     container:
-      image: ${{ needs.prepare.outputs.build_image }}
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     permissions:
       contents: read
       # The "id-token: write" permission is required by "get-vault-secrets" action. We request it here

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -38,7 +38,7 @@ jobs:
     needs:
       - prepare
     container:
-      image: ${{ needs.prepare.outputs.build_image }}
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     container:
-      image: ${{ needs.prepare.outputs.build_image }}
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     container:
-      image: ${{ needs.prepare.outputs.build_image }}
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
     needs:
       - prepare
     container:
-      image: ${{ needs.prepare.outputs.build_image }}
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
     needs:
       - prepare
     container:
-      image: ${{ needs.prepare.outputs.build_image }}
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -158,7 +158,7 @@ jobs:
     needs:
       - prepare
     container:
-      image: ${{ needs.prepare.outputs.build_image }}
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -191,7 +191,7 @@ jobs:
     needs:
       - prepare
     container:
-      image: ${{ needs.prepare.outputs.build_image }}
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -314,7 +314,7 @@ jobs:
     if: needs.prepare.outputs.is_deploy == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.prepare.outputs.build_image }}
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
#### What this PR does

This PR silences false-positive Zizmor warnings about unpinned Docker images like those seen [here](https://github.com/grafana/mimir/pull/12363#issuecomment-3178602800).

The image returned by the prepare step is pinned, but Zizmor's analysis isn't able to infer that.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
