### PR TITLE
Docs: Add default OOO window for Grafana Cloud

### DIFF
--- a/docs/sources/mimir/configure/configure-out-of-order-samples-ingestion.md
+++ b/docs/sources/mimir/configure/configure-out-of-order-samples-ingestion.md
@@ -13,6 +13,10 @@ If you have out-of-order samples, due to the nature of your architecture or the 
 
 As an **experimental** feature, Mimir allows you to ingest out-of-order samples. As a result, no sample is dropped if it is within the configured time window.
 
+{{< admonition type="note" >}}
+In Grafana Cloud, the default value for `out_of_order_time_window` is 2 hours.
+{{< /admonition >}}
+
 ## Configure out-of-order samples ingestion instance-wide
 
 To configure Mimir to accept out-of-order samples, see the following configuration snippet:


### PR DESCRIPTION
This pull request adds a clarifying note to the documentation for out-of-order sample ingestion in Mimir. The note specifies the default value for the `out_of_order_time_window` parameter in Grafana Cloud.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/support-escalations/issues/18670

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
