### PR TITLE
Docs: Add extra slash to DNS resolver scheme in Ruler's docs

### DIFF
--- a/docs/sources/mimir/references/architecture/components/ruler/index.md
+++ b/docs/sources/mimir/references/architecture/components/ruler/index.md
@@ -40,7 +40,7 @@ When you use the internal mode, the ruler uses no query acceleration techniques 
 
 In this mode the ruler delegates rules evaluation to the query-frontend. When enabled, the ruler leverages all the query acceleration techniques employed by the query-frontend, such as [query sharding](../../query-sharding/).
 To enable the remote operational mode, set the `-ruler.query-frontend.address` CLI flag or its respective YAML configuration parameter for the ruler.
-Communication between ruler and query-frontend is established over gRPC, so you can make use of client-side load balancing by prefixing the query-frontend address URL with `dns://`.
+Communication between ruler and query-frontend is established over gRPC, so you can make use of client-side load balancing by prefixing the query-frontend address URL with `dns:///`.
 
 ![Architecture of Grafana Mimir's ruler component in remote mode](ruler-remote.svg)
 


### PR DESCRIPTION
According to the [gRPC docs](https://grpc.github.io/grpc/core/md_doc_naming.html), the DNS URI scheme should have triple slashes:

```
dns:[//authority/]host[:port] – DNS (default)
host is the host to resolve via DNS.
port is the port to return for each address. If not specified, 443 is used (but some implementations default to 80 for insecure channels).
authority indicates the DNS server to use, although this is only supported by some implementations. 
```

This also aligns this page with Mimir's configuration docs, where it's detailed [how to configure `ruler` to talk with `query_frontend`](https://grafana.com/docs/mimir/latest/configure/configuration-parameters/#ruler):

```yaml
query_frontend:
  # GRPC listen address of the query-frontend(s). Must be a DNS address
  # (prefixed with dns:///) to enable client side load balancing.
  # CLI flag: -ruler.query-frontend.address
  [address: <string> | default = ""]
```

There it's specified a DNS address should be prefixed with `dns:///`.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
