### PR TITLE
index planning: Remove unnecessary error handling from estimatePredicateCardinality

### DIFF
--- a/pkg/ingester/lookupplan/predicate.go
+++ b/pkg/ingester/lookupplan/predicate.go
@@ -39,11 +39,7 @@ func newPlanPredicate(ctx context.Context, m *labels.Matcher, stats index.Statis
 	}
 	pred.selectivity = m.EstimateSelectivity(pred.labelNameUniqueVals)
 
-	pred.cardinality, err = estimatePredicateCardinality(ctx, m, stats, pred.selectivity)
-	if err != nil {
-		return planPredicate{}, fmt.Errorf("error estimating cardinality for label %s: %w", m.Name, err)
-	}
-
+	pred.cardinality = estimatePredicateCardinality(ctx, m, stats, pred.selectivity)
 	pred.indexScanCost = estimatePredicateIndexScanCost(pred, m)
 
 	return pred, nil
@@ -75,11 +71,10 @@ func estimatePredicateIndexScanCost(pred planPredicate, m *labels.Matcher) float
 	panic("estimatePredicateIndexScanCost called with unhandled matcher type: " + m.Type.String() + m.String())
 }
 
-func estimatePredicateCardinality(ctx context.Context, m *labels.Matcher, stats index.Statistics, selectivity float64) (uint64, error) {
+func estimatePredicateCardinality(ctx context.Context, m *labels.Matcher, stats index.Statistics, selectivity float64) uint64 {
 	var (
 		seriesBehindSelectedValues uint64
 		matchesAnyValues           bool
-		err                        error
 	)
 
 	switch m.Type {
@@ -107,18 +102,15 @@ func estimatePredicateCardinality(ctx context.Context, m *labels.Matcher, stats 
 			seriesBehindSelectedValues += uint64(float64(labelNameCardinality) * selectivity)
 		}
 	}
-	if err != nil {
-		return 0, fmt.Errorf("error getting series per label value for label %s: %w", m.Name, err)
-	}
 	switch m.Type {
 	case labels.MatchNotEqual, labels.MatchNotRegexp:
 		if !matchesAnyValues {
 			// This label name doesn't exist. This means that negating this will select everything.
-			return stats.TotalSeries(), nil
+			return stats.TotalSeries()
 		}
-		return stats.TotalSeries() - seriesBehindSelectedValues, nil
+		return stats.TotalSeries() - seriesBehindSelectedValues
 	}
-	return seriesBehindSelectedValues, nil
+	return seriesBehindSelectedValues
 }
 
 func (pr planPredicate) indexLookupCost() float64 {


### PR DESCRIPTION
The `estimatePredicateCardinality` function wasn't actually returning any errors in its implementation, so this simplifies the function signature by removing the unused error return value.

This cleanup removes dead code and simplifies the calling sites.