### PR TITLE
Replace BlockBuilderLagging alert with BlockBuilderSchedulerPendingJobs

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1802,22 +1802,25 @@ How to **fix**:
 
   1. Once ingesters are stable, revert the temporarily config applied in the previous step.
 
-### MimirBlockBuilderLagging
+### MimirBlockBuilderSchedulerPendingJobs
 
-This alert fires when the block-builder reports a large number of unprocessed records in Kafka partitions.
+This alert fires when the block-builder-scheduler reports pending jobs for an extended period of time.
 
 How it **works**:
 
-- The block-builder-scheduler watches the Kafka topic backlog. The lag is calculated per-partition as the difference between the partition's end and its last committed offset.
-- The block-builder-scheduler chops the backlog into jobs, and distributes the jobs between the block-builder instances.
-- A block-builder must consume and process the records in a job into TSDB blocks.
+- The block-builder-scheduler watches the Kafka topic backlog.
+- The block-builder-scheduler divide the backlog into jobs, and distributes the jobs between the block-builder instances.
+- A block-builder must consume records from a job's start offset to its end offset, and process the records into TSDB blocks.
 - When the job is processed, the block-builder-scheduler commits the offset of the last record from this job into Kafka.
+- The jobs that haven't been yet assigned to any block-builder instance are reported as "pending" jobs.
 
-If the block-builder reports high values in the lag, this could indicate that the block-builder cannot fully process and commit Kafka record.
+When the block-builder-scheduler reports that it has pending jobs, this can mean either that all block-builder instances are busy, and can't pick the pending jobs;
+or there are no block-builder instances running.
 
 How to **investigate**:
 
-- Check if the per-partition lag has been growing over the past hours.
+- Check if the block-builder instances are healthy, and that they progress with the assigned jobs.
+- Check if the per-partition lag has been growing over the previous hours.
 - Explore the block-builder logs for any errors reported while it processed the partition.
 
 ### MimirBlockBuilderCompactAndUploadFailed

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1809,7 +1809,7 @@ This alert fires when the block-builder-scheduler reports pending jobs for an ex
 How it **works**:
 
 - The block-builder-scheduler watches the Kafka topic backlog.
-- The block-builder-scheduler divide the backlog into jobs, and distributes the jobs between the block-builder instances.
+- The block-builder-scheduler divides the backlog into jobs, and distributes the jobs between the block-builder instances.
 - A block-builder must consume records from a job's start offset to its end offset, and process the records into TSDB blocks.
 - When the job is processed, the block-builder-scheduler commits the offset of the last record from this job into Kafka.
 - The jobs that haven't been yet assigned to any block-builder instance are reported as "pending" jobs.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1335,36 +1335,15 @@ spec:
             for: 5m
             labels:
               severity: critical
-          - alert: MimirBlockBuilderLagging
+          - alert: MimirBlockBuilderSchedulerPendingJobs
             annotations:
-              message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
+              message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports {{ printf "%.2f" $value }} pending jobs.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderschedulerpendingjobs
             expr: |
-              max by(cluster, namespace, pod) (
-              max_over_time(
-              (
-              cortex_blockbuilder_scheduler_partition_end_offset offset 1h
-              -
-              cortex_blockbuilder_scheduler_partition_committed_offset
-              )[10m:])) > 4e6
-            for: 75m
+              sum by (cluster, namespace, pod) (cortex_blockbuilder_scheduler_pending_jobs) > 0
+            for: 40m
             labels:
               severity: warning
-          - alert: MimirBlockBuilderLagging
-            annotations:
-              message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
-            expr: |
-              max by(cluster, namespace, pod) (
-              max_over_time(
-              (
-              cortex_blockbuilder_scheduler_partition_end_offset offset 1h
-              -
-              cortex_blockbuilder_scheduler_partition_committed_offset
-              )[10m:])) > 4e6
-            for: 140m
-            labels:
-              severity: critical
           - alert: MimirBlockBuilderCompactAndUploadFailed
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1309,36 +1309,15 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirBlockBuilderLagging
+        - alert: MimirBlockBuilderSchedulerPendingJobs
           annotations:
-            message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
+            message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports {{ printf "%.2f" $value }} pending jobs.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderschedulerpendingjobs
           expr: |
