### PR TITLE
MQE: separate query planner for querier and query-frontends

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -837,7 +837,8 @@ type Mimir struct {
 	CostAttributionManager           *costattribution.Manager
 
 	QueryFrontendQueryPlanner *streamingpromql.QueryPlanner
-	// The separate planner for queriers is a temporary thing until all query planning is happening solely in query-frontends.
+	// The separate planner for queriers is a temporary thing until all query planning is happening solely in query-frontends,
+	// and support for sending queries directly to queriers via the Prometheus HTTP API endpoints is removed.
 	// Until then, we need separate instances as the remote execution optimisation pass must only be applied in query-frontends,
 	// including when running in monolithic and read/write modes.
 	QuerierQueryPlanner *streamingpromql.QueryPlanner

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -366,7 +366,7 @@ func (c *Config) isAnyModuleExplicitlyTargeted(modules ...string) bool {
 }
 
 func (c *Config) isIngesterEnabled() bool {
-	return c.isAnyModuleExplicitlyTargeted(Ingester, Write, All)
+	return c.isAnyModuleExplicitlyTargeted(All, Ingester, Write)
 }
 
 func (c *Config) isAlertManagerEnabled() bool {

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -818,7 +818,6 @@ type Mimir struct {
 	MetadataSupplier                 querier.MetadataSupplier
 	QuerierEngine                    promql.QueryEngine
 	QuerierStreamingEngine           *streamingpromql.Engine // The MQE instance in QuerierEngine (without fallback wrapper), or nil if MQE is disabled.
-	QueryPlanner                     *streamingpromql.QueryPlanner
 	QueryFrontendTripperware         querymiddleware.Tripperware
 	QueryFrontendTopicOffsetsReaders map[string]*ingest.TopicOffsetsReader
 	QueryFrontendCodec               querymiddleware.Codec
@@ -836,6 +835,12 @@ type Mimir struct {
 	ContinuousTestManager            *continuoustest.Manager
 	BuildInfoHandler                 http.Handler
 	CostAttributionManager           *costattribution.Manager
+
+	QueryFrontendQueryPlanner *streamingpromql.QueryPlanner
+	// The separate planner for queriers is a temporary thing until all query planning is happening solely in query-frontends.
+	// Until then, we need separate instances as the remote execution optimisation pass must only be applied in query-frontends,
+	// including when running in monolithic and read/write modes.
+	QuerierQueryPlanner *streamingpromql.QueryPlanner
 }
 
 // New makes a new Mimir.

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/grafana/mimir/pkg/compactor"
 	"github.com/grafana/mimir/pkg/distributor"
 	"github.com/grafana/mimir/pkg/frontend"
+	v2 "github.com/grafana/mimir/pkg/frontend/v2"
 	"github.com/grafana/mimir/pkg/ingester"
 	"github.com/grafana/mimir/pkg/querier"
 	"github.com/grafana/mimir/pkg/ruler"
@@ -168,6 +169,9 @@ func TestMimir(t *testing.T) {
 		},
 		Frontend: frontend.CombinedFrontendConfig{
 			QueryEngine: "prometheus",
+			FrontendV2: v2.Config{
+				SchedulerAddress: "localhost",
+			},
 		},
 		MemberlistKV: memberlist.KVConfig{
 			WatchPrefixBufferSize: 128,

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -919,8 +919,8 @@ func (t *Mimir) initQuerierQueryPlanner() (services.Service, error) {
 	_, mqeOpts := engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, reg)
 	t.QuerierQueryPlanner = streamingpromql.NewQueryPlanner(mqeOpts)
 
-	// If the query-frontend is running in this process, we want to expose its planner through the analysis endpoint, not
-	// the querier's planner.
+	// Only expose the querier's planner through the analysis endpoint if the query-frontend isn't running in this process.
+	// If the query-frontend is running in this process, it will expose its planner through the analysis endpoint.
 	if !t.Cfg.isQueryFrontendEnabled() {
 		analysisHandler := streamingpromql.AnalysisHandler(t.QuerierQueryPlanner)
 		t.API.RegisterQueryAnalysisAPI(analysisHandler)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -96,12 +96,12 @@ const (
 	Overrides                        string = "overrides"
 	OverridesExporter                string = "overrides-exporter"
 	Querier                          string = "querier"
+	QuerierQueryPlanner              string = "querier-query-planner"
 	QueryFrontend                    string = "query-frontend"
 	QueryFrontendCodec               string = "query-frontend-codec"
+	QueryFrontendQueryPlanner        string = "query-frontend-query-planner"
 	QueryFrontendTopicOffsetsReaders string = "query-frontend-topic-offsets-reader"
 	QueryFrontendTripperware         string = "query-frontend-tripperware"
-	QuerierQueryPlanner              string = "querier-query-planner"
-	QueryFrontendQueryPlanner        string = "query-frontend-query-planner"
 	QueryScheduler                   string = "query-scheduler"
 	Queryable                        string = "queryable"
 	Ruler                            string = "ruler"
@@ -1192,7 +1192,7 @@ func (t *Mimir) initUsageStats() (services.Service, error) {
 
 	// Since it requires the access to the blocks storage, we enable it only for components
 	// accessing the blocks storage.
-	if !(t.Cfg.isIngesterEnabled() || t.Cfg.isQuerierEnabled() || t.Cfg.isStoreGatewayEnabled() || t.Cfg.isCompactorEnabled()) {
+	if !t.Cfg.isIngesterEnabled() && !t.Cfg.isQuerierEnabled() && !t.Cfg.isStoreGatewayEnabled() && !t.Cfg.isCompactorEnabled() {
 		return nil, nil
 	}
 

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -488,7 +488,7 @@ func (t *Mimir) initDistributorService() (serv services.Service, err error) {
 	// Check whether the distributor can join the distributors ring, which is
 	// whenever it's not running as an internal dependency (ie. querier or
 	// ruler's dependency)
-	canJoinDistributorsRing := t.Cfg.isAnyModuleEnabled(Distributor, Write, All)
+	canJoinDistributorsRing := t.Cfg.isAnyModuleExplicitlyTargeted(Distributor, Write, All)
 
 	t.Cfg.Distributor.StreamingChunksPerIngesterSeriesBufferSize = t.Cfg.Querier.StreamingChunksPerIngesterSeriesBufferSize
 	t.Cfg.Distributor.MinimizeIngesterRequests = t.Cfg.Querier.MinimizeIngesterRequests
@@ -645,7 +645,7 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 	// If the querier is running standalone without the query-frontend or query-scheduler, we must register it's internal
 	// HTTP handler externally and provide the external Mimir Server HTTP handler to the frontend worker
 	// to ensure requests it processes use the default middleware instrumentation.
-	if !t.Cfg.isAnyModuleEnabled(QueryFrontend, QueryScheduler, Read, All) {
+	if !t.Cfg.isAnyModuleExplicitlyTargeted(QueryFrontend, QueryScheduler, Read, All) {
 		// First, register the internal querier handler with the external HTTP server
 		t.API.RegisterQueryAPI(internalQuerierRouter, t.BuildInfoHandler)
 
@@ -864,7 +864,7 @@ func (t *Mimir) initQueryFrontend() (serv services.Service, err error) {
 	// If the query-frontend is running in the same process as the query-scheduler and
 	// the query-scheduler hasn't been explicitly configured, Mimir will default to trying
 	// to connect to a scheduler on localhost on its own gRPC listening port.
-	if t.Cfg.isAnyModuleEnabled(QueryScheduler, Read, All) && !t.Cfg.Frontend.FrontendV2.IsSchedulerConfigured() {
+	if t.Cfg.isAnyModuleExplicitlyTargeted(QueryScheduler, Read, All) && !t.Cfg.Frontend.FrontendV2.IsSchedulerConfigured() {
 		address := fmt.Sprintf("127.0.0.1:%d", t.Cfg.Server.GRPCListenPort)
 		level.Info(util_log.Logger).Log("msg", "The query-frontend has not been configured with the query-scheduler address. Because Mimir is running in monolithic mode, it's attempting an automatic frontend configuration. If queries are unresponsive, consider explicitly configuring the query-scheduler address for querier-frontend.", "address", address)
 		t.Cfg.Frontend.FrontendV2.SchedulerAddress = address
@@ -925,7 +925,7 @@ func (t *Mimir) initQueryPlanner() (services.Service, error) {
 
 func (t *Mimir) initRulerStorage() (serv services.Service, err error) {
 	// If the ruler is not configured and Mimir is running in monolithic or read-write mode, then we just skip starting the ruler.
-	if t.Cfg.isAnyModuleEnabled(Backend, All) && t.Cfg.RulerStorage.IsDefaults() {
+	if t.Cfg.isAnyModuleExplicitlyTargeted(Backend, All) && t.Cfg.RulerStorage.IsDefaults() {
 		level.Info(util_log.Logger).Log("msg", "The ruler is not being started because you need to configure the ruler storage.")
 		return
 	}
@@ -1175,7 +1175,7 @@ func (t *Mimir) initUsageStats() (services.Service, error) {
 
 	// Since it requires the access to the blocks storage, we enable it only for components
 	// accessing the blocks storage.
-	if !t.Cfg.isAnyModuleEnabled(All, Write, Read, Backend, Ingester, Querier, StoreGateway, Compactor) {
+	if !t.Cfg.isAnyModuleExplicitlyTargeted(All, Write, Read, Backend, Ingester, Querier, StoreGateway, Compactor) {
 		return nil, nil
 	}
 

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -915,7 +915,8 @@ func (t *Mimir) initQueryFrontend() (serv services.Service, err error) {
 }
 
 func (t *Mimir) initQuerierQueryPlanner() (services.Service, error) {
-	_, mqeOpts := engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, t.Registerer)
+	reg := prometheus.WrapRegistererWith(prometheus.Labels{"component": "querier"}, t.Registerer)
+	_, mqeOpts := engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, reg)
 	t.QuerierQueryPlanner = streamingpromql.NewQueryPlanner(mqeOpts)
 
 	// If the query-frontend is running in this process, we want to expose its planner through the analysis endpoint, not
@@ -929,7 +930,8 @@ func (t *Mimir) initQuerierQueryPlanner() (services.Service, error) {
 }
 
 func (t *Mimir) initQueryFrontendQueryPlanner() (services.Service, error) {
-	_, mqeOpts := engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, t.Registerer)
+	reg := prometheus.WrapRegistererWith(prometheus.Labels{"component": "query-frontend"}, t.Registerer)
+	_, mqeOpts := engine.NewPromQLEngineOptions(t.Cfg.Querier.EngineConfig, t.ActivityTracker, util_log.Logger, reg)
 	t.QueryFrontendQueryPlanner = streamingpromql.NewQueryPlanner(mqeOpts)
 
 	analysisHandler := streamingpromql.AnalysisHandler(t.QueryFrontendQueryPlanner)

--- a/pkg/mimir/sanity_check.go
+++ b/pkg/mimir/sanity_check.go
@@ -53,19 +53,19 @@ func checkDirectoriesReadWriteAccess(
 ) error {
 	errs := multierror.New()
 
-	if cfg.isAnyModuleExplicitlyTargeted(All, Ingester, Write) {
+	if cfg.isIngesterEnabled() {
 		errs.Add(errors.Wrap(checkDirReadWriteAccess(cfg.Ingester.BlocksStorageConfig.TSDB.Dir, dirExistFn, isDirReadWritableFn), "ingester"))
 	}
-	if cfg.isAnyModuleExplicitlyTargeted(All, StoreGateway, Backend) {
+	if cfg.isStoreGatewayEnabled() {
 		errs.Add(errors.Wrap(checkDirReadWriteAccess(cfg.BlocksStorage.BucketStore.SyncDir, dirExistFn, isDirReadWritableFn), "store-gateway"))
 	}
-	if cfg.isAnyModuleExplicitlyTargeted(All, Compactor, Backend) {
+	if cfg.isCompactorEnabled() {
 		errs.Add(errors.Wrap(checkDirReadWriteAccess(cfg.Compactor.DataDir, dirExistFn, isDirReadWritableFn), "compactor"))
 	}
-	if cfg.isAnyModuleExplicitlyTargeted(All, Ruler, Backend) {
+	if cfg.isRulerEnabled() {
 		errs.Add(errors.Wrap(checkDirReadWriteAccess(cfg.Ruler.RulePath, dirExistFn, isDirReadWritableFn), "ruler"))
 	}
-	if cfg.isAnyModuleExplicitlyTargeted(AlertManager, Backend) {
+	if cfg.isAlertManagerEnabled() {
 		errs.Add(errors.Wrap(checkDirReadWriteAccess(cfg.Alertmanager.DataDir, dirExistFn, isDirReadWritableFn), "alertmanager"))
 	}
 
@@ -127,17 +127,17 @@ func checkObjectStoresConfig(ctx context.Context, cfg Config, logger log.Logger)
 	errs := multierror.New()
 
 	// Check blocks storage config only if running at least one component using it.
-	if cfg.isAnyModuleExplicitlyTargeted(All, Ingester, Querier, Ruler, StoreGateway, Compactor, Write, Read, Backend) {
+	if cfg.isIngesterEnabled() || cfg.isQuerierEnabled() || cfg.isRulerEnabled() || cfg.isStoreGatewayEnabled() || cfg.isCompactorEnabled() {
 		errs.Add(errors.Wrap(checkObjectStoreConfig(ctx, cfg.BlocksStorage.Bucket, logger), "blocks storage"))
 	}
 
 	// Check alertmanager storage config.
-	if cfg.isAnyModuleExplicitlyTargeted(AlertManager, Backend) && cfg.AlertmanagerStorage.Backend != alertstorelocal.Name {
+	if cfg.isAlertManagerEnabled() && cfg.AlertmanagerStorage.Backend != alertstorelocal.Name {
 		errs.Add(errors.Wrap(checkObjectStoreConfig(ctx, cfg.AlertmanagerStorage.Config, logger), "alertmanager storage"))
 	}
 
 	// Check ruler storage config.
-	if cfg.isAnyModuleExplicitlyTargeted(All, Ruler, Backend) && cfg.RulerStorage.Backend != rulestore.BackendLocal {
+	if cfg.isRulerEnabled() && cfg.RulerStorage.Backend != rulestore.BackendLocal {
 		errs.Add(errors.Wrap(checkObjectStoreConfig(ctx, cfg.RulerStorage.Config, logger), "ruler storage"))
 	}
 

--- a/pkg/mimir/sanity_check.go
+++ b/pkg/mimir/sanity_check.go
@@ -53,19 +53,19 @@ func checkDirectoriesReadWriteAccess(
 ) error {
 	errs := multierror.New()
 
-	if cfg.isAnyModuleEnabled(All, Ingester, Write) {
+	if cfg.isAnyModuleExplicitlyTargeted(All, Ingester, Write) {
 		errs.Add(errors.Wrap(checkDirReadWriteAccess(cfg.Ingester.BlocksStorageConfig.TSDB.Dir, dirExistFn, isDirReadWritableFn), "ingester"))
 	}
-	if cfg.isAnyModuleEnabled(All, StoreGateway, Backend) {
+	if cfg.isAnyModuleExplicitlyTargeted(All, StoreGateway, Backend) {
 		errs.Add(errors.Wrap(checkDirReadWriteAccess(cfg.BlocksStorage.BucketStore.SyncDir, dirExistFn, isDirReadWritableFn), "store-gateway"))
 	}
-	if cfg.isAnyModuleEnabled(All, Compactor, Backend) {
+	if cfg.isAnyModuleExplicitlyTargeted(All, Compactor, Backend) {
 		errs.Add(errors.Wrap(checkDirReadWriteAccess(cfg.Compactor.DataDir, dirExistFn, isDirReadWritableFn), "compactor"))
 	}
-	if cfg.isAnyModuleEnabled(All, Ruler, Backend) {
+	if cfg.isAnyModuleExplicitlyTargeted(All, Ruler, Backend) {
 		errs.Add(errors.Wrap(checkDirReadWriteAccess(cfg.Ruler.RulePath, dirExistFn, isDirReadWritableFn), "ruler"))
 	}
-	if cfg.isAnyModuleEnabled(AlertManager, Backend) {
+	if cfg.isAnyModuleExplicitlyTargeted(AlertManager, Backend) {
 		errs.Add(errors.Wrap(checkDirReadWriteAccess(cfg.Alertmanager.DataDir, dirExistFn, isDirReadWritableFn), "alertmanager"))
 	}
 
@@ -127,17 +127,17 @@ func checkObjectStoresConfig(ctx context.Context, cfg Config, logger log.Logger)
 	errs := multierror.New()
 
 	// Check blocks storage config only if running at least one component using it.
-	if cfg.isAnyModuleEnabled(All, Ingester, Querier, Ruler, StoreGateway, Compactor, Write, Read, Backend) {
+	if cfg.isAnyModuleExplicitlyTargeted(All, Ingester, Querier, Ruler, StoreGateway, Compactor, Write, Read, Backend) {
 		errs.Add(errors.Wrap(checkObjectStoreConfig(ctx, cfg.BlocksStorage.Bucket, logger), "blocks storage"))
 	}
 
 	// Check alertmanager storage config.
-	if cfg.isAnyModuleEnabled(AlertManager, Backend) && cfg.AlertmanagerStorage.Backend != alertstorelocal.Name {
+	if cfg.isAnyModuleExplicitlyTargeted(AlertManager, Backend) && cfg.AlertmanagerStorage.Backend != alertstorelocal.Name {
 		errs.Add(errors.Wrap(checkObjectStoreConfig(ctx, cfg.AlertmanagerStorage.Config, logger), "alertmanager storage"))
 	}
 
 	// Check ruler storage config.
-	if cfg.isAnyModuleEnabled(All, Ruler, Backend) && cfg.RulerStorage.Backend != rulestore.BackendLocal {
+	if cfg.isAnyModuleExplicitlyTargeted(All, Ruler, Backend) && cfg.RulerStorage.Backend != rulestore.BackendLocal {
 		errs.Add(errors.Wrap(checkObjectStoreConfig(ctx, cfg.RulerStorage.Config, logger), "ruler storage"))
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR introduces a separate query planner for queriers and another for query-frontends.

Remote execution of query plans is implemented as an optimisation pass that identifies subtrees of the query plan that should be executed remotely. This optimisation pass must only run in query-frontends: queriers should not remotely execute parts of the query plan themselves.

Therefore, in order to behave correctly when running in monolithic or read/write mode, we need to have separate query planners for queriers and query-frontends.

I have not added a changelog entry given this is a refactoring.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
