### PR TITLE
Makefile: Update build image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr12712-28f11b4f26
+LATEST_BUILD_IMAGE_TAG ?= pr13212-11695d54ad
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.


### PR DESCRIPTION
#### What this PR does

Update build image tag in Make file to the one [built](https://github.com/grafana/mimir/pull/13212#issuecomment-3460233472) in #13212, since the automation somehow didn't commit the update 🤔 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
