### PR TITLE
Jsonnet: expose functions to create memcached deployments

### DIFF
--- a/operations/mimir/memcached.libsonnet
+++ b/operations/mimir/memcached.libsonnet
@@ -25,7 +25,7 @@ memcached {
   },
 
   // Creates a memcached instance used to cache query results.
-  newMemcachedFrontend(name)::
+  newMemcachedFrontend(name, nodeAffinityMatchers=[])::
     $.memcached {
       name: name,
       max_item_size: '%dm' % [$._config.cache_frontend_max_item_size_mb],
@@ -34,7 +34,8 @@ memcached {
       min_ready_seconds: $._config.cache_frontend_min_ready_seconds,
 
       statefulSet+:
-        statefulSet.mixin.spec.withReplicas($._config.memcached_frontend_replicas),
+        statefulSet.mixin.spec.withReplicas($._config.memcached_frontend_replicas) +
+        $.newMimirNodeAffinityMatchers(nodeAffinityMatchers),
     },
 
   memcached_frontend:
@@ -43,7 +44,7 @@ memcached {
     else {},
 
   // Creates a memcached instance used to temporarily cache index lookups.
-  newMemcachedIndexQueries(name)::
+  newMemcachedIndexQueries(name, nodeAffinityMatchers=[])::
     $.memcached {
       name: name,
       max_item_size: '%dm' % [$._config.cache_index_queries_max_item_size_mb],
@@ -52,7 +53,8 @@ memcached {
       min_ready_seconds: $._config.cache_index_queries_min_ready_seconds,
 
       statefulSet+:
-        statefulSet.mixin.spec.withReplicas($._config.memcached_index_queries_replicas),
+        statefulSet.mixin.spec.withReplicas($._config.memcached_index_queries_replicas) +
+        $.newMimirNodeAffinityMatchers(nodeAffinityMatchers),
     },
 
   memcached_index_queries:
@@ -61,7 +63,7 @@ memcached {
     else {},
 
   // Creates a memcached instance used to cache chunks.
-  newMemcachedChunks(name)::
+  newMemcachedChunks(name, nodeAffinityMatchers=[])::
     $.memcached {
       name: name,
       max_item_size: '%dm' % [$._config.cache_chunks_max_item_size_mb],
@@ -73,7 +75,8 @@ memcached {
       min_ready_seconds: $._config.cache_chunks_min_ready_seconds,
 
       statefulSet+:
-        statefulSet.mixin.spec.withReplicas($._config.memcached_chunks_replicas),
+        statefulSet.mixin.spec.withReplicas($._config.memcached_chunks_replicas) +
+        $.newMimirNodeAffinityMatchers(nodeAffinityMatchers),
     },
 
   memcached_chunks:
@@ -82,7 +85,7 @@ memcached {
     else {},
 
   // Creates a memcached instance for caching TSDB blocks metadata (meta.json files, deletion marks, list of users and blocks).
-  newMemcachedMetadata(name)::
+  newMemcachedMetadata(name, nodeAffinityMatchers=[])::
     $.memcached {
       name: name,
       max_item_size: '%dm' % [$._config.cache_metadata_max_item_size_mb],
@@ -94,7 +97,8 @@ memcached {
       overprovision_factor: 1.05,
 
       statefulSet+:
-        statefulSet.mixin.spec.withReplicas($._config.memcached_metadata_replicas),
+        statefulSet.mixin.spec.withReplicas($._config.memcached_metadata_replicas) +
+        $.newMimirNodeAffinityMatchers(nodeAffinityMatchers),
     },
 
   memcached_metadata:


### PR DESCRIPTION
#### What this PR does

I'm working to add multi-AZ support for the read path. As part of this work I need to setup per-zone memcached. In this PR I'm doing a refactoring to allow to create memcached deployments using functions. Each function takes in input the name and node affinity (it's similar to the args passed to other `newXXX()` functions we have for Mimir components).

This refactoring is expected to be a no-op.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
