### PR TITLE
Query-frontend: more efficient expression-walking code

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
+++ b/pkg/frontend/querymiddleware/astmapper/subtree_folder.go
@@ -65,48 +65,28 @@ func isVectorSelector(n parser.Node) (bool, error) {
 }
 
 // anyNode is a helper which walks the input node and returns true if any node in the subtree
-// returns true for the specified predicate function.
+// returns true for the specified predicate function. If fn returns an error, return that.
 func anyNode(node parser.Node, fn predicate) (bool, error) {
-	v := &visitor{
-		fn: fn,
+	result, err := fn(node)
+	if result || err != nil {
+		return result, err
 	}
 
-	if err := parser.Walk(v, node, nil); err != nil {
-		return false, err
+	for node := range parser.ChildrenIter(node) {
+		result, err := anyNode(node, fn)
+		if result || err != nil {
+			return result, err
+		}
 	}
-	return v.result, nil
+	return false, nil
 }
 
 // visitNode recursively traverse the node's subtree and call fn for each node encountered.
 func visitNode(node parser.Node, fn func(node parser.Node)) {
-	_ = parser.Walk(&visitor{fn: func(node parser.Node) (bool, error) {
-		fn(node)
-		return false, nil
-	}}, node, nil)
+	fn(node)
+	for e := range parser.ChildrenIter(node) {
+		visitNode(e, fn)
+	}
 }
 
 type predicate = func(parser.Node) (bool, error)
-
-type visitor struct {
-	fn     predicate
-	result bool
-}
-
-// Visit implements parser.Visitor
-func (v *visitor) Visit(node parser.Node, _ []parser.Node) (parser.Visitor, error) {
-	// if the visitor has already seen a predicate success, don't overwrite
-	if v.result {
-		return nil, nil
-	}
-
-	var err error
-
-	v.result, err = v.fn(node)
-	if err != nil {
-		return nil, err
-	}
-	if v.result {
-		return nil, nil
-	}
-	return v, nil
-}

--- a/pkg/frontend/querymiddleware/durations.go
+++ b/pkg/frontend/querymiddleware/durations.go
@@ -68,8 +68,7 @@ func (d *durationsMiddleware) rewriteIfNeeded(ctx context.Context, req MetricsQu
 		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}
 
-	checkVisitor := &durationVisitor{}
-	if err := parser.Walk(checkVisitor, expr, nil); err != nil {
+	if err := inspect(expr, durationVisitor); err != nil {
 		level.Warn(spanLog).Log("msg", "the query contains unsupported duration expressions", "err", err)
 		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}
@@ -90,58 +89,56 @@ func (d *durationsMiddleware) rewriteIfNeeded(ctx context.Context, req MetricsQu
 	return req, nil
 }
 
-type durationVisitor struct{}
-
-// Visit verifies that duration expressions only contain durations that Mimir supports.
+// durationVisitor verifies that duration expressions only contain durations that Mimir supports.
 // And also clear the original expressions to not confuse the frontend.
-func (v *durationVisitor) Visit(node parser.Node, _ []parser.Node) (parser.Visitor, error) {
+func durationVisitor(node parser.Node) error {
 	switch n := node.(type) {
 	case *parser.VectorSelector:
 		if n.OriginalOffsetExpr != nil {
-			err := v.checkDuration(n.OriginalOffsetExpr)
+			err := checkDuration(n.OriginalOffsetExpr)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			n.OriginalOffsetExpr = nil
 		}
 	case *parser.MatrixSelector:
 		if n.RangeExpr != nil {
-			err := v.checkDuration(n.RangeExpr)
+			err := checkDuration(n.RangeExpr)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			n.RangeExpr = nil
 		}
 	case *parser.SubqueryExpr:
 		if n.OriginalOffsetExpr != nil {
-			err := v.checkDuration(n.OriginalOffsetExpr)
+			err := checkDuration(n.OriginalOffsetExpr)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			n.OriginalOffsetExpr = nil
 		}
 		if n.StepExpr != nil {
-			err := v.checkDuration(n.StepExpr)
+			err := checkDuration(n.StepExpr)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			n.StepExpr = nil
 		}
 		if n.RangeExpr != nil {
-			err := v.checkDuration(n.RangeExpr)
+			err := checkDuration(n.RangeExpr)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			n.RangeExpr = nil
 		}
 	}
-	return v, nil
+	return nil
 }
 
 // checkDuration checks if we know how to handle the duration expression.
 // Has the same structure as in promql/durations.go, but does not calculate
 // the duration.
-func (v *durationVisitor) checkDuration(expr parser.Expr) error {
+func checkDuration(expr parser.Expr) error {
 	switch n := expr.(type) {
 	case *parser.NumberLiteral:
 		return nil
@@ -149,14 +146,14 @@ func (v *durationVisitor) checkDuration(expr parser.Expr) error {
 		var err error
 
 		if n.LHS != nil {
-			err = v.checkDuration(n.LHS)
+			err = checkDuration(n.LHS)
 			if err != nil {
 				return err
 			}
 		}
 
 		if n.RHS != nil {
-			err = v.checkDuration(n.RHS)
+			err = checkDuration(n.RHS)
 			if err != nil {
 				return err
 			}
@@ -187,4 +184,18 @@ func (v *durationVisitor) checkDuration(expr parser.Expr) error {
 	default:
 		return fmt.Errorf("unexpected duration expression type %T in query-frontend", n)
 	}
+}
+
+// inspect recursively traverses a PromQL AST and calls fn for each node encountered.
+// If fn returns an error, traversal stops and that error is returned by inspect.
+func inspect(node parser.Node, fn func(node parser.Node) error) error {
+	if err := fn(node); err != nil {
+		return err
+	}
+	for e := range parser.ChildrenIter(node) {
+		if err := inspect(e, fn); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/frontend/querymiddleware/durations_test.go
+++ b/pkg/frontend/querymiddleware/durations_test.go
@@ -129,8 +129,7 @@ func TestDurationVisitorRejectInvalid(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			v := &durationVisitor{}
-			err := parser.Walk(v, tc.expr, nil)
+			err := inspect(tc.expr, durationVisitor)
 			require.Error(t, err)
 			require.EqualError(t, err, tc.expectError)
 		})

--- a/pkg/frontend/querymiddleware/experimental_functions.go
+++ b/pkg/frontend/querymiddleware/experimental_functions.go
@@ -90,7 +90,7 @@ func (m *experimentalFunctionsMiddleware) Do(ctx context.Context, req MetricsQue
 // containedExperimentalFunctions returns any PromQL experimental functions used in the query.
 func containedExperimentalFunctions(expr parser.Expr) map[string]struct{} {
 	expFuncNames := map[string]struct{}{}
-	parser.Inspect(expr, func(node parser.Node, _ []parser.Node) error {
+	inspect(expr, func(node parser.Node) error {
 		call, ok := node.(*parser.Call)
 		if ok {
 			if parser.Functions[call.Func.Name].Experimental {

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -344,7 +344,7 @@ func areEvaluationTimeModifiersCachable(r MetricsQueryRequest, maxCacheTime int6
 		return nil
 	}
 
-	parser.Inspect(expr, func(n parser.Node, _ []parser.Node) error {
+	inspect(expr, func(n parser.Node) error {
 		switch e := n.(type) {
 		case *parser.VectorSelector:
 			return check(e.Timestamp, e.OriginalOffset)

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -710,7 +710,7 @@ func evaluateAtModifierFunction(query string, start, end int64) (string, error) 
 	if err != nil {
 		return "", apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}
-	parser.Inspect(expr, func(n parser.Node, _ []parser.Node) error {
+	inspect(expr, func(n parser.Node) error {
 		switch exprAt := n.(type) {
 		case *parser.VectorSelector:
 			switch exprAt.StartOrEnd {


### PR DESCRIPTION
#### What this PR does

Now that Prometheus exposes an iterator we can skip a couple of layers of indirection and run just the code that we need.

This is more efficient in particular because `parser.Walk` would allocate a slice for the expression path, which was never used.

Maybe one of the tree-walking functions can go in a utility package?  I didn't see an obvious place.

I don't think it needs a CHANGELOG entry as it should be invisible to users.

#### Checklist

- [x] Tests updated.
- NA Documentation added.
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
