### PR TITLE
Jsonnet: move multi_zone_availability_zones config out of multi-zone-distributor.libsonnet

### DIFF
--- a/operations/mimir/multi-zone-distributor.libsonnet
+++ b/operations/mimir/multi-zone-distributor.libsonnet
@@ -4,7 +4,6 @@
     // Multi-zone and single-zone can be enabled at the same time during migrations.
     single_zone_distributor_enabled: !$._config.multi_zone_distributor_enabled,
     multi_zone_distributor_enabled: false,
-    multi_zone_availability_zones: [],
     multi_zone_distributor_replicas: std.length($._config.multi_zone_availability_zones),
   },
 

--- a/operations/mimir/multi-zone.libsonnet
+++ b/operations/mimir/multi-zone.libsonnet
@@ -36,6 +36,11 @@
     // the regex subexpression group number - only required if the above regular expression has more then 1 grouping
     multi_zone_ingester_zpdb_partition_group: 1,
 
+    // Ordered list of availability zones where multi-zone components should be deployed to.
+    // Mimir zone-a deployments are scheduled to the first AZ in the list, zone-b deployment to the second AZ,
+    // and zone-c deployments to the third AZ. Maximum 3 AZs are supported.
+    multi_zone_availability_zones: [],
+
     // We can update the queryBlocksStorageConfig only once the migration is over. During the migration
     // we don't want to apply these changes to single-zone store-gateways too.
     queryBlocksStorageConfig+:: if !$._config.multi_zone_store_gateway_enabled || !$._config.multi_zone_store_gateway_read_path_enabled || $._config.multi_zone_store_gateway_migration_enabled then {} else {
@@ -48,6 +53,7 @@
   },
 
   assert !$._config.multi_zone_zpdb_enabled || $._config.rollout_operator_webhooks_enabled : 'zpdb configuration requires rollout_operator_webhooks_enabled=true',
+  assert std.length($._config.multi_zone_availability_zones) <= 3 : 'Mimir jsonnet supports a maximum of 3 availability zones',
 
   //
   // Utilities.


### PR DESCRIPTION
#### What this PR does

`multi_zone_availability_zones` is used by all Mimir components and it's not distributor specific. In this I'm moving it out of `multi-zone-distributor.libsonnet` and adding an assertion to ensure no more than 3 AZs are specified.

_This PR is expected to be a no-op._

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
