### PR TITLE
Clarify error message returned by query-frontends when queriers send a response for an unknown query ID

### DIFF
--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -723,7 +723,7 @@ func (f *Frontend) QueryResult(ctx context.Context, qrReq *frontendv2pb.QueryRes
 	// To avoid leaking query results between users, we verify the user here.
 	// To avoid mixing results from different queries, we randomize queryID counter on start.
 	if req == nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "query %d not found or response already received", qrReq.QueryID)
+		return nil, status.Errorf(codes.FailedPrecondition, "query %d not found, cancelled or response already received", qrReq.QueryID)
 	}
 
 	if req.userID != userID {
@@ -785,7 +785,7 @@ func (f *Frontend) QueryResultStream(stream frontendv2pb.FrontendForQuerier_Quer
 	req := f.requests.getAndDelete(firstMessage.QueryID)
 
 	if req == nil {
-		return status.Errorf(codes.FailedPrecondition, "query %d not found or response already received", firstMessage.QueryID)
+		return status.Errorf(codes.FailedPrecondition, "query %d not found, cancelled or response already received", firstMessage.QueryID)
 	}
 
 	if req.userID != userID {

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -1232,7 +1232,7 @@ func TestFrontend_HTTPGRPC_ResponseSentTwice(t *testing.T) {
 	// Wait for both responses to be sent off, then confirm one failed in the way we expect.
 	wg.Wait()
 	require.True(t, responseSucceeded.Load())
-	require.Equal(t, responseError.Load(), status.Errorf(codes.FailedPrecondition, "query %v not found or response already received", queryID.Load()))
+	require.Equal(t, responseError.Load(), status.Errorf(codes.FailedPrecondition, "query %v not found, cancelled or response already received", queryID.Load()))
 }
 
 func TestFrontend_Protobuf_ResponseSentTwice(t *testing.T) {
@@ -1304,7 +1304,7 @@ func TestFrontend_Protobuf_ResponseSentTwice(t *testing.T) {
 	// Wait for both responses to be sent off, then confirm one failed in the way we expect.
 	wg.Wait()
 	require.True(t, responseSucceeded.Load())
-	require.Equal(t, responseError.Load(), status.Errorf(codes.FailedPrecondition, "query %v not found or response already received", queryID))
+	require.Equal(t, responseError.Load(), status.Errorf(codes.FailedPrecondition, "query %v not found, cancelled or response already received", queryID))
 }
 
 func TestFrontend_Protobuf_ResponseWithUnexpectedUserID(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

This PR adds another possible explanation for why a query with the provided query ID can't be found.

I've chosen not to add a changelog entry given this is a minor change to an error message.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
