### PR TITLE
Cleanup: replace `mustLabelMatcher` with `labels.MustNewMatcher`

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper_test.go
@@ -36,7 +36,7 @@ func TestCloneExpr_ExplicitTestCases(t *testing.T) {
 			Expr: &parser.VectorSelector{
 				Name: "some_metric",
 				LabelMatchers: []*labels.Matcher{
-					mustLabelMatcher(labels.MatchEqual, model.MetricNameLabel, "some_metric"),
+					labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "some_metric"),
 				},
 				PosRange: posrange.PositionRange{Start: 119, End: 130},
 			},
@@ -226,14 +226,6 @@ func isTypeSafeToShare(o any) bool {
 	default:
 		return false
 	}
-}
-
-func mustLabelMatcher(mt labels.MatchType, name, val string) *labels.Matcher {
-	m, err := labels.NewMatcher(mt, name, val)
-	if err != nil {
-		panic(err)
-	}
-	return m
 }
 
 func TestSharding_BinaryExpressionsDontTakeExponentialTime(t *testing.T) {

--- a/pkg/frontend/querymiddleware/astmapper/parallel_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel_test.go
@@ -31,7 +31,7 @@ func TestCanParallel(t *testing.T) {
 				Expr: &parser.VectorSelector{
 					Name: "some_metric",
 					LabelMatchers: []*labels.Matcher{
-						mustLabelMatcher(labels.MatchEqual, string(model.MetricNameLabel), "some_metric"),
+						labels.MustNewMatcher(labels.MatchEqual, string(model.MetricNameLabel), "some_metric"),
 					},
 				},
 				Grouping: []string{"foo"},
@@ -46,7 +46,7 @@ func TestCanParallel(t *testing.T) {
 				Expr: &parser.VectorSelector{
 					Name: "some_metric",
 					LabelMatchers: []*labels.Matcher{
-						mustLabelMatcher(labels.MatchEqual, string(model.MetricNameLabel), "some_metric"),
+						labels.MustNewMatcher(labels.MatchEqual, string(model.MetricNameLabel), "some_metric"),
 					},
 				},
 				Grouping: []string{"foo"},
@@ -71,7 +71,7 @@ func TestCanParallel(t *testing.T) {
 						Expr: &parser.VectorSelector{
 							Name: "idk",
 							LabelMatchers: []*labels.Matcher{
-								mustLabelMatcher(labels.MatchEqual, string(model.MetricNameLabel), "bar1"),
+								labels.MustNewMatcher(labels.MatchEqual, string(model.MetricNameLabel), "bar1"),
 							},
 						},
 					},
@@ -81,7 +81,7 @@ func TestCanParallel(t *testing.T) {
 						Expr: &parser.VectorSelector{
 							Name: "idk",
 							LabelMatchers: []*labels.Matcher{
-								mustLabelMatcher(labels.MatchEqual, string(model.MetricNameLabel), "bar2"),
+								labels.MustNewMatcher(labels.MatchEqual, string(model.MetricNameLabel), "bar2"),
 							},
 						},
 					},
@@ -97,7 +97,7 @@ func TestCanParallel(t *testing.T) {
 				Expr: &parser.VectorSelector{
 					Name: "idk",
 					LabelMatchers: []*labels.Matcher{
-						mustLabelMatcher(labels.MatchEqual, string(model.MetricNameLabel), "bar1"),
+						labels.MustNewMatcher(labels.MatchEqual, string(model.MetricNameLabel), "bar1"),
 					},
 				},
 			},


### PR DESCRIPTION
#### What this PR does

This PR replaces our `mustLabelMatcher` function with Prometheus' equivalent `labels.MustNewMatcher`.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
