### PR TITLE
Revert moving dashboard links into config

### DIFF
--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -25,7 +25,14 @@
     // Added default flag for GEM-specific dashboards and alerts.
     gem_enabled: false,
 
-    mimir_dashboard_links: [
+    rollout_operator_dashboard_enable: true,
+    rollout_operator_dashboard_title: 'rollout-operator',
+    // This is the md5 of the rollout-operator dashboard name.
+    // This is set such that if the name / uid was to change an error will be raised in dashboard generation.
+    // This ensures that the uid is consistent and can be reliably linked to.
+    rollout_operator_dashboard_uid: 'f40e8042a6be71a98444a29b2c4e9421',
+    rollout_operator_container_name: 'rollout-operator',
+    rollout_operator_links: [
       {
         asDropdown: true,
         icon: 'external link',
@@ -37,15 +44,6 @@
         type: 'dashboards',
       },
     ],
-
-    rollout_operator_dashboard_enable: true,
-    rollout_operator_dashboard_title: 'rollout-operator',
-    // This is the md5 of the rollout-operator dashboard name.
-    // This is set such that if the name / uid was to change an error will be raised in dashboard generation.
-    // This ensures that the uid is consistent and can be reliably linked to.
-    rollout_operator_dashboard_uid: 'f40e8042a6be71a98444a29b2c4e9421',
-    rollout_operator_container_name: 'rollout-operator',
-    rollout_operator_links: $._config.mimir_dashboard_links,
     rollout_operator_instance_matcher:
       if std.get($._config, 'helm', '') == '' then $._config.rollout_operator_container_name + '.*' else '(.*%g-)?%g.*' % [$._config.helm, $._config.rollout_operator_container_name],
     rollout_operator_resources_panel_queries: self.resources_panel_queries.kubernetes,

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -97,7 +97,18 @@ local utils = import 'mixin-utils/utils.libsonnet';
       addClusterSelectorTemplates(multi=true)::
         local d = self {
           tags: $._config.tags,
-          links: $._config.mimir_dashboard_links,
+          links: [
+            {
+              asDropdown: true,
+              icon: 'external link',
+              includeVars: true,
+              keepTime: true,
+              tags: $._config.tags,
+              targetBlank: false,
+              title: '%(product)s dashboards' % $._config,
+              type: 'dashboards',
+            },
+          ],
         };
 
         if multi then


### PR DESCRIPTION
#### What this PR does

Reverts a [recent change](https://github.com/grafana/mimir/pull/12688) to set the mimir dashboard links via a $._config variable.

This change causes upstream vendoring issues.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/pull/12688
