### PR TITLE
helm: correct nginx removal version from 7.0 to 6.0

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/release-notes/v4.0.md
+++ b/docs/sources/helm-charts/mimir-distributed/release-notes/v4.0.md
@@ -28,6 +28,8 @@ Notable enhancements are as follows:
 - **Unified reverse proxy (`gateway`) configuration for Mimir and GEM**
   This change allows you to more easily upgrade from Mimir to GEM, without any downtime. The unified configuration also makes it possible to autoscale the GEM gateway pods and it supports OpenShift Route. The change also deprecates the `nginx` section in the configuration. The section will be removed in release `7.0.0`.
 
+  > **Note:** The `nginx` section was removed earlier than planned in release `6.0.0` instead of `7.0.0`.
+
 - **Various quality of life improvements**
   - Rollout strategies with zero downtime
   - Read-path and compactor configuration provide better default settings

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -10,7 +10,7 @@ remove a deprecated item from the third major release after it has been deprecat
 * GEM gateway: remove port 8080 on the Service resource. Deprecated in `3.1.0` and will be removed in `6.0.0`.
   * __How to migrate__: replace usages of port 8080 with port 80; these usages can be in dashboards, Prometheus remote-write configurations, or automation for updating rules.
 * NGINX configuration via `nginx` top-level values sections is being merged with by the `gateway` section. The
-  `nginx` section is deprecated in `4.0.0` and will be removed in `7.0.0`.
+  `nginx` section is deprecated in `4.0.0` and was removed in `6.0.0` (originally planned for `7.0.0`).
   * __How to migrate__: refer to [Migrate to using the unified proxy deployment for NGINX and GEM gateway](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-to-unified-proxy-deployment/)
 
 ## Format of changelog


### PR DESCRIPTION
The nginx section was deprecated in 4.0.0 with the intention to remove it in 7.0.0, but it was actually removed in 6.0.0.

Updated the deprecation notice in the CHANGELOG and added an addendum to the v4.0 release notes to clarify this.