### PR TITLE
Add support for ts_of_ promql functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [FEATURE] Alertmanager: add Microsoft Teams V2 as a supported integration. #12680
 * [FEATURE] Distributor: Add experimental flag `-validation.label-value-length-over-limit-strategy` to configure how to handle label values over the length limit. #12627
 * [FEATURE] Ingester: Introduce metric `cortex_ingester_owned_target_info_series` for counting the number of owned `target_info` series by tenant. #12681
+* [FEATURE] MQE: Add support for experimental `ts_of_min_over_time`, `ts_of_max_over_time`, `ts_of_first_over_time` and `ts_of_last_over_time` PromQL functions. #12819
 * [ENHANCEMENT] Query-frontend: CLI flag `-query-frontend.enabled-promql-experimental-functions` and its associated YAML configuration is now stable. #12368
 * [ENHANCEMENT] Query-scheduler/query-frontend: Add native histogram definitions to `cortex_query_{scheduler|frontend}_queue_duration_seconds`. #12288
 * [ENHANCEMENT] Querier: Add native histogram definition to `cortex_bucket_index_load_duration_seconds`. #12094

--- a/pkg/streamingpromql/functions_test.go
+++ b/pkg/streamingpromql/functions_test.go
@@ -113,8 +113,8 @@ func TestFunctionDeduplicateAndMerge(t *testing.T) {
 		"timestamp":                    `timestamp({__name__=~"float.*"})`,
 		"ts_of_first_over_time":        `ts_of_first_over_time({__name__=~"float.*"}[1m])`,
 		"ts_of_last_over_time":         `ts_of_last_over_time({__name__=~"float.*"}[1m])`,
-		"ts_of_min_over_time":          `ts_of_min_over_time({__name__=~"float.*"}[1m])`,
 		"ts_of_max_over_time":          `ts_of_max_over_time({__name__=~"float.*"}[1m])`,
+		"ts_of_min_over_time":          `ts_of_min_over_time({__name__=~"float.*"}[1m])`,
 		"vector":                       `<skip>`, // vector() takes a scalar, so this test doesn't apply.
 		"year":                         `year({__name__=~"float.*"})`,
 	}

