### PR TITLE
Remote execution: don't mark trace spans as failed if request is cancelled

### DIFF
--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -332,7 +332,12 @@ func (rth *engineQueryRequestRoundTripperHandler) Do(ctx context.Context, r Metr
 	spanLogger, ctx := spanlogger.New(ctx, rth.logger, tracer, "engineQueryRequestRoundTripperHandler.Do")
 	defer func() {
 		if err != nil {
-			spanLogger.Error(err)
+			// TypeForError handles both apierror.APIError instances as well as context.Canceled instances, so we don't need to check for both below.
+			if apierror.TypeForError(err, apierror.TypeNone) == apierror.TypeCanceled {
+				spanLogger.DebugLog("msg", "request returned cancellation error", "err", err)
+			} else {
+				spanLogger.Error(err)
+			}
 		}
 		spanLogger.Finish()
 	}()

--- a/pkg/querier/dispatcher.go
+++ b/pkg/querier/dispatcher.go
@@ -244,9 +244,12 @@ func (w *queryResponseWriter) Write(ctx context.Context, r querierpb.EvaluateQue
 func (w *queryResponseWriter) WriteError(ctx context.Context, fallbackType apierror.Type, err error) {
 	typ := errorTypeForError(err, fallbackType)
 	msg := err.Error()
-
 	span := trace.SpanFromContext(ctx)
-	span.SetStatus(codes.Error, msg)
+
+	if typ != mimirpb.QUERY_ERROR_TYPE_CANCELED {
+		span.SetStatus(codes.Error, msg)
+	}
+
 	span.AddEvent("returning error", trace.WithAttributes(attribute.String("type", typ.String()), attribute.String("msg", msg)))
 
 	w.status = "ERROR_" + strings.TrimPrefix(typ.String(), "QUERY_ERROR_TYPE_")


### PR DESCRIPTION
#### What this PR does

This PR fixes the issue where querier and query-frontend trace spans would be marked as failed if the request was cancelled.

#### Which issue(s) this PR fixes or relates to

#12302 and #12551

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
