### PR TITLE
cache: ignore non-SRV responses during service discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [BUGFIX] Memcached: Ignore invalid responses when discovering cache servers using `dnssrv+` or `dnssrvnoa+` service discovery prefixes. #13203
+
 ## 3.0.0-rc.1
 
 ### Jsonnet

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20251010193112-965b207c61b8
+	github.com/grafana/dskit v0.0.0-20251028171531-a4bfa505f5e9
 	github.com/grafana/e2e v0.1.2-0.20250825134630-3cea6f657739
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.7.12

--- a/go.sum
+++ b/go.sum
@@ -561,8 +561,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20251002141545-d513d62d3210 h1:R4+ks/StOXvv+j8U7J+WQXqpa0e5bLZKFac9y20xeck=
 github.com/grafana/alerting v0.0.0-20251002141545-d513d62d3210/go.mod h1:VGjS5gDwWEADPP6pF/drqLxEImgeuHlEW5u8E5EfIrM=
-github.com/grafana/dskit v0.0.0-20251010193112-965b207c61b8 h1:60HJvGdtHhS+o1RCaYuLNANkATpkLccUI252L930zyg=
-github.com/grafana/dskit v0.0.0-20251010193112-965b207c61b8/go.mod h1:8AGVTqx49L8iYNAW6ls2n3+li4v70nenYr74sBsLKMk=
+github.com/grafana/dskit v0.0.0-20251028171531-a4bfa505f5e9 h1:r2yVAmj1eYGbViQUoZtSzQl9vXOJvAOV/GVtS8PVXzg=
+github.com/grafana/dskit v0.0.0-20251028171531-a4bfa505f5e9/go.mod h1:8AGVTqx49L8iYNAW6ls2n3+li4v70nenYr74sBsLKMk=
 github.com/grafana/e2e v0.1.2-0.20250825134630-3cea6f657739 h1:74hHXvOG42Y87T7jO7naPB5sZpwO3TDGTFiUL48s2Yc=
 github.com/grafana/e2e v0.1.2-0.20250825134630-3cea6f657739/go.mod h1:9bciABa7gW4B3t12C9vpgk54NeeoOZ+1DLsUnOAf+8Y=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/vendor/github.com/grafana/dskit/dns/miekgdns/resolver.go
+++ b/vendor/github.com/grafana/dskit/dns/miekgdns/resolver.go
@@ -128,7 +128,13 @@ func (r *Resolver) lookupSRV(ctx context.Context, conf *dns.ClientConfig, servic
 				Port:     addr.Port,
 			})
 		default:
-			return "", nil, fmt.Errorf("invalid SRV response record %s", record)
+			// Ignore unexpected non-SRV responses. This matches the behavior of the
+			// built-in go resolver. See https://github.com/grafana/mimir/issues/12713
+			level.Debug(r.logger).Log(
+				"msg", "unexpected non-SRV response record",
+				"target", target,
+				"record", record,
+			)
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -764,7 +764,7 @@ github.com/grafana/alerting/receivers/wecom/v1
 github.com/grafana/alerting/templates
 github.com/grafana/alerting/templates/gomplate
 github.com/grafana/alerting/templates/mimir
-# github.com/grafana/dskit v0.0.0-20251010193112-965b207c61b8
+# github.com/grafana/dskit v0.0.0-20251028171531-a4bfa505f5e9
 ## explicit; go 1.23.0
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
Backport of https://github.com/grafana/mimir/pull/13194

When discovering cache servers using `SRV` queries, sometimes DNS servers return A or AAAA records. Change our resolver to match the behavior of the built-in go resolver and ignore any non-SRV responses.

Fixes https://github.com/grafana/mimir/issues/12713

Pulls in https://github.com/grafana/dskit/pull/775

