### PR TITLE
continuous-test: Improve adherence to max-records-per-run inside record correctness test

### DIFF
--- a/pkg/continuoustest/ingest_storage_record.go
+++ b/pkg/continuoustest/ingest_storage_record.go
@@ -245,7 +245,7 @@ func (t *IngestStorageRecordTest) Run(ctx context.Context, now time.Time) error 
 		if ctx.Err() != nil {
 			return err
 		}
-		fetches := t.client.PollFetches(ctx)
+		fetches := t.client.PollRecords(ctx, t.cfg.MaxRecordsPerRun)
 		if errs := fetches.Errors(); len(errs) > 0 {
 			level.Error(t.logger).Log("msg", "fetch errors", "err", fetches.Err())
 			break


### PR DESCRIPTION
#### What this PR does

Normally, we let the client choose the fetch size, and fetch until we exceed max-records-per-run. That means we follow the limit, plus or minus the size of one fetch. Fetches are bounded in size in terms of bytes.

When there are lots of small records (as there tends to be in big cells), the client might do a single fetch that contains a huge amount of records, so "+/- the size of one fetch" actually can be an enormous amount of variance. In such cells we sometimes see run sizes vastly exceeding the limit:
```
msg="run complete" size=113749
```
(with limit of 80k)

When there's a lot of extra records, even though they're small, each one gets processed to RW2 and back individually, so the memory usage is volatile.

This PR hard-limits the records returned from polling to the limit, so we adhere to the limit precisely instead of by +/- one fetch.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
