### PR TITLE
MQE: introduce `Finalize` method to operators

### DIFF
--- a/pkg/streamingpromql/evaluator.go
+++ b/pkg/streamingpromql/evaluator.go
@@ -121,7 +121,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, observer EvaluationObserver) e
 	}
 
 	if e.engine.pedantic {
-		// Finalize the root operator a second time to ensure all operators behave correctly if Close is called multiple times.
+		// Finalize the root operator a second time to ensure all operators behave correctly if Finalize is called multiple times.
 		if err := e.root.Finalize(ctx); err != nil {
 			return fmt.Errorf("pedantic mode: failed to finalize operator a second time after successfully finalizing the first time: %w", err)
 		}

--- a/pkg/streamingpromql/evaluator.go
+++ b/pkg/streamingpromql/evaluator.go
@@ -87,8 +87,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, observer EvaluationObserver) e
 
 	defer e.engine.activeQueryTracker.Delete(queryID)
 
-	err = e.root.Prepare(ctx, &types.PrepareParams{QueryStats: e.stats})
-	if err != nil {
+	if err := e.root.Prepare(ctx, &types.PrepareParams{QueryStats: e.stats}); err != nil {
 		return fmt.Errorf("failed to prepare query: %w", err)
 	}
 
@@ -115,6 +114,17 @@ func (e *Evaluator) Evaluate(ctx context.Context, observer EvaluationObserver) e
 
 	default:
 		return fmt.Errorf("operator type %T produces unknown result type", root)
+	}
+
+	if err := e.root.Finalize(ctx); err != nil {
+		return err
+	}
+
+	if e.engine.pedantic {
+		// Finalize the root operator a second time to ensure all operators behave correctly if Close is called multiple times.
+		if err := e.root.Finalize(ctx); err != nil {
+			return fmt.Errorf("pedantic mode: failed to finalize operator a second time after successfully finalizing the first time: %w", err)
+		}
 	}
 
 	// To make comparing to Prometheus' engine easier, only return the annotations if there are some, otherwise, return nil.

--- a/pkg/streamingpromql/operators/aggregations/aggregation.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation.go
@@ -280,6 +280,10 @@ func (a *Aggregation) Prepare(ctx context.Context, params *types.PrepareParams) 
 	return a.Inner.Prepare(ctx, params)
 }
 
+func (a *Aggregation) Finalize(ctx context.Context) error {
+	return a.Inner.Finalize(ctx)
+}
+
 func (a *Aggregation) Close() {
 	// The wrapping operator is responsible for returning any a.ParamData slice
 	// since it is responsible for setting them up.

--- a/pkg/streamingpromql/operators/aggregations/count_values.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values.go
@@ -252,6 +252,10 @@ func (c *CountValues) Prepare(ctx context.Context, params *types.PrepareParams) 
 	return c.Inner.Prepare(ctx, params)
 }
 
