### PR TITLE
jsonnet: Allow minReadySeconds to be set for cache STS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,8 +114,9 @@
 * [CHANGE] Ingester: Disable shipping of blocks on the third zone (zone-c) when using `ingest_storage_ingester_zones: 3` on ingest storage #12743 #12744
 * [CHANGE] Distributor: Increase `server.grpc-max-concurrent-streams` from 100 to 1000. #12742
 * [CHANGE] Ruler Query Frontend: Increase `server.grpc-max-concurrent-streams` from 100 to 300. #12742
-* [ENHANCEMENT] Add timeout validation for querier and query-frontend. Enhanced `parseDuration` to support milliseconds and combined formats (e.g., "4m30s"). #12766
 * [CHANGE] Rollout-operator: Vendor jsonnet from rollout-operator repository. #12688
+* [FEATURE] Memcached: Allow `minReadySeconds` to be set via `_config.cache_frontend_min_ready_seconds` (etc.) to slow down Memcached rollouts. #12938
+* [ENHANCEMENT] Add timeout validation for querier and query-frontend. Enhanced `parseDuration` to support milliseconds and combined formats (e.g., "4m30s"). #12766
 * [ENHANCEMENT] Allow the max number of OTEL events in a span to be configure via `_config.otel_span_event_count_limit`. #12865
 
 ### Documentation

