### PR TITLE
Fix more issues where some binary expressions aren't sharded

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/sharding.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding.go
@@ -63,7 +63,7 @@ type shardSummer struct {
 
 	shardLabeller ShardLabeller
 
-	canShardAllVectorSelectorsCache map[parser.Expr]bool
+	willShardAllSelectorsCache map[parser.Expr]bool
 }
 
 func newShardSummer(shards int, inspectOnly bool, squasher Squasher, logger log.Logger, stats *MapperStats, shardLabeller ShardLabeller) *shardSummer {
@@ -81,7 +81,7 @@ func newShardSummer(shards int, inspectOnly bool, squasher Squasher, logger log.
 
 		shardLabeller: shardLabeller,
 
-		canShardAllVectorSelectorsCache: make(map[parser.Expr]bool),
+		willShardAllSelectorsCache: make(map[parser.Expr]bool),
 	}
 }
 
@@ -148,15 +148,8 @@ func (summer *shardSummer) MapExpr(ctx context.Context, expr parser.Expr) (mappe
 		// process in the query-frontend. Since we can't estimate the cardinality, we prefer
 		// to be pessimistic and not parallelize at all the two legs unless we're able to
 		// parallelize all vector selectors in the legs.
-		canLHS, err := summer.canShardAllVectorSelectors(e.LHS)
-		if err != nil {
-			return e, true, err
-		}
-		if !canLHS {
-			return e, true, nil
-		}
-		canRHS, err := summer.canShardAllVectorSelectors(e.RHS)
-		return e, !canRHS, err
+		willShard, err := summer.willShardAllSelectors(e)
+		return e, !willShard, err
 
 	case *parser.SubqueryExpr:
 		// If the mapped expr is part of the sharded query, then it means we already checked whether it was
@@ -175,47 +168,84 @@ func (summer *shardSummer) MapExpr(ctx context.Context, expr parser.Expr) (mappe
 	}
 }
 
