### PR TITLE
refactor: change how loggers are passed to MQE

### DIFF
--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -337,8 +336,7 @@ func newEngineForTesting(t *testing.T, engine string, opts ...engineOpt) (promql
 		metrics := stats.NewQueryMetrics(promOpts.Reg)
 		planner, err := streamingpromql.NewQueryPlanner(mqeOpts)
 		require.NoError(t, err)
-		logger := log.NewNopLogger()
-		eng, err := streamingpromql.NewEngine(mqeOpts, limits, metrics, planner, logger)
+		eng, err := streamingpromql.NewEngine(mqeOpts, limits, metrics, planner)
 		if err != nil {
 			t.Fatalf("error creating MQE engine for testing: %s", err)
 		}

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -827,7 +827,7 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 	case querier.PrometheusEngine:
 		eng = promql.NewEngine(promOpts)
 	case querier.MimirEngine:
-		streamingEngine, err := streamingpromql.NewEngine(mqeOpts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(mqeOpts.CommonOpts.Reg), t.QueryFrontendQueryPlanner, util_log.Logger)
+		streamingEngine, err := streamingpromql.NewEngine(mqeOpts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(mqeOpts.CommonOpts.Reg), t.QueryFrontendQueryPlanner)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create Mimir Query Engine: %w", err)
 		}

--- a/pkg/querier/dispatcher_test.go
+++ b/pkg/querier/dispatcher_test.go
@@ -87,10 +87,9 @@ func TestDispatcher_HandleProtobuf(t *testing.T) {
 
 	opts := streamingpromql.NewTestEngineOpts()
 	ctx := context.Background()
-	logger := log.NewNopLogger()
 	planner, err := streamingpromql.NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, logger)
