### PR TITLE
Fix issue where notifications for vendoring PRs that fail `pkg/streamingpromql` tests aren't sent

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -155,6 +155,9 @@ jobs:
         test_group_total: [4]
     needs:
       - prepare
+    permissions:
+      contents: read
+      pull-requests: write
     container:
       image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     steps:


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where the "Notify on streamingpromql failures" step fails with `GraphQL: Resource not accessible by integration (addComment)` ([example](https://github.com/grafana/mimir/actions/runs/17961952631/job/51086925589?pr=12794#step:8:20)).

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/pull/12763 and https://github.com/grafana/mimir/pull/12668

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
