### PR TITLE
MQE: don't panic if remote execution attempted on querier with MQE disabled

### DIFF
--- a/pkg/querier/dispatcher.go
+++ b/pkg/querier/dispatcher.go
@@ -130,6 +130,11 @@ func writeErrorToStream(ctx context.Context, stream frontendv2pb.QueryResultStre
 }
 
 func (d *Dispatcher) evaluateQuery(ctx context.Context, body []byte, resp *queryResponseWriter) {
+	if d.engine == nil {
+		resp.WriteError(ctx, mimirpb.QUERY_ERROR_TYPE_NOT_FOUND, "MQE is not enabled on this querier")
+		return
+	}
+
 	req := &querierpb.EvaluateQueryRequest{}
 	if err := proto.Unmarshal(body, req); err != nil {
 		resp.WriteError(ctx, mimirpb.QUERY_ERROR_TYPE_INTERNAL, fmt.Sprintf("could not read request body: %s", err.Error()))


### PR DESCRIPTION
#### What this PR does

This PR fixes a potential issue with https://github.com/grafana/mimir/pull/12302. 

If a query-frontend requests remote evaluation of a query plan on a querier where MQE is not enabled, then the querier could panic.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/12302

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