--- a/pkg/streamingpromql/functions_test.go
+++ b/pkg/streamingpromql/functions_test.go
@@ -111,12 +111,12 @@ func TestFunctionDeduplicateAndMerge(t *testing.T) {
 		"tan":                          `tan({__name__=~"float.*"})`,
 		"tanh":                         `tanh({__name__=~"float.*"})`,
 		"timestamp":                    `timestamp({__name__=~"float.*"})`,
-		"vector":                       `<skip>`, // vector() takes a scalar, so this test doesn't apply.
-		"year":                         `year({__name__=~"float.*"})`,
 		"ts_of_first_over_time":        `ts_of_first_over_time({__name__=~"float.*"}[1m])`,
 		"ts_of_last_over_time":         `ts_of_last_over_time({__name__=~"float.*"}[1m])`,
 		"ts_of_min_over_time":          `ts_of_min_over_time({__name__=~"float.*"}[1m])`,
 		"ts_of_max_over_time":          `ts_of_max_over_time({__name__=~"float.*"}[1m])`,
+		"vector":                       `<skip>`, // vector() takes a scalar, so this test doesn't apply.
+		"year":                         `year({__name__=~"float.*"})`,
 	}
 
 	for f, functionMetadata := range functions.RegisteredFunctions {

--- a/pkg/streamingpromql/functions_test.go
+++ b/pkg/streamingpromql/functions_test.go
@@ -113,6 +113,10 @@ func TestFunctionDeduplicateAndMerge(t *testing.T) {
 		"timestamp":                    `timestamp({__name__=~"float.*"})`,
 		"vector":                       `<skip>`, // vector() takes a scalar, so this test doesn't apply.
 		"year":                         `year({__name__=~"float.*"})`,
+		"ts_of_first_over_time":        `ts_of_first_over_time({__name__=~"float.*"}[1m])`,
+		"ts_of_last_over_time":         `ts_of_last_over_time({__name__=~"float.*"}[1m])`,
+		"ts_of_min_over_time":          `ts_of_min_over_time({__name__=~"float.*"}[1m])`,
+		"ts_of_max_over_time":          `ts_of_max_over_time({__name__=~"float.*"}[1m])`,
 	}
 
 	for f, functionMetadata := range functions.RegisteredFunctions {

--- a/pkg/streamingpromql/operators/functions/factories.go
+++ b/pkg/streamingpromql/operators/functions/factories.go
@@ -729,6 +729,10 @@ func init() {
 	must(RegisterFunction(FUNCTION_TIMESTAMP, "timestamp", parser.ValueTypeVector, TimestampFunctionOperatorFactory))
 	must(RegisterFunction(FUNCTION_VECTOR, "vector", parser.ValueTypeVector, scalarToInstantVectorOperatorFactory))
 	must(RegisterFunction(FUNCTION_YEAR, "year", parser.ValueTypeVector, TimeTransformationFunctionOperatorFactory("year", Year)))
+	must(RegisterFunction(FUNCTION_TS_OF_MIN_OVER_TIME, "ts_of_min_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_min_over_time", TsOfMinOverTime)))
+	must(RegisterFunction(FUNCTION_TS_OF_MAX_OVER_TIME, "ts_of_max_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_max_over_time", TsOfMaxOverTime)))
+	must(RegisterFunction(FUNCTION_TS_OF_LAST_OVER_TIME, "ts_of_last_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_last_over_time", TsOfLastOverTime)))
+	must(RegisterFunction(FUNCTION_TS_OF_FIRST_OVER_TIME, "ts_of_first_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_first_over_time", TsOfFirstOverTime)))
 }
 
 func must(err error) {

--- a/pkg/streamingpromql/operators/functions/factories.go
+++ b/pkg/streamingpromql/operators/functions/factories.go
@@ -727,12 +727,12 @@ func init() {
 	must(RegisterFunction(FUNCTION_TANH, "tanh", parser.ValueTypeVector, InstantVectorTransformationFunctionOperatorFactory("tanh", Tanh)))
 	must(RegisterFunction(FUNCTION_TIME, "time", parser.ValueTypeScalar, timeOperatorFactory))
 	must(RegisterFunction(FUNCTION_TIMESTAMP, "timestamp", parser.ValueTypeVector, TimestampFunctionOperatorFactory))
-	must(RegisterFunction(FUNCTION_VECTOR, "vector", parser.ValueTypeVector, scalarToInstantVectorOperatorFactory))
-	must(RegisterFunction(FUNCTION_YEAR, "year", parser.ValueTypeVector, TimeTransformationFunctionOperatorFactory("year", Year)))
 	must(RegisterFunction(FUNCTION_TS_OF_MIN_OVER_TIME, "ts_of_min_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_min_over_time", TsOfMinOverTime)))
 	must(RegisterFunction(FUNCTION_TS_OF_MAX_OVER_TIME, "ts_of_max_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_max_over_time", TsOfMaxOverTime)))
 	must(RegisterFunction(FUNCTION_TS_OF_LAST_OVER_TIME, "ts_of_last_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_last_over_time", TsOfLastOverTime)))
 	must(RegisterFunction(FUNCTION_TS_OF_FIRST_OVER_TIME, "ts_of_first_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_first_over_time", TsOfFirstOverTime)))
