### PR TITLE
index planning: Add query cardinality metrics

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2353,7 +2353,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 		return err
 	}
 
-	i.metrics.queriedSeries.Observe(float64(numSeries))
+	i.metrics.queriedSeries.WithLabelValues("returned").Observe(float64(numSeries))
 	i.metrics.queriedSamples.Observe(float64(numSamples))
 	spanlog.DebugLog("series", numSeries, "samples", numSamples)
 	return nil

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2353,7 +2353,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 		return err
 	}
 
-	i.metrics.queriedSeries.WithLabelValues("returned").Observe(float64(numSeries))
+	i.metrics.queriedSeries.WithLabelValues("send").Observe(float64(numSeries))
 	i.metrics.queriedSamples.Observe(float64(numSamples))
 	spanlog.DebugLog("series", numSeries, "samples", numSamples)
 	return nil

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2956,10 +2956,10 @@ func (i *Ingester) createBlockChunkQuerier(userID string, b tsdb.BlockReader, mi
 		return nil, err
 	}
 
-	statsQuerier := newStatsTrackingChunkQuerier(defaultQuerier, i.metrics, i.lookupPlanMetrics.ForUser(userID))
+	lookupStatsQuerier := newStatsTrackingChunkQuerier(defaultQuerier, i.metrics, i.lookupPlanMetrics.ForUser(userID))
 
 	if rand.Float64() > i.cfg.BlocksStorageConfig.TSDB.IndexLookupPlanningComparisonPortion {
-		return statsQuerier, nil
+		return lookupStatsQuerier, nil
 	}
 
 	// If mirroring is enabled, wrap the stats querier with mirrored querier
@@ -2969,7 +2969,7 @@ func (i *Ingester) createBlockChunkQuerier(userID string, b tsdb.BlockReader, mi
 		mint, maxt,
 		b.Meta(),
 		i.logger,
-		statsQuerier,
+		lookupStatsQuerier,
 	)
 
 	return mirroredQuerier, nil

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2859,7 +2859,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 				MaxBytes:              i.cfg.BlocksStorageConfig.TSDB.HeadPostingsForMatchersCacheMaxBytes,
 				Force:                 i.cfg.BlocksStorageConfig.TSDB.HeadPostingsForMatchersCacheForce,
 				Metrics:               i.tsdbMetrics.headPostingsForMatchersCacheMetrics,
-				PostingsClonerFactory: tsdb.DefaultPostingsClonerFactory{},
+				PostingsClonerFactory: lookupplan.ActualSelectedPostingsClonerFactory{},
 			},
 		),
 		BlockPostingsForMatchersCacheFactory: tsdb.NewPostingsForMatchersCacheFactory(
@@ -2873,10 +2873,10 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 				MaxBytes:              i.cfg.BlocksStorageConfig.TSDB.BlockPostingsForMatchersCacheMaxBytes,
 				Force:                 i.cfg.BlocksStorageConfig.TSDB.BlockPostingsForMatchersCacheForce,
 				Metrics:               i.tsdbMetrics.blockPostingsForMatchersCacheMetrics,
-				PostingsClonerFactory: tsdb.DefaultPostingsClonerFactory{},
+				PostingsClonerFactory: lookupplan.ActualSelectedPostingsClonerFactory{},
 			},
 		),
-		PostingsClonerFactory:  tsdb.DefaultPostingsClonerFactory{},
+		PostingsClonerFactory:  lookupplan.ActualSelectedPostingsClonerFactory{},
 		EnableNativeHistograms: i.limits.NativeHistogramsIngestionEnabled(userID),
 		SecondaryHashFunction:  secondaryTSDBHashFunctionForUser(userID),
 		IndexLookupPlannerFunc: i.getIndexLookupPlannerFunc(userID),
@@ -2956,7 +2956,7 @@ func (i *Ingester) createBlockChunkQuerier(userID string, b tsdb.BlockReader, mi
 		return nil, err
 	}
 
