### PR TITLE
GitHub: Let build and push workflow execute for all PRs

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -3,7 +3,6 @@ name: Build and Push mimir-build-image
 # configure trigger by pull request
 on:
   pull_request:
-    types: [opened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -23,6 +22,9 @@ jobs:
     # publish new build images just by sending the PR. Hence this change.
     if: ${{ contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association ) || github.event.pull_request.user.login == 'renovate-sh-app[bot]' }}
     steps:
+      # We only want for this workflow to do anything when mimir-build-image/Dockerfile is modified.
+      # However, we want for it to be able to run for all PRs, just so it can be made a required check
+      # (i.e. so PRs can't be merged until it's done).
       - name: Check if Dockerfile was modified
         id: check_dockerfile
         run: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Let the build and push GitHub workflow execute for all PRs, so it can be made a required check (so it's not skipped before merging).

Context: I think https://github.com/grafana/mimir/pull/13212 got auto-merged (by me) before the image finished building, because it's not a required check.

I'm also removing the `on.pull_request.types` constraint, to harmonize with the `ci` workflow, just to make sure it can be a required check on all PRs.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
