### PR TITLE
Temporarily disable remote execution integration test

### DIFF
--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -249,6 +249,7 @@ func TestQueryFrontendWithIngestStorageViaFlagsAndQueryStatsEnabled(t *testing.T
 	})
 
 	t.Run("with remote execution enabled", func(t *testing.T) {
+		t.Skip() // TODO: This breaks in GEM, but only tests a new experimental flag. Fix me in GEM and re-enable me!
 		runScenario(t, true)
 	})
 }


### PR DESCRIPTION
#### What this PR does

This PR temporarily disables an integration test introduced in https://github.com/grafana/mimir/pull/12745 that is failing in GEM, similar to #12699.

#### Which issue(s) this PR fixes or relates to

#12745

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
