### PR TITLE
docs: update get-started-helm-charts replacing the deprated meta-monitoring

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -139,7 +139,7 @@ Using a custom namespace solves problems later on because you do not have to ove
 
 ## Generate test metrics
 
-We will install [Grafana Alloy](https://grafana.com/docs/alloy/latest/), preconfigured to scrap metrics from Grafana Mimir own pods, and write those metrics to the same Grafana Mimir instance.
+We will install [Grafana Alloy](https://grafana.com/docs/alloy/latest/), preconfigured to scrap metrics from Grafana Mimir pods, and write those metrics to the same Grafana Mimir instance.
 
 1. Create a YAML file called `alloy-values.yaml` for Grafana Alloy Helm chart overrides:
 


### PR DESCRIPTION
#### What this PR does

Here I'm updating the `get-started-helm-charts` docs, replacing the steps that use the deprecated meta-monitoring with a step that installs Grafana Alloy. Even though this is more verbose than it used to be, this represents the users' experience better.

Also, updated the doc's bits to list the actual list of Mimir pods, which now include Kafka by default.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/issues/5860

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
