### PR TITLE
Bump development/mimir-microservices-mode Grafana to v12.1.1

### DIFF
--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -361,7 +361,7 @@ std.manifestYamlDoc({
 
   grafana:: {
     grafana: {
-      image: 'grafana/grafana:10.4.3',
+      image: 'grafana/grafana:12.1.1',
       environment: [
         'GF_AUTH_ANONYMOUS_ENABLED=true',
         'GF_AUTH_ANONYMOUS_ORG_ROLE=Admin',

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -186,7 +186,7 @@
     "environment":
       - "GF_AUTH_ANONYMOUS_ENABLED=true"
       - "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin"
-    "image": "grafana/grafana:10.4.3"
+    "image": "grafana/grafana:12.1.1"
     "ports":
       - "3000:3000"
     "volumes":


### PR DESCRIPTION
This PR bumps Grafana in order to better use Native Histogram functionality. Cherrypicked from #12571.