### PR TITLE
OTLP underscore sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [CHANGE] Store-gateway: Removed experimental `-blocks-storage.bucket-store.index-header.eager-loading-startup-enabled` flag. The eager loading feature is now always enabled when lazy loading is enabled. #13126
 * [CHANGE] API: The `/api/v1/cardinality/active_series` endpoint is now stable and no longer experimental. #13111
 * [CHANGE] Compactor: remove experimental `-compactor.in-memory-tenant-meta-cache-size`. #13131
+* [FEATURE] Distributor: add `-distributor.otel-label-name-underscore-sanitization` and `-distributor.otel-label-name-preserve-underscores` that control sanitization of underscores during OTLP translation. #13133
 * [FEATURE] Query-frontends: Automatically adjust features used in query plans generated for remote execution based on what the available queriers support. #13017 #13164
 * [FEATURE] Memberlist: Add experimental support for zone-aware routing, in order to reduce memberlist cross-AZ data transfer. #13129
 * [ENHANCEMENT] Compactor, Store-gateway: Change default value of `-compactor.upload-sparse-index-headers` to `true`. This improves lazy loading performance in the store-gateway. #13089

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -6654,6 +6654,28 @@
         },
         {
           "kind": "field",
+          "name": "otel_label_name_underscore_sanitization",
+          "required": false,
+          "desc": "If enabled, prefixes label names starting with a single underscore with `key_` when translating OTel attribute names. Defaults to true.",
+          "fieldValue": null,
+          "fieldDefaultValue": true,
+          "fieldFlag": "distributor.otel-label-name-underscore-sanitization",
+          "fieldType": "boolean",
+          "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
+          "name": "otel_label_name_preserve_multiple_underscores",
+          "required": false,
+          "desc": "If enabled, keeps multiple consecutive underscores in label names when translating OTel attribute names. Defaults to true.",
+          "fieldValue": null,
+          "fieldDefaultValue": true,
+          "fieldFlag": "distributor.otel-label-name-preserve-underscores",
+          "fieldType": "boolean",
+          "fieldCategory": "advanced"
+        },
+        {
+          "kind": "field",
           "name": "ingest_storage_read_consistency",
           "required": false,
           "desc": "The default consistency level to enforce for queries when using the ingest storage. Supports values: strong, eventual.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1287,6 +1287,10 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.
   -distributor.otel-keep-identifying-resource-attributes
     	[experimental] Whether to keep identifying OTel resource attributes in the target_info metric on top of converting to job and instance labels.
+  -distributor.otel-label-name-preserve-underscores
+    	If enabled, keeps multiple consecutive underscores in label names when translating OTel attribute names. Defaults to true. (default true)
+  -distributor.otel-label-name-underscore-sanitization
+    	If enabled, prefixes label names starting with a single underscore with `key_` when translating OTel attribute names. Defaults to true. (default true)
   -distributor.otel-metric-suffixes-enabled
     	Whether to enable automatic suffixes to names of metrics ingested through OTLP.
   -distributor.otel-native-delta-ingestion

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4461,6 +4461,16 @@ ruler_alertmanager_client_config:
 # CLI flag: -distributor.otel-translation-strategy
 [otel_translation_strategy: <string> | default = ""]
 
+# (advanced) If enabled, prefixes label names starting with a single underscore
+# with `key_` when translating OTel attribute names. Defaults to true.
+# CLI flag: -distributor.otel-label-name-underscore-sanitization
+[otel_label_name_underscore_sanitization: <boolean> | default = true]
+
+# (advanced) If enabled, keeps multiple consecutive underscores in label names
+# when translating OTel attribute names. Defaults to true.
+# CLI flag: -distributor.otel-label-name-preserve-underscores
+[otel_label_name_preserve_multiple_underscores: <boolean> | default = true]
+
 # (experimental) The default consistency level to enforce for queries when using
 # the ingest storage. Supports values: strong, eventual.
 # CLI flag: -ingest-storage.read-consistency

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -457,6 +457,8 @@
   "alertmanager.notify-hook-timeout": 30000000000,
   "distributor.otel-promote-resource-attributes": "",
   "distributor.otel-translation-strategy": "",
+  "distributor.otel-label-name-underscore-sanitization": true,
+  "distributor.otel-label-name-preserve-underscores": true,
   "ingest-storage.read-consistency": "eventual",
   "ingest-storage.ingestion-partition-tenant-shard-size": 0,
   "querier.scheduler-address": "",

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -69,10 +69,14 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 		appendCustomMetric                func(pmetric.MetricSlice)
 		expectedLabels                    []mimirpb.LabelAdapter
 		expectedInfoLabels                []mimirpb.LabelAdapter
+		underscoreSanitization            bool
+		preserveMultipleUnderscores       bool
 	}{
 		{
-			name:                      "Successful conversion without resource attribute promotion",
-			promoteResourceAttributes: nil,
+			name:                        "Successful conversion without resource attribute promotion",
+			promoteResourceAttributes:   nil,
+			underscoreSanitization:      true,
+			preserveMultipleUnderscores: true,
 			expectedLabels: []mimirpb.LabelAdapter{
 				{
 					Name:  "__name__",
@@ -118,6 +122,8 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 			name:                              "Successful conversion without resource attribute promotion, and keep identifying resource attributes",
 			promoteResourceAttributes:         nil,
 			keepIdentifyingResourceAttributes: true,
+			underscoreSanitization:            true,
+			preserveMultipleUnderscores:       true,
 			expectedLabels: []mimirpb.LabelAdapter{
 				{
 					Name:  "__name__",
@@ -172,8 +178,10 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 			},
 		},
 		{
-			name:                      "Successful conversion with resource attribute promotion",
-			promoteResourceAttributes: []string{"non-existent-attr", "existent-attr"},
+			name:                        "Successful conversion with resource attribute promotion",
+			promoteResourceAttributes:   []string{"non-existent-attr", "existent-attr"},
+			underscoreSanitization:      true,
+			preserveMultipleUnderscores: true,
 			expectedLabels: []mimirpb.LabelAdapter{
 				{
 					Name:  "__name__",
@@ -220,8 +228,10 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 			},
 		},
 		{
-			name:                      "Successful conversion with resource attribute promotion, conflicting resource attributes are ignored",
-			promoteResourceAttributes: []string{"non-existent-attr", "existent-attr", "metric-attr", "job", "instance"},
+			name:                        "Successful conversion with resource attribute promotion, conflicting resource attributes are ignored",
+			promoteResourceAttributes:   []string{"non-existent-attr", "existent-attr", "metric-attr", "job", "instance"},
+			underscoreSanitization:      true,
+			preserveMultipleUnderscores: true,
 			expectedLabels: []mimirpb.LabelAdapter{
 				{
 					Name:  "__name__",
@@ -268,8 +278,10 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 			},
 		},
 		{
-			name:                      "Successful conversion of cumulative non-monotonic sum",
-			promoteResourceAttributes: nil,
+			name:                        "Successful conversion of cumulative non-monotonic sum",
+			promoteResourceAttributes:   nil,
+			underscoreSanitization:      true,
+			preserveMultipleUnderscores: true,
 			appendCustomMetric: func(metricSlice pmetric.MetricSlice) {
 				m := metricSlice.AppendEmpty()
 				m.SetName("test_metric")
@@ -323,8 +335,10 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 			},
 		},
 		{
-			name:                      "Successful conversion of cumulative monotonic sum",
-			promoteResourceAttributes: nil,
+			name:                        "Successful conversion of cumulative monotonic sum",
+			promoteResourceAttributes:   nil,
+			underscoreSanitization:      true,
+			preserveMultipleUnderscores: true,
 			appendCustomMetric: func(metricSlice pmetric.MetricSlice) {
 				m := metricSlice.AppendEmpty()
 				m.SetName("test_metric")
@@ -378,8 +392,10 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 			},
 		},
 		{
-			name:                      "Underscore sanitization",
-			promoteResourceAttributes: nil,
+			name:                        "Underscore sanitization",
+			promoteResourceAttributes:   nil,
+			underscoreSanitization:      true,
+			preserveMultipleUnderscores: true,
 			appendCustomMetric: func(metricSlice pmetric.MetricSlice) {
 				m := metricSlice.AppendEmpty()
 				m.SetName("test_metric")
@@ -389,12 +405,26 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 				dp := sum.DataPoints().AppendEmpty()
 				dp.SetIntValue(123)
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-				dp.Attributes().PutStr("_1", "metric value")
+				dp.Attributes().PutStr("_foo", "bar")
+				dp.Attributes().PutStr("_1", "bar")
+				dp.Attributes().PutStr("some__thing", "bar")
 			},
 			expectedLabels: []mimirpb.LabelAdapter{
 				{
 					Name:  "__name__",
 					Value: "test_metric",
+				},
+				{
+					Name:  "key_foo",
+					Value: "bar",
+				},
+				{
+					Name:  "key_1",
+					Value: "bar",
+				},
+				{
+					Name:  "some__thing",
+					Value: "bar",
 				},
 				{
 					Name:  "instance",
@@ -404,9 +434,139 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 					Name:  "job",
 					Value: "service namespace/service name",
 				},
+			},
+			expectedInfoLabels: []mimirpb.LabelAdapter{
 				{
-					Name:  "key_1",
-					Value: "metric value",
+					Name:  "__name__",
+					Value: "target_info",
+				},
+				{
+					Name:  "existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "metric_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "job",
+					Value: "service namespace/service name",
+				},
+				{
+					Name:  "instance",
+					Value: "service ID",
+				},
+			},
+		},
+		{
+			name:                        "Disable underscore sanitization",
+			promoteResourceAttributes:   nil,
+			underscoreSanitization:      false,
+			preserveMultipleUnderscores: true,
+			appendCustomMetric: func(metricSlice pmetric.MetricSlice) {
+				m := metricSlice.AppendEmpty()
+				m.SetName("test_metric")
+				sum := m.SetEmptySum()
+				sum.SetIsMonotonic(false)
+				sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				dp := sum.DataPoints().AppendEmpty()
+				dp.SetIntValue(123)
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+				dp.Attributes().PutStr("_foo", "bar")
+				dp.Attributes().PutStr("_1", "bar")
+				dp.Attributes().PutStr("some__thing", "bar")
+			},
+			expectedLabels: []mimirpb.LabelAdapter{
+				{
+					Name:  "__name__",
+					Value: "test_metric",
+				},
+				{
+					Name:  "_foo",
+					Value: "bar",
+				},
+				{
+					Name:  "_1",
+					Value: "bar",
+				},
+				{
+					Name:  "some__thing",
+					Value: "bar",
+				},
+				{
+					Name:  "instance",
+					Value: "service ID",
+				},
+				{
+					Name:  "job",
+					Value: "service namespace/service name",
+				},
+			},
+			expectedInfoLabels: []mimirpb.LabelAdapter{
+				{
+					Name:  "__name__",
+					Value: "target_info",
+				},
+				{
+					Name:  "existent_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "metric_attr",
+					Value: "resource value",
+				},
+				{
+					Name:  "job",
+					Value: "service namespace/service name",
+				},
+				{
+					Name:  "instance",
+					Value: "service ID",
+				},
+			},
+		},
+		{
+			name:                        "Disable multiple underscore preservation",
+			promoteResourceAttributes:   nil,
+			underscoreSanitization:      false,
+			preserveMultipleUnderscores: false,
+			appendCustomMetric: func(metricSlice pmetric.MetricSlice) {
+				m := metricSlice.AppendEmpty()
+				m.SetName("test_metric")
+				sum := m.SetEmptySum()
+				sum.SetIsMonotonic(false)
+				sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				dp := sum.DataPoints().AppendEmpty()
+				dp.SetIntValue(123)
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+				dp.Attributes().PutStr("_foo", "bar")
+				dp.Attributes().PutStr("_1", "bar")
+				dp.Attributes().PutStr("some__thing", "bar")
+			},
+			expectedLabels: []mimirpb.LabelAdapter{
+				{
+					Name:  "__name__",
+					Value: "test_metric",
+				},
+				{
+					Name:  "_foo",
+					Value: "bar",
+				},
+				{
+					Name:  "_1",
+					Value: "bar",
+				},
+				{
+					Name:  "some_thing",
+					Value: "bar",
+				},
+				{
+					Name:  "instance",
+					Value: "service ID",
+				},
+				{
+					Name:  "job",
+					Value: "service namespace/service name",
 				},
 			},
 			expectedInfoLabels: []mimirpb.LabelAdapter{
@@ -463,6 +623,8 @@ func TestOTelMetricsToTimeSeries(t *testing.T) {
 					addSuffixes:                       true,
 					keepIdentifyingResourceAttributes: tc.keepIdentifyingResourceAttributes,
 					promoteResourceAttributes:         tc.promoteResourceAttributes,
+					underscoreSanitization:            tc.underscoreSanitization,
+					preserveMultipleUnderscores:       tc.preserveMultipleUnderscores,
 				},
 				log.NewNopLogger(),
 			)

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -1855,6 +1855,14 @@ func (o otlpLimitsMock) NameValidationScheme(string) model.ValidationScheme {
 	return model.LegacyValidation
 }
 
+func (o otlpLimitsMock) OTelLabelNameUnderscoreSanitization(string) bool {
+	return true
+}
+
+func (o otlpLimitsMock) OTelLabelNamePreserveMultipleUnderscores(string) bool {
+	return true
+}
+
 func promToMimirHistogram(h *prompb.Histogram) mimirpb.Histogram {
 	pSpans := make([]mimirpb.BucketSpan, 0, len(h.PositiveSpans))
 	for _, span := range h.PositiveSpans {

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -74,6 +74,8 @@ func TestLimitsLoadingFromYaml(t *testing.T) {
 			testFunc: func(t *testing.T, l Limits) {
 				assert.Equal(t, 1024, l.MaxLabelNameLength)
 				assert.Equal(t, model.LegacyValidation, l.NameValidationScheme)
+				assert.True(t, l.OTelLabelNameUnderscoreSanitization)
+				assert.True(t, l.OTelLabelNamePreserveMultipleUnderscores)
 			},
 		},
 		{
@@ -95,6 +97,20 @@ func TestLimitsLoadingFromYaml(t *testing.T) {
 			input: `name_validation_scheme: "utf8"`,
 			testFunc: func(t *testing.T, l Limits) {
 				assert.Equal(t, model.UTF8Validation, l.NameValidationScheme)
+			},
+		},
+		{
+			name:  "otel_label_name_underscore_sanitization: true",
+			input: `otel_label_name_underscore_sanitization: true`,
+			testFunc: func(t *testing.T, l Limits) {
+				assert.True(t, l.OTelLabelNameUnderscoreSanitization)
+			},
+		},
+		{
+			name:  "otel_label_name_preserve_multiple_underscores: true",
+			input: `otel_label_name_preserve_multiple_underscores: true`,
+			testFunc: func(t *testing.T, l Limits) {
+				assert.True(t, l.OTelLabelNamePreserveMultipleUnderscores)
 			},
 		},
 	}
@@ -121,6 +137,8 @@ func TestLimitsLoadingFromJson(t *testing.T) {
 			testFunc: func(t *testing.T, l Limits) {
 				assert.Equal(t, 1024, l.MaxLabelNameLength)
 				assert.Equal(t, model.LegacyValidation, l.NameValidationScheme)
+				assert.True(t, l.OTelLabelNameUnderscoreSanitization)
+				assert.True(t, l.OTelLabelNamePreserveMultipleUnderscores)
 			},
 		},
 		{
@@ -135,6 +153,20 @@ func TestLimitsLoadingFromJson(t *testing.T) {
 			input: `{"name_validation_scheme": "utf8"}`,
 			testFunc: func(t *testing.T, l Limits) {
 				assert.Equal(t, model.UTF8Validation, l.NameValidationScheme)
+			},
+		},
+		{
+			name:  "otel_label_name_underscore_sanitization: true",
+			input: `{"otel_label_name_underscore_sanitization": true}`,
+			testFunc: func(t *testing.T, l Limits) {
+				assert.True(t, l.OTelLabelNameUnderscoreSanitization)
+			},
+		},
+		{
+			name:  "otel_label_name_preserve_multiple_underscores: true",
+			input: `{"otel_label_name_preserve_multiple_underscores": true}`,
+			testFunc: func(t *testing.T, l Limits) {
+				assert.True(t, l.OTelLabelNamePreserveMultipleUnderscores)
 			},
 		},
 	}


### PR DESCRIPTION
#### What this PR does

This PR adds two flags that control underscore sanitization.

- `-distributor.otel-label-name-underscore-sanitization` (default: true)
- `-distributor.otel-label-name-preserve-underscores` (default: true)

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
