### PR TITLE
MQE: query-frontend refactoring to support remote execution of query plans in queriers

### DIFF
--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -279,15 +279,14 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, httpRequest *httpgrpc.HTTP
 	case <-ctx.Done():
 		spanLogger.DebugLog("msg", "request context cancelled after enqueuing request, aborting", "err", ctx.Err())
 
-		if cancelCh != nil {
-			select {
-			case cancelCh <- freq.queryID:
-				// cancellation sent.
-			default:
-				// failed to cancel, ignore.
-				level.Warn(spanLogger).Log("msg", "failed to send cancellation request to scheduler, queue full")
-			}
+		select {
+		case cancelCh <- freq.queryID:
+			// cancellation sent.
+		default:
+			// failed to cancel, ignore.
+			level.Warn(spanLogger).Log("msg", "failed to send cancellation request to scheduler, queue full")
 		}
+
 		return nil, nil, ctx.Err()
 
 	case resp := <-freq.response:

--- a/pkg/frontend/v2/frontend_scheduler_adapter.go
+++ b/pkg/frontend/v2/frontend_scheduler_adapter.go
@@ -4,16 +4,21 @@ package v2
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/gogo/protobuf/types"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/tenant"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware"
 	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
+	"github.com/grafana/mimir/pkg/util/httpgrpcutil"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
@@ -27,29 +32,65 @@ type frontendToSchedulerAdapter struct {
 func (a *frontendToSchedulerAdapter) frontendToSchedulerEnqueueRequest(
 	req *frontendRequest, frontendAddr string,
 ) (*schedulerpb.FrontendToScheduler, error) {
-	var addlQueueDims []string
-	var err error
-	addlQueueDims, err = a.extractAdditionalQueueDimensions(req.ctx, req.request, time.Now())
-	if err != nil {
-		return nil, err
+	msg := &schedulerpb.FrontendToScheduler{
+		Type:            schedulerpb.ENQUEUE,
+		QueryID:         req.queryID,
+		UserID:          req.userID,
+		FrontendAddress: frontendAddr,
+		StatsEnabled:    req.statsEnabled,
 	}
 
-	return &schedulerpb.FrontendToScheduler{
-		Type:                      schedulerpb.ENQUEUE,
-		QueryID:                   req.queryID,
-		UserID:                    req.userID,
-		Payload:                   &schedulerpb.FrontendToScheduler_HttpRequest{HttpRequest: req.request},
-		FrontendAddress:           frontendAddr,
-		StatsEnabled:              req.statsEnabled,
-		AdditionalQueueDimensions: addlQueueDims,
-	}, nil
+	if req.httpRequest == nil && req.protobufRequest == nil {
+		return nil, errors.New("got neither a HTTP nor a Protobuf request payload")
+	}
+
+	if req.httpRequest != nil && req.protobufRequest != nil {
+		return nil, errors.New("got both a HTTP and a Protobuf request payload")
+	}
+
+	if req.httpRequest != nil {
+		var err error
+		msg.AdditionalQueueDimensions, err = a.extractAdditionalQueueDimensionsForHTTPRequest(req.ctx, req.httpRequest, time.Now())
+		if err != nil {
+			return nil, err
+		}
+
+		// Propagate trace context for this query in the HTTP payload.
+		// We can't use the trace headers from the gRPC request, as it is a long-running stream from the frontend to the scheduler
+		// that handles many queries.
+		otel.GetTextMapPropagator().Inject(req.ctx, (*httpgrpcutil.HttpgrpcHeadersCarrier)(req.httpRequest))
+
+		msg.Payload = &schedulerpb.FrontendToScheduler_HttpRequest{HttpRequest: req.httpRequest}
+	} else {
+		// TODO: set additional queue dimensions based on queried time range of request (taking into account lookback etc.)
+
+		encodedRequest, err := types.MarshalAny(req.protobufRequest)
+		if err != nil {
+			return nil, err
+		}
+
+		// Propagate trace context for this query in the request payload.
+		// We can't use the trace headers from the gRPC request, as it is a long-running stream from the frontend to the scheduler
+		// that handles many queries.
+		traceHeaders := map[string]string{}
+		otel.GetTextMapPropagator().Inject(req.ctx, propagation.MapCarrier(traceHeaders))
+
+		msg.Payload = &schedulerpb.FrontendToScheduler_ProtobufRequest{
+			ProtobufRequest: &schedulerpb.ProtobufRequest{
+				Payload:      encodedRequest,
+				TraceHeaders: traceHeaders,
+			},
+		}
+	}
+
+	return msg, nil
 }
 
 const ShouldQueryIngestersQueueDimension = "ingester"
 const ShouldQueryStoreGatewayQueueDimension = "store-gateway"
 const ShouldQueryIngestersAndStoreGatewayQueueDimension = "ingester-and-store-gateway"
 
-func (a *frontendToSchedulerAdapter) extractAdditionalQueueDimensions(
+func (a *frontendToSchedulerAdapter) extractAdditionalQueueDimensionsForHTTPRequest(
 	ctx context.Context, request *httpgrpc.HTTPRequest, now time.Time,
 ) ([]string, error) {
 	var err error

--- a/pkg/frontend/v2/frontend_scheduler_adapter_test.go
+++ b/pkg/frontend/v2/frontend_scheduler_adapter_test.go
@@ -139,7 +139,7 @@ func TestExtractAdditionalQueueDimensions(t *testing.T) {
 				httpgrpcReq, err := httpgrpc.FromHTTPRequest(req)
 				require.NoError(t, err)
 
-				additionalQueueDimensions, err := adapter.extractAdditionalQueueDimensions(
+				additionalQueueDimensions, err := adapter.extractAdditionalQueueDimensionsForHTTPRequest(
 					ctx, httpgrpcReq, now,
 				)
 				require.NoError(t, err)
@@ -182,7 +182,7 @@ func TestExtractAdditionalQueueDimensions(t *testing.T) {
 			httpgrpcReq, err := httpgrpc.FromHTTPRequest(instantHTTPReq)
 			require.NoError(t, err)
 
-			additionalQueueDimensions, err := adapter.extractAdditionalQueueDimensions(
+			additionalQueueDimensions, err := adapter.extractAdditionalQueueDimensionsForHTTPRequest(
 				ctx, httpgrpcReq, now,
 			)
 			require.NoError(t, err)
@@ -232,7 +232,7 @@ func TestQueryDecoding(t *testing.T) {
 			httpgrpcReq, err := httpgrpc.FromHTTPRequest(labelValuesHTTPReq)
 			require.NoError(t, err)
 
-			additionalQueueDimensions, err := adapter.extractAdditionalQueueDimensions(
+			additionalQueueDimensions, err := adapter.extractAdditionalQueueDimensionsForHTTPRequest(
 				ctx, httpgrpcReq, now,
 			)
 			require.NoError(t, err)
@@ -244,7 +244,7 @@ func TestQueryDecoding(t *testing.T) {
 	t.Run("malformed httpgrpc requests fail decoding", func(t *testing.T) {
 		reqFailsHTTPDecode := &httpgrpc.HTTPRequest{Method: ";"}
 
-		_, errHTTPDecode := adapter.extractAdditionalQueueDimensions(context.Background(), reqFailsHTTPDecode, time.Now())
+		_, errHTTPDecode := adapter.extractAdditionalQueueDimensionsForHTTPRequest(context.Background(), reqFailsHTTPDecode, time.Now())
 		require.Error(t, errHTTPDecode)
 		require.Contains(t, errHTTPDecode.Error(), "net/http")
 	})


### PR DESCRIPTION
#### What this PR does

This PR refactors parts of the query-frontend to make the introduction of remote execution of query plans in queriers easier.

I've tried to make each commit self-contained, and would recommend reviewing each separately.

This PR does not need a changelog entry as it makes no user-visible changes.

#### Which issue(s) this PR fixes or relates to

Related to #12302

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
