### PR TITLE
test: Update backwards compatibility integration test for 2.17.1

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -7,13 +7,13 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
-	"grafana/mimir:2.15.1": e2emimir.ChainFlagMappers(
-		removePartitionRingFlags,
-	),
 	"grafana/mimir:2.16.0": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 	),
 	"grafana/mimir:2.17.0": e2emimir.ChainFlagMappers(
+		removePartitionRingFlags,
+	),
+	"grafana/mimir:2.17.1": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 	),
 }


### PR DESCRIPTION
#### What this PR does

Update backwards compatibility integration test for 2.17.1

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/12039

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
