### PR TITLE
MQE: Improve fuzz tests erorr messages

### DIFF
--- a/pkg/streamingpromql/engine_fuzz_test.go
+++ b/pkg/streamingpromql/engine_fuzz_test.go
@@ -118,12 +118,12 @@ func testInstantQueries(t *testing.T, startT time.Time, query string, testEnviro
 
 	// if the Prometheus engine can not prepare the query then we expect the MQE to also fail
 	if prometheusError != nil {
-		require.Errorf(t, mqeError, "Failed to create query – Prometheus' engine returned error, but MQE returned no error.\nQuery - %q", query)
+		require.Errorf(t, mqeError, "Failed to create query: Prometheus' engine returned error, but MQE returned no error.\nQuery: %q", query)
 		return
 	}
-	require.NoError(t, mqeError, "Failed to create query – MQE returned error, but Prometheus' engine returned no error.\nQuery - %q", query)
-	require.NotNilf(t, prometheusQuery, "Failed to create query – Prometheus' engine query expected not to be nil.\nQuery - %q", query)
-	require.NotNilf(t, mqeQuery, "Failed to create query – MQE engine query expected not to be nil.\nQuery - %q", query)
+	require.NoError(t, mqeError, "Failed to create query: MQE returned error, but Prometheus' engine returned no error.\nQuery: %q", query)
+	require.NotNilf(t, prometheusQuery, "Failed to create query: Prometheus' engine query expected not to be nil.\nQuery: %q", query)
+	require.NotNilf(t, mqeQuery, "Failed to create query: MQE engine query expected not to be nil.\nQuery: %q", query)
 
 	executeQueriesAndCompareResults(t, *testEnvironment, mqeQuery, prometheusQuery, query)
 }
@@ -136,12 +136,12 @@ func testRangeQueries(t *testing.T, startT time.Time, endT time.Time, step time.
 	// Note - prometheus validates time ranges and steps in http api handler, so it will not return an error at query preparation time
 	// Note - max resolution size (end-start/step) is validated in codec.go so we don't validate that here either
 	if prometheusError != nil || startT.After(endT) {
-		require.Errorf(t, mqeError, "Failed to create query – Prometheus' engine returned error, but MQE returned no error.\nQuery - %q", query)
+		require.Errorf(t, mqeError, "Failed to create query: Prometheus' engine returned error, but MQE returned no error.\nQuery: %q", query)
 		return
 	}
-	require.NoError(t, mqeError, "Failed to create query – MQE returned error, but Prometheus' engine returned no error.\nQuery - %q", query)
-	require.NotNilf(t, prometheusQuery, "Failed to create query – Prometheus' engine query expected not to be nil.\nQuery - %q", query)
-	require.NotNilf(t, mqeQuery, "Failed to create query – MQE engine query expected not to be nil.\nQuery - %q", query)
+	require.NoError(t, mqeError, "Failed to create query: MQE returned error, but Prometheus' engine returned no error.\nQuery: %q", query)
+	require.NotNilf(t, prometheusQuery, "Failed to create query: Prometheus' engine query expected not to be nil.\nQuery: %q", query)
+	require.NotNilf(t, mqeQuery, "Failed to create query: MQE engine query expected not to be nil.\nQuery: %q", query)
 
 	executeQueriesAndCompareResults(t, *testEnvironment, mqeQuery, prometheusQuery, query)
 }

