### PR TITLE
improve logs of mimirtool analyze prometheus command

### DIFF
--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -316,13 +316,17 @@ func withBackoff(ctx context.Context, fn func() error) error {
 	backoff := backoff.New(ctx, backoff.Config{
 		MaxRetries: 10,
 	})
-
+	var err error
 	for backoff.Ongoing() {
-		if err := fn(); err == nil {
+		if err = fn(); err == nil {
 			return nil
 		}
 
 		backoff.Wait()
+	}
+
+	if err != nil {
+		return err
 	}
 
 	return backoff.Err()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When using `mimirtool analyze prometheus`, failing queries logs look like the following: 
```
WARN[0005] skipped up analysis because failed to run query count by (job) (up): terminated after 10 retries 
```
This isn't very helpful as you don't get to know why the query failed.

This behaviour is due to the withBackoff function that returns the error associated with the context, which is never set in the case of this command.

The simple fix proposed by this PR is to return the last error of the backoff if there was one, as the last error is most likely the most relevant.

After the fix, here is an example of log:
```
time="2025-09-25T11:47:05+02:00" level=warning msg="skipped up analysis because failed to run query count by (job) (up): client_error: client error: 404"
```




#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
