### PR TITLE
Remove `MimirFrontendQueriesStuck` alert

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -859,12 +859,6 @@ How to **investigate**:
 - Check the latest runtime config update (it's likely to be broken)
 - Check Mimir logs to get more details about what's wrong with the config
 
-### MimirFrontendQueriesStuck
-
-This alert fires if Mimir is running without query-scheduler and queries are piling up in the query-frontend queue.
-
-The procedure to investigate it is the same as the one for [`MimirSchedulerQueriesStuck`](#MimirSchedulerQueriesStuck): please see the other runbook for more details.
-
 ### MimirSchedulerQueriesStuck
 
 This alert fires if queries are piling up in the query-scheduler.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -91,16 +91,6 @@ spec:
             for: 5m
             labels:
               severity: critical
-          - alert: MimirFrontendQueriesStuck
-            annotations:
-              message: |
-                  There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirfrontendqueriesstuck
-            expr: |
-              sum by (cluster, namespace, job) (min_over_time(cortex_query_frontend_queue_length[1m])) > 0
-            for: 5m
-            labels:
-              severity: critical
           - alert: MimirSchedulerQueriesStuck
             annotations:
               message: |

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -79,16 +79,6 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirFrontendQueriesStuck
-          annotations:
-            message: |
-                There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirfrontendqueriesstuck
-          expr: |
-            sum by (cluster, namespace, job) (min_over_time(cortex_query_frontend_queue_length[1m])) > 0
-          for: 5m
-          labels:
-            severity: critical
         - alert: MimirSchedulerQueriesStuck
           annotations:
             message: |

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -79,16 +79,6 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirFrontendQueriesStuck
-          annotations:
-            message: |
-                There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirfrontendqueriesstuck
-          expr: |
-            sum by (cluster, namespace, job) (min_over_time(cortex_query_frontend_queue_length[1m])) > 0
-          for: 5m
-          labels:
-            severity: critical
         - alert: MimirSchedulerQueriesStuck
           annotations:
             message: |

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -79,16 +79,6 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirFrontendQueriesStuck
-          annotations:
-            message: |
-                There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirfrontendqueriesstuck
-          expr: |
-            sum by (cluster, namespace, job) (min_over_time(cortex_query_frontend_queue_length[1m])) > 0
-          for: 5m
-          labels:
-            severity: critical
         - alert: MimirSchedulerQueriesStuck
           annotations:
             message: |

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -172,25 +172,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
         },
         {
-          alert: $.alertName('FrontendQueriesStuck'),
-          expr: |||
-            sum by (%(group_by)s, %(job_label)s) (min_over_time(cortex_query_frontend_queue_length[%(range_interval)s])) > 0
-          ||| % {
-            group_by: $._config.alert_aggregation_labels,
-            job_label: $._config.per_job_label,
-            range_interval: $.alertRangeInterval(1),
-          },
-          'for': '5m',  // We don't want to block for longer.
-          labels: {
-            severity: 'critical',
-          },
-          annotations: {
-            message: |||
-              There are {{ $value }} queued up queries in %(alert_aggregation_variables)s {{ $labels.%(per_job_label)s }}.
-            ||| % $._config,
-          },
-        },
-        {
           alert: $.alertName('SchedulerQueriesStuck'),
           expr: |||
             sum by (%(group_by)s, %(job_label)s) (min_over_time(cortex_query_scheduler_queue_length[%(range_interval)s])) > 0


### PR DESCRIPTION
#### What this PR does

As of https://github.com/grafana/mimir/pull/12200 (part of https://github.com/grafana/mimir/issues/11884), the query-scheduler is required, so the `MimirFrontendQueriesStuck` alert is no longer relevant.

The `MimirSchedulerQueriesStuck` alert remains relevant and has not been removed.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
