### PR TITLE
MQE: enable upstream tests that are now supported

### DIFF
--- a/pkg/streamingpromql/testdata/upstream/functions.test
+++ b/pkg/streamingpromql/testdata/upstream/functions.test
@@ -754,145 +754,134 @@ load 5m
 	node_uname_info{job="node_exporter", instance="4m5", release="1.11.3"} 0+10x10
 	node_uname_info{job="node_exporter", instance="4m1000", release="1.111.3"} 0+10x10
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label(http_requests, "instance")
-# 	expect ordered
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="production", instance="1", job="app-server"} 600
-# 	http_requests{group="canary", instance="2", job="api-server"} NaN
-# 	http_requests{group="production", instance="2", job="api-server"} 100
+eval instant at 50m sort_by_label(http_requests, "instance")
+	expect ordered
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="production", instance="1", job="app-server"} 600
+	http_requests{group="canary", instance="2", job="api-server"} NaN
+	http_requests{group="production", instance="2", job="api-server"} 100
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label(http_requests, "instance", "group")
-#	expect ordered
-#	http_requests{group="canary", instance="0", job="api-server"} 300
-#	http_requests{group="canary", instance="0", job="app-server"} 700
-#	http_requests{group="production", instance="0", job="api-server"} 100
-#	http_requests{group="production", instance="0", job="app-server"} 500
-#	http_requests{group="canary", instance="1", job="api-server"} 400
-#	http_requests{group="canary", instance="1", job="app-server"} 800
-#	http_requests{group="production", instance="1", job="api-server"} 200
-#	http_requests{group="production", instance="1", job="app-server"} 600
-#	http_requests{group="canary", instance="2", job="api-server"} NaN
-#	http_requests{group="production", instance="2", job="api-server"} 100
+eval instant at 50m sort_by_label(http_requests, "instance", "group")
+	expect ordered
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="production", instance="1", job="app-server"} 600
+	http_requests{group="canary", instance="2", job="api-server"} NaN
+	http_requests{group="production", instance="2", job="api-server"} 100
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label(http_requests, "instance", "group")
-# 	expect ordered
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="production", instance="1", job="app-server"} 600
-# 	http_requests{group="canary", instance="2", job="api-server"} NaN
-# 	http_requests{group="production", instance="2", job="api-server"} 100
+eval instant at 50m sort_by_label(http_requests, "instance", "group")
+	expect ordered
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="production", instance="1", job="app-server"} 600
+	http_requests{group="canary", instance="2", job="api-server"} NaN
+	http_requests{group="production", instance="2", job="api-server"} 100
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label(http_requests, "group", "instance", "job")
-# 	expect ordered
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="canary", instance="2", job="api-server"} NaN
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="production", instance="1", job="app-server"} 600
-# 	http_requests{group="production", instance="2", job="api-server"} 100
+eval instant at 50m sort_by_label(http_requests, "group", "instance", "job")
+	expect ordered
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="canary", instance="2", job="api-server"} NaN
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="production", instance="1", job="app-server"} 600
+	http_requests{group="production", instance="2", job="api-server"} 100
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label(http_requests, "job", "instance", "group")
-# 	expect ordered
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="canary", instance="2", job="api-server"} NaN
-# 	http_requests{group="production", instance="2", job="api-server"} 100
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="production", instance="1", job="app-server"} 600
+eval instant at 50m sort_by_label(http_requests, "job", "instance", "group")
+	expect ordered
+	http_requests{group="canary", instance="0", job="api-server"} 300
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="canary", instance="2", job="api-server"} NaN
+	http_requests{group="production", instance="2", job="api-server"} 100
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="production", instance="1", job="app-server"} 600
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label_desc(http_requests, "instance")
-# 	expect ordered
-# 	http_requests{group="production", instance="2", job="api-server"} 100
-# 	http_requests{group="canary", instance="2", job="api-server"} NaN
-# 	http_requests{group="production", instance="1", job="app-server"} 600
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
+eval instant at 50m sort_by_label_desc(http_requests, "instance")
+	expect ordered
+	http_requests{group="production", instance="2", job="api-server"} 100
+	http_requests{group="canary", instance="2", job="api-server"} NaN
+	http_requests{group="production", instance="1", job="app-server"} 600
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="canary", instance="0", job="api-server"} 300
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label_desc(http_requests, "instance", "group")
-# 	expect ordered
-# 	http_requests{group="production", instance="2", job="api-server"} 100
-# 	http_requests{group="canary", instance="2", job="api-server"} NaN
-# 	http_requests{group="production", instance="1", job="app-server"} 600
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
+eval instant at 50m sort_by_label_desc(http_requests, "instance", "group")
+	expect ordered
+	http_requests{group="production", instance="2", job="api-server"} 100
+	http_requests{group="canary", instance="2", job="api-server"} NaN
+	http_requests{group="production", instance="1", job="app-server"} 600
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="canary", instance="0", job="api-server"} 300
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label_desc(http_requests, "instance", "group", "job")
-# 	expect ordered
-# 	http_requests{group="production", instance="2", job="api-server"} 100
-# 	http_requests{group="canary", instance="2", job="api-server"} NaN
-# 	http_requests{group="production", instance="1", job="app-server"} 600
-# 	http_requests{group="production", instance="1", job="api-server"} 200
-# 	http_requests{group="canary", instance="1", job="app-server"} 800
-# 	http_requests{group="canary", instance="1", job="api-server"} 400
-# 	http_requests{group="production", instance="0", job="app-server"} 500
-# 	http_requests{group="production", instance="0", job="api-server"} 100
-# 	http_requests{group="canary", instance="0", job="app-server"} 700
-# 	http_requests{group="canary", instance="0", job="api-server"} 300
+eval instant at 50m sort_by_label_desc(http_requests, "instance", "group", "job")
+	expect ordered
+	http_requests{group="production", instance="2", job="api-server"} 100
+	http_requests{group="canary", instance="2", job="api-server"} NaN
+	http_requests{group="production", instance="1", job="app-server"} 600
+	http_requests{group="production", instance="1", job="api-server"} 200
+	http_requests{group="canary", instance="1", job="app-server"} 800
+	http_requests{group="canary", instance="1", job="api-server"} 400
+	http_requests{group="production", instance="0", job="app-server"} 500
+	http_requests{group="production", instance="0", job="api-server"} 100
+	http_requests{group="canary", instance="0", job="app-server"} 700
+	http_requests{group="canary", instance="0", job="api-server"} 300
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label(cpu_time_total, "cpu")
-# 	expect ordered
-# 	cpu_time_total{job="cpu", cpu="0"} 100
-# 	cpu_time_total{job="cpu", cpu="1"} 100
-# 	cpu_time_total{job="cpu", cpu="2"} 100
-# 	cpu_time_total{job="cpu", cpu="3"} 100
-# 	cpu_time_total{job="cpu", cpu="10"} 100
-# 	cpu_time_total{job="cpu", cpu="11"} 100
-# 	cpu_time_total{job="cpu", cpu="12"} 100
-# 	cpu_time_total{job="cpu", cpu="20"} 100
-# 	cpu_time_total{job="cpu", cpu="21"} 100
-# 	cpu_time_total{job="cpu", cpu="100"} 100
+eval instant at 50m sort_by_label(cpu_time_total, "cpu")
+	expect ordered
+	cpu_time_total{job="cpu", cpu="0"} 100
+	cpu_time_total{job="cpu", cpu="1"} 100
+	cpu_time_total{job="cpu", cpu="2"} 100
+	cpu_time_total{job="cpu", cpu="3"} 100
+	cpu_time_total{job="cpu", cpu="10"} 100
+	cpu_time_total{job="cpu", cpu="11"} 100
+	cpu_time_total{job="cpu", cpu="12"} 100
+	cpu_time_total{job="cpu", cpu="20"} 100
+	cpu_time_total{job="cpu", cpu="21"} 100
+	cpu_time_total{job="cpu", cpu="100"} 100
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label(node_uname_info, "instance")
-# 	expect ordered
-# 	node_uname_info{job="node_exporter", instance="4m5", release="1.11.3"} 100
-# 	node_uname_info{job="node_exporter", instance="4m600", release="1.2.3"} 100
-# 	node_uname_info{job="node_exporter", instance="4m1000", release="1.111.3"} 100
+eval instant at 50m sort_by_label(node_uname_info, "instance")
+	expect ordered
+	node_uname_info{job="node_exporter", instance="4m5", release="1.11.3"} 100
+	node_uname_info{job="node_exporter", instance="4m600", release="1.2.3"} 100
+	node_uname_info{job="node_exporter", instance="4m1000", release="1.111.3"} 100
 
-# Unsupported by streaming engine.
-# eval instant at 50m sort_by_label(node_uname_info, "release")
-# 	expect ordered
-# 	node_uname_info{job="node_exporter", instance="4m600", release="1.2.3"} 100
-# 	node_uname_info{job="node_exporter", instance="4m5", release="1.11.3"} 100
-# 	node_uname_info{job="node_exporter", instance="4m1000", release="1.111.3"} 100
+eval instant at 50m sort_by_label(node_uname_info, "release")
+	expect ordered
+	node_uname_info{job="node_exporter", instance="4m600", release="1.2.3"} 100
+	node_uname_info{job="node_exporter", instance="4m5", release="1.11.3"} 100
+	node_uname_info{job="node_exporter", instance="4m1000", release="1.111.3"} 100
 
 # Tests for double_exponential_smoothing
 clear


### PR DESCRIPTION
#### What this PR does

This PR enables some tests from upstream for `sort_by_label` that are now supported by MQE.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/11930

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
