### PR TITLE
storage/ingest: refactor recordConsumer.Consume to take iter.Seq

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -7,6 +7,7 @@ import (
 	crypto_rand "crypto/rand"
 	"errors"
 	"fmt"
+	"iter"
 	"math/rand"
 	"slices"
 	"strconv"
@@ -74,14 +75,14 @@ func TestPartitionReader(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, records, 4)
-	assert.Equal(t, []byte("record 1"), records[0].content)
-	assert.Equal(t, 1, records[0].version)
-	assert.Equal(t, []byte("record 2"), records[1].content)
-	assert.Equal(t, 1, records[1].version)
-	assert.Equal(t, []byte("record 3"), records[2].content)
-	assert.Equal(t, 0, records[2].version)
-	assert.Equal(t, []byte("record 4"), records[3].content)
-	assert.Equal(t, 2, records[3].version)
+	assert.Equal(t, []byte("record 1"), records[0].Value)
+	assert.Equal(t, 1, ParseRecordVersion(records[0]))
+	assert.Equal(t, []byte("record 2"), records[1].Value)
+	assert.Equal(t, 1, ParseRecordVersion(records[1]))
+	assert.Equal(t, []byte("record 3"), records[2].Value)
+	assert.Equal(t, 0, ParseRecordVersion(records[2]))
+	assert.Equal(t, []byte("record 4"), records[3].Value)
+	assert.Equal(t, 2, ParseRecordVersion(records[3]))
 }
 
 func TestPartitionReader_ShouldHonorConfiguredFetchMaxWait(t *testing.T) {
@@ -157,13 +158,14 @@ func TestPartitionReader_ConsumerError(t *testing.T) {
 			invocations := atomic.NewInt64(0)
 			returnErrors := atomic.NewBool(true)
 			trackingConsumer := newTestConsumer(2)
-			consumer := consumerFunc(func(ctx context.Context, records []record) error {
+			consumer := consumerFunc(func(ctx context.Context, records iter.Seq[*kgo.Record]) error {
 				invocations.Inc()
 				if !returnErrors.Load() {
 					return trackingConsumer.Consume(ctx, records)
 				}
 				// There may be more records, but we only care that the one we failed to consume in the first place is still there.
-				assert.Equal(t, "1", string(records[0].content))
+				recs := slices.Collect(records)
+				assert.Equal(t, "1", string(recs[0].Value))
 				return errors.New("consumer error")
 			})
 			createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer, concurrencyVariant...)
@@ -212,15 +214,15 @@ func TestPartitionReader_ConsumerStopping(t *testing.T) {
 			// consumerErrs will store the last error returned by the consumer; its initial value doesn't matter, but it must be non-nil.
 			consumerErrs := atomic.NewError(errors.New("dummy error"))
 			type consumerCall struct {
-				f    func() []record
+				f    func() []*kgo.Record
 				resp chan error
 			}
 			consumeCalls := make(chan consumerCall)
-			consumer := consumerFunc(func(ctx context.Context, records []record) (err error) {
+			consumer := consumerFunc(func(ctx context.Context, records iter.Seq[*kgo.Record]) (err error) {
 				defer consumerErrs.Store(err)
 
 				call := consumerCall{
-					f:    func() []record { return records },
+					f:    func() []*kgo.Record { return slices.Collect(records) },
 					resp: make(chan error),
 				}
 				consumeCalls <- call
@@ -250,7 +252,7 @@ func TestPartitionReader_ConsumerStopping(t *testing.T) {
 
 				records := call.f()
 				require.Len(t, records, 1)
-				require.Equal(t, []byte("1"), records[0].content)
+				require.Equal(t, []byte("1"), records[0].Value)
 			}()
 
 			// Wait for the reader to stop completely.
@@ -267,9 +269,7 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 		partitionID = 0
 	)
 
-	var (
-		ctx = context.Background()
-	)
+	ctx := t.Context()
 
 	setup := func(t *testing.T, consumer recordConsumer, opts ...readerTestCfgOpt) (*PartitionReader, *kgo.Client, *prometheus.Registry) {
 		reg := prometheus.NewPedanticRegistry()
@@ -300,8 +300,8 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 				// We define a custom consume function which introduces a delay once the 2nd record
 				// has been consumed but before the function returns. From the PartitionReader perspective,
 				// the 2nd record consumption will be delayed.
-				consumer := consumerFunc(func(_ context.Context, records []record) error {
-					for _, record := range records {
+				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+					for record := range records {
 						// Introduce a delay before returning from the consume function once
 						// the 2nd record has been consumed.
 						if consumedRecords.Load()+1 == 2 {
@@ -309,8 +309,8 @@ func TestPartitionReader_WaitReadConsistencyUntilLastProducedOffset_And_WaitRead
 						}
 
 						consumedRecords.Inc()
-						assert.Equal(t, fmt.Sprintf("record-%d", consumedRecords.Load()), string(record.content))
-						t.Logf("consumed record: %s", string(record.content))
+						assert.Equal(t, fmt.Sprintf("record-%d", consumedRecords.Load()), string(record.Value))
+						t.Logf("consumed record: %s", string(record.Value))
 					}
 
 					return nil
@@ -555,7 +555,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 				var (
 					_, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					consumer       = consumerFunc(func(context.Context, []record) error { return nil })
+					consumer       = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 					reg            = prometheus.NewPedanticRegistry()
 				)
 
@@ -590,7 +590,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 				var (
 					cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					consumer             = consumerFunc(func(context.Context, []record) error { return nil })
+					consumer             = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 					reg                  = prometheus.NewPedanticRegistry()
 				)
 
@@ -643,8 +643,8 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 					consumedRecordsCount = atomic.NewInt64(0)
 				)
 
-				consumer := consumerFunc(func(_ context.Context, records []record) error {
-					consumedRecordsCount.Add(int64(len(records)))
+				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+					consumedRecordsCount.Add(int64(len(slices.Collect(records))))
 					return nil
 				})
 
@@ -735,8 +735,8 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 					consumedRecordsCount     = atomic.NewInt64(0)
 				)
 
-				consumer := consumerFunc(func(_ context.Context, records []record) error {
-					consumedRecordsCount.Add(int64(len(records)))
+				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+					consumedRecordsCount.Add(int64(len(slices.Collect(records))))
 					return nil
 				})
 
@@ -835,12 +835,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 					consumedRecords      []string
 				)
 
-				consumer := consumerFunc(func(_ context.Context, records []record) error {
+				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 					consumedRecordsMx.Lock()
 					defer consumedRecordsMx.Unlock()
 
-					for _, r := range records {
-						consumedRecords = append(consumedRecords, string(r.content))
+					for r := range records {
+						consumedRecords = append(consumedRecords, string(r.Value))
 					}
 					return nil
 				})
@@ -934,12 +934,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 					consumedRecords      []string
 				)
 
-				consumer := consumerFunc(func(_ context.Context, records []record) error {
+				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 					consumedRecordsMx.Lock()
 					defer consumedRecordsMx.Unlock()
 
-					for _, r := range records {
-						consumedRecords = append(consumedRecords, string(r.content))
+					for r := range records {
+						consumedRecords = append(consumedRecords, string(r.Value))
 					}
 					return nil
 				})
@@ -1049,12 +1049,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 					consumedRecords      []string
 				)
 
-				consumer := consumerFunc(func(_ context.Context, records []record) error {
+				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 					consumedRecordsMx.Lock()
 					defer consumedRecordsMx.Unlock()
 
-					for _, r := range records {
-						consumedRecords = append(consumedRecords, string(r.content))
+					for r := range records {
+						consumedRecords = append(consumedRecords, string(r.Value))
 					}
 					return nil
 				})
@@ -1180,12 +1180,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 					consumedRecords      []string
 				)
 
-				consumer := consumerFunc(func(_ context.Context, records []record) error {
+				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 					consumedRecordsMx.Lock()
 					defer consumedRecordsMx.Unlock()
 
-					for _, r := range records {
-						consumedRecords = append(consumedRecords, string(r.content))
+					for r := range records {
+						consumedRecords = append(consumedRecords, string(r.Value))
 					}
 					return nil
 				})
@@ -1296,12 +1296,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 					consumedRecords      []string
 				)
 
-				consumer := consumerFunc(func(_ context.Context, records []record) error {
+				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 					consumedRecordsMx.Lock()
 					defer consumedRecordsMx.Unlock()
 
-					for _, r := range records {
-						consumedRecords = append(consumedRecords, string(r.content))
+					for r := range records {
+						consumedRecords = append(consumedRecords, string(r.Value))
 					}
 					return nil
 				})
@@ -1418,9 +1418,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 					close(testDone)
 				})
 
-				consumer := consumerFunc(func(_ context.Context, _ []record) error {
-					return nil
-				})
+				consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 
 				cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 					cluster.KeepControl()
@@ -1506,7 +1504,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 				var (
 					cluster, clusterAddr     = testkafka.CreateCluster(t, partitionID+1, topicName)
-					consumer                 = consumerFunc(func(context.Context, []record) error { return nil })
+					consumer                 = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 					listOffsetsRequestsCount = atomic.NewInt64(0)
 					contextCancelled         = atomic.NewBool(false)
 				)
@@ -1580,7 +1578,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 
 				var (
 					cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					consumer             = consumerFunc(func(context.Context, []record) error { return nil })
+					consumer             = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 					fetchRequestsCount   = atomic.NewInt64(0)
 				)
 
@@ -1646,9 +1644,7 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 						ctx, cancel := context.WithCancel(context.Background())
 						t.Cleanup(cancel)
 
-						consumer := consumerFunc(func(context.Context, []record) error {
-							return nil
-						})
+						consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 
 						cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
 						cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
@@ -1733,12 +1729,12 @@ func TestPartitionReader_ConsumeAtStartup(t *testing.T) {
 			consumedRecords      []string
 		)
 
-		consumer := consumerFunc(func(_ context.Context, records []record) error {
+		consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 			consumedRecordsMx.Lock()
 			defer consumedRecordsMx.Unlock()
 
-			for _, r := range records {
-				consumedRecords = append(consumedRecords, string(r.content))
+			for r := range records {
+				consumedRecords = append(consumedRecords, string(r.Value))
 			}
 			return nil
 		})
@@ -1893,7 +1889,7 @@ func TestPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhenDone(t *testi
 				blocked           = atomic.NewBool(false)
 			)
 
-			consumer := consumerFunc(func(_ context.Context, records []record) error {
+			consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 				if blocked.Load() {
 					blockedTicker := time.NewTicker(100 * time.Millisecond)
 					defer blockedTicker.Stop()
@@ -1918,8 +1914,8 @@ func TestPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhenDone(t *testi
 
 				consumedRecordsMx.Lock()
 				defer consumedRecordsMx.Unlock()
-				for _, r := range records {
-					consumedRecords = append(consumedRecords, string(r.content))
+				for r := range records {
+					consumedRecords = append(consumedRecords, string(r.Value))
 				}
 				return nil
 			})
@@ -2154,12 +2150,12 @@ func TestPartitionReader_ShouldNotMissRecordsIfFetchRequestContainPartialFailure
 		consumedRecordIDs    = sync.Map{}
 	)
 
-	consumer := consumerFunc(func(_ context.Context, records []record) error {
-		for _, rec := range records {
+	consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+		for rec := range records {
 			totalConsumedRecords.Inc()
 
 			// Parse the record ID from the actual record data.
-			recordID, err := strconv.ParseInt(string(rec.content[7:12]), 10, 64)
+			recordID, err := strconv.ParseInt(string(rec.Value[7:12]), 10, 64)
 			require.NoError(t, err)
 			consumedRecordIDs.Store(recordID, struct{}{})
 		}
@@ -2294,12 +2290,12 @@ func TestPartitionReader_ShouldNotMissRecordsIfKafkaReturnsAFetchBothWithAnError
 				consumedRecordIDs    = sync.Map{}
 			)
 
-			consumer := consumerFunc(func(_ context.Context, records []record) error {
-				for _, rec := range records {
+			consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+				for rec := range records {
 					totalConsumedRecords.Inc()
 
 					// Parse the record ID from the actual record data.
-					recordID, err := strconv.ParseInt(string(rec.content[7:12]), 10, 64)
+					recordID, err := strconv.ParseInt(string(rec.Value[7:12]), 10, 64)
 					require.NoError(t, err)
 					consumedRecordIDs.Store(recordID, struct{}{})
 				}
@@ -2363,7 +2359,7 @@ func TestPartitionReader_fetchLastCommittedOffset(t *testing.T) {
 
 		var (
 			cluster, clusterAddr = testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitionID+1, topicName)
-			consumer             = consumerFunc(func(context.Context, []record) error { return nil })
+			consumer             = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 			reader               = createReader(t, clusterAddr, topicName, partitionID, consumer, withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second))
 		)
 
@@ -2394,7 +2390,7 @@ func TestPartitionReader_fetchLastCommittedOffset(t *testing.T) {
 
 		var (
 			cluster, clusterAddr = testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitionID+1, topicName)
-			consumer             = consumerFunc(func(context.Context, []record) error { return nil })
+			consumer             = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 			reader               = createReader(t, clusterAddr, topicName, partitionID, consumer, withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second))
 		)
 
@@ -2435,7 +2431,7 @@ func TestPartitionReader_fetchLastCommittedOffset(t *testing.T) {
 
 		var (
 			cluster, clusterAddr = testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitionID+1, topicName)
-			consumer             = consumerFunc(func(context.Context, []record) error { return nil })
+			consumer             = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 			reader               = createReader(t, clusterAddr, topicName, partitionID, consumer, withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second))
 		)
 
@@ -2932,17 +2928,17 @@ func TestPartitionReader_Commit(t *testing.T) {
 }
 
 type testConsumer struct {
-	records chan record
+	records chan *kgo.Record
 }
 
 func newTestConsumer(capacity int) testConsumer {
 	return testConsumer{
-		records: make(chan record, capacity),
+		records: make(chan *kgo.Record, capacity),
 	}
 }
 
-func (t testConsumer) Consume(ctx context.Context, records []record) error {
-	for _, r := range records {
+func (t testConsumer) Consume(ctx context.Context, records iter.Seq[*kgo.Record]) error {
+	for r := range records {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -2961,13 +2957,13 @@ func (t testConsumer) waitRecords(numRecords int, waitTimeout, drainPeriod time.
 	recs, err := t.waitRecordsAndMetadata(numRecords, waitTimeout, drainPeriod)
 	var content [][]byte
 	for _, rec := range recs {
-		content = append(content, rec.content)
+		content = append(content, rec.Value)
 	}
 	return content, err
 }
 
-func (t testConsumer) waitRecordsAndMetadata(numRecords int, waitTimeout, drainPeriod time.Duration) ([]record, error) {
-	var records []record
+func (t testConsumer) waitRecordsAndMetadata(numRecords int, waitTimeout, drainPeriod time.Duration) ([]*kgo.Record, error) {
+	var records []*kgo.Record
 	timeout := time.After(waitTimeout)
 	for {
 		select {
@@ -2989,9 +2985,9 @@ func (t testConsumer) waitRecordsAndMetadata(numRecords int, waitTimeout, drainP
 	}
 }
 
-type consumerFunc func(ctx context.Context, records []record) error
+type consumerFunc func(ctx context.Context, records iter.Seq[*kgo.Record]) error
 
-func (c consumerFunc) Consume(ctx context.Context, records []record) error {
+func (c consumerFunc) Consume(ctx context.Context, records iter.Seq[*kgo.Record]) error {
 	return c(ctx, records)
 }
 


### PR DESCRIPTION
#### What this PR does

The PR updates internals of `pkg/storage/ingest`. Now, the `recordConsumer.Consume` accepts an iterator over Kafka records, `iter.Seq[*kgo.Record]`. 

Following the discussion in https://github.com/grafana/mimir/pull/12443#discussion_r2294389113, we want the block-builder to reuse the `pusherConsumer`, but we want to avoid exposing the existing `record` data structs. Instead of expanding the existing interface, I propose we refactor the `recordConsumer` and get rid of the intermediate `record` data type completely.

---

I checked the benchmarks of the `PusherConsumer`, and, although this wasn't planned, I got some positive results from the refactoring (_I didn't investigate if the results represent real use case, or this is just a side effect of the benchmarks themselves_):

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/storage/ingest
cpu: Apple M2
                                   │   1.bench   │              2.bench               │
                                   │   sec/op    │   sec/op     vs base               │
PusherConsumer/sequential_pusher-8   332.6µ ± 0%   333.7µ ± 0%       ~ (p=0.089 n=10)
PusherConsumer/parallel_pusher-8     332.1µ ± 0%   334.0µ ± 0%  +0.59% (p=0.003 n=10)
geomean                              332.4µ        333.9µ       +0.46%

                                   │   1.bench    │               2.bench               │
                                   │     B/op     │     B/op      vs base               │
PusherConsumer/sequential_pusher-8   41.05Ki ± 0%   40.41Ki ± 0%  -1.57% (p=0.000 n=10)
PusherConsumer/parallel_pusher-8     41.64Ki ± 0%   40.97Ki ± 0%  -1.61% (p=0.000 n=10)
geomean                              41.35Ki        40.69Ki       -1.59%

                                   │  1.bench   │              2.bench              │
                                   │ allocs/op  │ allocs/op   vs base               │
PusherConsumer/sequential_pusher-8   564.0 ± 0%   519.0 ± 0%  -7.98% (p=0.000 n=10)
PusherConsumer/parallel_pusher-8     570.0 ± 0%   525.0 ± 0%  -7.89% (p=0.000 n=10)
geomean                              567.0        522.0       -7.94%
```

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
