### PR TITLE
parquet converter: add `parquet-converter.min-block-duration` flag

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -22781,6 +22781,17 @@
         },
         {
           "kind": "field",
+          "name": "min_block_duration",
+          "required": false,
+          "desc": "Minimum duration of blocks to convert. Blocks with a duration shorter than this will be skipped. Set to 0 to disable duration filtering.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "parquet-converter.min-block-duration",
+          "fieldType": "duration",
+          "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
           "name": "compression_enabled",
           "required": false,
           "desc": "Whether compression is enabled for labels and chunks parquet files. When disabled, parquet files will be converted and stored uncompressed.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2065,6 +2065,8 @@ Usage of ./cmd/mimir/mimir:
     	Maximum number of blocks that can be queued for conversion at once. This helps distribute work evenly across replicas. (default 5)
   -parquet-converter.max-rows-per-group int
     	Maximum number of rows per row group in Parquet files. (default 1000000)
+  -parquet-converter.min-block-duration duration
+    	Minimum duration of blocks to convert. Blocks with a duration shorter than this will be skipped. Set to 0 to disable duration filtering.
   -parquet-converter.min-block-timestamp int
     	Minimum block timestamp (based on ULID) to convert. Set to 0 to disable timestamp filtering.
   -parquet-converter.min-compaction-level int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1491,6 +1491,11 @@ parquet_converter:
   # CLI flag: -parquet-converter.min-compaction-level
   [min_compaction_level: <int> | default = 2]
 
+  # (advanced) Minimum duration of blocks to convert. Blocks with a duration
+  # shorter than this will be skipped. Set to 0 to disable duration filtering.
+  # CLI flag: -parquet-converter.min-block-duration
+  [min_block_duration: <duration> | default = 0s]
+
   # (advanced) Whether compression is enabled for labels and chunks parquet
   # files. When disabled, parquet files will be converted and stored
   # uncompressed.


### PR DESCRIPTION
Just another knob to filter the wanted blocks.