### PR TITLE
fix: TestMimir - include local wlan0 interface

### DIFF
--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -84,7 +84,7 @@ func TestMimir(t *testing.T) {
 					Store: "inmemory",
 				},
 				ReplicationFactor:      3,
-				InstanceInterfaceNames: []string{"en0", "eth0", "lo0", "lo"},
+				InstanceInterfaceNames: []string{"en0", "eth0", "wlan0", "lo0", "lo"},
 				HeartbeatPeriod:        5 * time.Second,
 				HeartbeatTimeout:       time.Minute,
 			},
@@ -137,7 +137,7 @@ func TestMimir(t *testing.T) {
 			ShardingRing: alertmanager.RingConfig{
 				Common: util.CommonRingConfig{
 					KVStore:                kv.Config{Store: "memberlist"},
-					InstanceInterfaceNames: []string{"en0", "eth0", "lo0", "lo"},
+					InstanceInterfaceNames: []string{"en0", "eth0", "wlan0", "lo0", "lo"},
 				},
 				ReplicationFactor: 1,
 			},
@@ -158,14 +158,14 @@ func TestMimir(t *testing.T) {
 					KVStore: kv.Config{
 						Store: "inmemory",
 					},
-					InstanceInterfaceNames: []string{"en0", "eth0", "lo0", "lo"},
+					InstanceInterfaceNames: []string{"en0", "eth0", "wlan0", "lo0", "lo"},
 				},
 			},
 		},
 		StoreGateway: storegateway.Config{ShardingRing: storegateway.RingConfig{
 			KVStore:                kv.Config{Store: "memberlist"},
 			ReplicationFactor:      1,
-			InstanceInterfaceNames: []string{"en0", "eth0", "lo0", "lo"},
+			InstanceInterfaceNames: []string{"en0", "eth0", "wlan0", "lo0", "lo"},
 		}},
 		Querier: querier.Config{
 			QueryEngine: "mimir",


### PR DESCRIPTION
The existing interfaces cover typical Linux wired and MacOS wireless (possibly wired) devices.

The Linux loopback interface `lo` doesn't appear to be used/suitable.

On a Linux laptop without a wired interface `eth0` but with the wireless interface `wlan0` the following test fails on `main` but passes with this commit:
```sh
$ go test ./... -run=TestMimir/-target=all,alertmanager

<snip>

--- FAIL: TestMimir (0.01s)
    --- FAIL: TestMimir/-target=all,alertmanager (0.01s)
        mimir_test.go:218:
            	Error Trace:	/<snip>/karlskewes/mimir/pkg/mimir/mimir_test.go:218
            	Error:      	Received unexpected error:
            	           	no useable address found for interfaces [en0 eth0 lo0 lo]
            	           	invalid ring lifecycler config
            	           	github.com/grafana/mimir/pkg/storegateway.newStoreGateway
            	           		/<snip>/karlskewes/mimir/pkg/storegateway/gateway.go:158
<snip - other components too>
```