### PR TITLE
Ingester: Introduce metric cortex_ingester_owned_target_info_series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [FEATURE] Query-frontend and querier: Add experimental support for performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #12302 #12551 #12665 #12687 #12745 #12757
 * [FEATURE] Alertmanager: add Microsoft Teams V2 as a supported integration. #12680
 * [FEATURE] Distributor: Add experimental flag `-validation.label-value-length-over-limit-strategy` to configure how to handle label values over the length limit. #12627
+* [FEATURE] Ingester: Introduce metric `cortex_ingester_owned_target_info_series` for counting the number of owned `target_info` series. #12681
 * [ENHANCEMENT] Query-frontend: CLI flag `-query-frontend.enabled-promql-experimental-functions` and its associated YAML configuration is now stable. #12368
 * [ENHANCEMENT] Query-scheduler/query-frontend: Add native histogram definitions to `cortex_query_{scheduler|frontend}_queue_duration_seconds`. #12288
 * [ENHANCEMENT] Querier: Add native histogram definition to `cortex_bucket_index_load_duration_seconds`. #12094

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * [FEATURE] Query-frontend and querier: Add experimental support for performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #12302 #12551 #12665 #12687 #12745 #12757
 * [FEATURE] Alertmanager: add Microsoft Teams V2 as a supported integration. #12680
 * [FEATURE] Distributor: Add experimental flag `-validation.label-value-length-over-limit-strategy` to configure how to handle label values over the length limit. #12627
-* [FEATURE] Ingester: Introduce metric `cortex_ingester_owned_target_info_series` for counting the number of owned `target_info` series. #12681
+* [FEATURE] Ingester: Introduce metric `cortex_ingester_owned_target_info_series` for counting the number of owned `target_info` series by tenant. #12681
 * [ENHANCEMENT] Query-frontend: CLI flag `-query-frontend.enabled-promql-experimental-functions` and its associated YAML configuration is now stable. #12368
 * [ENHANCEMENT] Query-scheduler/query-frontend: Add native histogram definitions to `cortex_query_{scheduler|frontend}_queue_duration_seconds`. #12288
 * [ENHANCEMENT] Querier: Add native histogram definition to `cortex_bucket_index_load_duration_seconds`. #12094

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -962,6 +962,7 @@ func (i *Ingester) updateLimitMetrics() {
 		if i.cfg.UseIngesterOwnedSeriesForLimits || i.cfg.UpdateIngesterOwnedSeries {
 			os := db.ownedSeriesState()
 			i.metrics.ownedSeriesPerUser.WithLabelValues(userID).Set(float64(os.ownedSeriesCount))
+			i.metrics.ownedTargetInfoSeriesPerUser.WithLabelValues(userID).Set(float64(os.ownedTargetInfoSeriesCount))
 
 			if i.cfg.UseIngesterOwnedSeriesForLimits {
 				minLocalSeriesLimit = os.localSeriesLimit

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -50,6 +50,8 @@ type ingesterMetrics struct {
 
 	// Owned series
 	ownedSeriesPerUser *prometheus.GaugeVec
+	// Owned target_info series
+	ownedTargetInfoSeriesPerUser *prometheus.GaugeVec
 
 	// Global limit metrics
 	maxUsersGauge                prometheus.GaugeFunc
@@ -200,6 +202,10 @@ func newIngesterMetrics(
 		ownedSeriesPerUser: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_ingester_owned_series",
 			Help: "Number of currently owned series per user.",
+		}, []string{"user"}),
+		ownedTargetInfoSeriesPerUser: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_ingester_owned_target_info_series",
+			Help: "Number of currently owned target_info series per user.",
 		}, []string{"user"}),
 		attributedActiveSeriesFailuresPerUser: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_ingester_attributed_active_series_failure",
@@ -428,6 +434,7 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 
 	m.maxLocalSeriesPerUser.DeleteLabelValues(userID)
 	m.ownedSeriesPerUser.DeleteLabelValues(userID)
+	m.ownedTargetInfoSeriesPerUser.DeleteLabelValues(userID)
 	m.attributedActiveSeriesFailuresPerUser.DeleteLabelValues(userID)
 }
 