-	statsQuerier := newStatsTrackingChunkQuerier(defaultQuerier, &lookupplan.QueryStats{}, i.metrics, i.lookupPlanMetrics.ForUser(userID))
+	statsQuerier := newStatsTrackingChunkQuerier(defaultQuerier, i.metrics, i.lookupPlanMetrics.ForUser(userID))
 
 	if rand.Float64() > i.cfg.BlocksStorageConfig.TSDB.IndexLookupPlanningComparisonPortion {
 		return statsQuerier, nil

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2956,7 +2956,7 @@ func (i *Ingester) createBlockChunkQuerier(userID string, b tsdb.BlockReader, mi
 		return nil, err
 	}
 
-	statsQuerier := newStatsTrackingChunkQuerier(defaultQuerier, &lookupplan.QueryStats{}, i.metrics)
+	statsQuerier := newStatsTrackingChunkQuerier(defaultQuerier, &lookupplan.QueryStats{}, i.metrics, i.lookupPlanMetrics.ForUser(userID))
 
 	if rand.Float64() > i.cfg.BlocksStorageConfig.TSDB.IndexLookupPlanningComparisonPortion {
 		return statsQuerier, nil

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -47,7 +47,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/hashcache"
 	"github.com/prometheus/prometheus/tsdb/index"
-	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/zeropool"
 	"github.com/thanos-io/objstore"
 	"go.opentelemetry.io/otel"
@@ -2354,7 +2353,7 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 		return err
 	}
 
-	i.metrics.queriedSeries.WithLabelValues("send").Observe(float64(numSeries))
+	i.metrics.queriedSeries.WithLabelValues("merged_blocks").Observe(float64(numSeries))
 	i.metrics.queriedSamples.Observe(float64(numSamples))
 	spanlog.DebugLog("series", numSeries, "samples", numSamples)
 	return nil
@@ -2957,11 +2956,7 @@ func (i *Ingester) createBlockChunkQuerier(userID string, b tsdb.BlockReader, mi
 		return nil, err
 	}
 
-	// Create query stats and add to context - one instance per block querier
-	queryStats, _ := lookupplan.ContextWithEmptyQueryStats(context.Background())
-
-	// Wrap with stats tracking querier
-	statsQuerier := newStatsTrackingChunkQuerier(defaultQuerier, queryStats, i.metrics)
+	statsQuerier := newStatsTrackingChunkQuerier(defaultQuerier, &lookupplan.QueryStats{}, i.metrics)
 
 	if rand.Float64() > i.cfg.BlocksStorageConfig.TSDB.IndexLookupPlanningComparisonPortion {
 		return statsQuerier, nil
@@ -2978,128 +2973,6 @@ func (i *Ingester) createBlockChunkQuerier(userID string, b tsdb.BlockReader, mi
 	)
 
 	return mirroredQuerier, nil
-}
-
-// statsTrackingChunkQuerier wraps a ChunkQuerier to track query statistics.
-type statsTrackingChunkQuerier struct {
-	delegate   storage.ChunkQuerier
-	queryStats *lookupplan.QueryStats
-	metrics    *ingesterMetrics
-}
-
-// newStatsTrackingChunkQuerier creates a new stats-tracking chunk querier.
-func newStatsTrackingChunkQuerier(delegate storage.ChunkQuerier, queryStats *lookupplan.QueryStats, metrics *ingesterMetrics) *statsTrackingChunkQuerier {
-	return &statsTrackingChunkQuerier{
-		delegate:   delegate,
-		queryStats: queryStats,
-		metrics:    metrics,
-	}
-}
-
-func (q *statsTrackingChunkQuerier) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
-	return q.delegate.LabelValues(ctx, name, hints, matchers...)
-}
-
-func (q *statsTrackingChunkQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
-	return q.delegate.LabelNames(ctx, hints, matchers...)
-}
-
-func (q *statsTrackingChunkQuerier) Close() error {
-	return q.delegate.Close()
-}
-
-func (q *statsTrackingChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
-	seriesSet := q.delegate.Select(ctx, sortSeries, hints, matchers...)
-
-	// Create a tracking series set that will count series and observe metrics
-	trackingSet := &statsTrackingChunkSeriesSet{
-		delegate:   seriesSet,
-		queryStats: q.queryStats,
-		metrics:    q.metrics,
-	}
-
-	return trackingSet
-}
-
-// statsTrackingChunkSeriesSet wraps a ChunkSeriesSet to track series count and record stats.
-type statsTrackingChunkSeriesSet struct {
-	delegate           storage.ChunkSeriesSet
-	queryStats         *lookupplan.QueryStats
-	metrics            *ingesterMetrics
-	seriesCount        uint64
-	exhausted          bool
-	indexStageObserved bool
-}
-
-func (s *statsTrackingChunkSeriesSet) Next() bool {
-	hasNext := s.delegate.Next()
-
-	// On first call, observe the index stage with actual selected postings
-	if !s.indexStageObserved {
-		s.indexStageObserved = true
-		if s.queryStats != nil && s.metrics != nil && s.metrics.queriedSeries != nil {
-			actualPostings := s.queryStats.LoadActualSelectedPostings()
-			s.metrics.queriedSeries.WithLabelValues("index").Observe(float64(actualPostings))
-		}
-	}
-
-	if hasNext {
-		s.seriesCount++
-	} else if !s.exhausted {
-		// When the series set is exhausted, record the actual final cardinality
-		s.exhausted = true
-		if s.queryStats != nil {
-			s.queryStats.SetActualFinalCardinality(s.seriesCount)
-			s.recordStatsToMetrics()
-		}
-		// Observe the actual final cardinality in queriedSeries with "filter" stage
-		if s.metrics != nil && s.metrics.queriedSeries != nil {
-			s.metrics.queriedSeries.WithLabelValues("filter").Observe(float64(s.seriesCount))
-		}
-	}
-	return hasNext
-}
-
-func (s *statsTrackingChunkSeriesSet) At() storage.ChunkSeries {
-	return s.delegate.At()
-}
-
-func (s *statsTrackingChunkSeriesSet) Err() error {
-	return s.delegate.Err()
-}
-
-func (s *statsTrackingChunkSeriesSet) Warnings() annotations.Annotations {
-	return s.delegate.Warnings()
-}
-
-// recordStatsToMetrics records the collected stats to the ingester metrics.
-func (s *statsTrackingChunkSeriesSet) recordStatsToMetrics() {
-	if s.queryStats == nil || s.metrics == nil {
-		return
-	}
-
-	actualPostings := s.queryStats.LoadActualSelectedPostings()
-	actualFinal := s.queryStats.LoadActualFinalCardinality()
-	estimatedPostings := s.queryStats.LoadEstimatedSelectedPostings()
-	estimatedFinal := s.queryStats.LoadEstimatedFinalCardinality()
-
-	// Record ratio between actual postings cardinality and actual final cardinality
-	if actualFinal > 0 && s.metrics.actualPostingsToFinalCardinalityRatio != nil {
-		ratio := float64(actualPostings) / float64(actualFinal)
-		s.metrics.actualPostingsToFinalCardinalityRatio.WithLabelValues().Observe(ratio)
-	}
-
-	// Record ratio between estimated and actual postings cardinality
-	if actualPostings > 0 && s.metrics.estimatedToActualPostingsCardinalityRatio != nil {
-		ratio := float64(estimatedPostings) / float64(actualPostings)
-		s.metrics.estimatedToActualPostingsCardinalityRatio.WithLabelValues().Observe(ratio)
-	}
-
-	// Record ratio between estimated and actual final cardinality
-	if actualFinal > 0 && s.metrics.estimatedToActualFinalCardinalityRatio != nil {
-		ratio := float64(estimatedFinal) / float64(actualFinal)
-		s.metrics.estimatedToActualFinalCardinalityRatio.WithLabelValues().Observe(ratio)
-	}
 }
 
 func (i *Ingester) closeAllTSDB() {

--- a/pkg/ingester/lookupplan/metrics.go
+++ b/pkg/ingester/lookupplan/metrics.go
@@ -17,6 +17,10 @@ type Metrics struct {
 }
 
 func NewMetrics(reg prometheus.Registerer) Metrics {
+	// We want a scale of 2 so we represent better ratios between 0 and 1. 2^(2^-n) for n=2 gives us 1.189207115.
+	// Prometheus picks the smallest scale such that it's factor is still smaller than our constant, so we choose a value slightly higher than 1.89207115.
+	const ratioHistogramBucketFactor = 1.19
+
 	return Metrics{
 		planningDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "cortex_ingester_lookup_planning_duration_seconds",
@@ -29,17 +33,17 @@ func NewMetrics(reg prometheus.Registerer) Metrics {
 		FilteredRatio: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                        "cortex_ingester_lookup_planning_filtered_ratio",
 			Help:                        "Ratio of series retrieved from the index which were also matching the vector selectors from the query. This should always be 1.0 when index_lookup_planning_enabled: true.",
-			NativeHistogramBucketFactor: 1.1,
+			NativeHistogramBucketFactor: ratioHistogramBucketFactor,
 		}, []string{"user"}),
 		IntersectionSizeRatio: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                        "cortex_ingester_lookup_planning_index_selection_accuracy_ratio",
 			Help:                        "Ratio between estimated number of series selected from the index and the actual number of series selected from the index.",
-			NativeHistogramBucketFactor: 1.1,
+			NativeHistogramBucketFactor: ratioHistogramBucketFactor,
 		}, []string{"user"}),
 		FinalCardinalityRatio: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                        "cortex_ingester_lookup_planning_block_cardinality_accuracy_ratio",
 			Help:                        "Ratio between estimated final number of series after all filtering and the actual final number of series after all filtering.",
