### PR TITLE
Remove references to make generate-otlp target

### DIFF
--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -143,7 +143,6 @@ jobs:
           
           echo "Dependencies updated successfully"
 
-
       - name: Create Pull Request
         id: create_pull_request
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3


### PR DESCRIPTION
## Summary

Remove references to the `make generate-otlp` target from the GitHub workflow.

## Context

PR #12652 removed the `generate-otlp` make target, but the 
`update-vendored-mimir-prometheus.yml` workflow still referenced it, 
causing automation failures when the workflow runs.