### PR TITLE
bucketcache: ignore context cancellation in cachedGetRange

### DIFF
--- a/pkg/storage/tsdb/bucketcache/caching_bucket.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket.go
@@ -522,7 +522,8 @@ func (cb *CachingBucket) cachedGetRange(ctx context.Context, name string, keyGen
 
 		// Try to get all subranges from the cache.
 		totalCachedBytes := int64(0)
-		hits = cfg.cache.GetMulti(ctx, keys, cacheOpts...)
+		// Don't pass a cancellable context, while we investigate the cause of https://github.com/grafana/mimir/issues/12691
+		hits = cfg.cache.GetMulti(context.WithoutCancel(ctx), keys, cacheOpts...)
 		for _, b := range hits {
 			totalCachedBytes += int64(len(b))
 		}


### PR DESCRIPTION
#### What this PR does

This PR is a temporal hack, while we investigate the details outlined in https://github.com/grafana/mimir/issues/12691#issuecomment-3356081978

My current lead is that there is a rare race condition, that got exacerbated, after the gomemcache `GetMulti` started to respect the cancelled context. I'm still trying to proof that with a test. But, meanwhile, I suggest we revert the behaviour to one before https://github.com/grafana/dskit/pull/737 

Note, we can't easily revert the changes in dskit at this moment, because there are already changes that depend on the new interface in the upstream dependencies, that GEM uses.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/issues/12691

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
