### PR TITLE
Alertmanager: Fix computeConfig warning log

### DIFF
--- a/pkg/alertmanager/multitenant.go
+++ b/pkg/alertmanager/multitenant.go
@@ -772,7 +772,7 @@ func (am *MultitenantAlertmanager) syncConfigs(ctx context.Context, cfgMap map[s
 func (am *MultitenantAlertmanager) computeConfig(cfgs alertspb.AlertConfigDescs) (amConfig, bool, error) {
 	// Custom Mimir configurations have the highest precedence.
 	if cfgs.Mimir.RawConfig != am.fallbackConfig && cfgs.Mimir.RawConfig != "" {
-		if !cfgs.Grafana.Default {
+		if cfgs.Grafana.Promoted {
 			level.Warn(am.logger).Log("msg", "merging configurations not implemented, using mimir config", "user", cfgs.Mimir.User)
 		}
 		am.removeFromSkippedList(cfgs.Mimir.User)


### PR DESCRIPTION
We're currently logging `"merging configurations not implemented, using mimir config"` whenever a tenant has a custom Mimir configuration and a Grafana configuration that's not marked as default.

If the tenant doesn't have a Grafana config, the struct will have the `Default` field set to `false` (zero value for booleans), and the line will be logged. We can fix this by checking for promoted configs instead of non-default configs.