-func (summer *shardSummer) canShardAllVectorSelectors(expr parser.Expr) (can bool, err error) {
+// willShardAllSelectors returns true if all selectors in expr will be sharded.
+// This differs from CanParallelize, which returns true if it is valid to shard the expr.
+//
+// For example, it is valid to shard a vector selector (so CanParallelize returns true), but we
+// don't bother doing this because it has no benefit (so willShardAllSelectors returns false).
+//
+// However, if the expression was a sum aggregation over a vector selector, for example, then
+// both methods would return true.
+func (summer *shardSummer) willShardAllSelectors(expr parser.Expr) (will bool, err error) {
 	// We need to cache the results of this function to avoid processing it again and again
 	// in queries like `a or b or c or d`, which would lead to exponential processing time.
-	if can, ok := summer.canShardAllVectorSelectorsCache[expr]; ok {
-		return can, nil
+	if cached, ok := summer.willShardAllSelectorsCache[expr]; ok {
+		return cached, nil
 	}
 	defer func() {
 		if err == nil {
-			summer.canShardAllVectorSelectorsCache[expr] = can
+			summer.willShardAllSelectorsCache[expr] = will
 		}
 	}()
 
-	if paren, ok := expr.(*parser.ParenExpr); ok {
-		// Unwrap the expression.
-		return summer.canShardAllVectorSelectors(paren.Expr)
-	}
+	switch expr := expr.(type) {
+	case *parser.VectorSelector, *parser.MatrixSelector:
+		return false, nil
+	case *parser.ParenExpr:
+		return summer.willShardAllSelectors(expr.Expr)
+	case *parser.AggregateExpr:
+		if CanParallelize(expr, summer.logger) {
+			return true, nil
+		}
 
-	hasSelector, err := AnyNode(expr, isVectorSelector)
-	if !hasSelector {
+		// If we can't shard this expression, we might still be able to shard the inner expression.
+		// eg. in avg(count(test)), we can't shard the avg(), but we can shard the count().
+		return summer.willShardAllSelectors(expr.Expr)
+
+	case *parser.BinaryExpr:
+		if CanParallelize(expr, summer.logger) && summer.isShardableBinOp(expr) {
+			return true, nil
+		}
+
+		willLHS, err := summer.willShardAllSelectors(expr.LHS)
+		if err != nil {
+			return false, err
+		}
+		if !willLHS {
+			return false, nil
+		}
+		willRHS, err := summer.willShardAllSelectors(expr.RHS)
+		return willRHS, err
+
+	case *parser.Call:
+		if isSubqueryCall(expr) {
+			return CanParallelize(expr, summer.logger) && !containsAggregateExpr(expr), nil
+		}
+
+		for _, arg := range argsWithDefaults(expr) {
+			if can, err := summer.willShardAllSelectors(arg); err != nil {
+				return false, err
+			} else if !can {
+				return false, nil
+			}
+		}
+
 		return true, nil
+
+	case *parser.NumberLiteral, *parser.StringLiteral:
+		return true, nil
+
+	case *parser.UnaryExpr:
+		return summer.willShardAllSelectors(expr.Expr)
+
+	case *parser.SubqueryExpr:
+		// If we've reached this point, then the subquery is not shardable.
+		// If the subquery was shardable, we would have returned true when examining the outer function call.
+		return false, nil
+
+	default:
+		return false, fmt.Errorf("willShardAllSelectors: unexpected expression type %T", expr)
 	}
-
-	if binop, ok := expr.(*parser.BinaryExpr); ok {
-		canShardLHS, err := summer.canShardAllVectorSelectors(binop.LHS)
-		if err != nil {
-			return false, err
-		}
-
-		canShardRHS, err := summer.canShardAllVectorSelectors(binop.RHS)
-		if err != nil {
-			return false, err
-		}
-		return canShardLHS && canShardRHS, nil
-	}
-
-	hasAggregation, err := AnyNode(expr, isAggregateExpr)
-	if err != nil {
-		return false, err
-	}
-
-	return CanParallelize(expr, summer.logger) && hasAggregation, nil
 }
 
 // shardAndSquashFuncCall shards the given function call by cloning it and adding the shard label to the most outer matrix/vector selector.
@@ -515,21 +545,29 @@ func (summer *shardSummer) shardAndSquashAggregateExpr(ctx context.Context, expr
 	return summer.squasher.Squash(children...)
 }
 
-// shardBinOp attempts to shard the given binary operation expression.
-func (summer *shardSummer) shardBinOp(ctx context.Context, expr *parser.BinaryExpr) (mapped parser.Expr, finished bool, err error) {
+func (summer *shardSummer) isShardableBinOp(expr *parser.BinaryExpr) bool {
 	switch expr.Op {
 	case parser.GTR,
 		parser.GTE,
 		parser.LSS,
 		parser.LTE:
-		mapped, err = summer.shardAndSquashBinOp(ctx, expr)
-		if err != nil {
-			return nil, false, err
-		}
-		return mapped, true, nil
+		return true
 	default:
+		return false
+	}
+}
+
+// shardBinOp attempts to shard the given binary operation expression.
+func (summer *shardSummer) shardBinOp(ctx context.Context, expr *parser.BinaryExpr) (mapped parser.Expr, finished bool, err error) {
+	if !summer.isShardableBinOp(expr) {
 		return expr, false, nil
 	}
+
+	mapped, err = summer.shardAndSquashBinOp(ctx, expr)
+	if err != nil {
+		return nil, false, err
+	}
+	return mapped, true, nil
 }
 
 // shardAndSquashBinOp returns a squashed CONCAT expression including N embedded

--- a/pkg/frontend/querymiddleware/astmapper/sharding.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding.go
@@ -203,7 +203,7 @@ func (summer *shardSummer) willShardAllSelectors(expr parser.Expr) (will bool, e
 		return summer.willShardAllSelectors(expr.Expr)
 
 	case *parser.BinaryExpr:
-		if CanParallelize(expr, summer.logger) && summer.isShardableBinOp(expr) {
+		if summer.isShardableBinOp(expr) && CanParallelize(expr, summer.logger) {
 			return true, nil
 		}
 

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -605,7 +605,7 @@ func TestShardSummer(t *testing.T) {
 				require.NoError(t, err)
 
 				if hasVectorSelectors {
-					require.Equal(t, tt.expectedShardableQueries > 0, willShardAllSelectors)
+					require.Equal(t, tt.expectedShardableQueries > 0, willShardAllSelectors, "willShardAllSelectors should be true if the expression is shardable, and false otherwise")
 				} else {
 					require.True(t, willShardAllSelectors, "expression has no selectors")
 				}

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -53,6 +53,11 @@ func TestShardSummer(t *testing.T) {
 			0,
 		},
 		{
+			`absent(sum(foo))`,
+			`absent(sum(` + concatShards(t, shardCount, `sum(foo{__query_shard__="x_of_y"})`) + `))`,
+			1,
+		},
+		{
 			`absent_over_time(foo[1m])`,
 			`absent_over_time(foo[1m])`,
 			0,
@@ -146,6 +151,11 @@ func TestShardSummer(t *testing.T) {
 		{
 			`count(up)`,
 			`sum(` + concatShards(t, shardCount, `count(up{__query_shard__="x_of_y"})`) + `)`,
+			1,
+		},
+		{
+			`-count(up)`,
+			`-sum(` + concatShards(t, shardCount, `count(up{__query_shard__="x_of_y"})`) + `)`,
 			1,
 		},
 		{
@@ -288,6 +298,11 @@ func TestShardSummer(t *testing.T) {
 			0,
 		},
 		{
+			`rate(metric_counter[5m])[10m:]`,
+			`rate(metric_counter[5m])[10m:]`,
+			0,
+		},
+		{
 			`absent_over_time(rate(metric_counter[5m])[10m:])`,
 			`absent_over_time(rate(metric_counter[5m])[10m:])`,
 			0,
@@ -417,6 +432,22 @@ func TestShardSummer(t *testing.T) {
 			0,
 		},
 		{
+			`month()`,
+			`month()`,
+			0,
+		},
+		{
+			// We could shard month(foo), but since it doesn't reduce the data set, we don't.
+			`month(foo)`,
+			`month(foo)`,
+			0,
+		},
+		{
+			`month(sum(foo))`,
+			`month(sum(` + concatShards(t, shardCount, `sum(foo{__query_shard__="x_of_y"})`) + `))`,
+			1,
+		},
+		{
 			// This query is not parallelized because the leg "year(foo)" could result in high cardinality results.
 			`sum(rate(metric_counter[1m])) / vector(3) ^ year(foo)`,
 			`sum(rate(metric_counter[1m])) / vector(3) ^ year(foo)`,
@@ -542,14 +573,43 @@ func TestShardSummer(t *testing.T) {
 			out:                      `count(group without() (` + concatShards(t, shardCount, `group without() ({namespace="foo",__query_shard__="x_of_y"})`) + `))`,
 			expectedShardableQueries: 1,
 		},
+		{
+			in:                       `vector(scalar(sum(foo)))`,
+			out:                      `vector(scalar(sum(` + concatShards(t, shardCount, `sum(foo{__query_shard__="x_of_y"})`) + `)))`,
+			expectedShardableQueries: 1,
+		},
 	} {
 		t.Run(tt.in, func(t *testing.T) {
-			runTest(t, tt.in, tt.out, shardCount, false, tt.expectedShardableQueries*shardCount)
-		})
+			t.Run("applying sharding", func(t *testing.T) {
+				runTest(t, tt.in, tt.out, shardCount, false, tt.expectedShardableQueries*shardCount)
+			})
 
-		t.Run(tt.in+" with 'inspect only' set", func(t *testing.T) {
-			// The query should be unchanged, but the number of sharded queries should still be reported.
-			runTest(t, tt.in, tt.in, 1, true, tt.expectedShardableQueries)
+			t.Run("inspecting", func(t *testing.T) {
+				// The query should be unchanged, but the number of sharded queries should still be reported.
+				runTest(t, tt.in, tt.in, 1, true, tt.expectedShardableQueries)
+			})
+
+			t.Run("checking if all vector selectors are sharded", func(t *testing.T) {
+				// There are a lot of edge cases in willShardAllSelectors, and this method is only called
+				// if an expression appears inside a binary expression.
+				// So rather than generating a whole set of test cases just for this, we directly check each of
+				// our existing test cases.
+				expr, err := parser.ParseExpr(tt.in)
+				require.NoError(t, err)
+				stats := NewMapperStats()
+				summer := newShardSummer(shardCount, false, EmbeddedQueriesSquasher, log.NewNopLogger(), stats, newQueryShardLabeller(shardCount))
+
+				willShardAllSelectors, err := summer.willShardAllSelectors(expr)
+				require.NoError(t, err)
+				hasVectorSelectors, err := AnyNode(expr, isVectorSelector)
+				require.NoError(t, err)
+
+				if hasVectorSelectors {
+					require.Equal(t, tt.expectedShardableQueries > 0, willShardAllSelectors)
+				} else {
+					require.True(t, willShardAllSelectors, "expression has no selectors")
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR is a follow up to https://github.com/grafana/mimir/pull/12900. It fixes a number of other similar cases that affect other expressions on one side of binary expressions. These were all caused by `canShardAllVectorSelectors` incorrectly returning false. 

I don't believe any of these would have caused incorrect query results, but instead would have caused sharding not to be applied when it should have been.

There is an opportunity to remove the "inspect only" mode introduced in #12677 and instead make use of `willShardAllVectorSelectors` when calculating the number of shardable legs, but I will do this in a follow up PR.

I haven't added a changelog entry for the same reason I did not add one in #12900.

#### Which issue(s) this PR fixes or relates to

#12900 and #12677

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
