### PR TITLE
Jsonnet: refactoring to expose function to create ruler, query-frontend and ruler-query-frontend ScaledObject

### DIFF
--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -602,16 +602,25 @@
     if !$._config.autoscaling_ruler_querier_enabled then {} else $.removeReplicasFromSpec
   ),
 
-  ruler_query_frontend_scaled_object: if !$._config.autoscaling_ruler_query_frontend_enabled || !$._config.ruler_remote_evaluation_enabled then null else
+  //
+  // Ruler-query-frontends
+  //
+
+  newRulerQueryFrontendScaledObject(name, extra_matchers='')::
     $.newResourceScaledObject(
-      name='ruler-query-frontend',
+      name=name,
+      container_name='ruler-query-frontend',
       cpu_requests=$.ruler_query_frontend_container.resources.requests.cpu,
       memory_requests=$.ruler_query_frontend_container.resources.requests.memory,
       min_replicas=$._config.autoscaling_ruler_query_frontend_min_replicas,
       max_replicas=$._config.autoscaling_ruler_query_frontend_max_replicas,
       cpu_target_utilization=$._config.autoscaling_ruler_query_frontend_cpu_target_utilization,
       memory_target_utilization=$._config.autoscaling_ruler_query_frontend_memory_target_utilization,
+      extra_matchers=extra_matchers,
     ),
+
+  ruler_query_frontend_scaled_object: if !$._config.autoscaling_ruler_query_frontend_enabled || !$._config.ruler_remote_evaluation_enabled then null else
+    $.newRulerQueryFrontendScaledObject('ruler-query-frontend'),
 
   ruler_query_frontend_deployment: overrideSuperIfExists(
     'ruler_query_frontend_deployment',
@@ -620,6 +629,10 @@
         queryFrontendReplicas($._config.autoscaling_ruler_querier_max_replicas) else
         {}
   ),
+
+  //
+  // Distributors
+  //
 
   newDistributorScaledObject(name, extra_matchers='')::
     $.newResourceScaledObject(


### PR DESCRIPTION
#### What this PR does

In this PR I'm proposing a refactoring to expose function to create ruler, query-frontend and ruler-query-frontend ScaledObject. The generated jsonnet is the exact same, but it allows downstream projects to easily create custom scaled objects (e.g. zonal ones, which is what I'm working on, and will be later upstreamed too).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
