### PR TITLE
ingester: mirror querier: ignore fresh series

### DIFF
--- a/pkg/ingester/mirror_querier_test.go
+++ b/pkg/ingester/mirror_querier_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -179,11 +180,11 @@ func TestRetainingChunkSeriesSet(t *testing.T) {
 func TestMirroredChunkQuerier_CompareResults(t *testing.T) {
 	series1 := &mockChunkSeries{
 		labels: labels.FromStrings("__name__", "metric1"),
-		chunks: []chunks.Meta{{MinTime: 1000, MaxTime: 2000}},
+		chunks: []chunks.Meta{{MinTime: time.Now().Add(-time.Hour).UnixMilli(), MaxTime: time.Now().Add(-time.Minute).UnixMilli()}},
 	}
 	series2 := &mockChunkSeries{
 		labels: labels.FromStrings("__name__", "metric2"),
-		chunks: []chunks.Meta{{MinTime: 1500, MaxTime: 2500}},
+		chunks: []chunks.Meta{{MinTime: time.Now().Add(-2 * time.Hour).UnixMilli(), MaxTime: time.Now().UnixMilli()}},
 	}
 
 	testCases := []struct {
@@ -235,9 +236,9 @@ func TestMirroredChunkQuerier_CompareResults(t *testing.T) {
 			primarySeries: []labels.Labels{series1.Labels()}, // Only series1 in primary
 			secondarySeries: []storage.ChunkSeries{
 				series1, // This should be included (chunk at 1000-2000, maxT=3000)
-				&mockChunkSeries{ // This should be ignored (chunk at 4000-5000, beyond maxT=3000)
+				&mockChunkSeries{ // This should be ignored (chunk at 4000-5000, beyond now-1 minute)
 					labels: labels.FromStrings("__name__", "metric3"),
-					chunks: []chunks.Meta{{MinTime: 4000, MaxTime: 5000}},
+					chunks: []chunks.Meta{{MinTime: time.Now().UnixMilli(), MaxTime: time.Now().Add(time.Second).UnixMilli()}},
 				},
 			},
 			expectedMetricLabel: "success", // Should match because the beyond-maxT series is ignored
@@ -261,7 +262,7 @@ func TestMirroredChunkQuerier_CompareResults(t *testing.T) {
 				},
 			}
 			querier.recordedRequest.ctx = context.Background()
-			querier.recordedRequest.maxT = 3000
+			querier.recordedRequest.startedAt = time.Now()
 
 			secondary := &mockChunkSeriesSet{
 				series: tc.secondarySeries,


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does


Series created between running the first query with index planning and running the second query without index planning may show up in the result and create a discrepancy. I call these fresh series.

Detecting fresh series isn't trivial because of out-of-order ingestion and because each series can potentially be created with samples from up to an hour ago. I chose to detect them based on their first sample.

If the first sample of a series is from the last minute, then we consider the series fresh and don't compare it. This is more robust than comparing with maxT of the query because maxT is often in the future.


#### Which issue(s) this PR fixes or relates to

related to #12460 https://github.com/grafana/mimir/issues/12085

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
