### PR TITLE
Replace default otel labels with xref to Cloud docs

### DIFF
--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -117,7 +117,11 @@ To optimize the storage of and ability to query this data, you can use the `-dis
 The `-distributor.otel-promote-resource-attributes` option is an experimental feature in Grafana Mimir.
 {{< /admonition >}}
 
-For details about how Grafana Cloud promotes OpenTelemetry resource attributes to labels during ingestion, refer to [Work with default OpenTelemetry labels](https://grafana.com/docs/grafana-cloud/send-data/otlp/otlp-format-considerations/#work-with-default-opentelemetry-labels) in the Grafana Cloud documentation.
+Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.
+
+To learn more about OpenTelemetry resource attributes, refer to [Resources](https://opentelemetry.io/docs/languages/js/resources/) in the OpenTelemetry documentation.
+
+To learn more about ingesting OpenTelemetry data in Grafana Cloud, including how Grafana Cloud promotes OpenTelemetry resouce attributes to labels during ingestion, refer to [OTLP: OpenTelemetry Protocol format considerations](https://grafana.com/docs/grafana-cloud/send-data/otlp/otlp-format-considerations/).
 
 ## Format considerations
 


### PR DESCRIPTION
This pull request updates the documentation for configuring the OpenTelemetry Collector in Mimir by removing the section about working with default OpenTelemetry labels and replacing it with a reference to the Grafana Cloud documentation. This streamlines the content and directs users to the most up-to-date information.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir-squad/issues/3270

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
