### PR TITLE
Multiple Components: Use irate in CPU HPA query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to be closer to the requested number of CPUs. #12150
 * [CHANGE] Query-scheduler: The query-scheduler is now a required component that is always used by queriers and query-frontends. #12187
-* [CHANGE] The query-scheduler is now a required component that is always used by queriers and query-frontends. #12384
+* [CHANGE] Use `irate()` when calculating CPU scaling metric. Using `irate()` prevents underestimating CPU utilization when scraping fails. #12384
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to be closer to the requested number of CPUs. #12150
 * [CHANGE] Query-scheduler: The query-scheduler is now a required component that is always used by queriers and query-frontends. #12187
+* [CHANGE] The query-scheduler is now a required component that is always used by queriers and query-frontends. #12384
 
 ### Documentation
 

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1976,7 +1976,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))
             and
             max by (pod) (up{container="alertmanager",namespace="default"}) > 0
           )[15m:]
@@ -2048,7 +2048,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2163,7 +2163,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))
             and
             max by (pod) (up{container="query-frontend",namespace="default"}) > 0
           )[15m:]
@@ -2225,7 +2225,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler",namespace="default"}) > 0
           )[15m:]
@@ -2287,7 +2287,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
           )[15m:]
@@ -2357,7 +2357,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
           )[15m:]

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1976,7 +1976,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))
             and
             max by (pod) (up{container="alertmanager",namespace="default"}) > 0
           )[15m:]
@@ -2048,7 +2048,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2163,7 +2163,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))
             and
             max by (pod) (up{container="query-frontend",namespace="default"}) > 0
           )[15m:]
@@ -2225,7 +2225,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler",namespace="default"}) > 0
           )[15m:]
@@ -2287,7 +2287,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
           )[15m:]
@@ -2357,7 +2357,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
           )[15m:]

--- a/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
@@ -2591,7 +2591,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2663,7 +2663,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-b.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-b.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-b.*"}[1m])) > 0
           )[15m:]

--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -1370,7 +1370,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_0.7__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_0.7__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_false_false_0.7__",namespace="default"}) > 0
           )[15m:]
@@ -1434,7 +1434,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -1498,7 +1498,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -1562,7 +1562,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -1626,7 +1626,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1.5__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_1.5__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_false_false_1.5__",namespace="default"}) > 0
           )[15m:]
@@ -1690,7 +1690,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -1754,7 +1754,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -1818,7 +1818,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -1882,7 +1882,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_1__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_false_false_1__",namespace="default"}) > 0
           )[15m:]
@@ -1944,7 +1944,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -2006,7 +2006,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -2068,7 +2068,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -2130,7 +2130,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_0.7__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_0.7__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2194,7 +2194,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2258,7 +2258,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2322,7 +2322,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2386,7 +2386,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1.5__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_1.5__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2450,7 +2450,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2514,7 +2514,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2578,7 +2578,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2642,7 +2642,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_1__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2704,7 +2704,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2766,7 +2766,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2828,7 +2828,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2890,7 +2890,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_0.7__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_0.7__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_true_false_0.7__",namespace="default"}) > 0
           )[15m:]
@@ -2954,7 +2954,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3018,7 +3018,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -3082,7 +3082,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3146,7 +3146,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1.5__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_1.5__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_true_false_1.5__",namespace="default"}) > 0
           )[15m:]
@@ -3210,7 +3210,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3274,7 +3274,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -3338,7 +3338,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3402,7 +3402,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_1__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_true_false_1__",namespace="default"}) > 0
           )[15m:]
@@ -3464,7 +3464,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3526,7 +3526,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -3588,7 +3588,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3650,7 +3650,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_0.7__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_0.7__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -3714,7 +3714,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -3778,7 +3778,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -3842,7 +3842,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -3906,7 +3906,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1.5__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_1.5__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -3970,7 +3970,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -4034,7 +4034,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -4098,7 +4098,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -4162,7 +4162,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1__",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_1__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -4224,7 +4224,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -4286,7 +4286,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -4348,7 +4348,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]

--- a/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
+++ b/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
@@ -2720,7 +2720,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod!~"distributor-zone.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod!~"distributor-zone.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod!~"distributor-zone.*"}[1m])) > 0
           )[15m:]
@@ -2792,7 +2792,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-a.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2864,7 +2864,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-b.*"}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-b.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-b.*"}[1m])) > 0
           )[15m:]

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -277,7 +277,7 @@
       |||
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"%(extra_matchers)s}[1m])) > 0
           )[15m:]
@@ -294,7 +294,7 @@
       |||
         max_over_time(
           sum(
-            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[5m]))
+            sum by (pod) (irate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[5m]))
             and
             max by (pod) (up{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}) > 0
           )[15m:]

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -274,6 +274,11 @@
       // We multiply by 1000 to get the result in millicores. This is due to HPA only working with ints.
       //
       // When computing the actual CPU utilization, We only take in account ready pods.
+      //
+      // We use irate() instead of rate() because it is more reliable when scrapes fail. It calculates
+      // the rate from only the last two data points in the range, whereas rate() extrapolates missing
+      // values over the full window, which can underestimate CPU utilization and trigger unnecessary
+      // downscaling.
       |||
         quantile_over_time(0.95,
           sum(
@@ -288,9 +293,14 @@
       // per replica over 5m (rolling window) and then we pick the highest value over the last 15m.
       // We multiply by 1000 to get the result in millicores. This is due to HPA only working with ints.
       //
-      // The "up" metrics correctly handles the stale marker when the pod is terminated, while it’s not the
+      // The "up" metrics correctly handles the stale marker when the pod is terminated, while it's not the
       // case for the cAdvisor metrics. By intersecting these 2 metrics, we only look the CPU utilization
       // of containers there are running at any given time, without suffering the PromQL lookback period.
+      //
+      // We use irate() instead of rate() because it is more reliable when scrapes fail. It calculates
+      // the rate from only the last two data points in the range, whereas rate() extrapolates missing
+      // values over the full window, which can underestimate CPU utilization and trigger unnecessary
+      // downscaling.
       |||
         max_over_time(
           sum(


### PR DESCRIPTION
#### What this PR does

At Grafana Labs, we have encountered cases where rate() extrapolates a metric over missing values, underestimates CPU utilization, and triggers an unnecessary downscaling. This PR switches the default CPU scaler metrics to use `irate()` rather than `rate()` (see:`autoscaling.libsonnet`) and affects the scaling behavior of the following components: 

- alertmanager
- query frontend
- ruler
- ruler querier 
- ruler query frontend 
- distributor

This change makes the scaling metric more reliable when scrapes fail, because irate() only uses the last two data points rather than extrapolating over the full window. For example, consider the following chart where the target prometheus instance begins failing intermittently around 21:17. The `rate()` based scaling metric (in green) drops while the `irate()` based metric (yellow) remains around its baseline levels.

<img width="2006" height="382" alt="Screenshot 2025-08-13 at 4 02 46 PM" src="https://github.com/user-attachments/assets/9e99342e-9190-42b3-838c-eee269e0c1a6" />

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
