### PR TITLE
Fix bug with pruning toggles not working in query planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
 * [BUGFIX] Ruler: Fix ruler remotequerier request body consumption on retries. #12514
 * [BUGFIX] Block-builder: Fix a bug where a consumption error can cause a job to stay assigned to a worker for the remainder of its lifetime. #12522
 * [BUGFIX] Querier: Fix possible panic when evaluating a nested subquery where the parent has no steps. #12524
-* [BUGFIX] Querier: Fix bug with pruning toggles AST optimization pass not working in query planner. #12783
+* [BUGFIX] Querier: Fix bug where the pruning toggles AST optimization pass doesn't work in the query planner. #12783
 * [BUGFIX] Ingester: Fix a bug where prepare-instance-ring-downscale endpoint would return an error while compacting and not read-only. #12548
 * [BUGFIX] Block-builder: Fix a bug where lease renewals would cease during graceful shutdown, leading to an elevated rate of job reassignments. #12643
 * [BUGFIX] OTLP: Return HTTP OK for partially rejected requests, e.g. due to OOO exemplars. #12579

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * [BUGFIX] Ruler: Fix ruler remotequerier request body consumption on retries. #12514
 * [BUGFIX] Block-builder: Fix a bug where a consumption error can cause a job to stay assigned to a worker for the remainder of its lifetime. #12522
 * [BUGFIX] Querier: Fix possible panic when evaluating a nested subquery where the parent has no steps. #12524
+* [BUGFIX] Querier: Fix bug with pruning toggles AST optimization pass not working in query planner. #12783
 * [BUGFIX] Ingester: Fix a bug where prepare-instance-ring-downscale endpoint would return an error while compacting and not read-only. #12548
 * [BUGFIX] Block-builder: Fix a bug where lease renewals would cease during graceful shutdown, leading to an elevated rate of job reassignments. #12643
 * [BUGFIX] OTLP: Return HTTP OK for partially rejected requests, e.g. due to OOO exemplars. #12579

--- a/pkg/streamingpromql/optimize/ast/propagate_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/propagate_matchers.go
@@ -120,8 +120,9 @@ func (mapper *propagateMatchers) extractVectorSelectors(expr parser.Expr) ([]*en
 		return mapper.propagateMatchersInBinaryExpr(e)
 	// Explicitly define what is not handled to avoid confusion.
 	case *parser.StepInvariantExpr:
-		// Used only for optimizations and not produced directly by parser.
-		return nil, nil
+		// Used only for optimizations and not produced directly by parser,
+		// but may be added in preprocessing step.
+		return mapper.extractVectorSelectors(e.Expr)
 	default:
 		return nil, nil
 	}

