### PR TITLE
Update about-versioning for experimental query frontend rewriting middleware

### DIFF
--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -236,6 +236,7 @@ The following features are currently experimental:
   - Support for configuring the maximum series limit for cardinality API requests on a per-tenant basis via `cardinality_analysis_max_results`.
   - [Mimir query engine](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/mimir-query-engine) (`-query-frontend.query-engine` and `-query-frontend.enable-query-engine-fallback`)
   - Labels query optimizer (`-query-frontend.labels-query-optimizer-enabled`)
+  - Rewriting of queries to optimize processing using a query frontend middleware: `-query-frontend.rewrite-histogram-queries` and `-query-frontend.rewrite-propagate-matchers`
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
 - Store-gateway


### PR DESCRIPTION
#### What this PR does

Update about-versioning for experimental query frontend rewriting middleware

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/grafana/mimir/pull/12304 and https://github.com/grafana/mimir/pull/12305

Ignoring https://github.com/grafana/mimir/pull/12303 as that is already covered under "all flags beginning with `-querier.mimir-query-engine`"

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
