### PR TITLE
CI: Notify MQE maintainers when pkg/streamingpromql tests fail on vendor PRs

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -196,7 +196,7 @@ jobs:
               
               cc @charleskorn @56quarters @lamida @zenador
               
-              Please review the [test logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+              Please review the [test logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and push fixes to this PR."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -194,7 +194,7 @@ jobs:
               ${{ env.FAILED_PACKAGES }}
               \`\`\`
               
-              cc @charleskorn @56quarters @lamida @zenador
+              cc @charleskorn @56quarters @lamida @zenador @Konstantinov-Innokentii 
               
               Please review the [test logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and push fixes to this PR."
           fi

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -182,6 +182,24 @@ jobs:
           command: |
             echo "Running unit tests (group ${{ matrix.test_group_id }} of ${{ matrix.test_group_total }}) with Go version: $(go version)"
             ./.github/workflows/scripts/run-unit-tests-group.sh --index ${{ matrix.test_group_id }} --total ${{ matrix.test_group_total }}
+      - name: Notify on streamingpromql failures
+        if: failure() && env.FAILED_PACKAGES != '' && contains(github.event.pull_request.labels.*.name, 'vendored-mimir-prometheus-update')
+        run: |
+          if echo "${{ env.FAILED_PACKAGES }}" | grep -q "pkg/streamingpromql"; then
+            gh pr comment ${{ github.event.pull_request.number }} --body \
+              "⚠️ Test failures detected in \`pkg/streamingpromql\` (test group ${{ matrix.test_group_id }}/${{ matrix.test_group_total }})
+              
+              Failed packages in this test group:
+              \`\`\`
+              ${{ env.FAILED_PACKAGES }}
+              \`\`\`
+              
+              cc @charleskorn @56quarters @lamida @zenador
+              
+              Please review the [test logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-docs:
     uses: ./.github/workflows/test-docs.yml


### PR DESCRIPTION
## Summary

Automatically notify MQE maintainers when `pkg/streamingpromql` tests fail on mimir-prometheus vendoring PRs by posting a GitHub comment with @mentions.

These tests usually fail because there are tests in `pkg/streamingpromql/testdata/upstream/*.test` which need updating. Usually there's also the need to update some other unit tests or fix functionality. This is hard to automate and needs human judgement.

This PR tags @charleskorn, @56quarters, @lamida, @zenador and @Konstantinov-Innokentii  when `pkg/stremingpromql` fails unit tests during vendoring PRs.

## Changes

- **Modified `.github/workflows/scripts/run-unit-tests-group.sh`**:
  - Capture test output using `tee` while preserving real-time display
  - Extract all failed package names and store in `FAILED_PACKAGES` environment variable
  - Maintain original exit code behavior

- **Updated `.github/workflows/test-build-deploy.yml`**:
  - Added notification step that runs on test failure for PRs with `vendored-mimir-prometheus-update` label
  - Checks if `pkg/streamingpromql` is in the list of failed packages
  - Posts PR comment with context about test group, failed packages, and links to logs
