### PR TITLE
Fix ruler remotequerier request body consumption on retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [BUGFIX] Block-builder-scheduler: Fix a caching bug in initial job probing causing excessive memory usage at startup. #12389
 * [BUGFIX] Ruler: Support labels at the rule group level. These were previously ignored even when set via the API. #12397
 * [BUGFIX] Distributor: Fix metric metadata of type Unknown being silently dropped from RW2 requests. #12461
+* [BUGFIX] Ruler: Fix ruler remotequerier request body consumption on retries. #12514
 
 ### Mixin
 

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -239,12 +239,7 @@ func (q *RemoteQuerier) query(ctx context.Context, query string, ts time.Time, l
 	ctx, cancel := context.WithTimeout(ctx, q.timeout)
 	defer cancel()
 
-	req, err := q.createRequest(ctx, query, ts)
-	if err != nil {
-		return promql.Vector{}, err
-	}
-
-	resp, err := q.sendRequest(req, logger)
+	resp, err := q.sendRequest(ctx, query, ts, logger)
 	if err != nil {
 		if code := grpcutil.ErrorToStatusCode(err); code/100 != 4 {
 			level.Warn(logger).Log("msg", "failed to remotely evaluate query expression", "err", err, "qs", query, "tm", ts)
@@ -308,8 +303,7 @@ func (q *RemoteQuerier) createRequest(ctx context.Context, query string, ts time
 	return req, nil
 }
 
-func (q *RemoteQuerier) sendRequest(req *http.Request, logger log.Logger) (*http.Response, error) {
-	ctx := req.Context()
+func (q *RemoteQuerier) sendRequest(ctx context.Context, query string, ts time.Time, logger log.Logger) (*http.Response, error) {
 	// Ongoing request may be cancelled during evaluation due to some transient error or server shutdown,
 	// so we'll keep retrying until we get a successful response or backoff is terminated.
 	retryConfig := backoff.Config{
@@ -320,6 +314,11 @@ func (q *RemoteQuerier) sendRequest(req *http.Request, logger log.Logger) (*http
 	retry := backoff.New(ctx, retryConfig)
 
 	for {
+		req, err := q.createRequest(ctx, query, ts)
+		if err != nil {
+			return nil, err
+		}
+
 		resp, err := q.client.RoundTrip(req)
 		if err == nil {
 			// Responses with status codes 4xx should always be considered erroneous.

--- a/pkg/ruler/remotequerier_test.go
+++ b/pkg/ruler/remotequerier_test.go
@@ -738,7 +738,7 @@ func TestRemoteQuerier_QueryRetryRequestBodyConsumption(t *testing.T) {
 			return nil, httpgrpc.Errorf(http.StatusInternalServerError, "simulated server error")
 		}
 
-		// Succeed on retry - but by now the body should be empty due to the bug
+		// Succeed on retry
 		return &httpgrpc.HTTPResponse{
 			Code: http.StatusOK,
 			Headers: []*httpgrpc.Header{

--- a/pkg/ruler/remotequerier_test.go
+++ b/pkg/ruler/remotequerier_test.go
@@ -723,6 +723,43 @@ func TestRemoteQuerier_QueryReqTimeout(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRemoteQuerier_QueryRetryRequestBodyConsumption(t *testing.T) {
+	const testQuery = "up"
+	var requestBodies []string
+	var callCount atomic.Int64
+
+	mockClientFn := func(_ context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error) {
+		count := callCount.Add(1)
+
+		requestBodies = append(requestBodies, string(req.Body))
+
+		// Fail on first call to trigger retry
+		if count == 1 {
+			return nil, httpgrpc.Errorf(http.StatusInternalServerError, "simulated server error")
+		}
+
+		// Succeed on retry - but by now the body should be empty due to the bug
+		return &httpgrpc.HTTPResponse{
+			Code: http.StatusOK,
+			Headers: []*httpgrpc.Header{
+				{Key: "Content-Type", Values: []string{"application/json"}},
+			},
+			Body: []byte(`{"status": "success","data": {"resultType":"vector","result":[]}}`),
+		}, nil
+	}
+
+	q := NewRemoteQuerier(newGrpcRoundTripper(mockHTTPGRPCClient(mockClientFn)), time.Minute, 1, formatJSON, prometheusGrpcURL, log.NewNopLogger())
+
+	_, err := q.Query(context.Background(), testQuery, time.Now())
+	require.NoError(t, err)
+
+	require.Equal(t, int64(2), callCount.Load())
+	require.Len(t, requestBodies, 2)
+
+	require.Contains(t, requestBodies[0], "query=up")
+	require.Contains(t, requestBodies[1], "query=up")
+}
+
 func TestRemoteQuerier_StatusErrorResponses(t *testing.T) {
 	var (
 		errorResp = &httpgrpc.HTTPResponse{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

PR #11833 introduced a bug where retried ruler remote querier requests were sent with empty bodies, meaning retries would never succeed and end up with `unknown position: parse error: no expression found in input` errors.

This is because the same `http.Request` is being reused for the retries. This uses a `bytes.Buffer` for the body:
https://github.com/grafana/mimir/blob/9b1e82284bd07b51040e51bbec36609819c7fef6/pkg/ruler/remotequerier.go#L163

The first request will read the entire buffer and get to the end, meaning retries would then send empty requests as they would only start reading from the end of the buffer. 

Previously we were using `httpgrpc.HTTPRequest` with a `[]byte` body that can be read multiple times, which is why the retries used to work:
https://github.com/grafana/mimir/blob/42099b0ea598e7e93d32deef3b7405e750ca3c16/pkg/ruler/remotequerier.go#L181-L192

The bug can be seen in the initial test commit: https://github.com/grafana/mimir/commit/382f66400fe94cbb212ffe4a53db0c3ac2a98bad

Fixed by recreating request on every retry.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
