### PR TITLE
parquet: Update benchmark to reuse generated block

### DIFF
--- a/pkg/storegateway/parquetbench/README.md
+++ b/pkg/storegateway/parquetbench/README.md
@@ -1,0 +1,44 @@
+# Parquet Benchmark
+
+This benchmark compares the performance of querying time series data from Parquet and TSDB storage formats in Grafana Mimir.
+
+## Quick Start
+
+### Option 1: Generate Data On-the-Fly (Default)
+
+The benchmark can generate test data automatically during the test run:
+
+```bash
+# Run with Parquet storage
+go test -bench=BenchmarkBucketStores_Series -benchmark-store=parquet
+
+# Run with TSDB storage  
+go test -bench=BenchmarkBucketStores_Series -benchmark-store=tsdb
+
+# Run specific test case
+go test -bench=SingleMetricAllSeries -benchmark-store=parquet
+```
+
+### Option 2: Use Pre-Generated Blocks (Recommended to speed up tests and ensure consistency)
+
+For a faster developer loop and consistent benchmarking, use pre-generated blocks with the `blockgen` tool:
+
+```bash
+# 1. Generate test blocks (see blockgen/README.md for details)
+cd blockgen
+go run main.go -verbose
+
+# 2. Run benchmark with pre-generated blocks
+cd ..
+go test -bench=BenchmarkBucketStores_Series -benchmark-store=parquet -benchmark-tsdb-dir=./blockgen/benchmark-data
+go test -bench=BenchmarkBucketStores_Series -benchmark-store=tsdb -benchmark-tsdb-dir=./blockgen/benchmark-data
+```
+
+## Benchmark Flags
+
+| Flag | Default | Description                                                                                               |
+|------|---------|-----------------------------------------------------------------------------------------------------------|
+| `-benchmark-store` | `parquet` | Store type to benchmark: 'parquet' or 'tsdb'                                                              |
+| `-benchmark-compression` | `true` | Enable compression for parquet data                                                                       |
+| `-benchmark-sort-by` | `""` | Comma-separated list of fields to sort by in parquet data                                                 |
+| `-benchmark-tsdb-dir` | `""` | Path to pre-generated TSDB blocks (optional) If set the above compression and sort-by options are ignored |