+	must(RegisterFunction(FUNCTION_VECTOR, "vector", parser.ValueTypeVector, scalarToInstantVectorOperatorFactory))
+	must(RegisterFunction(FUNCTION_YEAR, "year", parser.ValueTypeVector, TimeTransformationFunctionOperatorFactory("year", Year)))
 }
 
 func must(err error) {

--- a/pkg/streamingpromql/operators/functions/factories.go
+++ b/pkg/streamingpromql/operators/functions/factories.go
@@ -727,10 +727,10 @@ func init() {
 	must(RegisterFunction(FUNCTION_TANH, "tanh", parser.ValueTypeVector, InstantVectorTransformationFunctionOperatorFactory("tanh", Tanh)))
 	must(RegisterFunction(FUNCTION_TIME, "time", parser.ValueTypeScalar, timeOperatorFactory))
 	must(RegisterFunction(FUNCTION_TIMESTAMP, "timestamp", parser.ValueTypeVector, TimestampFunctionOperatorFactory))
-	must(RegisterFunction(FUNCTION_TS_OF_MIN_OVER_TIME, "ts_of_min_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_min_over_time", TsOfMinOverTime)))
-	must(RegisterFunction(FUNCTION_TS_OF_MAX_OVER_TIME, "ts_of_max_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_max_over_time", TsOfMaxOverTime)))
-	must(RegisterFunction(FUNCTION_TS_OF_LAST_OVER_TIME, "ts_of_last_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_last_over_time", TsOfLastOverTime)))
 	must(RegisterFunction(FUNCTION_TS_OF_FIRST_OVER_TIME, "ts_of_first_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_first_over_time", TsOfFirstOverTime)))
+	must(RegisterFunction(FUNCTION_TS_OF_LAST_OVER_TIME, "ts_of_last_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_last_over_time", TsOfLastOverTime)))
+	must(RegisterFunction(FUNCTION_TS_OF_MAX_OVER_TIME, "ts_of_max_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_max_over_time", TsOfMaxOverTime)))
+	must(RegisterFunction(FUNCTION_TS_OF_MIN_OVER_TIME, "ts_of_min_over_time", parser.ValueTypeVector, FunctionOverRangeVectorOperatorFactory("ts_of_min_over_time", TsOfMinOverTime)))
 	must(RegisterFunction(FUNCTION_VECTOR, "vector", parser.ValueTypeVector, scalarToInstantVectorOperatorFactory))
 	must(RegisterFunction(FUNCTION_YEAR, "year", parser.ValueTypeVector, TimeTransformationFunctionOperatorFactory("year", Year)))
 }

--- a/pkg/streamingpromql/operators/functions/range_vectors.go
+++ b/pkg/streamingpromql/operators/functions/range_vectors.go
@@ -135,6 +135,120 @@ func maxOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.
 	return maxSoFar, true, nil, nil
 }
 
