### PR TITLE
ingester: Add configurable tenant ID in profile labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [CHANGE] Query-frontend: Remove the CLI flags `-querier.frontend-address`, `-querier.max-outstanding-requests-per-tenant`, and `-query-frontend.querier-forget-delay` and corresponding YAML configurations. This is part of a change that makes the query-scheduler a required component. This removes the ability to run the query-frontend with an embedded query-scheduler. Instead, you must run a dedicated query-scheduler component. #12200
 * [FEATURE] Distributor, ruler: Add experimental `-validation.name-validation-scheme` flag to specify the validation scheme for metric and label names. #12215
 * [FEATURE] Distributor: Add experimental `-distributor.otel-translation-strategy` flag to support configuring the metric and label name translation strategy in the OTLP endpoint. #12284 #12306 #12369
+* [FEATURE] Ingester: Add experimental `-include-tenant-id-in-profile-labels` flag to include tenant ID in pprof profiling labels for sampled traces. Currently only supported by the ingester. This can help debug performance issues for specific tenants. #12404
 * [ENHANCEMENT] Query-frontend: CLI flag `-query-frontend.enabled-promql-experimental-functions` and its associated YAML configuration is now stable. #12368
 * [ENHANCEMENT] Query-scheduler/query-frontend: Add native histogram definitions to `cortex_query_{scheduler|frontend}_queue_duration_seconds`. #12288
 * [ENHANCEMENT] Querier: Add native histogram definition to `cortex_bucket_index_load_duration_seconds`. #12094

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -11895,6 +11895,17 @@
       "fieldDefaultValue": null
     },
     {
+      "kind": "field",
+      "name": "include_tenant_id_in_profile_labels",
+      "required": false,
+      "desc": "Include tenant ID in pprof labels for profiling. Currently only supported by the ingester. This can help debug performance issues for specific tenants.",
+      "fieldValue": null,
+      "fieldDefaultValue": false,
+      "fieldFlag": "include-tenant-id-in-profile-labels",
+      "fieldType": "boolean",
+      "fieldCategory": "experimental"
+    },
+    {
       "kind": "block",
       "name": "vault",
       "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1381,6 +1381,8 @@ Usage of ./cmd/mimir/mimir:
     	HTTP URL path under which the Alertmanager ui and api will be served. (default "/alertmanager")
   -http.prometheus-http-prefix string
     	HTTP URL path under which the Prometheus api will be served. (default "/prometheus")
+  -include-tenant-id-in-profile-labels
+    	[experimental] Include tenant ID in pprof labels for profiling. Currently only supported by the ingester. This can help debug performance issues for specific tenants.
   -ingest-storage.enabled
     	True to enable the ingestion via object storage.
   -ingest-storage.ingestion-partition-tenant-shard-size int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -233,6 +233,12 @@ activity_tracker:
   # CLI flag: -activity-tracker.max-entries
   [max_entries: <int> | default = 1024]
 
+# (experimental) Include tenant ID in pprof labels for profiling. Currently only
+# supported by the ingester. This can help debug performance issues for specific
+# tenants.
+# CLI flag: -include-tenant-id-in-profile-labels
+[include_tenant_id_in_profile_labels: <boolean> | default = false]
+
 vault:
   # (experimental) Enables fetching of keys and certificates from Vault
   # CLI flag: -vault.enabled

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/mimir/pkg/distributor/distributorpb"
 	frontendv2 "github.com/grafana/mimir/pkg/frontend/v2"
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
+	"github.com/grafana/mimir/pkg/ingester"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/querier"
 	querierapi "github.com/grafana/mimir/pkg/querier/api"
@@ -300,23 +301,8 @@ func (a *API) RegisterCostAttribution(customRegistryPath string, reg *prometheus
 	a.RegisterRoute(customRegistryPath, promhttp.HandlerFor(reg, promhttp.HandlerOpts{}), false, false, "GET")
 }
 
-// Ingester is defined as an interface to allow for alternative implementations
-// of ingesters to be passed into the API.RegisterIngester() method.
-type Ingester interface {
-	client.IngesterServer
-	FlushHandler(http.ResponseWriter, *http.Request)
-	ShutdownHandler(http.ResponseWriter, *http.Request)
-	PrepareShutdownHandler(http.ResponseWriter, *http.Request)
-	PreparePartitionDownscaleHandler(http.ResponseWriter, *http.Request)
-	PrepareUnregisterHandler(w http.ResponseWriter, r *http.Request)
-	UserRegistryHandler(http.ResponseWriter, *http.Request)
-	TenantsHandler(http.ResponseWriter, *http.Request)
-	TenantTSDBHandler(http.ResponseWriter, *http.Request)
-	PrepareInstanceRingDownscaleHandler(http.ResponseWriter, *http.Request)
-}
-
 // RegisterIngester registers the ingester HTTP and gRPC services.
-func (a *API) RegisterIngester(i Ingester) {
+func (a *API) RegisterIngester(i ingester.IngesterAPI) {
 	client.RegisterIngesterServer(a.server.GRPC, i)
 
 	a.indexPage.AddLinks(dangerousWeight, "Dangerous", []IndexPageLink{

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -302,7 +302,7 @@ func (a *API) RegisterCostAttribution(customRegistryPath string, reg *prometheus
 }
 
 // RegisterIngester registers the ingester HTTP and gRPC services.
-func (a *API) RegisterIngester(i ingester.IngesterAPI) {
+func (a *API) RegisterIngester(i ingester.API) {
 	client.RegisterIngesterServer(a.server.GRPC, i)
 
 	a.indexPage.AddLinks(dangerousWeight, "Dangerous", []IndexPageLink{

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/mimir/pkg/ingester"
 	"github.com/grafana/mimir/pkg/querier/tenantfederation"
 	"github.com/grafana/mimir/pkg/util/gziphandler"
 )
@@ -191,7 +192,7 @@ func TestApiGzip(t *testing.T) {
 }
 
 type MockIngester struct {
-	Ingester
+	ingester.IngesterAPI
 }
 
 func (mi MockIngester) ShutdownHandler(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -192,7 +192,7 @@ func TestApiGzip(t *testing.T) {
 }
 
 type MockIngester struct {
-	ingester.IngesterAPI
+	ingester.API
 }
 
 func (mi MockIngester) ShutdownHandler(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/ingester/api.go
+++ b/pkg/ingester/api.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+package ingester
+
+import (
+	"net/http"
+
+	"github.com/grafana/mimir/pkg/ingester/client"
+)
+
+type IngesterAPI interface {
+	client.IngesterServer
+	FlushHandler(http.ResponseWriter, *http.Request)
+	ShutdownHandler(http.ResponseWriter, *http.Request)
+	PrepareShutdownHandler(http.ResponseWriter, *http.Request)
+	PreparePartitionDownscaleHandler(http.ResponseWriter, *http.Request)
+	PrepareUnregisterHandler(w http.ResponseWriter, r *http.Request)
+	UserRegistryHandler(http.ResponseWriter, *http.Request)
+	TenantsHandler(http.ResponseWriter, *http.Request)
+	TenantTSDBHandler(http.ResponseWriter, *http.Request)
+	PrepareInstanceRingDownscaleHandler(http.ResponseWriter, *http.Request)
+}

--- a/pkg/ingester/api.go
+++ b/pkg/ingester/api.go
@@ -2,9 +2,11 @@
 package ingester
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/grafana/mimir/pkg/ingester/client"
+	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
 type IngesterAPI interface {
@@ -13,9 +15,10 @@ type IngesterAPI interface {
 	ShutdownHandler(http.ResponseWriter, *http.Request)
 	PrepareShutdownHandler(http.ResponseWriter, *http.Request)
 	PreparePartitionDownscaleHandler(http.ResponseWriter, *http.Request)
-	PrepareUnregisterHandler(w http.ResponseWriter, r *http.Request)
+	PrepareUnregisterHandler(http.ResponseWriter, *http.Request)
 	UserRegistryHandler(http.ResponseWriter, *http.Request)
 	TenantsHandler(http.ResponseWriter, *http.Request)
 	TenantTSDBHandler(http.ResponseWriter, *http.Request)
 	PrepareInstanceRingDownscaleHandler(http.ResponseWriter, *http.Request)
+	PushToStorageAndReleaseRequest(context.Context, *mimirpb.WriteRequest) error
 }

--- a/pkg/ingester/api.go
+++ b/pkg/ingester/api.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
-type IngesterAPI interface {
+type API interface {
 	client.IngesterServer
 	FlushHandler(http.ResponseWriter, *http.Request)
 	ShutdownHandler(http.ResponseWriter, *http.Request)

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -227,8 +227,6 @@ type Config struct {
 	// This config is dynamically injected because defined outside the ingester config.
 	IngestStorageConfig ingest.Config `yaml:"-"`
 
-	IncludeTenantIDInProfileLabels bool `yaml:"include_tenant_id_in_profile_labels" category:"experimental"`
-
 	// This config can be overridden in tests.
 	limitMetricsUpdatePeriod time.Duration `yaml:"-"`
 }
@@ -257,7 +255,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.UpdateIngesterOwnedSeries, "ingester.track-ingester-owned-series", false, "This option enables tracking of ingester-owned series based on ring state, even if -ingester.use-ingester-owned-series-for-limits is disabled.")
 	f.DurationVar(&cfg.OwnedSeriesUpdateInterval, "ingester.owned-series-update-interval", 15*time.Second, "How often to check for ring changes and possibly recompute owned series as a result of detected change.")
 	f.BoolVar(&cfg.PushGrpcMethodEnabled, "ingester.push-grpc-method-enabled", true, "Enables Push gRPC method on ingester. Can be only disabled when using ingest-storage to make sure ingesters only receive data from Kafka.")
-	f.BoolVar(&cfg.IncludeTenantIDInProfileLabels, "ingester.include-tenant-id-in-profile-labels", false, "Include tenant ID in pprof labels for profiling. This can help debug performance issues for specific tenants.")
 
 	// Hardcoded config (can only be overridden in tests).
 	cfg.limitMetricsUpdatePeriod = time.Second * 15

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -227,6 +227,8 @@ type Config struct {
 	// This config is dynamically injected because defined outside the ingester config.
 	IngestStorageConfig ingest.Config `yaml:"-"`
 
+	IncludeTenantIDInProfileLabels bool `yaml:"include_tenant_id_in_profile_labels" category:"experimental"`
+
 	// This config can be overridden in tests.
 	limitMetricsUpdatePeriod time.Duration `yaml:"-"`
 }
@@ -255,6 +257,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.UpdateIngesterOwnedSeries, "ingester.track-ingester-owned-series", false, "This option enables tracking of ingester-owned series based on ring state, even if -ingester.use-ingester-owned-series-for-limits is disabled.")
 	f.DurationVar(&cfg.OwnedSeriesUpdateInterval, "ingester.owned-series-update-interval", 15*time.Second, "How often to check for ring changes and possibly recompute owned series as a result of detected change.")
 	f.BoolVar(&cfg.PushGrpcMethodEnabled, "ingester.push-grpc-method-enabled", true, "Enables Push gRPC method on ingester. Can be only disabled when using ingest-storage to make sure ingesters only receive data from Kafka.")
+	f.BoolVar(&cfg.IncludeTenantIDInProfileLabels, "ingester.include-tenant-id-in-profile-labels", false, "Include tenant ID in pprof labels for profiling. This can help debug performance issues for specific tenants.")
 
 	// Hardcoded config (can only be overridden in tests).
 	cfg.limitMetricsUpdatePeriod = time.Second * 15

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -19,11 +19,11 @@ import (
 
 // ActivityTrackerWrapper is a wrapper around Ingester that adds queries to activity tracker.
 type ActivityTrackerWrapper struct {
-	ing     IngesterAPI
+	ing     API
 	tracker *activitytracker.ActivityTracker
 }
 
-func NewIngesterActivityTracker(ing IngesterAPI, tracker *activitytracker.ActivityTracker) *ActivityTrackerWrapper {
+func NewIngesterActivityTracker(ing API, tracker *activitytracker.ActivityTracker) *ActivityTrackerWrapper {
 	return &ActivityTrackerWrapper{
 		ing:     ing,
 		tracker: tracker,

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -31,8 +31,13 @@ func NewIngesterActivityTracker(ing IngesterAPI, tracker *activitytracker.Activi
 }
 
 func (i *ActivityTrackerWrapper) Push(ctx context.Context, request *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
-	// No tracking in Push
+	// No tracking in Push because it is called very frequently
 	return i.ing.Push(ctx, request)
+}
+
+func (i *ActivityTrackerWrapper) PushToStorageAndReleaseRequest(ctx context.Context, request *mimirpb.WriteRequest) error {
+	// No tracking in PushToStorageAndReleaseRequest because it is called very frequently
+	return i.ing.PushToStorageAndReleaseRequest(ctx, request)
 }
 
 func (i *ActivityTrackerWrapper) QueryStream(request *client.QueryRequest, server client.Ingester_QueryStreamServer) error {

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/tracing"
 
-	"github.com/grafana/mimir/pkg/api"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/activitytracker"
@@ -20,11 +19,11 @@ import (
 
 // ActivityTrackerWrapper is a wrapper around Ingester that adds queries to activity tracker.
 type ActivityTrackerWrapper struct {
-	ing     api.Ingester
+	ing     IngesterAPI
 	tracker *activitytracker.ActivityTracker
 }
 
-func NewIngesterActivityTracker(ing api.Ingester, tracker *activitytracker.ActivityTracker) *ActivityTrackerWrapper {
+func NewIngesterActivityTracker(ing IngesterAPI, tracker *activitytracker.ActivityTracker) *ActivityTrackerWrapper {
 	return &ActivityTrackerWrapper{
 		ing:     ing,
 		tracker: tracker,

--- a/pkg/ingester/ingester_activity.go
+++ b/pkg/ingester/ingester_activity.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/tracing"
 
+	"github.com/grafana/mimir/pkg/api"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/activitytracker"
@@ -19,11 +20,11 @@ import (
 
 // ActivityTrackerWrapper is a wrapper around Ingester that adds queries to activity tracker.
 type ActivityTrackerWrapper struct {
-	ing     *Ingester
+	ing     api.Ingester
 	tracker *activitytracker.ActivityTracker
 }
 
-func NewIngesterActivityTracker(ing *Ingester, tracker *activitytracker.ActivityTracker) *ActivityTrackerWrapper {
+func NewIngesterActivityTracker(ing api.Ingester, tracker *activitytracker.ActivityTracker) *ActivityTrackerWrapper {
 	return &ActivityTrackerWrapper{
 		ing:     ing,
 		tracker: tracker,

--- a/pkg/ingester/ingester_profiling.go
+++ b/pkg/ingester/ingester_profiling.go
@@ -8,206 +8,335 @@ import (
 	"runtime/pprof"
 
 	"github.com/grafana/dskit/tenant"
+	"go.opentelemetry.io/otel/trace"
 
+	"github.com/grafana/mimir/pkg/api"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
 // ProfilingWrapper is a wrapper around Ingester that adds tenant ID to pprof labels.
 type ProfilingWrapper struct {
-	ing *Ingester
+	ing api.Ingester
 }
 
-func NewIngesterProfilingWrapper(ing *Ingester) *ProfilingWrapper {
+func NewIngesterProfilingWrapper(ing api.Ingester) *ProfilingWrapper {
 	return &ProfilingWrapper{
 		ing: ing,
 	}
 }
 
-func (i *ProfilingWrapper) Push(ctx context.Context, request *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
-	userID, _ := tenant.TenantID(ctx)
-	var resp *mimirpb.WriteResponse
-	var err error
-	pprof.Do(ctx, pprof.Labels("method", "Ingester.Push", "userID", userID), func(ctx context.Context) {
-		resp, err = i.ing.Push(ctx, request)
-	})
-	return resp, err
+type baseCtxStream struct {
+	ctx context.Context
 }
 
-func (i *ProfilingWrapper) PushToStorageAndReleaseRequest(ctx context.Context, req *mimirpb.WriteRequest) error {
-	userID, _ := tenant.TenantID(ctx)
-	var err error
-	pprof.Do(ctx, pprof.Labels("method", "Ingester.PushToStorageAndReleaseRequest", "userID", userID), func(ctx context.Context) {
-		err = i.ing.PushToStorageAndReleaseRequest(ctx, req)
-	})
-	return err
+func (s baseCtxStream) Context() context.Context {
+	return s.ctx
+}
+
+// isTraceSampled checks if the current trace is sampled
+func isTraceSampled(ctx context.Context) bool {
+	return trace.SpanFromContext(ctx).SpanContext().IsSampled()
+}
+
+func (i *ProfilingWrapper) Push(ctx context.Context, request *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.Push", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+	}
+
+	return i.ing.Push(ctx, request)
 }
 
 func (i *ProfilingWrapper) QueryStream(request *client.QueryRequest, server client.Ingester_QueryStreamServer) error {
-	userID, _ := tenant.TenantID(server.Context())
-	var err error
-	pprof.Do(server.Context(), pprof.Labels("method", "Ingester.QueryStream", "userID", userID), func(ctx context.Context) {
-		err = i.ing.QueryStream(request, server)
-	})
-	return err
+	ctx := server.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.QueryStream", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+
+		type queryStreamStream struct {
+			baseCtxStream
+			client.Ingester_QueryStreamServer
+		}
+
+		server = queryStreamStream{baseCtxStream{ctx}, server}
+	}
+
+	return i.ing.QueryStream(request, server)
 }
 
 func (i *ProfilingWrapper) QueryExemplars(ctx context.Context, request *client.ExemplarQueryRequest) (*client.ExemplarQueryResponse, error) {
-	userID, _ := tenant.TenantID(ctx)
-	var resp *client.ExemplarQueryResponse
-	var err error
-	pprof.Do(ctx, pprof.Labels("method", "Ingester.QueryExemplars", "userID", userID), func(ctx context.Context) {
-		resp, err = i.ing.QueryExemplars(ctx, request)
-	})
-	return resp, err
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.QueryExemplars", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+	}
+
+	return i.ing.QueryExemplars(ctx, request)
 }
 
 func (i *ProfilingWrapper) LabelValues(ctx context.Context, request *client.LabelValuesRequest) (*client.LabelValuesResponse, error) {
-	userID, _ := tenant.TenantID(ctx)
-	var resp *client.LabelValuesResponse
-	var err error
-	pprof.Do(ctx, pprof.Labels("method", "Ingester.LabelValues", "userID", userID), func(ctx context.Context) {
-		resp, err = i.ing.LabelValues(ctx, request)
-	})
-	return resp, err
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.LabelValues", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+	}
+
+	return i.ing.LabelValues(ctx, request)
 }
 
 func (i *ProfilingWrapper) LabelNames(ctx context.Context, request *client.LabelNamesRequest) (*client.LabelNamesResponse, error) {
-	userID, _ := tenant.TenantID(ctx)
-	var resp *client.LabelNamesResponse
-	var err error
-	pprof.Do(ctx, pprof.Labels("method", "Ingester.LabelNames", "userID", userID), func(ctx context.Context) {
-		resp, err = i.ing.LabelNames(ctx, request)
-	})
-	return resp, err
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.LabelNames", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+	}
+
+	return i.ing.LabelNames(ctx, request)
 }
 
 func (i *ProfilingWrapper) UserStats(ctx context.Context, request *client.UserStatsRequest) (*client.UserStatsResponse, error) {
-	userID, _ := tenant.TenantID(ctx)
-	var resp *client.UserStatsResponse
-	var err error
-	pprof.Do(ctx, pprof.Labels("method", "Ingester.UserStats", "userID", userID), func(ctx context.Context) {
-		resp, err = i.ing.UserStats(ctx, request)
-	})
-	return resp, err
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.UserStats", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+	}
+
+	return i.ing.UserStats(ctx, request)
 }
 
 func (i *ProfilingWrapper) AllUserStats(ctx context.Context, request *client.UserStatsRequest) (*client.UsersStatsResponse, error) {
-	userID, _ := tenant.TenantID(ctx)
-	var resp *client.UsersStatsResponse
-	var err error
-	pprof.Do(ctx, pprof.Labels("method", "Ingester.AllUserStats", "userID", userID), func(ctx context.Context) {
-		resp, err = i.ing.AllUserStats(ctx, request)
-	})
-	return resp, err
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.AllUserStats", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+	}
+
+	return i.ing.AllUserStats(ctx, request)
 }
 
 func (i *ProfilingWrapper) MetricsForLabelMatchers(ctx context.Context, request *client.MetricsForLabelMatchersRequest) (*client.MetricsForLabelMatchersResponse, error) {
-	userID, _ := tenant.TenantID(ctx)
-	var resp *client.MetricsForLabelMatchersResponse
-	var err error
-	pprof.Do(ctx, pprof.Labels("method", "Ingester.MetricsForLabelMatchers", "userID", userID), func(ctx context.Context) {
-		resp, err = i.ing.MetricsForLabelMatchers(ctx, request)
-	})
-	return resp, err
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.MetricsForLabelMatchers", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+	}
+
+	return i.ing.MetricsForLabelMatchers(ctx, request)
 }
 
 func (i *ProfilingWrapper) MetricsMetadata(ctx context.Context, request *client.MetricsMetadataRequest) (*client.MetricsMetadataResponse, error) {
-	userID, _ := tenant.TenantID(ctx)
-	var resp *client.MetricsMetadataResponse
-	var err error
-	pprof.Do(ctx, pprof.Labels("method", "Ingester.MetricsMetadata", "userID", userID), func(ctx context.Context) {
-		resp, err = i.ing.MetricsMetadata(ctx, request)
-	})
-	return resp, err
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.MetricsMetadata", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+	}
+
+	return i.ing.MetricsMetadata(ctx, request)
 }
 
 func (i *ProfilingWrapper) LabelNamesAndValues(request *client.LabelNamesAndValuesRequest, server client.Ingester_LabelNamesAndValuesServer) error {
-	userID, _ := tenant.TenantID(server.Context())
-	var err error
-	pprof.Do(server.Context(), pprof.Labels("method", "Ingester.LabelNamesAndValues", "userID", userID), func(ctx context.Context) {
-		err = i.ing.LabelNamesAndValues(request, server)
-	})
-	return err
+	ctx := server.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.LabelNamesAndValues", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+
+		type labelNamesAndValuesStream struct {
+			baseCtxStream
+			client.Ingester_LabelNamesAndValuesServer
+		}
+
+		server = labelNamesAndValuesStream{baseCtxStream{ctx}, server}
+	}
+
+	return i.ing.LabelNamesAndValues(request, server)
 }
 
 func (i *ProfilingWrapper) LabelValuesCardinality(request *client.LabelValuesCardinalityRequest, server client.Ingester_LabelValuesCardinalityServer) error {
-	userID, _ := tenant.TenantID(server.Context())
-	var err error
-	pprof.Do(server.Context(), pprof.Labels("method", "Ingester.LabelValuesCardinality", "userID", userID), func(ctx context.Context) {
-		err = i.ing.LabelValuesCardinality(request, server)
-	})
-	return err
+	ctx := server.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.LabelValuesCardinality", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+
+		type labelValuesCardinalityStream struct {
+			baseCtxStream
+			client.Ingester_LabelValuesCardinalityServer
+		}
+
+		server = labelValuesCardinalityStream{baseCtxStream{ctx}, server}
+	}
+
+	return i.ing.LabelValuesCardinality(request, server)
 }
 
 func (i *ProfilingWrapper) ActiveSeries(request *client.ActiveSeriesRequest, server client.Ingester_ActiveSeriesServer) error {
-	userID, _ := tenant.TenantID(server.Context())
-	var err error
-	pprof.Do(server.Context(), pprof.Labels("method", "Ingester.ActiveSeries", "userID", userID), func(ctx context.Context) {
-		err = i.ing.ActiveSeries(request, server)
-	})
-	return err
+	ctx := server.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.ActiveSeries", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+
+		type activeSeriesStream struct {
+			baseCtxStream
+			client.Ingester_ActiveSeriesServer
+		}
+
+		server = activeSeriesStream{baseCtxStream{ctx}, server}
+	}
+
+	return i.ing.ActiveSeries(request, server)
 }
 
 func (i *ProfilingWrapper) FlushHandler(w http.ResponseWriter, r *http.Request) {
-	userID, _ := tenant.TenantID(r.Context())
-	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.FlushHandler", "userID", userID), func(ctx context.Context) {
-		i.ing.FlushHandler(w, r)
-	})
+	ctx := r.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.FlushHandler", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+		r = r.WithContext(ctx)
+	}
+
+	i.ing.FlushHandler(w, r)
 }
 
 func (i *ProfilingWrapper) PrepareShutdownHandler(w http.ResponseWriter, r *http.Request) {
-	userID, _ := tenant.TenantID(r.Context())
-	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.PrepareShutdownHandler", "userID", userID), func(ctx context.Context) {
-		i.ing.PrepareShutdownHandler(w, r)
-	})
+	ctx := r.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.PrepareShutdownHandler", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+		r = r.WithContext(ctx)
+	}
+
+	i.ing.PrepareShutdownHandler(w, r)
 }
 
 func (i *ProfilingWrapper) PreparePartitionDownscaleHandler(w http.ResponseWriter, r *http.Request) {
-	userID, _ := tenant.TenantID(r.Context())
-	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.PreparePartitionDownscaleHandler", "userID", userID), func(ctx context.Context) {
-		i.ing.PreparePartitionDownscaleHandler(w, r)
-	})
+	ctx := r.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.PreparePartitionDownscaleHandler", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+		r = r.WithContext(ctx)
+	}
+
+	i.ing.PreparePartitionDownscaleHandler(w, r)
 }
 
 func (i *ProfilingWrapper) PrepareInstanceRingDownscaleHandler(w http.ResponseWriter, r *http.Request) {
-	userID, _ := tenant.TenantID(r.Context())
-	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.PrepareInstanceRingDownscaleHandler", "userID", userID), func(ctx context.Context) {
-		i.ing.PrepareInstanceRingDownscaleHandler(w, r)
-	})
+	ctx := r.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.PrepareInstanceRingDownscaleHandler", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+		r = r.WithContext(ctx)
+	}
+
+	i.ing.PrepareInstanceRingDownscaleHandler(w, r)
 }
 
 func (i *ProfilingWrapper) PrepareUnregisterHandler(w http.ResponseWriter, r *http.Request) {
-	userID, _ := tenant.TenantID(r.Context())
-	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.PrepareUnregisterHandler", "userID", userID), func(ctx context.Context) {
-		i.ing.PrepareUnregisterHandler(w, r)
-	})
+	ctx := r.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.PrepareUnregisterHandler", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+		r = r.WithContext(ctx)
+	}
+
+	i.ing.PrepareUnregisterHandler(w, r)
 }
 
 func (i *ProfilingWrapper) ShutdownHandler(w http.ResponseWriter, r *http.Request) {
-	userID, _ := tenant.TenantID(r.Context())
-	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.ShutdownHandler", "userID", userID), func(ctx context.Context) {
-		i.ing.ShutdownHandler(w, r)
-	})
+	ctx := r.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.ShutdownHandler", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+		r = r.WithContext(ctx)
+	}
+
+	i.ing.ShutdownHandler(w, r)
 }
 
-func (i *ProfilingWrapper) UserRegistryHandler(writer http.ResponseWriter, request *http.Request) {
-	userID, _ := tenant.TenantID(request.Context())
-	pprof.Do(request.Context(), pprof.Labels("method", "Ingester.UserRegistryHandler", "userID", userID), func(ctx context.Context) {
-		i.ing.UserRegistryHandler(writer, request)
-	})
+func (i *ProfilingWrapper) UserRegistryHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.UserRegistryHandler", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+		r = r.WithContext(ctx)
+	}
+
+	i.ing.UserRegistryHandler(w, r)
 }
 
 func (i *ProfilingWrapper) TenantsHandler(w http.ResponseWriter, r *http.Request) {
-	userID, _ := tenant.TenantID(r.Context())
-	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.TenantsHandler", "userID", userID), func(ctx context.Context) {
-		i.ing.TenantsHandler(w, r)
-	})
+	ctx := r.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.TenantsHandler", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+		r = r.WithContext(ctx)
+	}
+
+	i.ing.TenantsHandler(w, r)
 }
 
 func (i *ProfilingWrapper) TenantTSDBHandler(w http.ResponseWriter, r *http.Request) {
-	userID, _ := tenant.TenantID(r.Context())
-	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.TenantTSDBHandler", "userID", userID), func(ctx context.Context) {
-		i.ing.TenantTSDBHandler(w, r)
-	})
+	ctx := r.Context()
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("method", "Ingester.TenantTSDBHandler", "userID", userID)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+		defer pprof.SetGoroutineLabels(ctx)
+		r = r.WithContext(ctx)
+	}
+
+	i.ing.TenantTSDBHandler(w, r)
 }

