### PR TITLE
[mimir-distributed-release-5.8] helm: replace kubectl image with alpine equivalent

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -27,7 +27,9 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
-## main / unreleased
+## 5.8.1 / unreleased
+
+* [CHANGE] Provisioner: Replace the default kubectl image, used by the provisioner job, to `alpine/kubectl`. #12498
 
 ## 5.8.0
 

--- a/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/provisioner/provisioner-job.yaml
@@ -80,14 +80,14 @@ spec:
           image: {{ include "mimir.kubectlImage" . }}
           imagePullPolicy: {{ .Values.kubectlImage.pullPolicy | default "IfNotPresent" }}
           command:
-            - /bin/bash
+            - /bin/sh
             - -exuc
             - |
               # In case, the admin resources have already been created, the provisioner job
               # does not write the token files to the bootstrap mount.
               # Therefore, secrets are only created if the respective token files exist.
-              # Note: the following bash commands should always return a success status code. 
-              # Therefore, in case the token file does not exist, the first clause of the 
+              # Note: the following bash commands should always return a success status code.
+              # Therefore, in case the token file does not exist, the first clause of the
               # or-operation is successful.
               {{- range .Values.provisioner.additionalTenants }}
               ! test -s /bootstrap/token-write-{{ .name }} || \

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -4183,10 +4183,8 @@ tokengenJob:
 
 # -- kubetclImage is used in the enterprise provisioner and tokengen jobs
 kubectlImage:
-  # -- The Docker registry for the kubectl image
-  registry: docker.io
   # -- The kubectl image repository
-  repository: bitnami/kubectl
+  repository: alpine/kubectl
   # -- The kubectl image tag
   tag: latest
   # -- The kubectl image pull policy

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/provisioner/provisioner-job.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/provisioner/provisioner-job.yaml
@@ -70,17 +70,17 @@ spec:
               subPath: token
       containers:
         - name: create-secret
-          image: bitnami/kubectl:latest
+          image: alpine/kubectl:latest
           imagePullPolicy: IfNotPresent
           command:
-            - /bin/bash
+            - /bin/sh
             - -exuc
             - |
               # In case, the admin resources have already been created, the provisioner job
               # does not write the token files to the bootstrap mount.
               # Therefore, secrets are only created if the respective token files exist.
-              # Note: the following bash commands should always return a success status code. 
-              # Therefore, in case the token file does not exist, the first clause of the 
+              # Note: the following bash commands should always return a success status code.
+              # Therefore, in case the token file does not exist, the first clause of the
               # or-operation is successful.
               ! test -s /bootstrap/token-write-team-a || \
                 kubectl --namespace "{{ .Release.Namespace }}" create secret generic "test-enterprise-values-mimir-team-a" \


### PR DESCRIPTION
Backport 90d1ab923194eab9d692056ef1d4c583937306c9 from #12498