### PR TITLE
parquet converter: test and refactor block conversion skip logic

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -22813,17 +22813,6 @@
           "fieldCategory": "advanced"
         },
         {
-          "kind": "field",
-          "name": "max_queue_size",
-          "required": false,
-          "desc": "Maximum number of blocks that can be queued for conversion at once. This helps distribute work evenly across replicas.",
-          "fieldValue": null,
-          "fieldDefaultValue": 5,
-          "fieldFlag": "parquet-converter.max-queue-size",
-          "fieldType": "int",
-          "fieldCategory": "advanced"
-        },
-        {
           "kind": "block",
           "name": "sharding_ring",
           "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2061,13 +2061,11 @@ Usage of ./cmd/mimir/mimir:
     	Comma-separated list of tenants that can have their TSDB blocks converted into Parquet. If specified, the Parquet-converter only converts these tenants. Otherwise, it converts all tenants. Subject to sharding.
   -parquet-converter.max-block-age duration
     	Maximum age of blocks to convert. Blocks older than this will be skipped. Set to 0 to disable age filtering.
-  -parquet-converter.max-queue-size int
-    	Maximum number of blocks that can be queued for conversion at once. This helps distribute work evenly across replicas. (default 5)
   -parquet-converter.max-rows-per-group int
     	Maximum number of rows per row group in Parquet files. (default 1000000)
   -parquet-converter.min-block-duration duration
     	Minimum duration of blocks to convert. Blocks with a duration shorter than this will be skipped. Set to 0 to disable duration filtering.
-  -parquet-converter.min-block-timestamp int
+  -parquet-converter.min-block-timestamp uint
     	Minimum block timestamp (based on ULID) to convert. Set to 0 to disable timestamp filtering.
   -parquet-converter.min-compaction-level int
     	Minimum compaction level required for blocks to be converted to Parquet. Blocks equal or greater than this level will be converted. (default 2)

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -555,7 +555,7 @@ Usage of ./cmd/mimir/mimir:
     	The frequency at which user and block discovery runs. (default 5m0s)
   -parquet-converter.max-block-age duration
     	Maximum age of blocks to convert. Blocks older than this will be skipped. Set to 0 to disable age filtering.
-  -parquet-converter.min-block-timestamp int
+  -parquet-converter.min-block-timestamp uint
     	Minimum block timestamp (based on ULID) to convert. Set to 0 to disable timestamp filtering.
   -parquet-converter.ring.consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1508,11 +1508,6 @@ parquet_converter:
   # CLI flag: -parquet-converter.compression-enabled
   [compression_enabled: <boolean> | default = true]
 
-  # (advanced) Maximum number of blocks that can be queued for conversion at
-  # once. This helps distribute work evenly across replicas.
-  # CLI flag: -parquet-converter.max-queue-size
-  [max_queue_size: <int> | default = 5]
-
   sharding_ring:
     # The key-value store used to share the hash ring across multiple instances.
     kvstore:

--- a/pkg/parquetconverter/parquet_converter_test.go
+++ b/pkg/parquetconverter/parquet_converter_test.go
@@ -4,7 +4,10 @@ package parquetconverter
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -118,6 +121,10 @@ func prepareConfig(t *testing.T) Config {
 }
 
 func uploadTestBlock(ctx context.Context, t *testing.T, bucket objstore.Bucket) ulid.ULID {
+	return uploadTestBlockWithLevel(ctx, t, bucket, 2) // Default level 2
+}
+
+func uploadTestBlockWithLevel(ctx context.Context, t *testing.T, bucket objstore.Bucket, level int) ulid.ULID {
 	dir := t.TempDir()
 
 	bid, err := block.CreateBlock(ctx, dir,
@@ -130,9 +137,148 @@ func uploadTestBlock(ctx context.Context, t *testing.T, bucket objstore.Bucket) 
 
 	require.NoError(t, err)
 
+	// Manually set the compaction level in the meta.json
+	metaFile := filepath.Join(dir, bid.String(), "meta.json")
+	metaBytes, err := os.ReadFile(metaFile)
+	require.NoError(t, err)
+
+	var meta block.Meta
+	require.NoError(t, json.Unmarshal(metaBytes, &meta))
+	meta.Compaction.Level = level
+
+	updatedMetaBytes, err := json.Marshal(&meta)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaFile, updatedMetaBytes, 0644))
+
 	b, err := tsdb.OpenBlock(nil, fmt.Sprintf("%s/%s", dir, bid.String()), nil, nil)
 	require.NoError(t, err)
 	err = block.Upload(ctx, log.NewNopLogger(), bucket, b.Dir(), nil)
 	require.NoError(t, err)
 	return bid
+}
+
+func TestShouldProcessBlock(t *testing.T) {
+	now := time.Now()
+	baseTime := now.Add(-2 * time.Hour)
+
+	meta := &block.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			ULID:       ulid.MustNew(uint64(baseTime.UnixMilli()), nil),
+			MinTime:    baseTime.UnixMilli(),
+			MaxTime:    baseTime.Add(1 * time.Hour).UnixMilli(),
+			Compaction: tsdb.BlockMetaCompaction{Level: 2},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		cfg      func(Config) Config
+		setup    func(*ParquetConverter, objstore.InstrumentedBucket, *block.Meta)
+		wantSkip bool
+	}{
+		{
+			name:     "no filtering",
+			wantSkip: false,
+		},
+		{
+			name: "should process",
+			cfg: func(c Config) Config {
+				c.MinCompactionLevel = meta.Compaction.Level - 1
+				c.MinBlockDuration = time.Duration(meta.MaxTime-meta.MinTime) - time.Hour
+				c.MaxBlockAge = time.Since(time.UnixMilli(meta.MinTime)) + time.Hour
+				c.MinDataAge = time.Since(time.UnixMilli(meta.MinTime)) - time.Hour
+				c.MinBlockTimestamp = meta.ULID.Time() - 1000
+				return c
+			},
+			wantSkip: false,
+		},
+		{
+			name: "compaction level too low",
+			cfg: func(c Config) Config {
+				c.MinCompactionLevel = meta.Compaction.Level + 1
+				return c
+			},
+			wantSkip: true,
+		},
+		{
+			name: "block duration too short",
+			cfg: func(c Config) Config {
+				c.MinBlockDuration = time.Duration(meta.MaxTime-meta.MinTime) + time.Hour
+				return c
+			},
+			wantSkip: true,
+		},
+		{
+			name: "block too old",
+			cfg: func(c Config) Config {
+				c.MaxBlockAge = time.Since(time.UnixMilli(meta.MinTime)) - time.Nanosecond
+				return c
+			},
+			wantSkip: true,
+		},
+		{
+			name: "data too recent",
+			cfg: func(c Config) Config {
+				c.MinDataAge = time.Since(time.UnixMilli(meta.MinTime)) + time.Hour
+				return c
+			},
+			wantSkip: true,
+		},
+		{
+			name: "already queued",
+			setup: func(c *ParquetConverter, bucket objstore.InstrumentedBucket, meta *block.Meta) {
+				c.queuedBlocks.Store(meta.ULID, time.Now())
+			},
+			wantSkip: true,
+		},
+		{
+			name: "already converted",
+			setup: func(c *ParquetConverter, bucket objstore.InstrumentedBucket, meta *block.Meta) {
+				WriteConversionMark(context.Background(), meta.ULID, bucket)
+			},
+			wantSkip: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup bucket
+			bucketClient, err := filesystem.NewBucket(t.TempDir())
+			require.NoError(t, err)
+			bucket := bucket.NewUserBucketClient("test", objstore.WithNoopInstr(bucketClient), nil)
+
+			// Setup ring (same pattern as TestParquetConverter)
+			ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+			defer closer.Close()
+
+			cfg := prepareConfig(t)
+			if tt.cfg != nil {
+				cfg = tt.cfg(cfg)
+			}
+			cfg.ShardingRing.Common.InstanceID = "test-converter"
+			cfg.ShardingRing.Common.InstanceAddr = "1.2.3.4"
+			cfg.ShardingRing.Common.KVStore.Mock = ringStore
+
+			c, _ := prepare(t, cfg, bucketClient)
+
+			// Start services for ring functionality
+			require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
+			defer func() { assert.NoError(t, services.StopAndAwaitTerminated(context.Background(), c)) }()
+
+			// Apply test-specific setup
+			if tt.setup != nil {
+				tt.setup(c, bucket, meta)
+			}
+
+			// Test the function
+			reason, err := c.shouldProcessBlock(context.Background(), meta, bucket)
+			require.NoError(t, err)
+
+			if tt.wantSkip {
+				assert.NotEmpty(t, reason)
+			} else {
+				assert.Empty(t, reason)
+			}
+		})
+	}
 }

