### PR TITLE
[r360] caching bucket: Don't release slabs after an error

### DIFF
--- a/pkg/storage/tsdb/bucketcache/caching_bucket.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket.go
@@ -539,6 +539,7 @@ func (cb *CachingBucket) cachedGetRange(ctx context.Context, name string, keyGen
 
 		err := cb.fetchMissingSubranges(ctx, name, startRange, endRange, offsetKeys, hits, lastSubrangeOffset, lastSubrangeLength, cfgName, cfg)
 		if err != nil {
+			releaseSlabs = false
 			return nil, err
 		}
 	}


### PR DESCRIPTION
the changes in https://github.com/grafana/gomemcache/pull/26 allow for goroutines to continue running after GetMulti returns. The goroutines continue allocating memory, so if we release the slabs, the goroutines are writing to already freed memory

this PR is to just prove this is actually the bug
