### PR TITLE
Add metrics for prune toggles optimization pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [CHANGE] Memcached: Remove experimental `-<prefix>.memcached.addresses-provider` flag to use alternate DNS service discovery backends. The more reliable backend introduced in 2.16.0 (#10895) is now the default. As a result of this change, DNS-based cache service discovery no longer supports search domains. #12175 #12385
 * [CHANGE] Query-frontend: Remove the CLI flag `-query-frontend.downstream-url` and corresponding YAML configuration and the ability to use the query-frontend to proxy arbitrary Prometheus backends. #12191
 * [CHANGE] Query-frontend: Remove experimental instant query splitting feature. #12267
-* [CHANGE] Query-frontend, querier: Replace `query-frontend.prune-queries` flag with `querier.mimir-query-engine.enable-prune-toggles` as pruning middleware has been moved into MQE. #12303
+* [CHANGE] Query-frontend, querier: Replace `query-frontend.prune-queries` flag with `querier.mimir-query-engine.enable-prune-toggles` as pruning middleware has been moved into MQE. #12303 #12375
 * [CHANGE] Distributor: Remove deprecated global HA tracker timeout configuration flags. #12321
 * [CHANGE] Query-frontend: Use the Mimir Query Engine (MQE) by default. #12361
 * [CHANGE] Query-frontend: Remove the CLI flags `-querier.frontend-address`, `-querier.max-outstanding-requests-per-tenant`, and `-query-frontend.querier-forget-delay` and corresponding YAML configurations. This is part of a change that makes the query-scheduler a required component. This removes the ability to run the query-frontend with an embedded query-scheduler. Instead, you must run a dedicated query-scheduler component. #12200

--- a/pkg/frontend/querymiddleware/astmapper/astmapper.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper.go
@@ -192,3 +192,31 @@ func (em ASTExprMapper) Map(ctx context.Context, expr parser.Expr) (parser.Expr,
 		return nil, errors.Errorf("ASTExprMapper: unhandled expr type %T", expr)
 	}
 }
+
+// ExprMapperWithState wraps ExprMapper to include a method for checking if the mapper has changed the expression.
+type ExprMapperWithState interface {
+	ExprMapper
+	// HasChanged returns whether the mapper made any changes during mapping
+	HasChanged() bool
+}
+
+// ASTExprMapperWithState is a wrapper around an ASTExprMapper that stores the original mapper to provide a method to check if any changes were made.
+type ASTExprMapperWithState struct {
+	mapper    ExprMapperWithState
+	astMapper ASTExprMapper
+}
+
+func NewASTExprMapperWithState(mapper ExprMapperWithState) *ASTExprMapperWithState {
+	return &ASTExprMapperWithState{
+		mapper:    mapper,
+		astMapper: NewASTExprMapper(mapper),
+	}
+}
+
+func (w *ASTExprMapperWithState) Map(ctx context.Context, expr parser.Expr) (parser.Expr, error) {
+	return w.astMapper.Map(ctx, expr)
+}
+
+func (w *ASTExprMapperWithState) HasChanged() bool {
+	return w.mapper.HasChanged()
+}

