### PR TITLE
distributor: validate content-encoding header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Distributor: Validate `Content-Encoding` header. #12739
 * [CHANGE] Build: Include updated Mozilla CA bundle from Debian Testing. #12247
 * [CHANGE] Query-frontend: Add support for UTF-8 label and metric names in `/api/v1/cardinality/{label_values|label_values|active_series}` endpoints. #11848.
 * [CHANGE] Querier: Add support for UTF-8 label and metric names in `label_join`, `label_replace` and `count_values` PromQL functions. #11848.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Grafana Mimir
 
-* [CHANGE] Distributor: Validate `Content-Encoding` header. #12739
+* [CHANGE] Distributor: Return `HTTP 415 Unsupported Media Type` when handling invalid `Content-Type` or `Content-Encoding` headers. #12739
 * [CHANGE] Build: Include updated Mozilla CA bundle from Debian Testing. #12247
 * [CHANGE] Query-frontend: Add support for UTF-8 label and metric names in `/api/v1/cardinality/{label_values|label_values|active_series}` endpoints. #11848.
 * [CHANGE] Querier: Add support for UTF-8 label and metric names in `label_join`, `label_replace` and `count_values` PromQL functions. #11848.

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -166,20 +166,14 @@ func handler(
 
 		isRW2, err := isRemoteWrite2(r)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, err.Error(), http.StatusUnsupportedMediaType)
 		}
 
 		// https://prometheus.io/docs/specs/prw/remote_write_spec_2_0/#unsupported-request-content:
 		// Receivers MUST return 415 HTTP Unsupported Media Type status code if they
