### PR TITLE
Re-enable disabled integration tests

### DIFF
--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -198,7 +198,6 @@ func TestQueryFrontendWithQueryResultPayloadFormats(t *testing.T) {
 }
 
 func TestQueryFrontendWithRemoteExecution(t *testing.T) {
-	t.Skip() // TODO: This breaks in GEM, but only tests a new expermental flag. Fix me in GEM and re-enable me!
 	for _, queryStatsEnabled := range []bool{true, false} {
 		t.Run(fmt.Sprintf("query stats enabled: %v", queryStatsEnabled), func(t *testing.T) {
 			runQueryFrontendTest(t, queryFrontendTestConfig{
@@ -249,7 +248,6 @@ func TestQueryFrontendWithIngestStorageViaFlagsAndQueryStatsEnabled(t *testing.T
 	})
 
 	t.Run("with remote execution enabled", func(t *testing.T) {
-		t.Skip() // TODO: This breaks in GEM, but only tests a new experimental flag. Fix me in GEM and re-enable me!
 		runScenario(t, true)
 	})
 }
@@ -544,7 +542,6 @@ func TestQueryFrontendErrorMessageParity(t *testing.T) {
 	})
 
 	t.Run("with remote execution enabled", func(t *testing.T) {
-		t.Skip() // TODO: This breaks in GEM, but only tests a new expermental flag. Fix me in GEM and re-enable me!
 		testQueryFrontendErrorMessageParityScenario(t, true, map[string]string{
 			"-query-frontend.enable-remote-execution": "true",
 		})


### PR DESCRIPTION
#### What this PR does

This PR re-enables the integration tests disabled in https://github.com/grafana/mimir/pull/12699 and https://github.com/grafana/mimir/pull/12756.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
