### PR TITLE
store-gateway: create block directory before storing sparse index header

### DIFF
--- a/pkg/storage/indexheader/lazy_binary_reader.go
+++ b/pkg/storage/indexheader/lazy_binary_reader.go
@@ -182,6 +182,17 @@ func tryDownloadSparseHeader(ctx context.Context, logger log.Logger, bkt objstor
 		level.Info(logger).Log("msg", "could not download sparse index-header from bucket; will reconstruct when the block is queried", "err", err)
 		return
 	}
+
+	dir := filepath.Dir(sparseHeaderPath)
+	if df, err := os.Open(dir); err != nil && os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			level.Info(logger).Log("msg", "could not create directory for sparse index-header; will reconstruct when the block is queried", "err", err)
+			return
+		}
+	} else {
+		_ = df.Close()
+	}
+
 	err = atomicfs.CreateFile(sparseHeaderPath, bytes.NewReader(bucketSparseHeaderBytes))
 	if err != nil {
 		level.Info(logger).Log("msg", "could not store sparse index-header on disk; will reconstruct when the block is queried", "err", err)


### PR DESCRIPTION
there's a race between those two functions. `ensureIndexHeaderOnDisk` creates a directory and `tryDownloadSparseHeader` needs that directory. Sometimes `tryDownloadSparseHeader` fails because it runs before `ensureIndexHeaderOnDisk`

https://github.com/grafana/mimir/blob/c8df29104106ce842c92cb38eeb81f972783607f/pkg/storage/indexheader/lazy_binary_reader.go#L141-L149

example log line
```
ts=2025-10-03T12:11:26.370447959Z caller=lazy_binary_reader.go:187 level=info user=10809 msg="could not store sparse index-header on disk; will reconstruct when the block is queried" err="open /data/tsdb/10809/01K6M9CCNX2WG0ZDKWPW59YSFM/sparse-index-header.tmp: no such file or directory"
```
