### PR TITLE
MQE: Add new optimization pass to rewrite average queries

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/astmapper.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper.go
@@ -198,6 +198,7 @@ type ExprMapperWithState interface {
 	ExprMapper
 	// HasChanged returns whether the mapper made any changes during mapping
 	HasChanged() bool
+	Stats() (int, int, int)
 }
 
 // ASTExprMapperWithState is a wrapper around an ASTExprMapper that stores the original mapper to provide a method to check if any changes were made.
@@ -219,4 +220,8 @@ func (w *ASTExprMapperWithState) Map(ctx context.Context, expr parser.Expr) (par
 
 func (w *ASTExprMapperWithState) HasChanged() bool {
 	return w.mapper.HasChanged()
+}
+
+func (w *ASTExprMapperWithState) Stats() (int, int, int) {
+	return w.mapper.Stats()
 }

--- a/pkg/streamingpromql/optimize/ast/average.go
+++ b/pkg/streamingpromql/optimize/ast/average.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ast
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
+)
+
+// NewRewriteAverageMapper rewrites sum/count to average wherever equivalent.
+func NewRewriteAverageMapper() *astmapper.ASTExprMapperWithState {
+	mapper := &rewriteAverage{}
+	return astmapper.NewASTExprMapperWithState(mapper)
+}
+
+type rewriteAverage struct {
+	changed bool
+}
+
+func (mapper *rewriteAverage) HasChanged() bool {
+	return mapper.changed
+}
+
+func (mapper *rewriteAverage) MapExpr(ctx context.Context, expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
+	e, ok := expr.(*parser.BinaryExpr)
+	if !ok {
+		return expr, false, nil
+	}
+
+	if e.Op != parser.DIV {
+		return expr, false, nil
+	}
+
+	newExpr, changed := mapper.rewriteExpr(e)
+	if !changed {
+		return expr, false, nil
+	}
+
+	mapper.changed = true
+	return newExpr, false, nil
+}
+
+func (mapper *rewriteAverage) rewriteExpr(e *parser.BinaryExpr) (parser.Expr, bool) {
+	lhsAgg, rhsAgg, ok := mapper.areAggregateExprs(e.LHS, e.RHS)
+	if ok {
+		if newExpr := mapper.handleAggregateExprs(lhsAgg, rhsAgg); newExpr != nil {
+			return newExpr, true
+		}
+		return e, false
+	}
+	lhsCall, rhsCall, ok := mapper.areFunctionCalls(e.LHS, e.RHS)
+	if ok {
+		if newExpr := mapper.handleFunctionCalls(lhsCall, rhsCall); newExpr != nil {
+			return newExpr, true
+		}
+		return e, false
+	}
+	return e, false
+}
+
+func (mapper *rewriteAverage) areAggregateExprs(lhs, rhs parser.Expr) (*parser.AggregateExpr, *parser.AggregateExpr, bool) {
+	lhsAgg, ok := lhs.(*parser.AggregateExpr)
+	if !ok {
+		return nil, nil, false
+	}
+
+	rhsAgg, ok := rhs.(*parser.AggregateExpr)
+	if !ok {
+		return nil, nil, false
+	}
+
+	return lhsAgg, rhsAgg, true
+}
+
+func (mapper *rewriteAverage) handleAggregateExprs(lhs, rhs *parser.AggregateExpr) parser.Expr {
+	if lhs.Op != parser.SUM || rhs.Op != parser.COUNT {
+		return nil
+	}
+
+	if !mapper.haveEqualContents(lhs, rhs) {
+		return nil
+	}
+
+	return &parser.AggregateExpr{
+		Op:       parser.AVG,
+		Expr:     lhs.Expr,
+		Param:    lhs.Param,
+		Grouping: lhs.Grouping,
+		Without:  lhs.Without,
+	}
+}
+
+func (mapper *rewriteAverage) areFunctionCalls(lhs, rhs parser.Expr) (*parser.Call, *parser.Call, bool) {
+	lhsCall, ok := lhs.(*parser.Call)
+	if !ok {
+		return nil, nil, false
+	}
+
+	rhsCall, ok := rhs.(*parser.Call)
+	if !ok {
+		return nil, nil, false
+	}
+
+	return lhsCall, rhsCall, true
+}
+
+func (mapper *rewriteAverage) handleFunctionCalls(lhs, rhs *parser.Call) parser.Expr {
+	var newFuncName string
+	switch {
+	case lhs.Func.Name == "histogram_sum" && rhs.Func.Name == "histogram_count":
+		newFuncName = "histogram_avg"
+	case lhs.Func.Name == "sum_over_time" && rhs.Func.Name == "count_over_time":
+		newFuncName = "avg_over_time"
+	default:
+		return nil
+	}
+
+	if len(lhs.Args) != len(rhs.Args) {
+		return nil
+	}
+
+	for i := range lhs.Args {
+		if lhs.Args[i].String() != rhs.Args[i].String() {
+			return nil
+		}
+	}
+
+	return &parser.Call{
+		Func: &parser.Function{
+			Name: newFuncName,
+		},
+		Args: lhs.Args,
+	}
+}
+
+func (*rewriteAverage) haveEqualContents(lhs, rhs *parser.AggregateExpr) bool {
+	if lhs.Without != rhs.Without {
+		return false
+	}
+
+	slices.SortFunc(lhs.Grouping, func(l, r string) int {
+		return strings.Compare(l, r)
+	})
+	slices.SortFunc(rhs.Grouping, func(l, r string) int {
+		return strings.Compare(l, r)
+	})
+	if !slices.Equal(lhs.Grouping, rhs.Grouping) {
+		return false
+	}
+
+	if lhs.Expr.String() != rhs.Expr.String() {
+		return false
+	}
+
+	if lhs.Param != nil && rhs.Param != nil && lhs.Param.String() != rhs.Param.String() {
+		return false
+	}
+
+	return true
+}