+func (c *CountValues) Finalize(ctx context.Context) error {
+	return c.Inner.Finalize(ctx)
+}
+
 func (c *CountValues) Close() {
 	c.Inner.Close()
 	c.LabelName.Close()

--- a/pkg/streamingpromql/operators/aggregations/quantile.go
+++ b/pkg/streamingpromql/operators/aggregations/quantile.go
@@ -86,12 +86,19 @@ func (q *QuantileAggregation) NextSeries(ctx context.Context) (types.InstantVect
 }
 
 func (q *QuantileAggregation) Prepare(ctx context.Context, params *types.PrepareParams) error {
-	err := q.Aggregation.Prepare(ctx, params)
-	if err != nil {
+	if err := q.Aggregation.Prepare(ctx, params); err != nil {
 		return err
 	}
 
 	return q.Param.Prepare(ctx, params)
+}
+
+func (q *QuantileAggregation) Finalize(ctx context.Context) error {
+	if err := q.Aggregation.Finalize(ctx); err != nil {
+		return err
+	}
+
+	return q.Param.Finalize(ctx)
 }
 
 func (q *QuantileAggregation) Close() {

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
@@ -301,6 +301,14 @@ func (t *InstantQuery) Prepare(ctx context.Context, params *types.PrepareParams)
 	return t.Param.Prepare(ctx, params)
 }
 
+func (t *InstantQuery) Finalize(ctx context.Context) error {
+	if err := t.Inner.Finalize(ctx); err != nil {
+		return err
+	}
+
+	return t.Param.Finalize(ctx)
+}
+
 func (t *InstantQuery) Close() {
 	t.Inner.Close()
 	t.Param.Close()

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
@@ -423,6 +423,14 @@ func (t *RangeQuery) Prepare(ctx context.Context, params *types.PrepareParams) e
 	return t.Param.Prepare(ctx, params)
 }
 
+func (t *RangeQuery) Finalize(ctx context.Context) error {
+	if err := t.Inner.Finalize(ctx); err != nil {
+		return err
+	}
+
+	return t.Param.Finalize(ctx)
+}
+
 func (t *RangeQuery) Close() {
 	t.Inner.Close()
 	t.Param.Close()

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
@@ -56,18 +56,33 @@ func NewAndUnlessBinaryOperation(
 }
 
 func (a *AndUnlessBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
-	defer func() {
-		if a.lastLeftSeriesIndexToRead == -1 {
-			// We're not going to read anything from the left side, close it now.
-			a.Left.Close()
+	series, err := a.computeSeriesMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if a.lastLeftSeriesIndexToRead == -1 {
+		// We're not going to read anything from the left side, close it now.
+		if err := a.Left.Finalize(ctx); err != nil {
+			return nil, err
 		}
 
-		if a.lastRightSeriesIndexToRead == -1 {
-			// We're not going to read anything from the right side, close it now.
-			a.Right.Close()
-		}
-	}()
+		a.Left.Close()
+	}
 
+	if a.lastRightSeriesIndexToRead == -1 {
+		// We're not going to read anything from the right side, close it now.
+		if err := a.Right.Finalize(ctx); err != nil {
+			return nil, err
+		}
+
+		a.Right.Close()
+	}
+
+	return series, nil
+}
+
+func (a *AndUnlessBinaryOperation) computeSeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
 	leftMetadata, err := a.Left.SeriesMetadata(ctx)
 	if err != nil {
 		return nil, err
@@ -172,14 +187,25 @@ func (a *AndUnlessBinaryOperation) computeUnlessSeriesMetadata(leftMetadata []ty
 }
 
 func (a *AndUnlessBinaryOperation) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
-	defer func() {
-		// If we're done reading the left side, close it so it can release any resources as early as possible.
-		// We do the same thing for the right side in readRightSideUntilGroupComplete.
-		if a.nextLeftSeriesIndex > a.lastLeftSeriesIndexToRead {
-			a.Left.Close()
-		}
-	}()
+	d, err := a.computeNextSeries(ctx)
+	if err != nil {
+		return types.InstantVectorSeriesData{}, err
+	}
 
+	// If we're done reading the left side, close it so it can release any resources as early as possible.
+	// We do the same thing for the right side in readRightSideUntilGroupComplete.
+	if a.nextLeftSeriesIndex > a.lastLeftSeriesIndexToRead {
+		if err := a.Left.Finalize(ctx); err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
+
+		a.Left.Close()
+	}
+
+	return d, nil
+}
+
+func (a *AndUnlessBinaryOperation) computeNextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
 	for {
 		if len(a.leftSeriesGroups) == 0 {
 			// No more series to return.
@@ -258,6 +284,10 @@ func (a *AndUnlessBinaryOperation) readRightSideUntilGroupComplete(ctx context.C
 
 	// If we're done reading the right side, close it so it can release any resources as early as possible.
 	if a.nextRightSeriesIndex > a.lastRightSeriesIndexToRead {
+		if err := a.Right.Finalize(ctx); err != nil {
+			return err
+		}
+
 		a.Right.Close()
 	}
 
@@ -269,11 +299,19 @@ func (a *AndUnlessBinaryOperation) ExpressionPosition() posrange.PositionRange {
 }
 
 func (a *AndUnlessBinaryOperation) Prepare(ctx context.Context, params *types.PrepareParams) error {
-	err := a.Left.Prepare(ctx, params)
-	if err != nil {
+	if err := a.Left.Prepare(ctx, params); err != nil {
 		return err
 	}
+
 	return a.Right.Prepare(ctx, params)
+}
+
+func (a *AndUnlessBinaryOperation) Finalize(ctx context.Context) error {
+	if err := a.Left.Finalize(ctx); err != nil {
+		return err
+	}
+
+	return a.Right.Finalize(ctx)
 }
 
 func (a *AndUnlessBinaryOperation) Close() {

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -327,14 +327,18 @@ func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testin
 			}
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, left.Finalized, "left side should be finalized after SeriesMetadata, but it is not")
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
 			} else {
+				require.False(t, left.Finalized, "left side should not be finalized after SeriesMetadata, but it is")
 				require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
 			}
 
 			if testCase.expectRightSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, right.Finalized, "right side should be finalized after SeriesMetadata, but it is not")
 				require.True(t, right.Closed, "right side should be closed after SeriesMetadata, but it is not")
 			} else {
+				require.False(t, right.Finalized, "right side should not be finalized after SeriesMetadata, but it is")
 				require.False(t, right.Closed, "right side should not be closed after SeriesMetadata, but it is")
 			}
 
@@ -343,14 +347,18 @@ func TestAndUnlessBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testin
 				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
 
 				if outputSeriesIdx >= testCase.expectLeftSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, left.Finalized, "left side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
 					require.Truef(t, left.Closed, "left side should be closed after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
+					require.Falsef(t, left.Finalized, "left side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
 					require.Falsef(t, left.Closed, "left side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 
 				if outputSeriesIdx >= testCase.expectRightSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, right.Finalized, "right side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
 					require.Truef(t, right.Closed, "right side should be closed after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
+					require.Falsef(t, right.Finalized, "right side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
 					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -485,14 +485,18 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 			}
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, left.Finalized, "left side should be finalized after SeriesMetadata, but it is not")
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
 			} else {
+				require.False(t, left.Finalized, "left side should not be finalized after SeriesMetadata, but it is")
 				require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
 			}
 
 			if testCase.expectRightSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, right.Finalized, "right side should be finalized after SeriesMetadata, but it is not")
 				require.True(t, right.Closed, "right side should be closed after SeriesMetadata, but it is not")
 			} else {
+				require.False(t, right.Finalized, "right side should not be finalized after SeriesMetadata, but it is")
 				require.False(t, right.Closed, "right side should not be closed after SeriesMetadata, but it is")
 			}
 
@@ -501,14 +505,18 @@ func TestGroupedVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible
 				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
 
 				if outputSeriesIdx >= testCase.expectLeftSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, left.Finalized, "left side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
 					require.Truef(t, left.Closed, "left side should be closed after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
+					require.Falsef(t, left.Finalized, "left side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
 					require.Falsef(t, left.Closed, "left side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 
 				if outputSeriesIdx >= testCase.expectRightSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, right.Finalized, "right side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
 					require.Truef(t, right.Closed, "right side should be closed after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
+					require.Falsef(t, right.Finalized, "right side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
 					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -638,14 +638,18 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 			}
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, left.Finalized, "left side should be finalized after SeriesMetadata, but it is not")
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
 			} else {
+				require.False(t, left.Finalized, "left side should not be finalized after SeriesMetadata, but it is")
 				require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
 			}
 
 			if testCase.expectRightSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, right.Finalized, "right side should be finalized after SeriesMetadata, but it is not")
 				require.True(t, right.Closed, "right side should be closed after SeriesMetadata, but it is not")
 			} else {
+				require.False(t, right.Finalized, "right side should not be finalized after SeriesMetadata, but it is")
 				require.False(t, right.Closed, "right side should not be closed after SeriesMetadata, but it is")
 			}
 
@@ -654,14 +658,18 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
 
 				if outputSeriesIdx >= testCase.expectLeftSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, left.Finalized, "left side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
 					require.Truef(t, left.Closed, "left side should be closed after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
+					require.Falsef(t, left.Finalized, "left side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
 					require.Falsef(t, left.Closed, "left side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 
 				if outputSeriesIdx >= testCase.expectRightSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, right.Finalized, "right side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
 					require.Truef(t, right.Closed, "right side should be closed after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
+					require.Falsef(t, right.Finalized, "right side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
 					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}

--- a/pkg/streamingpromql/operators/binops/or_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation.go
@@ -76,7 +76,16 @@ func (o *OrBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesM
 		types.SeriesMetadataSlicePool.Put(&leftMetadata, o.MemoryConsumptionTracker)
 		types.SeriesMetadataSlicePool.Put(&rightMetadata, o.MemoryConsumptionTracker)
 
+		if err := o.Left.Finalize(ctx); err != nil {
+			return nil, err
+		}
+
 		o.Left.Close()
+
+		if err := o.Right.Finalize(ctx); err != nil {
+			return nil, err
+		}
+
 		o.Right.Close()
 
 		return nil, nil
@@ -88,6 +97,10 @@ func (o *OrBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesM
 		o.rightSeriesCount = []int{len(rightMetadata)}
 		types.SeriesMetadataSlicePool.Put(&leftMetadata, o.MemoryConsumptionTracker)
 
+		if err := o.Left.Finalize(ctx); err != nil {
+			return nil, err
+		}
+
 		o.Left.Close()
 
 		return rightMetadata, nil
@@ -98,6 +111,10 @@ func (o *OrBinaryOperation) SeriesMetadata(ctx context.Context) ([]types.SeriesM
 		o.nextSeriesIsFromLeft = true
 		o.leftSeriesCount = []int{len(leftMetadata)}
 		types.SeriesMetadataSlicePool.Put(&rightMetadata, o.MemoryConsumptionTracker)
+
+		if err := o.Right.Finalize(ctx); err != nil {
+			return nil, err
+		}
 
 		o.Right.Close()
 
@@ -238,37 +255,38 @@ func (o *OrBinaryOperation) NextSeries(ctx context.Context) (types.InstantVector
 	}
 
 	if o.nextSeriesIsFromLeft {
-		o.leftSeriesCount[0]--
-
-		if o.leftSeriesCount[0] == 0 {
-			o.nextSeriesIsFromLeft = false
-			o.leftSeriesCount = o.leftSeriesCount[1:]
-
-			if len(o.leftSeriesCount) == 0 {
-				// No more series from left side remaining, close it after we read this next series.
-				defer o.Left.Close()
-			}
-		}
-
 		return o.nextLeftSeries(ctx)
-	}
-
-	o.rightSeriesCount[0]--
-
-	if o.rightSeriesCount[0] == 0 {
-		o.nextSeriesIsFromLeft = true
-		o.rightSeriesCount = o.rightSeriesCount[1:]
-
-		if len(o.rightSeriesCount) == 0 {
-			// No more series from right side remaining, close it after we read this next series.
-			defer o.Right.Close()
-		}
 	}
 
 	return o.nextRightSeries(ctx)
 }
 
 func (o *OrBinaryOperation) nextLeftSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+	o.leftSeriesCount[0]--
+
+	if o.leftSeriesCount[0] == 0 {
+		o.nextSeriesIsFromLeft = false
+		o.leftSeriesCount = o.leftSeriesCount[1:]
+	}
+
+	d, err := o.readNextLeftSeries(ctx)
+	if err != nil {
+		return types.InstantVectorSeriesData{}, err
+	}
+
+	if len(o.leftSeriesCount) == 0 {
+		// No more series from left side remaining, close it.
+		if err := o.Left.Finalize(ctx); err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
+
+		o.Left.Close()
+	}
+
+	return d, nil
+}
+
+func (o *OrBinaryOperation) readNextLeftSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
 	data, err := o.Left.NextSeries(ctx)
 	if err != nil {
 		return types.InstantVectorSeriesData{}, err
@@ -292,6 +310,32 @@ func (o *OrBinaryOperation) nextLeftSeries(ctx context.Context) (types.InstantVe
 }
 
 func (o *OrBinaryOperation) nextRightSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+	o.rightSeriesCount[0]--
+
+	if o.rightSeriesCount[0] == 0 {
+		o.nextSeriesIsFromLeft = true
+		o.rightSeriesCount = o.rightSeriesCount[1:]
+	}
+
+	d, err := o.readNextRightSeries(ctx)
+
+	if err != nil {
+		return types.InstantVectorSeriesData{}, err
+	}
+
+	if len(o.rightSeriesCount) == 0 {
+		// No more series from right side remaining, close it after we read this next series.
+		if err := o.Right.Finalize(ctx); err != nil {
+			return types.InstantVectorSeriesData{}, err
+		}
+
+		o.Right.Close()
+	}
+
+	return d, nil
+}
+
+func (o *OrBinaryOperation) readNextRightSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
 	data, err := o.Right.NextSeries(ctx) // We don't need to return this series to the pool: FilterRightSeries will handle that for us if needed.
 	if err != nil {
 		return types.InstantVectorSeriesData{}, err
@@ -329,12 +373,19 @@ func (o *OrBinaryOperation) ExpressionPosition() posrange.PositionRange {
 }
 
 func (o *OrBinaryOperation) Prepare(ctx context.Context, params *types.PrepareParams) error {
-	err := o.Left.Prepare(ctx, params)
-	if err != nil {
+	if err := o.Left.Prepare(ctx, params); err != nil {
 		return err
 	}
 
 	return o.Right.Prepare(ctx, params)
+}
+
+func (o *OrBinaryOperation) Finalize(ctx context.Context) error {
+	if err := o.Left.Finalize(ctx); err != nil {
+		return err
+	}
+
+	return o.Right.Finalize(ctx)
 }
 
 func (o *OrBinaryOperation) Close() {

--- a/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
@@ -548,14 +548,18 @@ func TestOrBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
 			}
 
 			if testCase.expectLeftSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, left.Finalized, "left side should be finalized after SeriesMetadata, but it is not")
 				require.True(t, left.Closed, "left side should be closed after SeriesMetadata, but it is not")
 			} else {
+				require.False(t, left.Finalized, "left side should not be finalized after SeriesMetadata, but it is")
 				require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
 			}
 
 			if testCase.expectRightSideClosedAfterOutputSeriesIndex == -1 {
+				require.True(t, right.Finalized, "right side should be finalized after SeriesMetadata, but it is not")
 				require.True(t, right.Closed, "right side should be closed after SeriesMetadata, but it is not")
 			} else {
+				require.False(t, right.Finalized, "right side should not be finalized after SeriesMetadata, but it is")
 				require.False(t, right.Closed, "right side should not be closed after SeriesMetadata, but it is")
 			}
 
@@ -564,14 +568,18 @@ func TestOrBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
 				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
 
 				if outputSeriesIdx >= testCase.expectLeftSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, left.Finalized, "left side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
 					require.Truef(t, left.Closed, "left side should be closed after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
+					require.Falsef(t, left.Finalized, "left side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
 					require.Falsef(t, left.Closed, "left side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 
 				if outputSeriesIdx >= testCase.expectRightSideClosedAfterOutputSeriesIndex {
+					require.Truef(t, right.Finalized, "right side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
 					require.Truef(t, right.Closed, "right side should be closed after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
+					require.Falsef(t, right.Finalized, "right side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
 					require.Falsef(t, right.Closed, "right side should not be closed after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}

--- a/pkg/streamingpromql/operators/binops/scalar_scalar_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/scalar_scalar_binary_operation.go
@@ -106,11 +106,19 @@ func (s *ScalarScalarBinaryOperation) ExpressionPosition() posrange.PositionRang
 }
 
 func (s *ScalarScalarBinaryOperation) Prepare(ctx context.Context, params *types.PrepareParams) error {
-	err := s.Left.Prepare(ctx, params)
-	if err != nil {
+	if err := s.Left.Prepare(ctx, params); err != nil {
 		return err
 	}
+
 	return s.Right.Prepare(ctx, params)
+}
+
+func (s *ScalarScalarBinaryOperation) Finalize(ctx context.Context) error {
+	if err := s.Left.Finalize(ctx); err != nil {
+		return err
+	}
+
+	return s.Right.Finalize(ctx)
 }
 
 func (s *ScalarScalarBinaryOperation) Close() {

--- a/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
@@ -253,11 +253,19 @@ func (v *VectorScalarBinaryOperation) ExpressionPosition() posrange.PositionRang
 }
 
 func (v *VectorScalarBinaryOperation) Prepare(ctx context.Context, params *types.PrepareParams) error {
-	err := v.Scalar.Prepare(ctx, params)
-	if err != nil {
+	if err := v.Scalar.Prepare(ctx, params); err != nil {
 		return err
 	}
+
 	return v.Vector.Prepare(ctx, params)
+}
+
+func (v *VectorScalarBinaryOperation) Finalize(ctx context.Context) error {
+	if err := v.Scalar.Finalize(ctx); err != nil {
+		return err
+	}
+
+	return v.Vector.Finalize(ctx)
 }
 
 func (v *VectorScalarBinaryOperation) Close() {

--- a/pkg/streamingpromql/operators/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge.go
@@ -147,6 +147,10 @@ func (d *DeduplicateAndMerge) Prepare(ctx context.Context, params *types.Prepare
 	return d.Inner.Prepare(ctx, params)
 }
 
+func (d *DeduplicateAndMerge) Finalize(ctx context.Context) error {
+	return d.Inner.Finalize(ctx)
+}
+
 func (d *DeduplicateAndMerge) Close() {
 	d.Inner.Close()
 

--- a/pkg/streamingpromql/operators/functions/absent.go
+++ b/pkg/streamingpromql/operators/functions/absent.go
@@ -117,6 +117,10 @@ func (a *Absent) Prepare(ctx context.Context, params *types.PrepareParams) error
 	return a.Inner.Prepare(ctx, params)
 }
 
+func (a *Absent) Finalize(ctx context.Context) error {
+	return a.Inner.Finalize(ctx)
+}
+
 func (a *Absent) Close() {
 	a.Inner.Close()
 

--- a/pkg/streamingpromql/operators/functions/absent_over_time.go
+++ b/pkg/streamingpromql/operators/functions/absent_over_time.go
@@ -123,6 +123,10 @@ func (a *AbsentOverTime) Prepare(ctx context.Context, params *types.PrepareParam
 	return a.Inner.Prepare(ctx, params)
 }
 
+func (a *AbsentOverTime) Finalize(ctx context.Context) error {
+	return a.Inner.Finalize(ctx)
+}
+
 func (a *AbsentOverTime) Close() {
 	a.Inner.Close()
 

--- a/pkg/streamingpromql/operators/functions/function_over_instant_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_instant_vector.go
@@ -117,6 +117,20 @@ func (m *FunctionOverInstantVector) Prepare(ctx context.Context, params *types.P
 	return nil
 }
 
+func (m *FunctionOverInstantVector) Finalize(ctx context.Context) error {
+	if err := m.Inner.Finalize(ctx); err != nil {
+		return err
+	}
+
+	for _, sa := range m.ScalarArgs {
+		if err := sa.Finalize(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *FunctionOverInstantVector) Close() {
 	m.Inner.Close()
 

--- a/pkg/streamingpromql/operators/functions/function_over_instant_vector_test.go
+++ b/pkg/streamingpromql/operators/functions/function_over_instant_vector_test.go
@@ -134,4 +134,8 @@ func (t *testScalarOperator) Prepare(_ context.Context, _ *types.PrepareParams) 
 	return nil
 }
 
+func (t *testScalarOperator) Finalize(_ context.Context) error {
+	return nil
+}
+
 func (t *testScalarOperator) Close() {}

--- a/pkg/streamingpromql/operators/functions/function_over_range_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_range_vector.go
@@ -201,6 +201,22 @@ func (m *FunctionOverRangeVector) Prepare(ctx context.Context, params *types.Pre
 	return nil
 }
 
+func (m *FunctionOverRangeVector) Finalize(ctx context.Context) error {
+	err := m.Inner.Finalize(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, sa := range m.ScalarArgs {
+		err := sa.Finalize(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (m *FunctionOverRangeVector) Close() {
 	m.Inner.Close()
 

--- a/pkg/streamingpromql/operators/functions/histogram_function.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function.go
@@ -475,11 +475,19 @@ func (h *HistogramFunction) computeOutputSeriesForGroup(g *bucketGroup) (types.I
 }
 
 func (h *HistogramFunction) Prepare(ctx context.Context, params *types.PrepareParams) error {
-	err := h.f.Prepare(ctx, params)
-	if err != nil {
+	if err := h.f.Prepare(ctx, params); err != nil {
 		return err
 	}
+
 	return h.inner.Prepare(ctx, params)
+}
+
+func (h *HistogramFunction) Finalize(ctx context.Context) error {
+	if err := h.inner.Finalize(ctx); err != nil {
+		return err
+	}
+
+	return h.inner.Finalize(ctx)
 }
 
 func (h *HistogramFunction) Close() {

--- a/pkg/streamingpromql/operators/functions/sort.go
+++ b/pkg/streamingpromql/operators/functions/sort.go
@@ -162,6 +162,10 @@ func (s *Sort) Prepare(ctx context.Context, params *types.PrepareParams) error {
 	return s.inner.Prepare(ctx, params)
 }
 
+func (s *Sort) Finalize(ctx context.Context) error {
+	return s.inner.Finalize(ctx)
+}
+
 func (s *Sort) Close() {
 	s.inner.Close()
 

--- a/pkg/streamingpromql/operators/functions/sort_by_label.go
+++ b/pkg/streamingpromql/operators/functions/sort_by_label.go
@@ -149,6 +149,10 @@ func (s *SortByLabel) Prepare(ctx context.Context, params *types.PrepareParams) 
 	return s.inner.Prepare(ctx, params)
 }
 
+func (s *SortByLabel) Finalize(ctx context.Context) error {
+	return s.inner.Finalize(ctx)
+}
+
 func (s *SortByLabel) Close() {
 	if s.buffer != nil {
 		// Closing the buffer also closes its source operator which is our `inner`.

--- a/pkg/streamingpromql/operators/scalars/instant_vector_to_scalar.go
+++ b/pkg/streamingpromql/operators/scalars/instant_vector_to_scalar.go
@@ -111,6 +111,10 @@ func (i *InstantVectorToScalar) Prepare(ctx context.Context, params *types.Prepa
 	return i.Inner.Prepare(ctx, params)
 }
 
+func (i *InstantVectorToScalar) Finalize(ctx context.Context) error {
+	return i.Inner.Finalize(ctx)
+}
+
 func (i *InstantVectorToScalar) Close() {
 	i.Inner.Close()
 }

--- a/pkg/streamingpromql/operators/scalars/scalar_constant.go
+++ b/pkg/streamingpromql/operators/scalars/scalar_constant.go
@@ -61,6 +61,11 @@ func (s *ScalarConstant) Prepare(_ context.Context, _ *types.PrepareParams) erro
 	return nil
 }
 
+func (s *ScalarConstant) Finalize(_ context.Context) error {
+	// Nothing to do.
+	return nil
+}
+
 func (s *ScalarConstant) Close() {
 	// Nothing to do.
 }

--- a/pkg/streamingpromql/operators/scalars/scalar_to_instant_vector.go
+++ b/pkg/streamingpromql/operators/scalars/scalar_to_instant_vector.go
@@ -70,6 +70,10 @@ func (s *ScalarToInstantVector) Prepare(ctx context.Context, params *types.Prepa
 	return s.Scalar.Prepare(ctx, params)
 }
 
+func (s *ScalarToInstantVector) Finalize(ctx context.Context) error {
+	return s.Scalar.Finalize(ctx)
+}
+
 func (s *ScalarToInstantVector) Close() {
 	s.Scalar.Close()
 }

--- a/pkg/streamingpromql/operators/scalars/unary_negation_scalar.go
+++ b/pkg/streamingpromql/operators/scalars/unary_negation_scalar.go
@@ -45,6 +45,10 @@ func (u *UnaryNegationOfScalar) Prepare(ctx context.Context, params *types.Prepa
 	return u.Inner.Prepare(ctx, params)
 }
 
+func (u *UnaryNegationOfScalar) Finalize(ctx context.Context) error {
+	return u.Inner.Finalize(ctx)
+}
+
 func (u *UnaryNegationOfScalar) Close() {
 	u.Inner.Close()
 }

--- a/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
@@ -40,6 +40,7 @@ func NewInstantVectorSelector(selector *Selector, memoryConsumptionTracker *limi
 		ReturnSampleTimestamps:   returnSampleTimestamps,
 	}
 }
+
 func (v *InstantVectorSelector) ExpressionPosition() posrange.PositionRange {
 	return v.Selector.ExpressionPosition
 }
@@ -189,6 +190,11 @@ func (v *InstantVectorSelector) NextSeries(ctx context.Context) (types.InstantVe
 func (v *InstantVectorSelector) Prepare(ctx context.Context, params *types.PrepareParams) error {
 	v.Stats = params.QueryStats
 	return v.Selector.Prepare(ctx, params)
+}
+
+func (v *InstantVectorSelector) Finalize(ctx context.Context) error {
+	// Nothing to do.
+	return nil
 }
 
 func (v *InstantVectorSelector) Close() {

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -155,6 +155,11 @@ func (m *RangeVectorSelector) Prepare(ctx context.Context, params *types.Prepare
 	return m.Selector.Prepare(ctx, params)
 }
 
+func (m *RangeVectorSelector) Finalize(ctx context.Context) error {
+	// Nothing to do.
+	return nil
+}
+
 func (m *RangeVectorSelector) Close() {
 	m.Selector.Close()
 	m.floats.Close()

--- a/pkg/streamingpromql/operators/string.go
+++ b/pkg/streamingpromql/operators/string.go
@@ -41,6 +41,11 @@ func (s *StringLiteral) Prepare(_ context.Context, _ *types.PrepareParams) error
 	return nil
 }
 
+func (s *StringLiteral) Finalize(_ context.Context) error {
+	// Nothing to do.
+	return nil
+}
+
 func (s *StringLiteral) Close() {
 	// Nothing to do.
 }

--- a/pkg/streamingpromql/operators/subquery.go
+++ b/pkg/streamingpromql/operators/subquery.go
@@ -171,6 +171,10 @@ func (s *Subquery) Prepare(ctx context.Context, params *types.PrepareParams) err
 	return s.Inner.Prepare(ctx, &childParams)
 }
 
+func (s *Subquery) Finalize(ctx context.Context) error {
+	return s.Inner.Finalize(ctx)
+}
+
 func (s *Subquery) Close() {
 	s.Inner.Close()
 	s.histograms.Close()

--- a/pkg/streamingpromql/operators/test_operator.go
+++ b/pkg/streamingpromql/operators/test_operator.go
@@ -16,6 +16,7 @@ import (
 type TestOperator struct {
 	Series                   []labels.Labels
 	Data                     []types.InstantVectorSeriesData
+	Finalized                bool
 	Closed                   bool
 	MemoryConsumptionTracker *limiter.MemoryConsumptionTracker
 }
@@ -68,6 +69,11 @@ func (t *TestOperator) ReleaseUnreadData(memoryConsumptionTracker *limiter.Memor
 
 func (t *TestOperator) Prepare(_ context.Context, _ *types.PrepareParams) error {
 	// Nothing to do.
+	return nil
+}
+
+func (t *TestOperator) Finalize(_ context.Context) error {
+	t.Finalized = true
 	return nil
 }
 

--- a/pkg/streamingpromql/operators/time.go
+++ b/pkg/streamingpromql/operators/time.go
@@ -58,6 +58,11 @@ func (s *Time) Prepare(_ context.Context, _ *types.PrepareParams) error {
 	return nil
 }
 
+func (s *Time) Finalize(_ context.Context) error {
+	// Nothing to do.
+	return nil
+}
+
 func (s *Time) Close() {
 	// Nothing to do.
 }

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -34,6 +34,7 @@ type RangeVectorDuplicationBuffer struct {
 type rangeVectorConsumerState struct {
 	currentSeriesIndex          int // -1 means the consumer hasn't advanced to the first series yet.
 	hasReadCurrentSeriesSamples bool
+	finalized                   bool
 	closed                      bool
 }
 
@@ -249,6 +250,32 @@ func (b *RangeVectorDuplicationBuffer) Prepare(ctx context.Context, params *type
 	return nil
 }
 
+func (b *RangeVectorDuplicationBuffer) Finalize(ctx context.Context, consumerIndex int) error {
+	consumer := b.consumers[consumerIndex]
+
+	if consumer.finalized {
+		return nil
+	}
+
+	consumer.finalized = true
+
+	if !b.allConsumersFinalized() {
+		return nil
+	}
+
+	return b.Inner.Finalize(ctx)
+}
+
+func (b *RangeVectorDuplicationBuffer) allConsumersFinalized() bool {
+	for _, consumer := range b.consumers {
+		if !consumer.finalized {
+			return false
+		}
+	}
+
+	return true
+}
+
 type bufferedRangeVectorStepData struct {
 	stepData        *types.RangeVectorStepData
 	floatBuffer     *types.FPointRingBuffer
@@ -315,6 +342,10 @@ func (d *RangeVectorDuplicationConsumer) ExpressionPosition() posrange.PositionR
 
 func (d *RangeVectorDuplicationConsumer) Prepare(ctx context.Context, params *types.PrepareParams) error {
 	return d.Buffer.Prepare(ctx, params)
+}
+
+func (d *RangeVectorDuplicationConsumer) Finalize(ctx context.Context) error {
+	return d.Buffer.Finalize(ctx, d.consumerIndex)
 }
 
 func (d *RangeVectorDuplicationConsumer) Close() {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -119,6 +119,18 @@ func TestRangeVectorOperator_Buffering(t *testing.T) {
 	requireEqualData(t, expectedData[5], d, memoryConsumptionTracker)
 	require.Equal(t, 0, buffer.buffer.Size())
 
+	// Check that the inner operator hasn't been closed or finalized yet.
+	require.False(t, inner.finalized)
+	require.False(t, inner.closed)
+
+	// Finalize each consumer, and check that the inner operator was only finalized after the last consumer is finalized.
+	require.NoError(t, consumer1.Finalize(ctx))
+	require.False(t, inner.finalized)
+	require.NoError(t, consumer2.Finalize(ctx))
+	require.True(t, inner.finalized)
+	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
+	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
+
 	// Close the second consumer, and check that the inner operator was closed.
 	consumer2.Close()
 	require.True(t, inner.closed)
@@ -376,6 +388,7 @@ type testRangeVectorOperator struct {
 	histograms                 *types.HPointRingBuffer
 	histogramsView             *types.HPointRingBufferView
 
+	finalized                bool
 	closed                   bool
 	memoryConsumptionTracker *limiter.MemoryConsumptionTracker
 }
@@ -466,6 +479,11 @@ func (t *testRangeVectorOperator) Prepare(_ context.Context, _ *types.PreparePar
 	return nil
 }
 
+func (t *testRangeVectorOperator) Finalize(_ context.Context) error {
+	t.finalized = true
+	return nil
+}
+
 func (t *testRangeVectorOperator) Close() {
 	t.closed = true
 
@@ -552,6 +570,10 @@ func (o *failingRangeVectorOperator) ExpressionPosition() posrange.PositionRange
 
 func (o *failingRangeVectorOperator) Prepare(_ context.Context, _ *types.PrepareParams) error {
 	// Nothing to do.
+	return nil
+}
+
+func (o *failingRangeVectorOperator) Finalize(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -18,15 +18,28 @@ type Operator interface {
 	// ExpressionPosition returns the position of the PromQL expression that this operator represents.
 	ExpressionPosition() posrange.PositionRange
 
-	// Close frees all resources associated with this operator.
-	// Calling SeriesMetadata or NextSeries after calling Close may result in unpredictable behaviour, corruption or crashes.
+	// Close frees all resources associated with this operator and any nested operators.
+	// Calling SeriesMetadata, NextSeries, NextStepSamples or Finalize after calling Close may result in unpredictable behaviour, corruption or crashes.
 	// It must be safe to call Close at any time, including if SeriesMetadata or NextSeries have returned an error.
 	// It must be safe to call Close multiple times.
+	// Calling Close must not modify query results, annotations or stats.
 	Close()
 
-	// Prepare prepares the operator for execution. It must be called before calling methods like `SeriesMetadata` or `NextSeries`.
-	// It must only be called once.
+	// Prepare prepares the operator for execution. It must be called before calling SeriesMetadata, NextSeries, NextStepSamples or Finalize.
+	// Prepare must not call SeriesMetadata, NextSeries, NextStepSamples or Finalize on another operator, and is expected to call Prepare on
+	// any nested operators.
+	// Prepare must only be called once.
 	Prepare(ctx context.Context, params *PrepareParams) error
+
+	// Finalize performs any outstanding work required before the query result is considered complete.
+	// For example, any outstanding annotations should be emitted and query stats should be updated.
+	// It must be safe to call Finalize even if Prepare, SeriesMetadata, NextSeries, NextStepSamples or Finalize have not been called.
+	// It must be safe to call Finalize multiple times.
+	// Finalize must not call SeriesMetadata, NextSeries, NextStepSamples or Prepare on another operator, and is expected to call Finalize on
+	// any nested operators.
+	// Calling Finalize after Prepare, SeriesMetadata, NextSeries or NextStepSamples have returned an error may result in unpredictable
+	// behaviour, corruption or crashes.
+	Finalize(ctx context.Context) error
 }
 
 // SeriesOperator represents all operators that return one or more series.


### PR DESCRIPTION
#### What this PR does

This PR introduces a new method to the `Operator` interface: `Finalize`.

`Finalize` is expected to be used to complete any outstanding work such as emitting annotations or updating query stats before the result is returned to the caller. The particular use case that inspired this is remote execution: we need to apply any annotations and query stats from the remote executor to the local query.

It differs from `Close` in that it is valid to call `Close` at any time, even if the query has failed or if the result has already been sent to the caller. In contrast, `Finalize` will only be called if the query has succeeded, and before results are sent to the caller.

I haven't added a changelog entry given this is an internal refactoring.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
