### PR TITLE
Only log plans starting with those that have at least one index matcher

### DIFF
--- a/pkg/ingester/lookupplan/planner.go
+++ b/pkg/ingester/lookupplan/planner.go
@@ -77,8 +77,9 @@ func (p CostBasedPlanner) PlanIndexLookup(ctx context.Context, inPlan index.Look
 
 	// Select the cheapest plan that has at least one index matcher.
 	// PostingsForMatchers will return incorrect results if there are no matchers.
-	for _, p := range allPlans {
+	for i, p := range allPlans {
 		if len(p.IndexMatchers()) > 0 {
+			allPlans = allPlans[i:]
 			return p, nil
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR updates `allPlans` in the index lookup planner once we find a plan that has at least one index matcher. This way, when `allPlans` is used later to record planning outcomes, it only records plans with index matchers, instead of logging plans with 0 cost and 0 index matchers that we were never going to use.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
