### PR TITLE
doc: Fix type for label_value_length_over_limit_strategy

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4875,9 +4875,9 @@
           "required": false,
           "desc": "What to do for label values over the length limit. Options are: 'error', 'truncate', 'drop'. For 'truncate', the hash of the full value replaces the end portion of the value. For 'drop', the hash fully replaces the value.",
           "fieldValue": null,
-          "fieldDefaultValue": null,
+          "fieldDefaultValue": "error",
           "fieldFlag": "validation.label-value-length-over-limit-strategy",
-          "fieldType": "int",
+          "fieldType": "string",
           "fieldCategory": "experimental"
         },
         {

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4490,7 +4490,7 @@ The `limits` block configures default and per-tenant limits imposed by component
 # replaces the end portion of the value. For 'drop', the hash fully replaces the
 # value.
 # CLI flag: -validation.label-value-length-over-limit-strategy
-[label_value_length_over_limit_strategy: <int> | default = error]
+[label_value_length_over_limit_strategy: <string> | default = "error"]
 
 # Maximum number of label names per series.
 # CLI flag: -validation.max-label-names-per-series

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/mimir/pkg/ruler/notifier"
 	"github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/util/configdoc"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 var (
@@ -384,6 +385,8 @@ func getFieldCustomType(t reflect.Type) (string, bool) {
 		return "relabel_config...", true
 	case reflect.TypeOf(asmodel.CustomTrackersConfig{}).String():
 		return "map of tracker name (string) to matcher (string)", true
+	case reflect.TypeOf(validation.LabelValueLengthOverLimitStrategy(0)).String():
+		return "string", true
 	default:
 		return "", false
 	}


### PR DESCRIPTION
#### What this PR does

Changes the type docs for `label_value_length_over_limit_strategy` from int to string, and the default value.

#### Which issue(s) this PR fixes or relates to

Follow-up of #12627

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
