### PR TITLE
MQE: simplify `RangeVectorOperator` interface

### DIFF
--- a/pkg/streamingpromql/operators/functions/common.go
+++ b/pkg/streamingpromql/operators/functions/common.go
@@ -80,7 +80,6 @@ func PassthroughData(seriesData types.InstantVectorSeriesData, _ []types.ScalarD
 //   - err error.
 type RangeVectorStepFunction func(
 	step *types.RangeVectorStepData,
-	rangeSeconds float64,
 	scalarArgsData []types.ScalarData,
 	timeRange types.QueryTimeRange,
 	emitAnnotation types.EmitAnnotationFunc,

--- a/pkg/streamingpromql/operators/functions/function_over_range_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_range_vector.go
@@ -32,8 +32,7 @@ type FunctionOverRangeVector struct {
 	metricNames        *operators.MetricNames
 	currentSeriesIndex int
 
-	timeRange    types.QueryTimeRange
-	rangeSeconds float64
+	timeRange types.QueryTimeRange
 
 	expressionPosition   posrange.PositionRange
 	emitAnnotationFunc   types.EmitAnnotationFunc
@@ -92,8 +91,6 @@ func (m *FunctionOverRangeVector) SeriesMetadata(ctx context.Context) ([]types.S
 		m.metricNames.CaptureMetricNames(metadata)
 	}
 
-	m.rangeSeconds = m.Inner.Range().Seconds()
-
 	if m.Func.SeriesMetadataFunction.Func != nil {
 		return m.Func.SeriesMetadataFunction.Func(metadata, m.MemoryConsumptionTracker)
 	}
@@ -144,7 +141,7 @@ func (m *FunctionOverRangeVector) NextSeries(ctx context.Context) (types.Instant
 			return types.InstantVectorSeriesData{}, err
 		}
 
-		f, hasFloat, h, err := m.Func.StepFunc(step, m.rangeSeconds, m.scalarArgsData, m.timeRange, m.emitAnnotationFunc, m.MemoryConsumptionTracker)
+		f, hasFloat, h, err := m.Func.StepFunc(step, m.scalarArgsData, m.timeRange, m.emitAnnotationFunc, m.MemoryConsumptionTracker)
 		if err != nil {
 			return types.InstantVectorSeriesData{}, err
 		}

--- a/pkg/streamingpromql/operators/functions/range_vectors.go
+++ b/pkg/streamingpromql/operators/functions/range_vectors.go
@@ -24,7 +24,7 @@ var CountOverTime = FunctionOverRangeVectorDefinition{
 	StepFunc:               countOverTime,
 }
 
-func countOverTime(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func countOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	fPointCount := step.Floats.Count()
 	hPointCount := step.Histograms.Count()
 
@@ -40,7 +40,7 @@ var LastOverTime = FunctionOverRangeVectorDefinition{
 	StepFunc: lastOverTime,
 }
 
-func lastOverTime(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func lastOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	lastFloat, floatAvailable := step.Floats.Last()
 	lastHistogram, histogramAvailable := step.Histograms.Last()
 
@@ -61,7 +61,7 @@ var PresentOverTime = FunctionOverRangeVectorDefinition{
 	StepFunc:               presentOverTime,
 }
 
-func presentOverTime(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func presentOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	if step.Floats.Any() || step.Histograms.Any() {
 		return 1, true, nil, nil
 	}
@@ -75,7 +75,7 @@ var MaxOverTime = FunctionOverRangeVectorDefinition{
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func maxOverTime(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func maxOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	head, tail := step.Floats.UnsafePoints()
 
 	if len(head) == 0 && len(tail) == 0 {
@@ -110,7 +110,7 @@ var MinOverTime = FunctionOverRangeVectorDefinition{
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func minOverTime(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func minOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	head, tail := step.Floats.UnsafePoints()
 
 	if len(head) == 0 && len(tail) == 0 {
@@ -145,7 +145,7 @@ var SumOverTime = FunctionOverRangeVectorDefinition{
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func sumOverTime(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func sumOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	fHead, fTail := step.Floats.UnsafePoints()
 	hHead, hTail := step.Histograms.UnsafePoints()
 
@@ -210,7 +210,7 @@ var AvgOverTime = FunctionOverRangeVectorDefinition{
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func avgOverTime(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func avgOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	fHead, fTail := step.Floats.UnsafePoints()
 	hHead, hTail := step.Histograms.UnsafePoints()
 
@@ -360,7 +360,7 @@ var Resets = FunctionOverRangeVectorDefinition{
 }
 
 func resetsChanges(isReset bool) RangeVectorStepFunction {
-	return func(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+	return func(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 		fHead, fTail := step.Floats.UnsafePoints()
 		hHead, hTail := step.Histograms.UnsafePoints()
 
@@ -486,7 +486,7 @@ var Deriv = FunctionOverRangeVectorDefinition{
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func deriv(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func deriv(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	fHead, fTail := step.Floats.UnsafePoints()
 
 	if step.Floats.Any() && step.Histograms.Any() {
@@ -508,7 +508,7 @@ var PredictLinear = FunctionOverRangeVectorDefinition{
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func predictLinear(step *types.RangeVectorStepData, _ float64, args []types.ScalarData, timeRange types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func predictLinear(step *types.RangeVectorStepData, args []types.ScalarData, timeRange types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	fHead, fTail := step.Floats.UnsafePoints()
 
 	if step.Floats.Any() && step.Histograms.Any() {
@@ -589,7 +589,7 @@ var Idelta = FunctionOverRangeVectorDefinition{
 }
 
 func irateIdelta(isRate bool) RangeVectorStepFunction {
-	return func(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+	return func(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 		// We need at least two samples to calculate irate or idelta
 		floatCount := step.Floats.Count()
 		histogramCount := step.Histograms.Count()
@@ -736,7 +736,7 @@ var StdvarOverTime = FunctionOverRangeVectorDefinition{
 }
 
 func stddevStdvarOverTime(isStdDev bool) RangeVectorStepFunction {
-	return func(step *types.RangeVectorStepData, _ float64, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+	return func(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 		head, tail := step.Floats.UnsafePoints()
 
 		if len(head) == 0 && len(tail) == 0 {
@@ -782,7 +782,7 @@ var QuantileOverTime = FunctionOverRangeVectorDefinition{
 	UseFirstArgumentPositionForAnnotations: true,
 }
 
-func quantileOverTime(step *types.RangeVectorStepData, _ float64, args []types.ScalarData, timeRange types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func quantileOverTime(step *types.RangeVectorStepData, args []types.ScalarData, timeRange types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	if !step.Floats.Any() {
 		return 0, false, nil, nil
 	}
@@ -831,7 +831,7 @@ var DoubleExponentialSmoothing = FunctionOverRangeVectorDefinition{
 // affects how trends in historical data will affect the current data. A higher
 // trend factor increases the influence. of trends. Algorithm taken from
 // https://en.wikipedia.org/wiki/Exponential_smoothing .
-func doubleExponentialSmoothing(step *types.RangeVectorStepData, _ float64, args []types.ScalarData, timeRange types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func doubleExponentialSmoothing(step *types.RangeVectorStepData, args []types.ScalarData, timeRange types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	if !step.Floats.Any() && !step.Histograms.Any() {
 		return 0, false, nil, nil
 	}

--- a/pkg/streamingpromql/operators/functions/rate_increase.go
+++ b/pkg/streamingpromql/operators/functions/rate_increase.go
@@ -38,7 +38,7 @@ var Delta = FunctionOverRangeVectorDefinition{
 
 // isRate is true for `rate` function, or false for `instant` function
 func rate(isRate bool) RangeVectorStepFunction {
-	return func(step *types.RangeVectorStepData, rangeSeconds float64, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+	return func(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 		fHead, fTail := step.Floats.UnsafePoints()
 		fCount := len(fHead) + len(fTail)
 
@@ -51,6 +51,8 @@ func rate(isRate bool) RangeVectorStepFunction {
 			emitAnnotation(annotations.NewMixedFloatsHistogramsWarning)
 			return 0, false, nil, nil
 		}
+
+		rangeSeconds := float64(step.RangeEnd-step.RangeStart) / 1000
 
 		if fCount >= 2 {
 			// TODO: just pass step here? (and below)
@@ -309,7 +311,7 @@ func rateSeriesValidator() RangeVectorSeriesValidationFunction {
 	}
 }
 
-func delta(step *types.RangeVectorStepData, rangeSeconds float64, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func delta(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	fHead, fTail := step.Floats.UnsafePoints()
 	fCount := len(fHead) + len(fTail)
 
@@ -322,6 +324,8 @@ func delta(step *types.RangeVectorStepData, rangeSeconds float64, _ []types.Scal
 		emitAnnotation(annotations.NewMixedFloatsHistogramsWarning)
 		return 0, false, nil, nil
 	}
+
+	rangeSeconds := float64(step.RangeEnd-step.RangeStart) / 1000
 
 	if fCount >= 2 {
 		val := floatDelta(fCount, fHead, fTail, step.RangeStart, step.RangeEnd, rangeSeconds)

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -8,7 +8,6 @@ package selectors
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/promql"
@@ -51,10 +50,6 @@ func (m *RangeVectorSelector) SeriesMetadata(ctx context.Context) ([]types.Serie
 	m.rangeMilliseconds = m.Selector.Range.Milliseconds()
 
 	return m.Selector.SeriesMetadata(ctx)
-}
-
-func (m *RangeVectorSelector) Range() time.Duration {
-	return m.Selector.Range
 }
 
 func (m *RangeVectorSelector) NextSeries(ctx context.Context) error {

--- a/pkg/streamingpromql/operators/subquery.go
+++ b/pkg/streamingpromql/operators/subquery.go
@@ -20,7 +20,6 @@ type Subquery struct {
 
 	SubqueryTimestamp *int64 // Milliseconds since Unix epoch, only set if selector uses @ modifier (eg. metric{...} @ 123)
 	SubqueryOffset    int64  // In milliseconds
-	SubqueryRange     time.Duration
 
 	expressionPosition posrange.PositionRange
 
@@ -60,7 +59,6 @@ func NewSubquery(
 		SubqueryTimeRange:        subqueryTimeRange,
 		SubqueryTimestamp:        subqueryTimestamp,
 		SubqueryOffset:           subqueryOffset.Milliseconds(),
-		SubqueryRange:            subqueryRange,
 		expressionPosition:       expressionPosition,
 		rangeMilliseconds:        subqueryRange.Milliseconds(),
 		floats:                   types.NewFPointRingBuffer(memoryConsumptionTracker),
@@ -159,10 +157,6 @@ func (s *Subquery) samplesProcessedInSubqueryPerParentStep(step *types.RangeVect
 	}
 
 	return sum
-}
-
-func (s *Subquery) Range() time.Duration {
-	return s.SubqueryRange
 }
 
 func (s *Subquery) ExpressionPosition() posrange.PositionRange {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 
@@ -308,10 +307,6 @@ func (d *RangeVectorDuplicationConsumer) NextSeries(ctx context.Context) error {
 
 func (d *RangeVectorDuplicationConsumer) NextStepSamples() (*types.RangeVectorStepData, error) {
 	return d.Buffer.NextStepSamples(d.consumerIndex)
-}
-
-func (d *RangeVectorDuplicationConsumer) Range() time.Duration {
-	return d.Buffer.Inner.Range()
 }
 
 func (d *RangeVectorDuplicationConsumer) ExpressionPosition() posrange.PositionRange {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -461,10 +461,6 @@ func (t *testRangeVectorOperator) ExpressionPosition() posrange.PositionRange {
 	return posrange.PositionRange{}
 }
 
-func (t *testRangeVectorOperator) Range() time.Duration {
-	return t.stepRange
-}
-
 func (t *testRangeVectorOperator) Prepare(_ context.Context, _ *types.PrepareParams) error {
 	// Nothing to do.
 	return nil

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -5,7 +5,6 @@ package types
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 )
@@ -55,11 +54,6 @@ type InstantVectorOperator interface {
 // RangeVectorOperator represents all operators that produce range vectors.
 type RangeVectorOperator interface {
 	SeriesOperator
-
-	// Range returns the time range selected by this operator at each time step.
-	//
-	// For example, if this operator represents the selector "some_metric[5m]", Range returns 5 minutes.
-	Range() time.Duration
 
 	// NextSeries advances to the next series produced by this operator, or EOS if no more series are available.
 	// SeriesMetadata must be called exactly once before calling NextSeries.


### PR DESCRIPTION
#### What this PR does

This PR removes the `StepCount` and `Range` methods from the `RangeVectorOperator` interface.

`StepCount` wasn't used anywhere, and `Range` was only used for a select few range vector functions. 

Despite now needing to compute the range on every step, removing `Range` seems to have had a neutral (or possibly even slightly positive) impact on latency in our benchmarks for range vector functions like `rate`.

I've opted not to add a changelog entry given this is an internal refactoring with no user-visible impact.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
