### PR TITLE
Upgrade franz-go/pkg/kmsg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/twmb/franz-go v1.19.5
 	github.com/twmb/franz-go/pkg/kadm v1.15.0
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20251006031941-e8cd62789735
-	github.com/twmb/franz-go/pkg/kmsg v1.11.2
+	github.com/twmb/franz-go/pkg/kmsg v1.12.1-0.20251024215757-aea970d4d0d2
 	github.com/twmb/franz-go/plugin/kotel v1.5.0
 	github.com/twmb/franz-go/plugin/kprom v1.1.0
 	github.com/tylertreat/BoomFilters v0.0.0-20251001182300-5b3723cc64ae

--- a/go.sum
+++ b/go.sum
@@ -1031,8 +1031,8 @@ github.com/twmb/franz-go/pkg/kadm v1.15.0 h1:Yo3NAPfcsx3Gg9/hdhq4vmwO77TqRRkvpUc
 github.com/twmb/franz-go/pkg/kadm v1.15.0/go.mod h1:MUdcUtnf9ph4SFBLLA/XxE29rvLhWYLM9Ygb8dfSCvw=
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20251006031941-e8cd62789735 h1:+zXPxxVPEb99GILrNbWvqXu/uOdPjnh8EJX6FgdYWss=
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20251006031941-e8cd62789735/go.mod h1:M+j4CNhSGufXI+DTyfprrLnXLY3nX82qGeyBJGHOV0w=
-github.com/twmb/franz-go/pkg/kmsg v1.11.2 h1:hIw75FpwcAjgeyfIGFqivAvwC5uNIOWRGvQgZhH4mhg=
-github.com/twmb/franz-go/pkg/kmsg v1.11.2/go.mod h1:CFfkkLysDNmukPYhGzuUcDtf46gQSqCZHMW1T4Z+wDE=
+github.com/twmb/franz-go/pkg/kmsg v1.12.1-0.20251024215757-aea970d4d0d2 h1:TW+DZqmgR3Xm1VcjqfpvOliiML3O4f/YZRBTXDcIsOs=
+github.com/twmb/franz-go/pkg/kmsg v1.12.1-0.20251024215757-aea970d4d0d2/go.mod h1:+DPt4NC8RmI6hqb8G09+3giKObE6uD2Eya6CfqBpeJY=
 github.com/twmb/franz-go/plugin/kotel v1.5.0 h1:TiPfGUbQK384OO7ZYGdo7JuPCbJn+/8njQ/D9Je9CDE=
 github.com/twmb/franz-go/plugin/kotel v1.5.0/go.mod h1:wRXzRo76x1myOUMaVHAyraXoGBdEcvlLChGTVv5+DWU=
 github.com/twmb/franz-go/plugin/kprom v1.1.0 h1:grGeIJbm4llUBF8jkDjTb/b8rKllWSXjMwIqeCCcNYQ=

--- a/vendor/github.com/twmb/franz-go/pkg/kmsg/api.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kmsg/api.go
@@ -421,3 +421,47 @@ func (t *Tags) AppendEach(dst []byte) []byte {
 	})
 	return dst
 }
+
+////////////////////////
+// DEPRECATED RENAMES //
+////////////////////////
+
+// Deprecated: this was renamed to ControlRecordKeyTypeSnapshotHeader.
+const ControlRecordKeyTypeLeaderChange = ControlRecordKeyTypeSnapshotHeader
+
+type (
+	// Deprecated: this was renamed to ListConfigResourcesRequest.
+	ListClientMetricsResourcesRequest = ListConfigResourcesRequest
+	// Deprecated: this was renamed to ListConfigResourcesResponse.
+	ListClientMetricsResourcesResponse = ListConfigResourcesResponse
+	// Deprecated: this was renamed to ListConfigResourcesResponseConfigResource.
+	ListClientMetricsResourcesResponseClientMetricsResource = ListConfigResourcesResponseConfigResource
+)
+
+// Deprecated: this was renamed to ListConfigResources.
+var ListClientMetricsResources Key = 74
+
+// Deprecated: this was renamed to NewPtrListConfigResourcesRequest.
+func NewPtrListClientMetricsResourcesRequest() *ListClientMetricsResourcesRequest {
+	return NewPtrListConfigResourcesRequest()
+}
+
+// Deprecated: this was renamed to NewListConfigResourcesRequest.
+func NewListClientMetricsResourcesRequest() ListClientMetricsResourcesRequest {
+	return NewListConfigResourcesRequest()
+}
+
+// Deprecated: this was renamed to NewListConfigResourcesResponseConfigResource.
+func NewListClientMetricsResourcesResponseClientMetricsResource() ListClientMetricsResourcesResponseClientMetricsResource {
+	return NewListConfigResourcesResponseConfigResource()
+}
+
+// Deprecated: this was renamed to NewPtrListConfigResourcesResponse.
+func NewPtrListClientMetricsResourcesResponse() *ListClientMetricsResourcesResponse {
+	return NewPtrListConfigResourcesResponse()
+}
+
+// Deprecated: this was renamed to NewListConfigResourcesResponse.
+func NewListClientMetricsResourcesResponse() ListClientMetricsResourcesResponse {
+	return NewListConfigResourcesResponse()
+}

--- a/vendor/github.com/twmb/franz-go/pkg/kmsg/internal/kbin/primitives.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kmsg/internal/kbin/primitives.go
@@ -88,6 +88,12 @@ func UvarintLen(u uint32) int {
 	return int(uvarintLens[byte(bits.Len32(u))])
 }
 
+// VarlongLen returns how long i would be if it were varlong encoded.
+func VarlongLen(i int64) int {
+	u := uint64(i)<<1 ^ uint64(i>>63)
+	return uvarlongLen(u)
+}
+
 func uvarlongLen(u uint64) int {
 	return int(uvarintLens[byte(bits.Len64(u))])
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1435,8 +1435,8 @@ github.com/twmb/franz-go/pkg/kadm
 # github.com/twmb/franz-go/pkg/kfake v0.0.0-20251006031941-e8cd62789735
 ## explicit; go 1.24.0
 github.com/twmb/franz-go/pkg/kfake
-# github.com/twmb/franz-go/pkg/kmsg v1.11.2
-## explicit; go 1.21
+# github.com/twmb/franz-go/pkg/kmsg v1.12.1-0.20251024215757-aea970d4d0d2
+## explicit; go 1.24.0
 github.com/twmb/franz-go/pkg/kmsg
 github.com/twmb/franz-go/pkg/kmsg/internal/kbin
 # github.com/twmb/franz-go/plugin/kotel v1.5.0


### PR DESCRIPTION
Upgrades `github.com/twmb/franz-go/pkg/kmsg` from v1.11.2 to v1.12.1.

This is the first in a stack of PRs upgrading franz-go dependencies (kmsg → franz-go → kadm → kfake) to get the latest fixes from the franz-go repository.

The dependency chain requires upgrading in this order:
- kmsg (this PR, base of the chain)
- franz-go (depends on kmsg)
- kadm (depends on franz-go + kmsg)
- kfake (depends on all three)