### PR TITLE
Add support to configure max eventual consistency delay on a per-query basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,8 @@
 * [ENHANCEMENT] Distributor: Support zstd decompression of OTLP messages. #12229
 * [ENHANCEMENT] Ingester: Improved the performance of active series custom trackers matchers. #12663
 * [ENHANCEMENT] Compactor: Log sizes of downloaded and uploaded blocks. #12656
-* [ENHANCEMENT] Ingester: Add `cortex_ingest_storage_reader_receive_and_consume_delay_seconds` metric tracking the time between when a write request is received in the distributor and its content is ingested in ingesters, when the ingest storage is enabled.
+* [ENHANCEMENT] Ingester: Add `cortex_ingest_storage_reader_receive_and_consume_delay_seconds` metric tracking the time between when a write request is received in the distributor and its content is ingested in ingesters, when the ingest storage is enabled. #12751
+* [ENHANCEMENT] Ruler: Add `ruler_evaluation_consistency_max_delay` per-tenant configuration option support, to specify the maximum tolerated ingestion delay for eventually consistent rule evaluations. This feature is used only when ingest storage is enabled. By default, no maximum delay is enforced. #12751
 * [BUGFIX] Distributor: Calculate `WriteResponseStats` before validation and `PushWrappers`. This prevents clients using Remote-Write 2.0 from seeing a diff in written samples, histograms and exemplars. #12682
 * [BUGFIX] Compactor: Fix cortex_compactor_block_uploads_failed_total metric showing type="unknown". #12477
 * [BUGFIX] Querier: Samples with the same timestamp are merged deterministically. Previously, this could lead to flapping query results when an out-of-order sample is ingested that conflicts with a previously ingested in-order sample's value. #8673

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * [ENHANCEMENT] Distributor: Support zstd decompression of OTLP messages. #12229
 * [ENHANCEMENT] Ingester: Improved the performance of active series custom trackers matchers. #12663
 * [ENHANCEMENT] Compactor: Log sizes of downloaded and uploaded blocks. #12656
