### PR TITLE
MQE: shift responsibilities of `Materializer`

### DIFF
--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -168,7 +168,7 @@ func (e *Engine) newQueryFromPlanner(ctx context.Context, queryable storage.Quer
 		EagerLoadSelectors:       e.eagerLoadSelectors,
 	}
 
-	materializer := NewMaterializer(operatorParams)
+	materializer := planning.NewMaterializer(operatorParams)
 	root, err := materializer.ConvertNodeToOperator(plan.Root, plan.TimeRange)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/planning/core/matrix_selector.go
+++ b/pkg/streamingpromql/planning/core/matrix_selector.go
@@ -61,7 +61,7 @@ func (m *MatrixSelector) ChildrenLabels() []string {
 	return nil
 }
 
-func (m *MatrixSelector) OperatorFactory(_ []types.Operator, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func (m *MatrixSelector) OperatorFactory(_ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	matchers, err := LabelMatchersToPrometheusType(m.Matchers)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/planning/core/number_literal.go
+++ b/pkg/streamingpromql/planning/core/number_literal.go
@@ -56,7 +56,7 @@ func (n *NumberLiteral) ChildrenLabels() []string {
 	return nil
 }
 
-func (n *NumberLiteral) OperatorFactory(_ []types.Operator, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func (n *NumberLiteral) OperatorFactory(_ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	o := scalars.NewScalarConstant(n.Value, timeRange, params.MemoryConsumptionTracker, n.ExpressionPosition.ToPrometheusType())
 
 	return planning.NewSingleUseOperatorFactory(o), nil

--- a/pkg/streamingpromql/planning/core/string_literal.go
+++ b/pkg/streamingpromql/planning/core/string_literal.go
@@ -56,7 +56,7 @@ func (s *StringLiteral) ChildrenLabels() []string {
 	return nil
 }
 
-func (s *StringLiteral) OperatorFactory(_ []types.Operator, _ types.QueryTimeRange, _ *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func (s *StringLiteral) OperatorFactory(_ *planning.Materializer, _ types.QueryTimeRange, _ *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	o := operators.NewStringLiteral(s.Value, s.ExpressionPosition.ToPrometheusType())
 
 	return planning.NewSingleUseOperatorFactory(o), nil

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -48,11 +48,6 @@ func (s *Subquery) Describe() string {
 }
 
 func (s *Subquery) ChildrenTimeRange(timeRange types.QueryTimeRange) types.QueryTimeRange {
-	return SubqueryTimeRange(timeRange, s.Range, s.Step, s.Timestamp, s.Offset)
-}
-
-// FIXME: inline this into the method above once we no longer support directly converting from PromQL expressions to operators
-func SubqueryTimeRange(parentTimeRange types.QueryTimeRange, rng time.Duration, step time.Duration, ts *time.Time, offset time.Duration) types.QueryTimeRange {
 	// Subqueries are evaluated as a single range query with steps aligned to Unix epoch time 0.
 	// They are not evaluated as queries aligned to the individual step timestamps.
 	// See https://www.robustperception.io/promql-subqueries-and-alignment/ for an explanation.
@@ -67,24 +62,23 @@ func SubqueryTimeRange(parentTimeRange types.QueryTimeRange, rng time.Duration, 
 	// This is relatively uncommon, and Prometheus' engine does the same thing. In the future, we
 	// could be smarter about this if it turns out to be a big problem.
 
-	start := parentTimeRange.StartT
-	end := parentTimeRange.EndT
-	stepMilliseconds := step.Milliseconds()
+	start := timeRange.StartT
+	end := timeRange.EndT
+	stepMilliseconds := s.Step.Milliseconds()
 
-	if ts != nil {
-		start = timestamp.FromTime(*ts)
+	if s.Timestamp != nil {
+		start = timestamp.FromTime(*s.Timestamp)
 		end = start
 	}
 
 	// Find the first timestamp inside the subquery range that is aligned to the step.
-	alignedStart := stepMilliseconds * ((start - offset.Milliseconds() - rng.Milliseconds()) / stepMilliseconds)
-	if alignedStart < start-offset.Milliseconds()-rng.Milliseconds() {
+	alignedStart := stepMilliseconds * ((start - s.Offset.Milliseconds() - s.Range.Milliseconds()) / stepMilliseconds)
+	if alignedStart < start-s.Offset.Milliseconds()-s.Range.Milliseconds() {
 		alignedStart += stepMilliseconds
 	}
 
-	end = end - offset.Milliseconds()
-
-	return types.NewRangeQueryTimeRange(timestamp.Time(alignedStart), timestamp.Time(end), step)
+	end = end - s.Offset.Milliseconds()
+	return types.NewRangeQueryTimeRange(timestamp.Time(alignedStart), timestamp.Time(end), s.Step)
 }
 
 func (s *Subquery) Details() proto.Message {
@@ -124,16 +118,14 @@ func (s *Subquery) ChildrenLabels() []string {
 	return []string{""}
 }
 
-func (s *Subquery) OperatorFactory(children []types.Operator, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
-	if len(children) != 1 {
-		return nil, fmt.Errorf("expected exactly 1 child for Subquery, got %v", len(children))
+func (s *Subquery) OperatorFactory(materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+	innerTimeRange := s.ChildrenTimeRange(timeRange)
+	inner, err := materializer.ConvertNodeToInstantVectorOperator(s.Inner, innerTimeRange)
+	if err != nil {
+		return nil, fmt.Errorf("could not create inner operator for Subquery: %w", err)
 	}
 
-	inner, ok := children[0].(types.InstantVectorOperator)
-	if !ok {
-		return nil, fmt.Errorf("expected InstantVectorOperator as child of Subquery, got %T", children[0])
-	}
-	o, err := operators.NewSubquery(inner, timeRange, s.ChildrenTimeRange(timeRange), TimestampFromTime(s.Timestamp), s.Offset, s.Range, s.ExpressionPosition.ToPrometheusType(), params.MemoryConsumptionTracker)
+	o, err := operators.NewSubquery(inner, timeRange, innerTimeRange, TimestampFromTime(s.Timestamp), s.Offset, s.Range, s.ExpressionPosition.ToPrometheusType(), params.MemoryConsumptionTracker)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/planning/core/vector_selector.go
+++ b/pkg/streamingpromql/planning/core/vector_selector.go
@@ -67,7 +67,7 @@ func (v *VectorSelector) ChildrenLabels() []string {
 	return nil
 }
 
-func (v *VectorSelector) OperatorFactory(_ []types.Operator, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func (v *VectorSelector) OperatorFactory(_ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	matchers, err := LabelMatchersToPrometheusType(v.Matchers)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/planning/materialize.go
+++ b/pkg/streamingpromql/planning/materialize.go
@@ -1,27 +1,26 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package streamingpromql
+package planning
 
 import (
-	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 // Materializer is responsible for converting query plan nodes to operators.
 // This type is not thread safe.
 type Materializer struct {
-	operatorFactories map[planning.Node]planning.OperatorFactory
-	operatorParams    *planning.OperatorParameters
+	operatorFactories map[Node]OperatorFactory
+	operatorParams    *OperatorParameters
 }
 
-func NewMaterializer(params *planning.OperatorParameters) *Materializer {
+func NewMaterializer(params *OperatorParameters) *Materializer {
 	return &Materializer{
-		operatorFactories: make(map[planning.Node]planning.OperatorFactory),
+		operatorFactories: make(map[Node]OperatorFactory),
 		operatorParams:    params,
 	}
 }
 
-func (m *Materializer) ConvertNodeToOperator(node planning.Node, timeRange types.QueryTimeRange) (types.Operator, error) {
+func (m *Materializer) ConvertNodeToOperator(node Node, timeRange types.QueryTimeRange) (types.Operator, error) {
 	// FIXME: we should check that we're not trying to get the same operator but with a different time range
 	if f, ok := m.operatorFactories[node]; ok {
 		return f.Produce()

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -76,7 +76,9 @@ type Node interface {
 	ChildrenTimeRange(timeRange types.QueryTimeRange) types.QueryTimeRange
 
 	// OperatorFactory returns a factory that produces operators for this node.
-	OperatorFactory(children []types.Operator, timeRange types.QueryTimeRange, params *OperatorParameters) (OperatorFactory, error)
+	//
+	// Implementations may retain the provided Materializer for later use.
+	OperatorFactory(materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters) (OperatorFactory, error)
 
 	// ResultType returns the kind of result this node produces.
 	//

--- a/pkg/streamingpromql/planning/plan_test.go
+++ b/pkg/streamingpromql/planning/plan_test.go
@@ -111,7 +111,7 @@ func (t *testNode) ChildrenTimeRange(_ types.QueryTimeRange) types.QueryTimeRang
 	panic("not supported")
 }
 
-func (t *testNode) OperatorFactory(_ []types.Operator, _ types.QueryTimeRange, _ *OperatorParameters) (OperatorFactory, error) {
+func (t *testNode) OperatorFactory(_ *Materializer, _ types.QueryTimeRange, _ *OperatorParameters) (OperatorFactory, error) {
 	panic("not supported")
 }
 


### PR DESCRIPTION
#### What this PR does

This PR changes the responsibilities of MQE's `Materializer` type.

Previously, `Materializer.ConvertNodeToOperator` would materialize all of the given node's children and pass it to `Node.OperatorFactory`, and `OperatorFactory` would have no access to the `Materializer`. With the existing set of query plan nodes, this was not an issue, but it is problematic for some scenarios, for example:

* for remote execution, there's no point materializing operators for the parts of the query plan that will be executed remotely
* for caching and splitting, there's also no point materializing operators for cached results, but we'll then need to materialize the child operator if there is a cache miss, or only materialize the child operator for a subset of the time range

This PR also moves `Materializer` to the `planning` package to prevent an import cycle (and seems like a more natural fit for there anyway).

Depending on which PR merges first, either this PR or https://github.com/grafana/mimir/pull/12302 will need changes to account for the changes in the other.

This PR has no user-visible impact and so I've chosen not to add a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
