### PR TITLE
[backport mimir-distributed-release-6.0] Add Support to customize gossip ring k8s service annotations  (#12718)

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Add Support to customize gossip ring k8s service annotations. #12718
+
 ## 6.0.0-rc.0
 
 * [CHANGE] Upgrade Mimir to [3.0.0](https://github.com/grafana/mimir/blob/main/CHANGELOG.md#300). #13078

--- a/operations/helm/charts/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "gossip-ring") | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    {{- toYaml .Values.gossip_ring.service.annotations | nindent 4 }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2467,6 +2467,10 @@ compactor:
   env: []
   extraEnvFrom: []
 
+gossip_ring:
+  service:
+    annotations: {}
+
 memcached:
   image:
     # -- Memcached Docker image repository

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/gossip-ring/gossip-ring-svc.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/component: gossip-ring
     app.kubernetes.io/managed-by: Helm
   namespace: "citestns"
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None


### PR DESCRIPTION
This is the backport for changes in #12718. Cherry-picked d92d4e31c1b0bddd35d82c55118eaded92e18b3e

I think the changes are small-enough to ship them in the 6.0 release