### PR TITLE
Bump Go to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/mimir
 
-go 1.24.2
+go 1.25.1
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2


### PR DESCRIPTION
#### What this PR does

I propose we update the allowed Go version to 1.25. This version provides [`testing/synctest`][1] that was can start adopting to make our tests less flaky.

[1]: https://pkg.go.dev/testing/synctest