### PR TITLE
Multiple Components: Include vector(0) in Memory HPA Metric

### DIFF
--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2005,6 +2005,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="alertmanager", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "9556302233"
@@ -2076,6 +2077,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "3058016714"
@@ -2190,6 +2192,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="query-frontend", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "559939584"
@@ -2251,6 +2254,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "5733781340"
@@ -2312,6 +2316,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-querier", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "955630223"
@@ -2381,6 +2386,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-query-frontend", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "559939584"

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2005,6 +2005,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="alertmanager", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="alertmanager", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "10737418240"
@@ -2076,6 +2077,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "3435973836"
@@ -2190,6 +2192,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="query-frontend", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="query-frontend", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "629145600"
@@ -2251,6 +2254,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6442450944"
@@ -2312,6 +2316,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-querier", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-querier", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "1073741824"
@@ -2381,6 +2386,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="ruler-query-frontend", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="ruler-query-frontend", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "629145600"

--- a/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
@@ -2620,6 +2620,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default",pod=~"distributor-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled",pod=~"distributor-zone-a.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2147483648"
@@ -2691,6 +2692,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default",pod=~"distributor-zone-b.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled",pod=~"distributor-zone-b.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2147483648"

--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -1400,6 +1400,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_0.7__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_0.7__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -1463,6 +1464,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_0.7__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_0.7__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -1526,6 +1528,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -1589,6 +1592,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -1652,6 +1656,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_1.5__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_1.5__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -1715,6 +1720,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_1.5__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_1.5__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -1778,6 +1784,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -1841,6 +1848,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -1903,6 +1911,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_1__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_1__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -1964,6 +1973,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_false_1__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_false_1__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -2025,6 +2035,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -2086,6 +2097,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -2148,6 +2160,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_0.7__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_0.7__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2211,6 +2224,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_0.7__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_0.7__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2274,6 +2288,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2337,6 +2352,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2400,6 +2416,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_1.5__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_1.5__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2463,6 +2480,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_1.5__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_1.5__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2526,6 +2544,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2589,6 +2608,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2651,6 +2671,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_1__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_1__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -2712,6 +2733,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_false_true_1__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_false_true_1__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -2773,6 +2795,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -2834,6 +2857,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -2896,6 +2920,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_0.7__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_0.7__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2959,6 +2984,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_0.7__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_0.7__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3022,6 +3048,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3085,6 +3112,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3148,6 +3176,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_1.5__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_1.5__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3211,6 +3240,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_1.5__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_1.5__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3274,6 +3304,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3337,6 +3368,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3399,6 +3431,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_1__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_1__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -3460,6 +3493,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_false_1__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_false_1__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -3521,6 +3555,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -3582,6 +3617,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -3644,6 +3680,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_0.7__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_0.7__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3707,6 +3744,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_0.7__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_0.7__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3770,6 +3808,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3833,6 +3872,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 0.70
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3896,6 +3936,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_1.5__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_1.5__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3959,6 +4000,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_1.5__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_1.5__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -4022,6 +4064,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -4085,6 +4128,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
         ) * 1.50
       serverAddress: http://prometheus.default:9090/prometheus
@@ -4147,6 +4191,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_1__", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_1__", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -4208,6 +4253,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_true_true_1__pod-zone-a.*", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_true_true_1__pod-zone-a.*", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -4269,6 +4315,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"
@@ -4330,6 +4377,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="test_container", namespace="default",pod=~"pod-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="test_container", namespace="default", reason="OOMKilled",pod=~"pod-zone-a.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "858993459"

--- a/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
+++ b/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
@@ -2749,6 +2749,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default",pod!~"distributor-zone.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled",pod!~"distributor-zone.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2147483648"
@@ -2820,6 +2821,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default",pod=~"distributor-zone-a.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled",pod=~"distributor-zone-a.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2147483648"
@@ -2891,6 +2893,7 @@ spec:
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default",pod=~"distributor-zone-b.*"}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled",pod=~"distributor-zone-b.*"})
+          or vector(0)
         )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "2147483648"

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -348,6 +348,7 @@
           max by (pod) (changes(kube_pod_container_status_restarts_total{container="%(container)s", namespace="%(namespace)s"%(extra_matchers)s}[15m]) > 0)
           and
           max by (pod) (kube_pod_container_status_last_terminated_reason{container="%(container)s", namespace="%(namespace)s", reason="OOMKilled"%(extra_matchers)s})
+          or vector(0)
         )
       |||
     ),


### PR DESCRIPTION
#### What this PR does

This PR follows https://github.com/grafana/mimir/pull/12386. The change to the CPU and memory HPA metrics must be re-worked to avoid breaking scaling when there are no OOMKilled pods. We previously [reverted](https://github.com/grafana/mimir/pull/12400) the CPU HPA and partially reverted the memory change.This PR fully restores the memory scaling metric (see comment: [here](https://github.com/grafana/mimir/pull/12386/files#r2276681205)). 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
