### PR TITLE
Do not track or check push request error in middleware

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1689,13 +1689,10 @@ type requestState struct {
 	// If positive, it means that size of mimirpb.WriteRequest has been checked and added to inflightPushRequestsBytes.
 	writeRequestSize int64
 
-	// If set, represents the error obtained by executing the respective push request.
-	pushErr error
-
 	// If set to true, it means that a reactive limiter permit has already been acquired for the respective push request.
 	reactiveLimiterPermitAcquired bool
 	// If set, represents the reactive limiter clean up function to be executed on cleaning up the respective push request.
-	reactiveLimiterCleanup func(error)
+	reactiveLimiterCleanup func()
 }
 
 func (d *Distributor) StartPushRequest(ctx context.Context, httpgrpcRequestSize int64) (context.Context, error) {
@@ -1734,8 +1731,8 @@ func (d *Distributor) acquireReactiveLimiterPermit(ctx context.Context) error {
 		d.rejectedRequests.WithLabelValues(reasonDistributorMaxInflightPushRequests).Inc()
 		return errReactiveLimiterLimitExceeded
 	}
-	cleanup := func(err error) {
-		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+	cleanup := func() {
+		if ctx.Err() != nil {
 			permit.Drop()
 		} else {
 			permit.Record()
@@ -1863,7 +1860,7 @@ func (d *Distributor) cleanupAfterPushFinished(rs *requestState) {
 		d.inflightPushRequestsBytes.Sub(rs.writeRequestSize)
 	}
 	if rs.reactiveLimiterCleanup != nil {
-		rs.reactiveLimiterCleanup(rs.pushErr)
+		rs.reactiveLimiterCleanup()
 	}
 }
 
@@ -1886,9 +1883,6 @@ func (d *Distributor) limitsMiddleware(next PushFunc) PushFunc {
 			d.rejectedRequests.WithLabelValues(reasonDistributorMaxInflightPushRequests).Inc()
 			return reactiveLimiterErr
 		}
-		defer func() {
-			rs.pushErr = retErr
-		}()
 
 		rs.pushHandlerPerformsCleanup = true
 		// Decrement counter after all ingester calls have finished or been cancelled.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -8450,7 +8450,7 @@ func TestDistributor_AcquireReactiveLimiterPermit(t *testing.T) {
 		reactiveLimiterCanAcquire     bool
 		contextCanceled               bool
 		expectedError                 error
-		verifyCleanUpFunc             func(func(error), *mockPermit)
+		verifyCleanUpFunc             func(func(), *mockPermit)
 		expectedRejectedRequestsCount int
 		expectedAcquiredPermit        bool
 	}
@@ -8465,7 +8465,7 @@ func TestDistributor_AcquireReactiveLimiterPermit(t *testing.T) {
 			reactiveLimiterEnabled:    true,
 			reactiveLimiterCanAcquire: true,
 			expectedError:             nil,
-			verifyCleanUpFunc: func(cleanUp func(error), _ *mockPermit) {
+			verifyCleanUpFunc: func(cleanUp func(), _ *mockPermit) {
 				require.NotNil(t, cleanUp)
 			},
 			expectedRejectedRequestsCount: 0,
@@ -8481,24 +8481,11 @@ func TestDistributor_AcquireReactiveLimiterPermit(t *testing.T) {
 			reactiveLimiterEnabled:    true,
 			reactiveLimiterCanAcquire: true,
 			expectedError:             nil,
-			verifyCleanUpFunc: func(cleanUp func(error), permit *mockPermit) {
+			verifyCleanUpFunc: func(cleanUp func(), permit *mockPermit) {
 				require.NotNil(t, cleanUp)
-				cleanUp(nil)
+				cleanUp()
 				require.True(t, permit.recordCalled)
 				require.False(t, permit.dropCalled)
-			},
-			expectedRejectedRequestsCount: 0,
-			expectedAcquiredPermit:        true,
-		},
-		"cleanup function calls permit.Drop() on context.Canceled error": {
-			reactiveLimiterEnabled:    true,
-			reactiveLimiterCanAcquire: true,
-			expectedError:             nil,
-			verifyCleanUpFunc: func(cleanUp func(error), permit *mockPermit) {
-				require.NotNil(t, cleanUp)
-				cleanUp(context.Canceled)
-				require.False(t, permit.recordCalled)
-				require.True(t, permit.dropCalled)
 			},
 			expectedRejectedRequestsCount: 0,
 			expectedAcquiredPermit:        true,
@@ -8508,9 +8495,9 @@ func TestDistributor_AcquireReactiveLimiterPermit(t *testing.T) {
 			reactiveLimiterCanAcquire: true,
 			contextCanceled:           true,
 			expectedError:             nil,
-			verifyCleanUpFunc: func(cleanUp func(error), permit *mockPermit) {
+			verifyCleanUpFunc: func(cleanUp func(), permit *mockPermit) {
 				require.NotNil(t, cleanUp)
-				cleanUp(errors.New("some error"))
+				cleanUp()
 				require.False(t, permit.recordCalled)
 				require.True(t, permit.dropCalled)
 			},
@@ -8521,9 +8508,9 @@ func TestDistributor_AcquireReactiveLimiterPermit(t *testing.T) {
 			reactiveLimiterEnabled:    true,
 			reactiveLimiterCanAcquire: true,
 			expectedError:             nil,
-			verifyCleanUpFunc: func(cleanUp func(error), permit *mockPermit) {
+			verifyCleanUpFunc: func(cleanUp func(), permit *mockPermit) {
 				require.NotNil(t, cleanUp)
-				cleanUp(errors.New("some error"))
+				cleanUp()
 				require.True(t, permit.recordCalled)
 				require.False(t, permit.dropCalled)
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

We've seen where the push request error can, in some rare occasion, be a nil typed error by the time it reaches some of the middleware. Let's avoid dereferencing it in the middleware just to be safe, since it's not necessary.


#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
