### PR TITLE
docs: ha-tracker allow usage of memberlist as kv store. (#12451)

### DIFF
--- a/docs/sources/mimir/configure/configure-high-availability-deduplication.md
+++ b/docs/sources/mimir/configure/configure-high-availability-deduplication.md
@@ -106,21 +106,14 @@ Alternatively, you can enable the HA tracker only on a per-tenant basis, keeping
 #### Configure the HA tracker KV store
 
 The HA tracker requires a key-value (KV) store to coordinate which replica is currently elected.
-The supported KV stores for the HA tracker are `consul` and `etcd`.
-
-{{< admonition type="note" >}}
-`memberlist` isn't supported.
-
-Memberlist-based KV stores propagate updates using the Gossip protocol, which is too slow for the HA tracker.
-
-The result would be that different distributors might see a different Prometheus server elected as leaders at the same time.
-{{< /admonition >}}
+In [Grafana Mimir versions 2.17](https://github.com/grafana/mimir/releases/tag/mimir-2.17.0) and later, use `memberlist` as the KV store backend for the HA tracker. The `consul` and `etcd` backends are deprecated.
 
 The following CLI flags (and their respective YAML configuration options) are available for configuring the HA tracker KV store:
 
-- `-distributor.ha-tracker.store`: The backend storage to use, which is either `consul` or `etcd`.
-- `-distributor.ha-tracker.consul.*`: The Consul client configuration. Only use this if you have defined `consul` as your backend storage.
-- `-distributor.ha-tracker.etcd.*`: The etcd client configuration. Only use this if you have defined `etcd` as your backend storage.
+- `-distributor.ha-tracker.store`: The backend storage to use, which is `memberlist`. The `consul` and `etcd` backends are deprecated.
+- `-memberlist.*`: The memberlist client configuration. It's common and used by other Mimir components as well.
+- [deprecated]`-distributor.ha-tracker.consul.*`: The Consul client configuration. Only use this if you have defined `consul` as your backend storage.
+- [deprecated]`-distributor.ha-tracker.etcd.*`: The etcd client configuration. Only use this if you have defined `etcd` as your backend storage.
 
 #### Configure expected label names for each Prometheus cluster and replica
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main -->

#### What this PR does

With version 2.17 we marked Memberlist as stable kv store for the Ha tracker, and marked etcd,consul as deprecated.
We update the docs so it represents that

#### Which issue(s) this PR fixes or relates to

Part of
https://github.com/grafana/mimir/issues/1597#issuecomment-3200265688

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
