### PR TITLE
index planning: fix config defaults and validation

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -10825,7 +10825,7 @@
               "required": false,
               "desc": "How frequently to collect head statistics, which are used in query execution optimization. 0 to disable.",
               "fieldValue": null,
-              "fieldDefaultValue": 0,
+              "fieldDefaultValue": 3600000000000,
               "fieldFlag": "blocks-storage.tsdb.head-statistics-collection-frequency",
               "fieldType": "duration",
               "fieldCategory": "experimental"

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -808,7 +808,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.tsdb.head-postings-for-matchers-cache-versions int
     	[experimental] The size of the metric versions cache in each ingester when invalidation is enabled. (default 2097152)
   -blocks-storage.tsdb.head-statistics-collection-frequency duration
-    	[experimental] How frequently to collect head statistics, which are used in query execution optimization. 0 to disable.
+    	[experimental] How frequently to collect head statistics, which are used in query execution optimization. 0 to disable. (default 1h0m0s)
   -blocks-storage.tsdb.index-lookup-planning-comparison-portion float
     	[experimental] Portion of queries where a mirrored chunk querier compares results with and without index lookup planning. Value between 0 (disabled) and 1 (all queries).
   -blocks-storage.tsdb.index-lookup-planning-enabled

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -5994,7 +5994,7 @@ tsdb:
   # (experimental) How frequently to collect head statistics, which are used in
   # query execution optimization. 0 to disable.
   # CLI flag: -blocks-storage.tsdb.head-statistics-collection-frequency
-  [head_statistics_collection_frequency: <duration> | default = 0s]
+  [head_statistics_collection_frequency: <duration> | default = 1h]
 
   # (advanced) Max size - in bytes - of the in-memory series hash cache. The
   # cache is shared across all tenants and it's used only when query sharding is

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -357,7 +357,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.TimelyHeadCompaction, "blocks-storage.tsdb.timely-head-compaction-enabled", false, "Allows head compaction to happen when the min block range can no longer be appended, without requiring 1.5x the chunk range worth of data in the head.")
 	f.BoolVar(&cfg.BiggerOutOfOrderBlocksForOldSamples, "blocks-storage.tsdb.bigger-out-of-order-blocks-for-old-samples", false, "When enabled, ingester produces 24h blocks for out-of-order data that is before the current day, instead of the usual 2h blocks.")
 	f.BoolVar(&cfg.IndexLookupPlanningEnabled, "blocks-storage.tsdb.index-lookup-planning-enabled", false, "Controls the collection of statistics and whether to defer some vector selector matchers to sequential scans. This leads to better performance.")
-	f.DurationVar(&cfg.HeadStatisticsCollectionFrequency, "blocks-storage.tsdb.head-statistics-collection-frequency", 0, "How frequently to collect head statistics, which are used in query execution optimization. 0 to disable.")
+	f.DurationVar(&cfg.HeadStatisticsCollectionFrequency, "blocks-storage.tsdb.head-statistics-collection-frequency", time.Hour, "How frequently to collect head statistics, which are used in query execution optimization. 0 to disable.")
 	f.Float64Var(&cfg.IndexLookupPlanningComparisonPortion, "blocks-storage.tsdb.index-lookup-planning-comparison-portion", 0.0, "Portion of queries where a mirrored chunk querier compares results with and without index lookup planning. Value between 0 (disabled) and 1 (all queries).")
 
 	cfg.HeadCompactionIntervalJitterEnabled = true
@@ -406,7 +406,7 @@ func (cfg *TSDBConfig) Validate(activeSeriesCfg activeseries.Config) error {
 		return errInvalidEarlyHeadCompactionMinSeriesReduction
 	}
 
-	if cfg.HeadStatisticsCollectionFrequency < 0 {
+	if cfg.IndexLookupPlanningEnabled && cfg.HeadStatisticsCollectionFrequency <= 0 {
 		return errors.Errorf("head statistics collection frequency must be a non-negative duration. 0 to disable")
 	}
 


### PR DESCRIPTION
I found this while working on https://github.com/grafana/mimir/pull/12752