### PR TITLE
Fix issue where log messages emitted by `queryResponseWriter` aren't attached to the request's trace

### DIFF
--- a/pkg/querier/dispatcher_test.go
+++ b/pkg/querier/dispatcher_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/propagation"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
 func TestDispatcher_HandleProtobuf(t *testing.T) {
@@ -1379,9 +1380,9 @@ func TestQueryResponseWriter_WriteError(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			reg, requestMetrics, serverMetrics := newMetrics()
 			stream := &mockQueryResultStream{t: t, route: "test-route", reg: reg}
-			writer := newQueryResponseWriter(stream, requestMetrics, serverMetrics, log.NewNopLogger())
-			writer.Start("test-route", 123)
 			ctx := context.Background()
+			writer := newQueryResponseWriter(stream, requestMetrics, serverMetrics, spanlogger.FromContext(ctx, log.NewNopLogger()))
+			writer.Start("test-route", 123)
 
 			writer.WriteError(ctx, apierror.TypeNotFound, testCase.err)
 


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where the log messages emitted by `queryResponseWriter` aren't attached to the request's trace.

I've chosen not to add a changelog entry given this is not a user-facing change.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
