### PR TITLE
MQE: use correct naming convention in metrics emitted by common subexpression elimination optimization pass

### DIFF
--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass.go
@@ -45,15 +45,15 @@ func NewOptimizationPass(enableEliminatingDuplicateRangeVectorExpressionsInInsta
 	return &OptimizationPass{
 		enableEliminatingDuplicateRangeVectorExpressionsInInstantQueries: enableEliminatingDuplicateRangeVectorExpressionsInInstantQueries,
 		duplicationNodesIntroduced: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_mimir_query_engine_common_subexpression_elimination_duplication_nodes_introduced",
+			Name: "cortex_mimir_query_engine_common_subexpression_elimination_duplication_nodes_introduced_total",
 			Help: "Number of duplication nodes introduced by the common subexpression elimination optimization pass.",
 		}),
 		selectorsEliminated: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_mimir_query_engine_common_subexpression_elimination_selectors_eliminated",
+			Name: "cortex_mimir_query_engine_common_subexpression_elimination_selectors_eliminated_total",
 			Help: "Number of selectors eliminated by the common subexpression elimination optimization pass.",
 		}),
 		selectorsInspected: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_mimir_query_engine_common_subexpression_elimination_selectors_inspected",
+			Name: "cortex_mimir_query_engine_common_subexpression_elimination_selectors_inspected_total",
 			Help: "Number of selectors inspected by the common subexpression elimination optimization pass, before elimination.",
 		}),
 		logger: logger,

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass_test.go
@@ -635,7 +635,7 @@ func TestOptimizationPass(t *testing.T) {
 }
 
 func requireDuplicateNodeCount(t *testing.T, g prometheus.Gatherer, expected int) {
-	const metricName = "cortex_mimir_query_engine_common_subexpression_elimination_duplication_nodes_introduced"
+	const metricName = "cortex_mimir_query_engine_common_subexpression_elimination_duplication_nodes_introduced_total"
 
 	expectedMetrics := fmt.Sprintf(`# HELP %v Number of duplication nodes introduced by the common subexpression elimination optimization pass.
 # TYPE %v counter
@@ -646,8 +646,8 @@ func requireDuplicateNodeCount(t *testing.T, g prometheus.Gatherer, expected int
 }
 
 func requireSelectorCounts(t *testing.T, g prometheus.Gatherer, expectedInspected int, expectedEliminated int) {
-	const inspectedMetricName = "cortex_mimir_query_engine_common_subexpression_elimination_selectors_inspected"
-	const eliminatedMetricName = "cortex_mimir_query_engine_common_subexpression_elimination_selectors_eliminated"
+	const inspectedMetricName = "cortex_mimir_query_engine_common_subexpression_elimination_selectors_inspected_total"
+	const eliminatedMetricName = "cortex_mimir_query_engine_common_subexpression_elimination_selectors_eliminated_total"
 
 	expectedMetrics := fmt.Sprintf(`# HELP %[1]v Number of selectors inspected by the common subexpression elimination optimization pass, before elimination.
 # TYPE %[1]v counter


### PR DESCRIPTION
#### What this PR does

This PR changes the names of the metrics emitted by the common subexpression elimination optimization pass to follow the Prometheus convention.

#### Which issue(s) this PR fixes or relates to

Relates to #12635.

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
