### PR TITLE
continuous-test: Improve record test logging/metrics, adjust tuneables

### DIFF
--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3292,7 +3292,7 @@ Usage of ./cmd/mimir/mimir:
   -tests.ingest-storage-record.enabled
     	Whether the test for ingest-storage record correctness is enabled.
   -tests.ingest-storage-record.max-jump-size int
-    	If a partition increases by this many offsets in a run, we skip processing it, to protect against downloading unexpectedly huge batches. (default 100000000)
+    	If a partition increases by this many offsets in a run, we skip processing it, to protect against downloading unexpectedly huge batches. (default 500000000)
   -tests.ingest-storage-record.max-records-per-run int
     	Limit on the number of total records to be processed in a run, to keep memory bounded in large cells. This limit is approximate, we might go over by a partial fetch. (default 200000)
   -tests.ingest-storage-record.records-processed-percent int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -868,7 +868,7 @@ Usage of ./cmd/mimir/mimir:
   -tests.ingest-storage-record.enabled
     	Whether the test for ingest-storage record correctness is enabled.
   -tests.ingest-storage-record.max-jump-size int
-    	If a partition increases by this many offsets in a run, we skip processing it, to protect against downloading unexpectedly huge batches. (default 100000000)
+    	If a partition increases by this many offsets in a run, we skip processing it, to protect against downloading unexpectedly huge batches. (default 500000000)
   -tests.ingest-storage-record.max-records-per-run int
     	Limit on the number of total records to be processed in a run, to keep memory bounded in large cells. This limit is approximate, we might go over by a partial fetch. (default 200000)
   -tests.ingest-storage-record.records-processed-percent int

--- a/pkg/continuoustest/ingest_storage_record.go
+++ b/pkg/continuoustest/ingest_storage_record.go
@@ -37,7 +37,7 @@ type IngestStorageRecordTestConfig struct {
 func (cfg *IngestStorageRecordTestConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.Enabled, "tests.ingest-storage-record.enabled", false, "Whether the test for ingest-storage record correctness is enabled.")
 	f.StringVar(&cfg.ConsumerGroup, "tests.ingest-storage-record.consumer-group", "ingest-storage-record", "The Kafka consumer group used for getting/setting commmitted offsets.")
-	f.IntVar(&cfg.MaxJumpLimitPerPartition, "tests.ingest-storage-record.max-jump-size", 100000000, "If a partition increases by this many offsets in a run, we skip processing it, to protect against downloading unexpectedly huge batches.")
+	f.IntVar(&cfg.MaxJumpLimitPerPartition, "tests.ingest-storage-record.max-jump-size", 500000000, "If a partition increases by this many offsets in a run, we skip processing it, to protect against downloading unexpectedly huge batches.")
 	f.IntVar(&cfg.MaxRecordsPerRun, "tests.ingest-storage-record.max-records-per-run", 200000, "Limit on the number of total records to be processed in a run, to keep memory bounded in large cells. This limit is approximate, we might go over by a partial fetch.")
 	f.IntVar(&cfg.RecordsProcessedPercent, "tests.ingest-storage-record.records-processed-percent", 5, "The approximate percent of records to actually fetch and compare.")
 }


### PR DESCRIPTION
#### What this PR does

This PR:
- Removes per-record statistics logs (anything per-record can generate spam) and replace them with metrics where appropriate.
- Tunes tuneables:
  - The limit at which to skip a partition on the current run and just jump to the end. This was simply too small for large cells and we jump too often.
  - Reduces `fetchMaxBytes` by 10x, to force more smaller fetches. Cells with a high partition count still grab a staggering number of records per fetch. Even with limits, this doesn't take advantage of parallelism very well.

#### Which issue(s) this PR fixes or relates to

contrib: https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
