### PR TITLE
Distributor: Auto-deduce OTel translation strategy in OTLP endpoint if unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [CHANGE] Distributor: Remove deprecated global HA tracker timeout configuration flags. #12321
 * [CHANGE] Query-frontend: Use the Mimir Query Engine (MQE) by default. #12361
 * [FEATURE] Distributor, ruler: Add experimental `-validation.name-validation-scheme` flag to specify the validation scheme for metric and label names. #12215
-* [FEATURE] Distributor: Add experimental `-distributor.otel-translation-strategy` flag to support configuring the metric and label name translation strategy in the OTLP endpoint. #12284 #12306
+* [FEATURE] Distributor: Add experimental `-distributor.otel-translation-strategy` flag to support configuring the metric and label name translation strategy in the OTLP endpoint. #12284 #12306 #12369
 * [ENHANCEMENT] Query-scheduler/query-frontend: Add native histogram definitions to `cortex_query_{scheduler|frontend}_queue_duration_seconds`. #12288
 * [ENHANCEMENT] Compactor: Add `-compactor.update-blocks-concurrency` flag to control concurrency for updating block metadata during bucket index updates, separate from deletion marker concurrency. #12117
 * [ENHANCEMENT] Stagger head compaction intervals across zones to prevent compactions from aligning simultaneously, which could otherwise cause strong consistency queries to fail when experimental ingest storage is enabled. #12090

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -292,24 +292,6 @@ func newOTLPParser(
 		promoteScopeMetadata := limits.OTelPromoteScopeMetadata(tenantID)
 		allowDeltaTemporality := limits.OTelNativeDeltaIngestion(tenantID)
 		translationStrategy := limits.OTelTranslationStrategy(tenantID)
-		if translationStrategy == "" {
-			// Generate translation strategy based on other settings.
-			suffixesEnabled := limits.OTelMetricSuffixesEnabled(tenantID)
-			switch limits.NameValidationScheme(tenantID) {
-			case model.LegacyValidation:
-				if suffixesEnabled {
-					translationStrategy = otlptranslator.UnderscoreEscapingWithSuffixes
-				} else {
-					translationStrategy = otlptranslator.UnderscoreEscapingWithoutSuffixes
-				}
-			case model.UTF8Validation:
-				if suffixesEnabled {
-					translationStrategy = otlptranslator.NoUTF8EscapingWithSuffixes
-				} else {
-					translationStrategy = otlptranslator.NoTranslation
-				}
-			}
-		}
 		validateTranslationStrategy(translationStrategy, limits, tenantID)
 
 		pushMetrics.IncOTLPRequest(tenantID)

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -1260,7 +1260,6 @@ func TestHandlerOTLPPush(t *testing.T) {
 			testLimits := &validation.Limits{
 				PromoteOTelResourceAttributes: tt.promoteResourceAttributes,
 				NameValidationScheme:          validation.ValidationSchemeValue(model.LegacyValidation),
-				OTelTranslationStrategy:       validation.OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithoutSuffixes),
 				OTelMetricSuffixesEnabled:     false,
 			}
 			limits := validation.NewOverrides(

--- a/pkg/mimir/runtime_config_test.go
+++ b/pkg/mimir/runtime_config_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
-	"github.com/prometheus/otlptranslator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -253,6 +252,5 @@ overrides:
 func getDefaultLimits() validation.Limits {
 	limits := validation.Limits{}
 	flagext.DefaultValues(&limits)
-	limits.OTelTranslationStrategy = validation.OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithoutSuffixes)
 	return limits
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -616,21 +616,6 @@ func (l *Limits) Validate() error {
 			return fmt.Errorf("OTLP translation strategy %s is not allowed unless metric suffixes are disabled", l.OTelTranslationStrategy)
 		}
 	case "":
-		// Generate translation strategy based on other settings.
-		switch validationScheme {
-		case model.LegacyValidation:
-			if l.OTelMetricSuffixesEnabled {
-				l.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithSuffixes)
-			} else {
-				l.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithoutSuffixes)
-			}
-		case model.UTF8Validation:
-			if l.OTelMetricSuffixesEnabled {
-				l.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.NoUTF8EscapingWithSuffixes)
-			} else {
-				l.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.NoTranslation)
-			}
-		}
 	default:
 		return fmt.Errorf("unsupported OTLP translation strategy %q", l.OTelTranslationStrategy)
 	}

