### PR TITLE
MQE: separate responsibilities of `Node`

### DIFF
--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -133,6 +133,15 @@ type Engine struct {
 	nodeMaterializers map[planning.NodeType]planning.NodeMaterializer
 }
 
+func (e *Engine) RegisterNodeMaterializer(nodeType planning.NodeType, materializer planning.NodeMaterializer) error {
+	if _, exists := e.nodeMaterializers[nodeType]; exists {
+		return fmt.Errorf("materializer for node type %s already registered", nodeType)
+	}
+
+	e.nodeMaterializers[nodeType] = materializer
+	return nil
+}
+
 func (e *Engine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
 	return e.newQueryFromPlanner(ctx, q, opts, qs, types.NewInstantQueryTimeRange(ts))
 }

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -23,7 +23,9 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/limiter"
 	"github.com/grafana/mimir/pkg/util/promqlext"
@@ -59,6 +61,20 @@ func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *sta
 		activeQueryTracker = &NoopQueryTracker{}
 	}
 
+	nodeMaterializers := map[planning.NodeType]planning.NodeMaterializer{
+		planning.NODE_TYPE_VECTOR_SELECTOR:      planning.NodeMaterializerFunc[*core.VectorSelector](core.MaterializeVectorSelector),
+		planning.NODE_TYPE_MATRIX_SELECTOR:      planning.NodeMaterializerFunc[*core.MatrixSelector](core.MaterializeMatrixSelector),
+		planning.NODE_TYPE_AGGREGATE_EXPRESSION: planning.NodeMaterializerFunc[*core.AggregateExpression](core.MaterializeAggregateExpression),
+		planning.NODE_TYPE_BINARY_EXPRESSION:    planning.NodeMaterializerFunc[*core.BinaryExpression](core.MaterializeBinaryExpression),
+		planning.NODE_TYPE_FUNCTION_CALL:        planning.NodeMaterializerFunc[*core.FunctionCall](core.MaterializeFunctionCall),
+		planning.NODE_TYPE_NUMBER_LITERAL:       planning.NodeMaterializerFunc[*core.NumberLiteral](core.MaterializeNumberLiteral),
+		planning.NODE_TYPE_STRING_LITERAL:       planning.NodeMaterializerFunc[*core.StringLiteral](core.MaterializeStringLiteral),
+		planning.NODE_TYPE_UNARY_EXPRESSION:     planning.NodeMaterializerFunc[*core.UnaryExpression](core.MaterializeUnaryExpression),
+		planning.NODE_TYPE_SUBQUERY:             planning.NodeMaterializerFunc[*core.Subquery](core.MaterializeSubquery),
+
+		planning.NODE_TYPE_DUPLICATE: planning.NodeMaterializerFunc[*commonsubexpressionelimination.Duplicate](commonsubexpressionelimination.MaterializeDuplicate),
+	}
+
 	return &Engine{
 		lookbackDelta:            DetermineLookbackDelta(opts.CommonOpts),
 		timeout:                  opts.CommonOpts.Timeout,
@@ -78,6 +94,7 @@ func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *sta
 		pedantic:           opts.Pedantic,
 		eagerLoadSelectors: opts.EagerLoadSelectors,
 		planner:            planner,
+		nodeMaterializers:  nodeMaterializers,
 	}, nil
 }
 
