### PR TITLE
Bump rollout-operator helm chart version in mimir-distributed

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -44,7 +44,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add support for `revisionhistorylimit` for all deployments. #12323
 * [ENHANCEMENT] Components with predefined `GOMAXPROCS` and/or `GOMEMLIMIT` environment variables (ie. distributor, ingester, querier, ruler-querier, store-gateway) allow user-defined overrides through the components `env` values. #11983
 * [ENHANCEMENT] Add documentation for livenessProbe support in Chart. #12182
-* [ENHANCEMENT] Upgrade rollout-operator to [0.33.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md). Note required actions for upgrading the rollout-operator chart. 
+* [ENHANCEMENT] Upgrade rollout-operator to [0.33.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md). Note required actions for upgrading the rollout-operator chart.
 
 ## 5.8.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -44,7 +44,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add support for `revisionhistorylimit` for all deployments. #12323
 * [ENHANCEMENT] Components with predefined `GOMAXPROCS` and/or `GOMEMLIMIT` environment variables (ie. distributor, ingester, querier, ruler-querier, store-gateway) allow user-defined overrides through the components `env` values. #11983
 * [ENHANCEMENT] Add documentation for livenessProbe support in Chart. #12182
-* [ENHANCEMENT] Upgrade rollout-operator to [0.33.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md). Note required actions for upgrading the rollout-operator chart. #12591
+* [ENHANCEMENT] Upgrade rollout-operator to [0.33.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator). Note required actions for upgrading the rollout-operator chart. #12591
 
 ## 5.8.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -44,6 +44,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add support for `revisionhistorylimit` for all deployments. #12323
 * [ENHANCEMENT] Components with predefined `GOMAXPROCS` and/or `GOMEMLIMIT` environment variables (ie. distributor, ingester, querier, ruler-querier, store-gateway) allow user-defined overrides through the components `env` values. #11983
 * [ENHANCEMENT] Add documentation for livenessProbe support in Chart. #12182
+* [ENHANCEMENT] Upgrade rollout-operator to [0.33.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md). Note required actions for upgrading the rollout-operator chart. 
 
 ## 5.8.0
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -44,7 +44,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add support for `revisionhistorylimit` for all deployments. #12323
 * [ENHANCEMENT] Components with predefined `GOMAXPROCS` and/or `GOMEMLIMIT` environment variables (ie. distributor, ingester, querier, ruler-querier, store-gateway) allow user-defined overrides through the components `env` values. #11983
 * [ENHANCEMENT] Add documentation for livenessProbe support in Chart. #12182
-* [ENHANCEMENT] Upgrade rollout-operator to [0.33.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md). Note required actions for upgrading the rollout-operator chart.
+* [ENHANCEMENT] Upgrade rollout-operator to [0.33.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md). Note required actions for upgrading the rollout-operator chart. #12591
 
 ## 5.8.0
 

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.5.1
 - name: rollout-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.30.0
-digest: sha256:5961f702517c1cb1c87e889bb2fdd26b6d61604215a11b02d203f9a3f0eda7ca
-generated: "2025-06-20T09:23:22.196464+02:00"
+  version: 0.33.0
+digest: sha256:cf5765ff9feeeec1bbaf6a9b79526ffe6aa9f5a267202f086048bbfd30cf94a9
+generated: "2025-09-03T06:54:09.512102464Z"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -20,5 +20,5 @@ dependencies:
   - name: rollout-operator
     alias: rollout_operator
     repository: https://grafana.github.io/helm-charts