--- a/pkg/streamingpromql/optimize/ast/prune_toggles.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles.go
@@ -20,9 +20,7 @@ type PruneToggles struct {
 }
 
 func NewPruneToggles() *PruneToggles {
-	return &PruneToggles{
-		mapper: NewPruneTogglesMapper(),
-	}
+	return &PruneToggles{}
 }
 
 func (p *PruneToggles) Name() string {
@@ -30,10 +28,14 @@ func (p *PruneToggles) Name() string {
 }
 
 func (p *PruneToggles) Apply(ctx context.Context, expr parser.Expr) (parser.Expr, error) {
+	p.mapper = NewPruneTogglesMapper()
 	return p.mapper.Map(ctx, expr)
 }
 
 func (p *PruneToggles) HasChanged() bool {
+	if p.mapper == nil {
+		return false
+	}
 	return p.mapper.HasChanged()
 }
 

--- a/pkg/streamingpromql/optimize/ast/prune_toggles.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles.go
@@ -18,16 +18,12 @@ import (
 // e.g. `(avg(rate(foo[1m]))) and on() (vector(1) == 1)` -> `(avg(rate(foo[1m])))`
 // e.g. `(avg(rate(foo[1m]))) and on() (vector(1) == -1)` -> `(vector(1) == -1)`
 type PruneToggles struct {
-	pruneTogglesMetrics
-}
-
-type pruneTogglesMetrics struct {
 	pruneTogglesAttempts prometheus.Counter
 	pruneTogglesRewrites prometheus.Counter
 }
 
 func NewPruneToggles(reg prometheus.Registerer) *PruneToggles {
-	metrics := pruneTogglesMetrics{
+	return &PruneToggles{
 		pruneTogglesAttempts: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_mimir_query_engine_prune_toggles_attempted_total",
 			Help: "Total number of queries that the optimization pass has attempted to rewrite by pruning toggles.",
@@ -36,9 +32,6 @@ func NewPruneToggles(reg prometheus.Registerer) *PruneToggles {
 			Name: "cortex_mimir_query_engine_prune_toggles_rewritten_total",
 			Help: "Total number of queries where the optimization pass has rewritten the query by pruning toggles.",
 		}),
-	}
-	return &PruneToggles{
-		pruneTogglesMetrics: metrics,
 	}
 }
 

--- a/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
@@ -52,7 +52,6 @@ var testCasesPruneToggles = map[string]string{
 }
 
 func TestPruneToggles(t *testing.T) {
-	optimizer := ast.NewPruneToggles()
 	ctx := context.Background()
 
 	for input, expected := range testCasesPruneToggles {
@@ -62,10 +61,12 @@ func TestPruneToggles(t *testing.T) {
 
 			inputExpr, err := parser.ParseExpr(input)
 			require.NoError(t, err)
+			optimizer := ast.NewPruneToggles()
 			outputExpr, err := optimizer.Apply(ctx, inputExpr)
 			require.NoError(t, err)
 
 			require.Equal(t, expectedExpr.String(), outputExpr.String())
+			require.Equal(t, input != expected, optimizer.HasChanged())
 		})
 	}
 }

--- a/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
@@ -82,10 +82,10 @@ func TestPruneToggles(t *testing.T) {
 
 func checkPruneTogglesMetrics(t *testing.T, g prometheus.Gatherer, expectedTotal, expectedChanged int) {
 	const metricNameTotal = "cortex_mimir_query_engine_prune_toggles_attempted_total"
-	expectedMetricsTotal := fmt.Sprintf(`# HELP %v Total number of queries that the optimization pass has attempted to rewrite by pruning toggles.
-# TYPE %v counter
-%v %v
-`, metricNameTotal, metricNameTotal, metricNameTotal, expectedTotal)
+	expectedMetricsTotal := fmt.Sprintf(`# HELP %[1]v Total number of queries that the optimization pass has attempted to rewrite by pruning toggles.
+# TYPE %[1]v counter
+%[1]v %[2]v
+`, metricNameTotal, expectedTotal)
 	require.NoError(t, testutil.GatherAndCompare(g, strings.NewReader(expectedMetricsTotal), metricNameTotal))
 
 	const metricNameChanged = "cortex_mimir_query_engine_prune_toggles_rewritten_total"

--- a/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
@@ -54,6 +54,8 @@ var testCasesPruneToggles = map[string]string{
 
 func TestPruneToggles(t *testing.T) {
 	ctx := context.Background()
+	reg := prometheus.NewPedanticRegistry()
+	optimizer := ast.NewPruneToggles(reg)
 
 	for input, expected := range testCasesPruneToggles {
 		t.Run(input, func(t *testing.T) {
@@ -62,8 +64,6 @@ func TestPruneToggles(t *testing.T) {
 
 			inputExpr, err := parser.ParseExpr(input)
 			require.NoError(t, err)
-			reg := prometheus.NewPedanticRegistry()
-			optimizer := ast.NewPruneToggles(reg)
 			outputExpr, err := optimizer.Apply(ctx, inputExpr)
 			require.NoError(t, err)
 

--- a/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 
@@ -61,7 +62,8 @@ func TestPruneToggles(t *testing.T) {
 
 			inputExpr, err := parser.ParseExpr(input)
 			require.NoError(t, err)
-			optimizer := ast.NewPruneToggles()
+			reg := prometheus.NewPedanticRegistry()
+			optimizer := ast.NewPruneToggles(reg)
 			outputExpr, err := optimizer.Apply(ctx, inputExpr)
 			require.NoError(t, err)
 

--- a/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
@@ -82,18 +82,15 @@ func TestPruneToggles(t *testing.T) {
 
 func checkPruneTogglesMetrics(t *testing.T, g prometheus.Gatherer, expectedTotal, expectedChanged int) {
 	const metricNameTotal = "cortex_mimir_query_engine_prune_toggles_attempted_total"
-	expectedMetricsTotal := fmt.Sprintf(`# HELP %[1]v Total number of queries that the optimization pass has attempted to rewrite by pruning toggles.
+	const metricNameChanged = "cortex_mimir_query_engine_prune_toggles_rewritten_total"
+	expectedMetrics := fmt.Sprintf(`# HELP %[1]v Total number of queries that the optimization pass has attempted to rewrite by pruning toggles.
 # TYPE %[1]v counter
 %[1]v %[2]v
-`, metricNameTotal, expectedTotal)
-	require.NoError(t, testutil.GatherAndCompare(g, strings.NewReader(expectedMetricsTotal), metricNameTotal))
-
-	const metricNameChanged = "cortex_mimir_query_engine_prune_toggles_rewritten_total"
-	expectedMetricsChanged := fmt.Sprintf(`# HELP %v Total number of queries where the optimization pass has rewritten the query by pruning toggles.
-# TYPE %v counter
-%v %v
-`, metricNameChanged, metricNameChanged, metricNameChanged, expectedChanged)
-	require.NoError(t, testutil.GatherAndCompare(g, strings.NewReader(expectedMetricsChanged), metricNameChanged))
+# HELP %[3]v Total number of queries where the optimization pass has rewritten the query by pruning toggles.
+# TYPE %[3]v counter
+%[3]v %[4]v
+`, metricNameTotal, expectedTotal, metricNameChanged, expectedChanged)
+	require.NoError(t, testutil.GatherAndCompare(g, strings.NewReader(expectedMetrics), metricNameTotal, metricNameChanged))
 }
 
 func TestPruneTogglesWithData(t *testing.T) {

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -51,7 +51,7 @@ func NewQueryPlanner(opts EngineOpts) *QueryPlanner {
 	//  2. We don't want to register these optimization passes in queriers.
 	planner.RegisterASTOptimizationPass(&ast.CollapseConstants{}) // We expect this to be the first to simplify the logic for the rest of the optimization passes.
 	if opts.EnablePruneToggles {
-		planner.RegisterASTOptimizationPass(ast.NewPruneToggles()) // Do this next to ensure that toggled off expressions are removed before the other optimization passes are applied.
+		planner.RegisterASTOptimizationPass(ast.NewPruneToggles(opts.CommonOpts.Reg)) // Do this next to ensure that toggled off expressions are removed before the other optimization passes are applied.
 	}
 	planner.RegisterASTOptimizationPass(&ast.SortLabelsAndMatchers{}) // This is a prerequisite for other optimization passes such as common subexpression elimination.
 


### PR DESCRIPTION
#### What this PR does

Add metrics for prune toggles optimization pass

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/grafana/mimir/pull/12303

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
