### PR TITLE
lookupplan BenchmarkQueryExecution: report counts as benchmark metrics

### DIFF
--- a/pkg/ingester/lookupplan/testing/benchmarks_test.go
+++ b/pkg/ingester/lookupplan/testing/benchmarks_test.go
@@ -127,10 +127,8 @@ func BenchmarkQueryExecution(b *testing.B) {
 					if err != nil {
 						b.Fatalf("Query failed: %v (query: %s)", err, q.Query)
 					}
-					// Report metrics only on first iteration to avoid clutter
-					if i == 0 {
-						b.Logf("series=%d chunks=%d", queryResult.SeriesCount, queryResult.ChunksCount)
-					}
+					b.ReportMetric(float64(queryResult.SeriesCount), "series")
+					b.ReportMetric(float64(queryResult.ChunksCount), "chunks")
 				}
 			})
 		}


### PR DESCRIPTION
#### What this PR does

Benchmark framework can run multiple sets of iterations to find the right benchtime, so the log line would print out multiple times. Doing them as metrics might make it easier to analyze the results too.

Before:
```
BenchmarkQueryExecution/query=1/selector=0-8                 171           6722296 ns/op         5526405 B/op      58721 allocs/op
--- BENCH: BenchmarkQueryExecution/query=1/selector=0-8
    benchmarks_test.go:132: series=2000 chunks=2545
    benchmarks_test.go:132: series=2000 chunks=2545
    benchmarks_test.go:132: series=2000 chunks=2545
```

After:
```
BenchmarkQueryExecution/query=1/selector=0-8                 177           6700066 ns/op              2545 chunks             2000 series       5511997 B/op       58504 allocs/op
```

#### Checklist

- [x] Tests updated.
- NA Documentation added.
- NA `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- NA [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