--- a/pkg/ingester/owned_series_test.go
+++ b/pkg/ingester/owned_series_test.go
@@ -63,9 +63,10 @@ func (c *ownedSeriesTestContextBase) checkUpdateReasonForUser(t *testing.T, expe
 	require.Equal(t, expectedReason, c.db.requiresOwnedSeriesUpdate.Load())
 }
 
-func (c *ownedSeriesTestContextBase) checkTestedIngesterOwnedSeriesState(t *testing.T, series, shards, limit int) {
+func (c *ownedSeriesTestContextBase) checkTestedIngesterOwnedSeriesState(t *testing.T, series, targetInfoSeries, shards, limit int) {
 	os := c.db.ownedSeriesState()
 	require.Equal(t, series, os.ownedSeriesCount, "owned series")
+	require.Equal(t, targetInfoSeries, os.ownedTargetInfoSeriesCount, "owned target_info series")
 	require.Equal(t, shards, os.shardSize, "shard size")
 	require.Equal(t, limit, os.localSeriesLimit, "local series limit")
 }
@@ -175,7 +176,7 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.pushUserSeries(t)
 
 				// first ingester owns all the series, even without any ownedSeries run. this is because each created series is automatically counted as "owned".
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// run initial owned series check
@@ -184,15 +185,50 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// first ingester still owns all the series
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// re-running shouldn't trigger a recompute, since no reason is set
 				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
 
 				// first ingester still owns all the series
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
+			},
+		},
+		"new user trigger with target_info series": {
+			limits: map[string]*validation.Limits{
+				ownedServiceTestUser: {
+					MaxGlobalSeriesPerUser:   ownedServiceTestUserSeriesLimit,
+					IngestionTenantShardSize: 0,
+				},
+			},
+			testFunc: func(t *testing.T, c *ownedSeriesWithIngesterRingTestContext, _ map[string]*validation.Limits) {
+				// Generate series with 2 target_info series using a timestamp that won't be rejected
+				const targetInfoCount = 2
+				baseTime := time.Now().Add(-time.Minute) // Use a time in the past to avoid "too far in future" errors
+				c.seriesToWrite, c.seriesTokens = generateSeriesWithTargetInfoAt(ownedServiceTestUser, baseTime, targetInfoCount)
+				c.pushUserSeries(t)
+
+				// first ingester owns all the series, even without any ownedSeries run. this is because each created series is automatically counted as "owned".
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount+targetInfoCount, targetInfoCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkActiveSeriesCount(t, ownedServiceSeriesCount+targetInfoCount)
+
+				// run initial owned series check
+				c.checkUpdateReasonForUser(t, recomputeOwnedSeriesReasonNewUser)
+				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonNewUser)
+				c.checkUpdateReasonForUser(t, "")
+
+				// first ingester still owns all the series including target_info
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount+targetInfoCount, targetInfoCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkActiveSeriesCount(t, ownedServiceSeriesCount+targetInfoCount)
+
+				// re-running shouldn't trigger a recompute, since no reason is set
+				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
+
+				// first ingester still owns all the series
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount+targetInfoCount, targetInfoCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkActiveSeriesCount(t, ownedServiceSeriesCount+targetInfoCount)
 			},
 		},
 		"new user trigger from WAL replay": {
@@ -208,7 +244,7 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				dataDir := c.ing.cfg.BlocksStorageConfig.TSDB.Dir
@@ -223,7 +259,7 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 
 				// the owned series will be counted during WAL replay and reason set to "new user"
 				// shard size and local limit are initialized to correct values
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, recomputeOwnedSeriesReasonNewUser)
 				c.checkActiveSeriesCount(t, 0) // active series do not get restored after a restart
 			},