--- a/pkg/streamingpromql/optimize/ast/average_test.go
+++ b/pkg/streamingpromql/optimize/ast/average_test.go
@@ -4,6 +4,7 @@ package ast_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/prometheus/promql/parser"
@@ -68,4 +69,19 @@ func TestRewriteAverageWithData(t *testing.T) {
 			foo_hist	{{schema:0 sum:4 count:4 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x<num samples>
 			bar_hist	{{schema:0 sum:4 count:4 buckets:[1 2 1]}}+{{sum:4 count:2 buckets:[1 2] offset:1}}x<num samples>
 	`, testCasesRewriteAverage)
+}
+
+func TestCountRewriteAverage(t *testing.T) {
+	ctx := context.Background()
+	optimizer := ast.NewRewriteAverageMapper()
+
+	for input, _ := range testCasesRewriteAverage {
+		inputExpr, err := parser.ParseExpr(input)
+		require.NoError(t, err)
+		_, err = optimizer.Map(ctx, inputExpr)
+		require.NoError(t, err)
+	}
+
+	fmt.Printf("total count: %d\n", len(testCasesRewriteAverage))
+	fmt.Println(optimizer.Stats())
 }

--- a/pkg/streamingpromql/optimize/ast/average_test.go
+++ b/pkg/streamingpromql/optimize/ast/average_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ast_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/optimize/ast"
+)
+
+var testCasesRewriteAverage = map[string]string{
+	// Rewrite
+	`sum(foo) / count(foo)`:                                                                                             `avg(foo)`,
+	`sum by (series) (foo) / count by (series) (foo)`:                                                                   `avg by (series) (foo)`,
+	`sum by (lbl, series) (foo) / count by (lbl, series) (foo)`:                                                         `avg by (lbl, series) (foo)`,
+	`sum by (lbl, series) (foo) / count by (series, lbl) (foo)`:                                                         `avg by (lbl, series) (foo)`,
+	`sum_over_time(foo[5m]) / count_over_time(foo[5m])`:                                                                 `avg_over_time(foo[5m])`,
+	`histogram_sum(foo_hist) / histogram_count(foo_hist)`:                                                               `histogram_avg(foo_hist)`,
+	`max(sum by (series) (foo) / count by (series) (foo))`:                                                              `max(avg by (series) (foo))`,
+	`sum(sum_over_time(foo[5m]) / count_over_time(foo[5m]))`:                                                            `sum(avg_over_time(foo[5m]))`,
+	`sum(sum_over_time(foo[5m]) / count_over_time(foo[5m])) / count(sum_over_time(foo[5m]) / count_over_time(foo[5m]))`: `avg(avg_over_time(foo[5m]))`,
+	// Ignore
+	`sum(foo) / count(bar)`:                                          `sum(foo) / count(bar)`,
+	`sum by (series) (foo) / count(foo)`:                             `sum by (series) (foo) / count(foo)`,
+	`sum by (series) (foo) / count by (lbl) (foo)`:                   `sum by (series) (foo) / count by (lbl) (foo)`,
+	`sum by (lbl, series) (foo) / count by (__name__, series) (foo)`: `sum by (lbl, series) (foo) / count by (__name__, series) (foo)`,
+	`sum(sum_over_time(foo[5m])) / sum(count_over_time(foo[5m]))`:    `sum(sum_over_time(foo[5m])) / sum(count_over_time(foo[5m]))`,
+	`sum(sum_over_time(foo[5m])) / count(count_over_time(foo[5m]))`:  `sum(sum_over_time(foo[5m])) / count(count_over_time(foo[5m]))`,
+}
+
+func TestRewriteAverage(t *testing.T) {
+	ctx := context.Background()
+
+	for input, expected := range testCasesRewriteAverage {
+		t.Run(input, func(t *testing.T) {
+			expectedExpr, err := parser.ParseExpr(expected)
+			require.NoError(t, err)
+
+			inputExpr, err := parser.ParseExpr(input)
+			require.NoError(t, err)
+			optimizer := ast.NewRewriteAverageMapper()
+			outputExpr, err := optimizer.Map(ctx, inputExpr)
+			require.NoError(t, err)
+
+			require.Equal(t, expectedExpr.String(), outputExpr.String())
+			require.Equal(t, input != expected, optimizer.HasChanged())
+		})
+	}
+}
+
+func TestRewriteAverageWithData(t *testing.T) {
+	testASTOptimizationPassWithData(t, `
+		load 1m
+			foo{series="1", lbl="odd"} 0+1x<num samples>
+			foo{series="2", lbl="even"} 0+2x<num samples>
+			foo{series="3", lbl="odd"} 0+3x<num samples>
+			foo{series="4", lbl="even"} 0+4x<num samples>
+			foo{series="5", lbl="odd"} 0+5x<num samples>
+			bar{series="1", lbl="odd"} 0+6x<num samples>
+			bar{series="2", lbl="even"} 0+7x<num samples>
+			bar{series="3", lbl="odd"} 0+8x<num samples>
+			bar{series="4", lbl="even"} 0+9x<num samples>
+			bar{series="5", lbl="odd"} 0+10x<num samples>
+			foo_hist	{{schema:0 sum:4 count:4 buckets:[1 2 1]}}+{{sum:2 count:1 buckets:[1] offset:1}}x<num samples>
+			bar_hist	{{schema:0 sum:4 count:4 buckets:[1 2 1]}}+{{sum:4 count:2 buckets:[1 2] offset:1}}x<num samples>
+	`, testCasesRewriteAverage)
+}

--- a/pkg/streamingpromql/optimize/ast/propagate_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/propagate_matchers.go
@@ -26,6 +26,10 @@ func (mapper *propagateMatchers) HasChanged() bool {
 	return mapper.changed
 }
 
+func (mapper *propagateMatchers) Stats() (int, int, int) {
+	return 0, 0, 0
+}
+
 func (mapper *propagateMatchers) MapExpr(ctx context.Context, expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
 	e, ok := expr.(*parser.BinaryExpr)
 	if !ok {

--- a/pkg/streamingpromql/optimize/ast/prune_toggles.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles.go
@@ -62,6 +62,10 @@ func (mapper *pruneToggles) HasChanged() bool {
 	return mapper.changed
 }
 
+func (mapper *pruneToggles) Stats() (int, int, int) {
+	return 0, 0, 0
+}
+
 func (mapper *pruneToggles) MapExpr(ctx context.Context, expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
 	e, ok := expr.(*parser.BinaryExpr)
 	if !ok {

--- a/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation.go
+++ b/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation.go
@@ -26,6 +26,10 @@ func (mapper *reorderHistogramAggregation) HasChanged() bool {
 	return mapper.changed
 }
 
+func (mapper *reorderHistogramAggregation) Stats() (int, int, int) {
+	return 0, 0, 0
+}
+
 func (mapper *reorderHistogramAggregation) MapExpr(ctx context.Context, expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
 	call, ok := expr.(*parser.Call)
 	if !ok || !mapper.isSwitchableCall(call.Func) {


### PR DESCRIPTION
#### What this PR does

Add new optimization pass to rewrite average queries:

- sum / count -> avg
- sum_over_time / count_over_time -> avg_over_time
- histogram_sum / histogram_count -> histogram_avg

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/3212

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
