### PR TITLE
[r359] backport storegateway: BucketChunkReader to validate chunk data length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [BUGFIX] Querier: Fix possible panic when evaluating a nested subquery where the parent has no steps. #12524
 * [BUGFIX] Ingester: Fix a bug where prepare-instance-ring-downscale endpoint would return an error while compacting and not read-only. #12548
 * [BUGFIX] OTLP: Return HTTP OK for partially rejected requests, e.g. due to OOO exemplars. #12579
+* [BUGFIX] Store-gateway: Fix a panic in BucketChunkReader when chunk loading encounter a broken chunk length. #12693 #12729
 
 ### Mixin
 

--- a/pkg/storegateway/bucket_chunk_reader.go
+++ b/pkg/storegateway/bucket_chunk_reader.go
@@ -29,6 +29,11 @@ import (
 	"github.com/grafana/mimir/pkg/util/pool"
 )
 
+// maxChunkDataLen is a safeguard to protect the chunk data parsing from over allocating in case of a broken chunk.
+// Refer to https://github.com/grafana/mimir/issues/12691 for the background.
+// 512MB would be a ridiculously large chunk. But, to keep things relaxed, we use a much larger value than tsdb.EstimatedMaxChunkSize.
+const maxChunkDataLen = 512 * 1024 * 1024
+
 type bucketChunkReader struct {
 	ctx   context.Context
 	block *bucketBlock
@@ -145,6 +150,14 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesChunks, 
 		if err != nil {
 			return errors.Wrap(err, "parsing chunk length")
 		}
+
+		// Validate chunk data length to prevent unreasonably large memory allocations or panics from a corrupted data.
+		// Note, that on a 64-bit system Go should allow to allocate up to ~140TB; a larger len causes "makeslice: len out of range".
+		// Such a large chunk data len is unrealistic.
+		if chunkDataLen > uint64(maxChunkDataLen) {
+			return fmt.Errorf("chunk seq %d: parsed data length %d exceeds expected maximum chunk size %d", seq, chunkDataLen, maxChunkDataLen)
+		}
+
 		// We ignore the crc32 after the chunk data.
 		chunkEncDataLen := chunks.ChunkEncodingSize + int(chunkDataLen)
 		cb := chunksPool.Get(chunkEncDataLen)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

CI failed to do this automatically from https://github.com/grafana/mimir/pull/12851 as there was a CHANGELOG conflict

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