-            max by(cluster, namespace, instance) (
-            max_over_time(
-            (
-            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
-            -
-            cortex_blockbuilder_scheduler_partition_committed_offset
-            )[10m:])) > 4e6
-          for: 75m
+            sum by (cluster, namespace, instance) (cortex_blockbuilder_scheduler_pending_jobs) > 0
+          for: 40m
           labels:
             severity: warning
-        - alert: MimirBlockBuilderLagging
-          annotations:
-            message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
-          expr: |
-            max by(cluster, namespace, instance) (
-            max_over_time(
-            (
-            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
-            -
-            cortex_blockbuilder_scheduler_partition_committed_offset
-            )[10m:])) > 4e6
-          for: 140m
-          labels:
-            severity: critical
         - alert: MimirBlockBuilderCompactAndUploadFailed
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -1323,36 +1323,15 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirBlockBuilderLagging
+        - alert: MimirBlockBuilderSchedulerPendingJobs
           annotations:
-            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports {{ printf "%.2f" $value }} pending jobs.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderschedulerpendingjobs
           expr: |
-            max by(cluster, namespace, pod) (
-            max_over_time(
-            (
-            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
-            -
-            cortex_blockbuilder_scheduler_partition_committed_offset
-            )[10m:])) > 4e6
-          for: 75m
+            sum by (cluster, namespace, pod) (cortex_blockbuilder_scheduler_pending_jobs) > 0
+          for: 40m
           labels:
             severity: warning
-        - alert: MimirBlockBuilderLagging
-          annotations:
-            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
-          expr: |
-            max by(cluster, namespace, pod) (
-            max_over_time(
-            (
-            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
-            -
-            cortex_blockbuilder_scheduler_partition_committed_offset
-            )[10m:])) > 4e6
-          for: 140m
-          labels:
-            severity: critical
         - alert: MimirBlockBuilderCompactAndUploadFailed
           annotations:
             message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1323,36 +1323,15 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirBlockBuilderLagging
+        - alert: MimirBlockBuilderSchedulerPendingJobs
           annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
+            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports {{ printf "%.2f" $value }} pending jobs.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderschedulerpendingjobs
           expr: |
-            max by(cluster, namespace, pod) (
-            max_over_time(
-            (
-            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
-            -
-            cortex_blockbuilder_scheduler_partition_committed_offset
-            )[10m:])) > 4e6
-          for: 75m
+            sum by (cluster, namespace, pod) (cortex_blockbuilder_scheduler_pending_jobs) > 0
+          for: 40m
           labels:
             severity: warning
-        - alert: MimirBlockBuilderLagging
-          annotations:
-            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports partition lag of {{ printf "%.2f" $value }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderlagging
-          expr: |
-            max by(cluster, namespace, pod) (
-            max_over_time(
-            (
-            cortex_blockbuilder_scheduler_partition_end_offset offset 1h
-            -
-            cortex_blockbuilder_scheduler_partition_committed_offset
-            )[10m:])) > 4e6
-          for: 140m
-          labels:
-            severity: critical
         - alert: MimirBlockBuilderCompactAndUploadFailed
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -233,7 +233,7 @@
           },
         },
 
-        // Alert if block-builder-scheduler reports pending jobs for extended period of time.
+        // Alert if block-builder scheduler reports pending jobs for extended period of time.
         {
           alert: $.alertName('BlockBuilderSchedulerPendingJobs'),
           'for': '40m',


### PR DESCRIPTION
#### What this PR does

This PR replaces the experimental `BlockBuilderLagging` alert with a new `BlockBuilderSchedulerPendingJobs`.

In our production, there is a huge difference between what a typical lag looks like in a small cell, comparing to a large one. So we noticed that alerting on lag against a fixed threshold doesn't work well in practice. That is, the block-builder consumes the backlog with a delay of one hour. The delta in the per-partition's lag between the beginning and the end of an hour, depends on how aggressively the distributors produce records to the partitions.

For an immediate alert, I propose we replace the `BlockBuilderLagging` with an alert that reports when the scheduler has "pending" jobs. If the number of such is positive for some period, this is an indicator that the block-builder instances have troubles coupling with the workload (or the block-builders are down).

I think we can re-visit the lag-based alert for in the future, to trigger when the lag grows for an extended period (e.g. 6-12h). But we need more data to tune such an alert, so we will do that separately.