--- a/pkg/util/validation/limits_mock.go
+++ b/pkg/util/validation/limits_mock.go
@@ -7,7 +7,6 @@ package validation
 
 import (
 	"github.com/grafana/dskit/flagext"
-	"github.com/prometheus/otlptranslator"
 )
 
 // mockTenantLimits exposes per-tenant limits based on a provided map
@@ -44,7 +43,6 @@ func MockOverrides(customize func(defaults *Limits, tenantLimits map[string]*Lim
 func MockDefaultLimits() *Limits {
 	defaults := Limits{}
 	flagext.DefaultValues(&defaults)
-	defaults.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithoutSuffixes)
 	return &defaults
 }
 

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -2166,6 +2166,109 @@ func TestLimitsCanonicalizeQueries(t *testing.T) {
 	}
 }
 
+func TestOverrides_OTelTranslationStrategy(t *testing.T) {
+	testCases := []struct {
+		name                        string
+		limits                      map[string]*Limits
+		tenantID                    string
+		expectedTranslationStrategy otlptranslator.TranslationStrategyOption
+	}{
+		{
+			name: "explicit strategy takes precedence",
+			limits: map[string]*Limits{
+				"tenant1": {
+					OTelTranslationStrategy:   OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithSuffixes),
+					NameValidationScheme:      ValidationSchemeValue(model.UTF8Validation),
+					OTelMetricSuffixesEnabled: false,
+				},
+			},
+			tenantID:                    "tenant1",
+			expectedTranslationStrategy: otlptranslator.UnderscoreEscapingWithSuffixes,
+		},
+		{
+			name: "auto-deduced: legacy validation + suffixes enabled",
+			limits: map[string]*Limits{
+				"tenant1": {
+					OTelTranslationStrategy:   OTelTranslationStrategyValue(""),
+					NameValidationScheme:      ValidationSchemeValue(model.LegacyValidation),
+					OTelMetricSuffixesEnabled: true,
+				},
+			},
+			tenantID:                    "tenant1",
+			expectedTranslationStrategy: otlptranslator.UnderscoreEscapingWithSuffixes,
+		},
+		{
+			name: "auto-deduced: legacy validation + suffixes disabled",
+			limits: map[string]*Limits{
+				"tenant1": {
+					OTelTranslationStrategy:   OTelTranslationStrategyValue(""),
+					NameValidationScheme:      ValidationSchemeValue(model.LegacyValidation),
+					OTelMetricSuffixesEnabled: false,
+				},
+			},
+			tenantID:                    "tenant1",
+			expectedTranslationStrategy: otlptranslator.UnderscoreEscapingWithoutSuffixes,
+		},
+		{
+			name: "auto-deduced: utf8 validation + suffixes enabled",
+			limits: map[string]*Limits{
+				"tenant1": {
+					OTelTranslationStrategy:   OTelTranslationStrategyValue(""),
+					NameValidationScheme:      ValidationSchemeValue(model.UTF8Validation),
+					OTelMetricSuffixesEnabled: true,
+				},
+			},
+			tenantID:                    "tenant1",
+			expectedTranslationStrategy: otlptranslator.NoUTF8EscapingWithSuffixes,
+		},
+		{
+			name: "auto-deduced: utf8 validation + suffixes disabled",
+			limits: map[string]*Limits{
+				"tenant1": {
+					OTelTranslationStrategy:   OTelTranslationStrategyValue(""),
+					NameValidationScheme:      ValidationSchemeValue(model.UTF8Validation),
+					OTelMetricSuffixesEnabled: false,
+				},
+			},
+			tenantID:                    "tenant1",
+			expectedTranslationStrategy: otlptranslator.NoTranslation,
+		},
+		{
+			name:                        "uses defaults for unknown tenant",
+			limits:                      map[string]*Limits{},
+			tenantID:                    "unknown",
+			expectedTranslationStrategy: otlptranslator.UnderscoreEscapingWithoutSuffixes, // Default: legacy + suffixes disabled
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defaults := getDefaultLimits()
+			overrides := NewOverrides(defaults, NewMockTenantLimits(tc.limits))
+
+			result := overrides.OTelTranslationStrategy(tc.tenantID)
+			assert.Equal(t, tc.expectedTranslationStrategy, result)
+		})
+	}
+
+	t.Run("panics on unknown name validation scheme", func(t *testing.T) {
+		limits := map[string]*Limits{
+			"tenant1": {
+				OTelTranslationStrategy:   OTelTranslationStrategyValue(""),
+				NameValidationScheme:      ValidationSchemeValue(999), // Invalid scheme
+				OTelMetricSuffixesEnabled: true,
+			},
+		}
+
+		defaults := getDefaultLimits()
+		overrides := NewOverrides(defaults, NewMockTenantLimits(limits))
+
+		assert.Panics(t, func() {
+			overrides.OTelTranslationStrategy("tenant1")
+		})
+	})
+}
+
 func getDefaultLimits() Limits {
 	limits := Limits{}
 	flagext.DefaultValues(&limits)

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -1640,7 +1640,7 @@ func TestLimits_Validate(t *testing.T) {
 			}(),
 			verify: func(t *testing.T, cfg Limits) {
 				t.Helper()
-				assert.Equal(t, OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithoutSuffixes), cfg.OTelTranslationStrategy)
+				assert.Equal(t, OTelTranslationStrategyValue(""), cfg.OTelTranslationStrategy)
 			},
 			expectedErr: nil,
 		},
