### PR TITLE
Distributor: Clone unsafe strings for logging truncated label values

### DIFF
--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -157,7 +157,7 @@ type labelValueTooLongSummaries struct {
 	summaries   []labelValueTooLongSummary
 }
 
-func (s *labelValueTooLongSummaries) measure(metric, label, originalValue mimirpb.UnsafeMutableString) {
+func (s *labelValueTooLongSummaries) measure(unsafeMetric, unsafeLabel, unsafeValue mimirpb.UnsafeMutableString) {
 	if s == nil {
 		return
 	}
@@ -167,7 +167,7 @@ func (s *labelValueTooLongSummaries) measure(metric, label, originalValue mimirp
 	}
 
 	i := slices.IndexFunc(s.summaries, func(summary labelValueTooLongSummary) bool {
-		return summary.metric == metric && summary.label == label
+		return summary.metric == unsafeMetric && summary.label == unsafeLabel
 	})
 	if i != -1 {
 		s.summaries[i].count++
@@ -179,16 +179,16 @@ func (s *labelValueTooLongSummaries) measure(metric, label, originalValue mimirp
 	}
 
 	s.summaries = append(s.summaries, labelValueTooLongSummary{
-		metric:            metric,
-		label:             label,
-		sampleValue:       fmt.Sprintf("%.200s (truncated)", originalValue),
-		sampleValueLength: len(originalValue),
+		metric:            strings.Clone(unsafeMetric),
+		label:             strings.Clone(unsafeLabel),
+		sampleValue:       fmt.Sprintf("%.200s (truncated)", unsafeValue),
+		sampleValueLength: len(unsafeValue),
 		count:             1,
 	})
 }
 
 type labelValueTooLongSummary struct {
-	metric, label     mimirpb.UnsafeMutableString
+	metric, label     string
 	count             int
 	sampleValueLength int
 	sampleValue       string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

In the distributor, clone unsafe strings used for logging truncated label values. It should not be necessary because label value truncation happens in the _pre-push_ middleware, but it's preferable to be robust especially as it should have no bearing on performance.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
