### PR TITLE
[ingester] Don't return a 409 from downscale endpoint if compacting while not in read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [BUGFIX] Block-builder: Fix a bug where a consumption error can cause a job to stay assigned to a worker for the remainder of its lifetime. #12522
 * [BUGFIX] Querier: Fix possible panic when evaluating a nested subquery where the parent has no steps. #12524
 * [BUGFIX] Ingester: Fix a bug ingesters would get stuck in read-only mode after compactions. #12538
+* [BUGFIX] Ingester: Fix a bug where prepare-instance-ring-downscale endpoint would return an error while compacting and not read-only. #12548
 
 ### Mixin
 

--- a/pkg/ingester/downscale.go
+++ b/pkg/ingester/downscale.go
@@ -53,8 +53,9 @@ func (i *Ingester) PrepareInstanceRingDownscaleHandler(w http.ResponseWriter, r 
 
 	case http.MethodDelete:
 		// Don't leave read-only mode if there is any compaction pending or in progress.
-		if i.numCompactionsInProgress.Load() != 0 {
-			msg := "cannot clear read-only mode while forced compaction is pending or in progress"
+		ro, _ := i.lifecycler.GetReadOnlyState()
+		if ro && i.numCompactionsInProgress.Load() != 0 {
+			msg := "cannot clear read-only mode while compaction is pending or in progress"
 			level.Warn(i.logger).Log("msg", msg)
 			http.Error(w, msg, http.StatusConflict)
 			return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The rollout-operator calls DELETE on the `prepare-instance-ring-downscale` endpoint for all ingesters constantly. We should only return an error if the ingester is in read-only mode and compacting; it should return OK if compacting while not in read-only mode.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