@@ -112,7 +129,8 @@ type Engine struct {
 
 	eagerLoadSelectors bool
 
-	planner *QueryPlanner
+	planner           *QueryPlanner
+	nodeMaterializers map[planning.NodeType]planning.NodeMaterializer
 }
 
 func (e *Engine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
@@ -216,7 +234,7 @@ func (e *Engine) newEvaluator(ctx context.Context, queryable storage.Queryable, 
 		EagerLoadSelectors:       e.eagerLoadSelectors,
 	}
 
-	materializer := planning.NewMaterializer(operatorParams)
+	materializer := planning.NewMaterializer(operatorParams, e.nodeMaterializers)
 	op, err := materializer.ConvertNodeToOperator(node, nodeTimeRange)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/storage/lazyquery"
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/globalerror"
@@ -4115,4 +4116,22 @@ func TestInstantQueryDurationExpression(t *testing.T) {
 	t.Cleanup(mimirQuery.Close)
 
 	testutils.RequireEqualResults(t, expr, prometheusResult, mimirResult, false)
+}
+
+func TestEngine_RegisterNodeMaterializer(t *testing.T) {
+	opts := NewTestEngineOpts()
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), NewQueryPlanner(opts), log.NewNopLogger())
+	require.NoError(t, err)
+
+	nodeType := planning.NodeType(1234)
+	materializer := dummyMaterializer{}
+	require.NoError(t, engine.RegisterNodeMaterializer(nodeType, materializer), "should not fail to register new node type")
+
+	require.EqualError(t, engine.RegisterNodeMaterializer(nodeType, materializer), "materializer for node type 1234 already registered", "should fail to register materializer again if already registered")
+}
+
+type dummyMaterializer struct{}
+
+func (d dummyMaterializer) Materialize(n planning.Node, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+	panic("not implemented")
 }

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
@@ -67,7 +67,7 @@ func (d *Duplicate) ResultType() (parser.ValueType, error) {
 	return d.Inner.ResultType()
 }
 