@@ -241,25 +277,25 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// add an ingester
 				c.registerSecondIngesterOwningHalfOfTheTokens(t)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// since no reason set, shard size and local limit are unchanged, and we pass ringChanged=false, no recompute will happen
 				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// passing ringChanged=true won't trigger a recompute either, because the user's subring hasn't changed
 				c.updateOwnedSeriesAndCheckResult(t, true, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
@@ -267,18 +303,18 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.removeSecondIngester(t)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// since no reason set, shard size and local limit are unchanged, and we pass ringChanged=false, no recompute will happen
 				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// passing ringChanged=true won't trigger a recompute either, because the user's subring hasn't changed
 				c.updateOwnedSeriesAndCheckResult(t, true, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 			},
@@ -297,25 +333,25 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// add an ingester (it will become the first ingester in the shuffle shard)
 				c.registerSecondIngesterOwningHalfOfTheTokens(t)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// since no reason set, shard size and local limit are unchanged, and we pass ringChanged=false, no recompute will happen
 				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// passing ringChanged=true will trigger recompute because the token ownership has changed
 				c.updateOwnedSeriesAndCheckResult(t, true, 1, recomputeOwnedSeriesReasonRingChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, 0)
 
@@ -323,18 +359,18 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.removeSecondIngester(t)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, 0)
 
 				// since no reason set, shard size and local limit are unchanged, and we pass ringChanged=false, no recompute will happen
 				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, 0)
 
 				// passing ringChanged=true will trigger recompute because the token ownership has changed
 				c.updateOwnedSeriesAndCheckResult(t, true, 1, recomputeOwnedSeriesReasonRingChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 
 				// active series stay reduced until more pushes come in
@@ -356,19 +392,19 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester.
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// add an ingester
 				c.registerSecondIngesterOwningHalfOfTheTokens(t)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// will recompute because the local limit has changed (takes precedence over ring change)
 				c.updateOwnedSeriesAndCheckResult(t, true, 1, recomputeOwnedSeriesReasonLocalLimitChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 0, ownedServiceTestUserSeriesLimit/2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount/2)
 
@@ -376,12 +412,12 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.removeSecondIngester(t)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 0, ownedServiceTestUserSeriesLimit/2)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount/2)
 
 				// will recompute because the local limit has changed (takes precedence over ring change)
 				c.updateOwnedSeriesAndCheckResult(t, true, 1, recomputeOwnedSeriesReasonLocalLimitChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 
 				// active series stay reduced until more pushes come in
@@ -403,7 +439,7 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester.
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// add a PENDING ingester with no tokens
@@ -412,12 +448,12 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				})
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// the ring has changed but the token ranges have not, so no recompute should happen
 				c.updateOwnedSeriesAndCheckResult(t, true, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 			},
@@ -439,7 +475,7 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 
 				// will recompute because the local limit has changed (takes precedence over ring change)
 				c.updateOwnedSeriesAndCheckResult(t, true, 1, recomputeOwnedSeriesReasonLocalLimitChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 0, ownedServiceTestUserSeriesLimit/2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount/2)
 
@@ -448,11 +484,11 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				limits[ownedServiceTestUser].IngestionTenantShardSize = 2
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 0, ownedServiceTestUserSeriesLimit/2)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount/2)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 2, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 2, ownedServiceTestUserSeriesLimit/2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount/2)
 			},
@@ -473,18 +509,18 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.registerSecondIngesterOwningHalfOfTheTokens(t)
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// change shard size to 2, splitting the series between ingesters
 				limits[ownedServiceTestUser].IngestionTenantShardSize = 2
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 2, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 2, ownedServiceTestUserSeriesLimit/2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount/2)
 
@@ -492,11 +528,11 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				limits[ownedServiceTestUser].IngestionTenantShardSize = 1
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 2, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 2, ownedServiceTestUserSeriesLimit/2)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount/2)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 
 				// active series stay reduced until more pushes come in
@@ -524,18 +560,18 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the second ingester
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, 0)
 
 				// change shard size to 2, splitting the series between ingesters
 				limits[ownedServiceTestUser].IngestionTenantShardSize = 2
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, 0)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 2, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 2, ownedServiceTestUserSeriesLimit/2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, 0) // active series stay reduced until more pushes come in
 
@@ -543,11 +579,11 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				limits[ownedServiceTestUser].IngestionTenantShardSize = 1
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 2, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 2, ownedServiceTestUserSeriesLimit/2)
 				c.checkActiveSeriesCount(t, 0) // active series stay reduced until more pushes come in
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, 0) // active series stay reduced until more pushes come in
 			},
