### PR TITLE
test: Update backwards compatibility integration test for 2.17.2

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -7,15 +7,15 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
-	"grafana/mimir:2.16.0": e2emimir.ChainFlagMappers(
+	"grafana/mimir:2.15.3": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),
-	"grafana/mimir:2.17.0": e2emimir.ChainFlagMappers(
+	"grafana/mimir:2.16.2": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),
-	"grafana/mimir:2.17.1": e2emimir.ChainFlagMappers(
+	"grafana/mimir:2.17.2": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),


### PR DESCRIPTION
Update backwards compatibility integration test for 2.17.2

Part of https://github.com/grafana/mimir/issues/12039

I mistakenly removed one of the 3 minor releases last time so putting it back here, and updating the patch versions.