### PR TITLE
[r354] Add CLI flag to set max Alertmanager notification batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [ENHANCEMENT] Stagger head compaction intervals across zones to prevent compactions from aligning simultaneously, which could otherwise cause strong consistency queries to fail when experimental ingest storage is enabled. #12090
 * [ENHANCEMENT] Querier: Add native histogram definition to `cortex_bucket_index_load_duration_seconds`. #12094
 * [ENHANCEMENT] MQE: Add support for applying common subexpression elimination to range vector expressions in instant queries. #12236
+* [ENHANCEMENT] Ruler: Add `-ruler.max-notification-batch-size` CLI flag that can be used to configure the maximum Alertmanager notification batch size. #12469
 * [BUGFIX] Querier: Samples with the same timestamp are merged deterministically. Previously, this could lead to flapping query results when an out-of-order sample is ingested that conflicts with a previously ingested in-order sample's value. #8673
 * [BUGFIX] Store-gateway: Fix potential goroutine leak by passing the scoped context in LabelValues. #12048
 * [BUGFIX] Distributor: Fix pooled memory reuse bug that can cause corrupt data to appear in the err-mimir-label-value-too-long error message. #12048

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -12514,6 +12514,17 @@
         },
         {
           "kind": "field",
+          "name": "max_notification_batch_size",
+          "required": false,
+          "desc": "Maximum number of notifications to send to Alertmanager in one request.",
+          "fieldValue": null,
+          "fieldDefaultValue": 256,
+          "fieldFlag": "ruler.max-notification-batch-size",
+          "fieldType": "int",
+          "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
           "name": "notification_timeout",
           "required": false,
           "desc": "HTTP timeout duration when sending notifications to the Alertmanager.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2811,6 +2811,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Number of rules rules that don't have dependencies that we allow to be evaluated concurrently across all tenants. 0 to disable.
   -ruler.max-independent-rule-evaluation-concurrency-per-tenant int
     	[experimental] Maximum number of independent rules that can run concurrently for each tenant. Depends on ruler.max-independent-rule-evaluation-concurrency being greater than 0. Ideally this flag should be a lower value. 0 to disable. (default 4)
+  -ruler.max-notification-batch-size int
+    	Maximum number of notifications to send to Alertmanager in one request. (default 256)
   -ruler.max-rule-groups-per-tenant int
     	Maximum number of rule groups per-tenant. 0 to disable. (default 70)
   -ruler.max-rule-groups-per-tenant-by-namespace value

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2007,6 +2007,11 @@ The `ruler` block configures the ruler.
 # CLI flag: -ruler.notification-queue-capacity
 [notification_queue_capacity: <int> | default = 10000]
 
+# (advanced) Maximum number of notifications to send to Alertmanager in one
+# request.
+# CLI flag: -ruler.max-notification-batch-size
+[max_notification_batch_size: <int> | default = 256]
+
 # (advanced) HTTP timeout duration when sending notifications to the
 # Alertmanager.
 # CLI flag: -ruler.notification-timeout

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -296,6 +296,7 @@ func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string) (*notifie
 	var err error
 	if n, err = newRulerNotifier(&notifier.Options{
 		QueueCapacity:   r.cfg.NotificationQueueCapacity,
+		MaxBatchSize:    r.cfg.MaxNotificationBatchSize,
 		DrainOnShutdown: true,
 		Registerer:      reg,
 		Do: func(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -39,6 +39,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/rulefmt"
+	promnotifier "github.com/prometheus/prometheus/notifier"
 	promRules "github.com/prometheus/prometheus/rules"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
@@ -120,6 +121,8 @@ type Config struct {
 	AlertmanagerRefreshInterval time.Duration `yaml:"alertmanager_refresh_interval" category:"advanced"`
 	// Capacity of the queue for notifications to be sent to the Alertmanager.
 	NotificationQueueCapacity int `yaml:"notification_queue_capacity" category:"advanced"`
+	// Maximum number of notifications to send to Alertmanager in one request.
+	MaxNotificationBatchSize int `yaml:"max_notification_batch_size" category:"advanced"`
 	// HTTP timeout duration when sending notifications to the Alertmanager.
 	NotificationTimeout time.Duration `yaml:"notification_timeout" category:"advanced"`
 	// Client configs for interacting with the Alertmanager
@@ -196,6 +199,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.DeprecatedAlertmanagerURL = ""
 	f.DurationVar(&cfg.AlertmanagerRefreshInterval, "ruler.alertmanager-refresh-interval", 1*time.Minute, "How long to wait between refreshing DNS resolutions of Alertmanager hosts.")
 	f.IntVar(&cfg.NotificationQueueCapacity, "ruler.notification-queue-capacity", 10000, "Capacity of the queue for notifications to be sent to the Alertmanager.")
+	f.IntVar(&cfg.MaxNotificationBatchSize, "ruler.max-notification-batch-size", promnotifier.DefaultMaxBatchSize, "Maximum number of notifications to send to Alertmanager in one request.")
 	f.DurationVar(&cfg.NotificationTimeout, "ruler.notification-timeout", 10*time.Second, "HTTP timeout duration when sending notifications to the Alertmanager.")
 
 	f.StringVar(&cfg.RulePath, "ruler.rule-path", "./data-ruler/", "Directory to store temporary rule files loaded by the Prometheus rule managers. This directory is not required to be persisted between restarts.")


### PR DESCRIPTION
Backports https://github.com/grafana/mimir/commit/9e9954481b6dced9bea1600ffe80b74d5ba2b5de from https://github.com/grafana/mimir/pull/12469 into r354