### PR TITLE
Tooling: Allow renovate to update regular dependencies daily

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,7 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'config:recommended',
+    'schedule:daily'
   ],
   baseBranchPatterns: [
     'main',
@@ -11,9 +12,6 @@
   postUpdateOptions: [
     'gomodTidy',
     'gomodUpdateImportPaths',
-  ],
-  schedule: [
-    'before 9am on Monday',
   ],
   packageRules: [
     {
@@ -73,6 +71,15 @@
         'docker',
       ],
       enabled: false,
+    },
+    {
+      description: 'Only update dependencies digests on Monday mornings to avoid PR spam from repos not using semver',
+      matchUpdateTypes: [
+        'digest',
+      ],
+      schedule: [
+        '* 0-4 * * 1'
+      ],
     },
   ],
   branchPrefix: 'deps-update/',


### PR DESCRIPTION
#### What this PR does
This PR amends the general renovate schedule to use the Daily option (`* 0-3 * * *`), and adds a package rule to limit digest updates to once weekly (`* 0-4 * * 1`) as we have several dependencies that just use digests/hashes on a repo's main branch instead of semver releases.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
