### PR TITLE
Avoid continuous active series tracker reloads when cost attribution is in overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 * [BUGFIX] Store-gateway: Fix a panic in BucketChunkReader when chunk loading encounter a broken chunk length. #12693 #12729
 * [BUGFIX] Ingester, Block-builder: silently ignore duplicate sample if it's due to zero sample from created timestamp. Created timestamp equal to the timestamp of the first sample of series is a common case if created timestamp comes from OTLP where start time equal to timestamp of the first sample simply means unknown start time. #12726
 * [BUGFIX] Distributor: Fix error when native histograms bucket limit is set then no NHCB passes validation. #12741
+* [BUGFIX] Ingester: Fix continous reload of active series counters when cost-attribution labels are above the max cardinality. #12822
 
 ### Mixin
 

--- a/pkg/costattribution/manager_test.go
+++ b/pkg/costattribution/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/costattribution/costattributionmodel"
 	"github.com/grafana/mimir/pkg/costattribution/testutils"
@@ -158,8 +159,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 	})
 
 	t.Run("Purge inactive attributions, only received/discarded samples are purged", func(t *testing.T) {
-		err := manager.purgeInactiveAttributionsUntil(time.Unix(10, 0))
-		assert.NoError(t, err)
+		manager.purgeInactiveAttributionsUntil(time.Unix(10, 0).Add(manager.inactiveTimeout))
 		expectedMetrics := `
 		# HELP cortex_discarded_attributed_samples_total The total number of samples that were discarded per attribution.
 		# TYPE cortex_discarded_attributed_samples_total counter
@@ -173,7 +173,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 
 	t.Run("Disabling user cost attribution", func(t *testing.T) {
 		manager.limits = testutils.NewMockCostAttributionLimits(1)
-		assert.NoError(t, manager.purgeInactiveAttributionsUntil(time.Unix(11, 0)))
+		manager.purgeInactiveAttributionsUntil(time.Unix(11, 0).Add(manager.inactiveTimeout))
 		assert.Equal(t, 1, len(manager.sampleTrackersByUserID))
 
 		expectedMetrics := `
@@ -186,7 +186,7 @@ func TestManager_CreateDeleteTracker(t *testing.T) {
 
 	t.Run("Updating user cardinality and labels", func(t *testing.T) {
 		manager.limits = testutils.NewMockCostAttributionLimits(2)
-		assert.NoError(t, manager.purgeInactiveAttributionsUntil(time.Unix(12, 0)))
+		manager.purgeInactiveAttributionsUntil(time.Unix(12, 0).Add(manager.inactiveTimeout))
 		assert.Equal(t, 1, len(manager.sampleTrackersByUserID))
 		assert.True(t, manager.SampleTracker("user3").hasSameLabels([]costattributionmodel.Label{{Input: "feature", Output: ""}, {Input: "team", Output: ""}}))
 		assert.True(t, manager.ActiveSeriesTracker("user3").hasSameLabels([]costattributionmodel.Label{{Input: "feature", Output: ""}, {Input: "team", Output: ""}}))
@@ -240,7 +240,7 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 	manager.SampleTracker("user3").IncrementDiscardedSamples([]mimirpb.LabelAdapter{{Name: "department", Value: "foo"}, {Name: "service", Value: "bar"}}, 1, "out-of-window", time.Unix(10, 0))
 
 	t.Run("Purge before inactive timeout", func(t *testing.T) {
-		assert.NoError(t, manager.purgeInactiveAttributionsUntil(time.Unix(0, 0)))
+		manager.purgeInactiveAttributionsUntil(time.Unix(0, 0).Add(manager.inactiveTimeout))
 		assert.Equal(t, 2, len(manager.sampleTrackersByUserID))
 
 		expectedMetrics := `
@@ -255,7 +255,7 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 	t.Run("Purge after inactive timeout", func(t *testing.T) {
 		// disable cost attribution for user1 to test purging
 		manager.limits = testutils.NewMockCostAttributionLimits(1)
-		assert.NoError(t, manager.purgeInactiveAttributionsUntil(time.Unix(5, 0)))
+		manager.purgeInactiveAttributionsUntil(time.Unix(5, 0).Add(manager.inactiveTimeout))
 
 		// User3's tracker should remain since it's active, user1's tracker should be removed
 		assert.Equal(t, 1, len(manager.sampleTrackersByUserID), "Expected one active tracker after purging")
@@ -272,7 +272,7 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 
 	t.Run("Purge all trackers", func(t *testing.T) {
 		// Trigger a purge that should remove all inactive trackers
-		assert.NoError(t, manager.purgeInactiveAttributionsUntil(time.Unix(20, 0)))
+		manager.purgeInactiveAttributionsUntil(time.Unix(20, 0).Add(manager.inactiveTimeout))
 
 		// Tracker would stay at 1 since user1's tracker is disabled
 		assert.Equal(t, 1, len(manager.sampleTrackersByUserID), "Expected one active tracker after full purge")
@@ -280,6 +280,109 @@ func TestManager_PurgeInactiveAttributionsUntil(t *testing.T) {
 		// No metrics should remain after all purged
 		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(""), "cortex_discarded_attributed_samples_total", "cortex_distributor_received_attributed_samples_total"))
 	})
+
+	t.Run("Overflown active series recover only after they are under the limit", func(t *testing.T) {
+		// Track two series, this is under the limit of 2, so no overflow should happen yet.
+		now := time.Unix(10, 0)
+		manager.ActiveSeriesTracker("user7").Increment(labels.FromStrings("team", "1"), now, 0)
+		manager.ActiveSeriesTracker("user7").Increment(labels.FromStrings("team", "2"), now, 0)
+
+		withLockedActiveSeriesTracker(manager.ActiveSeriesTracker("user7"), func(ast *ActiveSeriesTracker) {
+			require.Equal(t, 2, len(ast.observed), "Should have 2 series tracked")
+			require.True(t, ast.overflowSince.IsZero(), "Should not be in overflow state yet")
+			require.Zero(t, ast.overflowCounter.activeSeries.Load(), "Overflow counter should be zero")
+		})
+
+		manager.ActiveSeriesTracker("user7").Increment(labels.FromStrings("team", "3"), now, 0)
+
+		withLockedActiveSeriesTracker(manager.ActiveSeriesTracker("user7"), func(ast *ActiveSeriesTracker) {
+			require.Equal(t, 3, len(ast.observed), "Should have 3 series tracked")
+			require.False(t, ast.overflowSince.IsZero(), "Should be in overflow state")
+			require.Zero(t, ast.overflowCounter.activeSeries.Load(), "Overflow counter should be zero")
+		})
+
+		// Track more series, one goes to observed, another two go to overflow.
+		manager.ActiveSeriesTracker("user7").Increment(labels.FromStrings("team", "4"), now, 0)
+		manager.ActiveSeriesTracker("user7").Increment(labels.FromStrings("team", "5"), now, 0)
+		manager.ActiveSeriesTracker("user7").Increment(labels.FromStrings("team", "6"), now, 0)
+
+		withLockedActiveSeriesTracker(manager.ActiveSeriesTracker("user7"), func(ast *ActiveSeriesTracker) {
+			require.Equal(t, 4, len(ast.observed), "Should have 4 series tracked")
+			require.False(t, ast.overflowSince.IsZero(), "Should be in overflow state")
+			require.Equal(t, int64(2), ast.overflowCounter.activeSeries.Load(), "Overflow counter should be 1")
+		})
+
+		// Run purge after the cooldown, nothing should change since we are still over the limit.
+		now = now.Add(testutils.TestAttributionCooldown)
+		manager.purgeInactiveAttributionsUntil(now)
+
+		// Nothing has changed.
+		withLockedActiveSeriesTracker(manager.ActiveSeriesTracker("user7"), func(ast *ActiveSeriesTracker) {
+			require.Equal(t, 4, len(ast.observed), "Should have 4 series tracked")
+			require.False(t, ast.overflowSince.IsZero(), "Should be in overflow state")
+			require.Equal(t, int64(2), ast.overflowCounter.activeSeries.Load(), "Overflow counter should be 1")
+		})
+
+		now = now.Add(testutils.TestAttributionCooldown / 10)
+		// Decrement one of the observed series and one of the overflow series.
+		manager.ActiveSeriesTracker("user7").Decrement(labels.FromStrings("team", "1"), 0)
+		manager.ActiveSeriesTracker("user7").Decrement(labels.FromStrings("team", "6"), 0)
+
+		// Check the updated state.
+		withLockedActiveSeriesTracker(manager.ActiveSeriesTracker("user7"), func(ast *ActiveSeriesTracker) {
+			require.Equal(t, 3, len(ast.observed), "Should have 3 series tracked")
+			require.False(t, ast.overflowSince.IsZero(), "Should be in overflow state")
+			require.Equal(t, int64(1), ast.overflowCounter.activeSeries.Load(), "Overflow counter should be 1")
+		})
+
+		// Run purge after the cooldown, nothing should change since we are still over the limit.
+		now = now.Add(testutils.TestAttributionCooldown)
+		manager.purgeInactiveAttributionsUntil(now)
+
+		// Nothing has changed.
+		withLockedActiveSeriesTracker(manager.ActiveSeriesTracker("user7"), func(ast *ActiveSeriesTracker) {
+			require.Equal(t, 3, len(ast.observed), "Should have 3 series tracked")
+			require.False(t, ast.overflowSince.IsZero(), "Should be in overflow state")
+			require.Equal(t, int64(1), ast.overflowCounter.activeSeries.Load(), "Overflow counter should be 1")
+		})
+
+		now = now.Add(testutils.TestAttributionCooldown / 10)
+		// Increment a different series, it should go to observed because we have room there now.
+		manager.ActiveSeriesTracker("user7").Increment(labels.FromStrings("team", "7"), now, 0)
+		withLockedActiveSeriesTracker(manager.ActiveSeriesTracker("user7"), func(ast *ActiveSeriesTracker) {
+			require.Equal(t, 4, len(ast.observed), "Should have 4 series tracked")
+			require.False(t, ast.overflowSince.IsZero(), "Should be in overflow state")
+			require.Equal(t, int64(1), ast.overflowCounter.activeSeries.Load(), "Overflow counter should be 1")
+		})
+
+		now = now.Add(testutils.TestAttributionCooldown / 10)
+		// Decrement two observed series, this should bring us under the limit and recover from overflow state.
+		manager.ActiveSeriesTracker("user7").Decrement(labels.FromStrings("team", "3"), 0)
+		manager.ActiveSeriesTracker("user7").Decrement(labels.FromStrings("team", "4"), 0)
+
+		// NOTE: There are still series in the overflow counter, but can't tell how much cardinality those two add,
+		// The best we can say is "it's at least 1", so we just ignore here (with a limit set to thousands, doing this plus one won't change much).
+		withLockedActiveSeriesTracker(manager.ActiveSeriesTracker("user7"), func(ast *ActiveSeriesTracker) {
+			require.Equal(t, 2, len(ast.observed), "Should have 2 series tracked")
+			require.False(t, ast.overflowSince.IsZero(), "Should be in overflow state")
+			require.Equal(t, int64(1), ast.overflowCounter.activeSeries.Load(), "Overflow counter should be 1")
+		})
+
+		// Purge again, this should remove the tracker.
+		now = now.Add(testutils.TestAttributionCooldown)
+		manager.purgeInactiveAttributionsUntil(now)
+		withLockedActiveSeriesTracker(manager.ActiveSeriesTracker("user7"), func(ast *ActiveSeriesTracker) {
+			require.Equal(t, 0, len(ast.observed), "Should have no series tracked")
+			require.True(t, ast.overflowSince.IsZero(), "Should not be in overflow state anymore")
+			require.Zero(t, ast.overflowCounter.activeSeries.Load(), "Overflow counter should be zero")
+		})
+	})
+}
+
+func withLockedActiveSeriesTracker(ast *ActiveSeriesTracker, fn func(ast *ActiveSeriesTracker)) {
+	ast.observedMtx.Lock()
+	defer ast.observedMtx.Unlock()
+	fn(ast)
 }
 
 func TestManager_OutputLabels(t *testing.T) {

--- a/pkg/costattribution/testutils/test_utils.go
+++ b/pkg/costattribution/testutils/test_utils.go
@@ -3,10 +3,16 @@
 package testutils
 
 import (
+	"time"
+
+	"github.com/prometheus/common/model"
+
 	"github.com/grafana/mimir/pkg/costattribution/costattributionmodel"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
+
+const TestAttributionCooldown = 20 * time.Minute
 
 func NewMockCostAttributionLimits(idx int, userLabels ...[]string) *validation.Overrides {
 	return NewMockCostAttributionOverrides(validation.Limits{}, nil, idx, userLabels...)
@@ -24,6 +30,7 @@ func NewMockCostAttributionOverrides(limits validation.Limits, overrides map[str
 		"user5": {MaxCostAttributionCardinality: 10, CostAttributionLabels: []string{"a"}},
 		// user6 has opted to rename team to eng_team.
 		"user6": {MaxCostAttributionCardinality: 5, CostAttributionLabelsStructured: []costattributionmodel.Label{{Input: "team", Output: "eng_team"}}},
+		"user7": {MaxCostAttributionCardinality: 2, CostAttributionLabels: []string{"team"}, CostAttributionCooldown: model.Duration(TestAttributionCooldown)},
 	}
 	for _, uls := range userLabels {
 		baseLimits[uls[0]] = &validation.Limits{


### PR DESCRIPTION
#### What this PR does

This fixes the continuous (every cooldown period) reloads of the active series trackers when the cost-attribution tracker is above the max cardinality.

##### What is happening?

When cost-attribution active-series tracker observes more than the maxCardinality label combinations, it enters the overflow and tracks the time when it entered the overflow mode.

After a cooldown period (20 minutes by default) we delete the tracker, which causes active-series tracker to reload (in order to correctly fill the cost atttribution active series tracker again), and this process starts again.

#### How do we fix this?

We will track up to `2*maxCardinality` label combinations internally, this way we can have some insights about the customer behavior, even though it's not absolutely precise.

After the cooldown period, we'll check whether the number of label combinations is below the `maxCardinality`, and if it's not, we'll wait another cooldown period, and so on. 

This way we will only reload the trackers if customer has removed at least `maxCardinality` combinations and didn't add new ones. It is still possible that the customer is over the limit after this, because we can't know how much cardinality is added from the series that we've tracked in the `overflowCounter`: that information is lost forever, but a situation where there's cardinality in those ones and not in the observed ones is unlikely.

#### Which issue(s) this PR fixes or relates to

Fixes an internal issue.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
