### PR TITLE
Document scaling down ingesters in ingest storage arch

### DIFF
--- a/docs/sources/mimir/manage/run-production-environment/scaling-out.md
+++ b/docs/sources/mimir/manage/run-production-environment/scaling-out.md
@@ -65,7 +65,7 @@ In production environments, scaling down typically happens automatically through
 
 The rollout-operator is deployed by the Grafana Mimir Helm chart and is the recommended way to manage partitioned ingesters and scaling operations for ingest storage.
 
-If you’re managing ingesters manually, you can use GET, POST, or DELETE on the HTTP API endpoint  `/ingester/prepare-partition-downscale` to prepare ingesters for downscaling instead of relying on the rollout-operator.
+If you’re managing ingesters manually, you can use GET, POST, or DELETE on the [HTTP API endpoint `/ingester/prepare-partition-downscale`](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/http-api/#prepare-partition-downscale) to prepare ingesters for downscaling instead of relying on the rollout-operator.
 
 ### Scaling down ingesters in classic architecture
 


### PR DESCRIPTION
#### What this PR does
This pull request updates the documentation for scaling down ingesters in Grafana Mimir by clearly distinguishing between the ingest storage and classic architectures. It provides architecture-specific guidance, clarifies the procedures, and improves the accuracy and relevance of external documentation links.

**Improvements to ingester scaling documentation:**

* Added distinct sections for scaling down ingesters in the ingest storage architecture and the classic architecture, including architecture-specific notes and links to relevant documentation.
* For ingest storage architecture, explained that partition reassignment (not in-memory handoff) is used, and clarified that data durability is ensured via Kafka and object storage, with guidance to wait for partition reassignment before removing ingesters.
* For classic architecture, clarified the need to flush in-memory data to long-term storage using the `/ingester/shutdown` endpoint, and improved the explanation of potential data loss and query consistency during scale-down operations.
* Updated all internal documentation links to use the canonical Grafana documentation URLs with the `<MIMIR_VERSION>` placeholder for versioning consistency.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/3296

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
