### PR TITLE
Multiple Components: Revert Changes to Memory + CPU HPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@
 
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to be closer to the requested number of CPUs. #12150
 * [CHANGE] Query-scheduler: The query-scheduler is now a required component that is always used by queriers and query-frontends. #12187
-* [CHANGE] Use `irate()` when calculating CPU scaling metric. Using `irate()` prevents underestimating CPU utilization when scraping fails. #12384
-* [CHANGE] Remove `vector(0)` when calculating memory scaling metric to prevent underestimating memory usage when scraping fails. #12386
 
 ### Documentation
 

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1976,7 +1976,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))
             and
             max by (pod) (up{container="alertmanager",namespace="default"}) > 0
           )[15m:]
@@ -1995,7 +1995,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="alertmanager",namespace="default"})
               and
               max by (pod) (up{container="alertmanager",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2047,7 +2047,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2066,7 +2066,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2161,7 +2161,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))
             and
             max by (pod) (up{container="query-frontend",namespace="default"}) > 0
           )[15m:]
@@ -2180,7 +2180,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="query-frontend",namespace="default"})
               and
               max by (pod) (up{container="query-frontend",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2222,7 +2222,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler",namespace="default"}) > 0
           )[15m:]
@@ -2241,7 +2241,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="default"})
               and
               max by (pod) (up{container="ruler",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2283,7 +2283,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
           )[15m:]
@@ -2302,7 +2302,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="ruler-querier",namespace="default"})
               and
               max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2352,7 +2352,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
           )[15m:]
@@ -2371,7 +2371,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})
               and
               max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1976,7 +1976,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="alertmanager",namespace="default"}[5m]))
             and
             max by (pod) (up{container="alertmanager",namespace="default"}) > 0
           )[15m:]
@@ -1995,7 +1995,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="alertmanager",namespace="default"})
               and
               max by (pod) (up{container="alertmanager",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2047,7 +2047,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2066,7 +2066,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2161,7 +2161,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="query-frontend",namespace="default"}[5m]))
             and
             max by (pod) (up{container="query-frontend",namespace="default"}) > 0
           )[15m:]
@@ -2180,7 +2180,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="query-frontend",namespace="default"})
               and
               max by (pod) (up{container="query-frontend",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2222,7 +2222,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler",namespace="default"}) > 0
           )[15m:]
@@ -2241,7 +2241,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="ruler",namespace="default"})
               and
               max by (pod) (up{container="ruler",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2283,7 +2283,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-querier",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
           )[15m:]
@@ -2302,7 +2302,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="ruler-querier",namespace="default"})
               and
               max by (pod) (up{container="ruler-querier",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2352,7 +2352,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="ruler-query-frontend",namespace="default"}[5m]))
             and
             max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
           )[15m:]
@@ -2371,7 +2371,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="ruler-query-frontend",namespace="default"})
               and
               max by (pod) (up{container="ruler-query-frontend",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +

--- a/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
@@ -2591,7 +2591,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2610,7 +2610,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default",pod=~"distributor-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2662,7 +2662,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-b.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-b.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-b.*"}[1m])) > 0
           )[15m:]
@@ -2681,7 +2681,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default",pod=~"distributor-zone-b.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-b.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +

--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -1370,7 +1370,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_0.7__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_0.7__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_false_false_0.7__",namespace="default"}) > 0
           )[15m:]
