### PR TITLE
fix(distributor): NHCB bucket count validation wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [BUGFIX] OTLP: Return HTTP OK for partially rejected requests, e.g. due to OOO exemplars. #12579
 * [BUGFIX] Store-gateway: Fix a panic in BucketChunkReader when chunk loading encounter a broken chunk length. #12693 #12729
 * [BUGFIX] Ingester, Block-builder: silently ignore duplicate sample if it's due to zero sample from created timestamp. Created timestamp equal to the timestamp of the first sample of series is a common case if created timestamp comes from OTLP where start time equal to timestamp of the first sample simply means unknown start time. #12726
+* [BUGFIX] Distributor: Fix error when native histograms bucket limit is set then no NHCB passes validation. #12741
 
 ### Mixin
 

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -298,13 +298,13 @@ func validateSampleHistogram(m *sampleValidationMetrics, now model.Time, cfg sam
 
 	if bucketLimit := cfg.MaxNativeHistogramBuckets(userID); bucketLimit > 0 {
 		bucketCount := s.BucketCount()
-		if s.Schema == mimirpb.NativeHistogramsWithCustomBucketsSchema {
-			// Custom buckets cannot be scaled down.
-			cat.IncrementDiscardedSamples(ls, 1, reasonMaxNativeHistogramBuckets, now.Time())
-			m.maxNativeHistogramBuckets.WithLabelValues(userID, group).Inc()
-			return false, fmt.Errorf(nativeHistogramCustomBucketsNotReducibleMsgFormat, s.Timestamp, mimirpb.FromLabelAdaptersToString(ls), bucketCount, bucketLimit)
-		}
 		if bucketCount > bucketLimit {
+			if s.Schema == mimirpb.NativeHistogramsWithCustomBucketsSchema {
+				// Custom buckets cannot be scaled down.
+				cat.IncrementDiscardedSamples(ls, 1, reasonMaxNativeHistogramBuckets, now.Time())
+				m.maxNativeHistogramBuckets.WithLabelValues(userID, group).Inc()
+				return false, fmt.Errorf(nativeHistogramCustomBucketsNotReducibleMsgFormat, s.Timestamp, mimirpb.FromLabelAdaptersToString(ls), bucketCount, bucketLimit)
+			}
 			if !cfg.ReduceNativeHistogramOverMaxBuckets(userID) {
 				cat.IncrementDiscardedSamples(ls, 1, reasonMaxNativeHistogramBuckets, now.Time())
 				m.maxNativeHistogramBuckets.WithLabelValues(userID, group).Inc()

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -1028,6 +1028,13 @@ func TestNativeHistogramDownScaling(t *testing.T) {
 			expectedError:  nil,
 			expectedDeltas: []int64{1, 2, 3},
 		},
+		"valid nhcb and bucket limit is set": {
+			cfg:            sampleValidationCfg{maxNativeHistogramBuckets: 100, reduceNativeHistogramOverMaxBuckets: true},
+			schema:         -53,
+			deltas:         []int64{1, 2, 3},
+			expectedError:  nil,
+			expectedDeltas: []int64{1, 2, 3},
+		},
 		"downscaling not possible for nhcb": {
 			cfg:           sampleValidationCfg{maxNativeHistogramBuckets: 2, reduceNativeHistogramOverMaxBuckets: true},
 			schema:        -53,


### PR DESCRIPTION
#### What this PR does

If the bucket limit is set for native histograms then no NHCB passes validation due to a coding error.

Enabled bucket limit in test config to reproduce and fixed bug.

#### Which issue(s) this PR fixes or relates to

Related to RW2 compliance work. https://github.com/prometheus/prometheus/issues/16944

#### Checklist

- [x] Tests updated.
- N/A Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
