### PR TITLE
mimirpb: Preserve inconsistent metric metadata in RW1 to 2 conversion

### DIFF
--- a/pkg/mimirpb/prealloc_rw2_test.go
+++ b/pkg/mimirpb/prealloc_rw2_test.go
@@ -414,6 +414,108 @@ func TestWriteRequestRW2Conversion(t *testing.T) {
 		require.Equal(t, expSymbols, rw2.SymbolsRW2)
 		require.Equal(t, expTimeseries, rw2.TimeseriesRW2)
 	})
+
+	t.Run("when matching to timeseries, repeated metadata are deduplicated", func(t *testing.T) {
+		req := &WriteRequest{
+			Timeseries: []PreallocTimeseries{
+				{
+					TimeSeries: &TimeSeries{
+						Labels:  FromLabelsToLabelAdapters(labels.FromMap(map[string]string{"__name__": "my_cool_series", "job": "foo/bar"})),
+						Samples: []Sample{{Value: 123, TimestampMs: 1234567890}, {Value: 456, TimestampMs: 1234567900}},
+					},
+				},
+			},
+			Metadata: []*MetricMetadata{
+				{
+					Type:             COUNTER,
+					MetricFamilyName: "my_cool_series",
+					Help:             "It's a cool series.",
+					Unit:             "megawatts",
+				},
+				{
+					Type:             COUNTER,
+					MetricFamilyName: "my_cool_series",
+					Help:             "It's a cool series.",
+					Unit:             "megawatts",
+				},
+			},
+		}
+
+		rw2, err := FromWriteRequestToRW2Request(req, nil, 0)
+
+		expSymbols := []string{"", "__name__", "my_cool_series", "job", "foo/bar", "It's a cool series.", "megawatts"}
+		expTimeseries := []TimeSeriesRW2{
+			{
+				LabelsRefs: []uint32{1, 2, 3, 4},
+				Samples:    []Sample{{Value: 123, TimestampMs: 1234567890}, {Value: 456, TimestampMs: 1234567900}},
+				Metadata: MetadataRW2{
+					Type:    METRIC_TYPE_COUNTER,
+					HelpRef: 5,
+					UnitRef: 6,
+				},
+			},
+		}
+		require.NoError(t, err)
+		require.Nil(t, rw2.Timeseries)
+		require.Nil(t, rw2.Metadata)
+		require.Equal(t, expSymbols, rw2.SymbolsRW2)
+		require.Equal(t, expTimeseries, rw2.TimeseriesRW2)
+	})
+
+	t.Run("when matching to timeseries, and metadata conflicts, the first one is matched and the rest are preserved", func(t *testing.T) {
+		req := &WriteRequest{
+			Timeseries: []PreallocTimeseries{
+				{
+					TimeSeries: &TimeSeries{
+						Labels:  FromLabelsToLabelAdapters(labels.FromMap(map[string]string{"__name__": "my_cool_series", "job": "foo/bar"})),
+						Samples: []Sample{{Value: 123, TimestampMs: 1234567890}, {Value: 456, TimestampMs: 1234567900}},
+					},
+				},
+			},
+			Metadata: []*MetricMetadata{
+				{
+					Type:             COUNTER,
+					MetricFamilyName: "my_cool_series",
+					Help:             "It's a cool series, but old description.",
+					Unit:             "megawatts",
+				},
+				{
+					Type:             GAUGE,
+					MetricFamilyName: "my_cool_series",
+					Help:             "It's a cool series, but new description.",
+					Unit:             "megawatts",
+				},
+			},
+		}
+
+		rw2, err := FromWriteRequestToRW2Request(req, nil, 0)
+
+		expSymbols := []string{"", "__name__", "my_cool_series", "job", "foo/bar", "It's a cool series, but old description.", "megawatts", "It's a cool series, but new description."}
+		expTimeseries := []TimeSeriesRW2{
+			{
+				LabelsRefs: []uint32{1, 2, 3, 4},
+				Samples:    []Sample{{Value: 123, TimestampMs: 1234567890}, {Value: 456, TimestampMs: 1234567900}},
+				Metadata: MetadataRW2{
+					Type:    METRIC_TYPE_COUNTER,
+					HelpRef: 5,
+					UnitRef: 6,
+				},
+			},
+			{
+				LabelsRefs: []uint32{1, 2},
+				Metadata: MetadataRW2{
+					Type:    METRIC_TYPE_GAUGE,
+					HelpRef: 7,
+					UnitRef: 6,
+				},
+			},
+		}
+		require.NoError(t, err)
+		require.Nil(t, rw2.Timeseries)
+		require.Nil(t, rw2.Metadata)
+		require.Equal(t, expSymbols, rw2.SymbolsRW2)
+		require.Equal(t, expTimeseries, rw2.TimeseriesRW2)
+	})
 }
 
 func TestExemplarConversion(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Occasionally RW1.0 requests will contain inconsistent metadata. That is, they might contain multiple metadatas for the same series that don't agree with each other, like a new and old description simultaneously. The prometheus behavior when accepting RW1.0 is to not choose a winner; both metadatas are stored and will appear in the metadata API until they both age out.

RW2.0 tends to prevent this by attaching metadata to series. However, for requests that were converted from 1.0 to 2.0 transparently, we want to preserve the original behavior and ensure both metadata make it through the system.

This PR adjusts the RW1.0 to 2.0 conversion to only deduplicate metadata whose fields are exactly equal during the timeseries matching process. The previous implementation would discard inconsistent metadata beyond the first seen one. If we see multiple metadata that exactly match, we save space and deduplicate it; if we see a metadata that is inconsistent, we fabricate an extra timeseries and send both versions.

No changelog as it only affects record format V2, which is not marked stable.

#### Which issue(s) this PR fixes or relates to

contrib https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
