### PR TITLE
grpcurl-query-ingesters: Fix instructions to work around gogoproto import changes

### DIFF
--- a/tools/grpcurl-query-ingesters/README.md
+++ b/tools/grpcurl-query-ingesters/README.md
@@ -5,6 +5,8 @@ A simple hacky script + tool to download chunks from ingesters and dump their co
 # How to use it
 
 1. Edit `pkg/ingester/client/ingester.proto` and change the `import "github.com/grafana/mimir/pkg/mimirpb/mimir.proto"` statement to `import "pkg/mimirpb/mimir.proto"`
+1. Edit `pkg/ingester/client/ingester.proto` and change the `import "gogoproto/gogo.proto"` statement to `import "github.com/gogo/protobuf/gogoproto/gogo.proto"`
+1. Edit `pkg/mimirpb/mimir.proto` and change the `import "gogoproto/gogo.proto"` statement to `import "github.com/gogo/protobuf/gogoproto/gogo.proto"`
 1. Edit `download-chunks-from-ingesters-query.json` with the label matchers and time range to query.
 1. Edit `download-chunks-from-ingesters.sh` with the configuration about the Kubernetes namespace and Mimir tenant to query.
 1. Run `bash ./download-chunks-from-ingesters.sh` from this directory to download the chunks.


### PR DESCRIPTION
#### What this PR does

https://github.com/grafana/mimir/pull/11869 altered the way that gogoproto is imported. This is fine when compiling protos across the project, but `grpcurl` can't resolve the new file, meaning `grpcurl-query-ingesters` doesn't download any chunks anymore.

This PR just adds instructions to locally revert the change, so `grpcurl` can navigate proto files.
This doesn't seem too out of pocket given there's already instructions here to locally change the proto files.

#### Which issue(s) this PR fixes or relates to
n/a

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
