### PR TITLE
ruler: Remove unnecessary YAML marshalling of rules when loading

### DIFF
--- a/pkg/ruler/mapper.go
+++ b/pkg/ruler/mapper.go
@@ -59,7 +59,9 @@ func (r *ruleRegistry) users() ([]string, error) {
 
 	result := make([]string, 0, len(r.rules))
 	for userID := range r.rules {
-		result = append(result, userID)
+		if len(r.rules[userID]) > 0 {
+			result = append(result, userID)
+		}
 	}
 	return result, nil
 }

--- a/pkg/ruler/mapper.go
+++ b/pkg/ruler/mapper.go
@@ -32,6 +32,15 @@ type ruleRegistry struct {
 	logger log.Logger
 }
 
+func newRuleRegistry(prefix string, logger log.Logger) *ruleRegistry {
+	return &ruleRegistry{
+		prefix: prefix,
+		rules:  map[string]map[string]rulespb.RuleGroupList{},
+		mtx:    sync.RWMutex{},
+		logger: logger,
+	}
+}
+
 func (r *ruleRegistry) cleanupUser(userID string) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()

--- a/pkg/ruler/mapper.go
+++ b/pkg/ruler/mapper.go
@@ -299,7 +299,7 @@ type registryLoader struct {
 	user     string
 }
 
-func newRegsitryLoader(registry *ruleRegistry, user string) registryLoader {
+func newRegistryLoader(registry *ruleRegistry, user string) registryLoader {
 	return registryLoader{
 		registry: registry,
 		user:     user,

--- a/pkg/ruler/rulespb/custom.go
+++ b/pkg/ruler/rulespb/custom.go
@@ -15,10 +15,12 @@ func (l RuleGroupList) Equal(that RuleGroupList) bool {
 		return l == nil
 	}
 
-	// Shortcut for pointer equality TODO
-
 	if len(l) != len(that) {
 		return false
+	}
+
+	if len(l) == 0 || &l[0] == &that[0] {
+		return true
 	}
 
 	for i := range l {

--- a/pkg/ruler/rulespb/custom.go
+++ b/pkg/ruler/rulespb/custom.go
@@ -10,6 +10,25 @@ import "github.com/prometheus/prometheus/model/rulefmt"
 // RuleGroupList contains a set of rule groups
 type RuleGroupList []*RuleGroupDesc
 
+func (l RuleGroupList) Equal(that RuleGroupList) bool {
+	if that == nil {
+		return l == nil
+	}
+
+	// Shortcut for pointer equality TODO
+
+	if len(l) != len(that) {
+		return false
+	}
+
+	for i := range l {
+		if !l[i].Equal(that[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // Formatted returns the rule group list as a set of formatted rule groups mapped
 // by namespace
 func (l RuleGroupList) Formatted() map[string][]rulefmt.RuleGroup {
@@ -23,4 +42,15 @@ func (l RuleGroupList) Formatted() map[string][]rulefmt.RuleGroup {
 
 	}
 	return ruleMap
+}
+
+func (l RuleGroupList) FormattedProto() map[string]RuleGroupList {
+	groupMap := map[string]RuleGroupList{}
+	for _, g := range l {
+		if _, exists := groupMap[g.Namespace]; !exists {
+			groupMap[g.Namespace] = []*RuleGroupDesc{g}
+		}
+		groupMap[g.Namespace] = append(groupMap[g.Namespace], g)
+	}
+	return groupMap
 }

--- a/pkg/ruler/rulespb/custom.go
+++ b/pkg/ruler/rulespb/custom.go
@@ -51,6 +51,7 @@ func (l RuleGroupList) FormattedProto() map[string]RuleGroupList {
 	for _, g := range l {
 		if _, exists := groupMap[g.Namespace]; !exists {
 			groupMap[g.Namespace] = []*RuleGroupDesc{g}
+			continue
 		}
 		groupMap[g.Namespace] = append(groupMap[g.Namespace], g)
 	}

--- a/pkg/ruler/rulespb/custom_test.go
+++ b/pkg/ruler/rulespb/custom_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package rulespb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuleGroupList_Equal(t *testing.T) {
+	group1 := &RuleGroupDesc{
+		Name:      "group1",
+		Namespace: "ns1",
+		Interval:  60 * time.Second,
+		User:      "user1",
+		Rules:     []*RuleDesc{},
+	}
+	group2 := &RuleGroupDesc{
+		Name:      "group2",
+		Namespace: "ns2",
+		Interval:  30 * time.Second,
+		User:      "user2",
+		Rules:     []*RuleDesc{},
+	}
+	group1Copy := &RuleGroupDesc{
+		Name:      "group1",
+		Namespace: "ns1",
+		Interval:  60 * time.Second,
+		User:      "user1",
+		Rules:     []*RuleDesc{},
+	}
+
+	sharedSlice := RuleGroupList{group1, group2}
+
+	tests := map[string]struct {
+		a   RuleGroupList
+		b   RuleGroupList
+		exp bool
+	}{
+		"both nil": {
+			a:   nil,
+			b:   nil,
+			exp: true,
+		},
+		"a nil, b not nil": {
+			a:   nil,
+			b:   RuleGroupList{group1},
+			exp: false,
+		},
+		"a not nil, b nil": {
+			a:   RuleGroupList{group1},
+			b:   nil,
+			exp: false,
+		},
+		"both empty": {
+			a:   RuleGroupList{},
+			b:   RuleGroupList{},
+			exp: true,
+		},
+		"same slice pointer": {
+			a:   sharedSlice,
+			b:   sharedSlice,
+			exp: true,
+		},
+		"different lengths": {
+			a:   RuleGroupList{group1},
+			b:   RuleGroupList{group1, group2},
+			exp: false,
+		},
+		"same length, equal contents": {
+			a:   RuleGroupList{group1},
+			b:   RuleGroupList{group1Copy},
+			exp: true,
+		},
+		"same length, different contents": {
+			a:   RuleGroupList{group1},
+			b:   RuleGroupList{group2},
+			exp: false,
+		},
+		"multiple groups, all equal": {
+			a:   RuleGroupList{group1, group2},
+			b:   RuleGroupList{group1Copy, group2},
+			exp: true,
+		},
+		"multiple groups, different at end": {
+			a:   RuleGroupList{group1, group1},
+			b:   RuleGroupList{group1, group2},
+			exp: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.exp, tc.a.Equal(tc.b))
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does

The ruler mirrors rules to be loaded to a temporary store.

The previous PR, https://github.com/grafana/mimir/pull/13156, replaced the disk loading of rules with an in-memory FS-like data structure.

This eliminates the disk reads, but it leaves in all the other disk interaction logic. We still marshal the rules to a set of yaml files, which are then unmarshalled when groups are being updated.

This PR replaces the FS-like data structure with a map-like data structure that stores the rules in their already marshalled form. This eliminates the need to marshal rule files to yaml and back, and also removes several error paths.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