+var TsOfMinOverTime = FunctionOverRangeVectorDefinition{
+	SeriesMetadataFunction:         DropSeriesName,
+	StepFunc:                       tsOfMinOverTime,
+	NeedsSeriesNamesForAnnotations: true,
+}
+
+func tsOfMinOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+	cmpFunc := func(existing, next promql.FPoint) bool {
+		return next.F <= existing.F || math.IsNaN(existing.F)
+	}
+
+	return tsOverTime(cmpFunc, step, emitAnnotation)
+}
+
+var TsOfMaxOverTime = FunctionOverRangeVectorDefinition{
+	SeriesMetadataFunction:         DropSeriesName,
+	StepFunc:                       tsOfMaxOverTime,
+	NeedsSeriesNamesForAnnotations: true,
+}
+
+func tsOfMaxOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, emitAnnotation types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+	cmpFunc := func(existing, next promql.FPoint) bool {
+		return next.F >= existing.F || math.IsNaN(existing.F)
+	}
+
+	return tsOverTime(cmpFunc, step, emitAnnotation)
+}
+
+func tsOverTime(compareFn func(promql.FPoint, promql.FPoint) bool, step *types.RangeVectorStepData, emitAnnotation types.EmitAnnotationFunc) (float64, bool, *histogram.FloatHistogram, error) {
+	head, tail := step.Floats.UnsafePoints()
+
+	if len(head) == 0 && len(tail) == 0 {
+		return 0, false, nil, nil
+	}
+
+	if step.Histograms.Any() {
+		emitAnnotation(annotations.NewHistogramIgnoredInMixedRangeInfo)
+	}
+
+	best := head[0]
+	head = head[1:]
+
+	for _, p := range head {
+		if compareFn(best, p) {
+			best = p
+		}
+	}
+
+	for _, p := range tail {
+		if compareFn(best, p) {
+			best = p
+		}
+	}
+
+	return float64(best.T) / 1000, true, nil, nil
+}
+
+var TsOfLastOverTime = FunctionOverRangeVectorDefinition{
+	SeriesMetadataFunction:         DropSeriesName,
+	StepFunc:                       tsOflastOverTime,
+	NeedsSeriesNamesForAnnotations: true,
+}
+
+func tsOflastOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+	lastFloat, floatAvailable := step.Floats.Last()
+	lastHistogram, histogramAvailable := step.Histograms.Last()
+
+	if !floatAvailable && !histogramAvailable {
+		return 0, false, nil, nil
+	}
+
+	if floatAvailable && histogramAvailable {
+		if lastFloat.T > lastHistogram.T {
+			return float64(lastFloat.T) / 1000, true, nil, nil
+		}
+		return float64(lastHistogram.T) / 1000, true, nil, nil
+	}
+
+	if floatAvailable {
+		return float64(lastFloat.T) / 1000, true, nil, nil
+	}
+
+	return float64(lastHistogram.T) / 1000, true, nil, nil
+}
+
+var TsOfFirstOverTime = FunctionOverRangeVectorDefinition{
+	SeriesMetadataFunction:         DropSeriesName,
+	StepFunc:                       tsOfFirstOverTime,
+	NeedsSeriesNamesForAnnotations: true,
+}
+
+func tsOfFirstOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+
+	floats := step.Floats.Count()
+	histograms := step.Histograms.Count()
+
+	if floats == 0 && histograms == 0 {
+		return 0, false, nil, nil
+	}
+
+	if floats > 0 && histograms > 0 {
+		if step.Floats.First().T <= step.Histograms.First().T {
+			return float64(step.Floats.First().T) / 1000, true, nil, nil
+		}
+		return float64(step.Histograms.First().T) / 1000, true, nil, nil
+	}
+
+	if floats > 0 {
+		return float64(step.Floats.First().T) / 1000, true, nil, nil
+	}
+
+	return float64(step.Histograms.First().T) / 1000, true, nil, nil
+}
+
 var MinOverTime = FunctionOverRangeVectorDefinition{
 	SeriesMetadataFunction:         DropSeriesName,
 	StepFunc:                       minOverTime,

--- a/pkg/streamingpromql/operators/functions/range_vectors.go
+++ b/pkg/streamingpromql/operators/functions/range_vectors.go
@@ -194,11 +194,11 @@ func tsOverTime(compareFn func(promql.FPoint, promql.FPoint) bool, step *types.R
 
 var TsOfLastOverTime = FunctionOverRangeVectorDefinition{
 	SeriesMetadataFunction:         DropSeriesName,
-	StepFunc:                       tsOflastOverTime,
+	StepFunc:                       tsOfLastOverTime,
 	NeedsSeriesNamesForAnnotations: true,
 }
 
-func tsOflastOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
+func tsOfLastOverTime(step *types.RangeVectorStepData, _ []types.ScalarData, _ types.QueryTimeRange, _ types.EmitAnnotationFunc, _ *limiter.MemoryConsumptionTracker) (float64, bool, *histogram.FloatHistogram, error) {
 	lastFloat, floatAvailable := step.Floats.Last()
 	lastHistogram, histogramAvailable := step.Histograms.Last()
 

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -1348,55 +1348,55 @@ clear
 
 # Tests for ts_of_min_over_time using a mix of floats and histograms
 load 10s
-	metric 1 2 3 4 5 6
-    metric_histogram{type="only_histogram"} {{schema:1 sum:2 count:3}}x6
-    metric_histogram{type="mix"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 6
-    metric_histogram{type="mix_end"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1
+  metric 1 2 3 4 5 6
+  metric_histogram{type="only_histogram"} {{schema:1 sum:2 count:3}}x6
+  metric_histogram{type="mix"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 6
+  metric_histogram{type="mix_end"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1
 
 eval instant at 60s ts_of_min_over_time(metric[60s])
-	{} 10
-	expect no_info
+  {} 10
+  expect no_info
 
 eval instant at 60s ts_of_min_over_time(metric_histogram{type="mix"}[60s])
-	{type="mix"} 20
-	expect info regex: ignored histograms in a range containing both floats and histograms for metric name
+  {type="mix"} 20
+  expect info regex: ignored histograms in a range containing both floats and histograms for metric name
 
 eval instant at 60s ts_of_min_over_time(metric_histogram{type="mix_end"}[60s])
-    {type="mix_end"} 50
-    expect info regex: ignored histograms in a range containing both floats and histograms for metric name
+  {type="mix_end"} 50
+  expect info regex: ignored histograms in a range containing both floats and histograms for metric name
 
 clear
 
 # Tests for ts_of_last_over_time using a mix of floats and histograms
 load 10s
-    metric_histogram{type="mix_last_histogram"} 5 2 1 {{schema:1 sum:2 count:3}} 1 {{schema:1 sum:2 count:3}}
-    metric_histogram{type="mix_last_float"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1
-    metric_histogram{type="mix_last_missing"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} _
+  metric_histogram{type="mix_last_histogram"} 5 2 1 {{schema:1 sum:2 count:3}} 1 {{schema:1 sum:2 count:3}}
+  metric_histogram{type="mix_last_float"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1
+  metric_histogram{type="mix_last_missing"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} _
 
 eval instant at 60s ts_of_last_over_time(metric_histogram{type="mix_last_histogram"}[60s])
-    {type="mix_last_histogram"} 50
+  {type="mix_last_histogram"} 50
 
 eval instant at 60s ts_of_last_over_time(metric_histogram{type="mix_last_float"}[60s])
-    {type="mix_last_float"} 50
+  {type="mix_last_float"} 50
 
 eval instant at 60s ts_of_last_over_time(metric_histogram{type="mix_last_missing"}[60s])
-    {type="mix_last_missing"} 40
+  {type="mix_last_missing"} 40
 
 clear
 
 # Tests for ts_of_first_over_time using a mix of floats and histograms
 load 10s
-    metric_histogram{type="mix_first_histogram"} {{schema:1 sum:2 count:3}} 1 {{schema:1 sum:2 count:3}} 5 2 1
-    metric_histogram{type="mix_first_float"} 5 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1 2 1
-    metric_histogram{type="mix_first_missing"} _ 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} _
+  metric_histogram{type="mix_first_histogram"} {{schema:1 sum:2 count:3}} 1 {{schema:1 sum:2 count:3}} 5 2 1
+  metric_histogram{type="mix_first_float"} 5 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1 2 1
+  metric_histogram{type="mix_first_missing"} _ 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} _
 
 eval instant at 60s ts_of_first_over_time(metric_histogram{type="mix_first_histogram"}[80s])
-    {type="mix_first_histogram"} 0
+  {type="mix_first_histogram"} 0
 
 eval instant at 60s ts_of_first_over_time(metric_histogram{type="mix_first_float"}[80s])
-    {type="mix_first_float"} 0
+  {type="mix_first_float"} 0
 
 eval instant at 60s ts_of_first_over_time(metric_histogram{type="mix_first_missing"}[80s])
-    {type="mix_first_missing"} 10
+  {type="mix_first_missing"} 10
 
 clear

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -1346,23 +1346,44 @@ eval_fail instant at 0s double_exponential_smoothing(http_requests[5000s], 0.01,
 
 clear
 
-# Tests for ts_of_min_over_time using a mix of floats and histograms
+# Tests for ts_of_min_over_time and ts_of_max_over_time using a mix of floats and histograms
 load 10s
   metric 1 2 3 4 5 6
   metric_histogram{type="only_histogram"} {{schema:1 sum:2 count:3}}x6
   metric_histogram{type="mix"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 6
   metric_histogram{type="mix_end"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1
+  metric_histogram{type="mix_middle"} 10 2 60 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 10
 
 eval instant at 60s ts_of_min_over_time(metric[60s])
   {} 10
+  expect no_info
+
+eval instant at 60s ts_of_max_over_time(metric[60s])
+  {} 50
   expect no_info
 
 eval instant at 60s ts_of_min_over_time(metric_histogram{type="mix"}[60s])
   {type="mix"} 20
   expect info regex: ignored histograms in a range containing both floats and histograms for metric name
 
+eval instant at 60s ts_of_max_over_time(metric_histogram{type="mix"}[60s])
+  {type="mix"} 50
+  expect info regex: ignored histograms in a range containing both floats and histograms for metric name
+
 eval instant at 60s ts_of_min_over_time(metric_histogram{type="mix_end"}[60s])
   {type="mix_end"} 50
+  expect info regex: ignored histograms in a range containing both floats and histograms for metric name
+
+eval instant at 60s ts_of_max_over_time(metric_histogram{type="mix_end"}[60s])
+  {type="mix_end"} 10
+  expect info regex: ignored histograms in a range containing both floats and histograms for metric name
+
+eval instant at 60s ts_of_min_over_time(metric_histogram{type="mix_middle"}[60s])
+  {type="mix_middle"} 10
+  expect info regex: ignored histograms in a range containing both floats and histograms for metric name
+
+eval instant at 60s ts_of_max_over_time(metric_histogram{type="mix_middle"}[60s])
+  {type="mix_middle"} 20
   expect info regex: ignored histograms in a range containing both floats and histograms for metric name
 
 clear

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -1345,3 +1345,58 @@ eval_fail instant at 0s double_exponential_smoothing(http_requests[5000s], 0.01,
   expected_fail_message invalid trend factor. Expected: 0 < tf < 1, got: 0.000000
 
 clear
+
+# Tests for ts_of_min_over_time using a mix of floats and histograms
+load 10s
+	metric 1 2 3 4 5 6
+    metric_histogram{type="only_histogram"} {{schema:1 sum:2 count:3}}x6
+    metric_histogram{type="mix"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 6
+    metric_histogram{type="mix_end"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1
+
+eval instant at 60s ts_of_min_over_time(metric[60s])
+	{} 10
+	expect no_info
+
+eval instant at 60s ts_of_min_over_time(metric_histogram{type="mix"}[60s])
+	{type="mix"} 20
+	expect info regex: ignored histograms in a range containing both floats and histograms for metric name
+
+eval instant at 60s ts_of_min_over_time(metric_histogram{type="mix_end"}[60s])
+    {type="mix_end"} 50
+    expect info regex: ignored histograms in a range containing both floats and histograms for metric name
+
+clear
+
+# Tests for ts_of_last_over_time using a mix of floats and histograms
+load 10s
+    metric_histogram{type="mix_last_histogram"} 5 2 1 {{schema:1 sum:2 count:3}} 1 {{schema:1 sum:2 count:3}}
+    metric_histogram{type="mix_last_float"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1
+    metric_histogram{type="mix_last_missing"} 5 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} _
+
+eval instant at 60s ts_of_last_over_time(metric_histogram{type="mix_last_histogram"}[60s])
+    {type="mix_last_histogram"} 50
+
+eval instant at 60s ts_of_last_over_time(metric_histogram{type="mix_last_float"}[60s])
+    {type="mix_last_float"} 50
+
+eval instant at 60s ts_of_last_over_time(metric_histogram{type="mix_last_missing"}[60s])
+    {type="mix_last_missing"} 40
+
+clear
+
+# Tests for ts_of_first_over_time using a mix of floats and histograms
+load 10s
+    metric_histogram{type="mix_first_histogram"} {{schema:1 sum:2 count:3}} 1 {{schema:1 sum:2 count:3}} 5 2 1
+    metric_histogram{type="mix_first_float"} 5 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1 2 1
+    metric_histogram{type="mix_first_missing"} _ 2 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} _
+
+eval instant at 60s ts_of_first_over_time(metric_histogram{type="mix_first_histogram"}[80s])
+    {type="mix_first_histogram"} 0
+
+eval instant at 60s ts_of_first_over_time(metric_histogram{type="mix_first_float"}[80s])
+    {type="mix_first_float"} 0
+
+eval instant at 60s ts_of_first_over_time(metric_histogram{type="mix_first_missing"}[80s])
+    {type="mix_first_missing"} 10
+
+clear

--- a/pkg/streamingpromql/testdata/upstream/functions.test
+++ b/pkg/streamingpromql/testdata/upstream/functions.test
@@ -1314,13 +1314,11 @@ clear
 load 10s53ms
 	metric 1 2 3 0 5 6 2 1 4
 
-# Unsupported by streaming engine.
-# eval instant at 90s ts_of_min_over_time(metric[90s])
-#	{} 30.159
+eval instant at 90s ts_of_min_over_time(metric[90s])
+	{} 30.159
 
-# Unsupported by streaming engine.
-# eval instant at 90s ts_of_max_over_time(metric[90s])
-#	{} 50.265
+eval instant at 90s ts_of_max_over_time(metric[90s])
+	{} 50.265
 
 # Tests for ts_of_last_over_time. Using odd load interval to test for rounding bugs.
 clear
@@ -1329,21 +1327,17 @@ load 10s53ms
 	metric_histogram{type="only_histogram"} {{schema:1 sum:2 count:3}}x4
 	metric_histogram{type="mix"} 1 1 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1
 
-# Unsupported by streaming engine.
-# eval instant at 90s ts_of_last_over_time(metric[90s])
-#	{} 20.106
+eval instant at 90s ts_of_last_over_time(metric[90s])
+	{} 20.106
 
-# Unsupported by streaming engine.
-# eval instant at 95s ts_of_last_over_time(metric[90s])
-#	{} 20.106
+eval instant at 95s ts_of_last_over_time(metric[90s])
+	{} 20.106
 
-# Unsupported by streaming engine.
-# eval instant at 95s ts_of_last_over_time(metric_histogram{type="only_histogram"}[90s])
-# 	{type="only_histogram"} 40.212
+eval instant at 95s ts_of_last_over_time(metric_histogram{type="only_histogram"}[90s])
+	{type="only_histogram"} 40.212
 
-# Unsupported by streaming engine.
-# eval instant at 95s ts_of_last_over_time(metric_histogram{type="mix"}[90s])
-# 	{type="mix"} 50.265
+eval instant at 95s ts_of_last_over_time(metric_histogram{type="mix"}[90s])
+	{type="mix"} 50.265
 
 # Tests for ts_of_first_over_time
 clear
@@ -1352,25 +1346,20 @@ load 10s53ms
 	metric_histogram{type="only_histogram"} {{schema:1 sum:2 count:3}}x4
 	metric_histogram{type="mix"} _ 1 1 1 {{schema:1 sum:2 count:3}} {{schema:1 sum:2 count:3}} 1
 
-# Unsupported by streaming engine.
-# eval instant at 90s ts_of_first_over_time(metric[90s])
-# 	{} 20.106
+eval instant at 90s ts_of_first_over_time(metric[90s])
+	{} 20.106
 
-# Unsupported by streaming engine.
-# eval instant at 95s ts_of_first_over_time(metric[90s])
-# 	{} 20.106
+eval instant at 95s ts_of_first_over_time(metric[90s])
+	{} 20.106
 
-# Unsupported by streaming engine.
-# eval instant at 15s ts_of_first_over_time(metric[90s])
-# 	#empty
+eval instant at 15s ts_of_first_over_time(metric[90s])
+	#empty
 
-# Unsupported by streaming engine.
-# eval instant at 95s ts_of_first_over_time(metric_histogram{type="only_histogram"}[90s])
-# 	{type="only_histogram"} 10.053
+eval instant at 95s ts_of_first_over_time(metric_histogram{type="only_histogram"}[90s])
+	{type="only_histogram"} 10.053
 
-# Unsupported by streaming engine.
-# eval instant at 95s ts_of_first_over_time(metric_histogram{type="mix"}[90s])
-# 	{type="mix"} 10.053
+eval instant at 95s ts_of_first_over_time(metric_histogram{type="mix"}[90s])
+	{type="mix"} 10.053
 
 # Tests for quantile_over_time
 clear


### PR DESCRIPTION
#### What this PR does

This PR adds PromQL support for the experimental functions of ts_of_min_over_time, ts_of_max_over_time, ts_of_first_over_time and ts_of_last_over_time.

#### Which issue(s) this PR fixes or relates to

Fixes #3089

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