@@ -565,18 +601,18 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// increase series limit
 				limits[ownedServiceTestUser].MaxGlobalSeriesPerUser = ownedServiceTestUserSeriesLimit * 2
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonLocalLimitChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit*2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit*2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
@@ -584,11 +620,11 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				limits[ownedServiceTestUser].MaxGlobalSeriesPerUser = ownedServiceTestUserSeriesLimit
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit*2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit*2)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonLocalLimitChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 			},
@@ -609,7 +645,7 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.registerSecondIngesterOwningHalfOfTheTokens(t)
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// double series limit and shard size
@@ -617,11 +653,11 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				limits[ownedServiceTestUser].IngestionTenantShardSize = 2
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 2, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 2, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount/2)
 
@@ -630,11 +666,11 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				limits[ownedServiceTestUser].IngestionTenantShardSize = 1
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 2, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount/2, 0, 2, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount/2)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount/2) // active series stay reduced until more pushes come in
 			},
@@ -652,7 +688,7 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// run early compaction removing all series from the head
@@ -661,12 +697,12 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				require.Equal(t, uint64(0), c.db.Head().NumSeries())
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.checkUpdateReasonForUser(t, recomputeOwnedSeriesReasonEarlyCompaction)
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonEarlyCompaction)
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 
 				// series should be marked as deleted, but are still active
@@ -691,12 +727,12 @@ func TestOwnedSeriesServiceWithIngesterRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.db.requiresOwnedSeriesUpdate.Store(recomputeOwnedSeriesReasonGetTokenRangesFailed)
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonGetTokenRangesFailed)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 			},
@@ -769,6 +805,21 @@ func generateSeriesWithTokensAt(testUser string, startTime time.Time) ([]util_te
 		s := util_test.Series{
 			Labels:  labels.FromStrings(labels.MetricName, "test", fmt.Sprintf("lbl_%05d", seriesIdx), "value"),
 			Samples: []util_test.Sample{{TS: startTime.Add(time.Duration(seriesIdx) * time.Millisecond).UnixMilli(), Val: float64(0)}},
+		}
+		seriesToWrite = append(seriesToWrite, s)
+		seriesTokens = append(seriesTokens, mimirpb.ShardByAllLabels(testUser, s.Labels))
+	}
+	return seriesToWrite, seriesTokens
+}
+
+func generateSeriesWithTargetInfoAt(testUser string, startTime time.Time, targetInfoCount int) ([]util_test.Series, []uint32) {
+	seriesToWrite, seriesTokens := generateSeriesWithTokensAt(testUser, startTime)
+
+	// Generate target_info series
+	for i := range targetInfoCount {
+		s := util_test.Series{
+			Labels:  labels.FromStrings(labels.MetricName, "target_info", "instance", fmt.Sprintf("instance_%d", i), "job", "test_job"),
+			Samples: []util_test.Sample{{TS: startTime.Add(time.Duration(i) * time.Millisecond).UnixMilli(), Val: float64(1)}},
 		}
 		seriesToWrite = append(seriesToWrite, s)
 		seriesTokens = append(seriesTokens, mimirpb.ShardByAllLabels(testUser, s.Labels))
@@ -929,7 +980,7 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.pushUserSeries(t)
 
 				// first ingester owns all the series, even without any ownedSeries run. this is because each created series is automatically counted as "owned".
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// run initial owned series check
@@ -938,15 +989,50 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// first ingester still owns all the series
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// re-running shouldn't trigger a recompute, since no reason is set
 				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
 
 				// first ingester still owns all the series
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
+			},
+		},
+		"new user trigger with target_info series": {
+			limits: map[string]*validation.Limits{
+				ownedServiceTestUserPartitionsRing: {
+					MaxGlobalSeriesPerUser:             ownedServiceTestUserSeriesLimit,
+					IngestionPartitionsTenantShardSize: 0,
+				},
+			},
+			testFunc: func(t *testing.T, c *ownedSeriesWithPartitionsRingTestContext, _ map[string]*validation.Limits) {
+				// Generate series with 2 target_info series using a timestamp that won't be rejected
+				const targetInfoCount = 2
+				baseTime := time.Now().Add(-time.Minute) // Use a time in the past to avoid "too far in future" errors
+				c.seriesToWrite, _ = generateSeriesWithTargetInfoAt(ownedServiceTestUserPartitionsRing, baseTime, targetInfoCount)
+				c.pushUserSeries(t)
+
+				// first ingester owns all the series, even without any ownedSeries run. this is because each created series is automatically counted as "owned".
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount+targetInfoCount, targetInfoCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkActiveSeriesCount(t, ownedServiceSeriesCount+targetInfoCount)
+
+				// run initial owned series check
+				c.checkUpdateReasonForUser(t, recomputeOwnedSeriesReasonNewUser)
+				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonNewUser)
+				c.checkUpdateReasonForUser(t, "")
+
+				// first ingester still owns all the series including target_info
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount+targetInfoCount, targetInfoCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkActiveSeriesCount(t, ownedServiceSeriesCount+targetInfoCount)
+
+				// re-running shouldn't trigger a recompute, since no reason is set
+				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
+
+				// first ingester still owns all the series
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount+targetInfoCount, targetInfoCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkActiveSeriesCount(t, ownedServiceSeriesCount+targetInfoCount)
 			},
 		},
 		"new user trigger from WAL replay": {
@@ -962,7 +1048,7 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// stop the ingester
@@ -975,7 +1061,7 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 
 				// the owned series will be counted during WAL replay and reason set to "new user"
 				// shard size and local limit are initialized to correct values
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, recomputeOwnedSeriesReasonNewUser)
 				c.checkActiveSeriesCount(t, 0) // active series do not get restored after a restart
 			},
