### PR TITLE
perf(rw2): use mimirpb.TimeseriesFromPool()

### DIFF
--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/distributor/otlpappender"
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/mimirpb/testutil"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -699,6 +700,7 @@ func TestOTelDeltaIngestion(t *testing.T) {
 				require.Equal(t, 1, dropped)
 			} else {
 				require.NoError(t, err)
+				mimirTS = testutil.RemoveEmptyObjectFromSeries(mimirTS)
 				require.Len(t, mimirTS, 1)
 				require.Equal(t, 0, dropped)
 				require.Equal(t, tc.expected, *mimirTS[0].TimeSeries)
@@ -784,6 +786,7 @@ func TestOTelCTZeroIngestion(t *testing.T) {
 				log.NewNopLogger(),
 			)
 			require.NoError(t, err)
+			mimirTS = testutil.RemoveEmptyObjectFromSeries(mimirTS)
 			require.Len(t, mimirTS, 1)
 			require.Equal(t, 0, dropped)
 			require.Equal(t, tc.expected, *mimirTS[0].TimeSeries)

--- a/pkg/distributor/otlpappender/mimir_appender.go
+++ b/pkg/distributor/otlpappender/mimir_appender.go
@@ -142,11 +142,9 @@ func (c *MimirAppender) processLabelsAndMetadata(ls labels.Labels) (hash uint64,
 }
 
 func (c *MimirAppender) createNewSeries(idx *labelsIdx, collisionIdx int, hash uint64, ls labels.Labels, ct int64) {
-	// TODO(krajorama): consider using mimirpb.TimeseriesFromPool
-	ts := &mimirpb.TimeSeries{
-		Labels:           mimirpb.FromLabelsToLabelAdapters(ls),
-		CreatedTimestamp: ct,
-	}
+	ts := mimirpb.TimeseriesFromPool()
+	ts.Labels = mimirpb.FromLabelsToLabelAdapters(ls)
+	ts.CreatedTimestamp = ct
 	c.series = append(c.series, mimirpb.PreallocTimeseries{TimeSeries: ts})
 	idx.idx = len(c.series) - 1
 

--- a/pkg/distributor/otlpappender/mimir_appender_test.go
+++ b/pkg/distributor/otlpappender/mimir_appender_test.go
@@ -14,10 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/mimirpb/testutil"
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
-func TestCombinedAppender(t *testing.T) {
+func TestMimirAppender(t *testing.T) {
 	collidingLabels1, collidingLabels2 := labelsWithHashCollision()
 
 	testCases := map[string]struct {
@@ -577,6 +578,7 @@ func TestCombinedAppender(t *testing.T) {
 					}
 
 					series, metadata := appender.GetResult()
+					series = testutil.RemoveEmptyObjectFromSeries(series)
 					require.Equal(t, expectedTimeseries, series)
 					require.Equal(t, tc.expectMetadata, metadata)
 					if tc.expectCollisions {

--- a/pkg/mimirpb/testutil/timeseries.go
+++ b/pkg/mimirpb/testutil/timeseries.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package testutil
+
+import "github.com/grafana/mimir/pkg/mimirpb"
+
+// RemoveEmptyObjectFromSeries is a test utility to replace some empty fields
+// inside the given series with `nil` for easy comparition.
+func RemoveEmptyObjectFromSeries(series []mimirpb.PreallocTimeseries) []mimirpb.PreallocTimeseries {
+	for i := range series {
+		s := series[i].TimeSeries
+		// Clean extra empty objects due to pooling.
+		if len(s.Samples) == 0 {
+			s.Samples = nil
+		}
+		if len(s.Histograms) == 0 {
+			s.Histograms = nil
+		}
+		if len(s.Exemplars) == 0 {
+			s.Exemplars = nil
+		}
+	}
+	return series
+}

--- a/pkg/mimirpb/testutil/timeseries.go
+++ b/pkg/mimirpb/testutil/timeseries.go
@@ -5,7 +5,7 @@ package testutil
 import "github.com/grafana/mimir/pkg/mimirpb"
 
 // RemoveEmptyObjectFromSeries is a test utility to replace some empty fields
-// inside the given series with `nil` for easy comparition.
+// inside the given series with `nil` for easy comparison.
 func RemoveEmptyObjectFromSeries(series []mimirpb.PreallocTimeseries) []mimirpb.PreallocTimeseries {
 	for i := range series {
 		s := series[i].TimeSeries


### PR DESCRIPTION
#### What this PR does

Instead of allocating from heap.

#### Which issue(s) this PR fixes or relates to

Related to #12652

#### Checklist

- [x] Tests updated. With pooling enabled you can get mimirpb.Timeseries from the pool where fields are empty , not nil - randomly.
- N/A Documentation added.
- N/A  `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
