### PR TITLE
MQE: introduce `Node.ExpressionPosition()` method

### DIFF
--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
@@ -70,6 +71,10 @@ func (d *Duplicate) ResultType() (parser.ValueType, error) {
 
 func (d *Duplicate) QueriedTimeRange(queryTimeRange types.QueryTimeRange, lookbackDelta time.Duration) planning.QueriedTimeRange {
 	return d.Inner.QueriedTimeRange(queryTimeRange, lookbackDelta)
+}
+
+func (d *Duplicate) ExpressionPosition() posrange.PositionRange {
+	return d.Inner.ExpressionPosition()
 }
 
 func MaterializeDuplicate(d *Duplicate, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {

--- a/pkg/streamingpromql/planning/core/aggregate_expression.go
+++ b/pkg/streamingpromql/planning/core/aggregate_expression.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/aggregations"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/aggregations/topkbottomk"
@@ -116,7 +117,7 @@ func MaterializeAggregateExpression(a *AggregateExpression, materializer *planni
 			return nil, fmt.Errorf("could not create parameter operator for AggregateExpression %s: %w", a.Op.String(), err)
 		}
 
-		o = topkbottomk.New(inner, param, timeRange, a.Grouping, a.Without, a.Op == AGGREGATION_TOPK, params.MemoryConsumptionTracker, params.Annotations, a.ExpressionPosition.ToPrometheusType())
+		o = topkbottomk.New(inner, param, timeRange, a.Grouping, a.Without, a.Op == AGGREGATION_TOPK, params.MemoryConsumptionTracker, params.Annotations, a.ExpressionPosition())
 
 	case AGGREGATION_QUANTILE:
 		param, err := materializer.ConvertNodeToScalarOperator(a.Param, timeRange)
@@ -124,7 +125,7 @@ func MaterializeAggregateExpression(a *AggregateExpression, materializer *planni
 			return nil, fmt.Errorf("could not create parameter operator for AggregateExpression %s: %w", a.Op.String(), err)
 		}
 
-		o, err = aggregations.NewQuantileAggregation(inner, param, timeRange, a.Grouping, a.Without, params.MemoryConsumptionTracker, params.Annotations, a.ExpressionPosition.ToPrometheusType())
+		o, err = aggregations.NewQuantileAggregation(inner, param, timeRange, a.Grouping, a.Without, params.MemoryConsumptionTracker, params.Annotations, a.ExpressionPosition())
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +136,7 @@ func MaterializeAggregateExpression(a *AggregateExpression, materializer *planni
 			return nil, fmt.Errorf("could not create parameter operator for AggregateExpression %s: %w", a.Op.String(), err)
 		}
 
-		o = aggregations.NewCountValues(inner, param, timeRange, a.Grouping, a.Without, params.MemoryConsumptionTracker, a.ExpressionPosition.ToPrometheusType())
+		o = aggregations.NewCountValues(inner, param, timeRange, a.Grouping, a.Without, params.MemoryConsumptionTracker, a.ExpressionPosition())
 
 	default:
 		itemType, ok := a.Op.ToItemType()
@@ -144,7 +145,7 @@ func MaterializeAggregateExpression(a *AggregateExpression, materializer *planni
 		}
 
 		var err error
-		o, err = aggregations.NewAggregation(inner, timeRange, a.Grouping, a.Without, itemType, params.MemoryConsumptionTracker, params.Annotations, a.ExpressionPosition.ToPrometheusType())
+		o, err = aggregations.NewAggregation(inner, timeRange, a.Grouping, a.Without, itemType, params.MemoryConsumptionTracker, params.Annotations, a.ExpressionPosition())
 		if err != nil {
 			return nil, err
 		}
@@ -164,4 +165,8 @@ func (a *AggregateExpression) QueriedTimeRange(queryTimeRange types.QueryTimeRan
 	}
 
 	return innerRange.Union(a.Param.QueriedTimeRange(queryTimeRange, lookbackDelta))
+}
+
+func (a *AggregateExpression) ExpressionPosition() posrange.PositionRange {
+	return a.GetExpressionPosition().ToPrometheusType()
 }

--- a/pkg/streamingpromql/planning/core/function_call.go
+++ b/pkg/streamingpromql/planning/core/function_call.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
@@ -105,7 +106,7 @@ func MaterializeFunctionCall(f *FunctionCall, materializer *planning.Materialize
 		absentLabels = mimirpb.FromLabelAdaptersToLabels(f.AbsentLabels)
 	}
 
-	o, err := fnc.OperatorFactory(children, absentLabels, params.MemoryConsumptionTracker, params.Annotations, f.ExpressionPosition.ToPrometheusType(), timeRange)
+	o, err := fnc.OperatorFactory(children, absentLabels, params.MemoryConsumptionTracker, params.Annotations, f.ExpressionPosition(), timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -129,4 +130,8 @@ func (f *FunctionCall) QueriedTimeRange(queryTimeRange types.QueryTimeRange, loo
 	}
 
 	return timeRange
+}
+
+func (f *FunctionCall) ExpressionPosition() posrange.PositionRange {
+	return f.GetExpressionPosition().ToPrometheusType()
 }

--- a/pkg/streamingpromql/planning/core/matrix_selector.go
+++ b/pkg/streamingpromql/planning/core/matrix_selector.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/selectors"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -78,7 +79,7 @@ func MaterializeMatrixSelector(m *MatrixSelector, _ *planning.Materializer, time
 		Matchers:                 matchers,
 		EagerLoad:                params.EagerLoadSelectors,
 		SkipHistogramBuckets:     m.SkipHistogramBuckets,
-		ExpressionPosition:       m.ExpressionPosition.ToPrometheusType(),
+		ExpressionPosition:       m.ExpressionPosition(),
 		MemoryConsumptionTracker: params.MemoryConsumptionTracker,
 	}
 
@@ -96,4 +97,8 @@ func (m *MatrixSelector) QueriedTimeRange(queryTimeRange types.QueryTimeRange, _
 	minT, maxT := selectors.ComputeQueriedTimeRange(queryTimeRange, TimestampFromTime(m.Timestamp), m.Range, m.Offset.Milliseconds(), 0)
 
 	return planning.NewQueriedTimeRange(timestamp.Time(minT), timestamp.Time(maxT))
+}
+
+func (m *MatrixSelector) ExpressionPosition() posrange.PositionRange {
+	return m.GetExpressionPosition().ToPrometheusType()
 }

--- a/pkg/streamingpromql/planning/core/number_literal.go
+++ b/pkg/streamingpromql/planning/core/number_literal.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/scalars"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -58,7 +59,7 @@ func (n *NumberLiteral) ChildrenLabels() []string {
 }
 
 func MaterializeNumberLiteral(n *NumberLiteral, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
-	o := scalars.NewScalarConstant(n.Value, timeRange, params.MemoryConsumptionTracker, n.ExpressionPosition.ToPrometheusType())
+	o := scalars.NewScalarConstant(n.Value, timeRange, params.MemoryConsumptionTracker, n.ExpressionPosition())
 
 	return planning.NewSingleUseOperatorFactory(o), nil
 }
