### PR TITLE
store-gw: Second attempt at safe guarding chunk parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
 * [BUGFIX] Ingester: Fix a bug where prepare-instance-ring-downscale endpoint would return an error while compacting and not read-only. #12548
 * [BUGFIX] Block-builder: Fix a bug where lease renewals would cease during graceful shutdown, leading to an elevated rate of job reassignments. #12643
 * [BUGFIX] OTLP: Return HTTP OK for partially rejected requests, e.g. due to OOO exemplars. #12579
-* [BUGFIX] Store-gateway: Fix a panic in BucketChunkReader when chunk loading encounter a broken chunk length. #12693 #12729
+* [BUGFIX] Store-gateway: Fix a panic in BucketChunkReader when chunk loading encounter a broken chunk length. #12693 #12729 #12814
 * [BUGFIX] Ingester, Block-builder: silently ignore duplicate sample if it's due to zero sample from created timestamp. Created timestamp equal to the timestamp of the first sample of series is a common case if created timestamp comes from OTLP where start time equal to timestamp of the first sample simply means unknown start time. #12726
 * [BUGFIX] Distributor: Fix error when native histograms bucket limit is set then no NHCB passes validation. #12741
 

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"slices"
 	"sync"
 
@@ -156,6 +157,10 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesChunks, 
 		// Such a large chunk data len is unrealistic.
 		if chunkDataLen > uint64(maxChunkDataLen) {
 			return fmt.Errorf("chunk seq %d: parsed data length %d exceeds expected maximum chunk size %d", seq, chunkDataLen, maxChunkDataLen)
+		}
+
+		if chunkDataLen > uint64(math.MaxInt-chunks.ChunkEncodingSize) {
+			return fmt.Errorf("chunk seq %d: chunk data length %d too large for safe allocation", seq, chunkDataLen)
 		}
 
 		// We ignore the crc32 after the chunk data.


### PR DESCRIPTION
Signed-off-by: gotjosh <josue.abreu@gmail.com>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This is a third attempt at fixing https://github.com/grafana/mimir/issues/12691 and works on top of https://github.com/grafana/mimir/pull/12729.

We add a check to ensure chunkDataLen can be safely converted from uint64 to int
before conversion. The previous validation only checked against maxChunkDataLen
but didn’t prevent overflow when chunkDataLen + ChunkEncodingSize exceeded
math.MaxInt.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/12691

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
