### PR TITLE
mimirpb: Refactor RW2 metadata handling out of generated code

### DIFF
--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -759,6 +759,44 @@ func TestRW2Unmarshal(t *testing.T) {
 			require.Equal(t, "metric_2 help text.", received.Metadata[1].Help)
 		}
 	})
+
+	t.Run("conflicting metadata, first metadata wins by default", func(t *testing.T) {
+		writeRequest := &WriteRequest{
+			SymbolsRW2: []string{"", "__name__", "my_cool_series", "It's a cool series, but old description.", "It's a cool series, but new description.", "megawatts"},
+			TimeseriesRW2: []TimeSeriesRW2{
+				{
+					LabelsRefs: []uint32{1, 2},
+					Metadata: MetadataRW2{
+						Type:    METRIC_TYPE_COUNTER,
+						HelpRef: 3,
+						UnitRef: 5,
+					},
+				},
+				{
+					LabelsRefs: []uint32{1, 2},
+					Metadata: MetadataRW2{
+						Type:    METRIC_TYPE_COUNTER,
+						HelpRef: 4,
+						UnitRef: 5,
+					},
+				},
+			},
+		}
+		data, err := writeRequest.Marshal()
+		require.NoError(t, err)
+
+		// Unmarshal the data back into Mimir's WriteRequest.
+		received := PreallocWriteRequest{}
+		received.UnmarshalFromRW2 = true
+		err = received.Unmarshal(data)
+		require.NoError(t, err)
+
+		require.Len(t, received.Metadata, 1)
+		require.Equal(t, received.Metadata[0].MetricFamilyName, "my_cool_series")
+		require.Equal(t, received.Metadata[0].Type, COUNTER)
+		require.Equal(t, received.Metadata[0].Help, "It's a cool series, but old description.")
+		require.Equal(t, received.Metadata[0].Unit, "megawatts")
+	})
 }
 
 func makeTestRW2WriteRequest(syms *test.SymbolTableBuilder) *WriteRequest {

--- a/pkg/mimirpb/custom.go
+++ b/pkg/mimirpb/custom.go
@@ -452,35 +452,43 @@ type MarshalerWithSize interface {
 	MarshalWithSize(size int) ([]byte, error)
 }
 
+type metadataSet interface {
+	add(family string, mm MetricMetadata)
+	len() int
+	slice() []*MetricMetadata
+}
+
+var _ metadataSet = dedupingMetadataSet{}
+
 // metadataSet is the collection of metadata within a request.
 // It keeps the order at which metadata is added. Metadata may optionally be deduplicated by family name.
-type orderedMetadataSet struct {
-	dedupe bool
+type dedupingMetadataSet struct {
 	// We avoid unifying this into a map[string][]*Metadata or some equivalent for perf reasons.
 	// It reduces allocations and allows us to take a shortcut when not deduplicating.
 	deduplicated map[string]*orderAwareMetricMetadata
-	unmodified   []*MetricMetadata
 }
 
-func (m *orderedMetadataSet) add(family string, mm *MetricMetadata) {
-	if m.dedupe {
-		m.deduplicated[family] = &orderAwareMetricMetadata{MetricMetadata: *mm} // TODO: Make orderAware wrap the ptr and remove the inner *
+func newDedupingMetadataSet() dedupingMetadataSet {
+	return dedupingMetadataSet{
+		deduplicated: make(map[string]*orderAwareMetricMetadata),
+	}
+}
+
+func (m dedupingMetadataSet) add(family string, mm MetricMetadata) {
+	if _, ok := m.deduplicated[family]; ok {
+		// Already have metadata for this metric familiy name.
+		// Since we cannot have multiple definitions of the same
+		// metric family name, we ignore this metadata.
 		return
 	}
-	m.unmodified = append(m.unmodified, mm)
+	m.deduplicated[family] = &orderAwareMetricMetadata{MetricMetadata: mm, order: m.len()} // TODO: Make orderAware wrap the ptr and remove the inner *
 }
 
-func (m *orderedMetadataSet) len() int {
-	if m.dedupe {
-		return len(m.deduplicated)
-	}
-	return len(m.unmodified)
+func (m dedupingMetadataSet) len() int {
+	return len(m.deduplicated)
 }
 
-func (m *orderedMetadataSet) toSlice() []*MetricMetadata {
-	if !m.dedupe {
-		return m.unmodified
-	}
+func (m dedupingMetadataSet) slice() []*MetricMetadata {
 	result := make([]*MetricMetadata, m.len())
 	for _, meta := range m.deduplicated {
 		result[meta.order] = &meta.MetricMetadata

--- a/pkg/mimirpb/mimir.pb.go.expdiff
+++ b/pkg/mimirpb/mimir.pb.go.expdiff
@@ -1,5 +1,5 @@
 diff --git a/pkg/mimirpb/mimir.pb.go b/pkg/mimirpb/mimir.pb.go
-index 470222a18f..a314375963 100644
+index f8afd4cc9b..dda8609298 100644
 --- a/pkg/mimirpb/mimir.pb.go
 +++ b/pkg/mimirpb/mimir.pb.go
 @@ -14,7 +14,6 @@ import (
@@ -10,7 +10,7 @@ index 470222a18f..a314375963 100644
  	strconv "strconv"
  	strings "strings"
  )
-@@ -285,9 +284,6 @@ func (MetadataRW2_MetricType) EnumDescriptor() ([]byte, []int) {
+@@ -288,9 +287,6 @@ func (MetadataRW2_MetricType) EnumDescriptor() ([]byte, []int) {
  }
  
  type WriteRequest struct {
@@ -20,7 +20,7 @@ index 470222a18f..a314375963 100644
  	Timeseries []PreallocTimeseries    `protobuf:"bytes,1,rep,name=timeseries,proto3,customtype=PreallocTimeseries" json:"timeseries"`
  	Source     WriteRequest_SourceEnum `protobuf:"varint,2,opt,name=Source,proto3,enum=cortexpb.WriteRequest_SourceEnum" json:"Source,omitempty"`
  	Metadata   []*MetricMetadata       `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty"`
-@@ -299,14 +295,6 @@ type WriteRequest struct {
+@@ -302,14 +298,6 @@ type WriteRequest struct {
  	SkipLabelValidation bool `protobuf:"varint,1000,opt,name=skip_label_validation,json=skipLabelValidation,proto3" json:"skip_label_validation,omitempty"`
  	// Skip label count validation.
  	SkipLabelCountValidation bool `protobuf:"varint,1001,opt,name=skip_label_count_validation,json=skipLabelCountValidation,proto3" json:"skip_label_count_validation,omitempty"`
@@ -35,7 +35,7 @@ index 470222a18f..a314375963 100644
  }
  
  func (m *WriteRequest) Reset()      { *m = WriteRequest{} }
-@@ -469,11 +457,6 @@ func (m *ErrorDetails) GetSoft() bool {
+@@ -472,11 +460,6 @@ func (m *ErrorDetails) GetSoft() bool {
  	return false
  }
  
@@ -47,7 +47,7 @@ index 470222a18f..a314375963 100644
  type TimeSeries struct {
  	Labels []UnsafeMutableLabel `protobuf:"bytes,1,rep,name=labels,proto3,customtype=UnsafeMutableLabel" json:"labels"`
  	// Sorted by time, oldest sample first.
-@@ -486,9 +469,6 @@ type TimeSeries struct {
+@@ -489,9 +472,6 @@ type TimeSeries struct {
  	// Zero value means value not set. If you need to use exactly zero value for
  	// the timestamp, use 1 millisecond before or after.
  	CreatedTimestamp int64 `protobuf:"varint,6,opt,name=created_timestamp,json=createdTimestamp,proto3" json:"created_timestamp,omitempty"`
@@ -57,7 +57,7 @@ index 470222a18f..a314375963 100644
  }
  
  func (m *TimeSeries) Reset()      { *m = TimeSeries{} }
-@@ -5958,25 +5938,19 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+@@ -5961,25 +5941,19 @@ func (m *TimeSeriesRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
  		}
  	}
  	if len(m.LabelsRefs) > 0 {
@@ -88,7 +88,7 @@ index 470222a18f..a314375963 100644
  		i = encodeVarintMimir(dAtA, i, uint64(j21))
  		i--
  		dAtA[i] = 0xa
-@@ -6016,25 +5990,19 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+@@ -6019,25 +5993,19 @@ func (m *ExemplarRW2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
  		dAtA[i] = 0x11
  	}
  	if len(m.LabelsRefs) > 0 {
@@ -119,17 +119,17 @@ index 470222a18f..a314375963 100644
  		i = encodeVarintMimir(dAtA, i, uint64(j23))
  		i--
  		dAtA[i] = 0xa
-@@ -7382,9 +7350,6 @@ func valueToStringMimir(v interface{}) string {
+@@ -7385,9 +7353,6 @@ func valueToStringMimir(v interface{}) string {
  	return fmt.Sprintf("*%v", pv)
  }
  func (m *WriteRequest) Unmarshal(dAtA []byte) error {
--	var metadata map[string]*orderAwareMetricMetadata
+-	var metadata metadataSet
 -	seenFirstSymbol := false
 -
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -7414,9 +7379,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7417,9 +7382,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  		}
  		switch fieldNum {
  		case 1:
@@ -139,7 +139,7 @@ index 470222a18f..a314375963 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Timeseries", wireType)
  			}
-@@ -7446,8 +7408,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7449,8 +7411,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  				return io.ErrUnexpectedEOF
  			}
  			m.Timeseries = append(m.Timeseries, PreallocTimeseries{})
@@ -149,7 +149,7 @@ index 470222a18f..a314375963 100644
  				return err
  			}
  			iNdEx = postIndex
-@@ -7471,9 +7432,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7474,9 +7435,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  				}
  			}
  		case 3:
@@ -159,7 +159,7 @@ index 470222a18f..a314375963 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
  			}
-@@ -7508,9 +7466,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7511,9 +7469,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  			}
  			iNdEx = postIndex
  		case 4:
@@ -169,7 +169,7 @@ index 470222a18f..a314375963 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field SymbolsRW2", wireType)
  			}
-@@ -7540,16 +7495,9 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7543,16 +7498,9 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -187,14 +187,14 @@ index 470222a18f..a314375963 100644
  			if wireType != 2 {
  				return fmt.Errorf("proto: wrong wireType = %d for field TimeseriesRW2", wireType)
  			}
-@@ -7578,12 +7526,8 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7581,12 +7529,8 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
 -			m.Timeseries = append(m.Timeseries, PreallocTimeseries{})
 -			m.Timeseries[len(m.Timeseries)-1].skipUnmarshalingExemplars = m.skipUnmarshalingExemplars
 -			if metadata == nil {
--				metadata = make(map[string]*orderAwareMetricMetadata)
+-				metadata = newDedupingMetadataSet()
 -			}
 -			if err := m.Timeseries[len(m.Timeseries)-1].Unmarshal(dAtA[iNdEx:postIndex], &m.rw2symbols, metadata, m.skipNormalizeMetadataMetricName); err != nil {
 +			m.TimeseriesRW2 = append(m.TimeseriesRW2, TimeSeriesRW2{})
@@ -202,23 +202,20 @@ index 470222a18f..a314375963 100644
  				return err
  			}
  			iNdEx = postIndex
-@@ -7646,15 +7590,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7649,12 +7593,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  	if iNdEx > l {
  		return io.ErrUnexpectedEOF
  	}
 -
 -	if m.unmarshalFromRW2 {
--		m.Metadata = make([]*MetricMetadata, len(metadata))
--		for _, metadata := range metadata {
--			m.Metadata[metadata.order] = &metadata.MetricMetadata
--		}
+-		m.Metadata = metadata.slice()
 -		m.rw2symbols.releasePages()
 -	}
 -
  	return nil
  }
  func (m *WriteResponse) Unmarshal(dAtA []byte) error {
-@@ -7922,11 +7857,9 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
+@@ -7922,11 +7860,9 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -233,18 +230,18 @@ index 470222a18f..a314375963 100644
  			}
  			iNdEx = postIndex
  		case 4:
-@@ -11235,10 +11168,6 @@ func (m *WriteRequestRW2) Unmarshal(dAtA []byte) error {
+@@ -11235,10 +11171,6 @@ func (m *WriteRequestRW2) Unmarshal(dAtA []byte) error {
  	return nil
  }
  func (m *TimeSeriesRW2) Unmarshal(dAtA []byte) error {
 -	return errorInternalRW2
 -}
--func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata map[string]*orderAwareMetricMetadata, skipNormalizeMetricName bool) error {
+-func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata metadataSet, skipNormalizeMetricName bool) error {
 -	var metricName string
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -11269,7 +11198,22 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11269,7 +11201,22 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  		switch fieldNum {
  		case 1:
  			if wireType == 0 {
@@ -268,7 +265,7 @@ index 470222a18f..a314375963 100644
  			} else if wireType == 2 {
  				var packedLen int
  				for shift := uint(0); ; shift += 7 {
-@@ -11304,14 +11248,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11304,14 +11251,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  					}
  				}
  				elementCount = count
@@ -285,7 +282,7 @@ index 470222a18f..a314375963 100644
  				for iNdEx < postIndex {
  					var v uint32
  					for shift := uint(0); ; shift += 7 {
-@@ -11328,27 +11267,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11328,27 +11270,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  							break
  						}
  					}
@@ -314,7 +311,7 @@ index 470222a18f..a314375963 100644
  				}
  			} else {
  				return fmt.Errorf("proto: wrong wireType = %d for field LabelsRefs", wireType)
-@@ -11450,11 +11369,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11450,11 +11372,9 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -329,7 +326,7 @@ index 470222a18f..a314375963 100644
  			}
  			iNdEx = postIndex
  		case 5:
-@@ -11486,7 +11403,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11486,7 +11406,7 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  			if postIndex > l {
  				return io.ErrUnexpectedEOF
  			}
@@ -338,7 +335,7 @@ index 470222a18f..a314375963 100644
  				return err
  			}
  			iNdEx = postIndex
-@@ -11531,10 +11448,6 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
+@@ -11531,10 +11451,6 @@ func (m *TimeSeries) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadat
  	return nil
  }
  func (m *ExemplarRW2) Unmarshal(dAtA []byte) error {
@@ -349,7 +346,7 @@ index 470222a18f..a314375963 100644
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -11565,7 +11478,22 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11565,7 +11481,22 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  		switch fieldNum {
  		case 1:
  			if wireType == 0 {
@@ -373,23 +370,23 @@ index 470222a18f..a314375963 100644
  			} else if wireType == 2 {
  				var packedLen int
  				for shift := uint(0); ; shift += 7 {
-@@ -11600,13 +11528,9 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11600,13 +11531,9 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  					}
  				}
  				elementCount = count
 -				if elementCount%2 != 0 {
 -					return errorOddNumberOfExemplarLabelRefs
--				}
--				if elementCount != 0 && len(m.Labels) == 0 {
--					m.Labels = make([]LabelAdapter, 0, elementCount/2)
 +				if elementCount != 0 && len(m.LabelsRefs) == 0 {
 +					m.LabelsRefs = make([]uint32, 0, elementCount)
  				}
+-				if elementCount != 0 && len(m.Labels) == 0 {
+-					m.Labels = make([]LabelAdapter, 0, elementCount/2)
+-				}
 -				idx := 0
  				for iNdEx < postIndex {
  					var v uint32
  					for shift := uint(0); ; shift += 7 {
-@@ -11623,20 +11547,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11623,20 +11550,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  							break
  						}
  					}
@@ -411,7 +408,7 @@ index 470222a18f..a314375963 100644
  				}
  			} else {
  				return fmt.Errorf("proto: wrong wireType = %d for field LabelsRefs", wireType)
-@@ -11656,7 +11567,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11656,7 +11570,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  			if wireType != 0 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
  			}
@@ -420,7 +417,7 @@ index 470222a18f..a314375963 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11666,7 +11577,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11666,7 +11580,7 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -429,13 +426,13 @@ index 470222a18f..a314375963 100644
  				if b < 0x80 {
  					break
  				}
-@@ -11693,16 +11604,6 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
+@@ -11693,16 +11607,6 @@ func (m *Exemplar) UnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols) error {
  	return nil
  }
  func (m *MetadataRW2) Unmarshal(dAtA []byte) error {
 -	return errorInternalRW2
 -}
--func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata map[string]*orderAwareMetricMetadata, metricName string, skipNormalizeMetricName bool) error {
+-func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata metadataSet, metricName string, skipNormalizeMetricName bool) error {
 -	var (
 -		err error
 -		help string
@@ -446,7 +443,7 @@ index 470222a18f..a314375963 100644
  	l := len(dAtA)
  	iNdEx := 0
  	for iNdEx < l {
-@@ -11735,7 +11636,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11735,7 +11639,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  			if wireType != 0 {
  				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
  			}
@@ -455,7 +452,7 @@ index 470222a18f..a314375963 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11745,7 +11646,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11745,7 +11649,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -464,7 +461,7 @@ index 470222a18f..a314375963 100644
  				if b < 0x80 {
  					break
  				}
-@@ -11754,7 +11655,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11754,7 +11658,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  			if wireType != 0 {
  				return fmt.Errorf("proto: wrong wireType = %d for field HelpRef", wireType)
  			}
@@ -473,7 +470,7 @@ index 470222a18f..a314375963 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11764,20 +11665,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11764,20 +11668,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -496,7 +493,7 @@ index 470222a18f..a314375963 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11787,15 +11684,11 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11787,15 +11687,11 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -513,7 +510,7 @@ index 470222a18f..a314375963 100644
  		default:
  			iNdEx = preIndex
  			skippy, err := skipMimir(dAtA[iNdEx:])
-@@ -11815,32 +11708,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11815,23 +11711,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  	if iNdEx > l {
  		return io.ErrUnexpectedEOF
  	}
@@ -525,22 +522,13 @@ index 470222a18f..a314375963 100644
 -	if len(normalizedMetricName) == 0 {
 -		return nil
 -	}
--	if _, ok := metadata[normalizedMetricName]; ok {
--		// Already have metadata for this metric familiy name.
--		// Since we cannot have multiple definitions of the same
--		// metric family name, we ignore this metadata.
--		return nil
--	}
 -	if len(unit) > 0 || len(help) > 0 || metricType != 0 {
--		metadata[normalizedMetricName] = &orderAwareMetricMetadata{
--			MetricMetadata: MetricMetadata{
--				MetricFamilyName: normalizedMetricName,
--				Help:             help,
--				Unit:             unit,
--				Type:             MetricMetadata_MetricType(metricType),
--			},
--			order: len(metadata),
--		}
+-		metadata.add(normalizedMetricName, MetricMetadata{
+-			MetricFamilyName: normalizedMetricName,
+-			Help:             help,
+-			Unit:             unit,
+-			Type:             MetricMetadata_MetricType(metricType),
+-		})
 -	}
 -
  	return nil

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -275,7 +275,7 @@ var TimeseriesUnmarshalCachingEnabled = true
 //   - in case 3 the exemplars don't get unmarshaled if
 //     p.skipUnmarshalingExemplars is false,
 //   - is symbols is not nil, we unmarshal from Remote Write 2.0 format.
-func (p *PreallocTimeseries) Unmarshal(dAtA []byte, symbols *rw2PagedSymbols, metadata map[string]*orderAwareMetricMetadata, skipNormalizeMetricName bool) error {
+func (p *PreallocTimeseries) Unmarshal(dAtA []byte, symbols *rw2PagedSymbols, metadata metadataSet, skipNormalizeMetricName bool) error {
 	if TimeseriesUnmarshalCachingEnabled && symbols == nil {
 		// TODO(krajorama): check if it makes sense for RW2 as well.
 		p.marshalledData = dAtA


### PR DESCRIPTION
#### What this PR does

The RW2 unmarshal uses a `map[string]*orderAwareMetricMetadata` that's injected everywhere, used to track and deduplicate metadata, and also store them as we convert back to RW1.

This PR is a refactor that puts this behind a `metadataSet` interface. We then introduce a `dedupingMetadataSet` implementation that just wraps the very same map. In the future we want to introduce alternate metadata handling strategies that don't deduplicate, this makes it easy.

Just converting it to a `map[string][]*orderAwareMetricMetadata` is too unwieldy and allocations inside the inner slices are difficult to control, this approach is more minimal. It also means we can move a little custom logic out of `mimir.pb.go` and into regular Go files, reducing the divergence of our edits to the generated code.

This abstraction doesn't cause any perf difference or extra allocations.
<details>

<summary>benchmark results</summary>

Run with:
```
go test ./pkg/mimirpb/... -run ^$ -bench BenchmarkUnMarshal -benchtime 5s -benchmem
```

```
goos: linux
goarch: amd64
pkg: github.com/grafana/mimir/pkg/mimirpb
cpu: AMD Ryzen 7 PRO 5850U with Radeon Graphics
                                               │  before.txt  │              after.txt               │
                                               │    sec/op    │    sec/op     vs base                │
UnMarshal/Marshal/RW1-16                         39.04m ± ∞ ¹   38.45m ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Marshal/RW2-16                         21.19m ± ∞ ¹   21.08m ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW1/skipExemplars=true-16    24.75m ± ∞ ¹   23.54m ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW2/skipExemplars=true-16    26.15m ± ∞ ¹   26.80m ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW1/skipExemplars=false-16   27.58m ± ∞ ¹   26.16m ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW2/skipExemplars=false-16   28.39m ± ∞ ¹   29.15m ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                          27.36m         27.03m        -1.20%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                               │  before.txt   │               after.txt               │
                                               │     B/op      │     B/op       vs base                │
UnMarshal/Marshal/RW1-16                         25.58Mi ± ∞ ¹   25.58Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Marshal/RW2-16                         17.50Mi ± ∞ ¹   17.50Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
UnMarshal/Unmarshal/RW1/skipExemplars=true-16    54.48Mi ± ∞ ¹   54.48Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW2/skipExemplars=true-16    31.28Mi ± ∞ ¹   31.28Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW1/skipExemplars=false-16   59.05Mi ± ∞ ¹   59.05Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW2/skipExemplars=false-16   32.80Mi ± ∞ ¹   32.80Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                          33.75Mi         33.75Mi        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal

                                               │  before.txt  │              after.txt               │
                                               │  allocs/op   │  allocs/op    vs base                │
UnMarshal/Marshal/RW1-16                          2.000 ± ∞ ¹    2.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Marshal/RW2-16                          2.000 ± ∞ ¹    2.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW1/skipExemplars=true-16    60.43k ± ∞ ¹   60.43k ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW2/skipExemplars=true-16    50.02k ± ∞ ¹   50.02k ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW1/skipExemplars=false-16   100.4k ± ∞ ¹   100.4k ± ∞ ¹       ~ (p=1.000 n=1) ²
UnMarshal/Unmarshal/RW2/skipExemplars=false-16   60.02k ± ∞ ¹   60.02k ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                          2.044k         2.044k        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
```

<details>

#### Which issue(s) this PR fixes or relates to

contrib https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
