### PR TITLE
Fix incorrect metric name in block-builder errors dashboard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 * [BUGFIX] Querier: Fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #12261
 * [BUGFIX] Block-builder-scheduler: Fix a caching bug in initial job probing causing excessive memory usage at startup. #12389
 
+### Mixin
+
+* [BUGFIX] Block-builder dashboard: fix reference to detected gaps metric in errors panel. #12401
+
 ### Jsonnet
 
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to be closer to the requested number of CPUs. #12150

--- a/operations/mimir-mixin/dashboards/block-builder.libsonnet
+++ b/operations/mimir-mixin/dashboards/block-builder.libsonnet
@@ -56,7 +56,7 @@ local filename = 'mimir-block-builder.json';
           [
             'sum(increase(cortex_blockbuilder_scheduler_fetch_offsets_failed_total{%(job)s}[$__rate_interval]))' % { job: $.jobMatcher($._config.job_names.block_builder_scheduler) },
             'sum(increase(cortex_blockbuilder_scheduler_flush_failed_total{%(job)s}[$__rate_interval]))' % { job: $.jobMatcher($._config.job_names.block_builder_scheduler) },
-            'sum(increase(cortex_blockbuilder_scheduler_job_gap_detected_total{%(job)s}[$__rate_interval]))' % { job: $.jobMatcher($._config.job_names.block_builder_scheduler) },
+            'sum(increase(cortex_blockbuilder_scheduler_job_gap_detected{%(job)s}[$__rate_interval]))' % { job: $.jobMatcher($._config.job_names.block_builder_scheduler) },
           ],
           [
             'fetch offsets failed',


### PR DESCRIPTION
#### What this PR does

Fix a typo'd name in the block-builder-scheduler dashboard errors panel.


#### Checklist

- (n/a) Tests updated.
- (n/a) Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- (n/a) [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
