### PR TITLE
Tooling: Increase Renovate Limits to 10 hourly + 20 active PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -87,4 +87,6 @@
   },
   osvVulnerabilityAlerts: true,
   dependencyDashboard: false,
+  prHourlyLimit: 10,
+  prConcurrentLimit: 20,
 }


### PR DESCRIPTION
#### What this PR does
Increases renovates PR limits from a default of 2 hourly (effectively 2 a week with our schedule) and 10 active to 10 hourly and 20 active.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
