### PR TITLE
[release-2.17] cache: ignore non-SRV responses during service discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## unreleased
 
-
 * [BUGFIX] Add a missing attribute to the list of default promoted OTel resource attributes in the docs: deployment.environment. #12181
 * [BUGFIX] Ingest: Fix memory pool poisoning in Remote-Write 2.0/OTLP by not clearning created timestamp field before returning time series to the memory pool. #12735
 * [BUGFIX] Distributor: Fix error when native histograms bucket limit is set then no NHCB passes validation. #12746
 * [BUGFIX] Update Docker base images for tools from `alpine:3.22.1` to `alpine:3.22.2` to address [CVE-2025-9230](https://nvd.nist.gov/vuln/detail/CVE-2025-9230), [CVE-2025-9231](https://nvd.nist.gov/vuln/detail/CVE-2025-9231), [CVE-2025-2025-9232](https://nvd.nist.gov/vuln/detail/CVE-2025-9232). #12993
+* [BUGFIX] Memcached: Ignore invalid responses when discovering cache servers using `dnssrv+` or `dnssrvnoa+` service discovery prefixes. #13206
 
 ### Tools
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20250805180558-d916df8a1fad
+	github.com/grafana/dskit v0.0.0-20251028191123-0de50c403525
 	github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.7.12

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20250711181610-8eef376f49f8 h1:XUfln7L8Lz1E+gWU3Zz9+H+qIIqsBEls57vZmokoQog=
 github.com/grafana/alerting v0.0.0-20250711181610-8eef376f49f8/go.mod h1:gtR7agmxVfJOmNKV/n2ZULgOYTYNL+PDKYB5N48tQ7Q=
-github.com/grafana/dskit v0.0.0-20250805180558-d916df8a1fad h1:4M3+4bFppP28BmA0y42QSQB2cdNm/YSyNLLUr8m0Uqw=
-github.com/grafana/dskit v0.0.0-20250805180558-d916df8a1fad/go.mod h1:gVg14WngG7SMnJ/5mZGNFAs31+7BhspoWfmZ/U4rb90=
+github.com/grafana/dskit v0.0.0-20251028191123-0de50c403525 h1:jRWQt+3uA10AxFrdhDk1u8yE6rJNpQBLBVtYivaB0B0=
+github.com/grafana/dskit v0.0.0-20251028191123-0de50c403525/go.mod h1:gVg14WngG7SMnJ/5mZGNFAs31+7BhspoWfmZ/U4rb90=
 github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673 h1:Va04sDlP33f1SFUHRTho4QJfDlGTz+/HnBIpYwlqV9Q=
 github.com/grafana/e2e v0.1.2-0.20250428181430-708d63bcc673/go.mod h1:JVmqPBe8A/pZWwRoJW5ZjyALeY5OXMzPl7LrVXOdZAI=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/vendor/github.com/grafana/dskit/dns/miekgdns2/resolver.go
+++ b/vendor/github.com/grafana/dskit/dns/miekgdns2/resolver.go
@@ -128,7 +128,13 @@ func (r *Resolver) lookupSRV(ctx context.Context, conf *dns.ClientConfig, servic
 				Port:     addr.Port,
 			})
 		default:
-			return "", nil, fmt.Errorf("invalid SRV response record %s", record)
+			// Ignore unexpected non-SRV responses. This matches the behavior of the
+			// built-in go resolver. See https://github.com/grafana/mimir/issues/12713
+			level.Debug(r.logger).Log(
+				"msg", "unexpected non-SRV response record",
+				"target", target,
+				"record", record,
+			)
 		}
 	}
 

--- a/vendor/github.com/grafana/dskit/dns/provider.go
+++ b/vendor/github.com/grafana/dskit/dns/provider.go
@@ -63,7 +63,7 @@ func (t ResolverType) toResolver(logger log.Logger) ipLookupResolver {
 	case GolangResolverType:
 		r = &godns.Resolver{Resolver: net.DefaultResolver}
 	case MiekgdnsResolverType:
-		r = &miekgdns.Resolver{ResolvConf: miekgdns.DefaultResolvConfPath}
+		r = &miekgdns.Resolver{ResolvConf: miekgdns.DefaultResolvConfPath, Logger: logger}
 	case MiekgdnsResolverType2:
 		level.Info(logger).Log("msg", "using experimental DNS resolver type", "type", t)
 		r = miekgdns2.NewResolver(miekgdns2.DefaultResolvConfPath, logger)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -734,7 +734,7 @@ github.com/grafana/alerting/receivers/wecom
 github.com/grafana/alerting/templates
 github.com/grafana/alerting/templates/gomplate
 github.com/grafana/alerting/templates/mimir
-# github.com/grafana/dskit v0.0.0-20250805180558-d916df8a1fad
+# github.com/grafana/dskit v0.0.0-20251028191123-0de50c403525
 ## explicit; go 1.23.0
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
#### What this PR does

When discovering cache servers using SRV queries, sometimes DNS servers return A or AAAA records. Change our resolver to match the behavior of the built-in go resolver and ignore any non-SRV responses.

#### Which issue(s) this PR fixes or relates to

Fixes #12713

Pulls in grafana/dskit#777

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
