### PR TITLE
Introduce `FromSamplesToFPoints` and `FromHistogramsToHPoints`

### DIFF
--- a/pkg/mimirpb/compat.go
+++ b/pkg/mimirpb/compat.go
@@ -355,9 +355,19 @@ func FromFPointsToSamples(points []promql.FPoint) []Sample {
 	return *(*[]Sample)(unsafe.Pointer(&points))
 }
 
+// FromSamplesToFPoints casts []Sample to []promql.FPoint. It uses unsafe.
+func FromSamplesToFPoints(samples []Sample) []promql.FPoint {
+	return *(*[]promql.FPoint)(unsafe.Pointer(&samples))
+}
+
 // FromHPointsToHistograms converts []promql.HPoint to []FloatHistogramPair. It uses unsafe.
 func FromHPointsToHistograms(points []promql.HPoint) []FloatHistogramPair {
 	return *(*[]FloatHistogramPair)(unsafe.Pointer(&points))
+}
+
+// FromHistogramsToHPoints converts []FloatHistogramPair to []promql.HPoint. It uses unsafe.
+func FromHistogramsToHPoints(histograms []FloatHistogramPair) []promql.HPoint {
+	return *(*[]promql.HPoint)(unsafe.Pointer(&histograms))
 }
 
 // FromFloatHistogramToPromHistogram converts histogram.FloatHistogram to model.SampleHistogram.

--- a/pkg/mimirpb/compat_test.go
+++ b/pkg/mimirpb/compat_test.go
@@ -216,6 +216,13 @@ func TestFromFPointsToSamples(t *testing.T) {
 	assert.Equal(t, expected, FromFPointsToSamples(input))
 }
 
+func TestFromSamplesToFPoints(t *testing.T) {
+	input := []Sample{{TimestampMs: 1, Value: 2}, {TimestampMs: 3, Value: 4}}
+	expected := []promql.FPoint{{T: 1, F: 2}, {T: 3, F: 4}}
+
+	assert.Equal(t, expected, FromSamplesToFPoints(input))
+}
+
 // Check that Prometheus FPoint and Mimir Sample types converted
 // into each other with unsafe.Pointer are compatible
 func TestPrometheusFPointInSyncWithMimirPbSample(t *testing.T) {
@@ -242,6 +249,16 @@ func TestFromHPointsToHistograms(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, FromHPointsToHistograms(input))
+}
+
+func TestFromHistogramsToHPoints(t *testing.T) {
+	input := []FloatHistogramPair{
+		{TimestampMs: 3, Histogram: FloatHistogramFromPrometheusModel(test.GenerateTestFloatHistogram(0))},
+		{TimestampMs: 5, Histogram: FloatHistogramFromPrometheusModel(test.GenerateTestFloatHistogram(1))},
+	}
+	expected := []promql.HPoint{{T: 3, H: test.GenerateTestFloatHistogram(0)}, {T: 5, H: test.GenerateTestFloatHistogram(1)}}
+
+	assert.Equal(t, expected, FromHistogramsToHPoints(input))
 }
 
 // Check that Prometheus HPoint and Mimir FloatHistogramPair types converted


### PR DESCRIPTION
#### What this PR does

This PR introduces two new methods to the `mimirpb` package, to convert from the `mimirpb` types to their `promql` equivalents.

This has been extracted from a larger PR to try to make that PR smaller and easier to review.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
