### PR TITLE
MQE: add context parameter to `RangeVectorOperator.NextStepSamples`

### DIFF
--- a/pkg/streamingpromql/evaluator.go
+++ b/pkg/streamingpromql/evaluator.go
@@ -189,7 +189,7 @@ func (e *Evaluator) evaluateRangeVectorOperator(ctx context.Context, op types.Ra
 
 		stepIdx := 0
 		for {
-			step, err := op.NextStepSamples()
+			step, err := op.NextStepSamples(ctx)
 
 			// nolint:errorlint // errors.Is introduces a performance overhead, and NextStepSamples is guaranteed to return exactly EOS, never a wrapped error.
 			if err == types.EOS {

--- a/pkg/streamingpromql/operators/functions/absent_over_time.go
+++ b/pkg/streamingpromql/operators/functions/absent_over_time.go
@@ -77,7 +77,7 @@ func (a *AbsentOverTime) SeriesMetadata(ctx context.Context) ([]types.SeriesMeta
 			return nil, err
 		}
 		for stepIdx := range a.TimeRange.StepCount {
-			step, err := a.Inner.NextStepSamples()
+			step, err := a.Inner.NextStepSamples(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/streamingpromql/operators/functions/function_over_range_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_range_vector.go
@@ -128,7 +128,7 @@ func (m *FunctionOverRangeVector) NextSeries(ctx context.Context) (types.Instant
 	data := types.InstantVectorSeriesData{}
 
 	for {
-		step, err := m.Inner.NextStepSamples()
+		step, err := m.Inner.NextStepSamples(ctx)
 
 		// nolint:errorlint // errors.Is introduces a performance overhead, and NextStepSamples is guaranteed to return exactly EOS, never a wrapped error.
 		if err == types.EOS {

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -65,7 +65,7 @@ func (m *RangeVectorSelector) NextSeries(ctx context.Context) error {
 	return nil
 }
 
-func (m *RangeVectorSelector) NextStepSamples() (*types.RangeVectorStepData, error) {
+func (m *RangeVectorSelector) NextStepSamples(ctx context.Context) (*types.RangeVectorStepData, error) {
 	if m.nextStepT > m.Selector.TimeRange.EndT {
 		return nil, types.EOS
 	}

--- a/pkg/streamingpromql/operators/subquery.go
+++ b/pkg/streamingpromql/operators/subquery.go
@@ -106,7 +106,7 @@ func (s *Subquery) NextSeries(ctx context.Context) error {
 	return nil
 }
 
-func (s *Subquery) NextStepSamples() (*types.RangeVectorStepData, error) {
+func (s *Subquery) NextStepSamples(ctx context.Context) (*types.RangeVectorStepData, error) {
 	if s.nextStepT > s.ParentQueryTimeRange.EndT {
 		return nil, types.EOS
 	}

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -163,7 +163,7 @@ func (b *RangeVectorDuplicationBuffer) checkIfAllOtherConsumersAreAheadOf(consum
 	return true
 }
 
-func (b *RangeVectorDuplicationBuffer) NextStepSamples(consumerIndex int) (*types.RangeVectorStepData, error) {
+func (b *RangeVectorDuplicationBuffer) NextStepSamples(ctx context.Context, consumerIndex int) (*types.RangeVectorStepData, error) {
 	consumer := b.consumers[consumerIndex]
 
 	if consumer.hasReadCurrentSeriesSamples {
@@ -179,7 +179,7 @@ func (b *RangeVectorDuplicationBuffer) NextStepSamples(consumerIndex int) (*type
 	}
 
 	isLastConsumerOfThisSeries := b.checkIfAllOtherConsumersAreAheadOf(consumerIndex)
-	stepData, err := b.Inner.NextStepSamples()
+	stepData, err := b.Inner.NextStepSamples(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -332,8 +332,8 @@ func (d *RangeVectorDuplicationConsumer) NextSeries(ctx context.Context) error {
 	return d.Buffer.NextSeries(ctx, d.consumerIndex)
 }
 
-func (d *RangeVectorDuplicationConsumer) NextStepSamples() (*types.RangeVectorStepData, error) {
-	return d.Buffer.NextStepSamples(d.consumerIndex)
+func (d *RangeVectorDuplicationConsumer) NextStepSamples(ctx context.Context) (*types.RangeVectorStepData, error) {
+	return d.Buffer.NextStepSamples(ctx, d.consumerIndex)
 }
 
 func (d *RangeVectorDuplicationConsumer) ExpressionPosition() posrange.PositionRange {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -43,14 +43,14 @@ func TestRangeVectorOperator_Buffering(t *testing.T) {
 	// Read some data from the first consumer and ensure that it was buffered for the second consumer.
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err := consumer1.NextStepSamples()
+	d, err := consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[0], d, memoryConsumptionTracker)
 	require.Equal(t, 1, buffer.buffer.Size())
 
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer1.NextStepSamples()
+	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[1], d, memoryConsumptionTracker)
 	require.Equal(t, 2, buffer.buffer.Size())
@@ -58,28 +58,28 @@ func TestRangeVectorOperator_Buffering(t *testing.T) {
 	// Read the same data from the second consumer, and then keep reading data beyond what has already been buffered.
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer2.NextStepSamples()
+	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[0], d, memoryConsumptionTracker)
 	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer2.NextStepSamples()
+	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[1], d, memoryConsumptionTracker)
 	require.Equal(t, 1, buffer.buffer.Size())
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer2.NextStepSamples()
+	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[2], d, memoryConsumptionTracker)
 	require.Equal(t, 1, buffer.buffer.Size())
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer2.NextStepSamples()
+	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[3], d, memoryConsumptionTracker)
 	require.Equal(t, 2, buffer.buffer.Size())
@@ -87,14 +87,14 @@ func TestRangeVectorOperator_Buffering(t *testing.T) {
 	// Read some of the buffered data in the first consumer.
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer1.NextStepSamples()
+	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[2], d, memoryConsumptionTracker)
 	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer2.NextStepSamples()
+	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[4], d, memoryConsumptionTracker)
 	require.Equal(t, 2, buffer.buffer.Size())
@@ -102,7 +102,7 @@ func TestRangeVectorOperator_Buffering(t *testing.T) {
 	// Read some more of the buffered data in the first consumer.
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer1.NextStepSamples()
+	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[3], d, memoryConsumptionTracker)
 	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
@@ -114,7 +114,7 @@ func TestRangeVectorOperator_Buffering(t *testing.T) {
 	// Check that the second consumer can still read data and that we don't bother buffering it.
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer2.NextStepSamples()
+	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[5], d, memoryConsumptionTracker)
 	require.Equal(t, 0, buffer.buffer.Size())
@@ -168,21 +168,21 @@ func TestRangeVectorOperator_ClosedWithBufferedData(t *testing.T) {
 	// Read some data for the first consumer and ensure that it was buffered for the second consumer.
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err := consumer1.NextStepSamples()
+	d, err := consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[0], d, memoryConsumptionTracker)
 	require.Equal(t, 1, buffer.buffer.Size())
 
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer1.NextStepSamples()
+	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[1], d, memoryConsumptionTracker)
 	require.Equal(t, 2, buffer.buffer.Size())
 
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer1.NextStepSamples()
+	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[2], d, memoryConsumptionTracker)
 	require.Equal(t, 3, buffer.buffer.Size())
@@ -194,7 +194,7 @@ func TestRangeVectorOperator_ClosedWithBufferedData(t *testing.T) {
 	// Read some of the buffered data.
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
-	d, err = consumer2.NextStepSamples()
+	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualData(t, expectedData[0], d, memoryConsumptionTracker)
 	require.Equal(t, 3, buffer.buffer.Size(), "buffered data should remain in the buffer until the next NextSeries or Close call")
@@ -249,11 +249,11 @@ func TestRangeVectorOperator_Cloning(t *testing.T) {
 	// Both consumers should get the same ring buffer views.
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	d1, err := consumer1.NextStepSamples()
+	d1, err := consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
-	d2, err := consumer2.NextStepSamples()
+	d2, err := consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 
 	require.Equal(t, d1, d2, "both consumers should get same data")
@@ -320,7 +320,7 @@ func TestRangeVectorOperator_ClosingAfterFirstReadFails(t *testing.T) {
 
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	data, err := consumer1.NextStepSamples()
+	data, err := consumer1.NextStepSamples(ctx)
 	require.EqualError(t, err, "something went wrong reading data")
 	require.Nil(t, data)
 
@@ -353,14 +353,14 @@ func TestRangeVectorOperator_ClosingAfterSubsequentReadFails(t *testing.T) {
 	// Read the data for the first series for both consumers.
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	data, err := consumer1.NextStepSamples()
+	data, err := consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data.Floats.First(), promql.FPoint{T: 0, F: 1234})
 	require.Equal(t, data.Histograms.First(), promql.HPoint{T: 500, H: &histogram.FloatHistogram{Count: 100, Sum: 2}})
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
-	data, err = consumer2.NextStepSamples()
+	data, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data.Floats.First(), promql.FPoint{T: 0, F: 1234})
 	require.Equal(t, data.Histograms.First(), promql.HPoint{T: 500, H: &histogram.FloatHistogram{Count: 100, Sum: 2}})
@@ -368,7 +368,7 @@ func TestRangeVectorOperator_ClosingAfterSubsequentReadFails(t *testing.T) {
 	// Try reading the next series, which should fail.
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
-	data, err = consumer1.NextStepSamples()
+	data, err = consumer1.NextStepSamples(ctx)
 	require.EqualError(t, err, "something went wrong reading data")
 	require.Nil(t, data)
 
@@ -426,7 +426,7 @@ func (t *testRangeVectorOperator) NextSeries(_ context.Context) error {
 	return nil
 }
 
-func (t *testRangeVectorOperator) NextStepSamples() (*types.RangeVectorStepData, error) {
+func (t *testRangeVectorOperator) NextStepSamples(_ context.Context) (*types.RangeVectorStepData, error) {
 	if t.haveReadCurrentStepSamples {
 		return nil, types.EOS
 	}
@@ -524,7 +524,7 @@ func (o *failingRangeVectorOperator) NextSeries(_ context.Context) error {
 	return nil
 }
 
-func (o *failingRangeVectorOperator) NextStepSamples() (*types.RangeVectorStepData, error) {
+func (o *failingRangeVectorOperator) NextStepSamples(_ context.Context) (*types.RangeVectorStepData, error) {
 	if o.seriesRead > o.returnErrorAtSeriesIdx {
 		return nil, errors.New("something went wrong reading data")
 	}

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -75,7 +75,7 @@ type RangeVectorOperator interface {
 	// NextStepSamples returns populated RingBuffers with the samples for the next time step for the
 	// current series and the timestamps of the next time step, or returns EOS if no more time
 	// steps are available.
-	NextStepSamples() (*RangeVectorStepData, error)
+	NextStepSamples(ctx context.Context) (*RangeVectorStepData, error)
 }
 
 // ScalarOperator represents all operators that produce scalars.


### PR DESCRIPTION
#### What this PR does

This PR adds a `context.Context` parameter to `RangeVectorOperator.NextStepSamples()`.

This will be used by the remote range vector execution operator, as `NextStepSamples` may block waiting for the network, and so the context will allow it to abort if the query is cancelled or times out.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
