### PR TITLE
Fix MatcherReducerPlanner comments

### DIFF
--- a/pkg/ingester/lookupplan/matcher_reducer_planner.go
+++ b/pkg/ingester/lookupplan/matcher_reducer_planner.go
@@ -16,8 +16,7 @@ import (
 
 // MatcherReducerPlanner deduplicates matchers from the input plan,
 // and removes matchers that select for all non-empty values if a more selective matcher for the same label name already exists.
-// It returns the input index and scan matchers in the input order.
-// If matchers are duplicated across the index and scan matchers, they will be returned as index-only matchers.
+// It does not modify plans if the input plan has any scan matchers, and does not guarantee consistent matcher ordering in the output plan.
 type MatcherReducerPlanner struct{}
 
 // concreteLookupPlan implements LookupPlan by storing pre-computed index and scan matchers.

--- a/pkg/ingester/lookupplan/matcher_reducer_planner_test.go
+++ b/pkg/ingester/lookupplan/matcher_reducer_planner_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestMatcherReducerPlanner_PlanIndexLookup tests output plans, given certain input matchers.
+// These tests verify cases where output matchers should and should not be dropped.
 func TestMatcherReducerPlanner_PlanIndexLookup(t *testing.T) {
 	ctxPlanningDisabled := ContextWithDisabledPlanning(context.Background())
 	tests := []struct {
@@ -142,6 +144,9 @@ func TestMatcherReducerPlanner_PlanIndexLookup(t *testing.T) {
 	}
 }
 
+// TestMatcherReducerPlanner_MatchedSeries verifies that the same set of series is returned by queries run
+// with or without the MatcherReducerPlanner. Not all tests will drop matchers,
+// and the set of matchers returned by PlanIndexLookup is not checked, only the series resulting from each query.
 func TestMatcherReducerPlanner_MatchedSeries(t *testing.T) {
 	// Create TSDB instance with sample data
 	db, err := tsdb.Open(t.TempDir(), promslog.NewNopLogger(), nil, tsdb.DefaultOptions(), nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Adds some comments to tests to clarify intention, and fixes description of `MatcherReducerPlanner` -- output matcher order is _not_ guaranteed.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
