### PR TITLE
chore(localdev): fix alloy config

### DIFF
--- a/development/mimir-monolithic-mode/config/config.alloy
+++ b/development/mimir-monolithic-mode/config/config.alloy
@@ -12,7 +12,7 @@ prometheus.scrape "mimir" {
 
   scrape_interval = "5s"
   scrape_timeout = "4s"
-  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_native_histograms = true
   scrape_classic_histograms = true
 }
 


### PR DESCRIPTION
Followup to #12913

Version 1.11 Alloy had a breaking change, see
https://grafana.com/docs/alloy/latest/release-notes/

scrape_native_histograms default is now false.
Setting it to true changes scrape protos automatically.

