### PR TITLE
index planning: Disable planning for blocks older than 5 hours

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -48,6 +48,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/hashcache"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/zeropool"
 	"github.com/thanos-io/objstore"
 	"go.opentelemetry.io/otel"
@@ -2974,11 +2975,47 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 	return userDB, nil
 }
 
+// disabledPlanningChunkQuerier wraps a storage.ChunkQuerier and disables lookup planning for all operations
+type disabledPlanningChunkQuerier struct {
+	delegate storage.ChunkQuerier
+}
+
+func (q *disabledPlanningChunkQuerier) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	ctxWithoutPlanning := lookupplan.ContextWithDisabledPlanning(ctx)
+	return q.delegate.LabelValues(ctxWithoutPlanning, name, hints, matchers...)
+}
+
+func (q *disabledPlanningChunkQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	ctxWithoutPlanning := lookupplan.ContextWithDisabledPlanning(ctx)
+	return q.delegate.LabelNames(ctxWithoutPlanning, hints, matchers...)
+}
+
+func (q *disabledPlanningChunkQuerier) Close() error {
+	return q.delegate.Close()
+}
+
+func (q *disabledPlanningChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
+	ctxWithoutPlanning := lookupplan.ContextWithDisabledPlanning(ctx)
+	return q.delegate.Select(ctxWithoutPlanning, sortSeries, hints, matchers...)
+}
+
 // createBlockChunkQuerier creates a BlockChunkQuerier that optionally wraps the default querier with mirroring
 func (i *Ingester) createBlockChunkQuerier(userID string, b tsdb.BlockReader, mint, maxt int64) (storage.ChunkQuerier, error) {
 	defaultQuerier, err := tsdb.NewBlockChunkQuerier(b, mint, maxt)
 	if err != nil {
 		return nil, err
+	}
+
+	blockMeta := b.Meta()
+
+	// Check if block is older than 5 hours (5 * 60 * 60 * 1000 milliseconds)
+	// 1h in memory + 2h for compaction + 2h buffer for last compacted block
+	fiveHoursAgo := time.Now().UnixMilli() - (5 * 60 * 60 * 1000)
+	if blockMeta.MaxTime < fiveHoursAgo {
+		// For old blocks, use a querier with disabled lookup planning to avoid using outdated statistics
+		return &disabledPlanningChunkQuerier{
+			delegate: defaultQuerier,
+		}, nil
 	}
 
 	if rand.Float64() > i.cfg.BlocksStorageConfig.TSDB.IndexLookupPlanningComparisonPortion {
@@ -2989,7 +3026,7 @@ func (i *Ingester) createBlockChunkQuerier(userID string, b tsdb.BlockReader, mi
 		userID,
 		i.metrics.indexLookupComparisonOutcomes,
 		mint, maxt,
-		b.Meta(),
+		blockMeta,
 		i.logger,
 		defaultQuerier,
 	)


### PR DESCRIPTION
## Summary
- Adds a 5-hour age check for TSDB blocks in `createBlockChunkQuerier`
- For blocks older than 5 hours, disables lookup planning to avoid using outdated per-block statistics
- Implements `disabledPlanningChunkQuerier` wrapper that uses `lookupplan.ContextWithDisabledPlanning`

## Why
When the ingester stops receiving writes it's in memory state, on which we base statistics is empty. This leads to very suboptimal plans. 

The 5-hour threshold accounts for:
- 1h: data in memory (head block) 
- 2h: typical compaction window which is still kept in memory

## How
The wrapper ensures all `ChunkQuerier` methods (`Select`, `LabelValues`, `LabelNames`) bypass the cost-based planner and fall back to scanning-based execution for older blocks where statistics may be stale.