### PR TITLE
Incorporate matcher deduplication to lookup planning

### DIFF
--- a/pkg/ingester/lookupplan/matcher_reducer_planner.go
+++ b/pkg/ingester/lookupplan/matcher_reducer_planner.go
@@ -1,0 +1,108 @@
+package lookupplan
+
+import (
+	"context"
+	"slices"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/index"
+)
+
+// MatcherReducerPlanner deduplicates matchers from the input plan,
+// and removes matchers that select for all non-empty values if a more selective matcher for the same label name already exists.
+// It returns the input index and scan matchers in the input order.
+// If matchers are duplicated across the index and scan matchers, they will be returned as index-only matchers.
+type MatcherReducerPlanner struct{}
+
+// concreteLookupPlan implements LookupPlan by storing pre-computed index and scan matchers.
+type concreteLookupPlan struct {
+	indexMatchers []*labels.Matcher
+	scanMatchers  []*labels.Matcher
+}
+
+func (p concreteLookupPlan) ScanMatchers() []*labels.Matcher {
+	return p.scanMatchers
+}
+
+func (p concreteLookupPlan) IndexMatchers() []*labels.Matcher {
+	return p.indexMatchers
+}
+
+func (p MatcherReducerPlanner) PlanIndexLookup(ctx context.Context, inPlan index.LookupPlan, minT, maxT int64) (index.LookupPlan, error) {
+	if planningDisabled(ctx) {
+		return inPlan, nil
+	}
+
+	// For the purpose of deduping, we'll treat all matchers the same for now
+	matchers := slices.Concat(inPlan.IndexMatchers(), inPlan.ScanMatchers())
+
+	matchers = filterDuplicateLabelNameNonemptyMatchers(matchers)
+	dedupedMatchers := make(map[labels.Matcher][]bool, len(matchers))
+	for _, m := range matchers {
+		dedupedMatchers[*m] = []bool{true}
+	}
+	outIndexMatchers := make([]*labels.Matcher, 0)
+	outScanMatchers := make([]*labels.Matcher, 0)
+	for _, m := range inPlan.IndexMatchers() {
+		// We only want to add the matcher if it hasn't already been added to an output slice
+		if _, ok := dedupedMatchers[*m]; ok && len(dedupedMatchers[*m]) < 2 {
+			outIndexMatchers = append(outIndexMatchers, m)
+			dedupedMatchers[*m] = append(dedupedMatchers[*m], true)
+		}
+	}
+	for _, m := range inPlan.ScanMatchers() {
+		if _, ok := dedupedMatchers[*m]; ok && len(dedupedMatchers[*m]) < 2 {
+			outScanMatchers = append(outScanMatchers, m)
+			dedupedMatchers[*m] = append(dedupedMatchers[*m], true)
+		}
+	}
+	return &concreteLookupPlan{
+		indexMatchers: outIndexMatchers,
+		scanMatchers:  outScanMatchers,
+	}, nil
+}
+
+// filterDuplicateLabelNameNonemptyMatchers returns a slice of the input matchers,
+// excluding any matchers with duplicate label names where one of said matchers matches all nonempty values.
+// For example, an input of namespace="foo", namespace!="" should return only namespace="foo".
+// If multiple matchers all match any nonempty value, only one matcher for that label name will be returned.
+// Note that the input order is not maintained.
+func filterDuplicateLabelNameNonemptyMatchers(ms []*labels.Matcher) []*labels.Matcher {
+	matchersByName := make(map[string][]*labels.Matcher)
+	for _, m := range ms {
+		if _, ok := matchersByName[m.Name]; !ok {
+			matchersByName[m.Name] = make([]*labels.Matcher, 0, 1)
+		}
+		matchersByName[m.Name] = append(matchersByName[m.Name], m)
+	}
+	matcherNamesReturned := make(map[string]bool, len(matchersByName))
+	filteredMatchers := make([]*labels.Matcher, 0)
+
+	for name, matchers := range matchersByName {
+		if len(matchers) > 1 {
+			for i, matcherForName := range matchers {
+				// If this is the last matcher for the label name,
+				// and we haven't added any matchers for this label name to the result set,
+				// add this matcher to the result set.
+				if (i == len(matchers)-1) && !matcherNamesReturned[name] {
+					filteredMatchers = append(filteredMatchers, matcherForName)
+					matcherNamesReturned[name] = true
+					continue
+				}
+				// Otherwise, check for nonempty matchers and skip them
+				if matcherForName.Type == labels.MatchRegexp && matcherForName.Value == ".*" {
+					continue
+				}
+				if (matcherForName.Type == labels.MatchNotRegexp || matcherForName.Type == labels.MatchNotEqual) && matcherForName.Value == "" {
+					continue
+				}
+				filteredMatchers = append(filteredMatchers, matcherForName)
+				matcherNamesReturned[name] = true
+			}
+		} else {
+			filteredMatchers = append(filteredMatchers, matchers...)
+			matcherNamesReturned[name] = true
+		}
+	}
+	return filteredMatchers
+}

