### PR TITLE
[release-2.17] Docs: Add missing attribute from list of default promoted OTel resource attributes (#12181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+* [BUGFIX] Add a missing attribute to the list of default promoted OTel resource attributes in the docs: deployment.environment. #12181
+
 ## 2.17.1
 
 ### Grafana Mimir

--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -126,6 +126,7 @@ Grafana Cloud automatically promotes the following OTel resource attributes to l
 - `cloud.availability_zone`
 - `cloud.region`
 - `container.name`
+- `deployment.environment`
 - `deployment.environment.name`
 - `k8s.cluster.name`
 - `k8s.container.name`


### PR DESCRIPTION
#### What this PR does

Add missing attribute from list of default promoted OTel resource attributes in docs: `deployment.environment`. Backport of #12181.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
