### PR TITLE
Revert "GitHub: Let build and push workflow execute for all PRs (#13225)"

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -3,6 +3,9 @@ name: Build and Push mimir-build-image
 # configure trigger by pull request
 on:
   pull_request:
+    types: [opened, synchronize]
+    paths:
+      - mimir-build-image/Dockerfile
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -22,48 +25,26 @@ jobs:
     # publish new build images just by sending the PR. Hence this change.
     if: ${{ contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association ) || github.event.pull_request.user.login == 'renovate-sh-app[bot]' }}
     steps:
-      # We only want for this workflow to do anything when mimir-build-image/Dockerfile is modified.
-      # However, we want for it to be able to run for all PRs, just so it can be made a required check
-      # (i.e. so PRs can't be merged until it's done).
-      - name: Check if Dockerfile was modified
-        id: check_dockerfile
-        run: |
-          if gh pr diff ${{ github.event.pull_request.number }} --name-only | grep -q '^mimir-build-image/Dockerfile$'; then
-            echo "modified=true" >> $GITHUB_OUTPUT
-            echo "Dockerfile was modified"
-          else
-            echo "modified=false" >> $GITHUB_OUTPUT
-            echo "Dockerfile was not modified"
-          fi
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
       - name: Checkout Repository
-        if: steps.check_dockerfile.outputs.modified == 'true'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Checkout Pull Request Branch
-        if: steps.check_dockerfile.outputs.modified == 'true'
         run: gh pr checkout ${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Setup QEMU
-        if: steps.check_dockerfile.outputs.modified == 'true'
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        if: steps.check_dockerfile.outputs.modified == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to Docker Hub
-        if: steps.check_dockerfile.outputs.modified == 'true'
         uses: grafana/shared-workflows/actions/dockerhub-login@13fb504e3bfe323c1188bf244970d94b2d336e86 # v1.0.1
 
       - name: Prepare Variables
-        if: steps.check_dockerfile.outputs.modified == 'true'
         id: prepare
         run: |
           echo "path=mimir-build-image/Dockerfile" >> $GITHUB_OUTPUT
@@ -74,7 +55,6 @@ jobs:
           echo "main_image_tag=$main_image_tag" >> $GITHUB_OUTPUT
 
       - name: Compute Image Tag
-        if: steps.check_dockerfile.outputs.modified == 'true'
         id: compute_hash
         run: |
           current_hash=$(md5sum ${{ steps.prepare.outputs.path }} | awk '{print substr($1, 0, 10)}')
@@ -84,7 +64,6 @@ jobs:
           echo "tag=$tag" >> $GITHUB_OUTPUT
 
       - name: Check Should Build Image
-        if: steps.check_dockerfile.outputs.modified == 'true'
         id: check_build
         run: |
           echo "Checking if image should be built"
@@ -97,7 +76,6 @@ jobs:
           fi
 
       - name: Add Comment to the PR
-        if: steps.check_dockerfile.outputs.modified == 'true'
         id: notification
         run: |
           if [ ${{ steps.check_build.outputs.build }} == 'true' ]; then
@@ -114,13 +92,12 @@ jobs:
           IMAGE: ${{ steps.prepare.outputs.image }}
 
       - name: Build and Push Docker Image
-        if: steps.check_dockerfile.outputs.modified == 'true' && steps.check_build.outputs.build == 'true'
+        if: steps.check_build.outputs.build == 'true'
         run: |
           echo "Building and Pushing Docker Image"
           make push-multiarch-build-image IMAGE_TAG=${{ steps.compute_hash.outputs.tag }}
 
       - name: Compare built tag with Makefile
-        if: steps.check_dockerfile.outputs.modified == 'true'
         id: compare_tag
         run: |
           echo "Comparing built tag with Makefile"
@@ -136,7 +113,6 @@ jobs:
       # because any events triggered by the latter don't spawn GitHub actions.
       # Refer to https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
       - name: Retrieve GitHub App Credentials from Vault
-        if: steps.check_dockerfile.outputs.modified == 'true'
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # v1.1.0
         with:
@@ -145,7 +121,6 @@ jobs:
             PRIVATE_KEY=mimir-github-bot:private_key
 
       - name: Generate GitHub App Token
-        if: steps.check_dockerfile.outputs.modified == 'true'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
@@ -155,7 +130,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Add commit to PR in order to update Build Image version
-        if: steps.check_dockerfile.outputs.modified == 'true' && steps.compare_tag.outputs.isDifferent == 'true'
+        if: steps.compare_tag.outputs.isDifferent == 'true'
         run: |
           echo "Get current Build Image Version"
           echo "Current Build Image Version is $MAIN_TAG"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Revert #13225, because it looks as if it causes the "Build and Push mimir-build-image" GitHub workflow to always be skipped :/ If it's indeed broken, I'll have to iterate on it and see why it isn't working.

This reverts commit 54a1615793729decd2287bbd8b8c314fdb36e01b.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
