### PR TITLE
Limit parallelism of sharded queries when sharding is running inside MQE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * [FEATURE] Ingester: Add experimental `blocks-storage.tsdb.index-lookup-planning-enabled` flag to configure use of a cost-based index lookup planner. #12530
 * [FEATURE] MQE: Add support for applying extra selectors to one side of a binary operation to reduce data fetched. #12577
 * [FEATURE] Query-frontend: Add a native histogram presenting the length of query expressions handled by the query-frontend #12571
-* [FEATURE] Query-frontend and querier: Add experimental support for performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #12302 #12551 #12665 #12687 #12745 #12757 #12798 #12808 #12809 #12835 #12856 #12870 #12885 #12886
+* [FEATURE] Query-frontend and querier: Add experimental support for performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #12302 #12551 #12665 #12687 #12745 #12757 #12798 #12808 #12809 #12835 #12856 #12870 #12883 #12885 #12886
 * [FEATURE] Alertmanager: add Microsoft Teams V2 as a supported integration. #12680
 * [FEATURE] Distributor: Add experimental flag `-validation.label-value-length-over-limit-strategy` to configure how to handle label values over the length limit. #12627 #12844
 * [FEATURE] Ingester: Introduce metric `cortex_ingester_owned_target_info_series` for counting the number of owned `target_info` series by tenant. #12681

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7883,6 +7883,17 @@
         },
         {
           "kind": "field",
+          "name": "enable_remote_execution",
+          "required": false,
+          "desc": "If set to true and the Mimir query engine is in use, use remote execution to evaluate queries in queriers.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-frontend.enable-remote-execution",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "use_mimir_query_engine_for_sharding",
           "required": false,
           "desc": "Set to true to enable performing query sharding inside the Mimir query engine (MQE). This setting has no effect if sharding is disabled. Requires remote execution and MQE to be enabled.",
@@ -8018,17 +8029,6 @@
           "fieldValue": null,
           "fieldDefaultValue": true,
           "fieldFlag": "query-frontend.enable-query-engine-fallback",
-          "fieldType": "boolean",
-          "fieldCategory": "experimental"
-        },
-        {
-          "kind": "field",
-          "name": "enable_remote_execution",
-          "required": false,
-          "desc": "If set to true and the Mimir query engine is in use, use remote execution to evaluate queries in queriers.",
-          "fieldValue": null,
-          "fieldDefaultValue": false,
-          "fieldFlag": "query-frontend.enable-remote-execution",
           "fieldType": "boolean",
           "fieldCategory": "experimental"
         }

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2862,6 +2862,11 @@ results_cache:
 # CLI flag: -query-frontend.parallelize-shardable-queries
 [parallelize_shardable_queries: <boolean> | default = false]
 
+# (experimental) If set to true and the Mimir query engine is in use, use remote
+# execution to evaluate queries in queriers.
+# CLI flag: -query-frontend.enable-remote-execution
+[enable_remote_execution: <boolean> | default = false]
+
 # (experimental) Set to true to enable performing query sharding inside the
 # Mimir query engine (MQE). This setting has no effect if sharding is disabled.
 # Requires remote execution and MQE to be enabled.
@@ -2923,11 +2928,6 @@ client_cluster_validation:
 # Mimir query engine.
 # CLI flag: -query-frontend.enable-query-engine-fallback
 [enable_query_engine_fallback: <boolean> | default = true]