@@ -1655,7 +1655,7 @@ func TestLimits_Validate(t *testing.T) {
 			}(),
 			verify: func(t *testing.T, cfg Limits) {
 				t.Helper()
-				assert.Equal(t, OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithSuffixes), cfg.OTelTranslationStrategy)
+				assert.Equal(t, OTelTranslationStrategyValue(""), cfg.OTelTranslationStrategy)
 			},
 			expectedErr: nil,
 		},
@@ -1670,7 +1670,7 @@ func TestLimits_Validate(t *testing.T) {
 			}(),
 			verify: func(t *testing.T, cfg Limits) {
 				t.Helper()
-				assert.Equal(t, OTelTranslationStrategyValue(otlptranslator.NoUTF8EscapingWithSuffixes), cfg.OTelTranslationStrategy)
+				assert.Equal(t, OTelTranslationStrategyValue(""), cfg.OTelTranslationStrategy)
 			},
 			expectedErr: nil,
 		},
@@ -1685,7 +1685,7 @@ func TestLimits_Validate(t *testing.T) {
 			}(),
 			verify: func(t *testing.T, cfg Limits) {
 				t.Helper()
-				assert.Equal(t, OTelTranslationStrategyValue(otlptranslator.NoTranslation), cfg.OTelTranslationStrategy)
+				assert.Equal(t, OTelTranslationStrategyValue(""), cfg.OTelTranslationStrategy)
 			},
 			expectedErr: nil,
 		},


### PR DESCRIPTION
#### What this PR does

Modify validation code to not configure default OTel metric and label name translation strategy, but instead leave that to the distributor's OTLP endpoint logic. This is because we found a bug connected to automatically deducing the translation strategy within `Limits.Validate`, and it might as well be done at the call site (in the OTLP endpoint).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
