### PR TITLE
chore: replace ingester start/stop boilerplate in tests

### DIFF
--- a/pkg/ingester/circuitbreaker_test.go
+++ b/pkg/ingester/circuitbreaker_test.go
@@ -716,15 +716,9 @@ func TestIngester_StartPushRequest_CircuitBreakerOpen(t *testing.T) {
 	cfg := defaultIngesterTestConfig(t)
 	cfg.PushCircuitBreaker = CircuitBreakerConfig{Enabled: true, CooldownPeriod: 10 * time.Second}
 
-	i, err := prepareIngesterWithBlocksStorage(t, cfg, nil, reg)
+	i, r, err := prepareIngesterWithBlocksStorage(t, cfg, nil, reg)
 	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-	defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
-
-	// Wait until the ingester is healthy
-	test.Poll(t, 100*time.Millisecond, 1, func() interface{} {
-		return i.lifecycler.HealthyInstancesCount()
-	})
+	startAndWaitHealthy(t, i, r)
 
 	ctx := user.InjectOrgID(context.Background(), "test")
 
@@ -890,16 +884,9 @@ func TestIngester_FinishPushRequest(t *testing.T) {
 				RequestTimeout: 2 * time.Second,
 			}
 
-			i, err := prepareIngesterWithBlocksStorage(t, cfg, nil, reg)
+			i, r, err := prepareIngesterWithBlocksStorage(t, cfg, nil, reg)
 			require.NoError(t, err)
-
-			require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-			defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
-
-			// Wait until the ingester is healthy
-			test.Poll(t, 100*time.Millisecond, 1, func() interface{} {
-				return i.lifecycler.HealthyInstancesCount()
-			})
+			startAndWaitHealthy(t, i, r)
 
 			ctx := user.InjectOrgID(context.Background(), "test")
 
@@ -951,16 +938,9 @@ func TestIngester_Push_CircuitBreaker_DeadlineExceeded(t *testing.T) {
 				testModeEnabled:            true,
 			}
 
-			i, err := prepareIngesterWithBlocksStorage(t, cfg, nil, registry)
+			i, r, err := prepareIngesterWithBlocksStorage(t, cfg, nil, registry)
 			require.NoError(t, err)
-
-			require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-			defer services.StopAndAwaitTerminated(context.Background(), i) //nolint:errcheck
-
-			// Wait until the ingester is healthy
-			test.Poll(t, 100*time.Millisecond, 1, func() interface{} {
-				return i.lifecycler.HealthyInstancesCount()
-			})
+			startAndWaitHealthy(t, i, r)
 
 			// the first request is successful
 			ctx := user.InjectOrgID(context.Background(), "test-0")

--- a/pkg/ingester/downscale_test.go
+++ b/pkg/ingester/downscale_test.go
@@ -31,19 +31,10 @@ func TestIngester_PrepareInstanceRingDownscaleHandler(t *testing.T) {
 		cfg := defaultIngesterTestConfig(t)
 		ingestersRing := createAndStartRing(t, cfg.IngesterRing.ToRingConfig())
 
-		i, err := prepareIngesterWithBlocksStorage(t, cfg, ingestersRing, nil)
+		i, _, err := prepareIngesterWithBlocksStorage(t, cfg, ingestersRing, nil)
 		require.NoError(t, err)
 		if startIngester {
-			require.NoError(t, services.StartAndAwaitRunning(context.Background(), i))
-			t.Cleanup(func() {
-				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), i))
-			})
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-
-			// Tests require that we've joined the ring so ensure that here.
-			require.NoError(t, ring.WaitInstanceState(ctx, ingestersRing, cfg.IngesterRing.InstanceID, ring.ACTIVE))
+			startAndWaitHealthy(t, i, ingestersRing)
 		}
 
 		return i, ingestersRing

--- a/pkg/ingester/owned_series_test.go
+++ b/pkg/ingester/owned_series_test.go
@@ -1740,12 +1740,9 @@ func userToken(user, zone string, skip int) uint32 {
 }
 
 func setupIngesterWithOverrides(t *testing.T, cfg Config, overrides *validation.Overrides, ingesterRing ring.ReadRing, dataDir string) *Ingester {
-	ing, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, overrides, ingesterRing, dataDir, "", nil)
+	ing, r, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, overrides, ingesterRing, dataDir, "", nil)
 	require.NoError(t, err)
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), ing))
-	t.Cleanup(func() {
-		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ing))
-	})
+	startAndWaitHealthy(t, ing, r)
 	return ing
 }
 

--- a/pkg/ingester/tenants_http_test.go
+++ b/pkg/ingester/tenants_http_test.go
@@ -3,7 +3,6 @@
 package ingester
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,26 +10,16 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/grafana/dskit/services"
-	"github.com/grafana/dskit/test"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIngester_TenantsHandlers(t *testing.T) {
-	ctx := context.Background()
 	cfg := defaultIngesterTestConfig(t)
 
 	// Create ingester
-	i, err := prepareIngesterWithBlocksStorage(t, cfg, nil, nil)
+	i, r, err := prepareIngesterWithBlocksStorage(t, cfg, nil, nil)
 	require.NoError(t, err)
-
-	require.NoError(t, services.StartAndAwaitRunning(ctx, i))
-	defer services.StopAndAwaitTerminated(ctx, i) //nolint:errcheck
-
-	// Wait until it's healthy
-	test.Poll(t, 1*time.Second, 1, func() interface{} {
-		return i.lifecycler.HealthyInstancesCount()
-	})
+	startAndWaitHealthy(t, i, r)
 
 	pushSingleSampleAtTime(t, i, time.Now().UnixMilli())
 


### PR DESCRIPTION
#### What this PR does

Replace often repeated boilerplate for starting and stopping ingesters in tests with a helper method. The helper method also uses a more reliable method to ensure the ingester is healthy in the ring than the boilerplate did.

#### Which issue(s) this PR fixes or relates to

Related #10528

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
