### PR TITLE
Remote execution: don't panic if stream ends unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 * [FEATURE] Ingester: Add experimental `blocks-storage.tsdb.index-lookup-planning-enabled` flag to configure use of a cost-based index lookup planner. #12530
 * [FEATURE] MQE: Add support for applying extra selectors to one side of a binary operation to reduce data fetched. #12577
 * [FEATURE] Query-frontend: Add a native histogram presenting the length of query expressions handled by the query-frontend #12571
-* [FEATURE] Query-frontend and querier: Add experimental support for performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #12302 #12551 #12665 #12687 #12745 #12757 #12798 #12808 #12809
+* [FEATURE] Query-frontend and querier: Add experimental support for performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #12302 #12551 #12665 #12687 #12745 #12757 #12798 #12808 #12809 #12870
 * [FEATURE] Alertmanager: add Microsoft Teams V2 as a supported integration. #12680
 * [FEATURE] Distributor: Add experimental flag `-validation.label-value-length-over-limit-strategy` to configure how to handle label values over the length limit. #12627 #12844
 * [FEATURE] Ingester: Introduce metric `cortex_ingester_owned_target_info_series` for counting the number of owned `target_info` series by tenant. #12681

--- a/pkg/frontend/v2/remoteexec.go
+++ b/pkg/frontend/v2/remoteexec.go
@@ -4,6 +4,7 @@ package v2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -262,10 +263,15 @@ func (r *rangeVectorExecutionResponse) Close() {
 	r.stream.Close()
 }
 
+var errUnexpectedEndOfStream = errors.New("expected EvaluateQueryResponse, got end of stream")
+
 func readNextEvaluateQueryResponse(ctx context.Context, stream responseStream) (*querierpb.EvaluateQueryResponse, error) {
 	msg, err := stream.Next(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if msg == nil {
+		return nil, errUnexpectedEndOfStream
 	}
 
 	resp := msg.GetEvaluateQueryResponse()


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where query-frontends can panic if the stream from queriers ends unexpectedly.

This shouldn't be happening, but if it does happen for some reason, then we don't want the entire process to crash.

#### Which issue(s) this PR fixes or relates to

#12551

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
