### PR TITLE
fix: log non-SRV responses during service discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20250805180558-d916df8a1fad
+	github.com/grafana/dskit v0.0.0-20251027160554-1079dea5d776
 	github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.7.12

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20250711181610-8eef376f49f8 h1:XUfln7L8Lz1E+gWU3Zz9+H+qIIqsBEls57vZmokoQog=
 github.com/grafana/alerting v0.0.0-20250711181610-8eef376f49f8/go.mod h1:gtR7agmxVfJOmNKV/n2ZULgOYTYNL+PDKYB5N48tQ7Q=
-github.com/grafana/dskit v0.0.0-20250805180558-d916df8a1fad h1:4M3+4bFppP28BmA0y42QSQB2cdNm/YSyNLLUr8m0Uqw=
-github.com/grafana/dskit v0.0.0-20250805180558-d916df8a1fad/go.mod h1:gVg14WngG7SMnJ/5mZGNFAs31+7BhspoWfmZ/U4rb90=
+github.com/grafana/dskit v0.0.0-20251027160554-1079dea5d776 h1:2EZVzrgHrr5NHSFQrSwUFfy5b3tgk6nTX1YK4MEL5SU=
+github.com/grafana/dskit v0.0.0-20251027160554-1079dea5d776/go.mod h1:gVg14WngG7SMnJ/5mZGNFAs31+7BhspoWfmZ/U4rb90=
 github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673 h1:Va04sDlP33f1SFUHRTho4QJfDlGTz+/HnBIpYwlqV9Q=
 github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/vendor/github.com/grafana/dskit/dns/miekgdns2/resolver.go
+++ b/vendor/github.com/grafana/dskit/dns/miekgdns2/resolver.go
@@ -128,7 +128,11 @@ func (r *Resolver) lookupSRV(ctx context.Context, conf *dns.ClientConfig, servic
 				Port:     addr.Port,
 			})
 		default:
-			return "", nil, fmt.Errorf("invalid SRV response record %s", record)
+			level.Warn(r.logger).Log(
+				"msg", "unexpected non-SRV response record",
+				"target", target,
+				"record", fmt.Sprintf("%+v", record),
+			)
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -734,7 +734,7 @@ github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
 github.com/grafana/alerting/templates/gomplate
 github.com/grafana/alerting/templates/mimir
-# github.com/grafana/dskit v0.0.0-20250805180558-d916df8a1fad
+# github.com/grafana/dskit v0.0.0-20251027160554-1079dea5d776
 ## explicit; go 1.23.0
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
Pulls in https://github.com/grafana/dskit/pull/774 which logs non-SRV responses to a SRV query instead of returning an error.

Possible fix for https://github.com/grafana/mimir/issues/12713

