### PR TITLE
Base tooling images on distroless/static-debian12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,10 @@
 * [ENHANCEMENT] Improve the description of how to limit the number of buckets in native histograms. #12797
 * [BUGFIX] Add a missing attribute to the list of default promoted OTel resource attributes in the docs: deployment.environment. #12181
 
+### Tools
+
+* [ENHANCEMENT] Base `mimirtool`, `metaconvert`, `copyblocks`, and `query-tee` images on `distroless/static-debian12`. #13014
+
 ## 2.17.1
 
 ### Grafana Mimir

--- a/cmd/metaconvert/Dockerfile
+++ b/cmd/metaconvert/Dockerfile
@@ -3,9 +3,12 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.22.2
-ARG        EXTRA_PACKAGES
-RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
+ARG        BASEIMG=gcr.io/distroless/static-debian12
+# TODO(rwwiv): Remove once CA bundle is updated upstream.
+FROM debian:testing AS updated-ca-bundle
+RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+
+FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH
@@ -13,6 +16,8 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       metaconvert${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /metaconvert
+# Copy the updated CA bundle from the updated-ca-bundle stage
+COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["/metaconvert"]
 
 ARG revision

--- a/cmd/mimirtool/Dockerfile
+++ b/cmd/mimirtool/Dockerfile
@@ -1,8 +1,11 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: AGPL-3.0-only
 
-FROM       alpine:3.22.2
-ARG        EXTRA_PACKAGES
-RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
+ARG        BASEIMG=gcr.io/distroless/static-debian12
+# TODO(rwwiv): Remove once CA bundle is updated upstream.
+FROM debian:testing AS updated-ca-bundle
+RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+
+FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH
@@ -10,4 +13,11 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       mimirtool${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /bin/mimirtool
+# Copy the updated CA bundle from the updated-ca-bundle stage
+COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT [ "/bin/mimirtool" ]
+
+ARG revision
+LABEL org.opencontainers.image.title="mimirtool" \
+      org.opencontainers.image.source="https://github.com/grafana/mimir/tree/main/cmd/mimirtool" \
+      org.opencontainers.image.revision="${revision}"

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -3,9 +3,12 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM       alpine:3.22.2
-ARG        EXTRA_PACKAGES
-RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
+ARG        BASEIMG=gcr.io/distroless/static-debian12
+# TODO(rwwiv): Remove once CA bundle is updated upstream.
+FROM debian:testing AS updated-ca-bundle
+RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+
+FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH
@@ -13,6 +16,8 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       query-tee${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /query-tee
+# Copy the updated CA bundle from the updated-ca-bundle stage
+COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["/query-tee"]
 
 ARG revision

--- a/tools/copyblocks/Dockerfile
+++ b/tools/copyblocks/Dockerfile
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM       alpine:3.22.2
-ARG        EXTRA_PACKAGES
-RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
+ARG        BASEIMG=gcr.io/distroless/static-debian12
+# TODO(rwwiv): Remove once CA bundle is updated upstream.
+FROM debian:testing AS updated-ca-bundle
+RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+
+FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH
@@ -10,6 +13,8 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       copyblocks${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /copyblocks
+# Copy the updated CA bundle from the updated-ca-bundle stage
+COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE     8080
 ENTRYPOINT ["/copyblocks"]
 

--- a/tools/usage-tracker-load-generator/Dockerfile
+++ b/tools/usage-tracker-load-generator/Dockerfile
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM       alpine:3.22.2
-ARG        EXTRA_PACKAGES
-RUN        apk add --no-cache ca-certificates tzdata $EXTRA_PACKAGES
+ARG        BASEIMG=gcr.io/distroless/static-debian12
+# TODO(rwwiv): Remove once CA bundle is updated upstream.
+FROM debian:testing AS updated-ca-bundle
+RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+
+FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
 ARG        TARGETOS
 ARG        TARGETARCH
@@ -10,6 +13,8 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       usage-tracker-load-generator${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /usage-tracker-load-generator
+# Copy the updated CA bundle from the updated-ca-bundle stage
+COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE     8080
 ENTRYPOINT ["/usage-tracker-load-generator"]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

We moved Mimir to distroless a while ago, but the tooling images (`metaconvert`, `mimirtool`, etc.) are still based on `alpine`. This bases them on `distroless/static-debian12` like the main `mimir` image.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
