### PR TITLE
Do not wrap vector-scalar comparison in DeduplicateAndMerge

### DIFF
--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -411,10 +411,7 @@ func (p *QueryPlanner) nodeFromExpr(expr parser.Expr) (planning.Node, error) {
 		if isVectorScalar {
 			// Comparison vector-scalar operations without bool modifier don't drop the __name__ label.
 			// So don't need to wrap in DeduplicateAndMerge.
-			isComparison := expr.Op == parser.EQLC || expr.Op == parser.NEQ ||
-				expr.Op == parser.LTE || expr.Op == parser.LSS ||
-				expr.Op == parser.GTE || expr.Op == parser.GTR
-			if isComparison && !expr.ReturnBool {
+			if expr.Op.IsComparisonOperator() && !expr.ReturnBool {
 				return binExpr, nil
 			}
 

--- a/pkg/streamingpromql/planning_test.go
+++ b/pkg/streamingpromql/planning_test.go
@@ -1213,6 +1213,32 @@ func TestDeduplicateAndMergePlanning(t *testing.T) {
 					- MatrixSelector: {__name__="some_metric"}[5m0s]
 			`,
 		},
+		"aritmetic vector-scalar operation - should deduplicate and merge": {
+			expr: `some_metric * 2`,
+			expectedPlan: `
+				- DeduplicateAndMerge
+					- BinaryExpression: LHS * RHS
+						- LHS: VectorSelector: {__name__="some_metric"}
+						- RHS: NumberLiteral: 2
+			`,
+		},
+		"comparison vector-scalar operation - should NOT deduplicate and merge": {
+			expr: `some_metric > 2`,
+			expectedPlan: `
+				- BinaryExpression: LHS > RHS
+					- LHS: VectorSelector: {__name__="some_metric"}
+					- RHS: NumberLiteral: 2
+			`,
+		},
+		"comparison vector-scalar operation with bool modifier - should deduplicate and merge": {
+			expr: `some_metric > bool 2`,
+			expectedPlan: `
+				- DeduplicateAndMerge
+					- BinaryExpression: LHS > bool RHS
+						- LHS: VectorSelector: {__name__="some_metric"}
+						- RHS: NumberLiteral: 2
+			`,
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Vector-scalar comparison without bool modifier doesn't drop names, so it will not produce duplicates. Therefore, DeduplicateAndMerge is not needed.


#### Checklist

- [x] Tests updated.
- ~[ ] Documentation added.~
- ~[ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.~
- ~[ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.~