--- a/pkg/parquetconverter/parquet_converter_test.go
+++ b/pkg/parquetconverter/parquet_converter_test.go
@@ -173,7 +173,7 @@ func TestShouldProcessBlock(t *testing.T) {
 	tests := []struct {
 		name     string
 		cfg      func(Config) Config
-		setup    func(*ParquetConverter, objstore.InstrumentedBucket, *block.Meta)
+		setup    func(*testing.T, *ParquetConverter, objstore.InstrumentedBucket, *block.Meta)
 		wantSkip bool
 	}{
 		{
@@ -226,15 +226,16 @@ func TestShouldProcessBlock(t *testing.T) {
 		},
 		{
 			name: "already queued",
-			setup: func(c *ParquetConverter, bucket objstore.InstrumentedBucket, meta *block.Meta) {
+			setup: func(t *testing.T, c *ParquetConverter, bucket objstore.InstrumentedBucket, meta *block.Meta) {
 				c.queuedBlocks.Store(meta.ULID, time.Now())
 			},
 			wantSkip: true,
 		},
 		{
 			name: "already converted",
-			setup: func(c *ParquetConverter, bucket objstore.InstrumentedBucket, meta *block.Meta) {
-				WriteConversionMark(context.Background(), meta.ULID, bucket)
+			setup: func(t *testing.T, c *ParquetConverter, bucket objstore.InstrumentedBucket, meta *block.Meta) {
+				err := WriteConversionMark(context.Background(), meta.ULID, bucket)
+				require.NoError(t, err)
 			},
 			wantSkip: true,
 		},
@@ -267,7 +268,7 @@ func TestShouldProcessBlock(t *testing.T) {
 
 			// Apply test-specific setup
 			if tt.setup != nil {
-				tt.setup(c, bucket, meta)
+				tt.setup(t, c, bucket, meta)
 			}
 
 			// Test the function


### PR DESCRIPTION
Refactors the skipping logic out to make it testable. Ideally we'd test it end to end but that requires a more complex setup, for a code that will probably be discarded soon. For now this is enough.


Additionally, I'm removing the `parquet-converter.max-queue-size` flag. As it is now the flag does not fully limit the queue size, as the check is only done at the top of the discovery routine. Because we were leaving the default value of 5, this resulted in no blocks being added before the worker got to (roughly) the end of the queue, which skewed the real queue size for monitoring.  Also, with the current logic, it doesn't help with its original purpose of distributing load, probably because some things changed since it was added. 