### PR TITLE
Add read shard size override for graceful partition shard size migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [FEATURE] Ingest storage: Add `-ingest-storage.kafka.sasl-mechanism` flag supporting more ways to authenticate with Kafka. #14307 #14344 #14540
 * [FEATURE] Ingest storage: Add `-ingest-storage.kafka.tls*` flags to connect to Kafka using TLS. #14550
 * [FEATURE] MQE: Add experimental support for splitting and caching intermediate results for functions over range vectors in instant queries. #13472 #14479 #14506 #14499 #14517 #14536 #14614 #14645 #14677
+* [FEATURE] Ingest storage: Add experimental `-ingest-storage.ingestion-partition-tenant-read-shard-size` setting to enable graceful migration when decreasing partition shard sizes. When set, queries read from the specified number of partitions while writes use the regular shard size, allowing safe migration without disabling shuffle sharding. #13188
 * [ENHANCEMENT] Query-frontend: Add support for blocking queries exceeding a time range duration with `time_range_longer_than`. #14609
 * [ENHANCEMENT] Memberlist: Add experimental propagation delay tracker to measure gossip propagation delay across the memberlist cluster. Enable with `-memberlist.propagation-delay-tracker.enabled=true`. #14312 #14406
 * [ENHANCEMENT] Compactor: Add 0-100% jitter to the first compaction interval to spread compactions when multiple compactors start simultaneously. #14280

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7188,6 +7188,17 @@
         },
         {
           "kind": "field",
+          "name": "ingestion_partitions_tenant_read_shard_size",
+          "required": false,
+          "desc": "Optional override for the number of partitions to query on the read path when using ingest storage. When set to a value \u003e 0, this overrides -ingest-storage.ingestion-partition-tenant-shard-size for read operations only. This is useful for gracefully migrating to a smaller shard size without disabling shuffle sharding. Set to 0 to use the value from -ingest-storage.ingestion-partition-tenant-shard-size.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "ingest-storage.ingestion-partition-tenant-read-shard-size",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "name_validation_scheme",
           "required": false,
           "desc": "Validation scheme to use for metric and label names. Distributors reject time series that do not adhere to this scheme. Rulers reject rules with unsupported metric or label names. Supported values: legacy, utf8.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1457,6 +1457,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Include tenant ID in pprof labels for profiling. Currently only supported by the ingester. This can help debug performance issues for specific tenants. (default true)
   -ingest-storage.enabled
     	True to enable the ingestion via object storage.
+  -ingest-storage.ingestion-partition-tenant-read-shard-size int
+    	[experimental] Optional override for the number of partitions to query on the read path when using ingest storage. When set to a value > 0, this overrides -ingest-storage.ingestion-partition-tenant-shard-size for read operations only. This is useful for gracefully migrating to a smaller shard size without disabling shuffle sharding. Set to 0 to use the value from -ingest-storage.ingestion-partition-tenant-shard-size.
   -ingest-storage.ingestion-partition-tenant-shard-size int
     	[experimental] The number of partitions a tenant's data should be sharded to when using the ingest storage. Tenants are sharded across partitions using shuffle-sharding. 0 disables shuffle sharding and tenant is sharded across all partitions.
   -ingest-storage.kafka.address comma-separated-list-of-strings

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -5117,6 +5117,15 @@ ruler_alertmanager_client_config:
 # CLI flag: -ingest-storage.ingestion-partition-tenant-shard-size
 [ingestion_partitions_tenant_shard_size: <int> | default = 0]
 
+# (experimental) Optional override for the number of partitions to query on the
+# read path when using ingest storage. When set to a value > 0, this overrides
+# -ingest-storage.ingestion-partition-tenant-shard-size for read operations
+# only. This is useful for gracefully migrating to a smaller shard size without
+# disabling shuffle sharding. Set to 0 to use the value from
+# -ingest-storage.ingestion-partition-tenant-shard-size.
+# CLI flag: -ingest-storage.ingestion-partition-tenant-read-shard-size
+[ingestion_partitions_tenant_read_shard_size: <int> | default = 0]
+
 # (experimental) Validation scheme to use for metric and label names.
 # Distributors reject time series that do not adhere to this scheme. Rulers
 # reject rules with unsupported metric or label names. Supported values: legacy,

--- a/docs/sources/mimir/configure/configure-shuffle-sharding/index.md
+++ b/docs/sources/mimir/configure/configure-shuffle-sharding/index.md
@@ -129,14 +129,32 @@ If you’re running a Grafana Mimir cluster with shuffle sharding disabled, and 
 
 The shuffle sharding implementation in Grafana Mimir has a limitation that prevents you from abruptly decreasing the tenant shard size when shuffle sharding is enabled for distributors on the read path. This is because when shuffle sharding is disabled, the queriers check all ingesters for blocks, whereas when it's enabled, they only check the ones that are assigned to that tenant through the shuffle-shard.
 
-To safely decrease the tenant shard size, follow these steps.
+You can safely decrease the tenant shard size by using one of the following methods:
+
+- [Use the read shard size override](#use-the-read-shard-size-override) to keep shuffle sharding enabled while migrating.
+- [Temporarily disable shuffle sharding](#temporarily-disable-shuffle-sharding) if the read shard size override is not available.
+
+##### Use the read shard size override
+
+For partition shuffle sharding in ingest storage architecture, you can use the `-ingest-storage.ingestion-partition-tenant-read-shard-size` configuration to gracefully decrease the tenant shard size without requiring you to disable shuffle sharding globally:
+
+1. Set the read shard size to the current write shard size value via `-ingest-storage.ingestion-partition-tenant-read-shard-size=<current-size>` (or per-tenant via `ingestion_partitions_tenant_read_shard_size` in runtime configuration).
+1. Decrease the write shard size via `-ingest-storage.ingestion-partition-tenant-shard-size=<new-smaller-size>`.
+1. Wait for at least the amount of time specified in the `-blocks-storage.tsdb.retention-period`.
+1. Remove the read shard size override by setting `-ingest-storage.ingestion-partition-tenant-read-shard-size=0` or removing the runtime configuration override.
+
+This method allows queries to continue reading from the previous larger set of partitions while new writes go to the smaller set, without requiring shuffle sharding to be disabled for all tenants during the migration.
+
+##### Temporarily disable shuffle sharding
+
+If the read shard size override is not available, follow these steps:
 
 1. Disable shuffle sharding on the ingester read path via `-querier.shuffle-sharding-ingesters-enabled=false`.
 1. Decrease the configured tenant shard size.
 1. Wait for at least the amount of time specified via `-blocks-storage.tsdb.retention-period`.
 1. Re-enable shuffle sharding on the ingester read path via `-querier.shuffle-sharding-ingesters-enabled=true`.
 
-Decreasing the tenant shard size without following this procedure could lead to inaccurate or incomplete query results. The queriers and rulers can’t determine the previous shard size and could miss an ingester with data for a given tenant. When you change a tenant’s shard size, the tenant’s series are assigned to a new set of partitions with only new samples distributed to it. Samples written before the shard size change remain in the previously-assigned partition set and the ingesters consuming those partitions. Because the queriers can't determine the previous set of ingesters through the sharding ring, they must check all ingesters for the series until the value set in `blocks-storage.tsdb.retention-period` has passed. At this point, you can query the series from object storage through the store-gateway.
+Decreasing the tenant shard size without following one of these procedures could lead to inaccurate or incomplete query results. The queriers and rulers can't determine the previous shard size and could miss an ingester with data for a given tenant. When you change a tenant's shard size, the tenant's series are assigned to a new set of partitions with only new samples distributed to it. Samples written before the shard size change remain in the previously-assigned partition set and the ingesters consuming those partitions. Because the queriers can't determine the previous set of ingesters through the sharding ring, they must check all ingesters for the series until the value set in `blocks-storage.tsdb.retention-period` has passed. At this point, you can query the series from object storage through the store-gateway.
 
 {{< admonition type="note" >}}
 The procedure for decreasing the tenant shard size is the same as for enabling shuffle sharding. Enabling shuffle sharding for ingesters effectively decreases the tenant shard size.
@@ -189,7 +207,7 @@ If you’re running a Grafana Mimir cluster with shuffle sharding disabled, and 
 
 The shuffle sharding implementation in Grafana Mimir has a limitation that prevents you from abruptly decreasing the tenant shard size when shuffle sharding is enabled for ingesters on the read path. This is because when shuffle sharding is disabled, the queriers check all ingesters for blocks, whereas when it's enabled, they only check the ones that are assigned to that tenant through the shuffle-shard.
 
-To safely decrease the tenant shard size, follow these steps.
+To safely decrease the tenant shard size for classic architecture, follow these steps:
 
 1. Disable shuffle sharding on the ingester read path via `-querier.shuffle-sharding-ingesters-enabled=false`.
 1. Decrease the configured tenant shard size.

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -497,6 +497,7 @@
   "distributor.otel-label-name-preserve-underscores": true,
   "ingest-storage.read-consistency": "eventual",
   "ingest-storage.ingestion-partition-tenant-shard-size": 0,
+  "ingest-storage.ingestion-partition-tenant-read-shard-size": 0,
   "querier.scheduler-address": "",
   "querier.dns-lookup-period": 10000000000,
   "querier.id": "",

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -3602,7 +3602,8 @@ func (d *Distributor) adjustQueryRequestLimit(ctx context.Context, userID string
 	if d.cfg.IngestStorageConfig.Enabled {
 		// Get the number of active partitions in the ring. Here the ShuffleShardSize handles cases when a tenant has 0 or negative
 		// number of shards, or more shards than the number of active partitions in the ring.
-		shardSize = d.partitionsRing.PartitionRing().ShuffleShardSize(d.limits.IngestionPartitionsTenantShardSize(userID))
+		// Use the read shard size, which may be overridden for graceful shard size migration.
+		shardSize = d.partitionsRing.PartitionRing().ShuffleShardSize(d.limits.IngestionPartitionsTenantReadShardSize(userID))
 	} else {
 		// The ShuffleShard filters out read-only instances, leaving us with the number of active ingesters.
 		// Note, this can be costly to compute if the ring's caching is not enabled.

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -128,7 +128,8 @@ func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context) ([
 		// that have been inactive for longer than the lookback period.
 		shardSize := 0
 		if d.cfg.ShuffleShardingEnabled {
-			shardSize = d.limits.IngestionPartitionsTenantShardSize(userID)
+			// Use the read shard size, which may be overridden for graceful shard size migration.
+			shardSize = d.limits.IngestionPartitionsTenantReadShardSize(userID)
 		}
 		r, err = r.ShuffleShardWithLookback(userID, shardSize, d.cfg.IngestersLookbackPeriod, time.Now())
 		if err != nil {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -321,8 +321,9 @@ type Limits struct {
 	OTelLabelNamePreserveMultipleUnderscores bool                         `yaml:"otel_label_name_preserve_multiple_underscores" json:"otel_label_name_preserve_multiple_underscores" category:"advanced"`
 
 	// Ingest storage.
-	IngestStorageReadConsistency       string `yaml:"ingest_storage_read_consistency" json:"ingest_storage_read_consistency" category:"experimental"`
-	IngestionPartitionsTenantShardSize int    `yaml:"ingestion_partitions_tenant_shard_size" json:"ingestion_partitions_tenant_shard_size" category:"experimental"`
+	IngestStorageReadConsistency           string `yaml:"ingest_storage_read_consistency" json:"ingest_storage_read_consistency" category:"experimental"`
+	IngestionPartitionsTenantShardSize     int    `yaml:"ingestion_partitions_tenant_shard_size" json:"ingestion_partitions_tenant_shard_size" category:"experimental"`
+	IngestionPartitionsTenantReadShardSize int    `yaml:"ingestion_partitions_tenant_read_shard_size" json:"ingestion_partitions_tenant_read_shard_size" category:"experimental"`
 
 	// NameValidationScheme is the validation scheme for metric and label names.
 	NameValidationScheme model.ValidationScheme `yaml:"name_validation_scheme" json:"name_validation_scheme" category:"experimental"`
@@ -530,6 +531,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	// Ingest storage.
 	f.StringVar(&l.IngestStorageReadConsistency, "ingest-storage.read-consistency", api.ReadConsistencyEventual, fmt.Sprintf("The default consistency level to enforce for queries when using the ingest storage. Supports values: %s.", strings.Join(api.ReadConsistencies, ", ")))
 	f.IntVar(&l.IngestionPartitionsTenantShardSize, "ingest-storage.ingestion-partition-tenant-shard-size", 0, "The number of partitions a tenant's data should be sharded to when using the ingest storage. Tenants are sharded across partitions using shuffle-sharding. 0 disables shuffle sharding and tenant is sharded across all partitions.")
+	f.IntVar(&l.IngestionPartitionsTenantReadShardSize, "ingest-storage.ingestion-partition-tenant-read-shard-size", 0, "Optional override for the number of partitions to query on the read path when using ingest storage. When set to a value > 0, this overrides -ingest-storage.ingestion-partition-tenant-shard-size for read operations only. This is useful for gracefully migrating to a smaller shard size without disabling shuffle sharding. Set to 0 to use the value from -ingest-storage.ingestion-partition-tenant-shard-size.")
 
 	// Ensure the pointer holder is initialized.
 	l.activeSeriesMergedCustomTrackersConfig = atomic.NewPointer[asmodel.CustomTrackersConfig](nil)
@@ -1614,6 +1616,18 @@ func (o *Overrides) IngestStorageReadConsistency(userID string) string {
 
 func (o *Overrides) IngestionPartitionsTenantShardSize(userID string) int {
 	return o.getOverridesForUser(userID).IngestionPartitionsTenantShardSize
+}
+
+// IngestionPartitionsTenantReadShardSize returns the read shard size for the tenant.
+// If IngestionPartitionsTenantReadShardSize is set to a value > 0, it returns that value.
+// Otherwise, it returns IngestionPartitionsTenantShardSize (the write shard size).
+// This allows for graceful migration when decreasing shard sizes.
+func (o *Overrides) IngestionPartitionsTenantReadShardSize(userID string) int {
+	limits := o.getOverridesForUser(userID)
+	if limits.IngestionPartitionsTenantReadShardSize > 0 {
+		return limits.IngestionPartitionsTenantReadShardSize
+	}
+	return limits.IngestionPartitionsTenantShardSize
 }
 
 func (o *Overrides) SubquerySpinOffEnabled(userID string) bool {

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -2519,3 +2519,89 @@ func getDefaultLimits() Limits {
 	flagext.DefaultValues(&limits)
 	return limits
 }
+
+func TestOverrides_IngestionPartitionsTenantReadShardSize(t *testing.T) {
+	tests := []struct {
+		name             string
+		writeShardSize   int
+		readShardSize    int
+		expectedReadSize int
+		description      string
+	}{
+		{
+			name:             "read shard size not set - uses write shard size",
+			writeShardSize:   10,
+			readShardSize:    0,
+			expectedReadSize: 10,
+			description:      "When read shard size is 0 (not set), should return write shard size",
+		},
+		{
+			name:             "read shard size set - overrides write shard size",
+			writeShardSize:   10,
+			readShardSize:    20,
+			expectedReadSize: 20,
+			description:      "When read shard size is > 0, should return read shard size",
+		},
+		{
+			name:             "both disabled - returns 0",
+			writeShardSize:   0,
+			readShardSize:    0,
+			expectedReadSize: 0,
+			description:      "When both are 0, should return 0 (shuffle sharding disabled)",
+		},
+		{
+			name:             "write disabled but read enabled",
+			writeShardSize:   0,
+			readShardSize:    5,
+			expectedReadSize: 5,
+			description:      "Can have read shard size set even if write is disabled (edge case)",
+		},
+		{
+			name:             "read shard size smaller than write - migration scenario",
+			writeShardSize:   20,
+			readShardSize:    10,
+			expectedReadSize: 10,
+			description:      "During shard size decrease, read uses larger old value while writes use smaller new value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limits := Limits{
+				IngestionPartitionsTenantShardSize:     tt.writeShardSize,
+				IngestionPartitionsTenantReadShardSize: tt.readShardSize,
+			}
+
+			overrides := NewOverrides(limits, nil)
+			actual := overrides.IngestionPartitionsTenantReadShardSize("user1")
+
+			assert.Equal(t, tt.expectedReadSize, actual, tt.description)
+		})
+	}
+}
+
+func TestOverrides_IngestionPartitionsTenantReadShardSize_PerTenantOverride(t *testing.T) {
+	defaults := Limits{
+		IngestionPartitionsTenantShardSize:     10,
+		IngestionPartitionsTenantReadShardSize: 0,
+	}
+
+	tenantLimits := map[string]*Limits{
+		"tenant-with-override": {
+			IngestionPartitionsTenantShardSize:     5,  // New smaller write shard size
+			IngestionPartitionsTenantReadShardSize: 10, // Keep reading from old larger shard
+		},
+	}
+
+	overrides := NewOverrides(defaults, NewMockTenantLimits(tenantLimits))
+
+	// Tenant without override uses defaults
+	assert.Equal(t, 10, overrides.IngestionPartitionsTenantReadShardSize("tenant-default"),
+		"Tenant without override should use default write shard size (read=0 means use write)")
+
+	// Tenant with override
+	assert.Equal(t, 10, overrides.IngestionPartitionsTenantReadShardSize("tenant-with-override"),
+		"Tenant with read override should use read shard size")
+	assert.Equal(t, 5, overrides.IngestionPartitionsTenantShardSize("tenant-with-override"),
+		"Tenant should still use smaller write shard size for writes")
+}


### PR DESCRIPTION
#### What this PR does

This PR introduces an optional read shard size configuration that enables graceful migration when decreasing tenant partition shard sizes, without requiring shuffle sharding to be disabled for all tenants during the migration period.

**Key features:**

- New configuration: `-ingest-storage.ingestion-partition-tenant-read-shard-size` (CLI) / `ingestion_partitions_tenant_read_shard_size` (per-tenant runtime config)
- When set to > 0, overrides the read path shard size while writes continue using the regular shard size
- Default: 0 (disabled, falls back to write shard size for backward compatibility)

**Migration procedure:**

1. Set read shard size to current write shard size value
2. Decrease write shard size to new smaller value  
3. Wait for retention period (data ages out from old partitions)
4. Remove read shard size override

This allows queries to continue reading from the previous larger set of partitions while new writes go to the smaller set, providing a smooth migration path without global downtime.

#### Which issue(s) this PR fixes or relates to

Related to partition series limit work and operational improvements for ingest storage architecture.

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how ingest-storage queries choose partition shard size (and related per-shard request limiting) when the new override is set, which can impact query completeness and performance during migrations. Defaults preserve existing behavior, but misconfiguration could still cause under/over-querying.
> 
> **Overview**
> Adds an experimental read-path override `-ingest-storage.ingestion-partition-tenant-read-shard-size` / `ingestion_partitions_tenant_read_shard_size` to allow graceful decreases of partition shuffle-shard size while keeping writes on the regular shard size.
> 
> Updates distributor ingest-storage query routing and query request limit calculation to use `IngestionPartitionsTenantReadShardSize()` (fallbacks to the write shard size when unset), adds tests for the override behavior, and documents/exports the new setting across flags, config descriptor/defaults, docs, and the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d17b852aeca4f2df6ed02de92128fdbc7e14b80f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->