### PR TITLE
index planning: add benchmark for stats generation

### DIFF
--- a/pkg/ingester/lookupplan/testing/benchmarks_test.go
+++ b/pkg/ingester/lookupplan/testing/benchmarks_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DmitriyVTitov/size"
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
-	"github.com/grafana/mimir/pkg/ingester/lookupplan"
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/ingester"
 	"github.com/grafana/mimir/pkg/ingester/client"
+	"github.com/grafana/mimir/pkg/ingester/lookupplan"
 	"github.com/grafana/mimir/pkg/streamingpromql/benchmarks"
 	"github.com/grafana/mimir/pkg/util/bench"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Adds a benchmark test for statistics generation, which can be used to test different sketch thresholds on real TSDB blocks.

#### Which issue(s) this PR fixes or relates to

Relates to #11920

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