--- a/pkg/streamingpromql/engine_fuzz_test.go
+++ b/pkg/streamingpromql/engine_fuzz_test.go
@@ -118,12 +118,12 @@ func testInstantQueries(t *testing.T, startT time.Time, query string, testEnviro
 
 	// if the Prometheus engine can not prepare the query then we expect the MQE to also fail
 	if prometheusError != nil {
-		require.Errorf(t, mqeError, "Prometheus' engine returned error %v, but MQE returned no error", prometheusError)
+		require.Errorf(t, mqeError, "Failed to create query – Prometheus' engine returned error, but MQE returned no error.\nQuery - %q", query)
 		return
 	}
-
-	require.NotNil(t, prometheusQuery)
-	require.NotNil(t, mqeQuery)
+	require.NoError(t, mqeError, "Failed to create query – MQE returned error, but Prometheus' engine returned no error.\nQuery - %q", query)
+	require.NotNilf(t, prometheusQuery, "Failed to create query – Prometheus' engine query expected not to be nil.\nQuery - %q", query)
+	require.NotNilf(t, mqeQuery, "Failed to create query – MQE engine query expected not to be nil.\nQuery - %q", query)
 
 	executeQueriesAndCompareResults(t, *testEnvironment, mqeQuery, prometheusQuery, query)
 }
@@ -136,12 +136,12 @@ func testRangeQueries(t *testing.T, startT time.Time, endT time.Time, step time.
 	// Note - prometheus validates time ranges and steps in http api handler, so it will not return an error at query preparation time
 	// Note - max resolution size (end-start/step) is validated in codec.go so we don't validate that here either
 	if prometheusError != nil || startT.After(endT) {
-		require.NotNilf(t, mqeError, "Prometheus' engine returned error %v, but MQE returned no error", prometheusError)
+		require.Errorf(t, mqeError, "Failed to create query – Prometheus' engine returned error, but MQE returned no error.\nQuery - %q", query)
 		return
 	}
-
-	require.NotNil(t, prometheusQuery)
-	require.NotNil(t, mqeQuery)
+	require.NoError(t, mqeError, "Failed to create query – MQE returned error, but Prometheus' engine returned no error.\nQuery - %q", query)
+	require.NotNilf(t, prometheusQuery, "Failed to create query – Prometheus' engine query expected not to be nil.\nQuery - %q", query)
+	require.NotNilf(t, mqeQuery, "Failed to create query – MQE engine query expected not to be nil.\nQuery - %q", query)
 
 	executeQueriesAndCompareResults(t, *testEnvironment, mqeQuery, prometheusQuery, query)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Slightly improve the error messages for the fuzz tests.

Before:
```
 --- FAIL: FuzzQuery (76.73s)
      --- FAIL: FuzzQuery/seed#3348 (0.00s)
          engine_fuzz_test.go:126: 
              	Error Trace:	/__w/mimir/mimir/pkg/streamingpromql/engine_fuzz_test.go:126
              	            				/__w/mimir/mimir/pkg/streamingpromql/engine_fuzz_test.go:231
              	            				/usr/local/go/src/reflect/value.go:584
              	            				/usr/local/go/src/reflect/value.go:368
              	            				/usr/local/go/src/testing/fuzz.go:340
              	Error:      	Expected value not to be nil.
              	Test:       	FuzzQuery/seed#3348
```
After:
```
 --- FAIL: FuzzQuery (76.42s)
      --- FAIL: FuzzQuery/seed#3348 (0.00s)
          engine_fuzz_test.go:124: 
              	Error Trace:	/__w/mimir/mimir/pkg/streamingpromql/engine_fuzz_test.go:124
              	            				/__w/mimir/mimir/pkg/streamingpromql/engine_fuzz_test.go:231
              	            				/usr/local/go/src/reflect/value.go:584
              	            				/usr/local/go/src/reflect/value.go:368
              	            				/usr/local/go/src/testing/fuzz.go:340
              	Error:      	Received unexpected error:
              	            	could not create parameter operator for AggregateExpression AGGREGATION_QUANTILE: expected InstantVectorOperator, got *scalars.UnaryNegationOfScalar
              	Test:       	FuzzQuery/seed#3348
              	Messages:   	Failed to create query – MQE returned error, but Prometheus' engine returned no error.
              	            	Query - "(    quantile(      -(0.10197236029446011 >= bool 0.01279102879848448),      
```

#### Checklist

- [ ] ~Tests updated.~
- [ ] ~Documentation added.~
- [ ] ~`CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.~
- [ ] ~[`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.~