@@ -1390,7 +1390,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_false_0.7__",namespace="default"})
               and
               max by (pod) (up{container="test_false_false_0.7__",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1433,7 +1433,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -1453,7 +1453,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_false_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1496,7 +1496,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -1516,7 +1516,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (up{container="test_container",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1559,7 +1559,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -1579,7 +1579,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1622,7 +1622,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_1.5__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1.5__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_false_false_1.5__",namespace="default"}) > 0
           )[15m:]
@@ -1642,7 +1642,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_false_1.5__",namespace="default"})
               and
               max by (pod) (up{container="test_false_false_1.5__",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1685,7 +1685,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -1705,7 +1705,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_false_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1748,7 +1748,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -1768,7 +1768,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (up{container="test_container",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1811,7 +1811,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -1831,7 +1831,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1874,7 +1874,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_1__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_false_false_1__",namespace="default"}) > 0
           )[15m:]
@@ -1893,7 +1893,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_false_1__",namespace="default"})
               and
               max by (pod) (up{container="test_false_false_1__",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1935,7 +1935,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -1954,7 +1954,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_false_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -1996,7 +1996,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -2015,7 +2015,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (up{container="test_container",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2057,7 +2057,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -2076,7 +2076,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2118,7 +2118,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_0.7__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_0.7__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2138,7 +2138,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_true_0.7__",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2181,7 +2181,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2201,7 +2201,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2244,7 +2244,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2264,7 +2264,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2307,7 +2307,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2327,7 +2327,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2370,7 +2370,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_1.5__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1.5__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2390,7 +2390,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_true_1.5__",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2433,7 +2433,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2453,7 +2453,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2496,7 +2496,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2516,7 +2516,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2559,7 +2559,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2579,7 +2579,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2622,7 +2622,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_1__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2641,7 +2641,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_true_1__",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2683,7 +2683,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_false_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_false_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2702,7 +2702,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_false_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2744,7 +2744,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -2763,7 +2763,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2805,7 +2805,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2824,7 +2824,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2866,7 +2866,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_0.7__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_0.7__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_true_false_0.7__",namespace="default"}) > 0
           )[15m:]
@@ -2886,7 +2886,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_false_0.7__",namespace="default"})
               and
               max by (pod) (up{container="test_true_false_0.7__",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2929,7 +2929,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -2949,7 +2949,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_true_false_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2992,7 +2992,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -3012,7 +3012,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (up{container="test_container",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3055,7 +3055,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3075,7 +3075,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3118,7 +3118,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_1.5__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1.5__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_true_false_1.5__",namespace="default"}) > 0
           )[15m:]
@@ -3138,7 +3138,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_false_1.5__",namespace="default"})
               and
               max by (pod) (up{container="test_true_false_1.5__",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3181,7 +3181,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3201,7 +3201,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_true_false_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3244,7 +3244,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -3264,7 +3264,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (up{container="test_container",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3307,7 +3307,7 @@ spec:
       query: |-
         (max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3327,7 +3327,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3370,7 +3370,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_1__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1__",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_true_false_1__",namespace="default"}) > 0
           )[15m:]
@@ -3389,7 +3389,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_false_1__",namespace="default"})
               and
               max by (pod) (up{container="test_true_false_1__",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3431,7 +3431,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3450,7 +3450,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_true_false_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3492,7 +3492,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default"}) > 0
           )[15m:]
@@ -3511,7 +3511,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (up{container="test_container",namespace="default"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3553,7 +3553,7 @@ spec:
       query: |
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
           )[15m:]
@@ -3572,7 +3572,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (up{container="test_container",namespace="default",pod=~"pod-zone-a.*"}) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3614,7 +3614,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_0.7__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_0.7__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -3634,7 +3634,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_true_0.7__",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3677,7 +3677,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -3697,7 +3697,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_true_0.7__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3740,7 +3740,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -3760,7 +3760,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3803,7 +3803,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -3823,7 +3823,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3866,7 +3866,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_1.5__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1.5__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -3886,7 +3886,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_true_1.5__",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3929,7 +3929,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -3949,7 +3949,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_true_1.5__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -3992,7 +3992,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -4012,7 +4012,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -4055,7 +4055,7 @@ spec:
       query: |-
         (quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -4075,7 +4075,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -4118,7 +4118,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_1__",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1__",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -4137,7 +4137,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_true_1__",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -4179,7 +4179,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_true_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_true_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -4198,7 +4198,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_true_true_1__pod-zone-a.*",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -4240,7 +4240,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
           )[15m:]
@@ -4259,7 +4259,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -4301,7 +4301,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="test_container",namespace="default",pod=~"pod-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -4320,7 +4320,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="test_container",namespace="default",pod=~"pod-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"pod-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +

--- a/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
+++ b/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
@@ -2720,7 +2720,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod!~"distributor-zone.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod!~"distributor-zone.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod!~"distributor-zone.*"}[1m])) > 0
           )[15m:]
@@ -2739,7 +2739,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default",pod!~"distributor-zone.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod!~"distributor-zone.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2791,7 +2791,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-a.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-a.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-a.*"}[1m])) > 0
           )[15m:]
@@ -2810,7 +2810,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default",pod=~"distributor-zone-a.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-a.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +
@@ -2862,7 +2862,7 @@ spec:
       query: |
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-b.*"}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-b.*"}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-b.*"}[1m])) > 0
           )[15m:]
@@ -2881,7 +2881,7 @@ spec:
               sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default",pod=~"distributor-zone-b.*"})
               and
               max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-b.*"}[1m])) > 0
-            )
+            ) or vector(0)
           )[15m:]
         )
         +

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -274,15 +274,10 @@
       // We multiply by 1000 to get the result in millicores. This is due to HPA only working with ints.
       //
       // When computing the actual CPU utilization, We only take in account ready pods.
-      //
-      // We use irate() instead of rate() because it is more reliable when scrapes fail. It calculates
-      // the rate from only the last two data points in the range, whereas rate() extrapolates missing
-      // values over the full window, which can underestimate CPU utilization and trigger unnecessary
-      // downscaling.
       |||
         quantile_over_time(0.95,
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[5m]))
             and
             max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"%(extra_matchers)s}[1m])) > 0
           )[15m:]
@@ -296,15 +291,10 @@
       // The "up" metrics correctly handles the stale marker when the pod is terminated, while it's not the
       // case for the cAdvisor metrics. By intersecting these 2 metrics, we only look the CPU utilization
       // of containers there are running at any given time, without suffering the PromQL lookback period.
-      //
-      // We use irate() instead of rate() because it is more reliable when scrapes fail. It calculates
-      // the rate from only the last two data points in the range, whereas rate() extrapolates missing
-      // values over the full window, which can underestimate CPU utilization and trigger unnecessary
-      // downscaling.
       |||
         max_over_time(
           sum(
-            sum by (pod) (irate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[5m]))
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}[5m]))
             and
             max by (pod) (up{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}) > 0
           )[15m:]
@@ -326,7 +316,7 @@
                 sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s})
                 and
                 max by (pod) (min_over_time(kube_pod_status_ready{namespace="%(namespace)s",condition="true"%(extra_matchers)s}[1m])) > 0
-              )
+              ) or vector(0)
             )[15m:]
           )
         |||
@@ -344,7 +334,7 @@
                 sum by (pod) (container_memory_working_set_bytes{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s})
                 and
                 max by (pod) (up{container="%(container)s",namespace="%(namespace)s"%(extra_matchers)s}) > 0
-              )
+              ) or vector(0)
             )[15m:]
           )
         |||


### PR DESCRIPTION
#### What this PR does

Reverts https://github.com/grafana/mimir/pull/12386 and https://github.com/grafana/mimir/pull/12384. The changes introduced in these PRs introduced other problems with HPA scaling. 

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
