### PR TITLE
docs: fix indentation in "Continue using classic architecture" section

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-helm-chart-5.x-to-6.0.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-helm-chart-5.x-to-6.0.md
@@ -67,8 +67,8 @@ mimir:
   structuredConfig:
     ingest_storage:
       enabled: false
-  ingester:
-    push_grpc_method_enabled: true
+    ingester:
+      push_grpc_method_enabled: true
 kafka:
   enabled: false
 ```


### PR DESCRIPTION
#### What this PR does

* Fixes YAML indentation in the documentation as otherwise provided configuration results in config validation error, because `push_grpc_method_enabled` remains `false` and we're trying to set `ingest_storage.enabled: false`, which is not correct.


fixes https://github.com/grafana/mimir/issues/13381
