### PR TITLE
Alertmanager: Add ExtraData field to experimental pre-notification hook

### DIFF
--- a/pkg/alertmanager/notify_hooks_notifier.go
+++ b/pkg/alertmanager/notify_hooks_notifier.go
@@ -29,6 +29,7 @@ import (
 
 var (
 	ErrNoContent = errors.New("no content")
+	ExtraDataKey = "extraData"
 )
 
 type notifyHooksLimits interface {
@@ -170,6 +171,12 @@ type hookData struct {
 	Status      string         `json:"status"`
 	Alerts      []*types.Alert `json:"alerts"`
 	GroupLabels model.LabelSet `json:"groupLabels"`
+
+	ExtraData json.RawMessage `json:"extraData,omitempty"`
+}
+
+func withExtraData(ctx context.Context, extraData json.RawMessage) context.Context {
+	return context.WithValue(ctx, ExtraDataKey, extraData)
 }
 
 func (n *notifyHooksNotifier) getData(ctx context.Context, l log.Logger, alerts []*types.Alert) *hookData {
@@ -239,6 +246,9 @@ func (n *notifyHooksNotifier) invoke(ctx context.Context, l log.Logger, url stri
 	if err != nil {
 		return nil, 0, err
 	}
+
+	// Add additional data from pre-notify hook to the context
+	ctx = withExtraData(ctx, result.ExtraData)
 
 	return result.Alerts, 0, nil
 }

--- a/pkg/alertmanager/notify_hooks_notifier.go
+++ b/pkg/alertmanager/notify_hooks_notifier.go
@@ -29,7 +29,6 @@ import (
 
 var (
 	ErrNoContent = errors.New("no content")
-	ExtraDataKey = "extraData"
 )
 
 type notifyHooksLimits interface {
@@ -183,6 +182,12 @@ type hookData struct {
 
 	ExtraData json.RawMessage `json:"extraData,omitempty"`
 }
+
+type extraDataKey int
+
+const (
+	ExtraDataKey extraDataKey = iota
+)
 
 func withExtraData(ctx context.Context, extraData json.RawMessage) context.Context {
 	return context.WithValue(ctx, ExtraDataKey, extraData)

--- a/pkg/alertmanager/notify_hooks_notifier.go
+++ b/pkg/alertmanager/notify_hooks_notifier.go
@@ -106,12 +106,15 @@ func newNotifyHooksMetrics(reg prometheus.Registerer) *notifyHooksMetrics {
 }
 
 func (n *notifyHooksNotifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
-	newAlerts := n.apply(ctx, alerts)
+	result := n.apply(ctx, alerts)
 
-	return n.upstream.Notify(ctx, newAlerts...)
+	// Add additional data from pre-notify hook to the context
+	ctxWithData := withExtraData(ctx, result.ExtraData)
+
+	return n.upstream.Notify(ctxWithData, result.Alerts...)
 }
 
-func (n *notifyHooksNotifier) apply(ctx context.Context, alerts []*types.Alert) []*types.Alert {
+func (n *notifyHooksNotifier) apply(ctx context.Context, alerts []*types.Alert) *hookData {
 	l := n.logger
 
 	receiver, _ := notify.ReceiverName(ctx)
@@ -123,19 +126,23 @@ func (n *notifyHooksNotifier) apply(ctx context.Context, alerts []*types.Alert) 
 	url := n.limits.AlertmanagerNotifyHookURL(n.user)
 	if url == "" {
 		level.Debug(l).Log("msg", "Notify hooks not applied, no URL configured")
-		return alerts
+		return &hookData{
+			Alerts: alerts,
+		}
 	}
 
 	receivers := n.limits.AlertmanagerNotifyHookReceivers(n.user)
 	if len(receivers) > 0 && !slices.Contains(receivers, receiver) {
 		level.Debug(l).Log("msg", "Notify hooks not applied, not enabled for receiver")
-		return alerts
+		return &hookData{
+			Alerts: alerts,
+		}
 	}
 
 	timeout := n.limits.AlertmanagerNotifyHookTimeout(n.user)
 
 	start := time.Now()
-	newAlerts, code, err := n.invoke(ctx, l, url, timeout, alerts)
+	result, code, err := n.invoke(ctx, l, url, timeout, alerts)
 
 	duration := time.Since(start)
 	n.metrics.hookDuration.Observe(float64(duration))
@@ -157,12 +164,14 @@ func (n *notifyHooksNotifier) apply(ctx context.Context, alerts []*types.Alert) 
 			n.metrics.hookFailed.WithLabelValues(status).Inc()
 			level.Error(l).Log("msg", "Notify hooks failed", "err", err)
 		}
-		return alerts
+		return &hookData{
+			Alerts: alerts,
+		}
 	}
 
 	level.Debug(l).Log("msg", "Notify hooks applied successfully")
 
-	return newAlerts
+	return result
 }
 
 // hookData is the payload we send and receive from the notification hook.
@@ -197,7 +206,7 @@ func (n *notifyHooksNotifier) getData(ctx context.Context, l log.Logger, alerts 
 	}
 }
 
-func (n *notifyHooksNotifier) invoke(ctx context.Context, l log.Logger, url string, timeout time.Duration, alerts []*types.Alert) ([]*types.Alert, int, error) {
+func (n *notifyHooksNotifier) invoke(ctx context.Context, l log.Logger, url string, timeout time.Duration, alerts []*types.Alert) (*hookData, int, error) {
 	logger, ctx := spanlogger.New(ctx, l, tracer, "NotifyHooksNotifier.Invoke")
 	defer logger.Finish()
 
@@ -247,8 +256,5 @@ func (n *notifyHooksNotifier) invoke(ctx context.Context, l log.Logger, url stri
 		return nil, 0, err
 	}
 
-	// Add additional data from pre-notify hook to the context
-	ctx = withExtraData(ctx, result.ExtraData)
-
-	return result.Alerts, 0, nil
+	return &result, 0, nil
 }


### PR DESCRIPTION
#### What this PR does
Adds another field `ExtraData` to `hookData` which is a `json.RawMessage` - this additional data is then passed along via the context.

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
