### PR TITLE
chore(localdev): clean up prometheusRW2 profile in compose-down.sh

### DIFF
--- a/development/mimir-monolithic-mode/compose-down.sh
+++ b/development/mimir-monolithic-mode/compose-down.sh
@@ -35,6 +35,7 @@ done
 
 DEFAULT_PROFILES=(
     "--profile" "prometheus"
+    "--profile" "prometheusRW2"
     "--profile" "grafana-agent-static"
     "--profile" "grafana-agent-flow"
     "--profile" "otel-collector-remote-write"


### PR DESCRIPTION
Otherwise you can get some docker network errors on compose-up.sh the next time.
