### PR TITLE
docs: update rolling-update docs for ingest storage

### DIFF
--- a/docs/sources/mimir/manage/run-production-environment/perform-a-rolling-update.md
+++ b/docs/sources/mimir/manage/run-production-environment/perform-a-rolling-update.md
@@ -55,16 +55,12 @@ If you enabled [zone-aware replication](../../../configure/configure-zone-aware-
 ### Ingesters
 
 [Ingesters](../../../references/architecture/components/ingester/) store recently received samples in memory.
-When an ingester restarts, the samples stored in the restarting ingester are not available for querying until the ingester runs again.
+When an ingester restarts, the samples stored in the restarting ingester are not available for querying until the ingester is running again.
 
-By default, ingesters run with a replication factor equal to `3`.
-Ingesters running with the replication factor of `3` require a quorum of two instances to successfully query any series samples.
-Because series are sharded across all ingesters, Grafana Mimir tolerates up to one unavailable ingester.
-
-To ensure no query fails during a rolling update, roll out changes to one ingester at a time.
+To ensure no query fails during a rolling update, roll out changes to one ingester at a time. This ensures at least one ingester per partition remains available when using the ingest storage architecture, and a majority of ingesters remains available when using the classic architecture.
 
 {{< admonition type="note" >}}
-If you enabled [zone-aware replication](../../../configure/configure-zone-aware-replication/) for ingesters, you can roll out changes to all ingesters in one zone at the same time.
+If you enabled [zone-aware replication](../../../configure/configure-zone-aware-replication/) for ingesters, you can roll out changes to all ingesters in one zone at the same time with either the ingest storage or classic architectures.
 {{< /admonition >}}
 
 ### Store-gateways


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Updates the Perform a Rolling Update docs on ingesters to work for either ingest storage or the classic architecture. The references to replication factor were removed since they weren't strictly needed and don't change the rolling update strategy with either architecture.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/3293

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