+	engine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	createQueryRequestForSpecificNode := func(expr string, timeRange types.QueryTimeRange, nodeIndex int64) *prototypes.Any {
@@ -123,7 +122,7 @@ func TestDispatcher_HandleProtobuf(t *testing.T) {
 		return createQueryRequestForSpecificNode(expr, timeRange, -1)
 	}
 
-	dispatcher := NewDispatcher(logger, engine, storage)
+	dispatcher := NewDispatcher(opts.Logger, engine, storage)
 	startT := timestamp.Time(0)
 
 	testCases := map[string]struct {

--- a/pkg/querier/engine/config.go
+++ b/pkg/querier/engine/config.go
@@ -73,6 +73,7 @@ func NewPromQLEngineOptions(cfg Config, activityTracker *activitytracker.Activit
 
 	cfg.MimirQueryEngine.CommonOpts = commonOpts
 	cfg.MimirQueryEngine.ActiveQueryTracker = tracker
+	cfg.MimirQueryEngine.Logger = logger
 
 	return commonOpts, cfg.MimirQueryEngine
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -190,7 +190,7 @@ func New(cfg Config, limits *validation.Overrides, distributor Distributor, quer
 	case MimirEngine:
 		limitsProvider := NewTenantQueryLimitsProvider(limits)
 		var err error
-		streamingEngine, err = streamingpromql.NewEngine(mqeOpts, limitsProvider, queryMetrics, planner, logger)
+		streamingEngine, err = streamingpromql.NewEngine(mqeOpts, limitsProvider, queryMetrics, planner)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -45,7 +45,7 @@ func BenchmarkQuery(b *testing.B) {
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	planner, err := streamingpromql.NewQueryPlanner(opts)
 	require.NoError(b, err)
-	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(b, err)
 
 	// Important: the names below must remain in sync with the names used in tools/benchmark-query-engine.
@@ -101,7 +101,7 @@ func TestBothEnginesReturnSameResultsForBenchmarkQueries(t *testing.T) {
 	queryMetrics := stats.NewQueryMetrics(nil)
 	planner, err := streamingpromql.NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := streamingpromql.NewEngine(opts, limitsProvider, queryMetrics, planner, log.NewNopLogger())
+	mimirEngine, err := streamingpromql.NewEngine(opts, limitsProvider, queryMetrics, planner)
 	require.NoError(t, err)
 
 	ctx := user.InjectOrgID(context.Background(), UserID)
@@ -130,7 +130,7 @@ func TestBenchmarkSetup(t *testing.T) {
 	opts := streamingpromql.NewTestEngineOpts()
 	planner, err := streamingpromql.NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	ctx := user.InjectOrgID(context.Background(), UserID)

--- a/pkg/streamingpromql/config.go
+++ b/pkg/streamingpromql/config.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/promql"
 )
 
@@ -14,6 +15,7 @@ type EngineOpts struct {
 	CommonOpts promql.EngineOpts `yaml:"-"`
 
 	ActiveQueryTracker QueryTracker `yaml:"-"`
+	Logger             log.Logger   `yaml:"-"`
 
 	// When operating in pedantic mode, we panic if memory consumption is > 0 after Query.Close()
 	// (indicating something was not returned to a pool).
@@ -53,6 +55,7 @@ func NewTestEngineOpts() EngineOpts {
 		},
 
 		Pedantic: true,
+		Logger:   log.NewNopLogger(),
 
 		EnablePruneToggles: true,
 

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -41,7 +41,7 @@ var tracer = otel.Tracer("pkg/streamingpromql")
 
 const defaultLookbackDelta = 5 * time.Minute // This should be the same value as github.com/prometheus/prometheus/promql.defaultLookbackDelta.
 
-func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *stats.QueryMetrics, planner *QueryPlanner, logger log.Logger) (*Engine, error) {
+func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *stats.QueryMetrics, planner *QueryPlanner) (*Engine, error) {
 	if !opts.CommonOpts.EnableAtModifier {
 		return nil, errors.New("disabling @ modifier not supported by Mimir query engine")
 	}
@@ -90,7 +90,7 @@ func NewEngine(opts EngineOpts, limitsProvider QueryLimitsProvider, metrics *sta
 		noStepSubqueryIntervalFn: opts.CommonOpts.NoStepSubqueryIntervalFn,
 		enablePerStepStats:       opts.CommonOpts.EnablePerStepStats,
 
-		logger: logger,
+		logger: opts.Logger,
 		estimatedPeakMemoryConsumption: promauto.With(opts.CommonOpts.Reg).NewHistogram(prometheus.HistogramOpts{
 			Name:                        "cortex_mimir_query_engine_estimated_query_peak_memory_consumption",
 			Help:                        "Estimated peak memory consumption of each query (in bytes)",

--- a/pkg/streamingpromql/engine_concurrency_test.go
+++ b/pkg/streamingpromql/engine_concurrency_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/promqltest"
@@ -189,7 +188,7 @@ func TestConcurrentQueries(t *testing.T) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	// Populate the expected result for each query.

--- a/pkg/streamingpromql/engine_fuzz_test.go
+++ b/pkg/streamingpromql/engine_fuzz_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/storage"
@@ -90,7 +89,7 @@ func buildFuzzTestEnvironment(f *testing.F, dataFile string, queryFile string, s
 
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(f, err)
-	mqe, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mqe, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(f, err)
 
 	environment := &fuzzTestEnvironment{

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
@@ -97,7 +96,7 @@ func requireRangeQueryIsUnsupported(t *testing.T, expression string, expectedErr
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	qry, err := engine.NewRangeQuery(context.Background(), nil, nil, expression, time.Now().Add(-time.Hour), time.Now(), time.Minute)
@@ -110,7 +109,7 @@ func requireInstantQueryIsUnsupported(t *testing.T, expression string, expectedE
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	qry, err := engine.NewInstantQuery(context.Background(), nil, nil, expression, time.Now())
@@ -124,7 +123,7 @@ func TestNewRangeQuery_InvalidQueryTime(t *testing.T) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -140,7 +139,7 @@ func TestNewRangeQuery_InvalidExpressionTypes(t *testing.T) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -158,7 +157,7 @@ func TestNewInstantQuery_Strings(t *testing.T) {
 
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	storage := promqltest.LoadedStorage(t, ``)
@@ -184,7 +183,7 @@ func TestUpstreamTestCases(t *testing.T) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	testdataFS := os.DirFS("./testdata")
@@ -210,7 +209,7 @@ func TestOurTestCases(t *testing.T) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
@@ -255,7 +254,7 @@ func TestRangeVectorSelectors(t *testing.T) {
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	baseT := timestamp.Time(0)
@@ -803,7 +802,7 @@ func TestSubqueries(t *testing.T) {
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	storage := promqltest.LoadedStorage(t, data)
@@ -1229,7 +1228,7 @@ func TestQueryCancellation(t *testing.T) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	// Simulate the query being cancelled by another goroutine by waiting for the Select() call to be made,
@@ -1259,7 +1258,7 @@ func TestQueryTimeout(t *testing.T) {
 	opts.CommonOpts.Timeout = 20 * time.Millisecond
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	// Simulate the query doing some work and check that the query context has been cancelled.
@@ -1327,7 +1326,7 @@ func TestQueryContextCancelledOnceQueryFinished(t *testing.T) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	storage := promqltest.LoadedStorage(t, `
@@ -1539,7 +1538,7 @@ func TestMemoryConsumptionLimit_SingleQueries(t *testing.T) {
 
 		planner, err := NewQueryPlanner(opts)
 		require.NoError(t, err)
-		engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(limit), stats.NewQueryMetrics(reg), planner, log.NewNopLogger())
+		engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(limit), stats.NewQueryMetrics(reg), planner)
 		require.NoError(t, err)
 
 		spanExporter.Reset()
@@ -1659,7 +1658,7 @@ func TestMemoryConsumptionLimit_MultipleQueries(t *testing.T) {
 	limit := 32*types.FPointSize + 4*types.SeriesMetadataSize + 3*uint64(labels.FromStrings(labels.MetricName, "some_metric", "idx", "i").ByteSize())
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(limit), stats.NewQueryMetrics(reg), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(limit), stats.NewQueryMetrics(reg), planner)
 	require.NoError(t, err)
 
 	runQuery := func(expr string, shouldSucceed bool) {
@@ -1731,7 +1730,7 @@ func TestActiveQueryTracker_SuccessfulQuery(t *testing.T) {
 	opts.ActiveQueryTracker = tracker
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	testActiveQueryTracker(
@@ -1805,7 +1804,7 @@ func TestActiveQueryTracker_FailedQuery(t *testing.T) {
 	opts.ActiveQueryTracker = tracker
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	innerStorage := promqltest.LoadedStorage(t, "")
@@ -1902,7 +1901,7 @@ func TestActiveQueryTracker_WaitingForTrackerIncludesQueryTimeout(t *testing.T) 
 	opts.ActiveQueryTracker = tracker
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	queryTypes := map[string]func() (promql.Query, error){
@@ -1981,7 +1980,7 @@ func runAnnotationTests(t *testing.T, testCases map[string]annotationTestCase) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 
@@ -2998,7 +2997,7 @@ func runMixedMetricsTests(t *testing.T, expressions []string, pointsPerSeries in
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 
@@ -3234,7 +3233,7 @@ func TestQueryStats(t *testing.T) {
 	opts.CommonOpts.EnablePerStepStats = true
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
@@ -3540,7 +3539,7 @@ func TestQueryStatsUpstreamTestCases(t *testing.T) {
 	opts.CommonOpts.EnablePerStepStats = true
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
@@ -3924,7 +3923,6 @@ func TestQueryStatsUpstreamTestCases(t *testing.T) {
 func TestQueryStatementLookbackDelta(t *testing.T) {
 	limitsProvider := NewStaticQueryLimitsProvider(0)
 	stats := stats.NewQueryMetrics(nil)
-	logger := log.NewNopLogger()
 
 	runTest := func(t *testing.T, engine promql.QueryEngine, queryOpts promql.QueryOpts, expectedLookbackDelta time.Duration) {
 		q, err := engine.NewInstantQuery(context.Background(), nil, queryOpts, "1", time.Now())
@@ -3937,7 +3935,7 @@ func TestQueryStatementLookbackDelta(t *testing.T) {
 		engineOpts := NewTestEngineOpts()
 		planner, err := NewQueryPlanner(engineOpts)
 		require.NoError(t, err)
-		engine, err := NewEngine(engineOpts, limitsProvider, stats, planner, logger)
+		engine, err := NewEngine(engineOpts, limitsProvider, stats, planner)
 		require.NoError(t, err)
 
 		t.Run("lookback delta not set in query options", func(t *testing.T) {
@@ -3960,7 +3958,7 @@ func TestQueryStatementLookbackDelta(t *testing.T) {
 		engineOpts.CommonOpts.LookbackDelta = 12 * time.Minute
 		planner, err := NewQueryPlanner(engineOpts)
 		require.NoError(t, err)
-		engine, err := NewEngine(engineOpts, limitsProvider, stats, planner, logger)
+		engine, err := NewEngine(engineOpts, limitsProvider, stats, planner)
 		require.NoError(t, err)
 
 		t.Run("lookback delta not set in query options", func(t *testing.T) {
@@ -3995,7 +3993,7 @@ func TestQueryClose(t *testing.T) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	start := timestamp.Time(0)
@@ -4029,18 +4027,17 @@ func TestEagerLoadSelectors(t *testing.T) {
 
 	limitsProvider := NewStaticQueryLimitsProvider(0)
 	metrics := stats.NewQueryMetrics(nil)
-	logger := log.NewNopLogger()
 	optsWithoutEagerLoading := NewTestEngineOpts()
 	plannerWithoutEagerLoading, err := NewQueryPlanner(optsWithoutEagerLoading)
 	require.NoError(t, err)
-	engineWithoutEagerLoading, err := NewEngine(optsWithoutEagerLoading, limitsProvider, metrics, plannerWithoutEagerLoading, logger)
+	engineWithoutEagerLoading, err := NewEngine(optsWithoutEagerLoading, limitsProvider, metrics, plannerWithoutEagerLoading)
 	require.NoError(t, err)
 
 	optsWithEagerLoading := NewTestEngineOpts()
 	optsWithEagerLoading.EagerLoadSelectors = true
 	plannerWithEagerLoading, err := NewQueryPlanner(optsWithEagerLoading)
 	require.NoError(t, err)
-	engineWithEagerLoading, err := NewEngine(optsWithEagerLoading, limitsProvider, metrics, plannerWithEagerLoading, logger)
+	engineWithEagerLoading, err := NewEngine(optsWithEagerLoading, limitsProvider, metrics, plannerWithEagerLoading)
 	require.NoError(t, err)
 
 	testCases := []string{
@@ -4158,7 +4155,7 @@ func TestInstantQueryDurationExpression(t *testing.T) {
 	prometheusEngine := promql.NewEngine(opts.CommonOpts)
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	mimirEngine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -4184,7 +4181,7 @@ func TestEngine_RegisterNodeMaterializer(t *testing.T) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	nodeType := planning.NodeType(1234)

--- a/pkg/streamingpromql/functions_test.go
+++ b/pkg/streamingpromql/functions_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
@@ -31,7 +30,7 @@ func TestFunctionDeduplicateAndMerge(t *testing.T) {
 	opts := NewTestEngineOpts()
 	planner, err := NewQueryPlanner(opts)
 	require.NoError(t, err)
-	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass_test.go
@@ -607,7 +607,7 @@ func TestOptimizationPass(t *testing.T) {
 			plannerWithOptimizationPass, err := streamingpromql.NewQueryPlannerWithoutOptimizationPasses(opts)
 			require.NoError(t, err)
 			plannerWithOptimizationPass.RegisterASTOptimizationPass(&ast.CollapseConstants{})
-			plannerWithOptimizationPass.RegisterQueryPlanOptimizationPass(commonsubexpressionelimination.NewOptimizationPass(true, reg))
+			plannerWithOptimizationPass.RegisterQueryPlanOptimizationPass(commonsubexpressionelimination.NewOptimizationPass(true, reg, opts.Logger))
 
 			var timeRange types.QueryTimeRange
 

--- a/pkg/streamingpromql/optimize/plan/skip_histogram_decoding_test.go
+++ b/pkg/streamingpromql/optimize/plan/skip_histogram_decoding_test.go
@@ -448,7 +448,7 @@ func TestSkipHistogramDecodingOptimizationPass(t *testing.T) {
 	opts := streamingpromql.NewTestEngineOpts()
 	planner, err := streamingpromql.NewQueryPlannerWithoutOptimizationPasses(opts)
 	require.NoError(t, err)
-	planner.RegisterQueryPlanOptimizationPass(commonsubexpressionelimination.NewOptimizationPass(true, nil))
+	planner.RegisterQueryPlanOptimizationPass(commonsubexpressionelimination.NewOptimizationPass(true, nil, opts.Logger))
 	planner.RegisterQueryPlanOptimizationPass(plan.NewSkipHistogramDecodingOptimizationPass())
 
 	for name, testCase := range testCases {

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -62,7 +62,7 @@ func NewQueryPlanner(opts EngineOpts) (*QueryPlanner, error) {
 	// After query sharding is moved here, we want to move propagate matchers and reorder histogram aggregation here as well before query sharding.
 
 	if opts.EnableCommonSubexpressionElimination {
-		planner.RegisterQueryPlanOptimizationPass(commonsubexpressionelimination.NewOptimizationPass(opts.EnableCommonSubexpressionEliminationForRangeVectorExpressionsInInstantQueries, opts.CommonOpts.Reg))
+		planner.RegisterQueryPlanOptimizationPass(commonsubexpressionelimination.NewOptimizationPass(opts.EnableCommonSubexpressionEliminationForRangeVectorExpressionsInInstantQueries, opts.CommonOpts.Reg, opts.Logger))
 	}
 
 	if opts.EnableSkippingHistogramDecoding {

--- a/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
+++ b/tools/check-for-disabled-but-supported-mqe-test-cases/main.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/grafana/regexp"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
@@ -63,7 +62,7 @@ func run() error {
 		return fmt.Errorf("could not create planner: %w", err)
 	}
 
-	engine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner, log.NewNopLogger())
+	engine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
 	if err != nil {
 		return fmt.Errorf("could not create engine: %w", err)
 	}


### PR DESCRIPTION
#### What this PR does

Pass a logger to MQE using engine options instead of as a parameter of the engine constructor. This makes it easier to pass loggers to the various parts of MQE (planner, materializer, engine).

#### Which issue(s) this PR fixes or relates to

Prerequisite for #12577

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
