### PR TITLE
distributor: Replace pooling with arenas when GOEXPERIMENT=arenas

### DIFF
--- a/pkg/distributor/influx_test.go
+++ b/pkg/distributor/influx_test.go
@@ -51,7 +51,7 @@ func TestInfluxHandleSeriesPush(t *testing.T) {
 			push: func(t *testing.T) PushFunc {
 				return func(_ context.Context, pushReq *Request) error {
 					req, err := pushReq.WriteRequest()
-					assert.Equal(t, defaultExpectedWriteRequest, req)
+					assert.Equal(t, defaultExpectedWriteRequest.Timeseries, req.Timeseries)
 					assert.Nil(t, err)
 					return err
 				}
@@ -66,7 +66,7 @@ func TestInfluxHandleSeriesPush(t *testing.T) {
 			push: func(t *testing.T) PushFunc {
 				return func(_ context.Context, pushReq *Request) error {
 					req, err := pushReq.WriteRequest()
-					assert.Equal(t, defaultExpectedWriteRequest, req)
+					assert.Equal(t, defaultExpectedWriteRequest.Timeseries, req.Timeseries)
 					assert.Nil(t, err)
 					return err
 				}

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -42,7 +42,6 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/grafana/mimir/pkg/distributor/otlpappender"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/mimirpb/testutil"
 	util_log "github.com/grafana/mimir/pkg/util/log"
@@ -616,7 +615,7 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 					tc.appendCustomMetric(metrics)
 				}
 			}
-			converter := newOTLPMimirConverter(otlpappender.NewCombinedAppender())
+			converter := newOTLPMimirConverter(nil)
 			mimirTS, _, dropped, err := otelMetricsToSeriesAndMetadata(
 				context.Background(),
 				converter,
@@ -692,7 +691,7 @@ func TestConvertOTelHistograms(t *testing.T) {
 	}
 
 	for _, convertHistogramsToNHCB := range []bool{false, true} {
-		converter := newOTLPMimirConverter(otlpappender.NewCombinedAppender())
+		converter := newOTLPMimirConverter(nil)
 		mimirTS, _, dropped, err := otelMetricsToSeriesAndMetadata(
 			context.Background(),
 			converter,
@@ -903,7 +902,7 @@ func TestOTelDeltaIngestion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			converter := newOTLPMimirConverter(otlpappender.NewCombinedAppender())
+			converter := newOTLPMimirConverter(nil)
 			mimirTS, _, dropped, err := otelMetricsToSeriesAndMetadata(
 				context.Background(),
 				converter,
@@ -993,7 +992,7 @@ func TestOTelCTZeroIngestion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			converter := newOTLPMimirConverter(otlpappender.NewCombinedAppender())
+			converter := newOTLPMimirConverter(nil)
 			mimirTS, _, dropped, err := otelMetricsToSeriesAndMetadata(
 				context.Background(),
 				converter,

--- a/pkg/distributor/otlpappender/mimir_appender_test.go
+++ b/pkg/distributor/otlpappender/mimir_appender_test.go
@@ -557,7 +557,7 @@ func TestMimirAppender(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			for _, enableCreatedTimestampZeroIngestion := range []bool{false, true} {
 				t.Run(fmt.Sprintf("enableCreatedTimestampZeroIngestion=%v", enableCreatedTimestampZeroIngestion), func(t *testing.T) {
-					appender := NewCombinedAppender()
+					appender := NewCombinedAppender(nil)
 					appender.EnableCreatedTimestampZeroIngestion = enableCreatedTimestampZeroIngestion
 					appender.ValidIntervalCreatedTimestampZeroIngestion = tc.validIntervalCreatedTimestampZeroIngestion
 					tc.appends(t, appender)

--- a/pkg/distributor/validate_test.go
+++ b/pkg/distributor/validate_test.go
@@ -1053,7 +1053,7 @@ func TestValidateLabel_UseAfterRelease(t *testing.T) {
 
 	// Unmarshal into a reusable PreallocTimeseries.
 	var ts mimirpb.PreallocTimeseries
-	err = ts.Unmarshal(buf, nil, nil, false)
+	err = ts.Unmarshal(nil, buf, nil, nil, false)
 	require.NoError(t, err)
 
 	// Call validateLabels to get a LabelValueTooLongError.

--- a/pkg/mimirpb/custom_arenas.go
+++ b/pkg/mimirpb/custom_arenas.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build goexperiment.arenas
+
+package mimirpb
+
+import (
+	"github.com/grafana/mimir/pkg/util/arena"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc/mem"
+)
+
+// unmarshalSlicePool returns a BufferPool that allocates buffers in an arena.
+// Once all allocated buffers are put back in the pool, the arena is freed.
+func unmarshalSlicePool(a *arena.Arena) mem.BufferPool {
+	return &arenaBufferPool{arena: a}
+}
+
+type arenaBufferPool struct {
+	arena    *arena.Arena
+	bufCount atomic.Int64
+}
+
+// Get implements mem.BufferPool.
+func (a *arenaBufferPool) Get(length int) *[]byte {
+	a.bufCount.Add(1)
+	buf := arena.MakeSlice[byte](a.arena, length, length)
+	return &buf
+}
+
+// Put implements mem.BufferPool.
+func (a *arenaBufferPool) Put(*[]byte) {
+	count := a.bufCount.Sub(1)
+	switch {
+	case count == 0:
+		a.arena.Free()
+	case count < 0:
+		panic("arenaBufferPool buffer count below zero")
+	}
+}
+
+var _ mem.BufferPool = (*arenaBufferPool)(nil)

--- a/pkg/mimirpb/custom_pools.go
+++ b/pkg/mimirpb/custom_pools.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !goexperiment.arenas
+
+package mimirpb
+
+import (
+	"github.com/grafana/mimir/pkg/util/arena"
+	"google.golang.org/grpc/mem"
+)
+
+// mem.DefaultBufferPool() only has five sizes: 256 B, 4 KB, 16 KB, 32 KB and 1 MB.
+// This means that for messages between 32 KB and 1 MB, we may over-allocate by up to 992 KB,
+// or ~97%. If we have a lot of messages in this range, we can waste a lot of memory.
+// So instead, we create our own buffer pool with more sizes to reduce this wasted space, and
+// also include pools for larger sizes up to 256 MB.
+var pool = mem.NewTieredBufferPool(unmarshalSlicePoolSizes()...)
+
+func unmarshalSlicePool(*arena.Arena) mem.BufferPool {
+	return pool
+}
+
+func unmarshalSlicePoolSizes() []int {
+	var sizes []int
+
+	for s := 256; s <= 256<<20; s <<= 1 {
+		sizes = append(sizes, s)
+	}
+
+	return sizes
+}

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -288,6 +288,7 @@ func (MetadataRW2_MetricType) EnumDescriptor() ([]byte, []int) {
 }
 
 type WriteRequest struct {
+	ArenaHolder
 	// Keep reference to buffer for unsafe references.
 	BufferHolder
 	// sourceBufferHolders is populated when the WriteRequest is synthesized
@@ -7457,7 +7458,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 			}
 			m.Timeseries = append(m.Timeseries, PreallocTimeseries{})
 			m.Timeseries[len(m.Timeseries)-1].skipUnmarshalingExemplars = m.skipUnmarshalingExemplars
-			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(dAtA[iNdEx:postIndex], nil, nil, m.skipNormalizeMetadataMetricName); err != nil {
+			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(m.arena, dAtA[iNdEx:postIndex], nil, nil, m.skipNormalizeMetadataMetricName); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -7593,7 +7594,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 			if metadata == nil {
 				metadata = metadataSetFromSettings(m.skipDeduplicateMetadata)
 			}
-			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(dAtA[iNdEx:postIndex], &m.rw2symbols, metadata, m.skipNormalizeMetadataMetricName); err != nil {
+			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(m.arena, dAtA[iNdEx:postIndex], &m.rw2symbols, metadata, m.skipNormalizeMetadataMetricName); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/mimirpb/mimir.pb.go.expdiff
+++ b/pkg/mimirpb/mimir.pb.go.expdiff
@@ -1,5 +1,5 @@
 diff --git a/pkg/mimirpb/mimir.pb.go b/pkg/mimirpb/mimir.pb.go
-index 986c4e1867..dda8609298 100644
+index f5f9338fc1..dda8609298 100644
 --- a/pkg/mimirpb/mimir.pb.go
 +++ b/pkg/mimirpb/mimir.pb.go
 @@ -14,7 +14,6 @@ import (
@@ -10,10 +10,11 @@ index 986c4e1867..dda8609298 100644
  	strconv "strconv"
  	strings "strings"
  )
-@@ -288,14 +287,6 @@ func (MetadataRW2_MetricType) EnumDescriptor() ([]byte, []int) {
+@@ -288,15 +287,6 @@ func (MetadataRW2_MetricType) EnumDescriptor() ([]byte, []int) {
  }
  
  type WriteRequest struct {
+-	ArenaHolder
 -	// Keep reference to buffer for unsafe references.
 -	BufferHolder
 -	// sourceBufferHolders is populated when the WriteRequest is synthesized
@@ -25,7 +26,7 @@ index 986c4e1867..dda8609298 100644
  	Timeseries []PreallocTimeseries    `protobuf:"bytes,1,rep,name=timeseries,proto3,customtype=PreallocTimeseries" json:"timeseries"`
  	Source     WriteRequest_SourceEnum `protobuf:"varint,2,opt,name=Source,proto3,enum=cortexpb.WriteRequest_SourceEnum" json:"Source,omitempty"`
  	Metadata   []*MetricMetadata       `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty"`
-@@ -307,16 +298,6 @@ type WriteRequest struct {
+@@ -308,16 +298,6 @@ type WriteRequest struct {
  	SkipLabelValidation bool `protobuf:"varint,1000,opt,name=skip_label_validation,json=skipLabelValidation,proto3" json:"skip_label_validation,omitempty"`
  	// Skip label count validation.
  	SkipLabelCountValidation bool `protobuf:"varint,1001,opt,name=skip_label_count_validation,json=skipLabelCountValidation,proto3" json:"skip_label_count_validation,omitempty"`
@@ -42,7 +43,7 @@ index 986c4e1867..dda8609298 100644
  }
  
  func (m *WriteRequest) Reset()      { *m = WriteRequest{} }
-@@ -479,11 +460,6 @@ func (m *ErrorDetails) GetSoft() bool {
+@@ -480,11 +460,6 @@ func (m *ErrorDetails) GetSoft() bool {
  	return false
  }
  
@@ -54,7 +55,7 @@ index 986c4e1867..dda8609298 100644
  type TimeSeries struct {
  	Labels []UnsafeMutableLabel `protobuf:"bytes,1,rep,name=labels,proto3,customtype=UnsafeMutableLabel" json:"labels"`
  	// Sorted by time, oldest sample first.
-@@ -496,9 +472,6 @@ type TimeSeries struct {
+@@ -497,9 +472,6 @@ type TimeSeries struct {
  	// Zero value means value not set. If you need to use exactly zero value for
  	// the timestamp, use 1 millisecond before or after.
  	CreatedTimestamp int64 `protobuf:"varint,6,opt,name=created_timestamp,json=createdTimestamp,proto3" json:"created_timestamp,omitempty"`
@@ -64,7 +65,7 @@ index 986c4e1867..dda8609298 100644
  }
  
  func (m *TimeSeries) Reset()      { *m = TimeSeries{} }
-@@ -5968,25 +5941,19 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+@@ -5969,25 +5941,19 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
  		}
  	}
  	if len(m.LabelsRefs) > 0 {
@@ -95,7 +96,7 @@ index 986c4e1867..dda8609298 100644
  		i = encodeVarintMimir(dAtA, i, uint64(j21))
  		i--
  		dAtA[i] = 0xa
-@@ -6026,25 +5993,19 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+@@ -6027,25 +5993,19 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
  		dAtA[i] = 0x11
  	}
  	if len(m.LabelsRefs) > 0 {
@@ -126,7 +127,7 @@ index 986c4e1867..dda8609298 100644
  		i = encodeVarintMimir(dAtA, i, uint64(j23))
  		i--
  		dAtA[i] = 0xa
-@@ -7392,9 +7353,6 @@ func valueToStringMimir(v interface{}) string {
+@@ -7393,9 +7353,6 @@ func valueToStringMimir(v interface{}) string {
  	return fmt.Sprintf("*%v", pv)
  }
  func (m *WriteRequest) Unmarshal(dAtA []byte) error {
@@ -136,7 +137,7 @@ index 986c4e1867..dda8609298 100644
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -7424,9 +7382,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7425,9 +7382,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  		}
  		switch fieldNum {
  		case 1:
@@ -146,17 +147,17 @@ index 986c4e1867..dda8609298 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Timeseries", wireType)
  			}
-@@ -7456,8 +7411,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7457,8 +7411,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  				return io.ErrUnexpectedEOF
  			}
  			m.Timeseries = append(m.Timeseries, PreallocTimeseries{})
 -			m.Timeseries[len(m.Timeseries)-1].skipUnmarshalingExemplars = m.skipUnmarshalingExemplars
--			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(dAtA[iNdEx:postIndex], nil, nil, m.skipNormalizeMetadataMetricName); err != nil {
+-			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(m.arena, dAtA[iNdEx:postIndex], nil, nil, m.skipNormalizeMetadataMetricName); err != nil {
 +			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
  				return err
  			}
  			iNdEx = postIndex
-@@ -7481,9 +7435,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7482,9 +7435,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  				}
  			}
  		case 3:
@@ -166,7 +167,7 @@ index 986c4e1867..dda8609298 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
  			}
-@@ -7518,9 +7469,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7519,9 +7469,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  			}
  			iNdEx = postIndex
  		case 4:
@@ -176,7 +177,7 @@ index 986c4e1867..dda8609298 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field SymbolsRW2", wireType)
  			}
-@@ -7550,16 +7498,9 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7551,16 +7498,9 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -194,7 +195,7 @@ index 986c4e1867..dda8609298 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field TimeseriesRW2", wireType)
  			}
-@@ -7588,12 +7529,8 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7589,12 +7529,8 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -203,13 +204,13 @@ index 986c4e1867..dda8609298 100644
 -			if metadata == nil {
 -				metadata = metadataSetFromSettings(m.skipDeduplicateMetadata)
 -			}
--			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(dAtA[iNdEx:postIndex], &m.rw2symbols, metadata, m.skipNormalizeMetadataMetricName); err != nil {
+-			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(m.arena, dAtA[iNdEx:postIndex], &m.rw2symbols, metadata, m.skipNormalizeMetadataMetricName); err != nil {
 +			m.TimeseriesRW2 = append(m.TimeseriesRW2, TimeSeriesRW2{})
 +			if err := m.TimeseriesRW2[len(m.TimeseriesRW2)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
  				return err
  			}
  			iNdEx = postIndex
-@@ -7656,12 +7593,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7657,12 +7593,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  	if iNdEx > l {
  		return io.ErrUnexpectedEOF
  	}
@@ -222,7 +223,7 @@ index 986c4e1867..dda8609298 100644
  	return nil
  }
  func (m *WriteResponse) Unmarshal(dAtA []byte) error {
-@@ -7929,11 +7860,9 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
+@@ -7930,11 +7860,9 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -237,7 +238,7 @@ index 986c4e1867..dda8609298 100644
  			}
  			iNdEx = postIndex
  		case 4:
-@@ -11242,10 +11171,6 @@ func (m *WriteRequestRW2) Unmarshal(dAtA []byte) error {
+@@ -11243,10 +11171,6 @@ func (m *WriteRequestRW2) Unmarshal(dAtA []byte) error {
  	return nil
  }
  func (m *TimeSeriesRW2) Unmarshal(dAtA []byte) error {
@@ -248,7 +249,7 @@ index 986c4e1867..dda8609298 100644
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -11276,7 +11201,22 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11277,7 +11201,22 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  		switch fieldNum {
  		case 1:
  			if wireType == 0 {
@@ -272,7 +273,7 @@ index 986c4e1867..dda8609298 100644
  			} else if wireType == 2 {
  				var packedLen int
  				for shift := uint(0); ; shift += 7 {
-@@ -11311,14 +11251,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11312,14 +11251,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  					}
  				}
  				elementCount = count
@@ -289,7 +290,7 @@ index 986c4e1867..dda8609298 100644
  				for iNdEx < postIndex {
  					var v uint32
  					for shift := uint(0); ; shift += 7 {
-@@ -11335,27 +11270,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11336,27 +11270,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  							break
  						}
  					}
@@ -318,7 +319,7 @@ index 986c4e1867..dda8609298 100644
  				}
  			} else {
  				return fmt.Errorf("proto: wrong wireType = %d for field LabelsRefs", wireType)
-@@ -11457,11 +11372,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11458,11 +11372,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -333,7 +334,7 @@ index 986c4e1867..dda8609298 100644
  			}
  			iNdEx = postIndex
  		case 5:
-@@ -11493,7 +11406,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11494,7 +11406,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -342,7 +343,7 @@ index 986c4e1867..dda8609298 100644
  				return err
  			}
  			iNdEx = postIndex
-@@ -11538,10 +11451,6 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11539,10 +11451,6 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  	return nil
  }
  func (m *ExemplarRW2) Unmarshal(dAtA []byte) error {
@@ -353,7 +354,7 @@ index 986c4e1867..dda8609298 100644
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -11572,7 +11481,22 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11573,7 +11481,22 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  		switch fieldNum {
  		case 1:
  			if wireType == 0 {
@@ -377,7 +378,7 @@ index 986c4e1867..dda8609298 100644
  			} else if wireType == 2 {
  				var packedLen int
  				for shift := uint(0); ; shift += 7 {
-@@ -11607,13 +11531,9 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11608,13 +11531,9 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  					}
  				}
  				elementCount = count
@@ -393,7 +394,7 @@ index 986c4e1867..dda8609298 100644
  				for iNdEx < postIndex {
  					var v uint32
  					for shift := uint(0); ; shift += 7 {
-@@ -11630,20 +11550,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11631,20 +11550,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  							break
  						}
  					}
@@ -415,7 +416,7 @@ index 986c4e1867..dda8609298 100644
  				}
  			} else {
  				return fmt.Errorf("proto: wrong wireType = %d for field LabelsRefs", wireType)
-@@ -11663,7 +11570,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11664,7 +11570,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  			if wireType != 0 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
  			}
@@ -424,7 +425,7 @@ index 986c4e1867..dda8609298 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11673,7 +11580,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11674,7 +11580,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -433,7 +434,7 @@ index 986c4e1867..dda8609298 100644
  				if b < 0x80 {
  					break
  				}
-@@ -11700,16 +11607,6 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11701,16 +11607,6 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  	return nil
  }
  func (m *MetadataRW2) Unmarshal(dAtA []byte) error {
@@ -450,7 +451,7 @@ index 986c4e1867..dda8609298 100644
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -11742,7 +11639,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11743,7 +11639,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  			if wireType != 0 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
  			}
@@ -459,7 +460,7 @@ index 986c4e1867..dda8609298 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11752,7 +11649,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11753,7 +11649,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -468,7 +469,7 @@ index 986c4e1867..dda8609298 100644
  				if b < 0x80 {
  					break
  				}
-@@ -11761,7 +11658,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11762,7 +11658,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  			if wireType != 0 {
  				return fmt.Errorf("proto: wrong wireType = %d for field HelpRef", wireType)
  			}
@@ -477,7 +478,7 @@ index 986c4e1867..dda8609298 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11771,20 +11668,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11772,20 +11668,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -500,7 +501,7 @@ index 986c4e1867..dda8609298 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11794,15 +11687,11 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11795,15 +11687,11 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -517,7 +518,7 @@ index 986c4e1867..dda8609298 100644
  		default:
  			iNdEx = preIndex
  			skippy, err := skipMimir(dAtA[iNdEx:])
-@@ -11822,23 +11711,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11823,23 +11711,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  	if iNdEx > l {
  		return io.ErrUnexpectedEOF
  	}

--- a/pkg/mimirpb/prealloc_rw2_test.go
+++ b/pkg/mimirpb/prealloc_rw2_test.go
@@ -700,5 +700,6 @@ func TestWriteRequestRW2Conversion_WriteRequestHasChanged(t *testing.T) {
 		"rw2symbols",
 		"BufferHolder",
 		"sourceBufferHolders",
+		"arena",
 	}, fieldNames)
 }

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -450,6 +450,7 @@ func TestSplitWriteRequestByMaxMarshalSize_WriteRequestHasChanged(t *testing.T) 
 		"rw2symbols",
 		"BufferHolder",
 		"sourceBufferHolders",
+		"arena",
 	}, fieldNames)
 }
 

--- a/pkg/mimirpb/timeseries_arenas.go
+++ b/pkg/mimirpb/timeseries_arenas.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build goexperiment.arenas
+
+package mimirpb
+
+import (
+	"github.com/grafana/mimir/pkg/util/arena"
+)
+
+// AllocPreallocTimeseriesSlice allocates a slice of PreallocTimeseries using the provided arena.
+func AllocPreallocTimeseriesSlice(a *arena.Arena) []PreallocTimeseries {
+	return arena.MakeSlice[PreallocTimeseries](a, 0, minPreallocatedTimeseries)
+}
+
+// AllocTimeSeries allocates a pointer to a TimeSeries using the provided arena.
+func AllocTimeSeries(a *arena.Arena) *TimeSeries {
+	t := arena.New[TimeSeries](a)
+	t.Labels = arena.MakeSlice[LabelAdapter](a, 0, minPreallocatedLabels)
+	t.Samples = arena.MakeSlice[Sample](a, 0, minPreallocatedSamplesPerSeries)
+	t.Exemplars = arena.MakeSlice[Exemplar](a, 0, minPreallocatedExemplarsPerSeries)
+	return t
+}
+
+// allocYoloSlice allocates byte slices which are used to back the yoloStrings of this package.
+func allocYoloSlice(a *arena.Arena) *[]byte {
+	// The initial cap of 200 is an arbitrary number which has been chosen because the default
+	// of 0 is guaranteed to be insufficient, so any number greater than 0 would be better.
+	// 200 should be enough to back all the strings of one TimeSeries in many cases.
+	val := arena.MakeSlice[byte](a, 0, 200)
+	return &val
+}
+
+// ReuseSlice is a no-op in arena builds. Arena-allocated slices don't need explicit reuse.
+func ReuseSlice(ts []PreallocTimeseries) {
+	// No-op: arena-based allocation doesn't use pools
+}
+
+// ReuseSliceOnly is a no-op in arena builds. Arena-allocated slices don't need explicit reuse.
+func ReuseSliceOnly(ts []PreallocTimeseries) {
+	// No-op: arena-based allocation doesn't use pools
+}
+
+// ReuseTimeseries is a no-op in arena builds. Arena-allocated timeseries don't need explicit reuse.
+func ReuseTimeseries(ts *TimeSeries) {
+	// No-op: arena-based allocation doesn't use pools
+}
+
+// ReusePreallocTimeseries is a no-op in arena builds. Arena-allocated timeseries don't need explicit reuse.
+func ReusePreallocTimeseries(ts *PreallocTimeseries) {
+	// No-op: arena-based allocation doesn't use pools
+}
+
+// reuseYoloSlice is a no-op in arena builds. Arena-allocated slices don't need explicit reuse.
+func reuseYoloSlice(val *[]byte) {
+	// No-op: arena-based allocation doesn't use pools
+}
+
+// PreallocTimeseriesSliceFromPool is an alias for AllocPreallocTimeseriesSlice for backward compatibility.
+// In arena builds, this allocates using regular heap allocation instead of an arena.
+func PreallocTimeseriesSliceFromPool() []PreallocTimeseries {
+	return make([]PreallocTimeseries, 0, minPreallocatedTimeseries)
+}
+
+// TimeseriesFromPool is an alias for AllocTimeSeries for backward compatibility.
+// In arena builds, this allocates using regular heap allocation instead of an arena.
+func TimeseriesFromPool() *TimeSeries {
+	return &TimeSeries{
+		Labels:     make([]LabelAdapter, 0, minPreallocatedLabels),
+		Samples:    make([]Sample, 0, minPreallocatedSamplesPerSeries),
+		Exemplars:  make([]Exemplar, 0, minPreallocatedExemplarsPerSeries),
+		Histograms: nil,
+	}
+}
+
+// DeepCopyTimeseries copies the timeseries of one PreallocTimeseries into another one.
+// It copies all the properties, sub-properties and strings by value to ensure that the two timeseries are not sharing
+// anything after the deep copying.
+func DeepCopyTimeseries(a *arena.Arena, dst, src PreallocTimeseries, keepHistograms, keepExemplars bool) PreallocTimeseries {
+	srcTs := src.TimeSeries
+	dstTs := dst.TimeSeries
+
+	// Prepare a buffer which is large enough to hold all the label names and values of src.
+	requiredYoloSliceCap := countTotalLabelLen(srcTs, keepExemplars)
+	buf := arena.MakeSlice[byte](a, 0, requiredYoloSliceCap)
+	dst.yoloSlice = arena.New[[]byte](a)
+	*dst.yoloSlice = buf
+
+	// Copy the time series labels by using the prepared buffer.
+	dstTs.Labels, buf = copyToYoloLabels(buf, dstTs.Labels, srcTs.Labels)
+
+	// Copy the samples.
+	if cap(dstTs.Samples) < len(srcTs.Samples) {
+		dstTs.Samples = make([]Sample, len(srcTs.Samples))
+	} else {
+		dstTs.Samples = dstTs.Samples[:len(srcTs.Samples)]
+	}
+	copy(dstTs.Samples, srcTs.Samples)
+
+	// Copy the histograms.
+	if keepHistograms {
+		if cap(dstTs.Histograms) < len(srcTs.Histograms) {
+			dstTs.Histograms = make([]Histogram, len(srcTs.Histograms))
+		} else {
+			dstTs.Histograms = dstTs.Histograms[:len(srcTs.Histograms)]
+		}
+		for i := range srcTs.Histograms {
+			dstTs.Histograms[i] = copyHistogram(srcTs.Histograms[i])
+		}
+	} else {
+		dstTs.Histograms = nil
+	}
+
+	// Prepare the slice of exemplars.
+	if keepExemplars {
+		if cap(dstTs.Exemplars) < len(srcTs.Exemplars) {
+			dstTs.Exemplars = make([]Exemplar, len(srcTs.Exemplars))
+		} else {
+			dstTs.Exemplars = dstTs.Exemplars[:len(srcTs.Exemplars)]
+		}
+
+		for exemplarIdx := range srcTs.Exemplars {
+			// Copy the exemplar labels by using the prepared buffer.
+			dstTs.Exemplars[exemplarIdx].Labels, buf = copyToYoloLabels(buf, dstTs.Exemplars[exemplarIdx].Labels, srcTs.Exemplars[exemplarIdx].Labels)
+
+			// Copy the other exemplar properties.
+			dstTs.Exemplars[exemplarIdx].Value = srcTs.Exemplars[exemplarIdx].Value
+			dstTs.Exemplars[exemplarIdx].TimestampMs = srcTs.Exemplars[exemplarIdx].TimestampMs
+		}
+	} else {
+		dstTs.Exemplars = dstTs.Exemplars[:0]
+	}
+
+	return dst
+}

--- a/pkg/mimirpb/timeseries_pools.go
+++ b/pkg/mimirpb/timeseries_pools.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !goexperiment.arenas
+
+package mimirpb
+
+import (
+	"sync"
+
+	"github.com/grafana/mimir/pkg/util/arena"
+	"github.com/prometheus/prometheus/util/zeropool"
+)
+
+var (
+	preallocTimeseriesSlicePool = zeropool.New(func() []PreallocTimeseries {
+		return make([]PreallocTimeseries, 0, minPreallocatedTimeseries)
+	})
+
+	timeSeriesPool = sync.Pool{
+		New: func() interface{} {
+			return &TimeSeries{
+				Labels:     make([]LabelAdapter, 0, minPreallocatedLabels),
+				Samples:    make([]Sample, 0, minPreallocatedSamplesPerSeries),
+				Exemplars:  make([]Exemplar, 0, minPreallocatedExemplarsPerSeries),
+				Histograms: nil,
+			}
+		},
+	}
+
+	// yoloSlicePool is a pool of byte slices which are used to back the yoloStrings of this package.
+	yoloSlicePool = sync.Pool{
+		New: func() interface{} {
+			// The initial cap of 200 is an arbitrary number which has been chosen because the default
+			// of 0 is guaranteed to be insufficient, so any number greater than 0 would be better.
+			// 200 should be enough to back all the strings of one TimeSeries in many cases.
+			val := make([]byte, 0, 200)
+			return &val
+		},
+	}
+)
+
+// AllocPreallocTimeseriesSlice retrieves a slice of PreallocTimeseries from a sync.Pool.
+// The arena parameter is ignored in non-arena builds.
+// ReuseSlice should be called once done.
+func AllocPreallocTimeseriesSlice(a *arena.Arena) []PreallocTimeseries {
+	return preallocTimeseriesSlicePool.Get()
+}
+
+// AllocTimeSeries retrieves a pointer to a TimeSeries from a sync.Pool.
+// The arena parameter is ignored in non-arena builds.
+// ReuseTimeseries should be called once done, unless ReuseSlice was called on the slice that contains this TimeSeries.
+func AllocTimeSeries(a *arena.Arena) *TimeSeries {
+	ts := timeSeriesPool.Get().(*TimeSeries)
+
+	// Panic if the pool returns a TimeSeries that wasn't properly cleaned,
+	// which is indicative of a hard bug that we want to catch as soon as possible.
+	if len(ts.Labels) > 0 || len(ts.Samples) > 0 || len(ts.Histograms) > 0 || len(ts.Exemplars) > 0 || ts.CreatedTimestamp != 0 || ts.SkipUnmarshalingExemplars {
+		panic("pool returned dirty TimeSeries: this indicates a bug where ReuseTimeseries was called on a TimeSeries still in use")
+	}
+
+	return ts
+}
+
+// allocYoloSlice allocates byte slices which are used to back the yoloStrings of this package.
+// The arena parameter is ignored in non-arena builds.
+func allocYoloSlice(a *arena.Arena) *[]byte {
+	return yoloSlicePool.Get().(*[]byte)
+}
+
+// ReuseSlice puts the slice back into a sync.Pool for reuse.
+func ReuseSlice(ts []PreallocTimeseries) {
+	if cap(ts) == 0 {
+		return
+	}
+
+	for i := range ts {
+		ReusePreallocTimeseries(&ts[i])
+	}
+
+	ReuseSliceOnly(ts)
+}
+
+// ReuseSliceOnly reuses the slice of timeseries, but not its contents.
+// Only use this if you have another means of reusing the individual timeseries contained within.
+// Most times, you want to use ReuseSlice instead.
+func ReuseSliceOnly(ts []PreallocTimeseries) {
+	preallocTimeseriesSlicePool.Put(ts[:0])
+}
+
+// ReuseTimeseries puts the timeseries back into a sync.Pool for reuse.
+func ReuseTimeseries(ts *TimeSeries) {
+	// Name and Value may point into a large gRPC buffer, so clear the reference to allow GC
+	for i := 0; i < len(ts.Labels); i++ {
+		ts.Labels[i].Name = ""
+		ts.Labels[i].Value = ""
+	}
+
+	// Retain the slices only if their capacity is not bigger than the desired max pre-allocated size.
+	// This allows us to ensure we don't put very large slices back to the pool (e.g. a few requests with
+	// a huge number of samples may cause in-use heap memory to significantly increase, because the slices
+	// allocated by such poison requests would be reused by other requests with a normal number of samples).
+	if cap(ts.Labels) > maxPreallocatedLabels {
+		ts.Labels = nil
+	} else {
+		ts.Labels = ts.Labels[:0]
+	}
+
+	if cap(ts.Samples) > maxPreallocatedSamplesPerSeries {
+		ts.Samples = nil
+	} else {
+		ts.Samples = ts.Samples[:0]
+	}
+
+	if cap(ts.Histograms) > maxPreallocatedHistogramsPerSeries {
+		ts.Histograms = nil
+	} else {
+		ts.Histograms = ts.Histograms[:0]
+	}
+
+	ts.CreatedTimestamp = 0
+
+	ClearExemplars(ts)
+	timeSeriesPool.Put(ts)
+}
+
+// ReusePreallocTimeseries puts the timeseries and the yoloSlice back into their respective pools for re-use.
+func ReusePreallocTimeseries(ts *PreallocTimeseries) {
+	if ts.TimeSeries != nil {
+		ReuseTimeseries(ts.TimeSeries)
+	}
+
+	if ts.yoloSlice != nil {
+		reuseYoloSlice(ts.yoloSlice)
+		ts.yoloSlice = nil
+	}
+
+	ts.marshalledData = nil
+}
+
+func reuseYoloSlice(val *[]byte) {
+	*val = (*val)[:0]
+	yoloSlicePool.Put(val)
+}
+
+// PreallocTimeseriesSliceFromPool is an alias for AllocPreallocTimeseriesSlice for backward compatibility.
+func PreallocTimeseriesSliceFromPool() []PreallocTimeseries {
+	return AllocPreallocTimeseriesSlice(nil)
+}
+
+// TimeseriesFromPool is an alias for AllocTimeSeries for backward compatibility.
+func TimeseriesFromPool() *TimeSeries {
+	return AllocTimeSeries(nil)
+}
+
+// DeepCopyTimeseries copies the timeseries of one PreallocTimeseries into another one.
+// It copies all the properties, sub-properties and strings by value to ensure that the two timeseries are not sharing
+// anything after the deep copying.
+// The returned PreallocTimeseries has a yoloSlice property which should be returned to the yoloSlicePool on cleanup.
+func DeepCopyTimeseries(a *arena.Arena, dst, src PreallocTimeseries, keepHistograms, keepExemplars bool) PreallocTimeseries {
+	if dst.TimeSeries == nil {
+		dst.TimeSeries = AllocTimeSeries(a)
+	}
+
+	srcTs := src.TimeSeries
+	dstTs := dst.TimeSeries
+
+	// Prepare a buffer which is large enough to hold all the label names and values of src.
+	requiredYoloSliceCap := countTotalLabelLen(srcTs, keepExemplars)
+	dst.yoloSlice = allocYoloSlice(a)
+	buf := ensureCap(dst.yoloSlice, requiredYoloSliceCap)
+
+	// Copy the time series labels by using the prepared buffer.
+	dstTs.Labels, buf = copyToYoloLabels(buf, dstTs.Labels, srcTs.Labels)
+
+	// Copy the samples.
+	if cap(dstTs.Samples) < len(srcTs.Samples) {
+		dstTs.Samples = make([]Sample, len(srcTs.Samples))
+	} else {
+		dstTs.Samples = dstTs.Samples[:len(srcTs.Samples)]
+	}
+	copy(dstTs.Samples, srcTs.Samples)
+
+	// Copy the histograms.
+	if keepHistograms {
+		if cap(dstTs.Histograms) < len(srcTs.Histograms) {
+			dstTs.Histograms = make([]Histogram, len(srcTs.Histograms))
+		} else {
+			dstTs.Histograms = dstTs.Histograms[:len(srcTs.Histograms)]
+		}
+		for i := range srcTs.Histograms {
+			dstTs.Histograms[i] = copyHistogram(srcTs.Histograms[i])
+		}
+	} else {
+		dstTs.Histograms = nil
+	}
+
+	// Prepare the slice of exemplars.
+	if keepExemplars {
+		if cap(dstTs.Exemplars) < len(srcTs.Exemplars) {
+			dstTs.Exemplars = make([]Exemplar, len(srcTs.Exemplars))
+		} else {
+			dstTs.Exemplars = dstTs.Exemplars[:len(srcTs.Exemplars)]
+		}
+
+		for exemplarIdx := range srcTs.Exemplars {
+			// Copy the exemplar labels by using the prepared buffer.
+			dstTs.Exemplars[exemplarIdx].Labels, buf = copyToYoloLabels(buf, dstTs.Exemplars[exemplarIdx].Labels, srcTs.Exemplars[exemplarIdx].Labels)
+
+			// Copy the other exemplar properties.
+			dstTs.Exemplars[exemplarIdx].Value = srcTs.Exemplars[exemplarIdx].Value
+			dstTs.Exemplars[exemplarIdx].TimestampMs = srcTs.Exemplars[exemplarIdx].TimestampMs
+		}
+	} else {
+		dstTs.Exemplars = dstTs.Exemplars[:0]
+	}
+
+	return dst
+}

--- a/pkg/mimirpb/timeseries_pools_test.go
+++ b/pkg/mimirpb/timeseries_pools_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !goexperiment.arenas
+
+package mimirpb
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreallocTimeseriesSliceFromPool(t *testing.T) {
+	t.Run("new instance is provided when not available to reuse", func(t *testing.T) {
+		first := PreallocTimeseriesSliceFromPool()
+		second := PreallocTimeseriesSliceFromPool()
+
+		assert.NotSame(t, unsafe.SliceData(first), unsafe.SliceData(second))
+	})
+
+	t.Run("instance is cleaned before reusing", func(t *testing.T) {
+		slice := PreallocTimeseriesSliceFromPool()
+		slice = append(slice, PreallocTimeseries{TimeSeries: &TimeSeries{}})
+		ReuseSlice(slice)
+
+		reused := PreallocTimeseriesSliceFromPool()
+		assert.Len(t, reused, 0)
+	})
+}
+
+func TestTimeseriesFromPool(t *testing.T) {
+	t.Run("new instance is provided when not available to reuse", func(t *testing.T) {
+		first := TimeseriesFromPool()
+		second := TimeseriesFromPool()
+
+		assert.NotSame(t, first, second)
+	})
+
+	t.Run("instance is cleaned before reusing", func(t *testing.T) {
+		ts := TimeseriesFromPool()
+		ts.Labels = []LabelAdapter{{Name: "foo", Value: "bar"}}
+		ts.Samples = []Sample{{Value: 1, TimestampMs: 2}}
+		ReuseTimeseries(ts)
+
+		reused := TimeseriesFromPool()
+		assert.Len(t, reused.Labels, 0)
+		assert.Len(t, reused.Samples, 0)
+	})
+
+	// Test that TimeseriesFromPool panics when it receives a dirty object from the pool.
+	dirtyPoolTests := []struct {
+		name    string
+		dirtyTS *TimeSeries
+	}{
+		{"labels", &TimeSeries{Labels: []LabelAdapter{{Name: "foo", Value: "bar"}}}},
+		{"samples", &TimeSeries{Samples: []Sample{{Value: 1, TimestampMs: 2}}}},
+		{"histograms", &TimeSeries{Histograms: []Histogram{{Sum: 1.0}}}},
+		{"exemplars", &TimeSeries{Exemplars: []Exemplar{{Value: 1, TimestampMs: 2}}}},
+		{"CreatedTimestamp", &TimeSeries{CreatedTimestamp: 1234567890}},
+		{"SkipUnmarshalingExemplars", &TimeSeries{SkipUnmarshalingExemplars: true}},
+	}
+	for _, tc := range dirtyPoolTests {
+		t.Run("panics if pool returns dirty TimeSeries with "+tc.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				// Drain the pool to ensure isolation. sync.Pool.Get() never returns nil
+				// (it calls New if empty), so we just drain a fixed count.
+				for range 1000 {
+					timeSeriesPool.Get()
+				}
+			})
+			// Flood the pool with dirty objects because sync.Pool doesn't guarantee returning
+			// the same object that was just put in.
+			for range 100 {
+				timeSeriesPool.Put(tc.dirtyTS)
+			}
+
+			assert.Panics(t, func() {
+				TimeseriesFromPool()
+			})
+		})
+	}
+}

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -41,77 +41,6 @@ func TestLabelAdapter_Marshal(t *testing.T) {
 	}
 }
 
-func TestPreallocTimeseriesSliceFromPool(t *testing.T) {
-	t.Run("new instance is provided when not available to reuse", func(t *testing.T) {
-		first := PreallocTimeseriesSliceFromPool()
-		second := PreallocTimeseriesSliceFromPool()
-
-		assert.NotSame(t, unsafe.SliceData(first), unsafe.SliceData(second))
-	})
-
-	t.Run("instance is cleaned before reusing", func(t *testing.T) {
-		slice := PreallocTimeseriesSliceFromPool()
-		slice = append(slice, PreallocTimeseries{TimeSeries: &TimeSeries{}})
-		ReuseSlice(slice)
-
-		reused := PreallocTimeseriesSliceFromPool()
-		assert.Len(t, reused, 0)
-	})
-}
-
-func TestTimeseriesFromPool(t *testing.T) {
-	t.Run("new instance is provided when not available to reuse", func(t *testing.T) {
-		first := TimeseriesFromPool()
-		second := TimeseriesFromPool()
-
-		assert.NotSame(t, first, second)
-	})
-
-	t.Run("instance is cleaned before reusing", func(t *testing.T) {
-		ts := TimeseriesFromPool()
-		ts.Labels = []LabelAdapter{{Name: "foo", Value: "bar"}}
-		ts.Samples = []Sample{{Value: 1, TimestampMs: 2}}
-		ReuseTimeseries(ts)
-
-		reused := TimeseriesFromPool()
-		assert.Len(t, reused.Labels, 0)
-		assert.Len(t, reused.Samples, 0)
-	})
-
-	// Test that TimeseriesFromPool panics when it receives a dirty object from the pool.
-	dirtyPoolTests := []struct {
-		name    string
-		dirtyTS *TimeSeries
-	}{
-		{"labels", &TimeSeries{Labels: []LabelAdapter{{Name: "foo", Value: "bar"}}}},
-		{"samples", &TimeSeries{Samples: []Sample{{Value: 1, TimestampMs: 2}}}},
-		{"histograms", &TimeSeries{Histograms: []Histogram{{Sum: 1.0}}}},
-		{"exemplars", &TimeSeries{Exemplars: []Exemplar{{Value: 1, TimestampMs: 2}}}},
-		{"CreatedTimestamp", &TimeSeries{CreatedTimestamp: 1234567890}},
-		{"SkipUnmarshalingExemplars", &TimeSeries{SkipUnmarshalingExemplars: true}},
-	}
-	for _, tc := range dirtyPoolTests {
-		t.Run("panics if pool returns dirty TimeSeries with "+tc.name, func(t *testing.T) {
-			t.Cleanup(func() {
-				// Drain the pool to ensure isolation. sync.Pool.Get() never returns nil
-				// (it calls New if empty), so we just drain a fixed count.
-				for range 1000 {
-					timeSeriesPool.Get()
-				}
-			})
-			// Flood the pool with dirty objects because sync.Pool doesn't guarantee returning
-			// the same object that was just put in.
-			for range 100 {
-				timeSeriesPool.Put(tc.dirtyTS)
-			}
-
-			assert.Panics(t, func() {
-				TimeseriesFromPool()
-			})
-		})
-	}
-}
-
 func TestCopyToYoloString(t *testing.T) {
 	stringByteArray := func(val string) uintptr {
 		// Ignore deprecation warning for now
@@ -185,7 +114,7 @@ func TestDeepCopyTimeseries(t *testing.T) {
 		},
 	}
 	dst := PreallocTimeseries{}
-	dst = DeepCopyTimeseries(dst, src, true, true)
+	dst = DeepCopyTimeseries(nil, dst, src, true, true)
 
 	// Check that the values in src and dst are the same.
 	assert.Equal(t, src.TimeSeries, dst.TimeSeries)
@@ -298,7 +227,7 @@ func TestDeepCopyTimeseries(t *testing.T) {
 	}
 
 	dst = PreallocTimeseries{}
-	dst = DeepCopyTimeseries(dst, src, false, false)
+	dst = DeepCopyTimeseries(nil, dst, src, false, false)
 	assert.NotNil(t, dst.Exemplars)
 	assert.Len(t, dst.Exemplars, 0)
 	assert.Len(t, dst.Histograms, 0)
@@ -330,10 +259,10 @@ func TestDeepCopyTimeseriesExemplars(t *testing.T) {
 	}
 
 	dst1 := PreallocTimeseries{}
-	dst1 = DeepCopyTimeseries(dst1, src, false, false)
+	dst1 = DeepCopyTimeseries(nil, dst1, src, false, false)
 
 	dst2 := PreallocTimeseries{}
-	dst2 = DeepCopyTimeseries(dst2, src, false, true)
+	dst2 = DeepCopyTimeseries(nil, dst2, src, false, true)
 
 	// dst1 should use much smaller buffer than dst2.
 	assert.Less(t, cap(*dst1.yoloSlice), cap(*dst2.yoloSlice))
@@ -365,13 +294,13 @@ func TestPreallocTimeseries_Unmarshal(t *testing.T) {
 
 		TimeseriesUnmarshalCachingEnabled = false
 
-		require.NoError(t, msg.Unmarshal(data, nil, nil, false))
+		require.NoError(t, msg.Unmarshal(nil, data, nil, nil, false))
 		require.True(t, src.Equal(msg.TimeSeries))
 		require.Nil(t, msg.marshalledData)
 
 		TimeseriesUnmarshalCachingEnabled = true
 
-		require.NoError(t, msg.Unmarshal(data, nil, nil, false))
+		require.NoError(t, msg.Unmarshal(nil, data, nil, nil, false))
 		require.True(t, src.Equal(msg.TimeSeries))
 		require.NotNil(t, msg.marshalledData)
 	}

--- a/pkg/streamingpromql/benchmarks/ingester.go
+++ b/pkg/streamingpromql/benchmarks/ingester.go
@@ -238,7 +238,7 @@ func pushTestData(ing *ingester.Ingester, metricSizes []int) error {
 		}
 
 		for metricIdx, m := range metrics {
-			series := mimirpb.PreallocTimeseries{TimeSeries: mimirpb.TimeseriesFromPool()}
+			series := mimirpb.PreallocTimeseries{TimeSeries: &mimirpb.TimeSeries{}}
 			series.Labels = mimirpb.FromLabelsToLabelAdapters(m.Copy())
 
 			if strings.HasPrefix(m.Get("__name__"), "nh_") {

--- a/pkg/util/arena/arena.go
+++ b/pkg/util/arena/arena.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package arena
+
+// Append is like the append built-in, except it ensures that, if a new
+// underlying array needs to be allocated, it is allocated in the provided arena.
+func Append[T any](a *Arena, slice []T, elems ...T) []T {
+	if cap(slice)-len(slice) <= len(elems) || a == nil {
+		return append(slice, elems...)
+	}
+	return append(append(MakeSlice[T](a, 0, len(slice)+len(elems)), slice...), elems...)
+}

--- a/pkg/util/arena/arena_fake.go
+++ b/pkg/util/arena/arena_fake.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !goexperiment.arenas
+
+package arena
+
+type arena struct{}
+
+func newArena() *arena {
+	return nil
+}
+
+func allocate[T any](_ *arena) *T {
+	return new(T)
+}
+
+func makeSlice[T any](_ *arena, len, cap int) []T {
+	return make([]T, len, cap)
+}
+
+func clone[T any](s T) T {
+	return s
+}
+
+func (a *arena) Free() {}

--- a/pkg/util/arena/arena_goexperiment_arenas.go
+++ b/pkg/util/arena/arena_goexperiment_arenas.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build goexperiment.arenas
+
+package arena
+
+import (
+	stdarena "arena"
+)
+
+type arena struct {
+	a *stdarena.Arena
+}
+
+func newArena() *arena {
+	return &arena{a: stdarena.NewArena()}
+}
+
+func (a *arena) Free() {
+	a.a.Free()
+}
+
+func allocate[T any](a *arena) *T {
+	return stdarena.New[T](a.a)
+}
+
+func makeSlice[T any](a *arena, len, cap int) []T {
+	return stdarena.MakeSlice[T](a.a, len, cap)
+}
+
+func clone[T any](s T) T {
+	return stdarena.Clone(s)
+}

--- a/pkg/util/arena/arena_notracking.go
+++ b/pkg/util/arena/arena_notracking.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !mimir.tracking_arena
+
+package arena
+
+type Arena struct {
+	a *arena
+}
+
+func NewArena() *Arena {
+	return &Arena{a: newArena()}
+}
+
+func New[T any](a *Arena) *T {
+	if a == nil {
+		return new(T)
+	}
+	return allocate[T](a.a)
+}
+
+func MakeSlice[T any](a *Arena, len, cap int) []T {
+	if a == nil {
+		return make([]T, len, cap)
+	}
+	return makeSlice[T](a.a, len, cap)
+}
+
+func Clone[T any](s T) T {
+	return clone(s)
+}
+
+func (a *Arena) Free() {
+	if a == nil {
+		return
+	}
+	a.a.Free()
+}

--- a/pkg/util/arena/arena_tracking.go
+++ b/pkg/util/arena/arena_tracking.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build mimir.tracking_arena
+
+package arena
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"unsafe"
+	"weak"
+)
+
+type Arena struct {
+	a      *arena
+	allocs []alloc
+}
+
+func (a *Arena) inner() *arena {
+	if a == nil {
+		return nil
+	}
+	return a.a
+}
+
+type alloc struct {
+	typ     reflect.Type
+	caller  callSite
+	isFreed func() bool
+}
+
+func NewArena() *Arena {
+	return &Arena{a: newArena(), allocs: make([]alloc, 0, 100_000)}
+}
+
+func New[T any](a *Arena) *T {
+	if a == nil {
+		return new(T)
+	}
+
+	v := allocate[T](a.a)
+	weakPtr := weak.Make(v)
+	a.allocs = append(a.allocs, alloc{
+		typ:    reflect.TypeOf(v).Elem(),
+		caller: caller(),
+		isFreed: func() bool {
+			return weakPtr.Value() == nil
+		},
+	})
+	return v
+}
+
+func MakeSlice[T any](a *Arena, len, cap int) []T {
+	if a == nil {
+		return make([]T, len, cap)
+	}
+
+	v := makeSlice[T](a.a, len, cap)
+	weakPtr := weak.Make(unsafe.SliceData(v))
+	a.allocs = append(a.allocs, alloc{
+		typ:    reflect.TypeOf(v),
+		caller: caller(),
+		isFreed: func() bool {
+			return weakPtr.Value() == nil
+		},
+	})
+	return v
+}
+
+func Clone[T any](s T) T {
+	return clone(s)
+}
+
+func caller() callSite {
+	_, file, line, ok := runtime.Caller(2)
+	return callSite{file: file, line: line, ok: ok}
+}
+
+type callSite struct {
+	file string
+	line int
+	ok   bool
+}
+
+func (c callSite) String() string {
+	if !c.ok {
+		return "?"
+	}
+	return fmt.Sprintf("%s:%d", c.file, c.line)
+}
+
+func (a *Arena) Free() {
+	a.a.Free()
+
+	runtime.GC()
+	runtime.GC()
+	var liveAllocs strings.Builder
+	for _, a := range a.allocs {
+		if !a.isFreed() {
+			fmt.Fprintf(&liveAllocs, "%s\n\t%s\n", a.typ, a.caller)
+		}
+	}
+	if liveAllocs.Len() > 0 {
+		panic("references to arena allocations outlive the arena:\n\n" + liveAllocs.String())
+	}
+	a.allocs = nil
+}

--- a/pkg/util/arena/context.go
+++ b/pkg/util/arena/context.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package arena
+
+import (
+	"context"
+)
+
+type ctxKey struct{}
+
+func FromContext(ctx context.Context) *Arena {
+	v, _ := ctx.Value(ctxKey{}).(*Arena)
+	return v
+}
+
+func ContextWithArena(ctx context.Context, a *Arena) context.Context {
+	return context.WithValue(ctx, ctxKey{}, a)
+}

--- a/pkg/util/requestbuffers_arenas.go
+++ b/pkg/util/requestbuffers_arenas.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build goexperiment.arenas
+
+package util
+
+import (
+	"bytes"
+
+	"github.com/grafana/mimir/pkg/util/arena"
+)
+
+// Get obtains a buffer using the provided arena. The pool is ignored in arena builds.
+func (rb *RequestBuffers) Get(a *arena.Arena, size int) *bytes.Buffer {
+	if size < 0 {
+		size = 0
+	}
+	buf := bytes.NewBuffer(arena.MakeSlice[byte](a, size, size))
+	buf.Reset()
+	return buf
+}
+
+// CleanUp is mostly a no-op in arena builds, except for tainting buffers if configured.
+// The buffers list is cleared, but buffers are not returned to any pool.
+func (rb *RequestBuffers) CleanUp() {
+	if rb == nil {
+		return
+	}
+	for i, b := range rb.buffers {
+		// Make sure the backing array doesn't retain a reference
+		rb.buffers[i] = nil
+		if len(rb.taintOnCleanUp) > 0 {
+			buf := b.Bytes()
+			for i := range buf {
+				buf[i] = rb.taintOnCleanUp[i%len(rb.taintOnCleanUp)]
+			}
+		}
+		// No rb.p.Put(buf) in arena builds - memory is managed by arena
+	}
+	rb.buffers = rb.buffers[:0]
+}

--- a/pkg/util/requestbuffers_pools.go
+++ b/pkg/util/requestbuffers_pools.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !goexperiment.arenas
+
+package util
+
+import (
+	"bytes"
+
+	"github.com/grafana/mimir/pkg/util/arena"
+)
+
+// Get obtains a buffer from the pool. It will be returned back to the pool when CleanUp is called.
+// The arena parameter is ignored in non-arena builds.
+func (rb *RequestBuffers) Get(a *arena.Arena, size int) *bytes.Buffer {
+	if rb == nil || rb.p == nil {
+		if size < 0 {
+			size = 0
+		}
+		return bytes.NewBuffer(make([]byte, 0, size))
+	}
+
+	b := rb.p.Get()
+	buf := bytes.NewBuffer(b)
+	buf.Reset()
+	if size > 0 {
+		buf.Grow(size)
+	}
+
+	rb.buffers = append(rb.buffers, buf)
+	return buf
+}
+
+// CleanUp releases buffers back to the pool.
+func (rb *RequestBuffers) CleanUp() {
+	if rb == nil {
+		return
+	}
+	for i, b := range rb.buffers {
+		// Make sure the backing array doesn't retain a reference
+		rb.buffers[i] = nil
+		buf := b.Bytes()
+		if len(rb.taintOnCleanUp) > 0 {
+			for i := range buf {
+				buf[i] = rb.taintOnCleanUp[i%len(rb.taintOnCleanUp)]
+			}
+		}
+		if rb.p != nil {
+			rb.p.Put(buf)
+		}
+	}
+	rb.buffers = rb.buffers[:0]
+}


### PR DESCRIPTION
#### What this PR does

Replaces object pools for WriteRequests and children objects with allocations in request-scoped [arena](https://github.com/golang/go/issues/51317) allocations.

Just an experiment at this point.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