-			NativeHistogramBucketFactor: 1.1,
+			NativeHistogramBucketFactor: ratioHistogramBucketFactor,
 		}, []string{"user"}),
 	}
 }

--- a/pkg/ingester/lookupplan/metrics.go
+++ b/pkg/ingester/lookupplan/metrics.go
@@ -18,7 +18,7 @@ type Metrics struct {
 
 func NewMetrics(reg prometheus.Registerer) Metrics {
 	// We want a scale of 2 so we represent better ratios between 0 and 1. 2^(2^-n) for n=2 gives us 1.189207115.
-	// Prometheus picks the smallest scale such that it's factor is still smaller than our constant, so we choose a value slightly higher than 1.89207115.
+	// Prometheus picks the smallest scale such that its factor is still smaller than our constant, so we choose a value slightly higher than 1.189207115.
 	const ratioHistogramBucketFactor = 1.19
 
 	return Metrics{

--- a/pkg/ingester/lookupplan/planner.go
+++ b/pkg/ingester/lookupplan/planner.go
@@ -149,7 +149,7 @@ func (p CostBasedPlanner) recordPlanningOutcome(ctx context.Context, start time.
 
 		outcome = "success"
 		if traceSampled {
-			// Avoid logging overhead if the events aren't going to make it into a span.
+			// Only add span events when tracing is sampled to avoid unnecessary overhead.
 			p.addSpanEvents(span, start, selectedPlan, allPlans)
 		}
 	}

--- a/pkg/ingester/lookupplan/planner.go
+++ b/pkg/ingester/lookupplan/planner.go
@@ -141,25 +141,36 @@ func (p CostBasedPlanner) recordPlanningOutcome(ctx context.Context, start time.
 			))
 		}
 	default:
-		outcome = "success"
-		if !traceSampled {
-			// Avoid logging overhead if the events aren't going to make it into a span.
-			break
+		selectedPlan := allPlans[0]
+		if queryStats := QueryStatsFromContext(ctx); queryStats != nil {
+			queryStats.SetEstimatedSelectedPostings(selectedPlan.intersectionSize())
+			queryStats.SetEstimatedFinalCardinality(selectedPlan.cardinality())
 		}
-		span.AddEvent("selected lookup plan", trace.WithAttributes(
-			attribute.Stringer("duration", time.Since(start)),
-		))
-		const topKPlans = 2
-		allPlans[0].addPredicatesToSpan(span)
-		for i, plan := range allPlans[:min(topKPlans, len(allPlans))] {
-			planName := "selected_plan"
-			if i > 0 {
-				planName = strconv.Itoa(i + 1)
-			}
-			plan.addSpanEvent(span, planName)
+
+		outcome = "success"
+		if traceSampled {
+			// Avoid logging overhead if the events aren't going to make it into a span.
+			p.addSpanEvents(span, start, selectedPlan, allPlans)
+			break
 		}
 	}
 	p.metrics.planningDuration.WithLabelValues(outcome).Observe(time.Since(start).Seconds())
+}
+
+func (p CostBasedPlanner) addSpanEvents(span trace.Span, start time.Time, selectedPlan plan, allPlans []plan) {
+	span.AddEvent("selected lookup plan", trace.WithAttributes(
+		attribute.Stringer("duration", time.Since(start)),
+	))
+	selectedPlan.addPredicatesToSpan(span)
+
+	const topKPlans = 2
+	for i, plan := range allPlans[:min(topKPlans, len(allPlans))] {
+		planName := "selected_plan"
+		if i > 0 {
+			planName = strconv.Itoa(i + 1)
+		}
+		plan.addSpanEvent(span, planName)
+	}
 }
 
 type contextKey string

--- a/pkg/ingester/lookupplan/planner.go
+++ b/pkg/ingester/lookupplan/planner.go
@@ -151,7 +151,6 @@ func (p CostBasedPlanner) recordPlanningOutcome(ctx context.Context, start time.
 		if traceSampled {
 			// Avoid logging overhead if the events aren't going to make it into a span.
 			p.addSpanEvents(span, start, selectedPlan, allPlans)
-			break
 		}
 	}
 	p.metrics.planningDuration.WithLabelValues(outcome).Observe(time.Since(start).Seconds())

--- a/pkg/ingester/lookupplan/query_stats.go
+++ b/pkg/ingester/lookupplan/query_stats.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package lookupplan
+
+import (
+	"context"
+	"sync/atomic" //lint:ignore faillint we can't use go.uber.org/atomic with a protobuf struct without wrapping it.
+)
+
+type queryStatsContextKey int
+
+var queryStatsCtxKey = queryStatsContextKey(1)
+
+// ContextWithEmptyQueryStats returns a context with empty QueryStats.
+func ContextWithEmptyQueryStats(ctx context.Context) (*QueryStats, context.Context) {
+	stats := &QueryStats{}
+	ctx = context.WithValue(ctx, queryStatsCtxKey, stats)
+	return stats, ctx
+}
+
+// QueryStatsFromContext gets the QueryStats out of the Context. Returns nil if stats have not
+// been initialised in the context. Note that QueryStats methods are safe to call with
+// a nil receiver.
+func QueryStatsFromContext(ctx context.Context) *QueryStats {
+	o := ctx.Value(queryStatsCtxKey)
+	if o == nil {
+		return nil
+	}
+	return o.(*QueryStats)
+}
+
+// IsQueryStatsEnabled returns whether query stats tracking is enabled in the context.
+func IsQueryStatsEnabled(ctx context.Context) bool {
+	// When query statistics are enabled, the stats object is already initialised
+	// within the context, so we can just check it.
+	return QueryStatsFromContext(ctx) != nil
+}
+
+// QueryStats tracks query execution statistics for lookup planning.
+// All fields must be accessed using atomic operations for thread safety.
+type QueryStats struct {
+	estimatedFinalCardinality uint64
+	estimatedSelectedPostings uint64
+	actualSelectedPostings    uint64
+	actualFinalCardinality    uint64
+}
+
+// SetEstimatedFinalCardinality sets the estimated final cardinality.
+func (q *QueryStats) SetEstimatedFinalCardinality(cardinality uint64) {
+	if q == nil {
+		return
+	}
+	atomic.StoreUint64(&q.estimatedFinalCardinality, cardinality)
+}
+
+// LoadEstimatedFinalCardinality returns the estimated final cardinality.
+func (q *QueryStats) LoadEstimatedFinalCardinality() uint64 {
+	if q == nil {
+		return 0
+	}
+	return atomic.LoadUint64(&q.estimatedFinalCardinality)
+}
+
+// SetEstimatedSelectedPostings sets the estimated selected postings count.
+func (q *QueryStats) SetEstimatedSelectedPostings(postings uint64) {
+	if q == nil {
+		return
+	}
+	atomic.StoreUint64(&q.estimatedSelectedPostings, postings)
+}
+
+// LoadEstimatedSelectedPostings returns the estimated selected postings count.
+func (q *QueryStats) LoadEstimatedSelectedPostings() uint64 {
+	if q == nil {
+		return 0
+	}
+	return atomic.LoadUint64(&q.estimatedSelectedPostings)
+}
+
+// SetActualSelectedPostings sets the actual selected postings count.
+func (q *QueryStats) SetActualSelectedPostings(postings uint64) {
+	if q == nil {
+		return
+	}
+	atomic.StoreUint64(&q.actualSelectedPostings, postings)
+}
+
+// LoadActualSelectedPostings returns the actual selected postings count.
+func (q *QueryStats) LoadActualSelectedPostings() uint64 {
+	if q == nil {
+		return 0
+	}
+	return atomic.LoadUint64(&q.actualSelectedPostings)
+}
+
+// SetActualFinalCardinality sets the actual final cardinality.
+func (q *QueryStats) SetActualFinalCardinality(cardinality uint64) {
+	if q == nil {
+		return
+	}
+	atomic.StoreUint64(&q.actualFinalCardinality, cardinality)
+}
+
+// LoadActualFinalCardinality returns the actual final cardinality.
+func (q *QueryStats) LoadActualFinalCardinality() uint64 {
+	if q == nil {
+		return 0
+	}
+	return atomic.LoadUint64(&q.actualFinalCardinality)
+}

--- a/pkg/ingester/lookupplan/query_stats.go
+++ b/pkg/ingester/lookupplan/query_stats.go
@@ -4,11 +4,11 @@ package lookupplan
 
 import (
 	"context"
-	"sync/atomic" //lint:ignore faillint we can't use go.uber.org/atomic with a protobuf struct without wrapping it.
 
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/index"
+	"go.uber.org/atomic"
 )
 
 type queryStatsContextKey int
@@ -39,12 +39,12 @@ func IsQueryStatsEnabled(ctx context.Context) bool {
 }
 
 // QueryStats tracks query execution statistics for lookup planning.
-// All fields must be accessed using atomic operations for thread safety.
+// All fields use atomic types for thread safety.
 type QueryStats struct {
-	estimatedFinalCardinality uint64
-	estimatedSelectedPostings uint64
-	actualSelectedPostings    uint64
-	actualFinalCardinality    uint64
+	estimatedFinalCardinality atomic.Uint64
+	estimatedSelectedPostings atomic.Uint64
+	actualSelectedPostings    atomic.Uint64
+	actualFinalCardinality    atomic.Uint64
 }
 
 // SetEstimatedFinalCardinality sets the estimated final cardinality.
@@ -52,7 +52,7 @@ func (q *QueryStats) SetEstimatedFinalCardinality(cardinality uint64) {
 	if q == nil {
 		return
 	}
-	atomic.StoreUint64(&q.estimatedFinalCardinality, cardinality)
+	q.estimatedFinalCardinality.Store(cardinality)
 }
 
 // LoadEstimatedFinalCardinality returns the estimated final cardinality.
@@ -60,7 +60,7 @@ func (q *QueryStats) LoadEstimatedFinalCardinality() uint64 {
 	if q == nil {
 		return 0
 	}
-	return atomic.LoadUint64(&q.estimatedFinalCardinality)
+	return q.estimatedFinalCardinality.Load()
 }
 
 // SetEstimatedSelectedPostings sets the estimated selected postings count.
@@ -68,7 +68,7 @@ func (q *QueryStats) SetEstimatedSelectedPostings(postings uint64) {
 	if q == nil {
 		return
 	}
-	atomic.StoreUint64(&q.estimatedSelectedPostings, postings)
+	q.estimatedSelectedPostings.Store(postings)
 }
 
 // LoadEstimatedSelectedPostings returns the estimated selected postings count.
@@ -76,7 +76,7 @@ func (q *QueryStats) LoadEstimatedSelectedPostings() uint64 {
 	if q == nil {
 		return 0
 	}
-	return atomic.LoadUint64(&q.estimatedSelectedPostings)
+	return q.estimatedSelectedPostings.Load()
 }
 
 // SetActualSelectedPostings sets the actual selected postings count.
@@ -84,7 +84,7 @@ func (q *QueryStats) SetActualSelectedPostings(postings uint64) {
 	if q == nil {
 		return
 	}
-	atomic.StoreUint64(&q.actualSelectedPostings, postings)
+	q.actualSelectedPostings.Store(postings)
 }
 
 // LoadActualSelectedPostings returns the actual selected postings count.
@@ -92,7 +92,7 @@ func (q *QueryStats) LoadActualSelectedPostings() uint64 {
 	if q == nil {
 		return 0
 	}
-	return atomic.LoadUint64(&q.actualSelectedPostings)
+	return q.actualSelectedPostings.Load()
 }
 
 // SetActualFinalCardinality sets the actual final cardinality.
@@ -100,7 +100,7 @@ func (q *QueryStats) SetActualFinalCardinality(cardinality uint64) {
 	if q == nil {
 		return
 	}
-	atomic.StoreUint64(&q.actualFinalCardinality, cardinality)
+	q.actualFinalCardinality.Store(cardinality)
 }
 
 // LoadActualFinalCardinality returns the actual final cardinality.
@@ -108,7 +108,7 @@ func (q *QueryStats) LoadActualFinalCardinality() uint64 {
 	if q == nil {
 		return 0
 	}
-	return atomic.LoadUint64(&q.actualFinalCardinality)
+	return q.actualFinalCardinality.Load()
 }
 
 type ActualSelectedPostingsClonerFactory struct{}

--- a/pkg/ingester/lookupplan/query_stats.go
+++ b/pkg/ingester/lookupplan/query_stats.go
@@ -11,11 +11,9 @@ type queryStatsContextKey int
 
 const queryStatsCtxKey = queryStatsContextKey(1)
 
-// ContextWithEmptyQueryStats returns a context with empty QueryStats.
-func ContextWithEmptyQueryStats(ctx context.Context) (*QueryStats, context.Context) {
-	stats := &QueryStats{}
-	ctx = context.WithValue(ctx, queryStatsCtxKey, stats)
-	return stats, ctx
+// ContextWithQueryStats returns a context with empty QueryStats.
+func ContextWithQueryStats(ctx context.Context, stats *QueryStats) context.Context {
+	return context.WithValue(ctx, queryStatsCtxKey, stats)
 }
 
 // QueryStatsFromContext gets the QueryStats out of the Context. Returns nil if stats have not

--- a/pkg/ingester/lookupplan/query_stats.go
+++ b/pkg/ingester/lookupplan/query_stats.go
@@ -9,7 +9,7 @@ import (
 
 type queryStatsContextKey int
 
-var queryStatsCtxKey = queryStatsContextKey(1)
+const queryStatsCtxKey = queryStatsContextKey(1)
 
 // ContextWithEmptyQueryStats returns a context with empty QueryStats.
 func ContextWithEmptyQueryStats(ctx context.Context) (*QueryStats, context.Context) {

--- a/pkg/ingester/lookupplan/query_stats.go
+++ b/pkg/ingester/lookupplan/query_stats.go
@@ -31,13 +31,6 @@ func QueryStatsFromContext(ctx context.Context) *QueryStats {
 	return o.(*QueryStats)
 }
 
-// IsQueryStatsEnabled returns whether query stats tracking is enabled in the context.
-func IsQueryStatsEnabled(ctx context.Context) bool {
-	// When query statistics are enabled, the stats object is already initialised
-	// within the context, so we can just check it.
-	return QueryStatsFromContext(ctx) != nil
-}
-
 // QueryStats tracks query execution statistics for lookup planning.
 // All fields use atomic types for thread safety.
 type QueryStats struct {

--- a/pkg/ingester/lookupplan/query_stats_test.go
+++ b/pkg/ingester/lookupplan/query_stats_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package lookupplan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryStats_EstimatedFinalCardinality(t *testing.T) {
+	t.Run("set and load estimated final cardinality", func(t *testing.T) {
+		stats, _ := ContextWithEmptyQueryStats(context.Background())
+		stats.SetEstimatedFinalCardinality(100)
+		stats.SetEstimatedFinalCardinality(50)
+
+		assert.Equal(t, uint64(50), stats.LoadEstimatedFinalCardinality())
+	})
+
+	t.Run("set and load estimated final cardinality nil receiver", func(t *testing.T) {
+		var stats *QueryStats
+		stats.SetEstimatedFinalCardinality(100)
+
+		assert.Equal(t, uint64(0), stats.LoadEstimatedFinalCardinality())
+	})
+}
+
+func TestQueryStats_EstimatedSelectedPostings(t *testing.T) {
+	t.Run("set and load estimated selected postings", func(t *testing.T) {
+		stats, _ := ContextWithEmptyQueryStats(context.Background())
+		stats.SetEstimatedSelectedPostings(200)
+		stats.SetEstimatedSelectedPostings(150)
+
+		assert.Equal(t, uint64(150), stats.LoadEstimatedSelectedPostings())
+	})
+
+	t.Run("set and load estimated selected postings nil receiver", func(t *testing.T) {
+		var stats *QueryStats
+		stats.SetEstimatedSelectedPostings(200)
+
+		assert.Equal(t, uint64(0), stats.LoadEstimatedSelectedPostings())
+	})
+}
+
+func TestQueryStats_ActualSelectedPostings(t *testing.T) {
+	t.Run("set and load actual selected postings", func(t *testing.T) {
+		stats, _ := ContextWithEmptyQueryStats(context.Background())
+		stats.SetActualSelectedPostings(180)
+		stats.SetActualSelectedPostings(120)
+
+		assert.Equal(t, uint64(120), stats.LoadActualSelectedPostings())
+	})
+
+	t.Run("set and load actual selected postings nil receiver", func(t *testing.T) {
+		var stats *QueryStats
+		stats.SetActualSelectedPostings(180)
+
+		assert.Equal(t, uint64(0), stats.LoadActualSelectedPostings())
+	})
+}
+
+func TestQueryStats_ActualFinalCardinality(t *testing.T) {
+	t.Run("set and load actual final cardinality", func(t *testing.T) {
+		stats, _ := ContextWithEmptyQueryStats(context.Background())
+		stats.SetActualFinalCardinality(80)
+		stats.SetActualFinalCardinality(60)
+
+		assert.Equal(t, uint64(60), stats.LoadActualFinalCardinality())
+	})
+
+	t.Run("set and load actual final cardinality nil receiver", func(t *testing.T) {
+		var stats *QueryStats
+		stats.SetActualFinalCardinality(80)
+
+		assert.Equal(t, uint64(0), stats.LoadActualFinalCardinality())
+	})
+}
+
+func TestQueryStats_Context(t *testing.T) {
+	t.Run("context with empty stats", func(t *testing.T) {
+		stats, ctx := ContextWithEmptyQueryStats(context.Background())
+
+		assert.NotNil(t, stats)
+		assert.True(t, IsQueryStatsEnabled(ctx))
+
+		retrievedStats := QueryStatsFromContext(ctx)
+		assert.Equal(t, stats, retrievedStats)
+	})
+
+	t.Run("context without stats", func(t *testing.T) {
+		ctx := context.Background()
+
+		assert.False(t, IsQueryStatsEnabled(ctx))
+		assert.Nil(t, QueryStatsFromContext(ctx))
+	})
+}
+
+func TestQueryStats_AllFields(t *testing.T) {
+	t.Run("comprehensive test with all fields", func(t *testing.T) {
+		stats, _ := ContextWithEmptyQueryStats(context.Background())
+
+		stats.SetEstimatedFinalCardinality(1000)
+		stats.SetEstimatedSelectedPostings(2000)
+		stats.SetActualSelectedPostings(1800)
+		stats.SetActualFinalCardinality(900)
+
+		assert.Equal(t, uint64(1000), stats.LoadEstimatedFinalCardinality())
+		assert.Equal(t, uint64(2000), stats.LoadEstimatedSelectedPostings())
+		assert.Equal(t, uint64(1800), stats.LoadActualSelectedPostings())
+		assert.Equal(t, uint64(900), stats.LoadActualFinalCardinality())
+	})
+}

--- a/pkg/ingester/lookupplan/query_stats_test.go
+++ b/pkg/ingester/lookupplan/query_stats_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestQueryStats_EstimatedFinalCardinality(t *testing.T) {
 	t.Run("set and load estimated final cardinality", func(t *testing.T) {
-		stats, _ := ContextWithEmptyQueryStats(context.Background())
+		stats := &QueryStats{}
 		stats.SetEstimatedFinalCardinality(100)
 		stats.SetEstimatedFinalCardinality(50)
 
@@ -28,7 +28,7 @@ func TestQueryStats_EstimatedFinalCardinality(t *testing.T) {
 
 func TestQueryStats_EstimatedSelectedPostings(t *testing.T) {
 	t.Run("set and load estimated selected postings", func(t *testing.T) {
-		stats, _ := ContextWithEmptyQueryStats(context.Background())
+		stats := &QueryStats{}
 		stats.SetEstimatedSelectedPostings(200)
 		stats.SetEstimatedSelectedPostings(150)
 
@@ -45,7 +45,7 @@ func TestQueryStats_EstimatedSelectedPostings(t *testing.T) {
 
 func TestQueryStats_ActualSelectedPostings(t *testing.T) {
 	t.Run("set and load actual selected postings", func(t *testing.T) {
-		stats, _ := ContextWithEmptyQueryStats(context.Background())
+		stats := &QueryStats{}
 		stats.SetActualSelectedPostings(180)
 		stats.SetActualSelectedPostings(120)
 
@@ -62,7 +62,7 @@ func TestQueryStats_ActualSelectedPostings(t *testing.T) {
 
 func TestQueryStats_ActualFinalCardinality(t *testing.T) {
 	t.Run("set and load actual final cardinality", func(t *testing.T) {
-		stats, _ := ContextWithEmptyQueryStats(context.Background())
+		stats := &QueryStats{}
 		stats.SetActualFinalCardinality(80)
 		stats.SetActualFinalCardinality(60)
 
@@ -79,7 +79,8 @@ func TestQueryStats_ActualFinalCardinality(t *testing.T) {
 
 func TestQueryStats_Context(t *testing.T) {
 	t.Run("context with empty stats", func(t *testing.T) {
-		stats, ctx := ContextWithEmptyQueryStats(context.Background())
+		stats := &QueryStats{}
+		ctx := ContextWithQueryStats(context.Background(), stats)
 
 		assert.NotNil(t, stats)
 		assert.True(t, IsQueryStatsEnabled(ctx))
@@ -98,7 +99,7 @@ func TestQueryStats_Context(t *testing.T) {
 
 func TestQueryStats_AllFields(t *testing.T) {
 	t.Run("comprehensive test with all fields", func(t *testing.T) {
-		stats, _ := ContextWithEmptyQueryStats(context.Background())
+		stats := &QueryStats{}
 
 		stats.SetEstimatedFinalCardinality(1000)
 		stats.SetEstimatedSelectedPostings(2000)

--- a/pkg/ingester/lookupplan/query_stats_test.go
+++ b/pkg/ingester/lookupplan/query_stats_test.go
@@ -83,8 +83,6 @@ func TestQueryStats_Context(t *testing.T) {
 		ctx := ContextWithQueryStats(context.Background(), stats)
 
 		assert.NotNil(t, stats)
-		assert.True(t, IsQueryStatsEnabled(ctx))
-
 		retrievedStats := QueryStatsFromContext(ctx)
 		assert.Equal(t, stats, retrievedStats)
 	})
@@ -92,7 +90,8 @@ func TestQueryStats_Context(t *testing.T) {
 	t.Run("context without stats", func(t *testing.T) {
 		ctx := context.Background()
 
-		assert.False(t, IsQueryStatsEnabled(ctx))
+		// When query statistics are enabled, the stats object is already initialised
+		// within the context, so we can just check it.
 		assert.Nil(t, QueryStatsFromContext(ctx))
 	})
 }

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -27,10 +27,11 @@ type ingesterMetrics struct {
 	ingestedExemplarsFail prometheus.Counter
 	ingestedMetadataFail  prometheus.Counter
 
-	queries          prometheus.Counter
-	queriedSamples   prometheus.Histogram
-	queriedExemplars prometheus.Histogram
-	queriedSeries    *prometheus.HistogramVec
+	queries              prometheus.Counter
+	queriedSamples       prometheus.Histogram
+	queriedExemplars     prometheus.Histogram
+	queriedSeries        *prometheus.HistogramVec
+	discardedSeriesRatio prometheus.Histogram
 
 	memMetadata             prometheus.Gauge
 	memUsers                prometheus.Gauge
@@ -179,6 +180,11 @@ func newIngesterMetrics(
 			Buckets:                     prometheus.ExponentialBuckets(10, 8, 6),
 			NativeHistogramBucketFactor: 1.1,
 		}, []string{"stage"}),
+		discardedSeriesRatio: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
+			Name:                        "cortex_ingester_discarded_series_ratio",
+			Help:                        `Ratio of discarded series during query processing. These are series fetched form the index, but then discarded because they don't match the vector selector. This is the ratio of cortex_ingester_queried_series{stage="index"} over {stage="send"}.`,
+			NativeHistogramBucketFactor: 1.1,
+		}),
 		memMetadata: promauto.With(r).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_ingester_memory_metadata",
 			Help: "The current number of metadata in memory.",

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -94,11 +94,6 @@ type ingesterMetrics struct {
 
 	// Index lookup planning comparison outcomes.
 	indexLookupComparisonOutcomes *prometheus.CounterVec
-
-	// Query cardinality estimation metrics
-	actualPostingsToFinalCardinalityRatio     prometheus.Observer
-	estimatedToActualPostingsCardinalityRatio prometheus.Observer
-	estimatedToActualFinalCardinalityRatio    prometheus.Observer
 }
 
 func newIngesterMetrics(
@@ -419,22 +414,6 @@ func newIngesterMetrics(
 			Name: "cortex_ingester_index_lookup_planning_comparison_outcomes_total",
 			Help: "Total number of index lookup planning comparison outcomes when using mirrored chunk querier.",
 		}, []string{"outcome", "user"}),
-
-		actualPostingsToFinalCardinalityRatio: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name:                        "cortex_ingester_actual_postings_to_final_cardinality_ratio",
-			Help:                        "Ratio between actual postings cardinality and actual final cardinality.",
-			NativeHistogramBucketFactor: 1.1,
-		}),
-		estimatedToActualPostingsCardinalityRatio: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name:                        "cortex_ingester_estimated_to_actual_postings_cardinality_ratio",
-			Help:                        "Ratio between estimated postings cardinality and actual postings cardinality.",
-			NativeHistogramBucketFactor: 1.1,
-		}),
-		estimatedToActualFinalCardinalityRatio: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
-			Name:                        "cortex_ingester_estimated_to_actual_final_cardinality_ratio",
-			Help:                        "Ratio between estimated final cardinality and actual final cardinality.",
-			NativeHistogramBucketFactor: 1.1,
-		}),
 	}
 
 	// Initialize expected rejected request labels

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -96,9 +96,9 @@ type ingesterMetrics struct {
 	indexLookupComparisonOutcomes *prometheus.CounterVec
 
 	// Query cardinality estimation metrics
-	actualPostingsToFinalCardinalityRatio     *prometheus.HistogramVec
-	estimatedToActualPostingsCardinalityRatio *prometheus.HistogramVec
-	estimatedToActualFinalCardinalityRatio    *prometheus.HistogramVec
+	actualPostingsToFinalCardinalityRatio     prometheus.Observer
+	estimatedToActualPostingsCardinalityRatio prometheus.Observer
+	estimatedToActualFinalCardinalityRatio    prometheus.Observer
 }
 
 func newIngesterMetrics(
@@ -420,21 +420,21 @@ func newIngesterMetrics(
 			Help: "Total number of index lookup planning comparison outcomes when using mirrored chunk querier.",
 		}, []string{"outcome", "user"}),
 
-		actualPostingsToFinalCardinalityRatio: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+		actualPostingsToFinalCardinalityRatio: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name:                        "cortex_ingester_actual_postings_to_final_cardinality_ratio",
 			Help:                        "Ratio between actual postings cardinality and actual final cardinality.",
 			NativeHistogramBucketFactor: 1.1,
-		}, []string{}),
-		estimatedToActualPostingsCardinalityRatio: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+		}),
+		estimatedToActualPostingsCardinalityRatio: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name:                        "cortex_ingester_estimated_to_actual_postings_cardinality_ratio",
 			Help:                        "Ratio between estimated postings cardinality and actual postings cardinality.",
 			NativeHistogramBucketFactor: 1.1,
-		}, []string{}),
-		estimatedToActualFinalCardinalityRatio: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+		}),
+		estimatedToActualFinalCardinalityRatio: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name:                        "cortex_ingester_estimated_to_actual_final_cardinality_ratio",
 			Help:                        "Ratio between estimated final cardinality and actual final cardinality.",
 			NativeHistogramBucketFactor: 1.1,
-		}, []string{}),
+		}),
 	}
 
 	// Initialize expected rejected request labels

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -94,6 +94,11 @@ type ingesterMetrics struct {
 
 	// Index lookup planning comparison outcomes.
 	indexLookupComparisonOutcomes *prometheus.CounterVec
+
+	// Query cardinality estimation metrics
+	actualPostingsToFinalCardinalityRatio     *prometheus.HistogramVec
+	estimatedToActualPostingsCardinalityRatio *prometheus.HistogramVec
+	estimatedToActualFinalCardinalityRatio    *prometheus.HistogramVec
 }
 
 func newIngesterMetrics(
@@ -414,6 +419,22 @@ func newIngesterMetrics(
 			Name: "cortex_ingester_index_lookup_planning_comparison_outcomes_total",
 			Help: "Total number of index lookup planning comparison outcomes when using mirrored chunk querier.",
 		}, []string{"outcome", "user"}),
+
+		actualPostingsToFinalCardinalityRatio: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                        "cortex_ingester_actual_postings_to_final_cardinality_ratio",
+			Help:                        "Ratio between actual postings cardinality and actual final cardinality.",
+			NativeHistogramBucketFactor: 1.1,
+		}, []string{}),
+		estimatedToActualPostingsCardinalityRatio: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                        "cortex_ingester_estimated_to_actual_postings_cardinality_ratio",
+			Help:                        "Ratio between estimated postings cardinality and actual postings cardinality.",
+			NativeHistogramBucketFactor: 1.1,
+		}, []string{}),
+		estimatedToActualFinalCardinalityRatio: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                        "cortex_ingester_estimated_to_actual_final_cardinality_ratio",
+			Help:                        "Ratio between estimated final cardinality and actual final cardinality.",
+			NativeHistogramBucketFactor: 1.1,
+		}, []string{}),
 	}
 
 	// Initialize expected rejected request labels

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -182,7 +182,7 @@ func newIngesterMetrics(
 		}, []string{"stage"}),
 		discardedSeriesRatio: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name:                        "cortex_ingester_discarded_series_ratio",
