### PR TITLE
[release-2.17] backport fix(distributor): NHCB bucket count validation wrong (#12741)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [BUGFIX] Add a missing attribute to the list of default promoted OTel resource attributes in the docs: deployment.environment. #12181
 * [BUGFIX] Ingest: Fix memory pool poisoning in Remote-Write 2.0/OTLP by not clearning created timestamp field before returning time series to the memory pool. #12735
+* [BUGFIX] Distributor: Fix error when native histograms bucket limit is set then no NHCB passes validation. #12746
 
 ## 2.17.1
 

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -284,13 +284,13 @@ func validateSampleHistogram(m *sampleValidationMetrics, now model.Time, cfg sam
 
 	if bucketLimit := cfg.MaxNativeHistogramBuckets(userID); bucketLimit > 0 {
 		bucketCount := s.BucketCount()
-		if s.Schema == mimirpb.NativeHistogramsWithCustomBucketsSchema {
-			// Custom buckets cannot be scaled down.
-			cat.IncrementDiscardedSamples(ls, 1, reasonMaxNativeHistogramBuckets, now.Time())
-			m.maxNativeHistogramBuckets.WithLabelValues(userID, group).Inc()
-			return false, fmt.Errorf(nativeHistogramCustomBucketsNotReducibleMsgFormat, s.Timestamp, mimirpb.FromLabelAdaptersToString(ls), bucketCount, bucketLimit)
-		}
 		if bucketCount > bucketLimit {
+			if s.Schema == mimirpb.NativeHistogramsWithCustomBucketsSchema {
+				// Custom buckets cannot be scaled down.
+				cat.IncrementDiscardedSamples(ls, 1, reasonMaxNativeHistogramBuckets, now.Time())
+				m.maxNativeHistogramBuckets.WithLabelValues(userID, group).Inc()
+				return false, fmt.Errorf(nativeHistogramCustomBucketsNotReducibleMsgFormat, s.Timestamp, mimirpb.FromLabelAdaptersToString(ls), bucketCount, bucketLimit)
+			}
 			if !cfg.ReduceNativeHistogramOverMaxBuckets(userID) {
 				cat.IncrementDiscardedSamples(ls, 1, reasonMaxNativeHistogramBuckets, now.Time())
 				m.maxNativeHistogramBuckets.WithLabelValues(userID, group).Inc()

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -741,6 +741,13 @@ func TestNativeHistogramDownScaling(t *testing.T) {
 			expectedError:  nil,
 			expectedDeltas: []int64{1, 2, 3},
 		},
+		"valid nhcb and bucket limit is set": {
+			cfg:            sampleValidationCfg{maxNativeHistogramBuckets: 100, reduceNativeHistogramOverMaxBuckets: true},
+			schema:         -53,
+			deltas:         []int64{1, 2, 3},
+			expectedError:  nil,
+			expectedDeltas: []int64{1, 2, 3},
+		},
 		"downscaling not possible for nhcb": {
 			cfg:           sampleValidationCfg{maxNativeHistogramBuckets: 2, reduceNativeHistogramOverMaxBuckets: true},
 			schema:        -53,


### PR DESCRIPTION
#### What this PR does

If the bucket limit is set for native histograms then no NHCB passes validation due to a coding error.

Enabled bucket limit in test config to reproduce and fixed bug.

#### Which issue(s) this PR fixes or relates to

Related to RW2 compliance work.
https://github.com/prometheus/prometheus/issues/16944

#### Checklist

- [x] Tests updated.
- N/A Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- N/A [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
