### PR TITLE
GitHub: Fix Renovate bot references in workflows

### DIFF
--- a/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
+++ b/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   prepare:
-    if: github.event.pull_request.user.login == 'renovate[bot]'
+    if: github.event.pull_request.user.login == 'renovate-sh-app[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
     # We want to allow running github actions for all contributors, but don't want all contributors to be able to
     # publish new build images just by sending the PR. Hence this change.
-    if: ${{ contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association ) || github.event.pull_request.user.login == 'renovate[bot]' }}
+    if: ${{ contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association ) || github.event.pull_request.user.login == 'renovate-sh-app[bot]' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
#### What this PR does

Fix Renovate bot references in GitHub workflows to the new (self-hosted) bot name.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
