### PR TITLE
Use util_log to initialize logger in tsdb-* tools

### DIFF
--- a/tools/tsdb-gaps/main.go
+++ b/tools/tsdb-gaps/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/prometheus/model/labels"
@@ -149,7 +148,7 @@ type blockGapStats struct {
 	GapStats            []seriesGapStats `json:"gapStats"`
 }
 
-var logger = log.NewLogfmtLogger(os.Stderr)
+var logger = util_log.MakeLeveledLogger(os.Stderr, "info")
 
 func main() {
 	// Clean up all flags registered via init() methods of 3rd-party libraries.

--- a/tools/tsdb-print-chunk/main.go
+++ b/tools/tsdb-print-chunk/main.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/tsdb"
@@ -18,7 +17,7 @@ import (
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
-var logger = log.NewLogfmtLogger(os.Stderr)
+var logger = util_log.MakeLeveledLogger(os.Stderr, "info")
 
 func main() {
 	args := os.Args

--- a/tools/tsdb-series/main.go
+++ b/tools/tsdb-series/main.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/prometheus/model/labels"
@@ -25,7 +24,7 @@ import (
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )
 
-var logger = log.NewLogfmtLogger(os.Stderr)
+var logger = util_log.MakeLeveledLogger(os.Stderr, "info")
 
 func main() {
 	// Clean up all flags registered via init() methods of 3rd-party libraries.


### PR DESCRIPTION
#### What this PR does

When running these tools we would see a log like:

```
probe="internal message: if you see this, probably log initialization has gone wrong"
```

This comes from [here](https://github.com/grafana/mimir/blob/main/pkg/util/log/slogadapter.go#L16), and is mentioned in https://github.com/grafana/mimir/pull/10646 as a side-effect of using a non `util_log` logger with `SlogFromGoKit`.

This PR changes the logger initialization to use `util_log` to avoid the spurious line.

I don't think a changelog is required for this.

#### Which issue(s) this PR fixes or relates to

Fixes #

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