--- a/pkg/streamingpromql/optimize/ast/propagate_matchers_test.go
+++ b/pkg/streamingpromql/optimize/ast/propagate_matchers_test.go
@@ -68,6 +68,7 @@ var testCasesPropagateMatchers = map[string]string{
 	`rate(up{foo="bar"}[2m]) + delta(down{baz="fob"}[4m])`:                     `rate(up{foo="bar", baz="fob"}[2m]) + delta(down{foo="bar", baz="fob"}[4m])`,
 	`up * -down{foo="bar"}`:                                                    `up{foo="bar"} * -down{foo="bar"}`,
 	`up{foo="bar"} @ 1 + down @ 2`:                                             `up{foo="bar"} @ 1 + down{foo="bar"} @ 2`,
+	`up{foo="bar"} @ 1 + down`:                                                 `up{foo="bar"} @ 1 + down{foo="bar"}`,
 	`minute() * down{baz="fob"}`:                                               `minute() * down{baz="fob"}`,
 	`minute(up{foo="bar"}) * down{baz="fob"}`:                                  `minute(up{foo="bar", baz="fob"}) * down{foo="bar", baz="fob"}`,
 	`round(up{foo="bar"}) * down{baz="fob"}`:                                   `round(up{foo="bar", baz="fob"}) * down{foo="bar", baz="fob"}`,

--- a/pkg/streamingpromql/optimize/ast/propagate_matchers_test.go
+++ b/pkg/streamingpromql/optimize/ast/propagate_matchers_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 
@@ -138,6 +140,9 @@ func TestPropagateMatchers(t *testing.T) {
 
 			inputExpr, err := parser.ParseExpr(input)
 			require.NoError(t, err)
+			inputExpr, err = promql.PreprocessExpr(inputExpr, timestamp.Time(instantQueryTimeRange.StartT), timestamp.Time(instantQueryTimeRange.EndT), 0)
+			require.NoError(t, err)
+
 			optimizer := ast.NewPropagateMatchersMapper()
 			outputExpr, err := optimizer.Map(ctx, inputExpr)
 			require.NoError(t, err)

--- a/pkg/streamingpromql/optimize/ast/propagate_matchers_test.go
+++ b/pkg/streamingpromql/optimize/ast/propagate_matchers_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/prometheus/prometheus/model/timestamp"
-	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 
@@ -140,7 +138,7 @@ func TestPropagateMatchers(t *testing.T) {
 
 			inputExpr, err := parser.ParseExpr(input)
 			require.NoError(t, err)
-			inputExpr, err = promql.PreprocessExpr(inputExpr, timestamp.Time(instantQueryTimeRange.StartT), timestamp.Time(instantQueryTimeRange.EndT), 0)
+			inputExpr, err = preprocessQuery(t, inputExpr)
 			require.NoError(t, err)
 
 			optimizer := ast.NewPropagateMatchersMapper()

--- a/pkg/streamingpromql/optimize/ast/prune_toggles.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles.go
@@ -93,6 +93,8 @@ func (mapper *pruneToggles) MapExpr(ctx context.Context, expr parser.Expr) (mapp
 func (mapper *pruneToggles) isConst(expr parser.Expr) (isConst, isEmpty bool) {
 	var lhs, rhs parser.Expr
 	switch e := expr.(type) {
+	case *parser.StepInvariantExpr:
+		return mapper.isConst(e.Expr)
 	case *parser.ParenExpr:
 		return mapper.isConst(e.Expr)
 	case *parser.BinaryExpr:

--- a/pkg/streamingpromql/optimize/ast/prune_toggles.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles.go
@@ -133,6 +133,8 @@ func (mapper *pruneToggles) isVectorAndNumberEqual(lhs, rhs parser.Expr) (bool, 
 
 func (mapper *pruneToggles) isConstVector(expr parser.Expr) (isVector bool, value float64) {
 	switch e := expr.(type) {
+	case *parser.StepInvariantExpr:
+		return mapper.isConstVector(e.Expr)
 	case *parser.ParenExpr:
 		return mapper.isConstVector(e.Expr)
 	case *parser.Call:
@@ -150,6 +152,8 @@ func (mapper *pruneToggles) isConstVector(expr parser.Expr) (isVector bool, valu
 
 func (mapper *pruneToggles) isNumber(expr parser.Expr) (isNumber bool, value float64) {
 	switch e := expr.(type) {
+	case *parser.StepInvariantExpr:
+		return mapper.isNumber(e.Expr)
 	case *parser.ParenExpr:
 		return mapper.isNumber(e.Expr)
 	case *parser.NumberLiteral:

--- a/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/prometheus/prometheus/model/timestamp"
-	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 
@@ -66,7 +64,7 @@ func TestPruneToggles(t *testing.T) {
 			require.NoError(t, err)
 			inputExpr, err := parser.ParseExpr(input)
 			require.NoError(t, err)
-			inputExpr, err = promql.PreprocessExpr(inputExpr, timestamp.Time(instantQueryTimeRange.StartT), timestamp.Time(instantQueryTimeRange.EndT), 0)
+			inputExpr, err = preprocessQuery(t, inputExpr)
 			require.NoError(t, err)
 
 			reg := prometheus.NewPedanticRegistry()

--- a/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 
@@ -63,6 +65,8 @@ func TestPruneToggles(t *testing.T) {
 			expectedExpr, err := parser.ParseExpr(expected)
 			require.NoError(t, err)
 			inputExpr, err := parser.ParseExpr(input)
+			require.NoError(t, err)
+			inputExpr, err = promql.PreprocessExpr(inputExpr, timestamp.Time(instantQueryTimeRange.StartT), timestamp.Time(instantQueryTimeRange.EndT), 0)
 			require.NoError(t, err)
 
 			reg := prometheus.NewPedanticRegistry()

--- a/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation.go
+++ b/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation.go
@@ -90,6 +90,8 @@ func vectorSelectorContainsNonExactMetricNameMatcher(expr parser.Expr) bool {
 		return false
 	case *parser.MatrixSelector:
 		return vectorSelectorContainsNonExactMetricNameMatcher(e.VectorSelector)
+	case *parser.StepInvariantExpr:
+		return vectorSelectorContainsNonExactMetricNameMatcher(e.Expr)
 	case *parser.ParenExpr:
 		return vectorSelectorContainsNonExactMetricNameMatcher(e.Expr)
 	case *parser.UnaryExpr:

--- a/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation_test.go
+++ b/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation_test.go
@@ -37,6 +37,7 @@ var testCasesReorderHistogramAggregation = map[string]string{
 	"histogram_sum(rate(foo[2m]))":              "histogram_sum(rate(foo[2m]))",
 	`3 + (((histogram_sum(sum(foo)))))`:         `3 + (((sum(histogram_sum(foo)))))`,
 	`vector(3) + (((histogram_sum(sum(foo)))))`: `vector(3) + (((sum(histogram_sum(foo)))))`,
+	`histogram_sum(sum(foo @ 1234 * bar))`:      `sum(histogram_sum(foo @ 1234 * bar))`,
 
 	// Unsupported aggregations
 	`histogram_sum(max(foo))`:     `histogram_sum(max(foo))`,

--- a/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation_test.go
+++ b/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 
@@ -64,6 +66,9 @@ func TestReorderHistogramAggregation(t *testing.T) {
 
 			inputExpr, err := parser.ParseExpr(input)
 			require.NoError(t, err)
+			inputExpr, err = promql.PreprocessExpr(inputExpr, timestamp.Time(instantQueryTimeRange.StartT), timestamp.Time(instantQueryTimeRange.EndT), 0)
+			require.NoError(t, err)
+
 			optimizer := ast.NewReorderHistogramAggregationMapper()
 			outputExpr, err := optimizer.Map(ctx, inputExpr)
 			require.NoError(t, err)

--- a/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation_test.go
+++ b/pkg/streamingpromql/optimize/ast/reorder_histogram_aggregation_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/prometheus/prometheus/model/timestamp"
-	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 
@@ -66,7 +64,7 @@ func TestReorderHistogramAggregation(t *testing.T) {
 
 			inputExpr, err := parser.ParseExpr(input)
 			require.NoError(t, err)
-			inputExpr, err = promql.PreprocessExpr(inputExpr, timestamp.Time(instantQueryTimeRange.StartT), timestamp.Time(instantQueryTimeRange.EndT), 0)
+			inputExpr, err = preprocessQuery(t, inputExpr)
 			require.NoError(t, err)
 
 			optimizer := ast.NewReorderHistogramAggregationMapper()

--- a/pkg/streamingpromql/optimize/ast/util_test.go
+++ b/pkg/streamingpromql/optimize/ast/util_test.go
@@ -17,7 +17,10 @@ import (
 
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
+
+var instantQueryTimeRange = types.NewInstantQueryTimeRange(timestamp.Time(1000))
 
 func testASTOptimizationPassWithData(t *testing.T, loadTemplate string, testCases map[string]string) {
 	numSamples := 100

--- a/pkg/streamingpromql/optimize/ast/util_test.go
+++ b/pkg/streamingpromql/optimize/ast/util_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/stretchr/testify/require"
 
@@ -20,7 +21,11 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
-var instantQueryTimeRange = types.NewInstantQueryTimeRange(timestamp.Time(1000))
+var dummyTimeRange = types.NewInstantQueryTimeRange(timestamp.Time(1000))
+
+func preprocessQuery(t *testing.T, expr parser.Expr) (parser.Expr, error) {
+	return promql.PreprocessExpr(expr, timestamp.Time(dummyTimeRange.StartT), timestamp.Time(dummyTimeRange.EndT), 0)
+}
 
 func testASTOptimizationPassWithData(t *testing.T, loadTemplate string, testCases map[string]string) {
 	numSamples := 100

--- a/pkg/streamingpromql/optimize/ast/util_test.go
+++ b/pkg/streamingpromql/optimize/ast/util_test.go
@@ -21,9 +21,8 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
-var dummyTimeRange = types.NewInstantQueryTimeRange(timestamp.Time(1000))
-
 func preprocessQuery(t *testing.T, expr parser.Expr) (parser.Expr, error) {
+	dummyTimeRange := types.NewInstantQueryTimeRange(timestamp.Time(1000))
 	return promql.PreprocessExpr(expr, timestamp.Time(dummyTimeRange.StartT), timestamp.Time(dummyTimeRange.EndT), 0)
 }
 


### PR DESCRIPTION
#### What this PR does

Pruning query toggles was broken with https://github.com/grafana/mimir/pull/12303 when it moved to AST optimization passes, as the query planner preprocess step wraps some parts of the expression in StepInvariantExpressions which we did not account for in the code and unit tests working on it in isolation instead of as part of the query plan.

This fixes that bug and adds preprocessing to the unit tests for some AST optimization passes. Will do testing with more of the query plan in another [PR](https://github.com/grafana/mimir/pull/12784) as that requires bigger changes to the planning code.

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/grafana/mimir/pull/12303

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
