### PR TITLE
Use MQE and upstream test cases to further exercise `cloneExpr`

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/astmapper.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper.go
@@ -265,6 +265,9 @@ func cloneExpr(expr parser.Expr) (parser.Expr, error) {
 			Expr: expr,
 		}, nil
 
+	case *parser.DurationExpr:
+		return cloneDurationExpr(e)
+
 	default:
 		return nil, fmt.Errorf("cloneExpr: unknown expression type %T", expr)
 	}


### PR DESCRIPTION
#### What this PR does

@colega suggested fuzz testing `cloneExpr` in https://github.com/grafana/mimir/pull/12787#discussion_r2371969778.

Generating valid PromQL expressions through fuzzing is difficult and didn't produce a lot of useful results.

However, we do have a large corpus of PromQL expressions that are used to test MQE - both those we've written ourselves as well as those from upstream, so in this PR I'm exercising `cloneExpr` with these expressions. This should help catch any newly-added features, as these are very likely to be exercised with these test scripts.

This uncovered one case that was not being handled properly in `cloneExpr`, as well as some deficiencies in `requireNoSharedPointers`.

#### Which issue(s) this PR fixes or relates to

#12787

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
