### PR TITLE
Set up instructions for using ingest storage with Helm

### DIFF
--- a/docs/sources/mimir/set-up/helm-chart.md
+++ b/docs/sources/mimir/set-up/helm-chart.md
@@ -11,7 +11,7 @@ The [`mimir-distributed` Helm chart](https://github.com/grafana/mimir/blob/main/
 
 ## Use ingest storage
 
-Grafana Mimir uses the ingest storage architecture by default when deployed with the Helm chart.  
+Grafana Mimir uses the ingest storage architecture by default when deployed with the Helm chart.
 You can configure an external Kafka backend or disable ingest storage if needed.
 
 For details, refer to [Run Grafana Mimir in production using the Helm chart](https://grafana.com/docs/helm-charts/mimir-distributed/latest/run-production-environment-with-helm/), which provides complete setup and configuration guidance for production environments.


### PR DESCRIPTION
#### What this PR does
This pull request adds documentation to clarify how ingest storage is used by default in Grafana Mimir deployments via the Helm chart, and provides links to relevant setup and configuration guides. The update helps users understand the default architecture and how to configure or disable ingest storage.

Documentation improvements:

* Added a new "Use ingest storage" section in `helm-chart.md` explaining that ingest storage is enabled by default, with instructions for configuring an external Kafka backend or disabling ingest storage.
* Included links to production setup guidance, ingest storage architecture overview, and Kafka backend configuration documentation for further reference.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/10260

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
