### PR TITLE
docs: add docs on owned series tracking

### DIFF
--- a/docs/sources/mimir/configure/configure-owned-series.md
+++ b/docs/sources/mimir/configure/configure-owned-series.md
@@ -21,7 +21,7 @@ Additionally, since each ingester enforces only a fraction of a tenant's in-memo
 - The local limit on each ingester drops to 25k; the tenant's 30k series on the original 3 ingesters exceed the new local limit, and those ingesters immediately start to discard samples.
 
 <div align="center">
-  <img src="/media/docs/mimir/scale-up-owned-series.png" alt="Changing limits with in-memory series" width="700">
+  <img src="/media/docs/mimir/scale-up-memory-series.png" alt="Changing limits with in-memory series" width="700">
 </div>
 
 Owned series tracking addresses these problems by counting, per tenant, the subset of in-memory series that hash to a particular ingester or partition, based on the current ring state and shard configuration. When you enable owned series tracking and use owned series for series limits, Mimir ingesters enforce limits against a tenant's owned series count rather than the full count of in-memory series.
@@ -50,7 +50,7 @@ Because owned series are recomputed shortly after a change in the ring state, fo
 Additionally, if the recomputation is triggered by a series limit decrease, the owned series are recomputed before the new series limit takes effect. Series limit increases take effect immediately. This allows graceful handling of this situation, without dropping samples while the owned series are being recomputed.
 
 <div align="center">
-  <img src="/media/docs/mimir/scale-up-memory-series.png" alt="Changing limits with owned series" width="700">
+  <img src="/media/docs/mimir/scale-up-owned-series.png" alt="Changing limits with owned series" width="700">
 </div>
 
 ## Before you begin


### PR DESCRIPTION
#### What this PR does
This pull request adds comprehensive documentation for the experimental "owned series tracking" feature in Grafana Mimir. The new guide explains the motivation, behavior, configuration steps, monitoring metrics, and prerequisites for enabling owned series tracking to improve series limit enforcement during ring topology changes.

New documentation for owned series tracking:

* Added a new file, `configure-owned-series.md`, describing what owned series tracking is, why it's needed, and how it works in distributed Mimir deployments.
* Provided step-by-step instructions for enabling and configuring owned series tracking using ingester flags and intervals.
* Listed monitoring metrics exposed by ingesters to track owned series and related checks.
* Documented prerequisites, such as enabling zone-aware replication and matching replication factor to the number of zones.
* Linked to related resources for further configuration and reference.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/9730

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new documentation page `docs/sources/mimir/configure/configure-owned-series.md` describing the experimental owned series tracking feature and how to use it.
> 
> - Explains concept and behavior with hash ring/shuffle-sharding and when recomputation occurs
> - Configuration steps with ingester flags: `-ingester.track-ingester-owned-series`, `-ingester.owned-series-update-interval`, `-ingester.use-ingester-owned-series-for-limits`
> - Prerequisites: enable zone-aware replication and set replication factor equal to number of zones
> - Notes ingest storage vs classic architecture considerations
> - Monitoring guidance with metrics: `cortex_ingester_owned_series`, `cortex_ingester_owned_target_info_series`, `cortex_ingester_owned_series_check_duration_seconds`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1d38eb532054f3f62330907e7f47f448666f14b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->