@@ -69,4 +70,8 @@ func (n *NumberLiteral) ResultType() (parser.ValueType, error) {
 
 func (n *NumberLiteral) QueriedTimeRange(queryTimeRange types.QueryTimeRange, lookbackDelta time.Duration) planning.QueriedTimeRange {
 	return planning.NoDataQueried()
+}
+
+func (n *NumberLiteral) ExpressionPosition() posrange.PositionRange {
+	return n.GetExpressionPosition().ToPrometheusType()
 }

--- a/pkg/streamingpromql/planning/core/string_literal.go
+++ b/pkg/streamingpromql/planning/core/string_literal.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -58,7 +59,7 @@ func (s *StringLiteral) ChildrenLabels() []string {
 }
 
 func MaterializeStringLiteral(s *StringLiteral, _ *planning.Materializer, _ types.QueryTimeRange, _ *planning.OperatorParameters) (planning.OperatorFactory, error) {
-	o := operators.NewStringLiteral(s.Value, s.ExpressionPosition.ToPrometheusType())
+	o := operators.NewStringLiteral(s.Value, s.ExpressionPosition())
 
 	return planning.NewSingleUseOperatorFactory(o), nil
 }
@@ -69,4 +70,8 @@ func (s *StringLiteral) ResultType() (parser.ValueType, error) {
 
 func (s *StringLiteral) QueriedTimeRange(queryTimeRange types.QueryTimeRange, lookbackDelta time.Duration) planning.QueriedTimeRange {
 	return planning.NoDataQueried()
+}
+
+func (s *StringLiteral) ExpressionPosition() posrange.PositionRange {
+	return s.GetExpressionPosition().ToPrometheusType()
 }

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -125,7 +126,7 @@ func MaterializeSubquery(s *Subquery, materializer *planning.Materializer, timeR
 		return nil, fmt.Errorf("could not create inner operator for Subquery: %w", err)
 	}
 
-	o, err := operators.NewSubquery(inner, timeRange, innerTimeRange, TimestampFromTime(s.Timestamp), s.Offset, s.Range, s.ExpressionPosition.ToPrometheusType(), params.MemoryConsumptionTracker)
+	o, err := operators.NewSubquery(inner, timeRange, innerTimeRange, TimestampFromTime(s.Timestamp), s.Offset, s.Range, s.ExpressionPosition(), params.MemoryConsumptionTracker)
 	if err != nil {
 		return nil, err
 	}
@@ -139,4 +140,8 @@ func (s *Subquery) ResultType() (parser.ValueType, error) {
 
 func (s *Subquery) QueriedTimeRange(queryTimeRange types.QueryTimeRange, lookbackDelta time.Duration) planning.QueriedTimeRange {
 	return s.Inner.QueriedTimeRange(s.ChildrenTimeRange(queryTimeRange), lookbackDelta)
+}
+
+func (s *Subquery) ExpressionPosition() posrange.PositionRange {
+	return s.GetExpressionPosition().ToPrometheusType()
 }

--- a/pkg/streamingpromql/planning/core/unary_expression.go
+++ b/pkg/streamingpromql/planning/core/unary_expression.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
@@ -75,10 +76,10 @@ func MaterializeUnaryExpression(u *UnaryExpression, materializer *planning.Mater
 
 	switch inner := inner.(type) {
 	case types.InstantVectorOperator:
-		o := functions.UnaryNegationOfInstantVectorOperatorFactory(inner, params.MemoryConsumptionTracker, u.ExpressionPosition.ToPrometheusType(), timeRange)
+		o := functions.UnaryNegationOfInstantVectorOperatorFactory(inner, params.MemoryConsumptionTracker, u.ExpressionPosition(), timeRange)
 		return planning.NewSingleUseOperatorFactory(o), nil
 	case types.ScalarOperator:
-		o := scalars.NewUnaryNegationOfScalar(inner, u.ExpressionPosition.ToPrometheusType())
+		o := scalars.NewUnaryNegationOfScalar(inner, u.ExpressionPosition())
 		return planning.NewSingleUseOperatorFactory(o), nil
 	default:
 		return nil, fmt.Errorf("expected InstantVectorOperator or ScalarOperator as child of UnaryExpression, got %T", inner)
@@ -91,4 +92,8 @@ func (u *UnaryExpression) ResultType() (parser.ValueType, error) {
 
 func (u *UnaryExpression) QueriedTimeRange(queryTimeRange types.QueryTimeRange, lookbackDelta time.Duration) planning.QueriedTimeRange {
 	return u.Inner.QueriedTimeRange(queryTimeRange, lookbackDelta)
+}
+
+func (u *UnaryExpression) ExpressionPosition() posrange.PositionRange {
+	return u.GetExpressionPosition().ToPrometheusType()
 }

--- a/pkg/streamingpromql/planning/core/vector_selector.go
+++ b/pkg/streamingpromql/planning/core/vector_selector.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/selectors"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -83,7 +84,7 @@ func MaterializeVectorSelector(v *VectorSelector, _ *planning.Materializer, time
 		Matchers:                 matchers,
 		EagerLoad:                params.EagerLoadSelectors,
 		SkipHistogramBuckets:     v.SkipHistogramBuckets,
-		ExpressionPosition:       v.ExpressionPosition.ToPrometheusType(),
+		ExpressionPosition:       v.ExpressionPosition(),
 		MemoryConsumptionTracker: params.MemoryConsumptionTracker,
 	}
 
@@ -98,4 +99,8 @@ func (v *VectorSelector) QueriedTimeRange(queryTimeRange types.QueryTimeRange, l
 	minT, maxT := selectors.ComputeQueriedTimeRange(queryTimeRange, TimestampFromTime(v.Timestamp), 0, v.Offset.Milliseconds(), lookbackDelta)
 
 	return planning.NewQueriedTimeRange(timestamp.Time(minT), timestamp.Time(maxT))
+}
+
+func (v *VectorSelector) ExpressionPosition() posrange.PositionRange {
+	return v.GetExpressionPosition().ToPrometheusType()
 }

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
 
@@ -85,6 +86,10 @@ type Node interface {
 	//
 	// If no data is queried by this node and its children, QueriedTimeRange.AnyDataQueried will be false.
 	QueriedTimeRange(queryTimeRange types.QueryTimeRange, lookbackDelta time.Duration) QueriedTimeRange
+
+	// ExpressionPosition returns the position of the subexpression this node represents in the original
+	// expression.
+	ExpressionPosition() posrange.PositionRange
 
 	// FIXME: implementations for many of the above methods can be generated automatically
 }

--- a/pkg/streamingpromql/planning/plan_test.go
+++ b/pkg/streamingpromql/planning/plan_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
@@ -118,6 +119,10 @@ func (t *testNode) ResultType() (parser.ValueType, error) {
 }
 
 func (t *testNode) QueriedTimeRange(queryTimeRange types.QueryTimeRange, lookbackDelta time.Duration) QueriedTimeRange {
+	panic("not supported")
+}
+
+func (t *testNode) ExpressionPosition() posrange.PositionRange {
 	panic("not supported")
 }
 


### PR DESCRIPTION
#### What this PR does

This PR introduces an `ExpressionPosition` method to `planning.Node`.

This is necessary to support remote execution, because the remote execution operator needs to be able to provide an expression position based on the node it will evaluate.

I have not added a changelog entry as this should have no user-visible impact.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
