### PR TITLE
Docker: Pin distroless base images to a certain digest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 		--build-arg=goproxyValue=$(GOPROXY_VALUE) \
 		--build-arg=USE_BINARY_SUFFIX=true \
 		--build-arg=BINARY_SUFFIX=_race \
-		--build-arg=BASEIMG="gcr.io/distroless/base-nossl-debian12" \
+		--build-arg=BASEIMG="gcr.io/distroless/base-nossl-debian12@sha256:a7923659fdb38764d9c7f45e3b54cdadec32dbd46c375bf09918707317181af1" \
 		-t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG_RACE) $(@D)/
 	@echo
 	@echo Go binaries were built using GOOS=$(GOOS) and GOARCH=$(GOARCH)

--- a/cmd/metaconvert/Dockerfile
+++ b/cmd/metaconvert/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
+ARG        BASEIMG=gcr.io/distroless/static-debian12@sha256:87bce11be0af225e4ca761c40babb06d6d559f5767fbf7dc3c47f0f1a466b92c
 # TODO(rwwiv): Remove once CA bundle is updated upstream.
 FROM debian:testing AS updated-ca-bundle
 RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -2,7 +2,7 @@
 # We use different base images for mimir and mimir race images since race-detector needs glibc packages.
 # See difference between distroless static and base-nossl at https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md.
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
+ARG        BASEIMG=gcr.io/distroless/static-debian12@sha256:87bce11be0af225e4ca761c40babb06d6d559f5767fbf7dc3c47f0f1a466b92c
 # TODO(rwwiv): Remove once CA bundle is updated upstream.
 FROM debian:testing AS updated-ca-bundle
 RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean

--- a/cmd/mimirtool/Dockerfile
+++ b/cmd/mimirtool/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
+ARG        BASEIMG=gcr.io/distroless/static-debian12@sha256:87bce11be0af225e4ca761c40babb06d6d559f5767fbf7dc3c47f0f1a466b92c
 # TODO(rwwiv): Remove once CA bundle is updated upstream.
 FROM debian:testing AS updated-ca-bundle
 RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -3,7 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
+ARG        BASEIMG=gcr.io/distroless/static-debian12@sha256:87bce11be0af225e4ca761c40babb06d6d559f5767fbf7dc3c47f0f1a466b92c
 # TODO(rwwiv): Remove once CA bundle is updated upstream.
 FROM debian:testing AS updated-ca-bundle
 RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean

--- a/tools/copyblocks/Dockerfile
+++ b/tools/copyblocks/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
+ARG        BASEIMG=gcr.io/distroless/static-debian12@sha256:87bce11be0af225e4ca761c40babb06d6d559f5767fbf7dc3c47f0f1a466b92c
 # TODO(rwwiv): Remove once CA bundle is updated upstream.
 FROM debian:testing AS updated-ca-bundle
 RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean

--- a/tools/usage-tracker-load-generator/Dockerfile
+++ b/tools/usage-tracker-load-generator/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
+ARG        BASEIMG=gcr.io/distroless/static-debian12@sha256:87bce11be0af225e4ca761c40babb06d6d559f5767fbf7dc3c47f0f1a466b92c
 # TODO(rwwiv): Remove once CA bundle is updated upstream.
 FROM debian:testing AS updated-ca-bundle
 RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean


### PR DESCRIPTION
#### What this PR does

Pin distroless base images to a certain digest in Dockerfiles, so we can tell which version of each such image we built a certain Mimir version with. This helps us audit e.g. whether CVEs (yes, distroless can have CVEs) are present in the distroless image a certain Mimir image was based on, and to ensure they are _not_ present when building a new Mimir image without having to worry about potential caching etc.

It aligns in any case with our normal practice of not using the `latest` tag for our base images, but a more specific version (distroless doesn't offer any more specific version tag than Debian major version though).

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
