### PR TITLE
[Docs] Add explanation for excluding client-side error codes

### DIFF
--- a/docs/sources/mimir/manage/monitor-grafana-mimir/installing-dashboards-and-alerts.md
+++ b/docs/sources/mimir/manage/monitor-grafana-mimir/installing-dashboards-and-alerts.md
@@ -15,10 +15,14 @@ weight: 30
 
 Grafana Mimir is shipped with a comprehensive set of production-ready Grafana [dashboards](../dashboards/) and alerts to monitor the state and health of a Mimir cluster.
 
+## About HTTP status codes in alerting
+
+Mimir's default alerting mixins focus on actionable server-side issues. They include standard HTTP error codes, such as 500, 502, 503, that indicate service problems. They exclude error codes such as 529 and 598, that indicate client-side issues rather than server failures. You can create custom alerts for codes 529 and 598 if needed for your specific use case.
+
 ## Requirements
 
 - Grafana Mimir dashboards and alerts [require specific labels](../requirements/) to be set by Prometheus or Grafana Alloy when scraping your Mimir cluster metrics
-- Some dashboards require recording rules that you should install in your Prometheus
+- Some dashboards require recording rules that you should install in your Prometheus.
 
 ## Install from package
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This pull request adds documentation to clarify how HTTP status codes are handled in Mimir's default alerting mixins. The main change is an explanation of which error codes are included or excluded in the default alerts, helping users understand the focus on actionable server-side issues.

Documentation improvements:

* Added a new section describing the handling of HTTP status codes in Mimir's default alerting mixins, specifying that only server-side error codes (500, 502, 503) are included, while client-side codes (529, 598) are excluded, with guidance on creating custom alerts if needed.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/3106

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
