### PR TITLE
mixin: update ingester_tsdb_head_early_compaction_min_in_memory_series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@
 * [CHANGE] Store-gateway: The store-gateway disk class now honors the one configured via `$._config.store_gateway_data_disk_class` and doesn't replace `fast` with `fast-dont-retain`. #13152
 * [CHANGE] Rollout-operator: Vendor jsonnet from rollout-operator repository. #13245 #13317
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
-* [ENHANCEMENT] Ingester: update in-memory series threshold before TSDB head early compaction for when ingest-storage autoscaling is enabled. #13378
+* [ENHANCEMENT] Ingester: increase in-memory series threshold before TSDB head early compaction when ingest-storage autoscaling is enabled. #13378
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 * [CHANGE] Store-gateway: The store-gateway disk class now honors the one configured via `$._config.store_gateway_data_disk_class` and doesn't replace `fast` with `fast-dont-retain`. #13152
 * [CHANGE] Rollout-operator: Vendor jsonnet from rollout-operator repository. #13245 #13317
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
+* [ENHANCEMENT] Ingester: update in-memory series threshold before TSDB head early compaction for when ingest-storage autoscaling is enabled. #13378
 
 ### Documentation
 

--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -83,23 +83,22 @@
 
     // Optional overrides to the HPA behavior.
     ingest_storage_ingester_hpa_behavior: {},
-  } + (
-    if !$._config.ingest_storage_ingester_autoscaling_enabled then {} else {
-      // In the ingest storage architecture, if we hit the max series per ingester it causes a read path outage but
-      // not a write path outage, so it's a bit less severe than the classic architecture. For this reason, we intentionally
-      // set an higher in-memory series threshold before TSDB head early compaction triggers, as a last resort to push
-      // in-memory series down before the hard limit is hit.
-      local max_series_per_ingester =
-        if $._config.ingester_instance_limits != null && std.objectHas($._config.ingester_instance_limits, 'max_series') then
-          $._config.ingester_instance_limits.max_series
-        else
-          3e6,
-      ingester_tsdb_head_early_compaction_min_in_memory_series: std.max(
+
+    // In the ingest storage architecture, if we hit the max series per ingester it causes a read path outage but
+    // not a write path outage, so it's a bit less severe than the classic architecture. For this reason, we intentionally
+    // set an higher in-memory series threshold before TSDB head early compaction triggers, as a last resort to push
+    // in-memory series down before the hard limit is hit.
+    local max_series_per_ingester =
+      if 'ingester_instance_limits.max_series' in $._config then
+        $._config.ingester_instance_limits.max_series
+      else
+        3e6,
+    ingester_tsdb_head_early_compaction_min_in_memory_series: if $._config.ingest_storage_ingester_autoscaling_enabled then
+      std.max(
         std.ceil(1.2 * $._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold),
         std.ceil(max_series_per_ingester * 0.8)
-      ),
-    }
-  ),
+      ) else super.ingester_tsdb_head_early_compaction_min_in_memory_series,
+  },
 
   // Validate the configuration.
   assert !$._config.ingest_storage_ingester_autoscaling_enabled || $._config.multi_zone_ingester_enabled : 'partitions ingester autoscaling is only supported with multi-zone ingesters in namespace %s' % $._config.namespace,


### PR DESCRIPTION
The PR updates the mixin, setting the `ingester_tsdb_head_early_compaction_min_in_memory_series` when the ingester-storage autoscaling is enabled.

This is what we've been running with internally at Grafana Labs since late summer.