### PR TITLE
Update backward compatibility test versions

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -15,7 +15,7 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),
-	"grafana/mimir:2.18.0": e2emimir.ChainFlagMappers(
+	"grafana/mimir:3.0.0": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),


### PR DESCRIPTION
Add Mimir 3.0.0 and remove 2.15.3 to maintain the last 3 minor releases in the backward compatibility integration tests.