### PR TITLE
chore(localdev): add alloy config with otlp push

### DIFF
--- a/development/mimir-monolithic-mode/compose-down.sh
+++ b/development/mimir-monolithic-mode/compose-down.sh
@@ -38,6 +38,10 @@ DEFAULT_PROFILES=(
     "--profile" "prometheusRW2"
     "--profile" "grafana-agent-static"
     "--profile" "grafana-agent-flow"
+    "--profile" "grafana-alloy"
+    "--profile" "grafana-alloy-remote-write"
+    "--profile" "grafana-alloy-otlp-push"
+    "--profile" "otel-collector"
     "--profile" "otel-collector-remote-write"
     "--profile" "otel-collector-otlp-push"
 )

--- a/development/mimir-monolithic-mode/config/config-otlp-push.alloy
+++ b/development/mimir-monolithic-mode/config/config-otlp-push.alloy
@@ -1,0 +1,65 @@
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+prometheus.scrape "mimir" {
+  targets    = [
+    {"__address__" = "mimir-1:8001", "instance" = "mimir-1:8001"},
+    {"__address__" = "mimir-2:8002", "instance" = "mimir-2:8001"},
+  ]
+  forward_to = [prometheus.relabel.mimir.receiver]
+
+  honor_metadata = true
+  scrape_interval = "5s"
+  scrape_timeout = "4s"
+  scrape_native_histograms = true
+  scrape_classic_histograms = true
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+}
+
+prometheus.relabel "mimir" {
+  forward_to = [otelcol.receiver.prometheus.default.receiver]
+
+  rule {
+    action       = "replace"
+    replacement  = "grafana-alloy-otlp"
+    target_label = "scraped_by"
+  }
+  rule {
+    action        = "replace"
+    source_labels = ["instance"]
+    regex         = "([^:]+).*"
+    target_label  = "container"
+  }
+}
+
+otelcol.exporter.otlphttp "default" {
+  // Send metrics to a locally running Mimir.
+  client {
+    endpoint = "http://mimir-1:8001/otlp"
+  }
+}
+
+otelcol.processor.batch "default" {
+  output {
+    metrics = [otelcol.exporter.otlphttp.default.input]
+  }
+  send_batch_max_size = 8192
+  send_batch_size = 8192
+}
+
+otelcol.processor.memory_limiter "default" {
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+  }
+  check_interval = "5s"
+  limit_percentage = "80"
+  spike_limit_percentage = "25"
+}
+
+otelcol.receiver.prometheus "default" {
+  output {
+    metrics = [otelcol.processor.memory_limiter.default.input]
+  }
+}

--- a/development/mimir-monolithic-mode/config/config-remote-write.alloy
+++ b/development/mimir-monolithic-mode/config/config-remote-write.alloy
@@ -14,6 +14,7 @@ prometheus.scrape "mimir" {
   scrape_timeout = "4s"
   scrape_native_histograms = true
   scrape_classic_histograms = true
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
 }
 
 prometheus.relabel "mimir" {

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -60,13 +60,26 @@ services:
     ports:
       - 9191:9091
 
-  grafana-alloy:
+  grafana-alloy-remote-write:
     profiles:
       - grafana-alloy
+      - grafana-alloy-remote-write
     image: grafana/alloy:v1.11.3@sha256:8c7256f412feb9f5f48f9f6f9394dc97ca887f63dea9304f347970ecc1787669
     command: ["run", "--server.http.listen-addr=0.0.0.0:9092", "--storage.path=/var/lib/alloy/data", "/etc/alloy/config.alloy"]
     volumes:
-      - ./config/config.alloy:/etc/alloy/config.alloy
+      - ./config/config-remote-write.alloy:/etc/alloy/config.alloy
+    ports:
+      - 9092:9092
+
+  grafana-alloy-otlp:
+    profiles:
+      - grafana-alloy-otlp-push
+    image: grafana/alloy:v1.11.3@sha256:8c7256f412feb9f5f48f9f6f9394dc97ca887f63dea9304f347970ecc1787669
+    # Currently component "otelcol.receiver.prometheus" need stability level experimental to enable native histograms.
+    # Currently component "prometheus.scrape" needs stability level experimental to be able to use "honor_metadata" flag.
+    command: ["run", "--server.http.listen-addr=0.0.0.0:9092", "--stability.level=experimental", "--storage.path=/var/lib/alloy/data", "/etc/alloy/config.alloy"]
+    volumes:
+      - ./config/config-otlp-push.alloy:/etc/alloy/config.alloy
     ports:
       - 9092:9092
 
@@ -123,6 +136,7 @@ services:
     image: otel/opentelemetry-collector-contrib:0.136.0
     command: ["--config=file:/etc/otelcol-contrib/config.yaml", "--feature-gates", "receiver.prometheusreceiver.EnableNativeHistograms,receiver.prometheusreceiver.RemoveStartTimeAdjustment"]
     profiles:
+      - otel-collector
       - otel-collector-remote-write
     volumes:
       - ./config/otel-collector-remote-write-config.yaml:/etc/otelcol-contrib/config.yaml


### PR DESCRIPTION
#### What this PR does

Add a new profile in `development/mimir-monolithic-mode/docker-compose.yml` for testing Grafana Alloy scraping
Prometheus target and converting to and sending OTLP.

Based on setup at GL.
For testing https://github.com/grafana/alloy/pull/4309. Merge this PR once the Alloy PR is merged and released.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [N/A] Tests updated.
- [N/A] Documentation added.
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