--- a/pkg/ingester/lookupplan/matcher_reducer_planner_test.go
+++ b/pkg/ingester/lookupplan/matcher_reducer_planner_test.go
@@ -1,0 +1,150 @@
+package lookupplan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatcherReducerPlanner_PlanIndexLookup(t *testing.T) {
+	ctxPlanningDisabled := ContextWithDisabledPlanning(context.Background())
+
+	equalMatcher, _ := labels.NewMatcher(labels.MatchEqual, "foo", "bar")
+	selectiveRegexMatcher, _ := labels.NewMatcher(labels.MatchRegexp, "foo", ".*bar.*")
+	nonSelectiveRegexMatcher, _ := labels.NewMatcher(labels.MatchRegexp, "foo", ".*")
+	nonSelectiveNotRegexMatcher, _ := labels.NewMatcher(labels.MatchNotRegexp, "foo", "")
+	nonSelectiveNotEqualsMatcher, _ := labels.NewMatcher(labels.MatchNotEqual, "foo", "")
+
+	otherLabelNonSelectiveNotRegexMatcher, _ := labels.NewMatcher(labels.MatchNotRegexp, "baz", "")
+	otherLabelSelectiveMatcher, _ := labels.NewMatcher(labels.MatchNotEqual, "baz", "bananas")
+
+	tests := []struct {
+		name         string
+		ctx          context.Context
+		inPlan       concreteLookupPlan
+		expectedPlan concreteLookupPlan
+	}{
+		{
+			name: "planning disabled should not alter plan",
+			ctx:  ctxPlanningDisabled,
+			inPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{equalMatcher, nonSelectiveRegexMatcher, nonSelectiveNotEqualsMatcher},
+				scanMatchers:  []*labels.Matcher{equalMatcher, nonSelectiveNotRegexMatcher},
+			},
+			expectedPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{equalMatcher, nonSelectiveRegexMatcher, nonSelectiveNotEqualsMatcher},
+				scanMatchers:  []*labels.Matcher{equalMatcher, nonSelectiveNotRegexMatcher},
+			},
+		},
+		{
+			name: "planning should not alter plan with multiple selective matchers for label name",
+			ctx:  context.Background(),
+			inPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{equalMatcher},
+				scanMatchers:  []*labels.Matcher{selectiveRegexMatcher},
+			},
+			expectedPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{equalMatcher},
+				scanMatchers:  []*labels.Matcher{selectiveRegexMatcher},
+			},
+		},
+		{
+			name: "deduplicate index matchers",
+			ctx:  context.Background(),
+			inPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{equalMatcher, equalMatcher},
+				scanMatchers:  []*labels.Matcher{},
+			},
+			expectedPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{equalMatcher},
+				scanMatchers:  []*labels.Matcher{},
+			},
+		},
+		{
+			name: "deduplicate scan matchers",
+			ctx:  context.Background(),
+			inPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{},
+				scanMatchers:  []*labels.Matcher{selectiveRegexMatcher, selectiveRegexMatcher},
+			},
+			expectedPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{},
+				scanMatchers:  []*labels.Matcher{selectiveRegexMatcher},
+			},
+		},
+		{
+			name: "duplicate matchers across index and scan should be deduplicated to only index matcher",
+			ctx:  context.Background(),
+			inPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{equalMatcher},
+				scanMatchers:  []*labels.Matcher{equalMatcher},
+			},
+			expectedPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{equalMatcher},
+				scanMatchers:  []*labels.Matcher{},
+			},
+		},
+		{
+			name: "remove all non-selective matchers if a selective matcher exists",
+			ctx:  context.Background(),
+			inPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{nonSelectiveRegexMatcher},
+				scanMatchers:  []*labels.Matcher{equalMatcher, nonSelectiveNotEqualsMatcher},
+			},
+			expectedPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{},
+				scanMatchers:  []*labels.Matcher{equalMatcher},
+			},
+		},
+		{
+			name: "keep one non-selective matcher if no selective matcher exists",
+			ctx:  context.Background(),
+			inPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{nonSelectiveRegexMatcher},
+				scanMatchers:  []*labels.Matcher{nonSelectiveNotRegexMatcher, nonSelectiveNotRegexMatcher},
+			},
+			expectedPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{},
+				scanMatchers:  []*labels.Matcher{nonSelectiveNotRegexMatcher},
+			},
+		},
+		{
+			name: "keep at least one matcher for each label name",
+			ctx:  context.Background(),
+			inPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{nonSelectiveRegexMatcher, otherLabelNonSelectiveNotRegexMatcher},
+				scanMatchers:  []*labels.Matcher{nonSelectiveNotRegexMatcher, nonSelectiveNotRegexMatcher},
+			},
+			expectedPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{otherLabelNonSelectiveNotRegexMatcher},
+				scanMatchers:  []*labels.Matcher{nonSelectiveNotRegexMatcher},
+			},
+		},
+		{
+			name: "keep at least one matcher for each label name, keep selective matchers over non-selective matchers",
+			ctx:  context.Background(),
+			inPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{nonSelectiveRegexMatcher, otherLabelNonSelectiveNotRegexMatcher},
+				scanMatchers:  []*labels.Matcher{nonSelectiveNotRegexMatcher, nonSelectiveNotRegexMatcher, otherLabelSelectiveMatcher},
+			},
+			expectedPlan: concreteLookupPlan{
+				indexMatchers: []*labels.Matcher{},
+				scanMatchers:  []*labels.Matcher{nonSelectiveNotRegexMatcher, otherLabelSelectiveMatcher},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			planner := MatcherReducerPlanner{}
+			outPlan, err := planner.PlanIndexLookup(tt.ctx, tt.inPlan, 0, 0)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedPlan.IndexMatchers(), outPlan.IndexMatchers())
+			assert.Equal(t, tt.expectedPlan.ScanMatchers(), outPlan.ScanMatchers())
+
+		})
+	}
+}