-func (d *Duplicate) OperatorFactory(materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeDuplicate(d *Duplicate, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	inner, err := materializer.ConvertNodeToOperator(d.Inner, timeRange)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/planning/core/aggregate_expression.go
+++ b/pkg/streamingpromql/planning/core/aggregate_expression.go
@@ -100,7 +100,7 @@ func (a *AggregateExpression) ChildrenLabels() []string {
 	return []string{"expression", "parameter"}
 }
 
-func (a *AggregateExpression) OperatorFactory(materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeAggregateExpression(a *AggregateExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	inner, err := materializer.ConvertNodeToInstantVectorOperator(a.Inner, timeRange)
 	if err != nil {
 		return nil, fmt.Errorf("could not create inner operator for AggregateExpression: %w", err)

--- a/pkg/streamingpromql/planning/core/binary_expression.go
+++ b/pkg/streamingpromql/planning/core/binary_expression.go
@@ -117,7 +117,7 @@ func (b *BinaryExpression) ChildrenLabels() []string {
 	return []string{"LHS", "RHS"}
 }
 
-func (b *BinaryExpression) OperatorFactory(materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeBinaryExpression(b *BinaryExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	op, ok := b.Op.ToItemType()
 	if !ok {
 		return nil, compat.NewNotSupportedError(fmt.Sprintf("'%v' binary expression", b.Op.String()))

--- a/pkg/streamingpromql/planning/core/function_call.go
+++ b/pkg/streamingpromql/planning/core/function_call.go
@@ -82,7 +82,7 @@ func (f *FunctionCall) ChildrenLabels() []string {
 	return l
 }
 
-func (f *FunctionCall) OperatorFactory(materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeFunctionCall(f *FunctionCall, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	fnc, ok := functions.RegisteredFunctions[f.Function]
 	if !ok {
 		return nil, compat.NewNotSupportedError(fmt.Sprintf("'%v' function", f.Function.PromQLName()))

--- a/pkg/streamingpromql/planning/core/matrix_selector.go
+++ b/pkg/streamingpromql/planning/core/matrix_selector.go
@@ -61,7 +61,7 @@ func (m *MatrixSelector) ChildrenLabels() []string {
 	return nil
 }
 
-func (m *MatrixSelector) OperatorFactory(_ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeMatrixSelector(m *MatrixSelector, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	matchers, err := LabelMatchersToPrometheusType(m.Matchers)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/planning/core/number_literal.go
+++ b/pkg/streamingpromql/planning/core/number_literal.go
@@ -56,7 +56,7 @@ func (n *NumberLiteral) ChildrenLabels() []string {
 	return nil
 }
 
-func (n *NumberLiteral) OperatorFactory(_ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeNumberLiteral(n *NumberLiteral, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	o := scalars.NewScalarConstant(n.Value, timeRange, params.MemoryConsumptionTracker, n.ExpressionPosition.ToPrometheusType())
 
 	return planning.NewSingleUseOperatorFactory(o), nil

--- a/pkg/streamingpromql/planning/core/string_literal.go
+++ b/pkg/streamingpromql/planning/core/string_literal.go
@@ -56,7 +56,7 @@ func (s *StringLiteral) ChildrenLabels() []string {
 	return nil
 }
 
-func (s *StringLiteral) OperatorFactory(_ *planning.Materializer, _ types.QueryTimeRange, _ *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeStringLiteral(s *StringLiteral, _ *planning.Materializer, _ types.QueryTimeRange, _ *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	o := operators.NewStringLiteral(s.Value, s.ExpressionPosition.ToPrometheusType())
 
 	return planning.NewSingleUseOperatorFactory(o), nil

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -118,7 +118,7 @@ func (s *Subquery) ChildrenLabels() []string {
 	return []string{""}
 }
 
-func (s *Subquery) OperatorFactory(materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeSubquery(s *Subquery, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	innerTimeRange := s.ChildrenTimeRange(timeRange)
 	inner, err := materializer.ConvertNodeToInstantVectorOperator(s.Inner, innerTimeRange)
 	if err != nil {

--- a/pkg/streamingpromql/planning/core/unary_expression.go
+++ b/pkg/streamingpromql/planning/core/unary_expression.go
@@ -62,7 +62,7 @@ func (u *UnaryExpression) ChildrenLabels() []string {
 	return []string{""}
 }
 
-func (u *UnaryExpression) OperatorFactory(materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeUnaryExpression(u *UnaryExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	inner, err := materializer.ConvertNodeToOperator(u.Inner, timeRange)
 	if err != nil {
 		return nil, fmt.Errorf("could not create inner operator for UnaryExpression: %w", err)

--- a/pkg/streamingpromql/planning/core/vector_selector.go
+++ b/pkg/streamingpromql/planning/core/vector_selector.go
@@ -67,7 +67,7 @@ func (v *VectorSelector) ChildrenLabels() []string {
 	return nil
 }
 
-func (v *VectorSelector) OperatorFactory(_ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeVectorSelector(v *VectorSelector, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	matchers, err := LabelMatchersToPrometheusType(v.Matchers)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -75,11 +75,6 @@ type Node interface {
 	// Most nodes will return timeRange as is, with the exception of subqueries.
 	ChildrenTimeRange(timeRange types.QueryTimeRange) types.QueryTimeRange
 
-	// OperatorFactory returns a factory that produces operators for this node.
-	//
-	// Implementations may retain the provided Materializer for later use.
-	OperatorFactory(materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters) (OperatorFactory, error)
-
 	// ResultType returns the kind of result this node produces.
 	//
 	// May return an error if the kind of result cannot be determined (eg. because the node references an unknown function).

--- a/pkg/streamingpromql/planning/plan_test.go
+++ b/pkg/streamingpromql/planning/plan_test.go
@@ -111,10 +111,6 @@ func (t *testNode) ChildrenTimeRange(_ types.QueryTimeRange) types.QueryTimeRang
 	panic("not supported")
 }
 
-func (t *testNode) OperatorFactory(_ *Materializer, _ types.QueryTimeRange, _ *OperatorParameters) (OperatorFactory, error) {
-	panic("not supported")
-}
-
 func (t *testNode) ResultType() (parser.ValueType, error) {
 	panic("not supported")
 }


### PR DESCRIPTION
#### What this PR does

This PR refactors the responsibilities of the `planning.Node` type to remove responsibility for creating `OperatorFactory` instances.

Instead, this responsibility has been moved to the newly-introduced `NodeMaterializer` interface.

This will allow us to implement new kinds of nodes that can't be materialized with only values available from `OperatorParameters`, and where it doesn't make sense to extend `OperatorParameters` to include these values. For example, a caching operator might need cache connection information, and a remote execution node might need access to a client for remote executors, but these things are specific to only these kinds of nodes, so it doesn't make sense to have the engine itself depend on these things. 

From a code organisation perspective, it also means the `streamingpromql` package won't need to depend on a bunch of other packages that may introduce circular dependencies (eg. for remote execution, we would likely need to reference query-frontend packages, but the query-frontend also needs to reference the `streamingpromql` package).

I've not added a changelog entry given this should have no user-visible impact.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
