### PR TITLE
Fix bug in matcher reducer planner which would remove all wildcard matchers

### DIFF
--- a/pkg/ingester/lookupplan/matcher_reducer_planner.go
+++ b/pkg/ingester/lookupplan/matcher_reducer_planner.go
@@ -72,7 +72,13 @@ func buildOutMatchers(inMatchers []*labels.Matcher, allowedOutMatchers []*labels
 	for _, m := range allowedOutMatchers {
 		allowedInResultSet[m.String()] = false
 	}
-	for _, m := range dedupedMatchers {
+	// If we have reached the last deduped input matcher and are still not returning any matchers,
+	// we should return at least one matcher. This can happen if all input matchers are wildcard matchers.
+	for i, m := range dedupedMatchers {
+		if i == len(dedupedMatchers)-1 && len(outMatchers) == 0 {
+			outMatchers = append(outMatchers, m)
+			continue
+		}
 		// allowedOutMatchers is used to both keep track of all unique matchers (evidenced by existence in the map),
 		// and whether the matcher has already been seen and added to a set of output matchers (evidenced by the value in the map).
 		// We only want to add the matcher if it hasn't already been added to an output slice.

--- a/pkg/ingester/lookupplan/matcher_reducer_planner_test.go
+++ b/pkg/ingester/lookupplan/matcher_reducer_planner_test.go
@@ -294,6 +294,10 @@ func TestMatcherReducerPlanner_MatchedSeries(t *testing.T) {
 			name:     "all matcher types",
 			matchers: []string{`__name__="http_requests_total"`, `method="GET"`, `status!="500"`, `handler=~"/.*"`},
 		},
+		{
+			name:     "multiple wildcard matchers",
+			matchers: []string{`__name__=~".*"`, `method=~".*"`},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
This fixes an edge case where, if all matchers are wildcard matchers (e.g., `foo=~".*"`), they can all be excluded from the result set, which can produce inconsistent query results. 

#### Which issue(s) this PR fixes or relates to
Relates to https://github.com/grafana/mimir/pull/12831

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
