### PR TITLE
Replace StringsContain with slices.Contains.

### DIFF
--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -1689,7 +1689,7 @@ type mockBucketFailure struct {
 }
 
 func (m *mockBucketFailure) Delete(ctx context.Context, name string) error {
-	if util.StringsContain(m.DeleteFailures, name) {
+	if slices.Contains(m.DeleteFailures, name) {
 		return errors.New("mocked delete failure")
 	}
 	return m.Bucket.Delete(ctx, name)

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -201,7 +201,7 @@ func (cfg *Config) Validate(logger log.Logger) error {
 	if cfg.MaxBlockUploadValidationConcurrency < 0 {
 		return errInvalidMaxBlockUploadValidationConcurrency
 	}
-	if !util.StringsContain(CompactionOrders, cfg.CompactionJobsOrder) {
+	if !slices.Contains(CompactionOrders, cfg.CompactionJobsOrder) {
 		return errInvalidCompactionOrder
 	}
 

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1232,7 +1232,7 @@ func testQueryShardingFunctionCorrectness(t *testing.T, queryable storage.Querya
 		}
 		// It's OK if it's tested. Ignore if it's one of the non parallelizable functions.
 		_, ok := testedFns[expectedFn]
-		assert.Truef(t, ok || util.StringsContain(astmapper.NonParallelFuncs, expectedFn), "%s should be tested", expectedFn)
+		assert.Truef(t, ok || slices.Contains(astmapper.NonParallelFuncs, expectedFn), "%s should be tested", expectedFn)
 	}
 }
 

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
-	"github.com/grafana/mimir/pkg/util"
 )
 
 const (
@@ -66,7 +65,7 @@ func (cfg *ResultsCacheConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 func (cfg *ResultsCacheConfig) Validate() error {
-	if cfg.Backend != "" && !util.StringsContain(supportedResultsCacheBackends, cfg.Backend) {
+	if cfg.Backend != "" && !slices.Contains(supportedResultsCacheBackends, cfg.Backend) {
 		return errUnsupportedResultsCacheBackend(cfg.Backend)
 	}
 

--- a/pkg/frontend/querymiddleware/sharded_queryable.go
+++ b/pkg/frontend/querymiddleware/sharded_queryable.go
@@ -9,6 +9,7 @@ package querymiddleware
 import (
 	"context"
 	"math"
+	"slices"
 	"sync"
 
 	"github.com/grafana/dskit/concurrency"
@@ -23,7 +24,6 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/storage/series"
-	"github.com/grafana/mimir/pkg/util"
 )
 
 var (
@@ -206,7 +206,7 @@ func (t *responseHeadersTracker) mergeHeaders(headers []*PrometheusHeader) {
 	for _, header := range headers {
 		for _, value := range header.Values {
 			// Ensure no duplicates.
-			if !util.StringsContain(t.headers[header.Name], value) {
+			if !slices.Contains(t.headers[header.Name], value) {
 				t.headers[header.Name] = append(t.headers[header.Name], value)
 			}
 		}

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	goregexp "regexp" //lint:ignore faillint the Prometheus client library requires us to pass a regexp from this package
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -349,7 +350,7 @@ func (c *Config) ValidateLimits(limits *validation.Limits) error {
 }
 
 func (c *Config) isModuleEnabled(m string) bool {
-	return util.StringsContain(c.Target, m)
+	return slices.Contains(c.Target, m)
 }
 
 func (c *Config) isAnyModuleEnabled(modules ...string) bool {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -345,7 +346,7 @@ func (t *Mimir) initServer() (services.Service, error) {
 				continue
 			}
 
-			if util.StringsContain(serverDeps, m) {
+			if slices.Contains(serverDeps, m) {
 				continue
 			}
 

--- a/pkg/querier/blocks_store_replicated_set.go
+++ b/pkg/querier/blocks_store_replicated_set.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/grpcclient"
@@ -22,7 +23,6 @@ import (
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
 	"github.com/grafana/mimir/pkg/storegateway"
-	"github.com/grafana/mimir/pkg/util"
 )
 
 type loadBalancingStrategy int
@@ -154,7 +154,7 @@ func getNonExcludedInstance(set ring.ReplicationSet, exclude []string, balancing
 	}
 
 	for _, instance := range set.Instances {
-		if !util.StringsContain(exclude, instance.Addr) {
+		if !slices.Contains(exclude, instance.Addr) {
 			return &instance
 		}
 	}

--- a/pkg/scheduler/schedulerdiscovery/config.go
+++ b/pkg/scheduler/schedulerdiscovery/config.go
@@ -6,11 +6,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/go-kit/log"
-
-	"github.com/grafana/mimir/pkg/util"
 )
 
 const (
@@ -37,7 +36,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 }
 
 func (cfg *Config) Validate() error {
-	if !util.StringsContain(modes, cfg.Mode) {
+	if !slices.Contains(modes, cfg.Mode) {
 		return fmt.Errorf("unsupported query-scheduler service discovery mode (supported values are: %s)", strings.Join(modes, ", "))
 	}
 	if cfg.MaxUsedInstances > 0 && cfg.Mode != ModeRing {

--- a/pkg/storage/bucket/client.go
+++ b/pkg/storage/bucket/client.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/go-kit/log"
@@ -25,7 +26,6 @@ import (
 	"github.com/grafana/mimir/pkg/storage/bucket/gcs"
 	"github.com/grafana/mimir/pkg/storage/bucket/s3"
 	"github.com/grafana/mimir/pkg/storage/bucket/swift"
-	"github.com/grafana/mimir/pkg/util"
 )
 
 var tracer = otel.Tracer("storage/bucket")
@@ -110,7 +110,7 @@ func (cfg *StorageBackendConfig) RegisteredFlags() flagext.RegisteredFlags {
 }
 
 func (cfg *StorageBackendConfig) Validate() error {
-	if !util.StringsContain(cfg.supportedBackends(), cfg.Backend) {
+	if !slices.Contains(cfg.supportedBackends(), cfg.Backend) {
 		return ErrUnsupportedStorageBackend
 	}
 

--- a/pkg/storage/bucket/s3/config.go
+++ b/pkg/storage/bucket/s3/config.go
@@ -126,7 +126,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 
 // Validate config and returns error on failure
 func (cfg *Config) Validate() error {
-	if !util.StringsContain(supportedSignatureVersions, cfg.SignatureVersion) {
+	if !slices.Contains(supportedSignatureVersions, cfg.SignatureVersion) {
 		return errUnsupportedSignatureVersion
 	}
 	if cfg.Endpoint != "" {
@@ -138,7 +138,7 @@ func (cfg *Config) Validate() error {
 	if cfg.STSEndpoint != "" && !util.IsValidURL(cfg.STSEndpoint) {
 		return errInvalidSTSEndpoint
 	}
-	if !util.StringsContain(supportedStorageClasses, cfg.StorageClass) && cfg.StorageClass != "" {
+	if !slices.Contains(supportedStorageClasses, cfg.StorageClass) && cfg.StorageClass != "" {
 		return errUnsupportedStorageClass
 	}
 
@@ -165,7 +165,7 @@ func (cfg *SSEConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 }
 
 func (cfg *SSEConfig) Validate() error {
-	if cfg.Type != "" && !util.StringsContain(supportedSSETypes, cfg.Type) {
+	if cfg.Type != "" && !slices.Contains(supportedSSETypes, cfg.Type) {
 		return errUnsupportedSSEType
 	}
 

--- a/pkg/storage/tsdb/index_cache.go
+++ b/pkg/storage/tsdb/index_cache.go
@@ -8,6 +8,7 @@ package tsdb
 import (
 	"flag"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/alecthomas/units"
@@ -18,7 +19,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/mimir/pkg/storegateway/indexcache"
-	"github.com/grafana/mimir/pkg/util"
 )
 
 const (
@@ -58,7 +58,7 @@ func (cfg *IndexCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix str
 
 // Validate the config.
 func (cfg *IndexCacheConfig) Validate() error {
-	if !util.StringsContain(supportedIndexCacheBackends, cfg.Backend) {
+	if !slices.Contains(supportedIndexCacheBackends, cfg.Backend) {
 		return errUnsupportedIndexCacheBackend
 	}
 

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -821,7 +821,7 @@ func (u *userShardingStrategy) FilterUsers(context.Context, []string) ([]string,
 }
 
 func (u *userShardingStrategy) FilterBlocks(_ context.Context, userID string, metas map[ulid.ULID]*block.Meta, _ map[ulid.ULID]struct{}, _ block.GaugeVec) error {
-	if util.StringsContain(u.users, userID) {
+	if slices.Contains(u.users, userID) {
 		return nil
 	}
 

--- a/pkg/usagestats/reporter.go
+++ b/pkg/usagestats/reporter.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/bucket"
-	"github.com/grafana/mimir/pkg/util"
 )
 
 const (
@@ -60,7 +60,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 func (cfg *Config) Validate() error {
-	if !util.StringsContain(supportedInstallationModes, cfg.InstallationMode) {
+	if !slices.Contains(supportedInstallationModes, cfg.InstallationMode) {
 		return errors.Errorf("unsupported installation mode: %q", cfg.InstallationMode)
 
 	}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -5,17 +5,6 @@
 
 package util
 
-// StringsContain returns true if the search value is within the list of input values.
-func StringsContain(values []string, search string) bool {
-	for _, v := range values {
-		if search == v {
-			return true
-		}
-	}
-
-	return false
-}
-
 // StringsMap returns a map where keys are input values.
 func StringsMap(values []string) map[string]bool {
 	out := make(map[string]bool, len(values))

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -31,7 +32,6 @@ import (
 	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/ruler/notifier"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
-	"github.com/grafana/mimir/pkg/util"
 )
 
 const (
@@ -630,7 +630,7 @@ func (l *Limits) Validate() error {
 		return errInvalidMaxEstimatedChunksPerQueryMultiplier
 	}
 
-	if !util.StringsContain(api.ReadConsistencies, l.IngestStorageReadConsistency) {
+	if !slices.Contains(api.ReadConsistencies, l.IngestStorageReadConsistency) {
 		return errInvalidIngestStorageReadConsistency
 	}
 

--- a/pkg/util/validation/notifications_limit_flag.go
+++ b/pkg/util/validation/notifications_limit_flag.go
@@ -6,14 +6,14 @@
 package validation
 
 import (
+	"slices"
+
 	"github.com/grafana/dskit/flagext"
 	"github.com/pkg/errors"
-
-	"github.com/grafana/mimir/pkg/util"
 )
 
 func validateIntegrationLimit(k string, _ float64) error {
-	if !util.StringsContain(allowedIntegrationNames, k) {
+	if !slices.Contains(allowedIntegrationNames, k) {
 		return errors.Errorf("unknown integration name: %s", k)
 	}
 	return nil


### PR DESCRIPTION
#### What this PR does

This PR replaces `util.StringsContain` with the equivalent generic version from the standard library as of Go 1.21+.

#### Checklist

- n/a Tests updated.
- n/a Documentation added.
- n/a `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- n/a [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
