### PR TITLE
docs: DNS service discovery domains must be fully qualified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * [CHANGE] Query-frontend: Add support for UTF-8 label and metric names in `/api/v1/cardinality/{label_values|label_values|active_series}` endpoints. #11848.
 * [CHANGE] Querier: Add support for UTF-8 label and metric names in `label_join`, `label_replace` and `count_values` PromQL functions. #11848.
 * [CHANGE] Remove support for Redis as a cache backend. #12163
-* [CHANGE] Memcached: Remove experimental `-<prefix>.memcached.addresses-provider` flag to use alternate DNS service discovery backends. The more reliable backend introduced in 2.16.0 (#10895) is now the default. As a result of this change, DNS-based cache service discovery no longer supports search domains. #12175
+* [CHANGE] Memcached: Remove experimental `-<prefix>.memcached.addresses-provider` flag to use alternate DNS service discovery backends. The more reliable backend introduced in 2.16.0 (#10895) is now the default. As a result of this change, DNS-based cache service discovery no longer supports search domains. #12175 #12385
 * [CHANGE] Query-frontend: Remove the CLI flag `-query-frontend.downstream-url` and corresponding YAML configuration and the ability to use the query-frontend to proxy arbitrary Prometheus backends. #12191
 * [CHANGE] Query-frontend: Remove experimental instant query splitting feature. #12267
 * [CHANGE] Query-frontend, querier: Replace `query-frontend.prune-queries` flag with `querier.mimir-query-engine.enable-prune-toggles` as pruning middleware has been moved into MQE. #12303

--- a/docs/sources/mimir/configure/about-dns-service-discovery.md
+++ b/docs/sources/mimir/configure/about-dns-service-discovery.md
@@ -9,7 +9,9 @@ weight: 260
 
 # About Grafana Mimir DNS service discovery
 
-Some clients in Grafana Mimir support service discovery via DNS to locate the addresses of backend servers to connect to. The following clients support service discovery via DNS:
+Some clients in Grafana Mimir support service discovery via DNS to locate the addresses of backend servers to connect to.
+When using DNS service discovery search domains are not supported and so all domain names must be [fully qualified](https://en.wikipedia.org/wiki/Fully_qualified_domain_name).
+The following clients support service discovery via DNS:
 
 - [Memcached server addresses](../configuration-parameters/#memcached)
   - `-blocks-storage.bucket-store.chunks-cache.memcached.addresses`

--- a/docs/sources/mimir/configure/about-dns-service-discovery.md
+++ b/docs/sources/mimir/configure/about-dns-service-discovery.md
@@ -10,7 +10,7 @@ weight: 260
 # About Grafana Mimir DNS service discovery
 
 Some clients in Grafana Mimir support service discovery via DNS to locate the addresses of backend servers to connect to.
-When using DNS service discovery search domains are not supported and so all domain names must be [fully qualified](https://en.wikipedia.org/wiki/Fully_qualified_domain_name).
+When using DNS service discovery, search domains are not supported. As a result, all domain names must be [fully qualified](https://en.wikipedia.org/wiki/Fully_qualified_domain_name).
 The following clients support service discovery via DNS:
 
 - [Memcached server addresses](../configuration-parameters/#memcached)


### PR DESCRIPTION
#### What this PR does

Document that domain names used with DNS service discovery must be fully qualified after the changes from #12175

#### Which issue(s) this PR fixes or relates to

Related #12175

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
