### PR TITLE
[cost attribution]: get rid of remaining MustNewConstMetric calls

### DIFF
--- a/pkg/costattribution/manager.go
+++ b/pkg/costattribution/manager.go
@@ -36,14 +36,13 @@ type Manager struct {
 	logger log.Logger
 	limits *validation.Overrides
 
-	sampleTrackerCardinalityDesc       *prometheus.Desc
-	sampleTrackerOverflowDesc          *prometheus.Desc
-	activeSeriesTrackerCardinalityDesc *prometheus.Desc
-	activeSeriesTrackerOverflowDesc    *prometheus.Desc
+	sampleTrackerCardinalityDesc       *descriptor
+	sampleTrackerOverflowDesc          *descriptor
+	activeSeriesTrackerCardinalityDesc *descriptor
+	activeSeriesTrackerOverflowDesc    *descriptor
 	trackerCreationErrors              *prometheus.CounterVec
 
 	inactiveTimeout time.Duration
-	cleanupInterval time.Duration
 
 	stmtx                  sync.RWMutex
 	sampleTrackersByUserID map[string]*SampleTracker
@@ -60,26 +59,6 @@ func NewManager(cleanupInterval, inactiveTimeout time.Duration, logger log.Logge
 		atmtx:                  sync.RWMutex{},
 		activeTrackersByUserID: make(map[string]*ActiveSeriesTracker),
 
-		sampleTrackerCardinalityDesc: prometheus.NewDesc("cortex_cost_attribution_sample_tracker_cardinality",
-			"The cardinality of a cost attribution sample tracker for each user.",
-			[]string{"user"},
-			prometheus.Labels{trackerLabel: defaultTrackerName},
-		),
-		sampleTrackerOverflowDesc: prometheus.NewDesc("cortex_cost_attribution_sample_tracker_overflown",
-			"This metric is exported with value 1 when a sample tracker for a user is overflown. It's not exported otherwise.",
-			[]string{"user"},
-			prometheus.Labels{trackerLabel: defaultTrackerName},
-		),
-		activeSeriesTrackerCardinalityDesc: prometheus.NewDesc("cortex_cost_attribution_active_series_tracker_cardinality",
-			"The cardinality of a cost attribution active series tracker for each user.",
-			[]string{"user"},
-			prometheus.Labels{trackerLabel: defaultTrackerName},
-		),
-		activeSeriesTrackerOverflowDesc: prometheus.NewDesc("cortex_cost_attribution_active_series_tracker_overflown",
-			"This metric is exported with value 1 when an active series tracker for a user is overflown. It's not exported otherwise.",
-			[]string{"user"},
-			prometheus.Labels{trackerLabel: defaultTrackerName},
-		),
 		trackerCreationErrors: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_cost_attribution_tracker_creation_errors_total",
 			Help: "The total number of errors creating cost attribution trackers for each user.",
@@ -88,7 +67,10 @@ func NewManager(cleanupInterval, inactiveTimeout time.Duration, logger log.Logge
 		limits:          limits,
 		inactiveTimeout: inactiveTimeout,
 		logger:          logger,
-		cleanupInterval: cleanupInterval,
+	}
+
+	if err := m.createAndValidateDescriptors(); err != nil {
+		return nil, err
 	}
 
 	m.Service = services.NewTimerService(cleanupInterval, nil, m.iteration, nil).WithName("cost attribution manager")
@@ -99,6 +81,35 @@ func NewManager(cleanupInterval, inactiveTimeout time.Duration, logger log.Logge
 		return nil, fmt.Errorf("can't register cost attribution metrics: %w", err)
 	}
 	return m, nil
+}
+
+func (m *Manager) createAndValidateDescriptors() error {
+	var err error
+	if m.sampleTrackerCardinalityDesc, err = newDescriptor("cortex_cost_attribution_sample_tracker_cardinality",
+		"The cardinality of a cost attribution sample tracker for each user.",
+		[]string{"user"},
+		prometheus.Labels{trackerLabel: defaultTrackerName}); err != nil {
+		return err
+	}
+	if m.sampleTrackerOverflowDesc, err = newDescriptor("cortex_cost_attribution_sample_tracker_overflown",
+		"This metric is exported with value 1 when a sample tracker for a user is overflown. It's not exported otherwise.",
+		[]string{"user"},
+		prometheus.Labels{trackerLabel: defaultTrackerName}); err != nil {
+		return err
+	}
+	if m.activeSeriesTrackerCardinalityDesc, err = newDescriptor("cortex_cost_attribution_active_series_tracker_cardinality",
+		"The cardinality of a cost attribution active series tracker for each user.",
+		[]string{"user"},
+		prometheus.Labels{trackerLabel: defaultTrackerName}); err != nil {
+		return err
+	}
+	if m.activeSeriesTrackerOverflowDesc, err = newDescriptor("cortex_cost_attribution_active_series_tracker_overflown",
+		"This metric is exported with value 1 when an active series tracker for a user is overflown. It's not exported otherwise.",
+		[]string{"user"},
+		prometheus.Labels{trackerLabel: defaultTrackerName}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (m *Manager) iteration(_ context.Context) error {
@@ -211,38 +222,18 @@ func (m *Manager) Collect(out chan<- prometheus.Metric) {
 	for _, tracker := range sampleTrackersByUserID {
 		cardinality, overflown := tracker.cardinality()
 
-		out <- prometheus.MustNewConstMetric(
-			m.sampleTrackerCardinalityDesc,
-			prometheus.GaugeValue,
-			float64(cardinality),
-			tracker.userID,
-		)
+		out <- m.sampleTrackerCardinalityDesc.gauge(float64(cardinality), tracker.userID)
 		if overflown {
-			out <- prometheus.MustNewConstMetric(
-				m.sampleTrackerOverflowDesc,
-				prometheus.GaugeValue,
-				1,
-				tracker.userID,
-			)
+			out <- m.sampleTrackerOverflowDesc.gauge(1, tracker.userID)
 		}
 	}
 
 	for _, tracker := range activeTrackersByUserID {
 		cardinality, overflown := tracker.cardinality()
 
-		out <- prometheus.MustNewConstMetric(
-			m.activeSeriesTrackerCardinalityDesc,
-			prometheus.GaugeValue,
-			float64(cardinality),
-			tracker.userID,
-		)
+		out <- m.activeSeriesTrackerCardinalityDesc.gauge(float64(cardinality), tracker.userID)
 		if overflown {
-			out <- prometheus.MustNewConstMetric(
-				m.activeSeriesTrackerOverflowDesc,
-				prometheus.GaugeValue,
-				1,
-				tracker.userID,
-			)
+			out <- m.activeSeriesTrackerOverflowDesc.gauge(1, tracker.userID)
 		}
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR completes the refactoring of cost attribution metrics by replacing the remaining prometheus.MustNewConstMetric calls in the cost attribution manager with the new descriptor type introduced in #13273

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