--- a/pkg/ingester/lookupplan/planner_factory.go
+++ b/pkg/ingester/lookupplan/planner_factory.go
@@ -45,5 +45,6 @@ func (p *PlannerFactory) CreatePlanner(meta tsdb.BlockMeta, reader tsdb.IndexRea
 		level.Warn(logger).Log("msg", "failed to generate statistics; queries for this block won't use query planning", "err", err)
 		return NoopPlanner{}
 	}
-	return NewCostBasedPlanner(p.metrics, stats)
+
+	return index.ChainLookupPlanners(MatcherReducerPlanner{}, NewCostBasedPlanner(p.metrics, stats))
 }

--- a/pkg/ingester/lookupplan/planner_factory_test.go
+++ b/pkg/ingester/lookupplan/planner_factory_test.go
@@ -131,14 +131,10 @@ func TestPlannerFactory_CreatePlanner(t *testing.T) {
 			expectedPlanner: reflect.TypeOf(NoopPlanner{}),
 		},
 		{
-			name: "large block with working IndexReader returns CostBasedPlanner",
-			blockMeta: tsdb.BlockMeta{
-				Stats: tsdb.BlockStats{
-					NumSeries: 15000,
-				},
-			},
+			name:            "large block with working IndexReader returns CostBasedPlanner",
+			blockMeta:       tsdb.BlockMeta{Stats: tsdb.BlockStats{NumSeries: 15000}},
 			indexReader:     createMockIndexReaderWithSeries(15000),
-			expectedPlanner: reflect.TypeOf(&CostBasedPlanner{}),
+			expectedPlanner: reflect.TypeOf(index.ChainLookupPlanners(MatcherReducerPlanner{}, CostBasedPlanner{})),
 		},
 		{
 			name: "exactly at threshold with working IndexReader returns CostBasedPlanner",
@@ -148,7 +144,7 @@ func TestPlannerFactory_CreatePlanner(t *testing.T) {
 				},
 			},
 			indexReader:     createMockIndexReaderWithSeries(minSeriesPerBlockForQueryPlanning),
-			expectedPlanner: reflect.TypeOf(&CostBasedPlanner{}),
+			expectedPlanner: reflect.TypeOf(index.ChainLookupPlanners(MatcherReducerPlanner{}, CostBasedPlanner{})),
 		},
 		{
 			name: "very large block with working IndexReader returns CostBasedPlanner",
@@ -158,7 +154,7 @@ func TestPlannerFactory_CreatePlanner(t *testing.T) {
 				},
 			},
 			indexReader:     createMockIndexReaderWithSeries(100000),
-			expectedPlanner: reflect.TypeOf(&CostBasedPlanner{}),
+			expectedPlanner: reflect.TypeOf(index.ChainLookupPlanners(MatcherReducerPlanner{}, CostBasedPlanner{})),
 		},
 		{
 			name: "large block with error IndexReader fallbacks to NoopPlanner",
@@ -188,7 +184,7 @@ func TestPlannerFactory_CreatePlanner(t *testing.T) {
 				},
 			},
 			indexReader:     createMockIndexReaderWithSeries(1000000),
-			expectedPlanner: reflect.TypeOf(&CostBasedPlanner{}),
+			expectedPlanner: reflect.TypeOf(index.ChainLookupPlanners(MatcherReducerPlanner{}, CostBasedPlanner{})),
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This PR creates a new `MatcherReducerPlanner`, which can be used to deduplicate matchers and remove "nonselective matchers" if more selective matchers exist for the same label name.

Nonselective matchers are conservatively, an explicit set of matchers which would select all values of a label name:
* `foo=~".*"`
* `foo!=""`
* `foo!~""`

Conversely, selective matchers are any matcher not in the above set.

If no selective matchers exist for a label name, one nonselective matcher will be preserved.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/issues/11920

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