-		// don't support a given content type or encoding provided by Senders. Since this handler implements
-		// RW1 and RW2 (based on content-type header) we can only handle the case of invalid encoding when we are
-		// acting as a remote-write 2.0 receiver.
+		// don't support a given content type or encoding provided by Senders.
 		if !isValidContentEncoding(r) {
-			code := http.StatusBadRequest
-			if isRW2 {
-				code = http.StatusUnsupportedMediaType
-			}
-			http.Error(w, "invalid content encoding", code)
+			http.Error(w, "invalid content encoding", http.StatusUnsupportedMediaType)
 		}
 
 		supplier := func() (*mimirpb.WriteRequest, func(), error) {
@@ -316,8 +310,8 @@ func isRemoteWrite2(r *http.Request) (bool, error) {
 }
 
 // isValidContentEncoding validates the content-encoding header is either empty
-// (in which case Mimir assumes the "snappy") or set to a supported value.
-// Currently, Mimir supports only "snappy".
+// (in which case Mimir assumes "snappy") or set to a supported value. Currently,
+// Mimir supports only "snappy".
 func isValidContentEncoding(r *http.Request) bool {
 	contentEncoding := r.Header.Get("Content-Encoding")
 	switch contentEncoding {

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -845,6 +845,17 @@ func TestHandler_ContentEncoding(t *testing.T) {
 			isRW2:          false,
 		},
 		{
+			name: "RW1 request, no proto segments",
+			req: &http.Request{
+				Method: "GET",
+				Header: http.Header{
+					"Content-Type": []string{"application/x-protobuf"},
+				},
+			},
+			wantStatusCode: http.StatusOK,
+			isRW2:          false,
+		},
+		{
 			name: "malformed content-types (invalid segments)",
 			req: &http.Request{
 				Method: "GET",
@@ -852,7 +863,7 @@ func TestHandler_ContentEncoding(t *testing.T) {
 					"Content-Type": []string{"application/x-protobuf;proto=a=b"},
 				},
 			},
-			wantStatusCode: http.StatusBadRequest,
+			wantStatusCode: http.StatusUnsupportedMediaType,
 			isRW2:          false,
 		},
 		{
@@ -863,7 +874,7 @@ func TestHandler_ContentEncoding(t *testing.T) {
 					"Content-Type": []string{"application/x-protobuf;proto=unsupported"},
 				},
 			},
-			wantStatusCode: http.StatusBadRequest,
+			wantStatusCode: http.StatusUnsupportedMediaType,
 			isRW2:          false,
 		},
 		{
@@ -886,7 +897,7 @@ func TestHandler_ContentEncoding(t *testing.T) {
 					"Content-Encoding": []string{"unsupported"},
 				},
 			},
-			wantStatusCode: http.StatusBadRequest,
+			wantStatusCode: http.StatusUnsupportedMediaType,
 			isRW2:          false,
 		},
 		{

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -826,6 +826,117 @@ func TestHandler_ErrorTranslation(t *testing.T) {
 	}
 }
 
+func TestHandler_ContentEncoding(t *testing.T) {
+	parserTestCases := []struct {
+		name           string
+		req            *http.Request
+		wantStatusCode int
+		isRW2          bool
+	}{
+		{
+			name: "accept unknown content-types",
+			req: &http.Request{
+				Method: "GET",
+				Header: http.Header{
+					"Content-Type": []string{"unknown"},
+				},
+			},
+			wantStatusCode: http.StatusOK,
+			isRW2:          false,
+		},
+		{
+			name: "malformed content-types (invalid segments)",
+			req: &http.Request{
+				Method: "GET",
+				Header: http.Header{
+					"Content-Type": []string{"application/x-protobuf;proto=a=b"},
+				},
+			},
+			wantStatusCode: http.StatusBadRequest,
+			isRW2:          false,
+		},
+		{
+			name: "malformed content-types (invalid protobuf message)",
+			req: &http.Request{
+				Method: "GET",
+				Header: http.Header{
+					"Content-Type": []string{"application/x-protobuf;proto=unsupported"},
+				},
+			},
+			wantStatusCode: http.StatusBadRequest,
+			isRW2:          false,
+		},
+		{
+			name: "RW1 request, no content-encoding",
+			req: &http.Request{
+				Method: "GET",
+				Header: http.Header{
+					"Content-Type": []string{"application/x-protobuf;proto=prometheus.WriteRequest"},
+				},
+			},
+			wantStatusCode: http.StatusOK,
+			isRW2:          false,
+		},
+		{
+			name: "RW1 request, invalid content-encoding",
+			req: &http.Request{
+				Method: "GET",
+				Header: http.Header{
+					"Content-Type":     []string{"application/x-protobuf;proto=prometheus.WriteRequest"},
+					"Content-Encoding": []string{"unsupported"},
+				},
+			},
+			wantStatusCode: http.StatusBadRequest,
+			isRW2:          false,
+		},
+		{
+			name: "RW2 request, invalid content-encoding",
+			req: &http.Request{
+				Method: "GET",
+				Header: http.Header{
+					"Content-Type":     []string{"application/x-protobuf;proto=io.prometheus.write.v2.Request"},
+					"Content-Encoding": []string{"unsupported"},
+				},
+			},
+			wantStatusCode: http.StatusUnsupportedMediaType,
+			isRW2:          true,
+		},
+		{
+			name: "RW2 request, snappy content-encoding",
+			req: &http.Request{
+				Method: "GET",
+				Header: http.Header{
+					"Content-Type":     []string{"application/x-protobuf;proto=io.prometheus.write.v2.Request"},
+					"Content-Encoding": []string{"snappy"},
+				},
+			},
+			wantStatusCode: http.StatusOK,
+			isRW2:          true,
+		},
+	}
+	for _, tc := range parserTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pushFunc := func(_ context.Context, req *Request) error {
+				_, err := req.WriteRequest() // just read the body so we can trigger the parser
+				return err
+			}
+			parser := func(context.Context, *http.Request, int, *util.RequestBuffers, *mimirpb.PreallocWriteRequest, log.Logger) error {
+				return nil
+			}
+			h := handler(10, nil, nil, false, false, validation.MockDefaultOverrides(), RetryConfig{}, pushFunc, log.NewNopLogger(), parser)
+
+			recorder := httptest.NewRecorder()
+			ctxWithUser := user.InjectOrgID(context.Background(), "testuser")
+			h.ServeHTTP(recorder, tc.req.WithContext(ctxWithUser))
+
+			assert.Equal(t, tc.wantStatusCode, recorder.Code)
+
+			isRW2, _ := isRemoteWrite2(tc.req)
+			assert.Equal(t, isRW2, tc.isRW2)
+		})
+	}
+}
+
 func TestHandler_HandleRetryAfterHeader(t *testing.T) {
 	testCases := []struct {
 		name          string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds validation for the `Content-Encoding` header.
If receiving a value other than `""` or `"snappy"` we return 415.
The `content-type` header validation was also adjusted to return 415.

According to the spec, RW2 receivers should also return 415 for invalid content types. Since Mimir's
`handler` implements both versions (and switches based on `Content-Type` header) it must return 415 for both versions.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/issues/12736

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
