### PR TITLE
storegateway: safeguard chunk parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 * [BUGFIX] Ingester: Fix a bug where prepare-instance-ring-downscale endpoint would return an error while compacting and not read-only. #12548
 * [BUGFIX] Block-builder: Fix a bug where lease renewals would cease during graceful shutdown, leading to an elevated rate of job reassignments. #12643
 * [BUGFIX] OTLP: Return HTTP OK for partially rejected requests, e.g. due to OOO exemplars. #12579
-* [BUGFIX] Store-gateway: Fix a panic in BucketChunkReader when chunk loading encounter a broken chunk length. #12693
+* [BUGFIX] Store-gateway: Fix a panic in BucketChunkReader when chunk loading encounter a broken chunk length. #12693 #12729
 * [BUGFIX] Ingester, Block-builder: silently ignore duplicate sample if it's due to zero sample from created timestamp. Created timestamp equal to the timestamp of the first sample of series is a common case if created timestamp comes from OTLP where start time equal to timestamp of the first sample simply means unknown start time. #12726
 
 ### Mixin

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -31,7 +31,7 @@ import (
 
 // maxChunkDataLen is a safeguard to protect the chunk data parsing from over allocating in case of a broken chunk.
 // Refer to https://github.com/grafana/mimir/issues/12691 for the background.
-// 512MB would a ridiculously large chunk. But to keep things relaxed, we need a much larger value than tsdb.EstimatedMaxChunkSize.
+// 512MB would be a ridiculously large chunk. But, to keep things relaxed, we use a much larger value than tsdb.EstimatedMaxChunkSize.
 const maxChunkDataLen = 512 * 1024 * 1024
 
 type bucketChunkReader struct {
@@ -152,7 +152,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesChunks, 
 		}
 
 		// Validate chunk data length to prevent unreasonably large memory allocations or panics from a corrupted data.
-		// Note, that on a 64-bit system Go should allow to allocate up to 1<<47 bytes; a larger len causes "makeslice: len out of range".
+		// Note, that on a 64-bit system Go should allow to allocate up to ~140TB; a larger len causes "makeslice: len out of range".
 		// Such a large chunk data len is unrealistic.
 		if chunkDataLen > uint64(maxChunkDataLen) {
 			return fmt.Errorf("chunk seq %d: parsed data length %d exceeds expected maximum chunk size %d", seq, chunkDataLen, maxChunkDataLen)

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -29,6 +29,11 @@ import (
 	"github.com/grafana/mimir/pkg/util/pool"
 )
 
+// maxChunkDataLen is a safeguard to protect the chunk data parsing from over allocating in case of a broken chunk.
+// Refer to https://github.com/grafana/mimir/issues/12691 for the background.
+// 512MB would a ridiculously large chunk. But to keep things relaxed, we need a much larger value than tsdb.EstimatedMaxChunkSize.
+const maxChunkDataLen = 512 * 1024 * 1024
+
 type bucketChunkReader struct {
 	ctx   context.Context
 	block *bucketBlock
@@ -148,9 +153,9 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesChunks, 
 
 		// Validate chunk data length to prevent unreasonably large memory allocations or panics from a corrupted data.
 		// Note, that on a 64-bit system Go should allow to allocate up to 1<<47 bytes; a larger len causes "makeslice: len out of range".
-		// Such a large chunk data len is unrealistic. Here we're opting to a more conservative check.
-		if chunkDataLen > uint64(tsdb.EstimatedMaxChunkSize) {
-			return fmt.Errorf("chunk seq %d: data length %d exceeds estimated maximum chunk size %d", seq, chunkDataLen, tsdb.EstimatedMaxChunkSize)
+		// Such a large chunk data len is unrealistic.
+		if chunkDataLen > uint64(maxChunkDataLen) {
+			return fmt.Errorf("chunk seq %d: parsed data length %d exceeds expected maximum chunk size %d", seq, chunkDataLen, maxChunkDataLen)
 		}
 
 		// We ignore the crc32 after the chunk data.


### PR DESCRIPTION
#### What this PR does

As @dimitarvdimitrov brought in https://github.com/grafana/mimir/pull/12693#discussion_r2352625595 the `tsdb.EstimatedMaxChunkSize` is only an estimation, and we shouldn't use it as the parser's cap. The PR updates the code to cap it with a more relaxed value.

#### Which issue(s) this PR fixes or relates to

Follows https://github.com/grafana/mimir/pull/12693

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
