### PR TITLE
rw2: Do not silently drop metric metadata of type Unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [BUGFIX] Querier: Fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #12261
 * [BUGFIX] Block-builder-scheduler: Fix a caching bug in initial job probing causing excessive memory usage at startup. #12389
 * [BUGFIX] Ruler: Support labels at the rule group level. These were previously ignored even when set via the API. #12397
+* [BUGFIX] Distributor: Fix metric metadata of type Unknown being silently dropped from RW2 requests. #12461
 
 ### Mixin
 

--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -117,60 +117,79 @@ func TestRW2Unmarshal(t *testing.T) {
 		require.Equal(t, expected, &received)
 	})
 
-	t.Run("metadata with UNKNOWN type maps to expected value", func(t *testing.T) {
-		syms := test.NewSymbolTableBuilder(nil)
-		writeRequest := &WriteRequest{
-			TimeseriesRW2: []TimeSeriesRW2{
-				{
-					LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_total")},
-					Metadata: MetadataRW2{
-						Type:    METRIC_TYPE_UNSPECIFIED,
-						HelpRef: syms.GetSymbol("test_metric_help"),
-						UnitRef: syms.GetSymbol("test_metric_unit"),
-					},
-				},
-			},
+	t.Run("metadata for all metric types map to expected values", func(t *testing.T) {
+		tc := []struct {
+			name    string
+			rw2Type MetadataRW2_MetricType
+			rw1Type MetricMetadata_MetricType
+		}{
+			{"UNKNOWN", METRIC_TYPE_UNSPECIFIED, UNKNOWN},
+			{"COUNTER", METRIC_TYPE_COUNTER, COUNTER},
+			{"GAUGE", METRIC_TYPE_GAUGE, GAUGE},
+			{"HISTOGRAM", METRIC_TYPE_HISTOGRAM, HISTOGRAM},
+			{"GAUGEHISTOGRAM", METRIC_TYPE_GAUGEHISTOGRAM, GAUGEHISTOGRAM},
+			{"SUMMARY", METRIC_TYPE_SUMMARY, SUMMARY},
+			{"INFO", METRIC_TYPE_INFO, INFO},
+			{"STATESET", METRIC_TYPE_STATESET, STATESET},
 		}
-		writeRequest.SymbolsRW2 = syms.GetSymbols()
-		data, err := writeRequest.Marshal()
-		require.NoError(t, err)
 
-		// Unmarshal the data back into Mimir's WriteRequest.
-		received := PreallocWriteRequest{}
-		received.UnmarshalFromRW2 = true
-		err = received.Unmarshal(data)
-		require.NoError(t, err)
-
-		expected := &PreallocWriteRequest{
-			WriteRequest: WriteRequest{
-				Timeseries: []PreallocTimeseries{
-					{
-						TimeSeries: &TimeSeries{
-							Labels: []LabelAdapter{
-								{
-									Name:  "__name__",
-									Value: "test_metric_total",
-								},
+		for _, tt := range tc {
+			t.Run(tt.name, func(t *testing.T) {
+				syms := test.NewSymbolTableBuilder(nil)
+				writeRequest := &WriteRequest{
+					TimeseriesRW2: []TimeSeriesRW2{
+						{
+							LabelsRefs: []uint32{syms.GetSymbol("__name__"), syms.GetSymbol("test_metric_total")},
+							Metadata: MetadataRW2{
+								Type:    tt.rw2Type,
+								HelpRef: syms.GetSymbol("test_metric_help"),
+								UnitRef: syms.GetSymbol("test_metric_unit"),
 							},
-							Samples:   []Sample{},
-							Exemplars: []Exemplar{},
 						},
 					},
-				},
-				Metadata: []*MetricMetadata{
-					{
-						MetricFamilyName: "test_metric_total",
-						Type:             UNKNOWN,
-						Help:             "test_metric_help",
-						Unit:             "test_metric_unit",
+				}
+				writeRequest.SymbolsRW2 = syms.GetSymbols()
+				data, err := writeRequest.Marshal()
+				require.NoError(t, err)
+
+				// Unmarshal the data back into Mimir's WriteRequest.
+				received := PreallocWriteRequest{}
+				received.UnmarshalFromRW2 = true
+				err = received.Unmarshal(data)
+				require.NoError(t, err)
+
+				expected := &PreallocWriteRequest{
+					WriteRequest: WriteRequest{
+						Timeseries: []PreallocTimeseries{
+							{
+								TimeSeries: &TimeSeries{
+									Labels: []LabelAdapter{
+										{
+											Name:  "__name__",
+											Value: "test_metric_total",
+										},
+									},
+									Samples:   []Sample{},
+									Exemplars: []Exemplar{},
+								},
+							},
+						},
+						Metadata: []*MetricMetadata{
+							{
+								MetricFamilyName: "test_metric_total",
+								Type:             tt.rw1Type,
+								Help:             "test_metric_help",
+								Unit:             "test_metric_unit",
+							},
+						},
+						unmarshalFromRW2: true,
 					},
-				},
-				unmarshalFromRW2: true,
-			},
-			UnmarshalFromRW2: true,
+					UnmarshalFromRW2: true,
+				}
+				// Check that the unmarshalled data matches the original data.
+				require.Equal(t, expected, &received)
+			})
 		}
-		// Check that the unmarshalled data matches the original data.
-		require.Equal(t, expected, &received)
 	})
 
 	t.Run("rw2 with offset produces expected WriteRequest", func(t *testing.T) {

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -11690,13 +11690,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata 
 					break
 				}
 			}
-			normalizeMetricName, _ = getMetricName(metricName, metricType)
-			if _, ok := metadata[normalizeMetricName]; ok {
-				// Already have metadata for this metric familiy name.
-				// Since we cannot have multiple definitions of the same
-				// metric family name, we ignore this metadata.
-				return nil
-			}
+			// TODO from here
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field HelpRef", wireType)
@@ -11762,9 +11756,17 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata 
 	if iNdEx > l {
 		return io.ErrUnexpectedEOF
 	}
+	normalizeMetricName, _ = getMetricName(metricName, metricType)
 	if len(normalizeMetricName) == 0 {
 		return nil
 	}
+	if _, ok := metadata[normalizeMetricName]; ok {
+		// Already have metadata for this metric familiy name.
+		// Since we cannot have multiple definitions of the same
+		// metric family name, we ignore this metadata.
+		return nil
+	}
+	
 	if len(unit) > 0 || len(help) > 0 || metricType != 0 {
 		metadata[normalizeMetricName] = &orderAwareMetricMetadata{
 			MetricMetadata: MetricMetadata{

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -11690,7 +11690,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata 
 					break
 				}
 			}
-			// TODO from here
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field HelpRef", wireType)

--- a/pkg/mimirpb/mimir.pb.go.expdiff
+++ b/pkg/mimirpb/mimir.pb.go.expdiff
@@ -1,7 +1,7 @@
-diff --git b/pkg/mimirpb/mimir.pb.go a/pkg/mimirpb/mimir.pb.go
-index f9351f909d..2013d3ee8c 100644
---- b/pkg/mimirpb/mimir.pb.go
-+++ a/pkg/mimirpb/mimir.pb.go
+diff --git a/pkg/mimirpb/mimir.pb.go b/pkg/mimirpb/mimir.pb.go
+index 50ea1bc359..2013d3ee8c 100644
+--- a/pkg/mimirpb/mimir.pb.go
++++ b/pkg/mimirpb/mimir.pb.go
 @@ -14,7 +14,6 @@ import (
  	math "math"
  	math_bits "math/bits"
@@ -12,7 +12,7 @@ index f9351f909d..2013d3ee8c 100644
  )
 @@ -276,9 +275,6 @@ func (MetadataRW2_MetricType) EnumDescriptor() ([]byte, []int) {
  }
-
+ 
  type WriteRequest struct {
 -	// Keep reference to buffer for unsafe references.
 -	BufferHolder
@@ -31,12 +31,12 @@ index f9351f909d..2013d3ee8c 100644
 -	unmarshalFromRW2 bool
 -	rw2symbols       rw2PagedSymbols
  }
-
+ 
  func (m *WriteRequest) Reset()      { *m = WriteRequest{} }
 @@ -450,11 +440,6 @@ func (m *ErrorDetails) GetCause() ErrorCause {
  	return ERROR_CAUSE_UNKNOWN
  }
-
+ 
 -// # DO NOT SHALLOW-COPY
 -//
 -// Data referenced from a PreallocTimeseries may change once the timeseries is
@@ -53,7 +53,7 @@ index f9351f909d..2013d3ee8c 100644
 -	// Skip unmarshaling of exemplars.
 -	SkipUnmarshalingExemplars bool
  }
-
+ 
  func (m *TimeSeries) Reset()      { *m = TimeSeries{} }
 @@ -5922,25 +5904,19 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
  		}
@@ -453,7 +453,7 @@ index f9351f909d..2013d3ee8c 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11685,23 +11588,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11685,7 +11588,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -462,15 +462,7 @@ index f9351f909d..2013d3ee8c 100644
  				if b < 0x80 {
  					break
  				}
- 			}
--			normalizeMetricName, _ = getMetricName(metricName, metricType)
--			if _, ok := metadata[normalizeMetricName]; ok {
--				// Already have metadata for this metric familiy name.
--				// Since we cannot have multiple definitions of the same
--				// metric family name, we ignore this metadata.
--				return nil
--			}
- 		case 3:
+@@ -11694,7 +11597,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  			if wireType != 0 {
  				return fmt.Errorf("proto: wrong wireType = %d for field HelpRef", wireType)
  			}
@@ -479,7 +471,7 @@ index f9351f909d..2013d3ee8c 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11711,20 +11607,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11704,20 +11607,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -502,7 +494,7 @@ index f9351f909d..2013d3ee8c 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11734,15 +11626,11 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11727,15 +11626,11 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -519,13 +511,21 @@ index f9351f909d..2013d3ee8c 100644
  		default:
  			iNdEx = preIndex
  			skippy, err := skipMimir(dAtA[iNdEx:])
-@@ -11762,21 +11650,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11755,29 +11650,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  	if iNdEx > l {
  		return io.ErrUnexpectedEOF
  	}
+-	normalizeMetricName, _ = getMetricName(metricName, metricType)
 -	if len(normalizeMetricName) == 0 {
 -		return nil
 -	}
+-	if _, ok := metadata[normalizeMetricName]; ok {
+-		// Already have metadata for this metric familiy name.
+-		// Since we cannot have multiple definitions of the same
+-		// metric family name, we ignore this metadata.
+-		return nil
+-	}
+-	
 -	if len(unit) > 0 || len(help) > 0 || metricType != 0 {
 -		metadata[normalizeMetricName] = &orderAwareMetricMetadata{
 -			MetricMetadata: MetricMetadata{

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -262,6 +262,59 @@ func TestRecordSerializer(t *testing.T) {
 		// Metadata order is currently not preserved by the RW2 deser layer.
 		require.ElementsMatch(t, req.Metadata, resultReq.Metadata)
 	})
+
+	t.Run("metadata with UNKNOWN type", func(t *testing.T) {
+		req := &mimirpb.WriteRequest{
+			Source:              mimirpb.RULE,
+			SkipLabelValidation: true,
+			Timeseries:          []mimirpb.PreallocTimeseries{},
+			Metadata: []*mimirpb.MetricMetadata{
+				{Type: mimirpb.COUNTER, MetricFamilyName: "series_1", Help: "This is the first test metric."},
+				{Type: mimirpb.UNKNOWN, MetricFamilyName: "series_2", Help: "This is the second test metric."},
+				{Type: mimirpb.COUNTER, MetricFamilyName: "series_3", Help: "This is the third test metric."},
+			},
+		}
+
+		serializer := VersionTwoRecordSerializer{}
+		records, err := serializer.ToRecords(1234, "user-1", req, 100000)
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		record := records[0]
+
+		require.Equal(t, 2, ParseRecordVersion(record))
+
+		resultReq := &mimirpb.PreallocWriteRequest{}
+		err = DeserializeRecordContent(record.Value, resultReq, 2)
+		require.NoError(t, err)
+
+		require.Len(t, resultReq.Timeseries, 3)
+
+		// The only way to carry a metadata in RW2.0 is attached to a timeseries.
+		// Metadata not attached to any series in the request must fabricate extra timeseries to house it.
+		expMetadataSeries := []mimirpb.PreallocTimeseries{
+			{TimeSeries: &mimirpb.TimeSeries{
+				Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings(labels.MetricName, "series_1")),
+				Samples:   []mimirpb.Sample{},
+				Exemplars: []mimirpb.Exemplar{},
+			}},
+			{TimeSeries: &mimirpb.TimeSeries{
+				Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings(labels.MetricName, "series_2")),
+				Samples:   []mimirpb.Sample{},
+				Exemplars: []mimirpb.Exemplar{},
+			}},
+			{TimeSeries: &mimirpb.TimeSeries{
+				Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings(labels.MetricName, "series_3")),
+				Samples:   []mimirpb.Sample{},
+				Exemplars: []mimirpb.Exemplar{},
+			}},
+		}
+		require.Equal(t, expMetadataSeries, resultReq.Timeseries)
+
+		require.Nil(t, resultReq.SymbolsRW2)
+		require.Nil(t, resultReq.TimeseriesRW2)
+		// Metadata order is currently not preserved by the RW2 deser layer.
+		require.ElementsMatch(t, req.Metadata, resultReq.Metadata)
+	})
 }
 
 func BenchmarkDeserializeRecordContent(b *testing.B) {

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -262,59 +262,6 @@ func TestRecordSerializer(t *testing.T) {
 		// Metadata order is currently not preserved by the RW2 deser layer.
 		require.ElementsMatch(t, req.Metadata, resultReq.Metadata)
 	})
-
-	t.Run("metadata with UNKNOWN type", func(t *testing.T) {
-		req := &mimirpb.WriteRequest{
-			Source:              mimirpb.RULE,
-			SkipLabelValidation: true,
-			Timeseries:          []mimirpb.PreallocTimeseries{},
-			Metadata: []*mimirpb.MetricMetadata{
-				{Type: mimirpb.COUNTER, MetricFamilyName: "series_1", Help: "This is the first test metric."},
-				{Type: mimirpb.UNKNOWN, MetricFamilyName: "series_2", Help: "This is the second test metric."},
-				{Type: mimirpb.COUNTER, MetricFamilyName: "series_3", Help: "This is the third test metric."},
-			},
-		}
-
-		serializer := versionTwoRecordSerializer{}
-		records, err := serializer.ToRecords(1234, "user-1", req, 100000)
-		require.NoError(t, err)
-		require.Len(t, records, 1)
-		record := records[0]
-
-		require.Equal(t, 2, ParseRecordVersion(record))
-
-		resultReq := &mimirpb.PreallocWriteRequest{}
-		err = DeserializeRecordContent(record.Value, resultReq, 2)
-		require.NoError(t, err)
-
-		require.Len(t, resultReq.Timeseries, 3)
-
-		// The only way to carry a metadata in RW2.0 is attached to a timeseries.
-		// Metadata not attached to any series in the request must fabricate extra timeseries to house it.
-		expMetadataSeries := []mimirpb.PreallocTimeseries{
-			{TimeSeries: &mimirpb.TimeSeries{
-				Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings(labels.MetricName, "series_1")),
-				Samples:   []mimirpb.Sample{},
-				Exemplars: []mimirpb.Exemplar{},
-			}},
-			{TimeSeries: &mimirpb.TimeSeries{
-				Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings(labels.MetricName, "series_2")),
-				Samples:   []mimirpb.Sample{},
-				Exemplars: []mimirpb.Exemplar{},
-			}},
-			{TimeSeries: &mimirpb.TimeSeries{
-				Labels:    mimirpb.FromLabelsToLabelAdapters(labels.FromStrings(labels.MetricName, "series_3")),
-				Samples:   []mimirpb.Sample{},
-				Exemplars: []mimirpb.Exemplar{},
-			}},
-		}
-		require.Equal(t, expMetadataSeries, resultReq.Timeseries)
-
-		require.Nil(t, resultReq.SymbolsRW2)
-		require.Nil(t, resultReq.TimeseriesRW2)
-		// Metadata order is currently not preserved by the RW2 deser layer.
-		require.ElementsMatch(t, req.Metadata, resultReq.Metadata)
-	})
 }
 
 func BenchmarkDeserializeRecordContent(b *testing.B) {

--- a/pkg/storage/ingest/version_test.go
+++ b/pkg/storage/ingest/version_test.go
@@ -275,7 +275,7 @@ func TestRecordSerializer(t *testing.T) {
 			},
 		}
 
-		serializer := VersionTwoRecordSerializer{}
+		serializer := versionTwoRecordSerializer{}
 		records, err := serializer.ToRecords(1234, "user-1", req, 100000)
 		require.NoError(t, err)
 		require.Len(t, records, 1)


### PR DESCRIPTION
#### What this PR does

Fixes a bug where we silently drop a metric metadata, if the type is `UNKNOWN`. Such metadata might still contain help/unit text that we want to store. This affects both the Remote Write 2.0 push API and ingest-storage V2 record format.

This happens because we normalize the metric name at the moment we parse the type. Since `UNKNOWN` is the default metric type, Proto often chooses to save a few bytes and never send the field at all. That means we also never parse the `type` field, thus we never normalize the name, thus the value of `normalizeMetricName` is always empty string. The parser now thinks the metric name is empty and drops the metadata as it maps to no series.

The fix simply normalizes the metric name a little later, outside of the `metricType` parsing branch.

#### Which issue(s) this PR fixes or relates to

Contrib https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