-			Help:                        `Ratio of discarded series during query processing. These are series fetched form the index, but then discarded because they don't match the vector selector. This is the ratio of cortex_ingester_queried_series{stage="index"} over {stage="send"}.`,
+			Help:                        `Ratio of discarded series during query processing. These are series fetched from the index, but then discarded because they don't match the vector selector. This is the ratio of cortex_ingester_queried_series{stage="index"} over {stage="send"}.`,
 			NativeHistogramBucketFactor: 1.1,
 		}),
 		memMetadata: promauto.With(r).NewGauge(prometheus.GaugeOpts{

--- a/pkg/ingester/stats.go
+++ b/pkg/ingester/stats.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package ingester
 
 import (

--- a/pkg/ingester/stats.go
+++ b/pkg/ingester/stats.go
@@ -1,0 +1,111 @@
+package ingester
+
+import (
+	"context"
+
+	"github.com/grafana/dskit/instrument"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+
+	"github.com/grafana/mimir/pkg/ingester/lookupplan"
+)
+
+// statsTrackingChunkQuerier wraps a ChunkQuerier to track query statistics.
+type statsTrackingChunkQuerier struct {
+	delegate   storage.ChunkQuerier
+	queryStats *lookupplan.QueryStats
+	metrics    *ingesterMetrics
+}
+
+// newStatsTrackingChunkQuerier creates a new stats-tracking chunk querier.
+func newStatsTrackingChunkQuerier(delegate storage.ChunkQuerier, queryStats *lookupplan.QueryStats, metrics *ingesterMetrics) *statsTrackingChunkQuerier {
+	return &statsTrackingChunkQuerier{
+		delegate:   delegate,
+		queryStats: queryStats,
+		metrics:    metrics,
+	}
+}
+
+func (q *statsTrackingChunkQuerier) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	ctx = lookupplan.ContextWithQueryStats(ctx, q.queryStats)
+	return q.delegate.LabelValues(ctx, name, hints, matchers...)
+}
+
+func (q *statsTrackingChunkQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	ctx = lookupplan.ContextWithQueryStats(ctx, q.queryStats)
+	return q.delegate.LabelNames(ctx, hints, matchers...)
+}
+
+func (q *statsTrackingChunkQuerier) Close() error {
+	return q.delegate.Close()
+}
+
+func (q *statsTrackingChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
+	ctx = lookupplan.ContextWithQueryStats(ctx, q.queryStats)
+	seriesSet := q.delegate.Select(ctx, sortSeries, hints, matchers...)
+
+	trackingSet := &statsTrackingChunkSeriesSet{
+		ctx:        ctx,
+		delegate:   seriesSet,
+		queryStats: q.queryStats,
+		metrics:    q.metrics,
+	}
+
+	return trackingSet
+}
+
+// statsTrackingChunkSeriesSet wraps a ChunkSeriesSet to track series count and record stats.
+type statsTrackingChunkSeriesSet struct {
+	ctx         context.Context
+	delegate    storage.ChunkSeriesSet
+	queryStats  *lookupplan.QueryStats
+	metrics     *ingesterMetrics
+	seriesCount uint64
+	exhausted   bool
+}
+
+func (s *statsTrackingChunkSeriesSet) Next() bool {
+	hasNext := s.delegate.Next()
+
+	if hasNext {
+		s.seriesCount++
+	} else if !s.exhausted {
+		s.exhausted = true
+		s.queryStats.SetActualFinalCardinality(s.seriesCount)
+		s.recordStatsToMetrics()
+		s.metrics.queriedSeries.WithLabelValues("block_filter").Observe(float64(s.seriesCount))
+	}
+	return hasNext
+}
+
+func (s *statsTrackingChunkSeriesSet) At() storage.ChunkSeries {
+	return s.delegate.At()
+}
+
+func (s *statsTrackingChunkSeriesSet) Err() error {
+	return s.delegate.Err()
+}
+
+func (s *statsTrackingChunkSeriesSet) Warnings() annotations.Annotations {
+	return s.delegate.Warnings()
+}
+
+// recordStatsToMetrics records the collected stats to the ingester metrics.
+func (s *statsTrackingChunkSeriesSet) recordStatsToMetrics() {
+	actualPostings := s.queryStats.LoadActualSelectedPostings()
+	actualFinal := s.queryStats.LoadActualFinalCardinality()
+	estimatedPostings := s.queryStats.LoadEstimatedSelectedPostings()
+	estimatedFinal := s.queryStats.LoadEstimatedFinalCardinality()
+
+	s.metrics.queriedSeries.WithLabelValues("block_index").Observe(float64(actualPostings))
+	if actualFinal > 0 {
+		instrument.ObserveWithExemplar(s.ctx, s.metrics.actualPostingsToFinalCardinalityRatio, float64(actualPostings)/float64(actualFinal))
+	}
+	if actualPostings > 0 {
+		instrument.ObserveWithExemplar(s.ctx, s.metrics.estimatedToActualPostingsCardinalityRatio, float64(estimatedPostings)/float64(actualPostings))
+	}
+	if actualFinal > 0 {
+		instrument.ObserveWithExemplar(s.ctx, s.metrics.estimatedToActualFinalCardinalityRatio, float64(estimatedFinal)/float64(actualFinal))
+	}
+}


### PR DESCRIPTION
## Summary

Add infrastructure to track estimated vs actual cardinalities in query processing to improve observability of lookup planning accuracy. This enables monitoring how well the cost-based planner estimates match actual query execution.

There are 4 key metrics: 
* estimated/actual selected postings
* estimated/actual final series

We track the ratio between actual/estimated + ratio between actual postings/actual final series

## Changes

- Add `lookupplan.QueryStats` tracker with atomic operations for thread-safe cardinality tracking
- Add 3 native histogram metrics for cardinality ratio analysis. Measurements there are observed with exemplars.
- Implement stats-tracking querier wrapper to measure actual cardinalities
- Integrate PostingsCloner to capture actual selected postings count
- Populate estimated fields in CostBasedPlanner from plan `intersectionSize()` & `cardinality()`


this is the final piece of https://github.com/grafana/mimir/issues/11918; closes https://github.com/grafana/mimir/issues/11918
