### PR TITLE
chore: Remove release-2.15 from automated updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,7 @@
     "extends": [
       "config:recommended"
     ],
-    "baseBranches": ["main", "release-2.17", "release-2.16", "release-2.15"],
+    "baseBranches": ["main", "release-2.17", "release-2.16"],
     "postUpdateOptions": [
       "gomodTidy",
       "gomodUpdateImportPaths"
@@ -11,7 +11,7 @@
     "schedule": ["before 9am on Monday"],
     "packageRules": [
       {
-        "matchBaseBranches": ["release-2.16", "release-2.15"],
+        "matchBaseBranches": ["release-2.17", "release-2.16"],
         "packagePatterns": ["*"],
         "enabled": false
       },


### PR DESCRIPTION
Mimir 2.17 is released so 2.15 no longer gets automatic updates.

Part of https://github.com/grafana/mimir/issues/12039