### PR TITLE
MQE: don't ignore error in `RangeVectorSelector.fillBuffer`

### DIFF
--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -131,7 +131,10 @@ func (m *RangeVectorSelector) fillBuffer(floats *types.FPointRingBuffer, histogr
 			if t <= rangeStart {
 				continue
 			}
-			hPoint, _ := histograms.NextPoint()
+			hPoint, err := histograms.NextPoint()
+			if err != nil {
+				return err
+			}
 			hPoint.T, hPoint.H = m.chunkIterator.AtFloatHistogram(hPoint.H)
 			if value.IsStaleNaN(hPoint.H.Sum) {
 				// Range vectors ignore stale markers


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where errors returned by `NextPoint()` were ignored by `RangeVectorSelector.fillBuffer`.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
