### PR TITLE
[r362] Fix issue where aggregation parameters aren't sharded even if the rest of the expression is shardable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 * [BUGFIX] Ingester, Block-builder: silently ignore duplicate sample if it's due to zero sample from created timestamp. Created timestamp equal to the timestamp of the first sample of series is a common case if created timestamp comes from OTLP where start time equal to timestamp of the first sample simply means unknown start time. #12726
 * [BUGFIX] Distributor: Fix error when native histograms bucket limit is set then no NHCB passes validation. #12741
 * [BUGFIX] Ingester: Fix continous reload of active series counters when cost-attribution labels are above the max cardinality. #12822
+* [BUGFIX] Query-frontend: Fix issue where shardable expressions containing aggregations with a shardable parameter (eg. `sum(foo)` in `topk(scalar(sum(foo)), sum by (pod) (bar))`) would not have the parameter sharded. #12958
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/astmapper/astmapper.go
+++ b/pkg/frontend/querymiddleware/astmapper/astmapper.go
@@ -358,6 +358,15 @@ func (em ASTExprMapper) Map(ctx context.Context, expr parser.Expr) (parser.Expr,
 			return nil, err
 		}
 		e.Expr = expr
+
+		if e.Param != nil {
+			param, err := em.Map(ctx, e.Param)
+			if err != nil {
+				return nil, err
+			}
+			e.Param = param
+		}
+
 		return e, nil
 
 	case *parser.BinaryExpr:

--- a/pkg/frontend/querymiddleware/astmapper/sharding.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding.go
@@ -201,7 +201,21 @@ func (summer *shardSummer) willShardAllSelectors(expr parser.Expr) (will bool, e
 
 		// If we can't shard this expression, we might still be able to shard the inner expression.
 		// eg. in avg(count(test)), we can't shard the avg(), but we can shard the count().
-		return summer.willShardAllSelectors(expr.Expr)
+		if willShard, err := summer.willShardAllSelectors(expr.Expr); err != nil {
+			return false, err
+		} else if !willShard {
+			return false, nil
+		}
+
+		if expr.Param != nil {
+			if willShard, err := summer.willShardAllSelectors(expr.Param); err != nil {
+				return false, err
+			} else if !willShard {
+				return false, nil
+			}
+		}
+
+		return true, nil
 
 	case *parser.BinaryExpr:
 		if summer.isShardableBinOp(expr) && CanParallelize(expr, summer.logger) {


### PR DESCRIPTION
Backport https://github.com/grafana/mimir/commit/63087dada1ead7d1ad3ae17e2072d4a0c53a880e from https://github.com/grafana/mimir/pull/12958