--- a/operations/mimir-tests/test-all-components-generated.yaml
+++ b/operations/mimir-tests/test-all-components-generated.yaml
@@ -1212,6 +1212,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1271,6 +1272,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1330,6 +1332,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1389,6 +1392,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-max-skew-generated.yaml
@@ -1212,6 +1212,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1271,6 +1272,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1330,6 +1332,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1389,6 +1392,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-custom-runtime-config-generated.yaml
@@ -1221,6 +1221,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1280,6 +1281,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1339,6 +1341,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1398,6 +1401,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-tsdb-head-early-compaction-generated.yaml
@@ -1214,6 +1214,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1273,6 +1274,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1332,6 +1334,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1391,6 +1394,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-all-components-without-pod-topology-constraints-generated.yaml
+++ b/operations/mimir-tests/test-all-components-without-pod-topology-constraints-generated.yaml
@@ -1184,6 +1184,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1243,6 +1244,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1302,6 +1304,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1361,6 +1364,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1781,6 +1781,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1840,6 +1841,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1899,6 +1901,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1958,6 +1961,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -1854,6 +1854,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1913,6 +1914,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1972,6 +1974,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2031,6 +2034,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -1564,6 +1564,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1623,6 +1624,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1682,6 +1684,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1741,6 +1744,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -1564,6 +1564,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1623,6 +1624,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1682,6 +1684,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1741,6 +1744,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -1082,6 +1082,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1141,6 +1142,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1200,6 +1202,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1259,6 +1262,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -1082,6 +1082,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1141,6 +1142,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1200,6 +1202,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1259,6 +1262,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-consul-generated.yaml
+++ b/operations/mimir-tests/test-consul-generated.yaml
@@ -1582,6 +1582,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1641,6 +1642,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1700,6 +1702,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1759,6 +1762,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -2117,6 +2117,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2176,6 +2177,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2235,6 +2237,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2294,6 +2297,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
+++ b/operations/mimir-tests/test-consul-ruler-disabled-generated.yaml
@@ -1452,6 +1452,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1511,6 +1512,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1570,6 +1572,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1629,6 +1632,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-continuous-test-generated.yaml
+++ b/operations/mimir-tests/test-continuous-test-generated.yaml
@@ -1012,6 +1012,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1071,6 +1072,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1130,6 +1132,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1189,6 +1192,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-defaults-generated.yaml
+++ b/operations/mimir-tests/test-defaults-generated.yaml
@@ -958,6 +958,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1017,6 +1018,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1076,6 +1078,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1135,6 +1138,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-env-vars-generated.yaml
+++ b/operations/mimir-tests/test-env-vars-generated.yaml
@@ -1216,6 +1216,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1275,6 +1276,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1334,6 +1336,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1393,6 +1396,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-etcd-replicas-generated.yaml
+++ b/operations/mimir-tests/test-etcd-replicas-generated.yaml
@@ -958,6 +958,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1017,6 +1018,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1076,6 +1078,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1135,6 +1138,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-extra-runtime-config-generated.yaml
+++ b/operations/mimir-tests/test-extra-runtime-config-generated.yaml
@@ -1260,6 +1260,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1319,6 +1320,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1378,6 +1380,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1437,6 +1440,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -1319,6 +1319,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1378,6 +1379,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1437,6 +1439,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1496,6 +1499,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -2384,6 +2384,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2443,6 +2444,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2502,6 +2504,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2561,6 +2564,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -2315,6 +2315,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2374,6 +2375,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2433,6 +2435,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2492,6 +2495,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -2315,6 +2315,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2374,6 +2375,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2433,6 +2435,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2492,6 +2495,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -2238,6 +2238,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2297,6 +2298,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2356,6 +2358,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2415,6 +2418,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -2746,6 +2746,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2805,6 +2806,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2864,6 +2866,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2923,6 +2926,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -2218,6 +2218,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2277,6 +2278,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2336,6 +2338,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2395,6 +2398,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -2222,6 +2222,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2281,6 +2282,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2340,6 +2342,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2399,6 +2402,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -2761,6 +2761,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2820,6 +2821,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2879,6 +2881,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2938,6 +2941,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -2783,6 +2783,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2842,6 +2843,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2901,6 +2903,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2960,6 +2963,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -2781,6 +2781,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2840,6 +2841,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2899,6 +2901,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2958,6 +2961,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -2781,6 +2781,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2840,6 +2841,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2899,6 +2901,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2958,6 +2961,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -2781,6 +2781,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2840,6 +2841,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2899,6 +2901,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2958,6 +2961,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -2313,6 +2313,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2372,6 +2373,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2431,6 +2433,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2490,6 +2493,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -2330,6 +2330,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2389,6 +2390,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2448,6 +2450,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2507,6 +2510,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -2330,6 +2330,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2389,6 +2390,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2448,6 +2450,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2507,6 +2510,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -2159,6 +2159,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2218,6 +2219,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2277,6 +2279,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2336,6 +2339,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -2384,6 +2384,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2443,6 +2444,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2502,6 +2504,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2561,6 +2564,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-0-before-generated.yaml
@@ -1212,6 +1212,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1271,6 +1272,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1330,6 +1332,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1389,6 +1392,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-1-generated.yaml
@@ -1218,6 +1218,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1277,6 +1278,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1336,6 +1338,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1395,6 +1398,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-2-generated.yaml
@@ -1224,6 +1224,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1283,6 +1284,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1342,6 +1344,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1401,6 +1404,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-cluster-label-migration-step-3-generated.yaml
@@ -1218,6 +1218,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1277,6 +1278,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1336,6 +1338,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1395,6 +1398,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-0-before-generated.yaml
@@ -1582,6 +1582,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1641,6 +1642,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1700,6 +1702,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1759,6 +1762,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-1-generated.yaml
@@ -1668,6 +1668,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1727,6 +1728,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1786,6 +1788,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1845,6 +1848,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-2-generated.yaml
@@ -1668,6 +1668,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1727,6 +1728,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1786,6 +1788,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1845,6 +1848,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-3-generated.yaml
@@ -1668,6 +1668,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1727,6 +1728,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1786,6 +1788,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1845,6 +1848,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-4-generated.yaml
@@ -1668,6 +1668,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1727,6 +1728,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1786,6 +1788,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1845,6 +1848,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-5-generated.yaml
@@ -1215,6 +1215,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1274,6 +1275,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1333,6 +1335,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1392,6 +1395,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
+++ b/operations/mimir-tests/test-memberlist-migration-step-6-final-generated.yaml
@@ -1212,6 +1212,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1271,6 +1272,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1330,6 +1332,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1389,6 +1392,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-distributor-generated.yaml
@@ -2007,6 +2007,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2066,6 +2067,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2125,6 +2127,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2184,6 +2187,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-etcd-generated.yaml
@@ -1850,6 +1850,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1909,6 +1910,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1968,6 +1970,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2027,6 +2030,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1850,6 +1850,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1909,6 +1910,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1968,6 +1970,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2027,6 +2030,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -2016,6 +2016,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2075,6 +2076,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2134,6 +2136,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2193,6 +2196,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1850,6 +1850,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1909,6 +1910,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1968,6 +1970,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2027,6 +2030,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
+++ b/operations/mimir-tests/test-new-resource-scaled-object-generated.yaml
@@ -958,6 +958,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1017,6 +1018,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1076,6 +1078,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1135,6 +1138,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
+++ b/operations/mimir-tests/test-node-selector-and-affinity-generated.yaml
@@ -1052,6 +1052,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1113,6 +1114,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1174,6 +1176,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1235,6 +1238,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -1590,6 +1590,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1649,6 +1650,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1708,6 +1710,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1767,6 +1770,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-consul-ring-generated.yaml
@@ -1592,6 +1592,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1651,6 +1652,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1710,6 +1712,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1769,6 +1772,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1629,6 +1629,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1688,6 +1689,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1747,6 +1749,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1806,6 +1809,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-generated.yaml
@@ -1243,6 +1243,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1302,6 +1303,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1361,6 +1363,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1420,6 +1423,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-read-path-disabled-generated.yaml
@@ -1231,6 +1231,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1290,6 +1291,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1349,6 +1351,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1408,6 +1411,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -1217,6 +1217,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1276,6 +1277,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1335,6 +1337,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1394,6 +1397,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -1571,6 +1571,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1630,6 +1631,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1689,6 +1691,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1748,6 +1751,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-migration-generated.yaml
@@ -1569,6 +1569,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1628,6 +1629,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1687,6 +1689,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1746,6 +1749,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-shuffle-sharding-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-generated.yaml
@@ -1221,6 +1221,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1280,6 +1281,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1339,6 +1341,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1398,6 +1401,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-partitions-enabled-generated.yaml
@@ -1225,6 +1225,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1284,6 +1285,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1343,6 +1345,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1402,6 +1405,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
+++ b/operations/mimir-tests/test-shuffle-sharding-read-path-disabled-generated.yaml
@@ -1222,6 +1222,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1281,6 +1282,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1340,6 +1342,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1399,6 +1402,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
+++ b/operations/mimir-tests/test-single-to-multi-zone-distributor-migration-generated.yaml
@@ -2137,6 +2137,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2196,6 +2197,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2255,6 +2257,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -2314,6 +2317,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-storage-azure-generated.yaml
+++ b/operations/mimir-tests/test-storage-azure-generated.yaml
@@ -1222,6 +1222,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1281,6 +1282,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1340,6 +1342,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1399,6 +1402,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-storage-gcs-generated.yaml
+++ b/operations/mimir-tests/test-storage-gcs-generated.yaml
@@ -1212,6 +1212,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1271,6 +1272,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1330,6 +1332,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1389,6 +1392,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-storage-s3-generated.yaml
+++ b/operations/mimir-tests/test-storage-s3-generated.yaml
@@ -1217,6 +1217,7 @@ metadata:
   name: memcached
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1276,6 +1277,7 @@ metadata:
   name: memcached-frontend
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1335,6 +1337,7 @@ metadata:
   name: memcached-index-queries
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
@@ -1394,6 +1397,7 @@ metadata:
   name: memcached-metadata
   namespace: default
 spec:
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -117,18 +117,22 @@
     cache_frontend_enabled: true,
     cache_frontend_max_item_size_mb: 5,
     cache_frontend_connection_limit: 16384,
