### PR TITLE
Use upstream shared-workflows instead of fork

### DIFF
--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -45,7 +45,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Run Flaky Tests Analysis
-        uses: dimitarvdimitrov/shared-workflows/actions/go-flaky-tests@20a72aa1821825fb2871515ed53002e4c18842db # dimitar/analyze-test-failures/exclude-tests
+        uses: grafana/shared-workflows/actions/go-flaky-tests@175fc60e9f754baa0ec627fed4fb5c89fefd267b
         with:
           loki-url: ${{ env.LOKI_URL }}
           loki-username: ${{ env.LOKI_USERNAME }}


### PR DESCRIPTION
All GitHub Actions changes have been merged upstream and we no longer need to run off a fork.