--- a/pkg/ingester/ingester_profiling.go
+++ b/pkg/ingester/ingester_profiling.go
@@ -78,6 +78,18 @@ func (i *ProfilingWrapper) Push(ctx context.Context, request *mimirpb.WriteReque
 	return i.ing.Push(ctx, request)
 }
 
+func (i *ProfilingWrapper) PushToStorageAndReleaseRequest(ctx context.Context, request *mimirpb.WriteRequest) error {
+	if isTraceSampled(ctx) {
+		userID, _ := tenant.TenantID(ctx)
+		labels := pprof.Labels("userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
+		ctx = pprof.WithLabels(ctx, labels)
+		pprof.SetGoroutineLabels(ctx)
+	}
+
+	return i.ing.PushToStorageAndReleaseRequest(ctx, request)
+}
+
 func (i *ProfilingWrapper) QueryStream(request *client.QueryRequest, server client.Ingester_QueryStreamServer) error {
 	ctx := server.Context()
 	if isTraceSampled(ctx) {

--- a/pkg/ingester/ingester_profiling.go
+++ b/pkg/ingester/ingester_profiling.go
@@ -70,9 +70,9 @@ func (i *ProfilingWrapper) Push(ctx context.Context, request *mimirpb.WriteReque
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.Push", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 	}
 
 	return i.ing.Push(ctx, request)
@@ -83,9 +83,9 @@ func (i *ProfilingWrapper) QueryStream(request *client.QueryRequest, server clie
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.QueryStream", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		server = queryStreamStream{ctx, server}
 	}
 
@@ -96,9 +96,9 @@ func (i *ProfilingWrapper) QueryExemplars(ctx context.Context, request *client.E
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.QueryExemplars", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 	}
 
 	return i.ing.QueryExemplars(ctx, request)
@@ -108,9 +108,9 @@ func (i *ProfilingWrapper) LabelValues(ctx context.Context, request *client.Labe
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.LabelValues", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 	}
 
 	return i.ing.LabelValues(ctx, request)
@@ -120,9 +120,9 @@ func (i *ProfilingWrapper) LabelNames(ctx context.Context, request *client.Label
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.LabelNames", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 	}
 
 	return i.ing.LabelNames(ctx, request)
@@ -132,9 +132,9 @@ func (i *ProfilingWrapper) UserStats(ctx context.Context, request *client.UserSt
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.UserStats", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 	}
 
 	return i.ing.UserStats(ctx, request)
@@ -144,9 +144,9 @@ func (i *ProfilingWrapper) AllUserStats(ctx context.Context, request *client.Use
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.AllUserStats", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 	}
 
 	return i.ing.AllUserStats(ctx, request)
@@ -156,9 +156,9 @@ func (i *ProfilingWrapper) MetricsForLabelMatchers(ctx context.Context, request 
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.MetricsForLabelMatchers", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 	}
 
 	return i.ing.MetricsForLabelMatchers(ctx, request)
@@ -168,9 +168,9 @@ func (i *ProfilingWrapper) MetricsMetadata(ctx context.Context, request *client.
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.MetricsMetadata", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 	}
 
 	return i.ing.MetricsMetadata(ctx, request)
@@ -181,9 +181,9 @@ func (i *ProfilingWrapper) LabelNamesAndValues(request *client.LabelNamesAndValu
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.LabelNamesAndValues", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		server = labelNamesAndValuesStream{ctx, server}
 	}
 
@@ -195,9 +195,9 @@ func (i *ProfilingWrapper) LabelValuesCardinality(request *client.LabelValuesCar
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.LabelValuesCardinality", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		server = labelValuesCardinalityStream{ctx, server}
 	}
 
@@ -209,9 +209,9 @@ func (i *ProfilingWrapper) ActiveSeries(request *client.ActiveSeriesRequest, ser
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.ActiveSeries", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		server = activeSeriesStream{ctx, server}
 	}
 
@@ -223,9 +223,9 @@ func (i *ProfilingWrapper) FlushHandler(w http.ResponseWriter, r *http.Request) 
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.FlushHandler", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		r = r.WithContext(ctx)
 	}
 
@@ -237,9 +237,9 @@ func (i *ProfilingWrapper) PrepareShutdownHandler(w http.ResponseWriter, r *http
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.PrepareShutdownHandler", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		r = r.WithContext(ctx)
 	}
 
@@ -251,9 +251,9 @@ func (i *ProfilingWrapper) PreparePartitionDownscaleHandler(w http.ResponseWrite
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.PreparePartitionDownscaleHandler", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		r = r.WithContext(ctx)
 	}
 
@@ -265,9 +265,9 @@ func (i *ProfilingWrapper) PrepareInstanceRingDownscaleHandler(w http.ResponseWr
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.PrepareInstanceRingDownscaleHandler", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		r = r.WithContext(ctx)
 	}
 
@@ -279,9 +279,9 @@ func (i *ProfilingWrapper) PrepareUnregisterHandler(w http.ResponseWriter, r *ht
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.PrepareUnregisterHandler", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		r = r.WithContext(ctx)
 	}
 
@@ -293,9 +293,9 @@ func (i *ProfilingWrapper) ShutdownHandler(w http.ResponseWriter, r *http.Reques
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.ShutdownHandler", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		r = r.WithContext(ctx)
 	}
 
@@ -307,9 +307,9 @@ func (i *ProfilingWrapper) UserRegistryHandler(w http.ResponseWriter, r *http.Re
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.UserRegistryHandler", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		r = r.WithContext(ctx)
 	}
 
@@ -321,9 +321,9 @@ func (i *ProfilingWrapper) TenantsHandler(w http.ResponseWriter, r *http.Request
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.TenantsHandler", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		r = r.WithContext(ctx)
 	}
 
@@ -335,9 +335,9 @@ func (i *ProfilingWrapper) TenantTSDBHandler(w http.ResponseWriter, r *http.Requ
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
 		labels := pprof.Labels("method", "Ingester.TenantTSDBHandler", "userID", userID)
+		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
-		defer pprof.SetGoroutineLabels(ctx)
 		r = r.WithContext(ctx)
 	}
 

--- a/pkg/ingester/ingester_profiling.go
+++ b/pkg/ingester/ingester_profiling.go
@@ -69,7 +69,7 @@ func isTraceSampled(ctx context.Context) bool {
 func (i *ProfilingWrapper) Push(ctx context.Context, request *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.Push", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -82,7 +82,7 @@ func (i *ProfilingWrapper) QueryStream(request *client.QueryRequest, server clie
 	ctx := server.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.QueryStream", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -95,7 +95,7 @@ func (i *ProfilingWrapper) QueryStream(request *client.QueryRequest, server clie
 func (i *ProfilingWrapper) QueryExemplars(ctx context.Context, request *client.ExemplarQueryRequest) (*client.ExemplarQueryResponse, error) {
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.QueryExemplars", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -107,7 +107,7 @@ func (i *ProfilingWrapper) QueryExemplars(ctx context.Context, request *client.E
 func (i *ProfilingWrapper) LabelValues(ctx context.Context, request *client.LabelValuesRequest) (*client.LabelValuesResponse, error) {
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.LabelValues", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -119,7 +119,7 @@ func (i *ProfilingWrapper) LabelValues(ctx context.Context, request *client.Labe
 func (i *ProfilingWrapper) LabelNames(ctx context.Context, request *client.LabelNamesRequest) (*client.LabelNamesResponse, error) {
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.LabelNames", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -131,7 +131,7 @@ func (i *ProfilingWrapper) LabelNames(ctx context.Context, request *client.Label
 func (i *ProfilingWrapper) UserStats(ctx context.Context, request *client.UserStatsRequest) (*client.UserStatsResponse, error) {
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.UserStats", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -143,7 +143,7 @@ func (i *ProfilingWrapper) UserStats(ctx context.Context, request *client.UserSt
 func (i *ProfilingWrapper) AllUserStats(ctx context.Context, request *client.UserStatsRequest) (*client.UsersStatsResponse, error) {
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.AllUserStats", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -155,7 +155,7 @@ func (i *ProfilingWrapper) AllUserStats(ctx context.Context, request *client.Use
 func (i *ProfilingWrapper) MetricsForLabelMatchers(ctx context.Context, request *client.MetricsForLabelMatchersRequest) (*client.MetricsForLabelMatchersResponse, error) {
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.MetricsForLabelMatchers", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -167,7 +167,7 @@ func (i *ProfilingWrapper) MetricsForLabelMatchers(ctx context.Context, request 
 func (i *ProfilingWrapper) MetricsMetadata(ctx context.Context, request *client.MetricsMetadataRequest) (*client.MetricsMetadataResponse, error) {
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.MetricsMetadata", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -180,7 +180,7 @@ func (i *ProfilingWrapper) LabelNamesAndValues(request *client.LabelNamesAndValu
 	ctx := server.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.LabelNamesAndValues", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -194,7 +194,7 @@ func (i *ProfilingWrapper) LabelValuesCardinality(request *client.LabelValuesCar
 	ctx := server.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.LabelValuesCardinality", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -208,7 +208,7 @@ func (i *ProfilingWrapper) ActiveSeries(request *client.ActiveSeriesRequest, ser
 	ctx := server.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.ActiveSeries", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -222,7 +222,7 @@ func (i *ProfilingWrapper) FlushHandler(w http.ResponseWriter, r *http.Request) 
 	ctx := r.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.FlushHandler", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -236,7 +236,7 @@ func (i *ProfilingWrapper) PrepareShutdownHandler(w http.ResponseWriter, r *http
 	ctx := r.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.PrepareShutdownHandler", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -250,7 +250,7 @@ func (i *ProfilingWrapper) PreparePartitionDownscaleHandler(w http.ResponseWrite
 	ctx := r.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.PreparePartitionDownscaleHandler", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -264,7 +264,7 @@ func (i *ProfilingWrapper) PrepareInstanceRingDownscaleHandler(w http.ResponseWr
 	ctx := r.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.PrepareInstanceRingDownscaleHandler", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -278,7 +278,7 @@ func (i *ProfilingWrapper) PrepareUnregisterHandler(w http.ResponseWriter, r *ht
 	ctx := r.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.PrepareUnregisterHandler", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -292,7 +292,7 @@ func (i *ProfilingWrapper) ShutdownHandler(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.ShutdownHandler", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -306,7 +306,7 @@ func (i *ProfilingWrapper) UserRegistryHandler(w http.ResponseWriter, r *http.Re
 	ctx := r.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.UserRegistryHandler", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -320,7 +320,7 @@ func (i *ProfilingWrapper) TenantsHandler(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.TenantsHandler", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
@@ -334,7 +334,7 @@ func (i *ProfilingWrapper) TenantTSDBHandler(w http.ResponseWriter, r *http.Requ
 	ctx := r.Context()
 	if isTraceSampled(ctx) {
 		userID, _ := tenant.TenantID(ctx)
-		labels := pprof.Labels("method", "Ingester.TenantTSDBHandler", "userID", userID)
+		labels := pprof.Labels("userID", userID)
 		defer pprof.SetGoroutineLabels(ctx)
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)

--- a/pkg/ingester/ingester_profiling.go
+++ b/pkg/ingester/ingester_profiling.go
@@ -10,17 +10,16 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/grafana/mimir/pkg/api"
 	"github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
 // ProfilingWrapper is a wrapper around Ingester that adds tenant ID to pprof labels.
 type ProfilingWrapper struct {
-	ing api.Ingester
+	ing IngesterAPI
 }
 
-func NewIngesterProfilingWrapper(ing api.Ingester) *ProfilingWrapper {
+func NewIngesterProfilingWrapper(ing IngesterAPI) *ProfilingWrapper {
 	return &ProfilingWrapper{
 		ing: ing,
 	}

--- a/pkg/ingester/ingester_profiling.go
+++ b/pkg/ingester/ingester_profiling.go
@@ -26,11 +26,39 @@ func NewIngesterProfilingWrapper(ing api.Ingester) *ProfilingWrapper {
 	}
 }
 
-type baseCtxStream struct {
+type labelNamesAndValuesStream struct {
 	ctx context.Context
+	client.Ingester_LabelNamesAndValuesServer
 }
 
-func (s baseCtxStream) Context() context.Context {
+func (s labelNamesAndValuesStream) Context() context.Context {
+	return s.ctx
+}
+
+type labelValuesCardinalityStream struct {
+	ctx context.Context
+	client.Ingester_LabelValuesCardinalityServer
+}
+
+func (s labelValuesCardinalityStream) Context() context.Context {
+	return s.ctx
+}
+
+type activeSeriesStream struct {
+	ctx context.Context
+	client.Ingester_ActiveSeriesServer
+}
+
+func (s activeSeriesStream) Context() context.Context {
+	return s.ctx
+}
+
+type queryStreamStream struct {
+	ctx context.Context
+	client.Ingester_QueryStreamServer
+}
+
+func (s queryStreamStream) Context() context.Context {
 	return s.ctx
 }
 
@@ -59,13 +87,7 @@ func (i *ProfilingWrapper) QueryStream(request *client.QueryRequest, server clie
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
 		defer pprof.SetGoroutineLabels(ctx)
-
-		type queryStreamStream struct {
-			baseCtxStream
-			client.Ingester_QueryStreamServer
-		}
-
-		server = queryStreamStream{baseCtxStream{ctx}, server}
+		server = queryStreamStream{ctx, server}
 	}
 
 	return i.ing.QueryStream(request, server)
@@ -163,13 +185,7 @@ func (i *ProfilingWrapper) LabelNamesAndValues(request *client.LabelNamesAndValu
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
 		defer pprof.SetGoroutineLabels(ctx)
-
-		type labelNamesAndValuesStream struct {
-			baseCtxStream
-			client.Ingester_LabelNamesAndValuesServer
-		}
-
-		server = labelNamesAndValuesStream{baseCtxStream{ctx}, server}
+		server = labelNamesAndValuesStream{ctx, server}
 	}
 
 	return i.ing.LabelNamesAndValues(request, server)
@@ -183,13 +199,7 @@ func (i *ProfilingWrapper) LabelValuesCardinality(request *client.LabelValuesCar
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
 		defer pprof.SetGoroutineLabels(ctx)
-
-		type labelValuesCardinalityStream struct {
-			baseCtxStream
-			client.Ingester_LabelValuesCardinalityServer
-		}
-
-		server = labelValuesCardinalityStream{baseCtxStream{ctx}, server}
+		server = labelValuesCardinalityStream{ctx, server}
 	}
 
 	return i.ing.LabelValuesCardinality(request, server)
@@ -203,13 +213,7 @@ func (i *ProfilingWrapper) ActiveSeries(request *client.ActiveSeriesRequest, ser
 		ctx = pprof.WithLabels(ctx, labels)
 		pprof.SetGoroutineLabels(ctx)
 		defer pprof.SetGoroutineLabels(ctx)
-
-		type activeSeriesStream struct {
-			baseCtxStream
-			client.Ingester_ActiveSeriesServer
-		}
-
-		server = activeSeriesStream{baseCtxStream{ctx}, server}
+		server = activeSeriesStream{ctx, server}
 	}
 
 	return i.ing.ActiveSeries(request, server)

--- a/pkg/ingester/ingester_profiling.go
+++ b/pkg/ingester/ingester_profiling.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingester
+
+import (
+	"context"
+	"net/http"
+	"runtime/pprof"
+
+	"github.com/grafana/dskit/tenant"
+
+	"github.com/grafana/mimir/pkg/ingester/client"
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+// ProfilingWrapper is a wrapper around Ingester that adds tenant ID to pprof labels.
+type ProfilingWrapper struct {
+	ing *Ingester
+}
+
+func NewIngesterProfilingWrapper(ing *Ingester) *ProfilingWrapper {
+	return &ProfilingWrapper{
+		ing: ing,
+	}
+}
+
+func (i *ProfilingWrapper) Push(ctx context.Context, request *mimirpb.WriteRequest) (*mimirpb.WriteResponse, error) {
+	userID, _ := tenant.TenantID(ctx)
+	var resp *mimirpb.WriteResponse
+	var err error
+	pprof.Do(ctx, pprof.Labels("method", "Ingester.Push", "userID", userID), func(ctx context.Context) {
+		resp, err = i.ing.Push(ctx, request)
+	})
+	return resp, err
+}
+
+func (i *ProfilingWrapper) PushToStorageAndReleaseRequest(ctx context.Context, req *mimirpb.WriteRequest) error {
+	userID, _ := tenant.TenantID(ctx)
+	var err error
+	pprof.Do(ctx, pprof.Labels("method", "Ingester.PushToStorageAndReleaseRequest", "userID", userID), func(ctx context.Context) {
+		err = i.ing.PushToStorageAndReleaseRequest(ctx, req)
+	})
+	return err
+}
+
+func (i *ProfilingWrapper) QueryStream(request *client.QueryRequest, server client.Ingester_QueryStreamServer) error {
+	userID, _ := tenant.TenantID(server.Context())
+	var err error
+	pprof.Do(server.Context(), pprof.Labels("method", "Ingester.QueryStream", "userID", userID), func(ctx context.Context) {
+		err = i.ing.QueryStream(request, server)
+	})
+	return err
+}
+
+func (i *ProfilingWrapper) QueryExemplars(ctx context.Context, request *client.ExemplarQueryRequest) (*client.ExemplarQueryResponse, error) {
+	userID, _ := tenant.TenantID(ctx)
+	var resp *client.ExemplarQueryResponse
+	var err error
+	pprof.Do(ctx, pprof.Labels("method", "Ingester.QueryExemplars", "userID", userID), func(ctx context.Context) {
+		resp, err = i.ing.QueryExemplars(ctx, request)
+	})
+	return resp, err
+}
+
+func (i *ProfilingWrapper) LabelValues(ctx context.Context, request *client.LabelValuesRequest) (*client.LabelValuesResponse, error) {
+	userID, _ := tenant.TenantID(ctx)
+	var resp *client.LabelValuesResponse
+	var err error
+	pprof.Do(ctx, pprof.Labels("method", "Ingester.LabelValues", "userID", userID), func(ctx context.Context) {
+		resp, err = i.ing.LabelValues(ctx, request)
+	})
+	return resp, err
+}
+
+func (i *ProfilingWrapper) LabelNames(ctx context.Context, request *client.LabelNamesRequest) (*client.LabelNamesResponse, error) {
+	userID, _ := tenant.TenantID(ctx)
+	var resp *client.LabelNamesResponse
+	var err error
+	pprof.Do(ctx, pprof.Labels("method", "Ingester.LabelNames", "userID", userID), func(ctx context.Context) {
+		resp, err = i.ing.LabelNames(ctx, request)
+	})
+	return resp, err
+}
+
+func (i *ProfilingWrapper) UserStats(ctx context.Context, request *client.UserStatsRequest) (*client.UserStatsResponse, error) {
+	userID, _ := tenant.TenantID(ctx)
+	var resp *client.UserStatsResponse
+	var err error
+	pprof.Do(ctx, pprof.Labels("method", "Ingester.UserStats", "userID", userID), func(ctx context.Context) {
+		resp, err = i.ing.UserStats(ctx, request)
+	})
+	return resp, err
+}
+
+func (i *ProfilingWrapper) AllUserStats(ctx context.Context, request *client.UserStatsRequest) (*client.UsersStatsResponse, error) {
+	userID, _ := tenant.TenantID(ctx)
+	var resp *client.UsersStatsResponse
+	var err error
+	pprof.Do(ctx, pprof.Labels("method", "Ingester.AllUserStats", "userID", userID), func(ctx context.Context) {
+		resp, err = i.ing.AllUserStats(ctx, request)
+	})
+	return resp, err
+}
+
+func (i *ProfilingWrapper) MetricsForLabelMatchers(ctx context.Context, request *client.MetricsForLabelMatchersRequest) (*client.MetricsForLabelMatchersResponse, error) {
+	userID, _ := tenant.TenantID(ctx)
+	var resp *client.MetricsForLabelMatchersResponse
+	var err error
+	pprof.Do(ctx, pprof.Labels("method", "Ingester.MetricsForLabelMatchers", "userID", userID), func(ctx context.Context) {
+		resp, err = i.ing.MetricsForLabelMatchers(ctx, request)
+	})
+	return resp, err
+}
+
+func (i *ProfilingWrapper) MetricsMetadata(ctx context.Context, request *client.MetricsMetadataRequest) (*client.MetricsMetadataResponse, error) {
+	userID, _ := tenant.TenantID(ctx)
+	var resp *client.MetricsMetadataResponse
+	var err error
+	pprof.Do(ctx, pprof.Labels("method", "Ingester.MetricsMetadata", "userID", userID), func(ctx context.Context) {
+		resp, err = i.ing.MetricsMetadata(ctx, request)
+	})
+	return resp, err
+}
+
+func (i *ProfilingWrapper) LabelNamesAndValues(request *client.LabelNamesAndValuesRequest, server client.Ingester_LabelNamesAndValuesServer) error {
+	userID, _ := tenant.TenantID(server.Context())
+	var err error
+	pprof.Do(server.Context(), pprof.Labels("method", "Ingester.LabelNamesAndValues", "userID", userID), func(ctx context.Context) {
+		err = i.ing.LabelNamesAndValues(request, server)
+	})
+	return err
+}
+
+func (i *ProfilingWrapper) LabelValuesCardinality(request *client.LabelValuesCardinalityRequest, server client.Ingester_LabelValuesCardinalityServer) error {
+	userID, _ := tenant.TenantID(server.Context())
+	var err error
+	pprof.Do(server.Context(), pprof.Labels("method", "Ingester.LabelValuesCardinality", "userID", userID), func(ctx context.Context) {
+		err = i.ing.LabelValuesCardinality(request, server)
+	})
+	return err
+}
+
+func (i *ProfilingWrapper) ActiveSeries(request *client.ActiveSeriesRequest, server client.Ingester_ActiveSeriesServer) error {
+	userID, _ := tenant.TenantID(server.Context())
+	var err error
+	pprof.Do(server.Context(), pprof.Labels("method", "Ingester.ActiveSeries", "userID", userID), func(ctx context.Context) {
+		err = i.ing.ActiveSeries(request, server)
+	})
+	return err
+}
+
+func (i *ProfilingWrapper) FlushHandler(w http.ResponseWriter, r *http.Request) {
+	userID, _ := tenant.TenantID(r.Context())
+	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.FlushHandler", "userID", userID), func(ctx context.Context) {
+		i.ing.FlushHandler(w, r)
+	})
+}
+
+func (i *ProfilingWrapper) PrepareShutdownHandler(w http.ResponseWriter, r *http.Request) {
+	userID, _ := tenant.TenantID(r.Context())
+	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.PrepareShutdownHandler", "userID", userID), func(ctx context.Context) {
+		i.ing.PrepareShutdownHandler(w, r)
+	})
+}
+
+func (i *ProfilingWrapper) PreparePartitionDownscaleHandler(w http.ResponseWriter, r *http.Request) {
+	userID, _ := tenant.TenantID(r.Context())
+	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.PreparePartitionDownscaleHandler", "userID", userID), func(ctx context.Context) {
+		i.ing.PreparePartitionDownscaleHandler(w, r)
+	})
+}
+
+func (i *ProfilingWrapper) PrepareInstanceRingDownscaleHandler(w http.ResponseWriter, r *http.Request) {
+	userID, _ := tenant.TenantID(r.Context())
+	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.PrepareInstanceRingDownscaleHandler", "userID", userID), func(ctx context.Context) {
+		i.ing.PrepareInstanceRingDownscaleHandler(w, r)
+	})
+}
+
+func (i *ProfilingWrapper) PrepareUnregisterHandler(w http.ResponseWriter, r *http.Request) {
+	userID, _ := tenant.TenantID(r.Context())
+	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.PrepareUnregisterHandler", "userID", userID), func(ctx context.Context) {
+		i.ing.PrepareUnregisterHandler(w, r)
+	})
+}
+
+func (i *ProfilingWrapper) ShutdownHandler(w http.ResponseWriter, r *http.Request) {
+	userID, _ := tenant.TenantID(r.Context())
+	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.ShutdownHandler", "userID", userID), func(ctx context.Context) {
+		i.ing.ShutdownHandler(w, r)
+	})
+}
+
+func (i *ProfilingWrapper) UserRegistryHandler(writer http.ResponseWriter, request *http.Request) {
+	userID, _ := tenant.TenantID(request.Context())
+	pprof.Do(request.Context(), pprof.Labels("method", "Ingester.UserRegistryHandler", "userID", userID), func(ctx context.Context) {
+		i.ing.UserRegistryHandler(writer, request)
+	})
+}
+
+func (i *ProfilingWrapper) TenantsHandler(w http.ResponseWriter, r *http.Request) {
+	userID, _ := tenant.TenantID(r.Context())
+	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.TenantsHandler", "userID", userID), func(ctx context.Context) {
+		i.ing.TenantsHandler(w, r)
+	})
+}
+
+func (i *ProfilingWrapper) TenantTSDBHandler(w http.ResponseWriter, r *http.Request) {
+	userID, _ := tenant.TenantID(r.Context())
+	pprof.Do(r.Context(), pprof.Labels("method", "Ingester.TenantTSDBHandler", "userID", userID), func(ctx context.Context) {
+		i.ing.TenantTSDBHandler(w, r)
+	})
+}

--- a/pkg/ingester/ingester_profiling.go
+++ b/pkg/ingester/ingester_profiling.go
@@ -16,10 +16,10 @@ import (
 
 // ProfilingWrapper is a wrapper around Ingester that adds tenant ID to pprof labels.
 type ProfilingWrapper struct {
-	ing IngesterAPI
+	ing API
 }
 
-func NewIngesterProfilingWrapper(ing IngesterAPI) *ProfilingWrapper {
+func NewIngesterProfilingWrapper(ing API) *ProfilingWrapper {
 	return &ProfilingWrapper{
 		ing: ing,
 	}

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -112,25 +112,26 @@ type Config struct {
 	PrintConfig                     bool                   `yaml:"-"`
 	ApplicationName                 string                 `yaml:"-"`
 
-	API                   api.Config                      `yaml:"api"`
-	Server                server.Config                   `yaml:"server"`
-	Distributor           distributor.Config              `yaml:"distributor"`
-	Querier               querier.Config                  `yaml:"querier"`
-	IngesterClient        client.Config                   `yaml:"ingester_client"`
-	Ingester              ingester.Config                 `yaml:"ingester"`
-	Flusher               flusher.Config                  `yaml:"flusher"`
-	LimitsConfig          validation.Limits               `yaml:"limits"`
-	Worker                querier_worker.Config           `yaml:"frontend_worker"`
-	Frontend              frontend.CombinedFrontendConfig `yaml:"frontend"`
-	IngestStorage         ingest.Config                   `yaml:"ingest_storage"`
-	BlockBuilder          blockbuilder.Config             `yaml:"block_builder" doc:"hidden"`
-	BlockBuilderScheduler blockbuilderscheduler.Config    `yaml:"block_builder_scheduler" doc:"hidden"`
-	BlocksStorage         tsdb.BlocksStorageConfig        `yaml:"blocks_storage"`
-	Compactor             compactor.Config                `yaml:"compactor"`
-	StoreGateway          storegateway.Config             `yaml:"store_gateway"`
-	TenantFederation      tenantfederation.Config         `yaml:"tenant_federation"`
-	ActivityTracker       activitytracker.Config          `yaml:"activity_tracker"`
-	Vault                 vault.Config                    `yaml:"vault"`
+	API                            api.Config                      `yaml:"api"`
+	Server                         server.Config                   `yaml:"server"`
+	Distributor                    distributor.Config              `yaml:"distributor"`
+	Querier                        querier.Config                  `yaml:"querier"`
+	IngesterClient                 client.Config                   `yaml:"ingester_client"`
+	Ingester                       ingester.Config                 `yaml:"ingester"`
+	Flusher                        flusher.Config                  `yaml:"flusher"`
+	LimitsConfig                   validation.Limits               `yaml:"limits"`
+	Worker                         querier_worker.Config           `yaml:"frontend_worker"`
+	Frontend                       frontend.CombinedFrontendConfig `yaml:"frontend"`
+	IngestStorage                  ingest.Config                   `yaml:"ingest_storage"`
+	BlockBuilder                   blockbuilder.Config             `yaml:"block_builder" doc:"hidden"`
+	BlockBuilderScheduler          blockbuilderscheduler.Config    `yaml:"block_builder_scheduler" doc:"hidden"`
+	BlocksStorage                  tsdb.BlocksStorageConfig        `yaml:"blocks_storage"`
+	Compactor                      compactor.Config                `yaml:"compactor"`
+	StoreGateway                   storegateway.Config             `yaml:"store_gateway"`
+	TenantFederation               tenantfederation.Config         `yaml:"tenant_federation"`
+	ActivityTracker                activitytracker.Config          `yaml:"activity_tracker"`
+	IncludeTenantIDInProfileLabels bool                            `yaml:"include_tenant_id_in_profile_labels" category:"experimental"`
+	Vault                          vault.Config                    `yaml:"vault"`
 
 	Ruler               ruler.Config                               `yaml:"ruler"`
 	RulerStorage        rulestore.Config                           `yaml:"ruler_storage"`
@@ -204,6 +205,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.AlertmanagerStorage.RegisterFlags(f)
 	c.RuntimeConfig.RegisterFlags(f)
 	c.ActivityTracker.RegisterFlags(f)
+	f.BoolVar(&c.IncludeTenantIDInProfileLabels, "include-tenant-id-in-profile-labels", false, "Include tenant ID in pprof labels for profiling. Currently only supported by the ingester. This can help debug performance issues for specific tenants.")
 	c.QueryScheduler.RegisterFlags(f, logger)
 	c.UsageStats.RegisterFlags(f)
 	c.ContinuousTest.RegisterFlags(f)

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -179,6 +179,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&c.CostAttributionRegistryPath, "cost-attribution.registry-path", "", "Defines a custom path for the registry. When specified, Mimir exposes cost attribution metrics through this custom path. If not specified, cost attribution metrics aren't exposed.")
 	f.DurationVar(&c.CostAttributionEvictionInterval, "cost-attribution.eviction-interval", 20*time.Minute, "Specifies how often inactive cost attributions for received and discarded sample trackers are evicted from the counter, ensuring they do not contribute to the cost attribution cardinality per user limit. This setting does not apply to active series, which are managed separately.")
 	f.DurationVar(&c.CostAttributionCleanupInterval, "cost-attribution.cleanup-interval", 3*time.Minute, "Time interval at which the cost attribution cleanup process runs, ensuring inactive cost attribution entries are purged.")
+	f.BoolVar(&c.IncludeTenantIDInProfileLabels, "include-tenant-id-in-profile-labels", false, "Include tenant ID in pprof labels for profiling. Currently only supported by the ingester. This can help debug performance issues for specific tenants.")
 
 	c.API.RegisterFlags(f)
 	c.registerServerFlagsWithChangedDefaultValues(f)
@@ -205,7 +206,6 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.AlertmanagerStorage.RegisterFlags(f)
 	c.RuntimeConfig.RegisterFlags(f)
 	c.ActivityTracker.RegisterFlags(f)
-	f.BoolVar(&c.IncludeTenantIDInProfileLabels, "include-tenant-id-in-profile-labels", false, "Include tenant ID in pprof labels for profiling. Currently only supported by the ingester. This can help debug performance issues for specific tenants.")
 	c.QueryScheduler.RegisterFlags(f, logger)
 	c.UsageStats.RegisterFlags(f)
 	c.ContinuousTest.RegisterFlags(f)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -738,10 +738,10 @@ func (t *Mimir) initIngester() (serv services.Service, err error) {
 
 	ing = t.Ingester
 	if t.ActivityTracker != nil {
-		ing = ingester.NewIngesterActivityTracker(t.Ingester, t.ActivityTracker)
+		ing = ingester.NewIngesterActivityTracker(ing, t.ActivityTracker)
 	}
 	if t.Cfg.IncludeTenantIDInProfileLabels {
-		ing = ingester.NewIngesterProfilingWrapper(t.Ingester)
+		ing = ingester.NewIngesterProfilingWrapper(ing)
 	}
 	t.API.RegisterIngester(ing)
 	return nil, nil

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -734,7 +734,7 @@ func (t *Mimir) initIngesterService() (serv services.Service, err error) {
 }
 
 func (t *Mimir) initIngester() (serv services.Service, err error) {
-	var ing api.Ingester
+	var ing ingester.IngesterAPI
 
 	ing = t.Ingester
 	if t.ActivityTracker != nil {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -734,7 +734,7 @@ func (t *Mimir) initIngesterService() (serv services.Service, err error) {
 }
 
 func (t *Mimir) initIngester() (serv services.Service, err error) {
-	var ing ingester.IngesterAPI
+	var ing ingester.API
 
 	ing = t.Ingester
 	if t.ActivityTracker != nil {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -740,7 +740,7 @@ func (t *Mimir) initIngester() (serv services.Service, err error) {
 	if t.ActivityTracker != nil {
 		ing = ingester.NewIngesterActivityTracker(t.Ingester, t.ActivityTracker)
 	}
-	if t.Cfg.Ingester.IncludeTenantIDInProfileLabels {
+	if t.Cfg.IncludeTenantIDInProfileLabels {
 		ing = ingester.NewIngesterProfilingWrapper(t.Ingester)
 	}
 	t.API.RegisterIngester(ing)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -740,6 +740,9 @@ func (t *Mimir) initIngester() (serv services.Service, err error) {
 	if t.ActivityTracker != nil {
 		ing = ingester.NewIngesterActivityTracker(t.Ingester, t.ActivityTracker)
 	}
+	if t.Cfg.Ingester.IncludeTenantIDInProfileLabels {
+		ing = ingester.NewIngesterProfilingWrapper(t.Ingester)
+	}
 	t.API.RegisterIngester(ing)
 	return nil, nil
 }


### PR DESCRIPTION
Adds ability to include tenant ID in pprof labels for ingester operations. This helps debug performance issues when specific tenants are causing high CPU usage or slow queries.

Based on previous work in #8421, but simplified to just include tenant ID and made configurable via CLI flag.

The flag `-include-tenant-id-in-profile-labels` is disabled by default to avoid any overhead when not needed.

Uses a `ProfilingWrapper` pattern similar to `ActivityTrackerWrapper` to cleanly wrap all ingester methods.