+* [ENHANCEMENT] Ingester: Add `cortex_ingest_storage_reader_receive_and_consume_delay_seconds` metric tracking the time between when a write request is received in the distributor and its content is ingested in ingesters, when the ingest storage is enabled.
 * [BUGFIX] Distributor: Calculate `WriteResponseStats` before validation and `PushWrappers`. This prevents clients using Remote-Write 2.0 from seeing a diff in written samples, histograms and exemplars. #12682
 * [BUGFIX] Compactor: Fix cortex_compactor_block_uploads_failed_total metric showing type="unknown". #12477
 * [BUGFIX] Querier: Samples with the same timestamp are merged deterministically. Previously, this could lead to flapping query results when an out-of-order sample is ingested that conflicts with a previously ingested in-order sample's value. #8673

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5742,6 +5742,17 @@
         },
         {
           "kind": "field",
+          "name": "ruler_evaluation_consistency_max_delay",
+          "required": false,
+          "desc": "The maximum tolerated ingestion delay for eventually consistent rule evaluations. Set to 0 to disable the enforcement.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "ruler.evaluation-consistency-max-delay",
+          "fieldType": "duration",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "ruler_tenant_shard_size",
           "required": false,
           "desc": "The tenant's shard size when sharding is used by ruler. Value of 0 disables shuffle sharding for the tenant, and tenant rules will be sharded across all ruler replicas.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2867,6 +2867,8 @@ Usage of ./cmd/mimir/mimir:
     	Enable the ruler config API. (default true)
   -ruler.enabled-tenants comma-separated-list-of-strings
     	Comma separated list of tenants whose rules this ruler can evaluate. If specified, only these tenants will be handled by ruler, otherwise this ruler can process rules from all tenants. Subject to sharding.
+  -ruler.evaluation-consistency-max-delay duration
+    	[experimental] The maximum tolerated ingestion delay for eventually consistent rule evaluations. Set to 0 to disable the enforcement.
   -ruler.evaluation-delay-duration duration
     	Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed. (default 1m)
   -ruler.evaluation-interval duration

--- a/development/mimir-ingest-storage/config/runtime.yaml
+++ b/development/mimir-ingest-storage/config/runtime.yaml
@@ -2,3 +2,4 @@
 overrides:
   anonymous:
     labels_query_optimizer_enabled: true
+    ruler_evaluation_consistency_max_delay: 1m

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4952,6 +4952,11 @@ cost_attribution_labels_structured:
 # CLI flag: -ruler.evaluation-delay-duration
 [ruler_evaluation_delay_duration: <duration> | default = 1m]
 
+# (experimental) The maximum tolerated ingestion delay for eventually consistent
+# rule evaluations. Set to 0 to disable the enforcement.
+# CLI flag: -ruler.evaluation-consistency-max-delay
+[ruler_evaluation_consistency_max_delay: <duration> | default = 0s]
+
 # The tenant's shard size when sharding is used by ruler. Value of 0 disables
 # shuffle sharding for the tenant, and tenant rules will be sharded across all
 # ruler replicas.

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -54,9 +54,9 @@ var (
 	allFormats        = []string{formatJSON, formatProtobuf}
 
 	// List of HTTP headers to propagate when a Prometheus request is encoded into a HTTP request.
-	// api.ReadConsistencyHeader is propagated as HTTP header -> Request.Context -> Request.Header, so there's no need to explicitly propagate it here.
+	// Read consistency headers are propagated as HTTP header -> Request.Context -> Request.Header, so there's no need to explicitly propagate it here.
 	codecPropagateHeadersMetrics = []string{compat.ForceFallbackHeaderName, chunkinfologger.ChunkInfoLoggingHeader, api.ReadConsistencyOffsetsHeader, querier.FilterQueryablesHeader}
-	// api.ReadConsistencyHeader is propagated as HTTP header -> Request.Context -> Request.Header, so there's no need to explicitly propagate it here.
+	// Read consistency headers are propagated as HTTP header -> Request.Context -> Request.Header, so there's no need to explicitly propagate it here.
 	codecPropagateHeadersLabels = []string{api.ReadConsistencyOffsetsHeader, querier.FilterQueryablesHeader}
 )
 

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -54,9 +54,9 @@ var (
 	allFormats        = []string{formatJSON, formatProtobuf}
 
 	// List of HTTP headers to propagate when a Prometheus request is encoded into a HTTP request.
-	// Read consistency headers are propagated as HTTP header -> Request.Context -> Request.Header, so there's no need to explicitly propagate it here.
+	// Read consistency level and max delay headers are propagated as HTTP header -> Request.Context -> Request.Header, so there's no need to explicitly propagate it here.
 	codecPropagateHeadersMetrics = []string{compat.ForceFallbackHeaderName, chunkinfologger.ChunkInfoLoggingHeader, api.ReadConsistencyOffsetsHeader, querier.FilterQueryablesHeader}
-	// Read consistency headers are propagated as HTTP header -> Request.Context -> Request.Header, so there's no need to explicitly propagate it here.
+	// Read consistency level and max delay headers are propagated as HTTP header -> Request.Context -> Request.Header, so there's no need to explicitly propagate it here.
 	codecPropagateHeadersLabels = []string{api.ReadConsistencyOffsetsHeader, querier.FilterQueryablesHeader}
 )
 

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
+	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/util"
@@ -337,8 +338,9 @@ func (rth *engineQueryRequestRoundTripperHandler) Do(ctx context.Context, r Metr
 		spanLogger.Finish()
 	}()
 
-	headers := map[string][]string{}
-	if err := rth.codec.AddHeadersForMetricQueryRequest(ctx, r, propagation.MapCarrier(headers)); err != nil {
+	headers := http.Header{}
+	consistencyInjector := &api.ConsistencyInjector{}
+	if err := consistencyInjector.InjectToCarrier(ctx, propagation.HttpHeaderCarrier(headers)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
-	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/util"
@@ -338,9 +337,8 @@ func (rth *engineQueryRequestRoundTripperHandler) Do(ctx context.Context, r Metr
 		spanLogger.Finish()
 	}()
 
-	headers := http.Header{}
-	consistencyInjector := &api.ConsistencyInjector{}
-	if err := consistencyInjector.InjectToCarrier(ctx, propagation.HttpHeaderCarrier(headers)); err != nil {
+	headers := map[string][]string{}
+	if err := rth.codec.AddHeadersForMetricQueryRequest(ctx, r, propagation.MapCarrier(headers)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -1157,7 +1157,6 @@ func TestEngineQueryRequestRoundTripperHandler(t *testing.T) {
 		{Name: compat.ForceFallbackHeaderName, Values: []string{"true"}},
 		{Name: chunkinfologger.ChunkInfoLoggingHeader, Values: []string{"chunk-info-logging-enabled"}},
 		{Name: api.ReadConsistencyOffsetsHeader, Values: []string{encodedOffsets}},
-
 		{Name: "Some-Other-Ignored-Header", Values: []string{"some-value"}},
 	}
 
@@ -1167,8 +1166,9 @@ func TestEngineQueryRequestRoundTripperHandler(t *testing.T) {
 		chunkinfologger.ChunkInfoLoggingHeader: {"chunk-info-logging-enabled"},
 		api.ReadConsistencyOffsetsHeader:       {encodedOffsets},
 
-		// From read consistency level in context:
-		api.ReadConsistencyHeader: {api.ReadConsistencyStrong},
+		// From read consistency settings in context:
+		api.ReadConsistencyHeader:         {api.ReadConsistencyStrong},
+		api.ReadConsistencyMaxDelayHeader: {time.Minute.String()},
 	}
 
 	testCases := map[string]struct {
@@ -1337,6 +1337,7 @@ func TestEngineQueryRequestRoundTripperHandler(t *testing.T) {
 			handler.(*engineQueryRequestRoundTripperHandler).storage = contextCapturingStorage
 
 			ctx := api.ContextWithReadConsistencyLevel(context.Background(), api.ReadConsistencyStrong)
+			ctx = api.ContextWithReadConsistencyMaxDelay(ctx, time.Minute)
 			stats, ctx := stats.ContextWithEmptyStats(ctx)
 			response, err := handler.Do(ctx, testCase.req)
 			require.Equal(t, testCase.expectedErr, err)

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -403,6 +403,9 @@ func (f *Handler) reportQueryStats(
 	if consistency, ok := querierapi.ReadConsistencyLevelFromContext(r.Context()); ok {
 		logMessage = append(logMessage, "read_consistency", consistency)
 	}
+	if delay, ok := querierapi.ReadConsistencyMaxDelayFromContext(r.Context()); ok {
+		logMessage = append(logMessage, "read_consistency_max_delay", delay)
+	}
 
 	logMessage = append(logMessage, formatRequestHeaders(&r.Header, f.headersToLog)...)
 

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -1655,5 +1655,5 @@ func TestQueryDecoding(t *testing.T) {
 }
 
 func newTestCodec() querymiddleware.Codec {
-	return querymiddleware.NewCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, "json", nil, &api.ConsistencyLevelInjector{})
+	return querymiddleware.NewCodec(prometheus.NewPedanticRegistry(), 0*time.Minute, "json", nil, &api.ConsistencyInjector{})
 }

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -787,7 +787,7 @@ func (t *Mimir) initFlusher() (serv services.Service, err error) {
 // NOTE: Grafana Enterprise Metrics depends on this.
 func (t *Mimir) initQueryFrontendCodec() (services.Service, error) {
 	// Add our default injectors.
-	t.Injectors = append(t.Injectors, &querierapi.ConsistencyLevelInjector{})
+	t.Injectors = append(t.Injectors, &querierapi.ConsistencyInjector{})
 
 	t.QueryFrontendCodec = querymiddleware.NewCodec(
 		t.Registerer,

--- a/pkg/querier/api/consistency.go
+++ b/pkg/querier/api/consistency.go
@@ -22,7 +22,7 @@ import (
 const (
 	ReadConsistencyHeader         = "X-Read-Consistency"
 	ReadConsistencyOffsetsHeader  = "X-Read-Consistency-Offsets"
-	ReadConsistencyMaxDelayHeader = "X-Read-Max-Delay"
+	ReadConsistencyMaxDelayHeader = "X-Read-Consistency-Max-Delay"
 
 	// ReadConsistencyStrong means that a query sent by the same client will always observe the writes
 	// that have completed before issuing the query.

--- a/pkg/querier/api/consistency.go
+++ b/pkg/querier/api/consistency.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 	"unsafe"
 
 	"google.golang.org/grpc"
@@ -19,8 +20,9 @@ import (
 )
 
 const (
-	ReadConsistencyHeader        = "X-Read-Consistency"
-	ReadConsistencyOffsetsHeader = "X-Read-Consistency-Offsets"
+	ReadConsistencyHeader         = "X-Read-Consistency"
+	ReadConsistencyOffsetsHeader  = "X-Read-Consistency-Offsets"
+	ReadConsistencyMaxDelayHeader = "X-Read-Max-Delay"
 
 	// ReadConsistencyStrong means that a query sent by the same client will always observe the writes
 	// that have completed before issuing the query.
@@ -37,11 +39,16 @@ func IsValidReadConsistency(lvl string) bool {
 	return slices.Contains(ReadConsistencies, lvl)
 }
 
+func IsValidReadConsistencyMaxDelay(delay time.Duration) bool {
+	return delay > 0
+}
+
 type contextKey int
 
 const (
 	consistencyContextKey        contextKey = 1
 	consistencyOffsetsContextKey contextKey = 2
+	consistencyMaxDelayKey       contextKey = 3
 )
 
 // ContextWithReadConsistencyLevel returns a new context with the given consistency level.
@@ -74,8 +81,30 @@ func ReadConsistencyEncodedOffsetsFromContext(ctx context.Context) (EncodedOffse
 	return encoded, true
 }
 
+// ContextWithReadConsistencyMaxDelay returns a new context with the given max delay configured.
+// The delay can be retrieved with ReadConsistencyMaxDelayFromContext.
+func ContextWithReadConsistencyMaxDelay(ctx context.Context, delay time.Duration) context.Context {
+	return context.WithValue(ctx, consistencyMaxDelayKey, delay)
+}
+
+// ContextWithReadConsistencyMaxDelayString is like ContextWithReadConsistencyMaxDelay but accepts
+// the delay as a string in input, and returns an error if the provided string can't be parsed as duration.
+func ContextWithReadConsistencyMaxDelayString(ctx context.Context, delay string) (context.Context, error) {
+	parsedDelay, err := time.ParseDuration(delay)
+	if err != nil {
+		return ctx, err
+	}
+	return ContextWithReadConsistencyMaxDelay(ctx, parsedDelay), nil
+}
+
+// ReadConsistencyMaxDelayFromContext returns max delay / staleness to enforce on eventually consistent requests.
+// The second return value is true if the setting is found in the context.
+func ReadConsistencyMaxDelayFromContext(ctx context.Context) (time.Duration, bool) {
+	delay, _ := ctx.Value(consistencyMaxDelayKey).(time.Duration)
+	return delay, IsValidReadConsistencyMaxDelay(delay)
+}
+
 // ConsistencyExtractor takes the consistency level from the X-Read-Consistency header and sets it in the context.
-// It can be retrieved with ReadConsistencyLevelFromContext.
 type ConsistencyExtractor struct{}
 
 func (e *ConsistencyExtractor) ExtractFromCarrier(ctx context.Context, carrier propagation.Carrier) (context.Context, error) {
@@ -87,25 +116,35 @@ func (e *ConsistencyExtractor) ExtractFromCarrier(ctx context.Context, carrier p
 		ctx = ContextWithReadConsistencyEncodedOffsets(ctx, EncodedOffsets(offsets))
 	}
 
+	if delay := carrier.Get(ReadConsistencyMaxDelayHeader); len(delay) > 0 {
+		// Ignore the error since there's not much we can do. In case of error, the original context is returned.
+		ctx, _ = ContextWithReadConsistencyMaxDelayString(ctx, delay)
+	}
+
 	return ctx, nil
 }
 
-// ConsistencyLevelInjector injects the consistency level from the context (if any) into the carrier.
+// ConsistencyInjector injects the consistency level from the context (if any) into the carrier.
 //
 // It does not add the offsets to the carrier, as these are handled by the query-frontend's list of HTTP headers to propagate.
-type ConsistencyLevelInjector struct{}
+type ConsistencyInjector struct{}
 
-func (i *ConsistencyLevelInjector) InjectToCarrier(ctx context.Context, carrier propagation.Carrier) error {
+func (i *ConsistencyInjector) InjectToCarrier(ctx context.Context, carrier propagation.Carrier) error {
 	if level, ok := ReadConsistencyLevelFromContext(ctx); ok {
 		carrier.Add(ReadConsistencyHeader, level)
+	}
+
+	if delay, ok := ReadConsistencyMaxDelayFromContext(ctx); ok {
+		carrier.Add(ReadConsistencyMaxDelayHeader, delay.String())
 	}
 
 	return nil
 }
 
 const (
-	consistencyLevelGrpcMdKey   = "__consistency_level__"
-	consistencyOffsetsGrpcMdKey = "__consistency_offsets__"
+	consistencyLevelGrpcMdKey    = "__consistency_level__"
+	consistencyOffsetsGrpcMdKey  = "__consistency_offsets__"
+	consistencyMaxDelayGrpcMdKey = "__consistency_max_delay__"
 )
 
 func ReadConsistencyClientUnaryInterceptor(ctx context.Context, method string, req any, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
@@ -114,6 +153,9 @@ func ReadConsistencyClientUnaryInterceptor(ctx context.Context, method string, r
 	}
 	if value, ok := ReadConsistencyEncodedOffsetsFromContext(ctx); ok {
 		ctx = metadata.AppendToOutgoingContext(ctx, consistencyOffsetsGrpcMdKey, string(value))
+	}
+	if value, ok := ReadConsistencyMaxDelayFromContext(ctx); ok {
+		ctx = metadata.AppendToOutgoingContext(ctx, consistencyMaxDelayGrpcMdKey, value.String())
 	}
 	return invoker(ctx, method, req, reply, cc, opts...)
 }
@@ -129,6 +171,12 @@ func ReadConsistencyServerUnaryInterceptor(ctx context.Context, req interface{},
 		ctx = ContextWithReadConsistencyEncodedOffsets(ctx, EncodedOffsets(offsets[0]))
 	}
 
+	delay := metadata.ValueFromIncomingContext(ctx, consistencyMaxDelayGrpcMdKey)
+	if len(delay) > 0 {
+		// Ignore the error, given there's not much we can do.
+		ctx, _ = ContextWithReadConsistencyMaxDelayString(ctx, delay[0])
+	}
+
 	return handler(ctx, req)
 }
 
@@ -138,6 +186,9 @@ func ReadConsistencyClientStreamInterceptor(ctx context.Context, desc *grpc.Stre
 	}
 	if value, ok := ReadConsistencyEncodedOffsetsFromContext(ctx); ok {
 		ctx = metadata.AppendToOutgoingContext(ctx, consistencyOffsetsGrpcMdKey, string(value))
+	}
+	if value, ok := ReadConsistencyMaxDelayFromContext(ctx); ok {
+		ctx = metadata.AppendToOutgoingContext(ctx, consistencyMaxDelayGrpcMdKey, value.String())
 	}
 	return streamer(ctx, desc, cc, method, opts...)
 }
@@ -153,6 +204,12 @@ func ReadConsistencyServerStreamInterceptor(srv interface{}, ss grpc.ServerStrea
 	offsets := metadata.ValueFromIncomingContext(ctx, consistencyOffsetsGrpcMdKey)
 	if len(offsets) > 0 {
 		ctx = ContextWithReadConsistencyEncodedOffsets(ctx, EncodedOffsets(offsets[0]))
+	}
+
+	delay := metadata.ValueFromIncomingContext(ctx, consistencyMaxDelayGrpcMdKey)
+	if len(delay) > 0 {
+		// Ignore the error, given there's not much we can do.
+		ctx, _ = ContextWithReadConsistencyMaxDelayString(ctx, delay[0])
 	}
 
 	ss = ctxStream{

--- a/pkg/querier/api/consistency_test.go
+++ b/pkg/querier/api/consistency_test.go
@@ -38,6 +38,7 @@ func TestConsistencyExtractor(t *testing.T) {
 	headers := http.Header{}
 	headers.Set(ReadConsistencyHeader, ReadConsistencyStrong)
 	headers.Set(ReadConsistencyOffsetsHeader, string(encodedOffsets))
+	headers.Set(ReadConsistencyMaxDelayHeader, "1m")
 
 	extractor := ConsistencyExtractor{}
 	ctx, err := extractor.ExtractFromCarrier(context.Background(), propagation.HttpHeaderCarrier(headers))
@@ -51,6 +52,28 @@ func TestConsistencyExtractor(t *testing.T) {
 	actualOffsets, ok := ReadConsistencyEncodedOffsetsFromContext(ctx)
 	require.True(t, ok)
 	assert.Equal(t, encodedOffsets, actualOffsets)
+
+	actualDelay, ok := ReadConsistencyMaxDelayFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, time.Minute, actualDelay)
+}
+
+func TestConsistencyInjector(t *testing.T) {
+	ctx := context.Background()
+	ctx = ContextWithReadConsistencyLevel(ctx, ReadConsistencyStrong)
+	ctx = ContextWithReadConsistencyMaxDelay(ctx, time.Minute)
+	ctx = ContextWithReadConsistencyEncodedOffsets(ctx, EncodeOffsets(map[int32]int64{0: 1, 1: 2}))
+
+	headers := http.Header{}
+
+	injector := &ConsistencyInjector{}
+	require.NoError(t, injector.InjectToCarrier(ctx, propagation.HttpHeaderCarrier(headers)))
+
+	assert.Equal(t, ReadConsistencyStrong, headers.Get(ReadConsistencyHeader))
+	assert.Equal(t, time.Minute.String(), headers.Get(ReadConsistencyMaxDelayHeader))
+
+	// Offsets should not be propagated, because internally we propagate them differently when required.
+	assert.Empty(t, headers.Get(ReadConsistencyOffsetsHeader))
 }
 
 func TestReadConsistencyClientUnaryInterceptor_And_ReadConsistencyServerUnaryInterceptor(t *testing.T) {
@@ -60,6 +83,7 @@ func TestReadConsistencyClientUnaryInterceptor_And_ReadConsistencyServerUnaryInt
 	clientIncomingCtx := context.Background()
 	clientIncomingCtx = ContextWithReadConsistencyLevel(clientIncomingCtx, ReadConsistencyStrong)
 	clientIncomingCtx = ContextWithReadConsistencyEncodedOffsets(clientIncomingCtx, encodedOffsets)
+	clientIncomingCtx = ContextWithReadConsistencyMaxDelay(clientIncomingCtx, time.Minute)
 
 	var clientOutgoingCtx context.Context
 	clientHandler := func(ctx context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
@@ -93,6 +117,10 @@ func TestReadConsistencyClientUnaryInterceptor_And_ReadConsistencyServerUnaryInt
 	actualOffsets, ok := ReadConsistencyEncodedOffsetsFromContext(serverOutgoingCtx)
 	require.True(t, ok)
 	assert.Equal(t, encodedOffsets, actualOffsets)
+
+	actualDelay, ok := ReadConsistencyMaxDelayFromContext(serverOutgoingCtx)
+	require.True(t, ok)
+	assert.Equal(t, time.Minute, actualDelay)
 }
 
 func TestReadConsistencyClientStreamInterceptor_And_ReadConsistencyServerStreamInterceptor(t *testing.T) {
@@ -102,6 +130,7 @@ func TestReadConsistencyClientStreamInterceptor_And_ReadConsistencyServerStreamI
 	clientIncomingCtx := context.Background()
 	clientIncomingCtx = ContextWithReadConsistencyLevel(clientIncomingCtx, ReadConsistencyStrong)
 	clientIncomingCtx = ContextWithReadConsistencyEncodedOffsets(clientIncomingCtx, encodedOffsets)
+	clientIncomingCtx = ContextWithReadConsistencyMaxDelay(clientIncomingCtx, time.Minute)
 
 	var clientOutgoingCtx context.Context
 	clientHandler := func(ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
@@ -135,6 +164,10 @@ func TestReadConsistencyClientStreamInterceptor_And_ReadConsistencyServerStreamI
 	actualOffsets, ok := ReadConsistencyEncodedOffsetsFromContext(serverOutgoingCtx)
 	require.True(t, ok)
 	assert.Equal(t, encodedOffsets, actualOffsets)
+
+	actualDelay, ok := ReadConsistencyMaxDelayFromContext(serverOutgoingCtx)
+	require.True(t, ok)
+	assert.Equal(t, time.Minute, actualDelay)
 }
 
 func BenchmarkReadConsistencyServerUnaryInterceptor(b *testing.B) {
@@ -145,8 +178,9 @@ func BenchmarkReadConsistencyServerUnaryInterceptor(b *testing.B) {
 			md := exampleIncomingMetadata
 			if withReadConsistency {
 				md = metadata.Join(md, metadata.New(map[string]string{
-					consistencyLevelGrpcMdKey:   ReadConsistencyStrong,
-					consistencyOffsetsGrpcMdKey: string(EncodeOffsets(generateTestOffsets(numPartitions))),
+					consistencyLevelGrpcMdKey:    ReadConsistencyStrong,
+					consistencyOffsetsGrpcMdKey:  string(EncodeOffsets(generateTestOffsets(numPartitions))),
+					consistencyMaxDelayGrpcMdKey: "1m",
 				}))
 			}
 
@@ -170,8 +204,9 @@ func BenchmarkReadConsistencyServerStreamInterceptor(b *testing.B) {
 			md := exampleIncomingMetadata
 			if withReadConsistency {
 				md = metadata.Join(md, metadata.New(map[string]string{
-					consistencyLevelGrpcMdKey:   ReadConsistencyStrong,
-					consistencyOffsetsGrpcMdKey: string(EncodeOffsets(generateTestOffsets(numPartitions))),
+					consistencyLevelGrpcMdKey:    ReadConsistencyStrong,
+					consistencyOffsetsGrpcMdKey:  string(EncodeOffsets(generateTestOffsets(numPartitions))),
+					consistencyMaxDelayGrpcMdKey: "1m",
 				}))
 			}
 

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"net/textproto"
 	"net/url"
 	"slices"
 	"strconv"
@@ -36,6 +35,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/util/grpcencoding/s2"
 	"github.com/grafana/mimir/pkg/util/httpgrpcutil"
+	"github.com/grafana/mimir/pkg/util/propagation"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/grafana/mimir/pkg/util/version"
 )
@@ -173,13 +173,12 @@ func (q *RemoteQuerier) Read(ctx context.Context, query *prompb.Query, sortSerie
 	if err != nil {
 		return nil, err
 	}
-	req.Header = injectHTTPReadConsistencyHeader(ctx, http.Header{
-		textproto.CanonicalMIMEHeaderKey("Content-Encoding"):                 []string{"snappy"},
-		textproto.CanonicalMIMEHeaderKey("Accept-Encoding"):                  []string{"snappy"},
-		textproto.CanonicalMIMEHeaderKey("Content-Type"):                     []string{"application/x-protobuf"},
-		textproto.CanonicalMIMEHeaderKey("User-Agent"):                       []string{version.UserAgent()},
-		textproto.CanonicalMIMEHeaderKey("X-Prometheus-Remote-Read-Version"): []string{"0.1.0"},
-	})
+	req.Header.Set("Content-Encoding", "snappy")
+	req.Header.Set("Accept-Encoding", "snappy")
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	req.Header.Set("User-Agent", version.UserAgent())
+	req.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
+	api.InjectHTTPReadConsistencyHeaders(ctx, req)
 
 	for _, mdw := range q.middlewares {
 		if err := mdw(ctx, req); err != nil {
@@ -296,12 +295,14 @@ func (q *RemoteQuerier) createRequest(ctx context.Context, query string, ts time
 	if err != nil {
 		return nil, err
 	}
-	req.Header = injectHTTPReadConsistencyHeader(ctx, http.Header{
-		textproto.CanonicalMIMEHeaderKey("User-Agent"):     []string{version.UserAgent()},
-		textproto.CanonicalMIMEHeaderKey("Content-Type"):   []string{mimeTypeFormPost},
-		textproto.CanonicalMIMEHeaderKey("Content-Length"): []string{strconv.Itoa(len(body))},
-		textproto.CanonicalMIMEHeaderKey("Accept"):         []string{acceptHeader},
-	})
+	req.Header.Set("User-Agent", version.UserAgent())
+	req.Header.Set("Content-Type", mimeTypeFormPost)
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	req.Header.Set("Accept", acceptHeader)
+	consistencyInjector := &api.ConsistencyInjector{}
+	if err := consistencyInjector.InjectToCarrier(ctx, propagation.HttpHeaderCarrier(req.Header)); err != nil {
+		return nil, err
+	}
 
 	for _, mdw := range q.middlewares {
 		if err := mdw(ctx, req); err != nil {
@@ -398,15 +399,4 @@ func WithOrgIDMiddleware(ctx context.Context, req *http.Request) error {
 	}
 	req.Header.Set(user.OrgIDHeaderName, orgID)
 	return nil
-}
-
-// injectHTTPReadConsistencyHeader reads the read consistency level from the ctx and, if defined, injects
-// it as an HTTP header to the list of input headers. This is required to propagate the read consistency
-// through the network when issuing an HTTPgRPC request.
-func injectHTTPReadConsistencyHeader(ctx context.Context, headers http.Header) http.Header {
-	if level, ok := api.ReadConsistencyLevelFromContext(ctx); ok {
-		headers[textproto.CanonicalMIMEHeaderKey(api.ReadConsistencyHeader)] = []string{level}
-	}
-
-	return headers
 }

--- a/pkg/ruler/remotequerier.go
+++ b/pkg/ruler/remotequerier.go
@@ -178,7 +178,10 @@ func (q *RemoteQuerier) Read(ctx context.Context, query *prompb.Query, sortSerie
 	req.Header.Set("Content-Type", "application/x-protobuf")
 	req.Header.Set("User-Agent", version.UserAgent())
 	req.Header.Set("X-Prometheus-Remote-Read-Version", "0.1.0")
-	api.InjectHTTPReadConsistencyHeaders(ctx, req)
+	consistencyInjector := &api.ConsistencyInjector{}
+	if err := consistencyInjector.InjectToCarrier(ctx, propagation.HttpHeaderCarrier(req.Header)); err != nil {
+		return nil, err
+	}
 
 	for _, mdw := range q.middlewares {
 		if err := mdw(ctx, req); err != nil {

--- a/pkg/ruler/rule_query_consistency_test.go
+++ b/pkg/ruler/rule_query_consistency_test.go
@@ -4,11 +4,13 @@ package ruler
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -18,44 +20,75 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/querier/api"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 func TestWrapQueryFuncWithReadConsistency(t *testing.T) {
-	runWrappedFunc := func(ctx context.Context) (hasReadConsistency bool, readConsistencyLevel string) {
+	const userID = "user-1"
+
+	runWrappedFunc := func(ctx context.Context, limits RulesLimits) (hasConsistencyLevel bool, consistencyLevel string, hasConsistencyMaxDelay bool, consistencyMaxDelay time.Duration, err error) {
 		orig := func(ctx context.Context, _ string, _ time.Time) (promql.Vector, error) {
-			readConsistencyLevel, hasReadConsistency = api.ReadConsistencyLevelFromContext(ctx)
+			consistencyLevel, hasConsistencyLevel = api.ReadConsistencyLevelFromContext(ctx)
+			consistencyMaxDelay, hasConsistencyMaxDelay = api.ReadConsistencyMaxDelayFromContext(ctx)
 			return promql.Vector{}, nil
 		}
 
-		_, _ = WrapQueryFuncWithReadConsistency(orig, log.NewNopLogger())(ctx, "", time.Now())
+		_, _ = WrapQueryFuncWithReadConsistency(orig, limits, userID, log.NewNopLogger())(ctx, "", time.Now())
 		return
 	}
 
 	t.Run("should inject strong read consistency if the rule detail is missing in the context", func(t *testing.T) {
-		hasReadConsistency, readConsistencyLevel := runWrappedFunc(context.Background())
-		assert.True(t, hasReadConsistency)
-		assert.Equal(t, api.ReadConsistencyStrong, readConsistencyLevel)
+		for _, configuredMaxDelay := range []time.Duration{0, time.Minute} {
+			t.Run(fmt.Sprintf("configured consistency max delay: %s", configuredMaxDelay.String()), func(t *testing.T) {
+				limits := validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
+					defaults.RulerEvaluationConsistencyMaxDelay = model.Duration(configuredMaxDelay)
+				})
+
+				hasConsistencyLevel, consistencyLevel, hasConsistencyMaxDelay, _, _ := runWrappedFunc(context.Background(), limits)
+				assert.True(t, hasConsistencyLevel)
+				assert.Equal(t, api.ReadConsistencyStrong, consistencyLevel)
+				assert.False(t, hasConsistencyMaxDelay)
+			})
+		}
 	})
 
 	t.Run("should inject strong read consistency if it's unknown whether the rule has dependencies", func(t *testing.T) {
-		var (
-			r   = rules.NewRecordingRule("", &parser.StringLiteral{}, labels.New())
-			ctx = rules.NewOriginContext(context.Background(), rules.NewRuleDetail(r))
-		)
+		for _, configuredMaxDelay := range []time.Duration{0, time.Minute} {
+			t.Run(fmt.Sprintf("configured consistency max delay: %s", configuredMaxDelay.String()), func(t *testing.T) {
+				var (
+					r   = rules.NewRecordingRule("", &parser.StringLiteral{}, labels.New())
+					ctx = rules.NewOriginContext(context.Background(), rules.NewRuleDetail(r))
+				)
 
-		hasReadConsistency, readConsistencyLevel := runWrappedFunc(ctx)
-		assert.True(t, hasReadConsistency)
-		assert.Equal(t, api.ReadConsistencyStrong, readConsistencyLevel)
+				limits := validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
+					defaults.RulerEvaluationConsistencyMaxDelay = model.Duration(configuredMaxDelay)
+				})
+
+				hasConsistencyLevel, consistencyLevel, hasConsistencyMaxDelay, _, _ := runWrappedFunc(ctx, limits)
+				assert.True(t, hasConsistencyLevel)
+				assert.Equal(t, api.ReadConsistencyStrong, consistencyLevel)
+				assert.False(t, hasConsistencyMaxDelay)
+			})
+		}
 	})
 
 	t.Run("should inject strong read consistency if the rule has dependencies", func(t *testing.T) {
-		r := rules.NewRecordingRule("", &parser.StringLiteral{}, labels.New())
-		r.SetDependencyRules([]rules.Rule{rules.NewRecordingRule("other", &parser.StringLiteral{}, labels.New())})
+		for _, configuredMaxDelay := range []time.Duration{0, time.Minute} {
+			t.Run(fmt.Sprintf("configured consistency max delay: %s", configuredMaxDelay.String()), func(t *testing.T) {
+				limits := validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
+					defaults.RulerEvaluationConsistencyMaxDelay = model.Duration(configuredMaxDelay)
+				})
 
-		ctx := rules.NewOriginContext(context.Background(), rules.NewRuleDetail(r))
-		hasReadConsistency, readConsistencyLevel := runWrappedFunc(ctx)
-		assert.True(t, hasReadConsistency)
-		assert.Equal(t, api.ReadConsistencyStrong, readConsistencyLevel)
+				r := rules.NewRecordingRule("", &parser.StringLiteral{}, labels.New())
+				r.SetDependencyRules([]rules.Rule{rules.NewRecordingRule("other", &parser.StringLiteral{}, labels.New())})
+
+				ctx := rules.NewOriginContext(context.Background(), rules.NewRuleDetail(r))
+				hasConsistencyLevel, consistencyLevel, hasConsistencyMaxDelay, _, _ := runWrappedFunc(ctx, limits)
+				assert.True(t, hasConsistencyLevel)
+				assert.Equal(t, api.ReadConsistencyStrong, consistencyLevel)
+				assert.False(t, hasConsistencyMaxDelay)
+			})
+		}
 	})
 
 	t.Run("should not inject read consistency level if the rule has no dependencies, to let run with the per-tenant default", func(t *testing.T) {
@@ -63,8 +96,24 @@ func TestWrapQueryFuncWithReadConsistency(t *testing.T) {
 		r.SetDependencyRules([]rules.Rule{})
 
 		ctx := rules.NewOriginContext(context.Background(), rules.NewRuleDetail(r))
-		hasReadConsistency, _ := runWrappedFunc(ctx)
-		assert.False(t, hasReadConsistency)
+		hasConsistencyLevel, _, hasConsistencyMaxDelay, _, _ := runWrappedFunc(ctx, validation.MockDefaultOverrides())
+		assert.False(t, hasConsistencyLevel)
+		assert.False(t, hasConsistencyMaxDelay)
+	})
+
+	t.Run("should inject read consistency max delay if the rule has no dependencies, and max delay has been configured", func(t *testing.T) {
+		limits := validation.MockOverrides(func(defaults *validation.Limits, _ map[string]*validation.Limits) {
+			defaults.RulerEvaluationConsistencyMaxDelay = model.Duration(time.Minute)
+		})
+
+		r := rules.NewRecordingRule("", &parser.StringLiteral{}, labels.New())
+		r.SetDependencyRules([]rules.Rule{})
+
+		ctx := rules.NewOriginContext(context.Background(), rules.NewRuleDetail(r))
+		hasConsistencyLevel, _, hasConsistencyMaxDelay, consistencyMaxDelay, _ := runWrappedFunc(ctx, limits)
+		assert.False(t, hasConsistencyLevel)
+		assert.True(t, hasConsistencyMaxDelay)
+		assert.Equal(t, time.Minute, consistencyMaxDelay)
 	})
 }
 

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -88,6 +88,10 @@ type PartitionReader struct {
 	consumedOffsetWatcher *PartitionOffsetWatcher
 	offsetReader          *partitionOffsetReader
 
+	// The highest record timestamp consumed so far, or zero if no record was consumed yet or we've
+	// consumed up until the end of the partition. This timestamp is used the compute the consumption delay.
+	highestConsumedTimestamp *atomic.Time
+
 	logger         log.Logger
 	reg            prometheus.Registerer
 	lastSeenOffset int64
@@ -109,6 +113,7 @@ func newPartitionReader(kafkaCfg KafkaConfig, partitionID int32, instanceID stri
 		consumerGroup:                         kafkaCfg.GetConsumerGroup(instanceID, partitionID),
 		consumedOffsetWatcher:                 NewPartitionOffsetWatcher(),
 		concurrentFetchersMinBytesMaxWaitTime: kafkaCfg.FetchMaxWait,
+		highestConsumedTimestamp:              atomic.NewTime(time.Time{}),
 		logger:                                log.With(logger, "partition", partitionID),
 		reg:                                   reg,
 	}
@@ -302,7 +307,7 @@ func (r *PartitionReader) stopDependencies() error {
 
 func (r *PartitionReader) run(ctx context.Context) error {
 	for ctx.Err() == nil {
-		err := r.processNextFetches(ctx, r.metrics.receiveDelayWhenRunning)
+		err := r.processNextFetches(ctx, r.metrics.receiveDelayWhenRunning, r.metrics.receiveAndConsumeDelayWhenRunning)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			// Fail the whole service in case of a non-recoverable error.
 			return err
@@ -312,11 +317,11 @@ func (r *PartitionReader) run(ctx context.Context) error {
 	return nil
 }
 
-func (r *PartitionReader) processNextFetches(ctx context.Context, delayObserver prometheus.Observer) error {
+func (r *PartitionReader) processNextFetches(ctx context.Context, receiveDelayObserver, receiveAndConsumeDelayObserver prometheus.Observer) error {
 	fetches, fetchCtx := r.getFetcher().PollFetches(ctx)
 	// Propagate the fetching span to consuming the records.
 	ctx = trace.ContextWithSpan(ctx, trace.SpanFromContext(fetchCtx))
-	r.recordFetchesMetrics(fetches, delayObserver)
+	r.recordFetchesMetrics(fetches, receiveDelayObserver)
 	r.logFetchErrors(fetches)
 	fetches = filterOutErrFetches(fetches)
 
@@ -324,12 +329,14 @@ func (r *PartitionReader) processNextFetches(ctx context.Context, delayObserver 
 	instrumentGaps(findGapsInRecords(fetches, r.lastSeenOffset), r.metrics.missedRecords, r.logger)
 	r.lastSeenOffset = max(r.lastSeenOffset, lastOffset(fetches))
 
+	r.updateHighestConsumedTimestampBeforeConsumption(fetches)
 	err := r.consumeFetches(ctx, fetches)
 	if err != nil {
 		return fmt.Errorf("consume %d records: %w", fetches.NumRecords(), err)
 	}
 	r.enqueueCommit(fetches)
 	r.notifyLastConsumedOffset(fetches)
+	r.updateHighestConsumedTimestampAfterConsumption(fetches, receiveAndConsumeDelayObserver)
 	return nil
 }
 
@@ -447,7 +454,7 @@ func (r *PartitionReader) processNextFetchesUntilLagHonored(ctx context.Context,
 				break
 			}
 
-			err := r.processNextFetches(ctx, r.metrics.receiveDelayWhenStarting)
+			err := r.processNextFetches(ctx, r.metrics.receiveDelayWhenStarting, r.metrics.receiveAndConsumeDelayWhenStarting)
 			if err != nil {
 				return 0, err
 			}
@@ -617,7 +624,7 @@ func (r *PartitionReader) notifyLastConsumedOffset(fetches kgo.Fetches) {
 	})
 }
 
-func (r *PartitionReader) recordFetchesMetrics(fetches kgo.Fetches, delayObserver prometheus.Observer) {
+func (r *PartitionReader) recordFetchesMetrics(fetches kgo.Fetches, receiveDelayObserver prometheus.Observer) {
 	var (
 		now        = time.Now()
 		numRecords = 0
@@ -625,11 +632,76 @@ func (r *PartitionReader) recordFetchesMetrics(fetches kgo.Fetches, delayObserve
 
 	fetches.EachRecord(func(record *kgo.Record) {
 		numRecords++
-		delayObserver.Observe(now.Sub(record.Timestamp).Seconds())
+		receiveDelayObserver.Observe(now.Sub(record.Timestamp).Seconds())
 	})
 
 	r.metrics.fetchesTotal.Add(float64(len(fetches)))
 	r.metrics.recordsPerFetch.Observe(float64(numRecords))
+}
+
+func (r *PartitionReader) updateHighestConsumedTimestampBeforeConsumption(fetches kgo.Fetches) {
+	// The only case we want to update the highest consumed timestamp before actually consuming the records
+	// is in the case we don't have any timestamp stored yet. This is used to detect a stuck consumption
+	// after a previous consumption up until the partition end.
+	//
+	// In this case you may think that the right thing to do would be keeping the previous timestamp.
+	// However, if the consumption was paused and this is the first record after resume, then if we keep
+	// the previous timestamp we end up with a brief period of during which we incorrectly compute the delay.
+	// To stay on the safer side, we do pick the next batch's first record timestamp instead.
+	if r.highestConsumedTimestamp.Load().IsZero() {
+		fetches.EachPartition(func(partition kgo.FetchTopicPartition) {
+			// We expect all records to belong to the partition consumed by this reader,
+			// but we double check it here.
+			if partition.Partition != r.partitionID {
+				return
+			}
+
+			if len(partition.Records) == 0 {
+				return
+			}
+
+			firstRecord := partition.Records[0]
+			r.highestConsumedTimestamp.Store(firstRecord.Timestamp)
+		})
+	}
+}
+
+func (r *PartitionReader) updateHighestConsumedTimestampAfterConsumption(fetches kgo.Fetches, receiveAndConsumeDelayObserver prometheus.Observer) {
+	var (
+		now              = time.Now()
+		highestTimestamp = time.Time{}
+	)
+
+	fetches.EachPartition(func(partition kgo.FetchTopicPartition) {
+		// We expect all records to belong to the partition consumed by this reader,
+		// but we double check it here.
+		if partition.Partition != r.partitionID {
+			return
+		}
+
+		if len(partition.Records) == 0 {
+			return
+		}
+
+		partition.EachRecord(func(record *kgo.Record) {
+			receiveAndConsumeDelayObserver.Observe(now.Sub(record.Timestamp).Seconds())
+
+			if record.Timestamp.After(highestTimestamp) {
+				highestTimestamp = record.Timestamp
+			}
+		})
+
+		// Records are expected to be sorted by offsets, so we can simply look at the last one
+		// to check if we consumed until the partition end.
+		lastRecord := partition.Records[len(partition.Records)-1]
+		consumedUntilPartitionEnd := lastRecord.Offset+1 >= partition.HighWatermark
+
+		if consumedUntilPartitionEnd {
+			r.highestConsumedTimestamp.Store(time.Time{})
+		} else {
+			r.highestConsumedTimestamp.Store(highestTimestamp)
+		}
+	})
 }
 
 func (r *PartitionReader) getStartOffset(ctx context.Context) (startOffset, lastConsumedOffset int64, err error) {
@@ -797,6 +869,27 @@ func (r *PartitionReader) waitReadConsistency(ctx context.Context, withOffset bo
 	return err
 }
 
+// EnforceReadMaxDelay returns an error if the PartitionReader is lagging behind more than the
+// input maxDelay.
+func (r *PartitionReader) EnforceReadMaxDelay(maxDelay time.Duration) error {
+	if maxDelay <= 0 {
+		return nil
+	}
+
+	highestConsumedTimestamp := r.highestConsumedTimestamp.Load()
+	if highestConsumedTimestamp.IsZero() {
+		// We consumed until partition end.
+		return nil
+	}
+
+	if time.Since(highestConsumedTimestamp) <= maxDelay {
+		// The consumption delay is within the allowed max.
+		return nil
+	}
+
+	return fmt.Errorf("partition reader is lagging behind more than the allowed max delay")
+}
+
 func (r *PartitionReader) setFetcher(f fetcher) {
 	r.fetcher.Store(&f)
 }
@@ -950,22 +1043,24 @@ func (r *partitionCommitter) stop(error) error {
 type ReaderMetrics struct {
 	services.Service
 
-	bufferedFetchedRecords           prometheus.GaugeFunc
-	bufferedFetchedBytes             prometheus.GaugeFunc
-	estimatedBytesPerRecord          prometheus.Histogram
-	receiveDelayWhenStarting         prometheus.Observer
-	receiveDelayWhenRunning          prometheus.Observer
-	recordsPerFetch                  prometheus.Histogram
-	fetchesErrors                    prometheus.Counter
-	fetchesTotal                     prometheus.Counter
-	fetchWaitDuration                prometheus.Histogram
-	fetchMaxBytes                    prometheus.Histogram
-	fetchedDiscardedRecordBytes      prometheus.Counter
-	strongConsistencyInstrumentation *StrongReadConsistencyInstrumentation[struct{}]
-	lastConsumedOffset               *prometheus.GaugeVec
-	consumeLatency                   prometheus.Histogram
-	kprom                            *kprom.Metrics
-	missedRecords                    prometheus.Counter
+	bufferedFetchedRecords             prometheus.GaugeFunc
+	bufferedFetchedBytes               prometheus.GaugeFunc
+	estimatedBytesPerRecord            prometheus.Histogram
+	receiveDelayWhenStarting           prometheus.Observer
+	receiveDelayWhenRunning            prometheus.Observer
+	receiveAndConsumeDelayWhenStarting prometheus.Observer
+	receiveAndConsumeDelayWhenRunning  prometheus.Observer
+	recordsPerFetch                    prometheus.Histogram
+	fetchesErrors                      prometheus.Counter
+	fetchesTotal                       prometheus.Counter
+	fetchWaitDuration                  prometheus.Histogram
+	fetchMaxBytes                      prometheus.Histogram
+	fetchedDiscardedRecordBytes        prometheus.Counter
+	strongConsistencyInstrumentation   *StrongReadConsistencyInstrumentation[struct{}]
+	lastConsumedOffset                 *prometheus.GaugeVec
+	consumeLatency                     prometheus.Histogram
+	kprom                              *kprom.Metrics
+	missedRecords                      prometheus.Counter
 }
 
 type ReaderMetricsSource interface {
@@ -980,6 +1075,16 @@ func NewReaderMetrics(reg prometheus.Registerer, metricsSource ReaderMetricsSour
 	receiveDelay := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            "cortex_ingest_storage_reader_receive_delay_seconds",
 		Help:                            "Delay between producing a record and receiving it in the consumer.",
+		NativeHistogramZeroThreshold:    math.Pow(2, -10), // Values below this will be considered to be 0. Equals to 0.0009765625, or about 1ms.
+		NativeHistogramBucketFactor:     1.2,              // We use higher factor (scheme=2) to have wider spread of buckets.
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+		Buckets:                         prometheus.ExponentialBuckets(0.125, 2, 18), // Buckets between 125ms and 9h.
+	}, []string{"phase"})
+
+	receiveAndConsumeDelay := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name:                            "cortex_ingest_storage_reader_receive_and_consume_delay_seconds",
+		Help:                            "Delay between producing a record and consuming it in the consumer.",
 		NativeHistogramZeroThreshold:    math.Pow(2, -10), // Values below this will be considered to be 0. Equals to 0.0009765625, or about 1ms.
 		NativeHistogramBucketFactor:     1.2,              // We use higher factor (scheme=2) to have wider spread of buckets.
 		NativeHistogramMaxBucketNumber:  100,
@@ -1011,8 +1116,10 @@ func NewReaderMetrics(reg prometheus.Registerer, metricsSource ReaderMetricsSour
 			Help:                        "Observations with the current size estimation of records fetched from Kafka. Sampled at 10Hz.",
 			NativeHistogramBucketFactor: 1.1,
 		}),
-		receiveDelayWhenStarting: receiveDelay.WithLabelValues("starting"),
-		receiveDelayWhenRunning:  receiveDelay.WithLabelValues("running"),
+		receiveDelayWhenStarting:           receiveDelay.WithLabelValues("starting"),
+		receiveDelayWhenRunning:            receiveDelay.WithLabelValues("running"),
+		receiveAndConsumeDelayWhenStarting: receiveAndConsumeDelay.WithLabelValues("starting"),
+		receiveAndConsumeDelayWhenRunning:  receiveAndConsumeDelay.WithLabelValues("running"),
 		recordsPerFetch: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:    "cortex_ingest_storage_reader_records_per_fetch",
 			Help:    "The number of records received by the consumer in a single fetch operation.",

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -646,7 +646,7 @@ func (r *PartitionReader) updateHighestConsumedTimestampBeforeConsumption(fetche
 	//
 	// In this case you may think that the right thing to do would be keeping the previous timestamp.
 	// However, if the consumption was paused and this is the first record after resume, then if we keep
-	// the previous timestamp we end up with a brief period of during which we incorrectly compute the delay.
+	// the previous timestamp we end up with a brief period of time during which we incorrectly compute the delay.
 	// To stay on the safer side, we do pick the next batch's first record timestamp instead.
 	if r.highestConsumedTimestamp.Load().IsZero() {
 		fetches.EachPartition(func(partition kgo.FetchTopicPartition) {

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -558,7 +558,7 @@ func TestPartitionReader_EnforceReadMaxDelay(t *testing.T) {
 
 		reader, _ := setup(t, consumer)
 
-		assert.Zero(t, reader.highestConsumedTimestamp.Load())
+		assert.Zero(t, reader.highestConsumedTimestampBeforePartitionEnd.Load())
 		assert.NoError(t, reader.EnforceReadMaxDelay(time.Minute))
 	})
 
@@ -599,7 +599,7 @@ func TestPartitionReader_EnforceReadMaxDelay(t *testing.T) {
 				// Wait until highest consumed timestamp is reset to the zero value because we reached the
 				// end of the partition.
 				test.Poll(t, 5*time.Second, true, func() interface{} {
-					return reader.highestConsumedTimestamp.Load().IsZero()
+					return reader.highestConsumedTimestampBeforePartitionEnd.Load().IsZero()
 				})
 
 				assert.NoError(t, reader.EnforceReadMaxDelay(time.Minute))
@@ -649,11 +649,11 @@ func TestPartitionReader_EnforceReadMaxDelay(t *testing.T) {
 		// At this point we expect the max delay to not be honored. Due to async consumption it may not be immediate,
 		// so we wait until a timestamp is stored.
 		test.Poll(t, 5*time.Second, true, func() interface{} {
-			return !reader.highestConsumedTimestamp.Load().IsZero()
+			return !reader.highestConsumedTimestampBeforePartitionEnd.Load().IsZero()
 		})
 
-		require.NotZero(t, reader.highestConsumedTimestamp.Load())
-		assert.Greater(t, time.Since(reader.highestConsumedTimestamp.Load()), time.Minute)
+		require.NotZero(t, reader.highestConsumedTimestampBeforePartitionEnd.Load())
+		assert.Greater(t, time.Since(reader.highestConsumedTimestampBeforePartitionEnd.Load()), time.Minute)
 		assert.Error(t, reader.EnforceReadMaxDelay(time.Minute))
 	})
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -237,6 +237,7 @@ type Limits struct {
 
 	// Ruler defaults and limits.
 	RulerEvaluationDelay                                  model.Duration                    `yaml:"ruler_evaluation_delay_duration" json:"ruler_evaluation_delay_duration"`
+	RulerEvaluationConsistencyMaxDelay                    model.Duration                    `yaml:"ruler_evaluation_consistency_max_delay" json:"ruler_evaluation_consistency_max_delay" category:"experimental"`
 	RulerTenantShardSize                                  int                               `yaml:"ruler_tenant_shard_size" json:"ruler_tenant_shard_size"`
 	RulerMaxRulesPerRuleGroup                             int                               `yaml:"ruler_max_rules_per_rule_group" json:"ruler_max_rules_per_rule_group"`
 	RulerMaxRuleGroupsPerTenant                           int                               `yaml:"ruler_max_rule_groups_per_tenant" json:"ruler_max_rule_groups_per_tenant"`
@@ -413,6 +414,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	_ = l.RulerEvaluationDelay.Set("1m")
 	f.Var(&l.RulerEvaluationDelay, "ruler.evaluation-delay-duration", "Duration to delay the evaluation of rules to ensure the underlying metrics have been pushed.")
+	_ = l.RulerEvaluationConsistencyMaxDelay.Set("0s")
+	f.Var(&l.RulerEvaluationConsistencyMaxDelay, "ruler.evaluation-consistency-max-delay", "The maximum tolerated ingestion delay for eventually consistent rule evaluations. Set to 0 to disable the enforcement.")
 	f.IntVar(&l.RulerTenantShardSize, "ruler.tenant-shard-size", 0, "The tenant's shard size when sharding is used by ruler. Value of 0 disables shuffle sharding for the tenant, and tenant rules will be sharded across all ruler replicas.")
 	f.IntVar(&l.RulerMaxRulesPerRuleGroup, "ruler.max-rules-per-rule-group", 20, "Maximum number of rules per rule group per-tenant. 0 to disable.")
 	f.IntVar(&l.RulerMaxRuleGroupsPerTenant, "ruler.max-rule-groups-per-tenant", 70, "Maximum number of rule groups per-tenant. 0 to disable.")
@@ -1091,9 +1094,15 @@ func (o *Overrides) CompactorMaxPerBlockUploadConcurrency(userID string) int {
 	return o.getOverridesForUser(userID).CompactorMaxPerBlockUploadConcurrency
 }
 
-// EvaluationDelay returns the rules evaluation delay for a given user.
-func (o *Overrides) EvaluationDelay(userID string) time.Duration {
+// RulerEvaluationDelay returns the rules evaluation delay for a given user.
+func (o *Overrides) RulerEvaluationDelay(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).RulerEvaluationDelay)
+}
+
+// RulerEvaluationConsistencyMaxDelay returns the maximum tolerated ingestion delay for eventually consistent
+// rule evaluations, or 0 if it shouldn't be enforced.
+func (o *Overrides) RulerEvaluationConsistencyMaxDelay(userID string) time.Duration {
+	return time.Duration(o.getOverridesForUser(userID).RulerEvaluationConsistencyMaxDelay)
 }
 
 // CompactorMaxLookback returns the duration of the compactor lookback period, blocks uploaded before the lookback period aren't


### PR DESCRIPTION
#### What this PR does

In this PR I'm adding the experimental support to configure the max eventual consistency delay on a per-query basis. The max delay is currently propagated via a new internal HTTP header named `X-Read-Consistency-Max-Delay`, but in a follow up PR I will try to reuse the existing `X-Read-Consistency` header to both specify the level (as of today) and the max delay (new).

The max delay is intended to be used internally, and in particular by ruler. When a rule is evaluated with eventual consistency, we may want to specify a max delay to ensure it doesn't get executed on very stale data. I initially though to set the delay equal to the configured `ruler_evaluation_delay_duration`, but in this PR I'm introducing a new experimental configuration option called `ruler_evaluation_consistency_max_delay`. The new config option give us the ability to experiment with the delay, before deciding whether just setting the delay to `ruler_evaluation_delay_duration` is a good idea or not.

When the ingester receives a request with `eventual` consistency level and max delay configured, the ingester checks if the max delay is honored. If it's not honored, the ingester immediately fail the query. I opted for this solution, rather than having the ingester waiting until max delay is honored, because the idea is to set max delay to a fairly high value (e.g. 1 minute) and so waiting extra time may not give much benefit, but would slow down other enqueued queries not having max delay enforcement (the possible slowdown is due to  saturating querier workers, that would get occupied just by waiting for max delay to be enforced).

The max delay is not enforced when the consistency level of a query is `strong`, because strong consistency already implies an up to date state.

I've also manually tested this PR in a local dev env, injecting a fake high latency when consuming from Kafka and looks working as expected.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
