### PR TITLE
[r359] Fix Timeseries CreatedTimestamp reset before putting back to the pool

### DIFF
--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -596,6 +596,8 @@ func ReuseTimeseries(ts *TimeSeries) {
 		ts.Histograms = ts.Histograms[:0]
 	}
 
+	ts.CreatedTimestamp = 0
+
 	ClearExemplars(ts)
 	timeSeriesPool.Put(ts)
 }


### PR DESCRIPTION
#### What this PR does

Backporting to r359 a 1-line fix that was part of a bigger PR (https://github.com/grafana/mimir/pull/12652). This fix an data corruption issue caused by memory pooling when a newer version is rolled out and the experimental `-distributor.otel-created-timestamp-zero-ingestion-enabled` feature is enabled.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
