### PR TITLE
distributor: calculate write response stats early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [ENHANCEMENT] Distributor: The metric `cortex_distributor_uncompressed_request_body_size_bytes` now differentiates by the handler serving the request. #12661
 * [ENHANCEMENT] Query-frontend, querier: Add support for experimental `first_over_time` PromQL function. #12662
 * [ENHANCEMENT] OTLP: native support for OpenTelemetry metric start time to Prometheus metric created timestamp conversion, instead of converting to QuietZeroNaNs introduced in #10238. The configuration parameter `-distributor.otel-start-time-quiet-zero` is therefore deprecated and will be removed. Now supports start time for exponential histograms. This is a major rewrite of the endpoint in upstream Prometheus and Mimir. #12652
+* [BUGFIX] Distributor: Calculate `WriteResponseStats` before validation and `PushWrappers`. This prevents clients using Remote-Write 2.0 from seeing a diff in written samples, histograms and exemplars. #12682
 * [BUGFIX] Compactor: Fix cortex_compactor_block_uploads_failed_total metric showing type="unknown". #12477
 * [BUGFIX] Querier: Samples with the same timestamp are merged deterministically. Previously, this could lead to flapping query results when an out-of-order sample is ingested that conflicts with a previously ingested in-order sample's value. #8673
 * [BUGFIX] Store-gateway: Fix potential goroutine leak by passing the scoped context in LabelValues. #12048

--- a/integration/distributor_test.go
+++ b/integration/distributor_test.go
@@ -931,7 +931,11 @@ func testDistributorWithCachingUnmarshalData(t *testing.T, cachingUnmarshalDataE
 				{
 					Samples:    1,
 					Histograms: 0,
-					Exemplars:  0,
+					// Mimir may silently drop outdated samples/histograms/exemplars during aggregation, due to age or
+					// other middlewares running in distributors. Mimir can't differentiate if a data point was dropped
+					// deliberately or accidentally. Hence, to avoid confusing clients we count every sample, histogram
+					// and exemplar that was received, even if we didn't ingest it.
+					Exemplars: 1,
 				},
 			},
 		},

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1540,23 +1540,29 @@ func (d *Distributor) metricsMiddleware(next PushFunc) PushFunc {
 		}
 
 		numSamples := 0
+		numHistograms := 0
 		numExemplars := 0
 		for _, ts := range req.Timeseries {
-			numSamples += len(ts.Samples) + len(ts.Histograms)
+			numSamples += len(ts.Samples)
+			numHistograms += len(ts.Histograms)
 			numExemplars += len(ts.Exemplars)
 		}
 
 		span := trace.SpanFromContext(ctx)
 		span.SetAttributes(
-			attribute.Int("write.samples", numSamples),
+			attribute.Int("write.samples", numSamples+numHistograms),
 			attribute.Int("write.exemplars", numExemplars),
 			attribute.Int("write.metadata", len(req.Metadata)),
 		)
 
 		d.incomingRequests.WithLabelValues(userID, req.ProtocolVersion()).Inc()
-		d.incomingSamples.WithLabelValues(userID).Add(float64(numSamples))
+		d.incomingSamples.WithLabelValues(userID).Add(float64(numSamples + numHistograms))
 		d.incomingExemplars.WithLabelValues(userID).Add(float64(numExemplars))
 		d.incomingMetadata.WithLabelValues(userID).Add(float64(len(req.Metadata)))
+
+		// Update the write response stats, which are returned to callers using remote write
+		// version 2.0.
+		updateWriteResponseStatsCtx(ctx, numSamples, numHistograms, numExemplars)
 
 		return next(ctx, pushReq)
 	}
@@ -1855,7 +1861,7 @@ func (d *Distributor) push(ctx context.Context, pushReq *Request) error {
 		return err
 	}
 
-	d.updateReceivedMetrics(ctx, req, userID)
+	d.updateReceivedMetrics(req, userID)
 
 	if len(req.Timeseries) == 0 && len(req.Metadata) == 0 {
 		return nil
@@ -2110,7 +2116,7 @@ func tokenForMetadata(userID string, metricName string) uint32 {
 	return mimirpb.ShardByMetricName(userID, metricName)
 }
 
-func (d *Distributor) updateReceivedMetrics(ctx context.Context, req *mimirpb.WriteRequest, userID string) {
+func (d *Distributor) updateReceivedMetrics(req *mimirpb.WriteRequest, userID string) {
 	var receivedSamples, receivedHistograms, receivedHistogramBuckets, receivedExemplars, receivedMetadata int
 	for _, ts := range req.Timeseries {
 		receivedSamples += len(ts.Samples)
@@ -2128,8 +2134,6 @@ func (d *Distributor) updateReceivedMetrics(ctx context.Context, req *mimirpb.Wr
 	d.receivedNativeHistogramBuckets.WithLabelValues(userID).Add(float64(receivedHistogramBuckets))
 	d.receivedExemplars.WithLabelValues(userID).Add(float64(receivedExemplars))
 	d.receivedMetadata.WithLabelValues(userID).Add(float64(receivedMetadata))
-
-	updateWriteResponseStatsCtx(ctx, receivedSamples, receivedHistograms, receivedExemplars)
 }
 
 // forReplicationSets runs f, in parallel, for all ingesters in the input replicationSets.


### PR DESCRIPTION
#### What this PR does

Clients using Remote Write 2.0 get the "received" sample count instead of the true "ingested" count in ["x-Written" response headers](https://prometheus.io/docs/specs/prw/remote_write_spec_2_0/#required-written-response-headers). This is achieved by moving the `WriteResponseStats` calculation ahead of validation and `PushWrappers` (instead of doing it afterwards). 

**Background:**

Validation and other middlewares in the distributor may silently (2xx status code) drop samples, histograms or exemplars. Mimir can't differentiate the reasons for dropping a data point (e.g. due to aggregation, exemplar age). To avoid clients from unnecessarily logging a diff this PR counts every sample, histogram and exemplar that was received, even if we didn't ingest it. 

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/12622

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