-
-# (experimental) If set to true and the Mimir query engine is in use, use remote
-# execution to evaluate queries in queriers.
-# CLI flag: -query-frontend.enable-remote-execution
-[enable_remote_execution: <boolean> | default = false]
 ```
 
 ### query_scheduler

--- a/pkg/frontend/config.go
+++ b/pkg/frontend/config.go
@@ -36,7 +36,6 @@ type CombinedFrontendConfig struct {
 
 	QueryEngine               string `yaml:"query_engine" category:"experimental"`
 	EnableQueryEngineFallback bool   `yaml:"enable_query_engine_fallback" category:"experimental"`
-	EnableRemoteExecution     bool   `yaml:"enable_remote_execution" category:"experimental"`
 }
 
 func (cfg *CombinedFrontendConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
@@ -47,7 +46,6 @@ func (cfg *CombinedFrontendConfig) RegisterFlags(f *flag.FlagSet, logger log.Log
 
 	f.StringVar(&cfg.QueryEngine, "query-frontend.query-engine", querier.MimirEngine, fmt.Sprintf("Query engine to use, either '%v' or '%v'", querier.PrometheusEngine, querier.MimirEngine))
 	f.BoolVar(&cfg.EnableQueryEngineFallback, "query-frontend.enable-query-engine-fallback", true, "If set to true and the Mimir query engine is in use, fall back to using the Prometheus query engine for any queries not supported by the Mimir query engine.")
-	f.BoolVar(&cfg.EnableRemoteExecution, "query-frontend.enable-remote-execution", false, "If set to true and the Mimir query engine is in use, use remote execution to evaluate queries in queriers.")
 }
 
 func (cfg *CombinedFrontendConfig) Validate() error {
@@ -58,14 +56,14 @@ func (cfg *CombinedFrontendConfig) Validate() error {
 		return err
 	}
 
-	if cfg.EnableRemoteExecution && cfg.QueryEngine != querier.MimirEngine {
+	if cfg.QueryMiddleware.EnableRemoteExecution && cfg.QueryEngine != querier.MimirEngine {
 		return errors.New("remote execution is only supported when the Mimir query engine is in use")
 	}
 
 	if cfg.QueryMiddleware.ShardedQueries && cfg.QueryMiddleware.UseMQEForSharding {
 		// We don't need to explicitly check that MQE is enabled here: remote execution is only supported when MQE is enabled, and we
 		// enforce that above.
-		if !cfg.EnableRemoteExecution {
+		if !cfg.QueryMiddleware.EnableRemoteExecution {
 			return errors.New("using MQE for sharding is only supported when the Mimir query engine is in use and remote execution is enabled")
 		}
 	}

--- a/pkg/frontend/config_test.go
+++ b/pkg/frontend/config_test.go
@@ -43,7 +43,7 @@ func TestConfig_Validate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			config := &CombinedFrontendConfig{}
 			flagext.DefaultValues(config)
-			config.EnableRemoteExecution = testCase.enableRemoteExecution
+			config.QueryMiddleware.EnableRemoteExecution = testCase.enableRemoteExecution
 			config.QueryEngine = testCase.queryEngine
 			err := config.Validate()
 

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -260,7 +260,7 @@ func NewCodec(
 // MergeResponse merges responses from multiple requests into a single Response
 func (Codec) MergeResponse(responses ...Response) (Response, error) {
 	if len(responses) == 0 {
-		return newEmptyPrometheusResponse(), nil
+		return NewEmptyPrometheusResponse(), nil
 	}
 
 	promResponses := make([]*PrometheusResponse, 0, len(responses))

--- a/pkg/frontend/querymiddleware/error_caching_test.go
+++ b/pkg/frontend/querymiddleware/error_caching_test.go
@@ -60,7 +60,7 @@ func TestErrorCachingHandler_Do(t *testing.T) {
 			t.Run("no user set", func(t *testing.T) {
 				c := cache.NewInstrumentedMockCache()
 
-				innerRes := newEmptyPrometheusResponse()
+				innerRes := NewEmptyPrometheusResponse()
 				inner := &mockHandler{}
 				inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
@@ -77,7 +77,7 @@ func TestErrorCachingHandler_Do(t *testing.T) {
 			t.Run("disabled by option", func(t *testing.T) {
 				c := cache.NewInstrumentedMockCache()
 
-				innerRes := newEmptyPrometheusResponse()
+				innerRes := NewEmptyPrometheusResponse()
 				inner := &mockHandler{}
 				inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
@@ -121,7 +121,7 @@ func TestErrorCachingHandler_Do(t *testing.T) {
 			t.Run("cache hit key collision", func(t *testing.T) {
 				c := cache.NewInstrumentedMockCache()
 
-				innerRes := newEmptyPrometheusResponse()
+				innerRes := NewEmptyPrometheusResponse()
 				inner := &mockHandler{}
 				inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
@@ -149,7 +149,7 @@ func TestErrorCachingHandler_Do(t *testing.T) {
 			t.Run("corrupt cache data", func(t *testing.T) {
 				c := cache.NewInstrumentedMockCache()
 
-				innerRes := newEmptyPrometheusResponse()
+				innerRes := NewEmptyPrometheusResponse()
 				inner := &mockHandler{}
 				inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
@@ -171,7 +171,7 @@ func TestErrorCachingHandler_Do(t *testing.T) {
 			t.Run("cache miss no error", func(t *testing.T) {
 				c := cache.NewInstrumentedMockCache()
 
-				innerRes := newEmptyPrometheusResponse()
+				innerRes := NewEmptyPrometheusResponse()
 				inner := &mockHandler{}
 				inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -211,14 +211,18 @@ func (l limitsMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Respon
 
 type limitedParallelismRoundTripper struct {
 	downstream MetricsQueryHandler
-	limits     Limits
+	limits     LimitedParallelismLimits
 
 	codec      Codec
 	middleware MetricsQueryMiddleware
 }
 
+type LimitedParallelismLimits interface {
+	MaxQueryParallelism(userID string) int
+}
+
 // NewLimitedParallelismRoundTripper creates a new roundtripper that enforces MaxQueryParallelism to the `next` roundtripper across `middlewares`.
-func NewLimitedParallelismRoundTripper(next MetricsQueryHandler, codec Codec, limits Limits, middlewares ...MetricsQueryMiddleware) http.RoundTripper {
+func NewLimitedParallelismRoundTripper(next MetricsQueryHandler, codec Codec, limits LimitedParallelismLimits, middlewares ...MetricsQueryMiddleware) http.RoundTripper {
 	return limitedParallelismRoundTripper{
 		downstream: next,
 		codec:      codec,

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -258,9 +258,10 @@ func (rt limitedParallelismRoundTripper) RoundTrip(r *http.Request) (*http.Respo
 	// sub-requests run in parallel.
 	response, err := rt.middleware.Wrap(
 		HandlerFunc(func(ctx context.Context, r MetricsQueryRequest) (Response, error) {
-			// If remote execution is enabled, then don't apply the parallelism limit here, as we'll enforce it in Frontend.DoProtobufRequest instead.
-			// If we enforce the limit here, then we'll count requests twice: once here, and again in Frontend.DoProtobufRequest.
+			// If remote execution is disabled, apply the parallelism limit here.
+			// If remote execution is enabled, we'll enforce the limit in Frontend.DoProtobufRequest instead.
 			// We need to enforce the limit in DoProtobufRequest because the requests we see here are before sharding is applied if sharding inside MQE is enabled.
+			// If we were to enforce the limit here with remote execution enabled, then we'll count requests twice: once here, and again in Frontend.DoProtobufRequest.
 			if !rt.remoteExecutionEnabled {
 				if err := limiter.BeginRequest(ctx); err != nil {
 					return nil, err

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -172,7 +172,7 @@ func (l limitsMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Respon
 				"maxQueryLookback", maxQueryLookback,
 				"blocksRetentionPeriod", blocksRetentionPeriod)
 
-			return newEmptyPrometheusResponse(), nil
+			return NewEmptyPrometheusResponse(), nil
 		}
 
 		if r.GetStart() < minStartTime {

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -906,12 +906,12 @@ func TestLimitedRoundTripper_MaxQueryParallelism(t *testing.T) {
 	codec := newTestCodec()
 	r, err := codec.EncodeMetricsQueryRequest(ctx, &PrometheusRangeQueryRequest{
 		path:      "/api/v1/query_range",
-		start:     time.Now().Add(time.Hour).Unix(),
-		end:       util.TimeToMillis(time.Now()),
+		start:     time.Now().Add(-time.Hour).Unix(),
+		end:       time.Now().Unix(),
 		step:      int64(1 * time.Second * time.Millisecond),
 		queryExpr: parseQuery(t, `foo`),
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	handler := NewHTTPQueryRequestRoundTripperHandler(downstream, codec, log.NewNopLogger())
 	_, err = NewLimitedParallelismRoundTripper(handler, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -917,7 +917,7 @@ func TestLimitedRoundTripper_MaxQueryParallelism(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := NewHTTPQueryRequestRoundTripperHandler(downstream, codec, log.NewNopLogger())
-	_, err = NewLimitedParallelismRoundTripper(handler, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
+	_, err = NewLimitedParallelismRoundTripper(handler, codec, mockLimits{maxQueryParallelism: maxQueryParallelism}, false,
 		MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				var wg sync.WaitGroup
@@ -962,7 +962,7 @@ func TestLimitedRoundTripper_MaxQueryParallelismLateScheduling(t *testing.T) {
 	require.Nil(t, err)
 
 	handler := NewHTTPQueryRequestRoundTripperHandler(downstream, codec, log.NewNopLogger())
-	_, err = NewLimitedParallelismRoundTripper(handler, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
+	_, err = NewLimitedParallelismRoundTripper(handler, codec, mockLimits{maxQueryParallelism: maxQueryParallelism}, false,
 		MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				// fire up work and we don't wait.
@@ -1004,7 +1004,7 @@ func TestLimitedRoundTripper_OriginalRequestContextCancellation(t *testing.T) {
 	require.Nil(t, err)
 
 	handler := NewHTTPQueryRequestRoundTripperHandler(downstream, codec, log.NewNopLogger())
-	_, err = NewLimitedParallelismRoundTripper(handler, codec, mockLimits{maxQueryParallelism: maxQueryParallelism},
+	_, err = NewLimitedParallelismRoundTripper(handler, codec, mockLimits{maxQueryParallelism: maxQueryParallelism}, false,
 		MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 			return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 				var wg sync.WaitGroup
@@ -1064,7 +1064,7 @@ func BenchmarkLimitedParallelismRoundTripper(b *testing.B) {
 	for _, concurrentRequestCount := range []int{1, 10, 100} {
 		for _, subRequestCount := range []int{1, 2, 5, 10, 20, 50, 100} {
 			handler := NewHTTPQueryRequestRoundTripperHandler(downstream, codec, log.NewNopLogger())
-			tripper := NewLimitedParallelismRoundTripper(handler, codec, mockLimits{maxQueryParallelism: maxParallelism},
+			tripper := NewLimitedParallelismRoundTripper(handler, codec, mockLimits{maxQueryParallelism: maxParallelism}, false,
 				MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 					return HandlerFunc(func(c context.Context, _ MetricsQueryRequest) (Response, error) {
 						wg := sync.WaitGroup{}

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -166,7 +166,7 @@ func TestLimitsMiddleware_MaxQueryLookback_RangeQueryAndRemoteRead(t *testing.T)
 					limits := mockLimits{maxQueryLookback: testData.maxQueryLookback, compactorBlocksRetentionPeriod: testData.blocksRetentionPeriod}
 					middleware := newLimitsMiddleware(limits, log.NewNopLogger())
 
-					innerRes := newEmptyPrometheusResponse()
+					innerRes := NewEmptyPrometheusResponse()
 					inner := &mockHandler{}
 					inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
@@ -265,7 +265,7 @@ func TestLimitsMiddleware_MaxQueryLookback_InstantQuery(t *testing.T) {
 			limits := mockLimits{maxQueryLookback: testData.maxQueryLookback, compactorBlocksRetentionPeriod: testData.blocksRetentionPeriod}
 			middleware := newLimitsMiddleware(limits, log.NewNopLogger())
 
-			innerRes := newEmptyPrometheusResponse()
+			innerRes := NewEmptyPrometheusResponse()
 			inner := &mockHandler{}
 			inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
@@ -362,7 +362,7 @@ func TestLimitsMiddleware_MaxQueryLookback_TenantFederation(t *testing.T) {
 
 			middleware := newLimitsMiddleware(limits, log.NewNopLogger())
 
-			innerRes := newEmptyPrometheusResponse()
+			innerRes := NewEmptyPrometheusResponse()
 			inner := &mockHandler{}
 			inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
@@ -469,7 +469,7 @@ func TestLimitsMiddleware_MaxQueryExpressionSizeBytes(t *testing.T) {
 					}
 					middleware := newLimitsMiddleware(limits, log.NewNopLogger())
 
-					innerRes := newEmptyPrometheusResponse()
+					innerRes := NewEmptyPrometheusResponse()
 					inner := &mockHandler{}
 					inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
@@ -566,7 +566,7 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 					limits := mockLimits{maxQueryLength: testData.maxQueryLength, maxTotalQueryLength: testData.maxTotalQueryLength}
 					middleware := newLimitsMiddleware(limits, log.NewNopLogger())
 
-					innerRes := newEmptyPrometheusResponse()
+					innerRes := NewEmptyPrometheusResponse()
 					inner := &mockHandler{}
 					inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
 
@@ -926,7 +926,7 @@ func TestLimitedRoundTripper_MaxQueryParallelism(t *testing.T) {
 					}()
 				}
 				wg.Wait()
-				return newEmptyPrometheusResponse(), nil
+				return NewEmptyPrometheusResponse(), nil
 			})
 		}),
 	).RoundTrip(r)
@@ -968,7 +968,7 @@ func TestLimitedRoundTripper_MaxQueryParallelismLateScheduling(t *testing.T) {
 						_, _ = next.Do(c, &PrometheusRangeQueryRequest{})
 					}()
 				}
-				return newEmptyPrometheusResponse(), nil
+				return NewEmptyPrometheusResponse(), nil
 			})
 		}),
 	).RoundTrip(r)
@@ -1028,7 +1028,7 @@ func TestLimitedRoundTripper_OriginalRequestContextCancellation(t *testing.T) {
 				wg.Wait()
 				assert.Less(t, time.Since(waitStart).Milliseconds(), int64(100))
 
-				return newEmptyPrometheusResponse(), nil
+				return NewEmptyPrometheusResponse(), nil
 			})
 		}),
 	).RoundTrip(r)
@@ -1073,7 +1073,7 @@ func BenchmarkLimitedParallelismRoundTripper(b *testing.B) {
 							}()
 						}
 						wg.Wait()
-						return newEmptyPrometheusResponse(), nil
+						return NewEmptyPrometheusResponse(), nil
 					})
 				}),
 			)

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -884,6 +884,9 @@ func (m *mockHandler) Do(ctx context.Context, req MetricsQueryRequest) (Response
 }
 
 func TestLimitedRoundTripper_MaxQueryParallelism(t *testing.T) {
+	// This test only applies to requests sent to queriers over HTTPGRPC.
+	// For the equivalent test for remote execution, see TestMaxQueryParallelismWithRemoteExecution in pkg/frontend/v2/remoteexec_test.go
+
 	var (
 		maxQueryParallelism = 2
 		count               atomic.Int32

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -35,8 +35,8 @@ var (
 	}.Froze()
 )
 
-// newEmptyPrometheusResponse returns an empty successful Prometheus query range response.
-func newEmptyPrometheusResponse() *PrometheusResponse {
+// NewEmptyPrometheusResponse returns an empty successful Prometheus query range response.
+func NewEmptyPrometheusResponse() *PrometheusResponse {
 	return &PrometheusResponse{
 		Status: statusSuccess,
 		Data: &PrometheusData{

--- a/pkg/frontend/querymiddleware/prom2_range_compat_test.go
+++ b/pkg/frontend/querymiddleware/prom2_range_compat_test.go
@@ -33,7 +33,7 @@ func TestProm2RangeCompat_Do(t *testing.T) {
 		ctx := context.Background()
 		req := newRangeRequest("sum(rate(some_series[1m:1m]))")
 
-		innerRes := newEmptyPrometheusResponse()
+		innerRes := NewEmptyPrometheusResponse()
 		inner := &mockHandler{}
 		inner.On("Do", mock.Anything, req).Return(innerRes, nil)
 
@@ -48,7 +48,7 @@ func TestProm2RangeCompat_Do(t *testing.T) {
 		ctx := user.InjectOrgID(context.Background(), "1234")
 		req := newRangeRequest("sum(rate(some_series[1m:1m]))")
 
-		innerRes := newEmptyPrometheusResponse()
+		innerRes := NewEmptyPrometheusResponse()
 		inner := &mockHandler{}
 		inner.On("Do", mock.Anything, req).Return(innerRes, nil)
 
@@ -63,7 +63,7 @@ func TestProm2RangeCompat_Do(t *testing.T) {
 		ctx := user.InjectOrgID(context.Background(), "1234")
 		req := newRangeRequest("sum(rate(some_series[1m]))")
 
-		innerRes := newEmptyPrometheusResponse()
+		innerRes := NewEmptyPrometheusResponse()
 		inner := &mockHandler{}
 		inner.On("Do", mock.Anything, req).Return(innerRes, nil)
 
@@ -79,7 +79,7 @@ func TestProm2RangeCompat_Do(t *testing.T) {
 		orig := newRangeRequest("sum(rate(some_series[1m:1m]))")
 		rewritten := newRangeRequest("sum(rate(some_series[1m1ms:1m]))")
 
-		innerRes := newEmptyPrometheusResponse()
+		innerRes := NewEmptyPrometheusResponse()
 		inner := &mockHandler{}
 		inner.On("Do", mock.Anything, mock.MatchedBy(func(req MetricsQueryRequest) bool {
 			return req.GetQuery() == rewritten.GetQuery()

--- a/pkg/frontend/querymiddleware/remote_read_test.go
+++ b/pkg/frontend/querymiddleware/remote_read_test.go
@@ -243,7 +243,7 @@ func TestRemoteReadRoundTripper_ShouldAllowMiddlewaresToReturnEmptyResponse(t *t
 	// Create a middleware that return an empty response.
 	middleware := MetricsQueryMiddlewareFunc(func(_ MetricsQueryHandler) MetricsQueryHandler {
 		return HandlerFunc(func(_ context.Context, _ MetricsQueryRequest) (Response, error) {
-			return newEmptyPrometheusResponse(), nil
+			return NewEmptyPrometheusResponse(), nil
 		})
 	})
 

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -397,8 +397,8 @@ func (f *Frontend) DoProtobufRequest(requestContext context.Context, req proto.M
 			f.inflightRequestCount.Dec()
 		}()
 
-		parallelismLimiter := querymiddleware.ParallelismLimiterFromContext(ctx)
-		if err := parallelismLimiter.BeginRequest(ctx); err != nil {
+		parallelismLimiter := querymiddleware.ParallelismLimiterFromContext(streamContext)
+		if err := parallelismLimiter.BeginRequest(streamContext); err != nil {
 			freq.protobufResponseStream.writeEnqueueError(err)
 			return
 		}

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -207,6 +208,7 @@ func TestFrontend_Protobuf_HappyPath(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	ctx = querymiddleware.ContextWithHeadersToPropagate(ctx, headers)
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now().Add(-5*time.Hour), time.Now())
@@ -261,6 +263,7 @@ func TestFrontend_Protobuf_ShouldNotCancelRequestAfterSuccess(t *testing.T) {
 
 			for range 10000 { // Send many requests to try to trigger the race condition that previously caused this test to fail.
 				ctx := user.InjectOrgID(context.Background(), userID)
+				ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 				req := &querierpb.EvaluateQueryRequest{}
 				resp, err := f.DoProtobufRequest(ctx, req, time.Now().Add(-5*time.Hour), time.Now())
 				require.NoError(t, err)
@@ -309,6 +312,7 @@ func TestFrontend_Protobuf_QuerierResponseReceivedBeforeSchedulerResponse(t *tes
 	})
 
 	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)
@@ -349,6 +353,7 @@ func TestFrontend_Protobuf_ResponseClosedBeforeStreamExhausted(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)
@@ -425,6 +430,7 @@ func TestFrontend_Protobuf_ErrorReturnedByQuerier(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)
@@ -472,6 +478,7 @@ func TestFrontend_ShouldTrackPerRequestMetrics(t *testing.T) {
 			},
 			makeRequest: func(t *testing.T, f *Frontend) {
 				ctx := user.InjectOrgID(context.Background(), userID)
+				ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 				req := &querierpb.EvaluateQueryRequest{}
 				resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 				require.NoError(t, err)
@@ -580,6 +587,7 @@ func TestFrontend_Protobuf_RetryEnqueue(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)
@@ -596,6 +604,7 @@ func TestFrontend_Protobuf_EnqueueRetriesExhausted(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), "test")
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)
@@ -626,6 +635,7 @@ func TestFrontend_Protobuf_ReadingResponseAfterAllMessagesReceived(t *testing.T)
 	})
 
 	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)
@@ -685,6 +695,7 @@ func TestFrontend_Protobuf_TooManyRequests(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), "test")
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)
@@ -727,6 +738,7 @@ func TestFrontend_Protobuf_SchedulerError(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), "test")
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)
@@ -821,6 +833,7 @@ func TestFrontendCancellation(t *testing.T) {
 			f, ms := setupFrontend(t, nil, nil)
 
 			ctx, cancel := context.WithTimeout(user.InjectOrgID(context.Background(), "test"), 200*time.Millisecond)
+			ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 			defer cancel()
 
 			makeRequest(ctx, t, f)
@@ -875,6 +888,7 @@ func TestFrontendWorkerCancellation(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(user.InjectOrgID(context.Background(), "test"), 200*time.Millisecond)
 			defer cancel()
+			ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 
 			// send multiple requests > maxconcurrency of scheduler. So that it keeps all the frontend worker busy in serving requests.
 			reqCount := testFrontendWorkerConcurrency + 5
@@ -944,6 +958,7 @@ func TestFrontendFailedCancellation(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(user.InjectOrgID(context.Background(), "test"))
 			defer cancel()
+			ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 
 			go func() {
 				time.Sleep(100 * time.Millisecond)
@@ -989,6 +1004,7 @@ func TestFrontend_Protobuf_ReadingResponseWithCanceledContext(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), "test")
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)
@@ -1008,6 +1024,7 @@ func TestFrontend_Protobuf_ReadingResponseWithCanceledContext(t *testing.T) {
 
 func TestFrontend_Protobuf_ReadingCancelledRequestBeforeResponseReceivedFromQuerier(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(user.InjectOrgID(context.Background(), "test"))
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	cancellationError := cancellation.NewErrorf("the request has been canceled")
 
 	f, _ := setupFrontend(t, nil, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
@@ -1032,6 +1049,7 @@ func TestFrontend_Protobuf_ReadingCancelledRequestBeforeResponseReceivedFromQuer
 
 func TestFrontend_Protobuf_ReadingCancelledRequestAfterResponseReceivedFromQuerier(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(user.InjectOrgID(context.Background(), "test"))
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 
 	f, _ := setupFrontend(t, nil, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
 		switch msg.Type {
@@ -1178,6 +1196,7 @@ func TestFrontend_Protobuf_ResponseSentTwice(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), userID)
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)
@@ -1224,6 +1243,7 @@ func TestFrontend_Protobuf_ResponseWithUnexpectedUserID(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), "the-user")
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -387,6 +387,7 @@ func TestFrontend_Protobuf_ResponseClosedBeforeResponseReceived(t *testing.T) {
 	})
 
 	ctx := user.InjectOrgID(context.Background(), "user-1")
+	ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
 	req := &querierpb.EvaluateQueryRequest{}
 	resp, err := f.DoProtobufRequest(ctx, req, time.Now(), time.Now())
 	require.NoError(t, err)

--- a/pkg/frontend/v2/remoteexec_test.go
+++ b/pkg/frontend/v2/remoteexec_test.go
@@ -5,20 +5,31 @@ package v2
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/gogo/protobuf/proto"
+	"github.com/grafana/dskit/user"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware"
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/querierpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/scheduler/schedulerpb"
+	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/remoteexec"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
@@ -835,4 +846,82 @@ func TestResponseStreamBuffer(t *testing.T) {
 	require.Equal(t, msg4, buf.Pop())
 	require.Equal(t, msg5, buf.Pop())
 	require.Equal(t, msg6, buf.Pop())
+}
+
+func TestMaxQueryParallelismWithRemoteExecution(t *testing.T) {
+	const maxQueryParallelism = int64(2)
+	count := atomic.NewInt64(0)
+	maxMtx := &sync.Mutex{}
+	maxConcurrent := int64(0)
+	ctx := user.InjectOrgID(context.Background(), "the-user")
+	codec := newTestCodec()
+	logger := log.NewNopLogger()
+
+	opts := streamingpromql.NewTestEngineOpts()
+	planner, err := streamingpromql.NewQueryPlannerWithoutOptimizationPasses(opts)
+	require.NoError(t, err)
+	planner.RegisterQueryPlanOptimizationPass(remoteexec.NewOptimizationPass())
+	engine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
+	require.NoError(t, err)
+
+	frontend, _ := setupFrontend(t, nil, func(f *Frontend, msg *schedulerpb.FrontendToScheduler) *schedulerpb.SchedulerToFrontend {
+		if msg.Type != schedulerpb.ENQUEUE {
+			return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.ERROR, Error: fmt.Sprintf("scheduler received unexpected message type: %v", msg.Type)}
+		}
+
+		go func() {
+			current := count.Inc()
+			maxMtx.Lock()
+			maxConcurrent = max(current, maxConcurrent)
+			maxMtx.Unlock()
+			defer count.Dec()
+
+			// Simulate doing some work, then send an empty response.
+			time.Sleep(20 * time.Millisecond)
+			sendStreamingResponse(t, f, msg.UserID, msg.QueryID, newSeriesMetadata(false), newEvaluationCompleted(0, nil, nil))
+		}()
+
+		return &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
+	})
+
+	cfg := Config{LookBackDelta: 7 * time.Minute}
+	executor := NewRemoteExecutor(frontend, cfg)
+	require.NoError(t, engine.RegisterNodeMaterializer(planning.NODE_TYPE_REMOTE_EXEC, remoteexec.NewRemoteExecutionMaterializer(executor)))
+
+	expr, err := parser.ParseExpr("foo")
+	require.NoError(t, err)
+	request := querymiddleware.NewPrometheusRangeQueryRequest("/api/v1/query_range", nil, timestamp.FromTime(time.Now().Add(-time.Hour)), timestamp.FromTime(time.Now()), time.Second.Milliseconds(), 5*time.Minute, expr, querymiddleware.Options{}, nil, "")
+	httpRequest, err := codec.EncodeMetricsQueryRequest(ctx, request)
+	require.NoError(t, err)
+
+	middleware := querymiddleware.MetricsQueryMiddlewareFunc(func(next querymiddleware.MetricsQueryHandler) querymiddleware.MetricsQueryHandler {
+		return querymiddleware.HandlerFunc(func(c context.Context, _ querymiddleware.MetricsQueryRequest) (querymiddleware.Response, error) {
+			wg := &errgroup.Group{}
+
+			// Simulate many parts of the request being split and evaluated in parallel.
+			for range maxQueryParallelism + 20 {
+				wg.Go(func() error {
+					_, err := next.Do(c, request)
+					return err
+				})
+			}
+
+			err := wg.Wait()
+			return querymiddleware.NewEmptyPrometheusResponse(), err
+		})
+	})
+
+	handler := querymiddleware.NewEngineQueryRequestRoundTripperHandler(engine, codec, logger)
+	_, err = querymiddleware.NewLimitedParallelismRoundTripper(handler, codec, &mockLimitedParallelismLimits{maxQueryParallelism: int(maxQueryParallelism)}, middleware).RoundTrip(httpRequest)
+	require.NoError(t, err)
+	require.NotZero(t, maxConcurrent, "expected at least one query to be executed")
+	require.LessOrEqualf(t, maxConcurrent, maxQueryParallelism, "max query parallelism %v went over the configured limit of %v", maxConcurrent, maxQueryParallelism)
+}
+
+type mockLimitedParallelismLimits struct {
+	maxQueryParallelism int
+}
+
+func (m mockLimitedParallelismLimits) MaxQueryParallelism(_ string) int {
+	return m.maxQueryParallelism
 }

--- a/pkg/frontend/v2/remoteexec_test.go
+++ b/pkg/frontend/v2/remoteexec_test.go
@@ -931,7 +931,7 @@ func runQueryParallelismTestCase(t *testing.T, enableMQESharding bool) {
 	})
 
 	handler := querymiddleware.NewEngineQueryRequestRoundTripperHandler(engine, codec, logger)
-	_, err = querymiddleware.NewLimitedParallelismRoundTripper(handler, codec, limits, middleware).RoundTrip(httpRequest)
+	_, err = querymiddleware.NewLimitedParallelismRoundTripper(handler, codec, limits, true, middleware).RoundTrip(httpRequest)
 	require.NoError(t, err)
 	require.NotZero(t, maxConcurrent, "expected at least one query to be executed")
 	require.LessOrEqualf(t, maxConcurrent, maxQueryParallelism, "max query parallelism %v went over the configured limit of %v", maxConcurrent, maxQueryParallelism)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -882,7 +882,7 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 		eng,
 		promOpts,
 		t.QueryFrontendTopicOffsetsReaders,
-		t.Cfg.Frontend.EnableRemoteExecution,
+		t.Cfg.Frontend.QueryMiddleware.EnableRemoteExecution,
 		t.QueryFrontendStreamingEngine,
 		t.Registerer,
 	)
@@ -922,7 +922,7 @@ func (t *Mimir) initQueryFrontend() (serv services.Service, err error) {
 
 	t.API.RegisterQueryFrontend2(frontend)
 
-	if t.QueryFrontendStreamingEngine != nil && t.Cfg.Frontend.EnableRemoteExecution {
+	if t.QueryFrontendStreamingEngine != nil && t.Cfg.Frontend.QueryMiddleware.EnableRemoteExecution {
 		executor := v2.NewRemoteExecutor(frontend, t.Cfg.Frontend.FrontendV2)
 
 		if err := t.QueryFrontendStreamingEngine.RegisterNodeMaterializer(planning.NODE_TYPE_REMOTE_EXEC, remoteexec.NewRemoteExecutionMaterializer(executor)); err != nil {
@@ -989,7 +989,7 @@ func (t *Mimir) initQueryFrontendQueryPlanner() (services.Service, error) {
 		return nil, err
 	}
 
-	if t.Cfg.Frontend.EnableRemoteExecution {
+	if t.Cfg.Frontend.QueryMiddleware.EnableRemoteExecution {
 		t.QueryFrontendQueryPlanner.RegisterQueryPlanOptimizationPass(remoteexec.NewOptimizationPass())
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR fixes the issue where the `max_query_parallelism` / `-querier.max-query-parallelism` option is not respected if sharding is running inside MQE.

⚠️ This PR is dependent on https://github.com/grafana/mimir/pull/12835 and https://github.com/grafana/mimir/pull/12885.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/12835

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
