### PR TITLE
fix: `TestIngester_inflightPushRequestsBytes` relax wait time & use a better condition verification

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -8852,7 +8852,7 @@ func TestIngester_inflightPushRequestsBytes(t *testing.T) {
 		}
 
 		require.Eventually(t, func() bool {
-			return i.inflightPushRequestsBytes.Load() > 0
+			return i.inflightPushRequestsBytes.Load() == int64(requestSize)
 		}, targetRequestDuration/3, 3*time.Millisecond)
 
 		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

`inflightPushRequestsBytes` is updated after `inflightPushRequests` has been updated, and `inflightPushRequestsBytes` is required for later assertion. Thus, updating the assertion condition would help reduce the flakiness. In addition, since the request is meant to complete at least 1 second, we can relax a bit on the wait time to achieve a better success rate on overloaded machine.

#### Which issue(s) this PR fixes or relates to

Fixes #11294

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
