### PR TITLE
[release-2.17] Fix Timeseries CT reset before putting back to the pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * [BUGFIX] Add a missing attribute to the list of default promoted OTel resource attributes in the docs: deployment.environment. #12181
+* [BUGFIX] Ingest: Fix memory pool poisoning in Remote-Write 2.0/OTLP by not clearning created timestamp field before returning time series to the memory pool. #12735
 
 ## 2.17.1
 

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -570,6 +570,8 @@ func ReuseTimeseries(ts *TimeSeries) {
 		ts.Histograms = ts.Histograms[:0]
 	}
 
+	ts.CreatedTimestamp = 0
+
 	ClearExemplars(ts)
 	timeSeriesPool.Put(ts)
 }


### PR DESCRIPTION
#### What this PR does

Backporting to 2.17 a 1-line fix that was part of a bigger PR (#12652). This fix an data corruption issue caused by memory pooling when a newer version is rolled out and the experimental
-distributor.otel-created-timestamp-zero-ingestion-enabled feature is enabled.

#### Which issue(s) this PR fixes or relates to

Related to #12652 

#### Checklist

- N/A Tests updated.
- N/A Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
