### PR TITLE
Alertmanager: Add HTTP tracing to notify hooks outgoing requests

### DIFF
--- a/pkg/alertmanager/notify_hooks_notifier.go
+++ b/pkg/alertmanager/notify_hooks_notifier.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -68,6 +69,8 @@ func newNotifyHooksNotifier(upstream notify.Notifier, limits notifyHooksLimits, 
 	if err != nil {
 		return nil, err
 	}
+
+	client.Transport = otelhttp.NewTransport(client.Transport)
 
 	return &notifyHooksNotifier{
 		upstream: upstream,


### PR DESCRIPTION
#### What this PR does

Adds HTTP tracing to Alertmanager notify hooks by wrapping the HTTP client transport with `otelhttp.NewTransport`. Span is already created [here](https://github.com/grafana/mimir/blob/f095c6dbfb9449299568138ae6bb53b1a3559026/pkg/alertmanager/notify_hooks_notifier.go#L191).

<img width="1161" height="841" alt="image" src="https://github.com/user-attachments/assets/bbd2494a-fdbb-4a83-8482-de265d1d3556" />


#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
