### PR TITLE
chore: update shebang to use env for bash in compose scripts

### DIFF
--- a/development/mimir-monolithic-mode/compose-down.sh
+++ b/development/mimir-monolithic-mode/compose-down.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # Provenance-includes-location: https://github.com/cortexproject/cortex/development/tsdb-blocks-storage-s3-single-binary/compose-down.sh
 # Provenance-includes-license: Apache-2.0

--- a/development/mimir-monolithic-mode/compose-up.sh
+++ b/development/mimir-monolithic-mode/compose-up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
 # Provenance-includes-location: https://github.com/cortexproject/cortex/development/tsdb-blocks-storage-s3-single-binary/compose-up.sh
 # Provenance-includes-license: Apache-2.0


### PR DESCRIPTION
Replaced `#!/bin/bash` with `#!/usr/bin/env bash` in compose-up.sh and compose-down.sh to improve portability across different environments where bash may not be located at /bin/bash.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
