### PR TITLE
index planning: log predicates to spans

### DIFF
--- a/pkg/ingester/lookupplan/planner.go
+++ b/pkg/ingester/lookupplan/planner.go
@@ -156,6 +156,7 @@ func (p CostBasedPlanner) recordPlanningOutcome(ctx context.Context, start time.
 			attribute.Stringer("duration", time.Since(start)),
 		))
 		const topKPlans = 2
+		allPlans[0].addPredicatesToSpan(span)
 		for i, plan := range allPlans[:min(topKPlans, len(allPlans))] {
 			planName := "selected_plan"
 			if i > 0 {


### PR DESCRIPTION
this is helpful to understand why cost in plans in traces doesn't match the cost of plans when running against the same block locally.

related to https://github.com/grafana/mimir/issues/11920

Co-authored-by: Casie Chen <casie.chen@grafana.com>

