### PR TITLE
Revert "parquet store-gateway: track all blocks, check for converted on demand (#13179)"

### DIFF
--- a/pkg/storegateway/parquet_bucket_store.go
+++ b/pkg/storegateway/parquet_bucket_store.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/parquetconverter"
 	"github.com/grafana/mimir/pkg/storage/parquet"
 	parquetBlock "github.com/grafana/mimir/pkg/storage/parquet/block"
 	"github.com/grafana/mimir/pkg/storage/sharding"
@@ -351,8 +352,7 @@ func (s *ParquetBucketStore) LabelNames(ctx context.Context, req *storepb.LabelN
 	var sets [][]string
 	var blocksQueriedByBlockMeta = make(map[blockQueriedMeta]int)
 
-	logger := spanlogger.FromContext(ctx, s.logger)
-	s.blockSet.filter(ctx, s.bkt, req.Start, req.End, reqBlockMatchers, logger, func(b *parquetBucketBlock) {
+	s.blockSet.filter(req.Start, req.End, reqBlockMatchers, func(b *parquetBucketBlock) {
 		resHints.AddQueriedBlock(b.meta.ULID)
 		blocksQueriedByBlockMeta[newBlockQueriedMeta(b.meta)]++
 
@@ -461,8 +461,7 @@ func (s *ParquetBucketStore) LabelValues(ctx context.Context, req *storepb.Label
 	var sets [][]string
 	var blocksQueriedByBlockMeta = make(map[blockQueriedMeta]int)
 
-	logger := spanlogger.FromContext(ctx, s.logger)
-	s.blockSet.filter(ctx, s.bkt, req.Start, req.End, reqBlockMatchers, logger, func(b *parquetBucketBlock) {
+	s.blockSet.filter(req.Start, req.End, reqBlockMatchers, func(b *parquetBucketBlock) {
 		resHints.AddQueriedBlock(b.meta.ULID)
 		blocksQueriedByBlockMeta[newBlockQueriedMeta(b.meta)]++
 
@@ -539,13 +538,13 @@ func (s *ParquetBucketStore) LabelValues(ctx context.Context, req *storepb.Label
 
 // Placeholder methods for parquet-specific functionality
 func (s *ParquetBucketStore) openParquetBlocksForReading(ctx context.Context, _ bool, minTime, maxTime int64, reqBlockMatchers []*labels.Matcher, stats *safeQueryStats) ([]*parquetBucketBlock, []ParquetShardReaderCloser) {
-	ctx, span := tracer.Start(ctx, "parquet_bucket_store_open_blocks_for_reading")
+	_, span := tracer.Start(ctx, "parquet_bucket_store_open_blocks_for_reading")
 	defer span.End()
 
 	var blocks []*parquetBucketBlock
 	var allShardReaders []ParquetShardReaderCloser
-	logger := spanlogger.FromContext(ctx, s.logger)
-	s.blockSet.filter(ctx, s.bkt, minTime, maxTime, reqBlockMatchers, logger, func(b *parquetBucketBlock) {
+
+	s.blockSet.filter(minTime, maxTime, reqBlockMatchers, func(b *parquetBucketBlock) {
 		blocks = append(blocks, b)
 		blockShardReaders := b.ShardReaders()
 		allShardReaders = append(allShardReaders, blockShardReaders...)
@@ -955,6 +954,18 @@ func (s *ParquetBucketStore) syncBlocks(ctx context.Context) error {
 		level.Debug(s.logger).Log("msg", "syncing block", "id", id, "meta", meta)
 		if s.blockSet.contains(id) {
 			level.Debug(s.logger).Log("msg", "block already loaded, skipping", "id", id)
+			continue
+		}
+
+		markPath := path.Join(id.String(), parquetconverter.ParquetConversionMarkFileName)
+		exists, err := s.bkt.Exists(ctx, markPath)
+		if err != nil {
+			level.Debug(s.logger).Log("msg", "failed to check parquet conversion mark existence, skipping block", "block", id, "err", err)
+			continue
+		}
+
+		if !exists {
+			level.Debug(s.logger).Log("msg", "parquet conversion mark not found, block not converted, skipping", "block", id)
 			continue
 		}
 

--- a/pkg/storegateway/parquet_bucket_store_test.go
+++ b/pkg/storegateway/parquet_bucket_store_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/dskit/gate"
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/services"
-	"github.com/oklog/ulid/v2"
 	"github.com/prometheus-community/parquet-common/convert"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/promslog"
@@ -24,13 +23,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 
-	"github.com/grafana/mimir/pkg/parquetconverter"
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/bucket/filesystem"
 	"github.com/grafana/mimir/pkg/storage/indexheader"
 	"github.com/grafana/mimir/pkg/storage/sharding"
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
-	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/storegateway/storepb"
 	"github.com/grafana/mimir/pkg/util"
 )
@@ -388,63 +385,4 @@ func generateStorageBlockWithMultipleSeries(t *testing.T, storageDir, userID str
 
 	// Snapshot TSDB to the storage directory.
 	require.NoError(t, db.Snapshot(userDir, true))
-}
-
-func TestParquetBlockSet_Filter_ConversionCheck(t *testing.T) {
-	ctx := context.Background()
-	storageDir := t.TempDir()
-
-	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
-	require.NoError(t, err)
-
-	logger := log.NewNopLogger()
-
-	// Two blocks: one converted, one not
-	nonConvertedID := ulid.MustNewDefault(time.Now())
-	convertedID := ulid.MustNewDefault(time.Now())
-
-	nonConvertedMeta := &block.Meta{
-		BlockMeta: tsdb.BlockMeta{
-			ULID:    nonConvertedID,
-			MinTime: 100,
-			MaxTime: 200,
-		},
-	}
-
-	convertedMeta := &block.Meta{
-		BlockMeta: tsdb.BlockMeta{
-			ULID:    convertedID,
-			MinTime: 100,
-			MaxTime: 200,
-		},
-	}
-	convertedBlockDir := filepath.Join(storageDir, convertedID.String())
-	err = os.MkdirAll(convertedBlockDir, 0755)
-	require.NoError(t, err)
-
-	markPath := filepath.Join(convertedBlockDir, parquetconverter.ParquetConversionMarkFileName)
-	err = os.WriteFile(markPath, []byte(`{"version": 1}`), 0644)
-	require.NoError(t, err)
-
-	blockSet := &parquetBlockSet{}
-	nonConvertedBlock := newParquetBucketBlock(nonConvertedMeta, nil)
-	convertedBlock := newParquetBucketBlock(convertedMeta, nil)
-	err = blockSet.add(nonConvertedBlock)
-	require.NoError(t, err)
-	err = blockSet.add(convertedBlock)
-	require.NoError(t, err)
-
-	// Filter should only return the converted block.
-	// Exercise caching logic by calling twice.
-	do := func() {
-		var filteredBlocks []*parquetBucketBlock
-		blockSet.filter(ctx, bkt, 100, 200, nil, logger, func(b *parquetBucketBlock) {
-			filteredBlocks = append(filteredBlocks, b)
-		})
-
-		require.Len(t, filteredBlocks, 1, "Only converted block should be included")
-		require.Equal(t, convertedID, filteredBlocks[0].meta.ULID)
-	}
-	do()
-	do()
 }


### PR DESCRIPTION
There's a bug: we are trying to count shards for all blocks, even if they were not converted. This leads to a constant stream of `iter` operations. And also we don't update the shard count if a block is converter afterwards. 