### PR TITLE
Docs: Update Config > Kafka to note that ingest storage is stable

### DIFF
--- a/docs/sources/mimir/configure/configure-kafka-backend.md
+++ b/docs/sources/mimir/configure/configure-kafka-backend.md
@@ -9,8 +9,9 @@ weight: 130
 
 # Configure the Grafana Mimir Kafka backend
 
-Grafana Mimir supports using Kafka for the first layer of ingestion. This is an experimental feature released in Mimir 2.14.
-This page is incomplete. It will be updated as the ingest storage feature matures and moves out of the experimental phase.
+Grafana Mimir supports using Kafka as the first layer of ingestion in the ingest storage architecture. This configuration allows for scalable, decoupled ingestion that separates write and read paths to improve performance and resilience.
+
+Starting with Grafana Mimir 3.0, ingest storage is the preferred and stable architecture for running Grafana Mimir.
 
 ## Configure ingest storage
 


### PR DESCRIPTION
#### What this PR does
This PR updates the documentation for configuring the Kafka backend in Grafana Mimir. The main change is updating the introductory explanation to reflect that ingest storage is now the preferred and stable architecture as of Mimir 3.0, and providing a clearer description of Kafka's role in the architecture.

Documentation updates:

* Updated the introduction in `configure-kafka-backend.md` to clarify that Kafka is used as the first layer of ingestion in the ingest storage architecture, emphasizing improved scalability, decoupling, and resilience. Also noted that as of Mimir 3.0, ingest storage is the preferred and stable architecture.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/3163

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
