### PR TITLE
Hide max_active_series_per_user from the docs, and remove the TODO fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 * [FEATURE] Query-frontend: Add `query-frontend.rewrite-propagate-matchers` flag that enables a new MQE AST optimization pass that copies relevant label matchers across binary operations. #12304
 * [FEATURE] Query-frontend: Add `query-frontend.rewrite-histogram-queries` flag that enables a new MQE AST optimization pass that rewrites histogram queries for a more efficient order of execution. #12305
 * [FEATURE] Query-frontend: Support delayed name removal (Prometheus experimental feature) in MQE. #12509
-* [FEATURE] Usage-tracker: Introduce a new experimental service to enforce active series limits before Kafka ingestion. #12358 #12895 #12940 #12942 #12970
+* [FEATURE] Usage-tracker: Introduce a new experimental service to enforce active series limits before Kafka ingestion. #12358 #12895 #12940 #12942 #12970 #13085
 * [FEATURE] Ingester: Add experimental `-include-tenant-id-in-profile-labels` flag to include tenant ID in pprof profiling labels for sampled traces. Currently only supported by the ingester. This can help debug performance issues for specific tenants. #12404
 * [FEATURE] Alertmanager: Add experimental `-alertmanager.storage.state-read-timeout` flag to configure the timeout for reading the Alertmanager state (notification log, silences) from object storage during the initial sync. #12425
 * [FEATURE] Ingester: Add experimental `-blocks-storage.tsdb.index-lookup-planning.*` flags to configure use of a cost-based index lookup planner. This should reduce the cost of queries in the ingester. #12197 #12199 #12245 #12248 #12457 #12530 #12407 #12460 #12550 #12597 #12603 #12608 #12658 #12696 #12731 #12755 #12738 #12752 #12807 #12830 #12896 #13039

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -4487,16 +4487,6 @@
       "blockEntries": [
         {
           "kind": "field",
-          "name": "max_active_series_per_user",
-          "required": false,
-          "desc": "Maximum number of active series per user. 0 means no limit. This limit only applies with ingest storage enabled.",
-          "fieldValue": null,
-          "fieldDefaultValue": 0,
-          "fieldFlag": "distributor.max-active-series-per-user",
-          "fieldType": "int"
-        },
-        {
-          "kind": "field",
           "name": "request_rate",
           "required": false,
           "desc": "Per-tenant push request rate limit in requests per second. 0 to disable.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1273,8 +1273,6 @@ Usage of ./cmd/mimir/mimir:
     	The sum of the request sizes in bytes of inflight push requests that this distributor can handle. This limit is per-distributor, not per-tenant. Additional requests will be rejected. 0 = unlimited.
   -distributor.instance-limits.max-ingestion-rate float
     	Max ingestion rate (samples/sec) that this distributor will accept. This limit is per-distributor, not per-tenant. Additional push requests will be rejected. Current ingestion rate is computed as exponentially weighted moving average, updated every second. 0 = unlimited.
-  -distributor.max-active-series-per-user int
-    	Maximum number of active series per user. 0 means no limit. This limit only applies with ingest storage enabled.
   -distributor.max-exemplars-per-series-per-request int
     	[experimental] Maximum number of exemplars per series per request. 0 to disable limit in request. The exceeding exemplars are dropped.
   -distributor.max-otlp-request-size int

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -379,8 +379,6 @@ Usage of ./cmd/mimir/mimir:
     	Per-tenant ingestion rate limit in samples per second. (default 10000)
   -distributor.ingestion-tenant-shard-size int
     	The tenant's shard size used by shuffle-sharding. This value is the total size of the shard (ie. it is not the number of ingesters in the shard per zone, but the number of ingesters in the shard across all zones, if zone-awareness is enabled). Must be set both on ingesters and distributors. 0 disables shuffle sharding.
-  -distributor.max-active-series-per-user int
-    	Maximum number of active series per user. 0 means no limit. This limit only applies with ingest storage enabled.
   -distributor.request-burst-size int
     	Per-tenant allowed push request burst size. 0 to disable.
   -distributor.request-rate-limit float

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3431,11 +3431,6 @@ The `memberlist` block configures the Gossip memberlist.
 The `limits` block configures default and per-tenant limits imposed by components.
 
 ```yaml
-# Maximum number of active series per user. 0 means no limit. This limit only
-# applies with ingest storage enabled.
-# CLI flag: -distributor.max-active-series-per-user
-[max_active_series_per_user: <int> | default = 0]
-
 # Per-tenant push request rate limit in requests per second. 0 to disable.
 # CLI flag: -distributor.request-rate-limit
 [request_rate: <float> | default = 0]

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -304,7 +304,6 @@
   "ingester.read-reactive-limiter.initial-rejection-factor": 2,
   "ingester.read-reactive-limiter.max-rejection-factor": 3,
   "flusher.exit-after-flush": true,
-  "distributor.max-active-series-per-user": 0,
   "distributor.request-rate-limit": 0,
   "distributor.request-burst-size": 0,
   "distributor.ingestion-rate-limit": 10000,

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -117,7 +117,7 @@ func IsLimitError(err error) bool {
 // limits via flags, or per-user limits via yaml config.
 type Limits struct {
 	// Distributor enforced limits.
-	MaxActiveSeriesPerUser int     `yaml:"max_active_series_per_user" json:"max_active_series_per_user"`
+	MaxActiveSeriesPerUser int     `yaml:"max_active_series_per_user" json:"max_active_series_per_user" category:"experimental" doc:"hidden"`
 	RequestRate            float64 `yaml:"request_rate" json:"request_rate"`
 	RequestBurstSize       int     `yaml:"request_burst_size" json:"request_burst_size"`
 	IngestionRate          float64 `yaml:"ingestion_rate" json:"ingestion_rate"`
@@ -862,14 +862,7 @@ func (o *Overrides) PastGracePeriod(userID string) time.Duration {
 
 // MaxActiveSeriesPerUser returns the maximum number of active series a user is allowed to store across the cluster.
 func (o *Overrides) MaxActiveSeriesPerUser(userID string) int {
-	overrides := o.getOverridesForUser(userID)
-	limit := overrides.MaxActiveSeriesPerUser
-	// TODO temporary to simplify testing.
-	if limit == 0 {
-		// Fallback to MaxGlobalSeriesPerUser if no per-user active series limit is set.
-		limit = overrides.MaxGlobalSeriesPerUser
-	}
-	return limit
+	return o.getOverridesForUser(userID).MaxActiveSeriesPerUser
 }
 
 // MaxGlobalSeriesPerUser returns the maximum number of series a user is allowed to store across the cluster.


### PR DESCRIPTION
#### What this PR does

Removes the new `max_active_series_per_user` field from the doc, as that feature is experimental so far. Also removes the TODO fallback to the `max_global_series_per_user` when it's unset.

#### Which issue(s) this PR fixes or relates to

Fixes docs

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
