### PR TITLE
Jsonnet: add extra_matchers support to newQuerierScaledObject(), and add newRulerQuerierScaledObject()

### DIFF
--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -574,6 +574,7 @@
   newRulerQuerierScaledObject(name, querier_args, extra_matchers='')::
     $.newResourceScaledObject(
       name=name,
+      container_name='ruler-querier',
       cpu_requests=$.ruler_querier_container.resources.requests.cpu,
       memory_requests=$.ruler_querier_container.resources.requests.memory,
       min_replicas=$._config.autoscaling_ruler_querier_min_replicas,


### PR DESCRIPTION
#### What this PR does

Similarly to the other functions used to create ScaledObject, in this PR I'm adding `extra_matchers` parameter to `newQuerierScaledObject()` and I'm creating `newRulerQuerierScaledObject()`. This will be used to add multi-zone support to jsonnet deployment (I will do it in a downstream project first, and I will later upstream it to OSS).

I recomment to review the diff with "hide whitespace changes".

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
