### PR TITLE
remove invalid option in frontend documentation configure-the-query-frontend-work-with-prometheus.md

### DIFF
--- a/docs/sources/mimir/configure/configure-the-query-frontend-work-with-prometheus.md
+++ b/docs/sources/mimir/configure/configure-the-query-frontend-work-with-prometheus.md
@@ -38,7 +38,6 @@ server:
 
 frontend:
   split_queries_by_interval: 24h
-  align_queries_with_step: true
   cache_results: true
 
   results_cache:


### PR DESCRIPTION
"align_queries_with_step: true" is not a valid option in frontend

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
It fixes a documentation error in mimir frontend, as align_queries_with_step: true is not a valid option.

#### Which issue(s) this PR fixes or relates to

none

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
