### PR TITLE
[r354] Fix ruler remotequerier request body consumption on retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * [BUGFIX] Store-gateway: Fix potential goroutine leak by passing the scoped context in LabelValues. #12048
 * [BUGFIX] Distributor: Fix pooled memory reuse bug that can cause corrupt data to appear in the err-mimir-label-value-too-long error message. #12048
 * [BUGFIX] Querier: Fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #12261
-* [BUGFIX] Ruler: Fix ruler remotequerier request body consumption on retries. #12514, #12519
+* [BUGFIX] Ruler: Fix ruler remotequerier request body consumption on retries. #12514
 
 ### Jsonnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [BUGFIX] Store-gateway: Fix potential goroutine leak by passing the scoped context in LabelValues. #12048
 * [BUGFIX] Distributor: Fix pooled memory reuse bug that can cause corrupt data to appear in the err-mimir-label-value-too-long error message. #12048
 * [BUGFIX] Querier: Fix timeout responding to query-frontend when response size is very close to `-querier.frontend-client.grpc-max-send-msg-size`. #12261
+* [BUGFIX] Ruler: Fix ruler remotequerier request body consumption on retries. #12514, #12519
 
 ### Jsonnet
 

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -233,12 +233,7 @@ func (q *RemoteQuerier) query(ctx context.Context, query string, ts time.Time, l
 	ctx, cancel := context.WithTimeout(ctx, q.timeout)
 	defer cancel()
 
-	req, err := q.createRequest(ctx, query, ts)
-	if err != nil {
-		return promql.Vector{}, err
-	}
-
-	resp, err := q.sendRequest(req, logger)
+	resp, err := q.sendRequest(ctx, query, ts, logger)
 	if err != nil {
 		if code := grpcutil.ErrorToStatusCode(err); code/100 != 4 {
 			level.Warn(logger).Log("msg", "failed to remotely evaluate query expression", "err", err, "qs", query, "tm", ts)
@@ -302,8 +297,7 @@ func (q *RemoteQuerier) createRequest(ctx context.Context, query string, ts time
 	return req, nil
 }
 
-func (q *RemoteQuerier) sendRequest(req *http.Request, logger log.Logger) (*http.Response, error) {
-	ctx := req.Context()
+func (q *RemoteQuerier) sendRequest(ctx context.Context, query string, ts time.Time, logger log.Logger) (*http.Response, error) {
 	// Ongoing request may be cancelled during evaluation due to some transient error or server shutdown,
 	// so we'll keep retrying until we get a successful response or backoff is terminated.
 	retryConfig := backoff.Config{
@@ -314,6 +308,11 @@ func (q *RemoteQuerier) sendRequest(req *http.Request, logger log.Logger) (*http
 	retry := backoff.New(ctx, retryConfig)
 
 	for {
+		req, err := q.createRequest(ctx, query, ts)
+		if err != nil {
+			return nil, err
+		}
+
 		resp, err := q.client.RoundTrip(req)
 		if err == nil {
 			// Responses with status codes 4xx should always be considered erroneous.


### PR DESCRIPTION
Backport 898f6c10be98df02da772e1fa742d773aeba0c3c from #12514