@@ -995,25 +1081,25 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// Partition 2 was added at first, now we add partition 1. However partition 2 will still "own" the test user (see TestOwnedSeriesPartitionsTestUserShuffleSharding).
 				c.addPartition(t, 1, ring.PartitionActive)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// since no reason set, shard size and local limit are unchanged, and we pass ringChanged=false, no recompute will happen
 				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// passing ringChanged=true won't trigger a recompute either, because the user's partition subring hasn't changed
 				c.updateOwnedSeriesAndCheckResult(t, true, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
@@ -1021,18 +1107,18 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.removePartition(t, 1)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// since no reason set, shard size and local limit are unchanged, and we pass ringChanged=false, no recompute will happen
 				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// passing ringChanged=true won't trigger a recompute either, because the user's subring hasn't changed
 				c.updateOwnedSeriesAndCheckResult(t, true, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 			},
@@ -1052,25 +1138,25 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// Add new partition. This will become the only partition in the shuffle shard for the test user. See TestOwnedSeriesPartitionsTestUserShuffleSharding.
 				c.addPartition(t, 2, ring.PartitionActive)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// since no reason set, shard size and local limit are unchanged, and we pass ringChanged=false, no recompute will happen
 				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// passing ringChanged=true will trigger recompute because the token ownership has changed
 				c.updateOwnedSeriesAndCheckResult(t, true, 1, recomputeOwnedSeriesReasonRingChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, 0)
 
@@ -1078,17 +1164,17 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.removePartition(t, 2)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 
 				// since no reason set, shard size and local limit are unchanged, and we pass ringChanged=false, no recompute will happen
 				c.updateOwnedSeriesAndCheckResult(t, false, 0, "")
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, 0)
 
 				// passing ringChanged=true will trigger recompute because the token ownership has changed
 				c.updateOwnedSeriesAndCheckResult(t, true, 1, recomputeOwnedSeriesReasonRingChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 
 				// active series stay reduced until more pushes come in
@@ -1110,19 +1196,19 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first partition.
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// add new partition. Since shard size = 0, tenant will use both partitions.
 				c.addPartition(t, 1, ring.PartitionActive)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// will recompute because the local limit has changed (takes precedence over ring change)
 				c.updateOwnedSeriesAndCheckResult(t, true, 1, recomputeOwnedSeriesReasonLocalLimitChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[0], 0, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[0], 0, 0, ownedServiceTestUserSeriesLimit/2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions0And1[0])
 
@@ -1130,12 +1216,12 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.removePartition(t, 1)
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[0], 0, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[0], 0, 0, ownedServiceTestUserSeriesLimit/2)
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions0And1[0])
 
 				// will recompute because the local limit has changed (takes precedence over ring change)
 				c.updateOwnedSeriesAndCheckResult(t, true, 1, recomputeOwnedSeriesReasonLocalLimitChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions0And1[0]) // active series stay reduced until more pushes come in
 			},
