### PR TITLE
helm: add query-frontend to memberlist gossip

### DIFF
--- a/operations/compare-helm-with-jsonnet/helm/06-pods/kustomization.yaml
+++ b/operations/compare-helm-with-jsonnet/helm/06-pods/kustomization.yaml
@@ -69,7 +69,7 @@ patches:
 
   # Minor Difference: Helm names the memberlist port slightly differently
   - target:
-      name: mimir-(distributor|querier|alertmanager|ingester|store-gateway|compactor)
+      name: mimir-(distributor|querier|query-frontend|alertmanager|ingester|store-gateway|compactor)
       kind: Deployment|StatefulSet
     patch: |-
       - op: replace

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -41,6 +41,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Distributor: Reduce calculated `GOMAXPROCS` to closer to the requested number of CPUs. #12150
 * [CHANGE] Query-scheduler: The query-scheduler is now a required component that is always used by queriers and query-frontends. #12188
 * [CHANGE] Provisioner: Replace the default kubectl image, used by the provisioner job, to `alpine/kubectl`. #12498
+* [CHANGE] Query-frontend: Expose memberlist gossip port since this is required in some configurations. #12950
 * [ENHANCEMENT] Gateway ingress: Support labels for gateway ingress. #11964
 * [ENHANCEMENT] Store-gateway: Configure options for emptyDir. #11951
 * [ENHANCEMENT] Add support for `revisionhistorylimit` for all deployments. #12323

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "query-frontend") }}
   labels:
-    {{- include "mimir.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
+    {{- include "mimir.labels" (dict "ctx" . "component" "query-frontend" "memberlist" true) | nindent 4 }}
   annotations:
     {{- toYaml .Values.query_frontend.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
@@ -20,13 +20,13 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-frontend") | nindent 6 }}
+      {{- include "mimir.selectorLabels" (dict "ctx" . "component" "query-frontend" "memberlist" true) | nindent 6 }}
   strategy:
     {{- toYaml .Values.query_frontend.strategy | nindent 4 }}
   template:
     metadata:
       labels:
-        {{- include "mimir.podLabels" (dict "ctx" . "component" "query-frontend") | nindent 8 }}
+        {{- include "mimir.podLabels" (dict "ctx" . "component" "query-frontend" "memberlist" true) | nindent 8 }}
       annotations:
         {{- include "mimir.podAnnotations" (dict "ctx" . "component" "query-frontend") | nindent 8 }}
       namespace: {{ .Release.Namespace | quote }}
@@ -89,6 +89,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: {{ include "mimir.serverGrpcListenPort" . }}
+              protocol: TCP
+            - name: memberlist
+              containerPort: {{ include "mimir.memberlistBindPort" . }}
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.query_frontend.livenessProbe | nindent 12 }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ include "mimir.resourceName" (dict "ctx" . "component" "query-frontend") }}
   labels:
-    {{- include "mimir.labels" (dict "ctx" . "component" "query-frontend") | nindent 4 }}
+    {{- include "mimir.labels" (dict "ctx" . "component" "query-frontend" "memberlist" true) | nindent 4 }}
     {{- with .Values.query_frontend.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: classic-architecture-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: classic-architecture-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: classic-architecture-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: enterprise-https-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: enterprise-https-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -74,6 +76,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: enterprise-https-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: gateway-enterprise-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -70,6 +72,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-enterprise-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: gateway-nginx-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: gateway-nginx-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: graphite-enabled-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: graphite-enabled-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -70,6 +72,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/graphite-enabled-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: graphite-enabled-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-global-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,6 +31,7 @@ spec:
         app.kubernetes.io/instance: keda-autoscaling-global-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -66,6 +68,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-global-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -30,6 +31,7 @@ spec:
         app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -66,6 +68,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: keda-autoscaling-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: keda-autoscaling-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: large-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: large-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: large-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: metamonitoring-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: metamonitoring-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: metamonitoring-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: openshift-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: openshift-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -67,6 +69,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: openshift-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: scheduler-name-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: scheduler-name-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: scheduler-name-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: small-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: small-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: small-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-component-image-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-enterprise-component-image-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -71,6 +73,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-component-image-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-enterprise-configmap-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
         minio-secret-version: "42"
       namespace: "citestns"
@@ -71,6 +73,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-enterprise-configmap-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-configmap-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -70,6 +72,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-k8s-1.25-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -28,6 +28,7 @@ spec:
       labels:
         app: enterprise-metrics-query-frontend
         name: query-frontend
+        gossip_ring_member: "true"
         target: query-frontend
         release: test-enterprise-legacy-label-values
       annotations:
@@ -68,6 +69,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-enterprise-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -70,6 +72,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-enterprise-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-extra-args-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-extra-args-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -75,6 +77,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-extra-args-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-extra-objects-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-extra-objects-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-extra-objects-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-gomaxprocs-override-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-gomaxprocs-override-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-gomaxprocs-override-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ingest-storage-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-ingest-storage-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ingest-storage-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ingress-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-ingress-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ingress-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-component-image-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-oss-component-image-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -69,6 +71,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-component-image-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-emptydir-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-oss-emptydir-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-emptydir-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-oss-k8s-1.25-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-k8s-1.25-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-oss-logical-multizone-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-logical-multizone-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-oss-multizone-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-multizone-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -70,6 +72,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-oss-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
         minio-secret-version: "42"
       namespace: "citestns"
@@ -69,6 +71,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-oss-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-requests-and-limits-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-requests-and-limits-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-requests-and-limits-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-revisionhistorylimit-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -33,6 +34,7 @@ spec:
         app.kubernetes.io/instance: test-revisionhistorylimit-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -69,6 +71,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-revisionhistorylimit-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
       namespace: "citestns"
     spec:
@@ -68,6 +70,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-vault-agent-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -32,6 +33,7 @@ spec:
         app.kubernetes.io/instance: test-vault-agent-values
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
       annotations:
         vault.hashicorp.com/agent-inject: 'true'
         vault.hashicorp.com/role: 'test-role-name'
@@ -75,6 +77,9 @@ spec:
               protocol: TCP
             - name: grpc
               containerPort: 9095
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           livenessProbe:
             null

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: mimir
     app.kubernetes.io/instance: test-vault-agent-values
     app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/part-of: memberlist
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}


### PR DESCRIPTION
#### What this PR does

Add the memberlist gossip port to query-frontends since they participate to discover query-schedulers in some configurations.

#### Which issue(s) this PR fixes or relates to

Fixes #12876

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
