### PR TITLE
jsonnet: Remove block shipping on the third ingester zone when running ingest storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@
 * [CHANGE] Rollout-operator: Add `watch` permission to the rollout-operators's cluster role. #12360. See [rollout-operator#262](https://github.com/grafana/rollout-operator/pull/262)
 * [CHANGE] Updates to CPU and memory scaling metric. Use `irate()` when calculating the CPU metric and remove `or vector(0)` from a leg of the memory query. These changes prevent downscaling deployments when scraping fails. #12406
 * [CHANGE] Memcached: Remove configuration for enabling mTLS connections to Memcached servers. #12434
-* [CHANGE] Ingester: Disable shipping of blocks on the third zone (zone-c) when using `ingest_storage_ingester_zones: 3` on ingest storage #XXXX
+* [CHANGE] Ingester: Disable shipping of blocks on the third zone (zone-c) when using `ingest_storage_ingester_zones: 3` on ingest storage #12743
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 * [CHANGE] Rollout-operator: Add `watch` permission to the rollout-operators's cluster role. #12360. See [rollout-operator#262](https://github.com/grafana/rollout-operator/pull/262)
 * [CHANGE] Updates to CPU and memory scaling metric. Use `irate()` when calculating the CPU metric and remove `or vector(0)` from a leg of the memory query. These changes prevent downscaling deployments when scraping fails. #12406
 * [CHANGE] Memcached: Remove configuration for enabling mTLS connections to Memcached servers. #12434
+* [CHANGE] Ingester: Disable shipping of blocks on the third zone (zone-c) when using `ingest_storage_ingester_zones: 3` on ingest storage #XXXX
 
 ### Documentation
 

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1632,7 +1632,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -1705,7 +1705,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1972,7 +1972,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -2153,7 +2153,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -2153,7 +2153,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -2153,7 +2153,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -2016,7 +2016,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -2381,7 +2381,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
@@ -2514,7 +2514,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -2396,7 +2396,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
@@ -2529,7 +2529,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -2418,7 +2418,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
@@ -2551,7 +2551,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -2416,7 +2416,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
@@ -2549,7 +2549,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -2416,7 +2416,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
@@ -2549,7 +2549,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -2416,7 +2416,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
@@ -2549,7 +2549,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -2081,7 +2081,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -2098,7 +2098,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -2098,7 +2098,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -2153,7 +2153,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
@@ -1786,7 +1786,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
@@ -1630,7 +1630,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1630,7 +1630,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1798,7 +1798,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1711,7 +1711,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -1372,7 +1372,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
+++ b/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
@@ -1915,7 +1915,7 @@ spec:
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
-        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.ship-interval=0
         - -blocks-storage.tsdb.wal-replay-concurrency=3
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -170,7 +170,7 @@
     then null
     else super.ingester_zone_c_service,
 
-  // Given that the data is the same on all ingesters when using ingestt storage we only need 1 zone shipping blocks.
+  // Given that the data is the same on all ingesters when using ingest storage, we only need 1 zone shipping blocks.
   // We keep two to ensure we have redundancy but a third would be a waste of resources.
   ingester_zone_c_args+:: if $._config.ingest_storage_enabled && $._config.ingest_storage_ingester_zones < 3 then {} else {
     'blocks-storage.tsdb.ship-interval': 0,

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -170,6 +170,12 @@
     then null
     else super.ingester_zone_c_service,
 
+  // Given that the data is the same on all ingesters when using ingestt storage we only need 1 zone shipping blocks.
+  // We keep two to ensure we have redundancy but a third would be a waste of resources.
+  ingester_zone_c_args+:: if $._config.ingest_storage_enabled && $._config.ingest_storage_ingester_zones < 3 then {} else {
+    'blocks-storage.tsdb.ship-interval': 0,
+  },
+
   //
   // Utilities.
   //


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

If we're running ingest storage and have enabled three zones there's no need to ship blocks from it. Because all ingesters consume data from the partitions, they all have the _exact_ same data.
Technically, we only need 1 zone shipping blocks, but we run two for redudancy - three would be a waste of resources at this point.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Signed-off-by: gotjosh <josue.abreu@gmail.com>
