### PR TITLE
fix: flaky `TestWriter_WriteSync` due to explicit context cancellation 

### DIFF
--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -327,12 +327,9 @@ func TestWriter_WriteSync(t *testing.T) {
 		// Once the 1st Produce request is received by the server but still processing (there's a 1s sleep),
 		// issue two more requests. One with a short context timeout (expected to expire before the next Produce
 		// request will be sent) and one with no timeout.
-		var cancelSecondRequest context.CancelFunc
 
 		runAsyncAfter(&wg, firstRequestReceived, func() {
-			var secondRequestCtx context.Context
-
-			secondRequestCtx, cancelSecondRequest = context.WithTimeout(ctx, 10*time.Millisecond)
+			secondRequestCtx, cancelSecondRequest := context.WithTimeout(ctx, 10*time.Millisecond)
 			t.Cleanup(cancelSecondRequest)
 
 			assert.ErrorIs(t, writer.WriteSync(secondRequestCtx, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series2, Metadata: nil, Source: mimirpb.API}), context.DeadlineExceeded)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Current `TestWriter_WriteSync`'s subtest "should interrupt the WriteSync() on context cancelled but other concurrent requests should not fail" fires two gorountines after the first request's completion, and cancel the first gorountine's context after there are 3 records buffered. However, the buffered record doesn't imply the write has completed, and the first gorountine's context can be cancelled before it expires (due to concurrency)

To address this issue,  we can remove the `cancelSecondRequest()` to avoid the context cancellation.

#### Which issue(s) this PR fixes or relates to

Fixes #12703

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
