### PR TITLE
fix(parquet store gateway): map limit errors to UnprocessableEntity status

### DIFF
--- a/pkg/storegateway/parquet_bucket_store_test.go
+++ b/pkg/storegateway/parquet_bucket_store_test.go
@@ -5,6 +5,7 @@ package storegateway
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/gate"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/promslog"
@@ -309,6 +311,9 @@ func TestParquetBucketStores_RowLimits(t *testing.T) {
 		seriesSet, warnings, err := queryParquetSeries(t, stores, userID, metricName, 10, 100)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "would fetch too many rows")
+		status, ok := grpcutil.ErrorToStatus(err)
+		require.True(t, ok)
+		require.Equal(t, http.StatusUnprocessableEntity, int(status.Code()))
 		require.Empty(t, warnings)
 		require.Empty(t, seriesSet)
 	})


### PR DESCRIPTION
Limit errors coming from parquet-common are currently mapped to Internal errors in gRPC. Those will be retried by queriers: https://github.com/grafana/mimir/blob/443ec0c7bb290e42e587a64697822e894cf96a28/pkg/querier/blocks_store_queryable.go#L1049-L1059


We should instead return a `422`, like the main path does: 
https://github.com/grafana/mimir/blob/443ec0c7bb290e42e587a64697822e894cf96a28/pkg/storegateway/limiter.go#L62-L73

A nicer way of fixing this would be introducing an interface in parquet-common for the limiter, so we can return our own errors. The simpler way I went with is by detecting the error type and wrapping it with the correct status, at the top level to catch all paths.

See parquet common: https://github.com/grafana/mimir/blob/443ec0c7bb290e42e587a64697822e894cf96a28/vendor/github.com/prometheus-community/parquet-common/search/limits.go#L34-L36
