### PR TITLE
parquet-converter: conversion latency metric to only look at successes

### DIFF
--- a/pkg/parquetconverter/parquet_converter.go
+++ b/pkg/parquetconverter/parquet_converter.go
@@ -517,11 +517,11 @@ func (c *ParquetConverter) processBlock(ctx context.Context, userID string, meta
 		c.queuedBlocks.Delete(meta.ULID)
 
 		duration := time.Since(start)
-		c.metrics.conversionDuration.WithLabelValues(userID).Observe(duration.Seconds())
 		if err != nil {
 			c.metrics.blocksConvertedFailed.WithLabelValues(userID).Inc()
 		} else if !skipped {
 			c.metrics.blocksConverted.WithLabelValues(userID).Inc()
+			c.metrics.conversionDuration.WithLabelValues(userID).Observe(duration.Seconds())
 		}
 	}()
 


### PR DESCRIPTION
Failed or skipped blocks are usually processed instantly, so they skew the metrics