### PR TITLE
continuous-test: Fix false positive in continuous tester metadata assertion

### DIFF
--- a/pkg/continuoustest/ingest_storage_record.go
+++ b/pkg/continuoustest/ingest_storage_record.go
@@ -410,8 +410,8 @@ func (t *IngestStorageRecordTest) testRec(rec *kgo.Record, report batchReport) b
 		sortMetadata := cmpopts.SortSlices(func(m1, m2 *mimirpb.MetricMetadata) bool {
 			return m1.MetricFamilyName < m2.MetricFamilyName
 		})
-		if !cmp.Equal(dropExactDuplicates(req.Metadata), v2Req.Metadata, sortMetadata) {
-			diff := cmp.Diff(dropExactDuplicates(req.Metadata), v2Req.Metadata, sortMetadata)
+		if !cmp.Equal(dropExactDuplicates(req.Metadata), dropExactDuplicates(v2Req.Metadata), sortMetadata) {
+			diff := cmp.Diff(dropExactDuplicates(req.Metadata), dropExactDuplicates(v2Req.Metadata), sortMetadata)
 			return report.Error(fmt.Errorf("metadata did not match (adjusting for ordering, exact duplicates dropped). numTimeseries: %d, numMetadata: %d,\noriginalMetadata: %v,\nv2Metadata: %v\n Diff: %s", len(req.Timeseries), len(req.Metadata), req.Metadata, v2Req.Metadata, diff))
 		}
 	}


### PR DESCRIPTION
#### What this PR does

If a request contains multiple metadata that are exact duplicates of each other, the request has the same meaning if we deduplicate them.

In the translation logic we generally try to do this, but opportunistically. We drop duplicates when it's computationally convenient to do so, but we aren't guaranteed to drop dupes on every single request. In RW2.0 duplicates are cheap given the strings are already symbolized, so it's a best-effort approach.

When asserting metadata, the correctness tester adjusts the V1 metadata for dupes but forgot to adjust the V2 metadata. So, for a request that didn't fall in the best effort category, we're comparing deduplicated against duplicates being present, meaning the `cmp.Equal` fails. The requests still mean the same thing, but we flag it when we shouldn't.

To avoid the false positive we simply adjust for duplicates on both sides before comparing.
no-changelog because this is an experimental test.

#### Which issue(s) this PR fixes or relates to

contrib https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
