### PR TITLE
Expose rollout_operator_enabled into $._config

### DIFF
--- a/operations/mimir/rollout-operator.libsonnet
+++ b/operations/mimir/rollout-operator.libsonnet
@@ -39,8 +39,6 @@
                               $._config.enable_rollout_operator_webhook,
   },
 
-  local rollout_operator_enabled = $._config.rollout_operator_enabled,
-
   rollout_operator_args:: {
     'kubernetes.namespace': $._config.namespace,
     'use-zone-tracker': true,
@@ -68,7 +66,7 @@
     container.mixin.readinessProbe.withTimeoutSeconds(1) +
     $.tracing_env_mixin,
 
-  rollout_operator_deployment: if !rollout_operator_enabled then null else
+  rollout_operator_deployment: if !$._config.rollout_operator_enabled then null else
     deployment.new('rollout-operator', 1, [$.rollout_operator_container]) +
     deployment.mixin.metadata.withName('rollout-operator') +
     deployment.mixin.spec.template.spec.withServiceAccountName('rollout-operator') +
@@ -77,7 +75,7 @@
     deployment.mixin.spec.strategy.rollingUpdate.withMaxUnavailable(1) +
     $.newMimirNodeAffinityMatchers($.rollout_operator_node_affinity_matchers),
 
-  rollout_operator_service: if !rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
+  rollout_operator_service: if !$._config.rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
     service.new(
       'rollout-operator',
       { name: 'rollout-operator' },
@@ -85,7 +83,7 @@
       servicePort.withProtocol('TCP'),
     ),
 
-  rollout_operator_role: if !rollout_operator_enabled then null else
+  rollout_operator_role: if !$._config.rollout_operator_enabled then null else
     role.new('rollout-operator-role') +
     role.mixin.metadata.withNamespace($._config.namespace) +
     role.withRulesMixin(
@@ -111,7 +109,7 @@
       )
     ),
 
-  rollout_operator_rolebinding: if !rollout_operator_enabled then null else
+  rollout_operator_rolebinding: if !$._config.rollout_operator_enabled then null else
     roleBinding.new('rollout-operator-rolebinding') +
     roleBinding.mixin.metadata.withNamespace($._config.namespace) +
     roleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
@@ -123,7 +121,7 @@
       namespace: $._config.namespace,
     }),
 
-  rollout_operator_webhook_cert_secret_role: if !rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
+  rollout_operator_webhook_cert_secret_role: if !$._config.rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
     role.new('rollout-operator-webhook-cert-secret-role') +
     role.mixin.metadata.withNamespace($._config.namespace) +
     role.withRulesMixin([
@@ -136,7 +134,7 @@
       + policyRule.withResourceNames(['rollout-operator-self-signed-certificate']),
     ]),
 
-  rollout_operator_webhook_cert_secret_rolebinding: if !rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
+  rollout_operator_webhook_cert_secret_rolebinding: if !$._config.rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
     roleBinding.new('rollout-operator-webhook-cert-secret-rolebinding') +
     roleBinding.mixin.metadata.withNamespace($._config.namespace) +
     roleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
@@ -148,7 +146,7 @@
       namespace: $._config.namespace,
     }),
 
-  rollout_operator_webhook_cert_update_clusterrole: if !rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
+  rollout_operator_webhook_cert_update_clusterrole: if !$._config.rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
     clusterRole.new('rollout-operator-%s-webhook-cert-update-role' % $._config.namespace) +
     clusterRole.withRulesMixin([
       policyRule.withApiGroups('admissionregistration.k8s.io')
@@ -156,7 +154,7 @@
       + policyRule.withVerbs(['list', 'patch', 'watch']),
     ]),
 
-  rollout_operator_webhook_cert_update_clusterrolebinding: if !rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
+  rollout_operator_webhook_cert_update_clusterrolebinding: if !$._config.rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
     clusterRoleBinding.new('rollout-operator-%s-webhook-cert-secret-rolebinding' % $._config.namespace) +
     clusterRoleBinding.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
     clusterRoleBinding.mixin.roleRef.withKind('ClusterRole') +
@@ -167,7 +165,7 @@
       namespace: $._config.namespace,
     }),
 
-  no_downscale_webhook: if !rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
+  no_downscale_webhook: if !$._config.rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
     validatingWebhookConfiguration.new('no-downscale-%s' % $._config.namespace) +
     validatingWebhookConfiguration.mixin.metadata.withLabels({
       'grafana.com/namespace': $._config.namespace,
@@ -206,7 +204,7 @@
       },
     ]),
 
-  prepare_downscale_webhook: if !rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
+  prepare_downscale_webhook: if !$._config.rollout_operator_enabled || !$._config.enable_rollout_operator_webhook then null else
     mutatingWebhookConfiguration.new('prepare-downscale-%s' % $._config.namespace) +
     mutatingWebhookConfiguration.mixin.metadata.withLabels({
       'grafana.com/namespace': $._config.namespace,
@@ -245,9 +243,9 @@
       },
     ]),
 
-  rollout_operator_service_account: if !rollout_operator_enabled then null else
+  rollout_operator_service_account: if !$._config.rollout_operator_enabled then null else
     serviceAccount.new('rollout-operator'),
 
-  rollout_operator_pdb: if !rollout_operator_enabled then null else
+  rollout_operator_pdb: if !$._config.rollout_operator_enabled then null else
     $.newMimirPdb('rollout-operator'),
 }


### PR DESCRIPTION
#### What this PR does

Expose the rollout_operator_enabled variable into $._config so it can be referenced externally. 

#### Which issue(s) this PR fixes or relates to

Exposing this variable in the config will allow for better conditions in deployment-tools libsonnet overrides. eg https://github.com/grafana/deployment_tools/pull/324750.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