@@ -1157,7 +1243,7 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 
 				// will recompute because the local limit has changed (takes precedence over ring change)
 				c.updateOwnedSeriesAndCheckResult(t, true, 1, recomputeOwnedSeriesReasonLocalLimitChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[0], 0, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[0], 0, 0, ownedServiceTestUserSeriesLimit/2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions0And1[0])
 
@@ -1166,11 +1252,11 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				limits[ownedServiceTestUserPartitionsRing].IngestionPartitionsTenantShardSize = 2
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[0], 0, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[0], 0, 0, ownedServiceTestUserSeriesLimit/2)
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions0And1[0])
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[0], 2, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[0], 0, 2, ownedServiceTestUserSeriesLimit/2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions0And1[0])
 			},
@@ -1193,18 +1279,18 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.addPartition(t, 1, ring.PartitionActive)
 
 				// initial state: all series are owned by the first ingester (partition 0)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// change shard size to 2, splitting the series between two partitions.
 				limits[ownedServiceTestUserPartitionsRing].IngestionPartitionsTenantShardSize = 2
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions1And2[2], 2, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions1And2[2], 0, 2, ownedServiceTestUserSeriesLimit/2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions1And2[2])
 
@@ -1212,11 +1298,11 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				limits[ownedServiceTestUserPartitionsRing].IngestionPartitionsTenantShardSize = 1
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions1And2[2], 2, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions1And2[2], 0, 2, ownedServiceTestUserSeriesLimit/2)
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions1And2[2])
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions1And2[2]) // active series stay reduced until more pushes come in
 			},
@@ -1243,18 +1329,18 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by partition 2.
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, 0)
 
 				// change shard size to 2, splitting the series between ingesters
 				limits[ownedServiceTestUserPartitionsRing].IngestionPartitionsTenantShardSize = 2
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, 0)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions1And2[1], 2, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions1And2[1], 0, 2, ownedServiceTestUserSeriesLimit/2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, 0)
 
@@ -1262,11 +1348,11 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				limits[ownedServiceTestUserPartitionsRing].IngestionPartitionsTenantShardSize = 1
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions1And2[1], 2, ownedServiceTestUserSeriesLimit/2)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions1And2[1], 0, 2, ownedServiceTestUserSeriesLimit/2)
 				c.checkActiveSeriesCount(t, 0)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 
 				// active series stay reduced until more pushes come in
@@ -1288,18 +1374,18 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the partition 0.
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// increase series limit
 				limits[ownedServiceTestUserPartitionsRing].MaxGlobalSeriesPerUser = ownedServiceTestUserSeriesLimit * 2
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonLocalLimitChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit*2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit*2)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
@@ -1307,11 +1393,11 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				limits[ownedServiceTestUserPartitionsRing].MaxGlobalSeriesPerUser = ownedServiceTestUserSeriesLimit
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit*2)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit*2)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonLocalLimitChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 			},
@@ -1334,7 +1420,7 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.addPartition(t, 0, ring.PartitionActive)
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// double series limit and shard size
@@ -1342,11 +1428,11 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				limits[ownedServiceTestUserPartitionsRing].IngestionPartitionsTenantShardSize = 2
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[1], 2, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[1], 0, 2, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions0And1[1])
 
@@ -1355,11 +1441,11 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				limits[ownedServiceTestUserPartitionsRing].IngestionPartitionsTenantShardSize = 1
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[1], 2, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, seriesSplitForPartitions0And1[1], 0, 2, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions0And1[1])
 
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonShardSizeChanged)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 1, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 1, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, seriesSplitForPartitions0And1[1]) // active series stay reduced until more pushes come in
 			},