-    version: 0.30.0
+    version: 0.33.0
     condition: rollout_operator.enabled

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -26,7 +26,7 @@ Kubernetes: `^1.29.0-0`
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 5.4.0 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.5.1 |
-| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.30.0 |
+| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.33.0 |
 
 # Contributing and releasing
 

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: classic-architecture-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: classic-architecture-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: classic-architecture-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: classic-architecture-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: classic-architecture-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: classic-architecture-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: classic-architecture-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: classic-architecture-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: classic-architecture-values

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: classic-architecture-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: classic-architecture-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: classic-architecture-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: classic-architecture-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: classic-architecture-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: classic-architecture-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: classic-architecture-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: classic-architecture-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: classic-architecture-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: classic-architecture-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: enterprise-https-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: enterprise-https-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: enterprise-https-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: enterprise-https-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: enterprise-https-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: enterprise-https-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: enterprise-https-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: enterprise-https-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: enterprise-https-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: enterprise-https-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: enterprise-https-values

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: enterprise-https-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: enterprise-https-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: enterprise-https-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: enterprise-https-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: enterprise-https-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: enterprise-https-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: enterprise-https-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: enterprise-https-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: enterprise-https-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: enterprise-https-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: enterprise-https-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: enterprise-https-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: gateway-enterprise-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-enterprise-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-enterprise-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: gateway-enterprise-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-enterprise-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: gateway-enterprise-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-enterprise-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: gateway-enterprise-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-enterprise-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-enterprise-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-enterprise-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-enterprise-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-enterprise-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-enterprise-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-enterprise-values

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: gateway-enterprise-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-enterprise-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gateway-enterprise-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gateway-enterprise-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: gateway-enterprise-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gateway-enterprise-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-enterprise-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gateway-enterprise-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: gateway-enterprise-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-enterprise-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-enterprise-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: gateway-enterprise-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: gateway-nginx-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: gateway-nginx-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: gateway-nginx-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-nginx-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-nginx-values

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gateway-nginx-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gateway-nginx-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: gateway-nginx-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gateway-nginx-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-nginx-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gateway-nginx-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: gateway-nginx-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-nginx-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: gateway-nginx-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: gateway-nginx-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-global-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-global-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-global-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-global-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-global-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-global-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-autoscaling-global-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-global-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-global-values

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: keda-autoscaling-global-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: keda-autoscaling-global-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: keda-autoscaling-global-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keda-autoscaling-global-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keda-autoscaling-global-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keda-autoscaling-global-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: keda-autoscaling-global-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keda-autoscaling-global-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-global-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-global-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-metamonitoring-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-metamonitoring-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-metamonitoring-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-autoscaling-metamonitoring-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: keda-autoscaling-metamonitoring-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: keda-autoscaling-metamonitoring-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: keda-autoscaling-metamonitoring-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keda-autoscaling-metamonitoring-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keda-autoscaling-metamonitoring-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keda-autoscaling-metamonitoring-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: keda-autoscaling-metamonitoring-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keda-autoscaling-metamonitoring-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-metamonitoring-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-autoscaling-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-values

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: keda-autoscaling-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: keda-autoscaling-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: keda-autoscaling-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keda-autoscaling-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keda-autoscaling-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keda-autoscaling-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: keda-autoscaling-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keda-autoscaling-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: keda-autoscaling-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: keda-autoscaling-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: large-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: large-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: large-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: large-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: large-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: large-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: large-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: large-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: large-values

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: large-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: large-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: large-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: large-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: large-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: large-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: large-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: large-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: large-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: large-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: openshift-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: openshift-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: openshift-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: openshift-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: openshift-values

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: openshift-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: openshift-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: openshift-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: openshift-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: scheduler-name-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: scheduler-name-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: scheduler-name-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: scheduler-name-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: scheduler-name-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: scheduler-name-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: scheduler-name-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: scheduler-name-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: scheduler-name-values

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scheduler-name-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scheduler-name-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: scheduler-name-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scheduler-name-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: scheduler-name-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: scheduler-name-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: scheduler-name-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: scheduler-name-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: scheduler-name-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: scheduler-name-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: small-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: small-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: small-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: small-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: small-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: small-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: small-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: small-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: small-values

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: small-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: small-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: small-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: small-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: small-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: small-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: small-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: small-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: small-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: small-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-enterprise-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-component-image-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-component-image-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-component-image-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-component-image-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-component-image-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-component-image-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-component-image-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-enterprise-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-component-image-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-enterprise-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-component-image-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-enterprise-component-image-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-component-image-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-component-image-values

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-enterprise-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-component-image-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-enterprise-component-image-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-enterprise-component-image-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-enterprise-component-image-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-enterprise-component-image-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-component-image-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-enterprise-component-image-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-enterprise-component-image-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-component-image-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-component-image-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-component-image-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-enterprise-k8s-1.25-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-k8s-1.25-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-k8s-1.25-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-k8s-1.25-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-enterprise-k8s-1.25-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-enterprise-k8s-1.25-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-enterprise-k8s-1.25-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-k8s-1.25-values

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-enterprise-k8s-1.25-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-enterprise-k8s-1.25-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-enterprise-k8s-1.25-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-enterprise-k8s-1.25-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-enterprise-k8s-1.25-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-k8s-1.25-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-enterprise-k8s-1.25-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-enterprise-k8s-1.25-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-k8s-1.25-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-k8s-1.25-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-enterprise-legacy-label-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-legacy-label-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-legacy-label-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-legacy-label-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-legacy-label-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-legacy-label-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-legacy-label-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-legacy-label-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-enterprise-legacy-label-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-legacy-label-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-enterprise-legacy-label-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-legacy-label-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-enterprise-legacy-label-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-legacy-label-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-legacy-label-values

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-enterprise-legacy-label-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-legacy-label-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-enterprise-legacy-label-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-enterprise-legacy-label-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-enterprise-legacy-label-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-enterprise-legacy-label-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-legacy-label-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-enterprise-legacy-label-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-enterprise-legacy-label-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-legacy-label-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-legacy-label-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-legacy-label-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-enterprise-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-enterprise-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-enterprise-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-enterprise-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-values

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-enterprise-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-enterprise-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-enterprise-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-enterprise-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-enterprise-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-enterprise-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-enterprise-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-enterprise-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-enterprise-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-enterprise-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-enterprise-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-enterprise-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-extra-args-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-extra-args-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-extra-args-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-args-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-args-values

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-extra-args-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-extra-args-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-extra-args-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-extra-args-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-extra-args-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-extra-args-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-extra-args-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-extra-args-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-args-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-extra-args-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-objects-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-extra-objects-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-objects-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-extra-objects-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-objects-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-extra-objects-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-extra-objects-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-objects-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-objects-values

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-extra-objects-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-extra-objects-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-extra-objects-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-extra-objects-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-extra-objects-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-extra-objects-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-extra-objects-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-extra-objects-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-extra-objects-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-extra-objects-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-gomaxprocs-override-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-gomaxprocs-override-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-gomaxprocs-override-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-gomaxprocs-override-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-gomaxprocs-override-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-gomaxprocs-override-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-gomaxprocs-override-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-gomaxprocs-override-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-gomaxprocs-override-values

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-gomaxprocs-override-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-gomaxprocs-override-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-gomaxprocs-override-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-gomaxprocs-override-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-gomaxprocs-override-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-gomaxprocs-override-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-gomaxprocs-override-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-gomaxprocs-override-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-gomaxprocs-override-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-gomaxprocs-override-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingest-storage-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ingest-storage-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingest-storage-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ingest-storage-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingest-storage-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ingest-storage-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-ingest-storage-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingest-storage-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingest-storage-values

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-ingest-storage-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-ingest-storage-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-ingest-storage-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-ingest-storage-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-ingest-storage-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-ingest-storage-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-ingest-storage-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-ingest-storage-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingest-storage-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ingest-storage-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingress-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ingress-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingress-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ingress-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingress-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ingress-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-ingress-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingress-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingress-values

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-ingress-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-ingress-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-ingress-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-ingress-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-ingress-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-ingress-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-ingress-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-ingress-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ingress-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ingress-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-component-image-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-component-image-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-component-image-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-component-image-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-component-image-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-component-image-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-component-image-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-component-image-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-component-image-values

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-oss-component-image-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-oss-component-image-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-component-image-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-oss-component-image-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-oss-component-image-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-oss-component-image-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-component-image-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-oss-component-image-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-component-image-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-component-image-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-emptydir-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-emptydir-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-emptydir-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-emptydir-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-emptydir-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-emptydir-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-emptydir-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-emptydir-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-emptydir-values

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-oss-emptydir-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-oss-emptydir-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-emptydir-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-oss-emptydir-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-oss-emptydir-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-oss-emptydir-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-emptydir-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-oss-emptydir-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-emptydir-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-emptydir-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-oss-k8s-1.25-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-k8s-1.25-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-k8s-1.25-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-k8s-1.25-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-k8s-1.25-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-k8s-1.25-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-k8s-1.25-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-k8s-1.25-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-k8s-1.25-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-k8s-1.25-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-k8s-1.25-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-k8s-1.25-values

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-k8s-1.25-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-oss-k8s-1.25-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-oss-k8s-1.25-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-k8s-1.25-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-oss-k8s-1.25-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-oss-k8s-1.25-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-oss-k8s-1.25-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-k8s-1.25-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-oss-k8s-1.25-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-k8s-1.25-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-k8s-1.25-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-logical-multizone-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-logical-multizone-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-logical-multizone-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-logical-multizone-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-logical-multizone-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-logical-multizone-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-logical-multizone-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-logical-multizone-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-logical-multizone-values

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-oss-logical-multizone-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-oss-logical-multizone-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-logical-multizone-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-oss-logical-multizone-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-oss-logical-multizone-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-oss-logical-multizone-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-logical-multizone-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-oss-logical-multizone-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-logical-multizone-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-logical-multizone-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-multizone-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-multizone-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-multizone-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-multizone-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-multizone-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-multizone-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-multizone-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-multizone-values

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-oss-multizone-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-oss-multizone-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-multizone-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-oss-multizone-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-oss-multizone-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-oss-multizone-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-multizone-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-oss-multizone-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-multizone-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-multizone-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-topology-spread-constraints-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-topology-spread-constraints-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-topology-spread-constraints-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-topology-spread-constraints-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-topology-spread-constraints-values

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-oss-topology-spread-constraints-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-oss-topology-spread-constraints-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-topology-spread-constraints-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-oss-topology-spread-constraints-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-oss-topology-spread-constraints-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-oss-topology-spread-constraints-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-oss-topology-spread-constraints-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-oss-topology-spread-constraints-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-oss-topology-spread-constraints-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-requests-and-limits-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-requests-and-limits-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-requests-and-limits-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-requests-and-limits-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-requests-and-limits-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-requests-and-limits-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-requests-and-limits-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-requests-and-limits-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-requests-and-limits-values

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-requests-and-limits-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-requests-and-limits-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-requests-and-limits-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-requests-and-limits-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-requests-and-limits-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-requests-and-limits-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-requests-and-limits-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-requests-and-limits-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-requests-and-limits-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-requests-and-limits-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-revisionhistorylimit-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-revisionhistorylimit-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-revisionhistorylimit-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-revisionhistorylimit-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-revisionhistorylimit-values

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-revisionhistorylimit-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-revisionhistorylimit-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-revisionhistorylimit-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-revisionhistorylimit-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-revisionhistorylimit-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-revisionhistorylimit-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-revisionhistorylimit-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-revisionhistorylimit-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-revisionhistorylimit-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ruler-dedicated-query-path-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ruler-dedicated-query-path-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ruler-dedicated-query-path-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-ruler-dedicated-query-path-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ruler-dedicated-query-path-values

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-ruler-dedicated-query-path-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-ruler-dedicated-query-path-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-ruler-dedicated-query-path-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-ruler-dedicated-query-path-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-ruler-dedicated-query-path-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-ruler-dedicated-query-path-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-ruler-dedicated-query-path-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-ruler-dedicated-query-path-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-ruler-dedicated-query-path-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,13 +6,14 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   minReadySeconds: 10
   selector:
     matchLabels:
