### PR TITLE
Calculate plan costs only once

### DIFF
--- a/pkg/ingester/lookupplan/planner.go
+++ b/pkg/ingester/lookupplan/planner.go
@@ -63,17 +63,32 @@ func (p CostBasedPlanner) PlanIndexLookup(ctx context.Context, inPlan index.Look
 
 	statistics, err := p.stats.UserTSDBStatistics(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving stattistics: %w", err)
+		return nil, fmt.Errorf("error retrieving statistics: %w", err)
 	}
 
-	allPlans, err = p.generatePlans(ctx, statistics, matchers)
+	allPlansUnordered, err := p.generatePlans(ctx, statistics, matchers)
 	if err != nil {
 		return nil, fmt.Errorf("error generating plans: %w", err)
 	}
 
-	slices.SortFunc(allPlans, func(a, b plan) int {
-		return cmp.Compare(a.totalCost(), b.totalCost())
+	type planWithCost struct {
+		plan
+		totalCost float64
+	}
+	// calculate the cost of all plans once, instead of calculating them every time we compare during sort
+	allPlansWithCosts := make([]planWithCost, len(allPlansUnordered))
+	for i, p := range allPlansUnordered {
+		allPlansWithCosts[i] = planWithCost{plan: p, totalCost: p.totalCost()}
+	}
+
+	slices.SortFunc(allPlansWithCosts, func(a, b planWithCost) int {
+		return cmp.Compare(a.totalCost, b.totalCost)
 	})
+
+	// build the sorted slice of plans
+	for _, pwc := range allPlansWithCosts {
+		allPlans = append(allPlans, pwc.plan)
+	}
 
 	// Select the cheapest plan that has at least one index matcher.
 	// PostingsForMatchers will return incorrect results if there are no matchers.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR precomputes costs for all plans once before sorting, so that `slices.SortFunc` does not compute each plan cost every time it does a comparison. This saves on CPU when using the `CostBasedPlanner`.

#### Which issue(s) this PR fixes or relates to

Loosely related to https://github.com/grafana/mimir/issues/11921

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