@@ -1377,7 +1463,7 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				// run early compaction removing all series from the head
@@ -1386,12 +1472,12 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				require.Equal(t, uint64(0), c.db.Head().NumSeries())
 
 				// verify no change in state before owned series run
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.checkUpdateReasonForUser(t, recomputeOwnedSeriesReasonEarlyCompaction)
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonEarlyCompaction)
-				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, 0, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 
 				// series should be marked as deleted, but are still active
@@ -1416,12 +1502,12 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 				c.checkUpdateReasonForUser(t, "")
 
 				// initial state: all series are owned by the first ingester
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 
 				c.db.requiresOwnedSeriesUpdate.Store(recomputeOwnedSeriesReasonGetTokenRangesFailed)
 				c.updateOwnedSeriesAndCheckResult(t, false, 1, recomputeOwnedSeriesReasonGetTokenRangesFailed)
-				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, ownedServiceTestUserSeriesLimit)
+				c.checkTestedIngesterOwnedSeriesState(t, ownedServiceSeriesCount, 0, 0, ownedServiceTestUserSeriesLimit)
 				c.checkUpdateReasonForUser(t, "")
 				c.checkActiveSeriesCount(t, ownedServiceSeriesCount)
 			},

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -18,6 +18,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
@@ -86,9 +87,10 @@ var (
 )
 
 type ownedSeriesState struct {
-	ownedSeriesCount int // Number of "owned" series, based on current ring.
-	shardSize        int // Tenant shard size when "owned" series was last updated due to ring or shard size changes. Used to detect shard size changes.
-	localSeriesLimit int // Local series limit when "owned" series was last updated due to ring or shard size changes. Used as a minimum when calculating series limits.
+	ownedSeriesCount           int // Number of "owned" series, based on current ring.
+	ownedTargetInfoSeriesCount int // Number of "owned" target_info series, based on current ring.
+	shardSize                  int // Tenant shard size when "owned" series was last updated due to ring or shard size changes. Used to detect shard size changes.
+	localSeriesLimit           int // Local series limit when "owned" series was last updated due to ring or shard size changes. Used as a minimum when calculating series limits.
 }
 
 type userTSDB struct {
@@ -334,6 +336,9 @@ func (u *userTSDB) PostCreation(metric labels.Labels) {
 	// but we will recompute owned series when ingester joins the ring.)
 	u.ownedStateMtx.Lock()
 	u.ownedState.ownedSeriesCount++
+	if metric.Get(model.MetricNameLabel) == "target_info" {
+		u.ownedState.ownedTargetInfoSeriesCount++
+	}
 	u.ownedStateMtx.Unlock()
 
 	metricName, err := extract.MetricNameFromLabels(metric)
@@ -550,10 +555,15 @@ const (
 	recomputeOwnedSeriesMaxSeriesDiff = 1000
 )
 
-func (u *userTSDB) recomputeOwnedSeriesWithComputeFn(shardSize int, reason string, logger log.Logger, compute func() int) (success bool, _ int) {
+func (u *userTSDB) recomputeOwnedSeriesWithComputeFn(shardSize int, reason string, logger log.Logger, compute func() (int, int)) (success bool, _ int) {
 	start := time.Now()
 
-	var ownedSeriesNew, ownedSeriesBefore, shardSizeBefore, localLimitBefore, localLimitNew int
+	var (
+		ownedSeriesNew, ownedSeriesBefore,
+		ownedTargetInfoSeriesNew, ownedTargetInfoSeriesBefore,
+		shardSizeBefore,
+		localLimitBefore, localLimitNew int
+	)
 
 	success = false
 	attempts := 0
@@ -562,11 +572,12 @@ func (u *userTSDB) recomputeOwnedSeriesWithComputeFn(shardSize int, reason strin
 
 		os := u.ownedSeriesState()
 		ownedSeriesBefore = os.ownedSeriesCount
+		ownedTargetInfoSeriesBefore = os.ownedTargetInfoSeriesCount
 		shardSizeBefore = os.shardSize
 		localLimitBefore = os.localSeriesLimit
 
 		localLimitNew = u.limiter.maxSeriesPerUser(u.userID, 0)
-		ownedSeriesNew = compute()
+		ownedSeriesNew, ownedTargetInfoSeriesNew = compute()
 
 		u.ownedStateMtx.Lock()
 
@@ -575,12 +586,14 @@ func (u *userTSDB) recomputeOwnedSeriesWithComputeFn(shardSize int, reason strin
 		// (it may or may not include the new series, we don't know).
 		// In that case, just run the computation again -- if there are more attempts left.
 		seriesDiff := u.ownedState.ownedSeriesCount - ownedSeriesBefore
-		if seriesDiff >= 0 && seriesDiff <= recomputeOwnedSeriesMaxSeriesDiff {
+		targetInfoSeriesDiff := u.ownedState.ownedTargetInfoSeriesCount - ownedTargetInfoSeriesBefore
+		if seriesDiff >= 0 && targetInfoSeriesDiff >= 0 && seriesDiff <= recomputeOwnedSeriesMaxSeriesDiff && targetInfoSeriesDiff <= recomputeOwnedSeriesMaxSeriesDiff {
 			success = true
 		}
 
-		// Even if we run computation again, we can start using our (possibly incorrect) values already.
+		// Even if we run the computation again, we can start using our (possibly incorrect) values already.
 		u.ownedState.ownedSeriesCount = ownedSeriesNew
+		u.ownedState.ownedTargetInfoSeriesCount = ownedTargetInfoSeriesNew
 		u.ownedState.shardSize = shardSize
 		u.ownedState.localSeriesLimit = localLimitNew
 
@@ -598,6 +611,8 @@ func (u *userTSDB) recomputeOwnedSeriesWithComputeFn(shardSize int, reason strin
 		"reason", reason,
 		"ownedSeriesBefore", ownedSeriesBefore,
 		"ownedSeriesNew", ownedSeriesNew,
+		"ownedTargetInfoSeriesBefore", ownedTargetInfoSeriesBefore,
+		"ownedTargetInfoSeriesNew", ownedTargetInfoSeriesNew,
 		"shardSizeBefore", shardSizeBefore,
 		"shardSizeNew", shardSize,
 		"localLimitBefore", localLimitBefore,
@@ -618,25 +633,34 @@ func (u *userTSDB) updateTokenRanges(newTokenRanges []uint32) bool {
 	return !prev.Equal(newTokenRanges)
 }
 
-func (u *userTSDB) computeOwnedSeries() int {
+func (u *userTSDB) computeOwnedSeries() (int, int) {
 	// This can happen if ingester doesn't own this tenant anymore.
 	if len(u.ownedTokenRanges) == 0 {
 		u.activeSeries.Clear()
-		return 0
+		return 0, 0
 	}
 
 	count := 0
+	targetInfoCount := 0
 	idx := u.Head().MustIndex()
 	defer idx.Close()
 
+	lb := labels.NewScratchBuilder(128)
 	u.Head().ForEachSecondaryHash(func(refs []chunks.HeadSeriesRef, secondaryHashes []uint32) {
 		for i, sh := range secondaryHashes {
 			if u.ownedTokenRanges.IncludesKey(sh) {
 				count++
+				lb.Reset()
+				if err := idx.Series(storage.SeriesRef(refs[i]), &lb, nil); err != nil {
+					panic(fmt.Errorf("obtain owned series labels: %w", err))
+				}
+				if lb.Labels().Get(model.MetricNameLabel) == "target_info" {
+					targetInfoCount++
+				}
 			} else {
 				u.activeSeries.Delete(refs[i], idx)
 			}
 		}
 	})
-	return count
+	return count, targetInfoCount
 }


### PR DESCRIPTION
#### What this PR does

Introduce the `cortex_ingester_owned_target_info_series` metric, for counting of owned `target_info` series per tenant. The motivation is to make it possible to determine the amount of churn before relabeling of `target_info` series.

I don't think the changes to owned series recomputation should have any significant perf impact, especially considering this is only called every 15 seconds.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
