### PR TITLE
fix: parquet-converter block storage path check

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -424,6 +424,10 @@ func (c *Config) isUsageTrackerEnabled() bool {
 	return c.isAnyModuleExplicitlyTargeted(UsageTracker)
 }
 
+func (c *Config) isParquetConverterEnabled() bool {
+	return c.isAnyModuleExplicitlyTargeted(ParquetConverter)
+}
+
 func (c *Config) validateBucketConfigs() error {
 	errs := multierror.New()
 
@@ -494,8 +498,7 @@ func (c *Config) validateFilesystemPaths(logger log.Logger) error {
 	var paths []pathConfig
 
 	// Blocks storage (check only for components using it).
-	// TODO(jesus.vazquez) Add parquet converter
-	if (c.isIngesterEnabled() || c.isQuerierEnabled() || c.isStoreGatewayEnabled() || c.isCompactorEnabled() || c.isRulerEnabled()) && c.BlocksStorage.Bucket.Backend == bucket.Filesystem {
+	if (c.isIngesterEnabled() || c.isQuerierEnabled() || c.isStoreGatewayEnabled() || c.isCompactorEnabled() || c.isRulerEnabled() || c.isParquetConverterEnabled()) && c.BlocksStorage.Bucket.Backend == bucket.Filesystem {
 		// Add the optional prefix to the path, because that's the actual location where blocks will be stored.
 		paths = append(paths, pathConfig{
 			name:       "blocks storage filesystem directory",


### PR DESCRIPTION
During yesterday's rebase I noticed i left something to be done at the end due to the code changes and then forgot doing it. Hopefully this addresses it.

Previously the code looked like this https://github.com/grafana/mimir/blob/98de3421672b5807dae88d7ba5c8a869a666d4cf/pkg/mimir/mimir.go#L432-L440

But after rebasing I noticed that some of these bits got refactored. The diff in this PR should accommodate those.

cc @npazosmendez @seizethedave @francoposa 