@@ -45,13 +46,18 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: "grafana/rollout-operator:v0.28.0"
+          image: "grafana/rollout-operator:v0.29.0"
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -server-tls.enabled=true
+          - -server-tls.self-signed-cert.secret-name=certificate
           ports:
             - name: http-metrics
               containerPort: 8001
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -1,0 +1,40 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: no-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-vault-agent-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: no-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-vault-agent-values-rollout-operator
+        path: /admission/no-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: pod-eviction-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-vault-agent-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: pod-eviction-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-vault-agent-values-rollout-operator
+        path: /admission/pod-eviction
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        resources:
+          - pods/eviction
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -1,0 +1,42 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: prepare-downscale-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-vault-agent-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: prepare-downscale-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-vault-agent-values-rollout-operator
+        path: /admission/prepare-downscale
+        port: 443
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        resources:
+          - statefulsets
+          - statefulsets/scale
+        scope: Namespaced
+    admissionReviewVersions:
+      - v1
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: NoneOnDryRun
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -36,3 +36,19 @@ rules:
   - statefulsets/status
   verbs:
   - update
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - rollout-operator.grafana.com
+  resources:
+    - replicatemplates/scale
+    - replicatemplates/status
+  verbs:
+    - get
+    - patch

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-vault-agent-values-rollout-operator
+  namespace: "citestns"
+  labels:
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-vault-agent-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+      name: https
+  selector:
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-vault-agent-values

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.30.0
+    helm.sh/chart: rollout-operator-0.33.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.28.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-vault-agent-values-rollout-operator-webhook-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-vault-agent-values-rollout-operator-webhook-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: test-vault-agent-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-vault-agent-values-rollout-operator-webhook-clusterrole
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - patch
+      - watch

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
@@ -1,0 +1,15 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-vault-agent-values-rollout-operator-webhook-rolebinding
+  namespace: "citestns"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-vault-agent-values-rollout-operator-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: test-vault-agent-values-rollout-operator
+    namespace: "citestns"

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
@@ -1,0 +1,23 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/webhook-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-vault-agent-values-rollout-operator-webhook-role
+  namespace: "citestns"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - get
+    resourceNames:
+      - certificate
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -1,0 +1,39 @@
+---
+# Source: mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: zpdb-validation-citestns
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: "citestns"
+    helm.sh/chart: rollout-operator-0.33.0
+    app.kubernetes.io/name: rollout-operator
+    app.kubernetes.io/instance: test-vault-agent-values
+    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: zpdb-validation-citestns.grafana.com
+    clientConfig:
+      service:
+        namespace: "citestns"
+        name: test-vault-agent-values-rollout-operator
+        path: /admission/zpdb-validation
+        port: 443
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - rollout-operator.grafana.com
+        apiVersions:
+          - v1
+        resources:
+          - zoneawarepoddisruptionbudgets
+        scope: Namespaced
+    admissionReviewVersions: ["v1"]
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: "citestns"
+    sideEffects: None
+    failurePolicy: Fail


### PR DESCRIPTION
#### What this PR does

Bump the included rollout-operator helm chart version in mimir-distributed to use the latest v0.33.0 chart.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir-squad/issues/2365

#### Checklist

- [x ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