--- a/pkg/storegateway/parquetbench/bench_test.go
+++ b/pkg/storegateway/parquetbench/bench_test.go
@@ -37,6 +37,7 @@ import (
 var benchmarkStore = flag.String("benchmark-store", "parquet", "Store type to benchmark: 'parquet' or 'tsdb'")
 var benchmarkCompression = flag.Bool("benchmark-compression", true, "Enable compression for parquet data")
 var benchmarkSortBy = flag.String("benchmark-sort-by", "", "Comma-separated list of fields to sort by in parquet data")
+var benchmarkTSDBDir = flag.String("benchmark-tsdb-dir", "", "Path to directory containing pre-generated TSDB blocks (if not set, generates data on the fly)")
 
 var benchmarkCases = []struct {
 	name     string
@@ -71,7 +72,7 @@ var benchmarkCases = []struct {
 		matchers: []*labels.Matcher{
 			labels.MustNewMatcher(labels.MatchEqual, "__name__", "test_metric_1"),
 			labels.MustNewMatcher(labels.MatchEqual, "service", "service-1"),
-			labels.MustNewMatcher(labels.MatchEqual, "environment", "environment-0"),
+			labels.MustNewMatcher(labels.MatchEqual, "environment", "environment-1"),
 		},
 	},
 	// TODO this one is commented because it returns no series and current implementation requires it
@@ -151,7 +152,7 @@ func BenchmarkBucketStores_Series(b *testing.B) {
 		}
 	}
 
-	bkt, mint, maxt := setupBenchmarkData(b, user, *benchmarkCompression, sortByFields)
+	bkt, mint, maxt := setupBenchmarkData(b, user, *benchmarkCompression, sortByFields, *benchmarkTSDBDir)
 
 	ctx := grpc_metadata.NewIncomingContext(b.Context(), grpc_metadata.MD{
 		storegateway.GrpcContextMetadataTenantID: []string{user},

--- a/pkg/storegateway/parquetbench/blockgen/README.md
+++ b/pkg/storegateway/parquetbench/blockgen/README.md
@@ -13,7 +13,7 @@ go run main.go [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-output` | `./benchmark-data` | Output directory for generated blocks |
-| `-user` | `test-user` | User ID for the generated blocks |
+| `-user` | `benchmark-user` | User ID for the generated blocks |
 | `-compression` | `true` | Enable compression for parquet data |
 | `-sort-by` | `""` | Comma-separated list of fields to sort by in parquet data |
 | `-store` | `both` | Store type to generate: 'parquet', 'tsdb', or 'both' |

--- a/pkg/storegateway/parquetbench/blockgen/README.md
+++ b/pkg/storegateway/parquetbench/blockgen/README.md
@@ -1,0 +1,105 @@
+# Block Generator Tool
+
+A standalone tool for generating benchmark data blocks with configurable series counts and realistic time series data.
+
+## Usage
+
+```bash
+go run main.go [flags]
+```
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-output` | `./benchmark-data` | Output directory for generated blocks |
+| `-user` | `test-user` | User ID for the generated blocks |
+| `-series` | `1500000` | Total number of series to generate |
+| `-compression` | `true` | Enable compression for parquet data |
+| `-sort-by` | `""` | Comma-separated list of fields to sort by in parquet data |
+| `-store` | `both` | Store type to generate: 'parquet', 'tsdb', or 'both' |
+| `-metrics` | `5` | Number of different metrics to generate |
+| `-sample-value` | `0` | Fixed sample value (0 = random) |
+| `-samples` | `10` | Number of samples per series |
+| `-time-range` | `2` | Time range in hours for the generated block |
+| `-verbose` | `false` | Verbose logging |
+
+## Examples
+
+### Generate 1.5M series (default)
+```bash
+go run main.go -verbose
+```
+
+### Generate 15M series
+```bash
+go run main.go -series 15000000 -verbose
+```
+
+### Generate only parquet blocks
+```bash
+go run main.go -store parquet -verbose
+```
+
+### Generate only TSDB blocks
+```bash
+go run main.go -store tsdb -verbose
+```
+
+### Generate with custom sorting
+```bash
+go run main.go -sort-by "__name__,instance,region" -verbose
+```
+
+### Generate with fixed sample values (for deterministic testing)
+```bash
+go run main.go -sample-value 42.0 -verbose
+```
+
+### Generate with custom time series density
+```bash
+# Generate 100 samples per series over 6 hours
+go run main.go -samples 100 -time-range 6 -verbose
+```
+
+## Fixed Issues
+
+The tool now correctly generates blocks with:
+- **Proper timestamps**: Uses realistic time ranges instead of all samples at timestamp 0
+- **Multiple samples per series**: Configurable number of samples distributed over the time range
+- **Correct metadata**: Blocks contain proper minTime/maxTime and sample counts
+- **TSDB components**: Generated TSDB blocks include index files and chunk files with actual data
+
+## Output
+
+The tool creates:
+- TSDB blocks (if `-store tsdb` or `-store both`)
+  - `index` file with series index
+  - `chunks/000001` file with actual sample data  
+  - `meta.json` with block metadata
+- Parquet blocks (if `-store parquet` or `-store both`) 
+  - `0.labels.parquet` with series labels
+  - `0.chunks.parquet` with sample data
+  - `parquet-conversion-mark.json`
+- Bucket index files
+- All data organized under the specified user ID
+
+## Series Distribution
+
+The tool calculates dimensions to achieve the target series count:
+- Metrics: Configurable via `-metrics` flag
+- Instances, regions, zones, services, environments: Automatically calculated
+
+For 1.5M series with 5 metrics:
+- 5 metrics × 100 instances × 5 regions × 10 zones × 20 services × 3 environments = 1,500,000 series
+
+For 15M series with 5 metrics:
+- 5 metrics × 1000 instances × 5 regions × 10 zones × 20 services × 3 environments = 15,000,000 series
+
+## Time Series Data
+
+Each series gets multiple samples distributed evenly across the specified time range:
+- Default: 10 samples over 2 hours = 1 sample every 13.3 minutes
+- Custom: `-samples 60 -time-range 6` = 60 samples over 6 hours = 1 sample every 6 minutes
+
+Sample values are random (0-100) unless `-sample-value` is specified.

--- a/pkg/storegateway/parquetbench/blockgen/README.md
+++ b/pkg/storegateway/parquetbench/blockgen/README.md
@@ -1,6 +1,6 @@
 # Block Generator Tool
 
-A standalone tool for generating benchmark data blocks with configurable series counts and realistic time series data.
+A standalone tool for generating benchmark data blocks with configurable label cardinality dimensions and realistic time series data.
 
 ## Usage
 
@@ -14,11 +14,15 @@ go run main.go [flags]
 |------|---------|-------------|
 | `-output` | `./benchmark-data` | Output directory for generated blocks |
 | `-user` | `test-user` | User ID for the generated blocks |
-| `-series` | `1500000` | Total number of series to generate |
 | `-compression` | `true` | Enable compression for parquet data |
 | `-sort-by` | `""` | Comma-separated list of fields to sort by in parquet data |
 | `-store` | `both` | Store type to generate: 'parquet', 'tsdb', or 'both' |
 | `-metrics` | `5` | Number of different metrics to generate |
+| `-instances` | `100` | Number of different instances to generate |
+| `-regions` | `5` | Number of different regions to generate |
+| `-zones` | `10` | Number of different zones to generate |
+| `-services` | `20` | Number of different services to generate |
+| `-environments` | `3` | Number of different environments to generate |
 | `-sample-value` | `0` | Fixed sample value (0 = random) |
 | `-samples` | `10` | Number of samples per series |
 | `-time-range` | `2` | Time range in hours for the generated block |
@@ -26,14 +30,26 @@ go run main.go [flags]
 
 ## Examples
 
-### Generate 1.5M series (default)
+### Generate 1.5M series (default dimensions: 5×100×5×10×20×3)
 ```bash
 go run main.go -verbose
 ```
 
-### Generate 15M series
+### Generate 15M series by scaling instances
 ```bash
-go run main.go -series 15000000 -verbose
+go run main.go -instances 1000 -verbose
+```
+
+### High cardinality for specific dimensions
+```bash
+# 10M series with many instances and services
+go run main.go -instances 500 -services 100 -verbose
+```
+
+### Low cardinality test scenario
+```bash
+# Only 60 series with minimal dimensions
+go run main.go -metrics 2 -instances 2 -regions 3 -zones 5 -services 1 -environments 1 -verbose
 ```
 
 ### Generate only parquet blocks
@@ -84,17 +100,22 @@ The tool creates:
 - Bucket index files
 - All data organized under the specified user ID
 
-## Series Distribution
+## Series Calculation
 
-The tool calculates dimensions to achieve the target series count:
-- Metrics: Configurable via `-metrics` flag
-- Instances, regions, zones, services, environments: Automatically calculated
+Total series = metrics × instances × regions × zones × services × environments
 
-For 1.5M series with 5 metrics:
-- 5 metrics × 100 instances × 5 regions × 10 zones × 20 services × 3 environments = 1,500,000 series
+**Default dimensions:**
+- 5 metrics × 100 instances × 5 regions × 10 zones × 20 services × 3 environments = **1,500,000 series**
 
-For 15M series with 5 metrics:
-- 5 metrics × 1000 instances × 5 regions × 10 zones × 20 services × 3 environments = 15,000,000 series
+**Examples:**
+- **60 series**: `-metrics 2 -instances 2 -regions 3 -zones 5 -services 1 -environments 1`  
+- **15M series**: `-instances 1000` (keeping other defaults)
+- **10M series**: `-instances 500 -services 100` (with defaults: zones=10, regions=5, environments=3)
+
+**Cardinality Control:**
+- High cardinality dimensions (instances, services) → More realistic distribution patterns
+- Low cardinality dimensions (regions, environments) → Smaller label sets
+- Use different combinations to test various query selectivity scenarios
 
 ## Time Series Data
 

--- a/pkg/storegateway/parquetbench/blockgen/main.go
+++ b/pkg/storegateway/parquetbench/blockgen/main.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	kitlog "github.com/go-kit/log"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus-community/parquet-common/convert"
+	"github.com/prometheus-community/parquet-common/schema"
+	"github.com/prometheus/common/promslog"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/util/teststorage"
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/mimir/pkg/parquetconverter"
+	"github.com/grafana/mimir/pkg/storage/bucket"
+	"github.com/grafana/mimir/pkg/storage/bucket/filesystem"
+	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	"github.com/grafana/mimir/pkg/storage/tsdb/bucketindex"
+)
+
+var (
+	outputDir        = flag.String("output", "./benchmark-data", "Output directory for generated blocks")
+	userID           = flag.String("user", "test-user", "User ID for the generated blocks")
+	seriesCount      = flag.Int64("series", 1500000, "Total number of series to generate")
+	compression      = flag.Bool("compression", true, "Enable compression for parquet data")
+	sortBy           = flag.String("sort-by", "", "Comma-separated list of fields to sort by in parquet data")
+	storeType        = flag.String("store", "both", "Store type to generate: 'parquet', 'tsdb', or 'both'")
+	metricsCount     = flag.Int("metrics", 5, "Number of different metrics to generate")
+	sampleValue      = flag.Float64("sample-value", 0, "Fixed sample value (0 = random)")
+	samplesPerSeries = flag.Int("samples", 10, "Number of samples per series")
+	timeRangeHours   = flag.Int("time-range", 2, "Time range in hours for the generated block")
+	verboseLogging   = flag.Bool("verbose", false, "Verbose logging")
+)
+
+func main() {
+	flag.Parse()
+
+	if *seriesCount <= 0 {
+		log.Fatal("Series count must be positive")
+	}
+
+	var sortByLabels []string
+	if *sortBy != "" {
+		fields := strings.Split(*sortBy, ",")
+		for _, field := range fields {
+			if trimmed := strings.TrimSpace(field); trimmed != "" {
+				sortByLabels = append(sortByLabels, trimmed)
+			}
+		}
+	}
+
+	if err := generateBlocks(*outputDir, *userID, *seriesCount, *compression, sortByLabels, 
+		*storeType, *metricsCount, *sampleValue, *samplesPerSeries, *timeRangeHours, *verboseLogging); err != nil {
+		log.Fatalf("Failed to generate blocks: %v", err)
+	}
+}
+
+func generateBlocks(outputDir, userID string, seriesCount int64, compression bool, 
+	sortByLabels []string, storeType string, metricsCount int, sampleValue float64, 
+	samplesPerSeries, timeRangeHours int, verbose bool) error {
+	
+	ctx := context.Background()
+
+	if verbose {
+		log.Printf("Generating %d series for user %s", seriesCount, userID)
+		log.Printf("Output directory: %s", outputDir)
+		log.Printf("Store type: %s", storeType)
+		log.Printf("Samples per series: %d", samplesPerSeries)
+		log.Printf("Time range: %d hours", timeRangeHours)
+	}
+
+	// Create output directory
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	// Generate time series data
+	st := teststorage.New(nil)
+	defer func() { _ = st.Close() }()
+	
+	app := st.Appender(ctx)
+	
+	if err := generateSeries(app, seriesCount, metricsCount, sampleValue, samplesPerSeries, timeRangeHours, verbose); err != nil {
+		return fmt.Errorf("failed to generate series: %w", err)
+	}
+
+	if err := app.Commit(); err != nil {
+		return fmt.Errorf("failed to commit appender: %w", err)
+	}
+
+	// Create filesystem bucket
+	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: outputDir})
+	if err != nil {
+		return fmt.Errorf("failed to create filesystem bucket: %w", err)
+	}
+	defer func() { _ = bkt.Close() }()
+
+	// Create block from TSDB head
+	blockDir := filepath.Join(outputDir, "temp-blocks")
+	if err := os.MkdirAll(blockDir, 0755); err != nil {
+		return fmt.Errorf("failed to create block directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(blockDir) }()
+
+	head := st.Head()
+	blockID := createBlockFromHead(blockDir, head)
+
+	userBkt := bucket.NewUserBucketClient(userID, bkt, nil)
+
+	// Inject Thanos metadata
+	_, err = block.InjectThanosMeta(kitlog.NewNopLogger(), filepath.Join(blockDir, blockID.String()), block.ThanosMeta{
+		Labels: labels.FromStrings("ext1", "1").Map(),
+		Source: block.TestSource,
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to inject Thanos metadata: %w", err)
+	}
+
+	// Upload TSDB block if requested
+	if storeType == "tsdb" || storeType == "both" {
+		if err := block.Upload(ctx, kitlog.NewNopLogger(), userBkt, filepath.Join(blockDir, blockID.String()), nil); err != nil {
+			return fmt.Errorf("failed to upload TSDB block: %w", err)
+		}
+		if verbose {
+			log.Printf("Generated TSDB block: %s", blockID.String())
+		}
+	}
+
+	// Convert to Parquet if requested
+	if storeType == "parquet" || storeType == "both" {
+		if err := convertToParquet(ctx, userBkt, head, blockID, compression, sortByLabels); err != nil {
+			return fmt.Errorf("failed to convert to parquet: %w", err)
+		}
+		if verbose {
+			log.Printf("Generated Parquet block: %s", blockID.String())
+		}
+	}
+
+	// Create bucket index
+	if err := createBucketIndex(ctx, bkt, userID); err != nil {
+		return fmt.Errorf("failed to create bucket index: %w", err)
+	}
+
+	if verbose {
+		log.Printf("Successfully generated blocks in: %s", outputDir)
+		log.Printf("Time range: %d - %d", head.MinTime(), head.MaxTime())
+	}
+
+	return nil
+}
+
+func generateSeries(app storage.Appender, seriesCount int64, metricsCount int, 
+	sampleValue float64, samplesPerSeries, timeRangeHours int, verbose bool) error {
+	
+	// Calculate dimensions to achieve target series count
+	dimensions := calculateDimensions(seriesCount, metricsCount)
+	
+	actualSeries := int64(dimensions.metrics * dimensions.instances * dimensions.regions * 
+						  dimensions.zones * dimensions.services * dimensions.environments)
+	
+	if verbose {
+		log.Printf("Calculated dimensions: %d metrics × %d instances × %d regions × %d zones × %d services × %d environments = %d series",
+			dimensions.metrics, dimensions.instances, dimensions.regions, dimensions.zones, 
+			dimensions.services, dimensions.environments, actualSeries)
+		log.Printf("Generating %d samples per series over %d hours", samplesPerSeries, timeRangeHours)
+	}
+
+	// Calculate time range - use realistic timestamps
+	now := time.Now()
+	startTime := now.Add(-time.Duration(timeRangeHours) * time.Hour)
+	endTime := now
+	timeStep := time.Duration(timeRangeHours) * time.Hour / time.Duration(samplesPerSeries-1)
+	
+	if verbose {
+		log.Printf("Time range: %s to %s (step: %s)", startTime.Format(time.RFC3339), endTime.Format(time.RFC3339), timeStep)
+	}
+
+	seriesGenerated := int64(0)
+	sampleCount := int64(0)
+	
+	for m := 0; m < dimensions.metrics; m++ {
+		for i := 0; i < dimensions.instances; i++ {
+			for r := 0; r < dimensions.regions; r++ {
+				for z := 0; z < dimensions.zones; z++ {
+					for s := 0; s < dimensions.services; s++ {
+						for e := 0; e < dimensions.environments; e++ {
+							lbls := labels.FromStrings(
+								"__name__", fmt.Sprintf("test_metric_%d", m+1),
+								"instance", fmt.Sprintf("instance-%d", i+1),
+								"region", fmt.Sprintf("region-%d", r+1),
+								"zone", fmt.Sprintf("zone-%d", z+1),
+								"service", fmt.Sprintf("service-%d", s+1),
+								"environment", fmt.Sprintf("environment-%d", e+1),
+							)
+							
+							// Generate multiple samples for this series
+							for sample := 0; sample < samplesPerSeries; sample++ {
+								timestamp := startTime.Add(time.Duration(sample) * timeStep)
+								
+								value := sampleValue
+								if value == 0 {
+									value = rand.Float64() * 100 // Scale to 0-100 for more realistic values
+								}
+								
+								_, err := app.Append(0, lbls, timestamp.UnixMilli(), value)
+								if err != nil {
+									return fmt.Errorf("failed to append sample for series %s at time %s: %w", 
+										lbls.String(), timestamp.Format(time.RFC3339), err)
+								}
+								sampleCount++
+							}
+							seriesGenerated++
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if verbose {
+		log.Printf("Generated %d series with %d total samples", seriesGenerated, sampleCount)
+	}
+
+	return nil
+}
+
+type dimensions struct {
+	metrics      int
+	instances    int
+	regions      int
+	zones        int
+	services     int
+	environments int
+}
+
+func calculateDimensions(targetSeries int64, metricsCount int) dimensions {
+	// Start with the metrics count as specified
+	remainingSeries := targetSeries / int64(metricsCount)
+	
+	// Use reasonable defaults that multiply to close to remainingSeries
+	instances := 100
+	regions := 5
+	zones := 10
+	services := 20
+	environments := 3
+	
+	// Adjust dimensions to get closer to target
+	current := int64(instances * regions * zones * services * environments)
+	
+	// Scale instances to get closer to target
+	if current != 0 {
+		scaleFactor := float64(remainingSeries) / float64(current)
+		instances = max(1, int(float64(instances)*scaleFactor))
+	}
+
+	return dimensions{
+		metrics:      metricsCount,
+		instances:    instances,
+		regions:      regions,
+		zones:        zones,
+		services:     services,
+		environments: environments,
+	}
+}
+
+func convertToParquet(ctx context.Context, userBkt objstore.InstrumentedBucket, head *tsdb.Head, blockID ulid.ULID, 
+	compression bool, sortByLabels []string) error {
+	
+	convertOpts := []convert.ConvertOption{
+		convert.WithName(blockID.String()),
+		convert.WithLabelsCompression(schema.WithCompressionEnabled(compression)),
+		convert.WithChunksCompression(schema.WithCompressionEnabled(compression)),
+	}
+
+	if len(sortByLabels) > 0 {
+		convertOpts = append(convertOpts, convert.WithSortBy(sortByLabels...))
+	}
+
+	_, err := convert.ConvertTSDBBlock(
+		ctx,
+		userBkt,
+		head.MinTime(),
+		head.MaxTime(),
+		[]convert.Convertible{head},
+		convertOpts...)
+	
+	if err != nil {
+		return err
+	}
+
+	return parquetconverter.WriteConversionMark(ctx, blockID, userBkt)
+}
+
+func createBlockFromHead(dir string, head *tsdb.Head) ulid.ULID {
+	opts := tsdb.LeveledCompactorOptions{
+		MaxBlockChunkSegmentSize:    3 * 1024 * 1024,
+		EnableOverlappingCompaction: true,
+	}
+	compactor, err := tsdb.NewLeveledCompactorWithOptions(context.Background(), nil, promslog.NewNopLogger(), []int64{1000000}, nil, opts)
+	if err != nil {
+		log.Fatalf("Failed to create compactor: %v", err)
+	}
+
+	if err := os.MkdirAll(dir, 0777); err != nil {
+		log.Fatalf("Failed to create directory: %v", err)
+	}
+
+	ulids, err := compactor.Write(dir, head, head.MinTime(), head.MaxTime()+1, nil)
+	if err != nil {
+		log.Fatalf("Failed to write block: %v", err)
+	}
+	if len(ulids) != 1 {
+		log.Fatalf("Expected 1 ULID, got %d", len(ulids))
+	}
+	return ulids[0]
+}
+
+func createBucketIndex(ctx context.Context, bkt objstore.Bucket, userID string) error {
+	updater := bucketindex.NewUpdater(bkt, userID, nil, 16, 16, kitlog.NewNopLogger())
+	idx, _, err := updater.UpdateIndex(ctx, nil)
+	if err != nil {
+		return err
+	}
+	return bucketindex.WriteIndex(ctx, bkt, userID, nil, idx)
+}

--- a/pkg/storegateway/parquetbench/blockgen/main.go
+++ b/pkg/storegateway/parquetbench/blockgen/main.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	outputDir        = flag.String("output", "./benchmark-data", "Output directory for generated blocks")
-	userID           = flag.String("user", "test-user", "User ID for the generated blocks")
+	userID           = flag.String("user", "benchmark-user", "User ID for the generated blocks")
 	compression      = flag.Bool("compression", true, "Enable compression for parquet data")
 	sortBy           = flag.String("sort-by", "", "Comma-separated list of fields to sort by in parquet data. If unset it still sorts by __name__.")
 	storeType        = flag.String("store", "both", "Store type to generate: 'parquet', 'tsdb', or 'both'")


### PR DESCRIPTION
This PR is a follow up to https://github.com/grafana/mimir/pull/12532 

The previous PR was able to benchmark store-gateway current performance against the newly created parquet code however it would always have to generate the data before each run, slowing us down if we wanted to test with different configurations or block sizes.

In this PR:
- There is a new `blockgen` tool we can use to generate a tsdb + block directory for an user. Includes README documenting the opts.
- The existing benchmark now accepts a `-benchmark-tsdb-dir` argument accepting an entire tsdb. If set it won't generate data on the fly for the benchmark, if not set then it will.

Quick run:
```
$ cd pkg/storegateway/parquetbench
$ go run blockgen/main.go -zones 1000 -instances 10 -verbose -output benchmark-data-15M # generates a block with 15M series and 1k cardinality on zones
...
$ go test': go test -bench=. -benchmark-store=parquet  -benchmark-tsdb-dir=./blockgen/benchmark-data-15M 
...
```

Note: Remember to use `-benchmark-store=parquet` to benchtest the parquet code and `-benchmark-store=tsdb` for the current store-gateway code.