+    cache_frontend_min_ready_seconds: 60,
 
     cache_index_queries_enabled: true,
     cache_index_queries_max_item_size_mb: 5,
     cache_index_queries_connection_limit: 16384,
+    cache_index_queries_min_ready_seconds: 60,
 
     cache_chunks_enabled: true,
     cache_chunks_max_item_size_mb: 1,
     cache_chunks_connection_limit: 16384,
+    cache_chunks_min_ready_seconds: 60,
 
     cache_metadata_enabled: true,
     cache_metadata_max_item_size_mb: 1,
     cache_metadata_connection_limit: 16384,
+    cache_metadata_min_ready_seconds: 60,
 
     // Number of etcd replicas.
     etcd_replicas: 3,

--- a/operations/mimir/jsonnetfile.lock.json
+++ b/operations/mimir/jsonnetfile.lock.json
@@ -38,8 +38,8 @@
           "subdir": "memcached"
         }
       },
-      "version": "cd4dd9a04aa740b2644e12810e48382188c25adc",
-      "sum": "f+DYmgxR3spwx8DbIyY4+qSaFsshg/SE+MDG6jUQhJg="
+      "version": "dfc90cc58ffd46be49aeafe57014ef55ea4e3cd8",
+      "sum": "zNTCDRaCqJUHjQSQRsxGR3jLrMP9tU7YNQb13dbm1bU="
     },
     {
       "source": {

--- a/operations/mimir/memcached.libsonnet
+++ b/operations/mimir/memcached.libsonnet
@@ -32,6 +32,7 @@ memcached {
         max_item_size: '%dm' % [$._config.cache_frontend_max_item_size_mb],
         overprovision_factor: 1.05,
         connection_limit: std.toString($._config.cache_frontend_connection_limit),
+        min_ready_seconds: $._config.cache_frontend_min_ready_seconds,
 
         statefulSet+:
           statefulSet.mixin.spec.withReplicas($._config.memcached_frontend_replicas),
@@ -46,6 +47,7 @@ memcached {
         max_item_size: '%dm' % [$._config.cache_index_queries_max_item_size_mb],
         overprovision_factor: 1.05,
         connection_limit: std.toString($._config.cache_index_queries_connection_limit),
+        min_ready_seconds: $._config.cache_index_queries_min_ready_seconds,
 
         statefulSet+:
           statefulSet.mixin.spec.withReplicas($._config.memcached_index_queries_replicas),
@@ -63,6 +65,7 @@ memcached {
         memory_limit_mb: 6 * 1024,
         overprovision_factor: 1.05,
         connection_limit: std.toString($._config.cache_chunks_connection_limit),
+        min_ready_seconds: $._config.cache_chunks_min_ready_seconds,
 
         statefulSet+:
           statefulSet.mixin.spec.withReplicas($._config.memcached_chunks_replicas),
@@ -76,6 +79,7 @@ memcached {
         name: 'memcached-metadata',
         max_item_size: '%dm' % [$._config.cache_metadata_max_item_size_mb],
         connection_limit: std.toString($._config.cache_metadata_connection_limit),
+        min_ready_seconds: $._config.cache_metadata_min_ready_seconds,
 
         // Metadata cache doesn't need much memory.
         memory_limit_mb: 512,


### PR DESCRIPTION
#### What this PR does

Allow minReadySeconds to be set on each cache STS to slow rollouts down by requiring that they are "ready" for at least 60 seconds before moving on to the next pod.

#### Which issue(s) this PR fixes or relates to

Fixes #12925

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
