### PR TITLE
add retry for index header corruption to avoid index headers getting deleted from store-gateway

### DIFF
--- a/pkg/storage/tsdb/bucketindex/storage_test.go
+++ b/pkg/storage/tsdb/bucketindex/storage_test.go
@@ -7,7 +7,6 @@ package bucketindex
 
 import (
 	"context"
-	"github.com/thanos-io/objstore"
 	"io"
 	"path"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	mimir_testutil "github.com/grafana/mimir/pkg/storage/tsdb/testutil"

--- a/pkg/storage/tsdb/bucketindex/storage_test.go
+++ b/pkg/storage/tsdb/bucketindex/storage_test.go
@@ -7,8 +7,11 @@ package bucketindex
 
 import (
 	"context"
+	"github.com/thanos-io/objstore"
+	"io"
 	"path"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -117,4 +120,63 @@ func TestDeleteIndex_ShouldNotReturnErrorIfIndexDoesNotExist(t *testing.T) {
 	bkt, _ := mimir_testutil.PrepareFilesystemBucket(t)
 
 	assert.NoError(t, DeleteIndex(ctx, bkt, "user-1", nil))
+}
+
+func TestReadIndex_ShouldRetryIfIndexIsCorrupted(t *testing.T) {
+	const userID = "user-1"
+
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	// Create base bucket with valid index
+	baseBkt, _ := mimir_testutil.PrepareFilesystemBucket(t)
+	baseBkt = block.BucketWithGlobalMarkers(baseBkt)
+
+	// Create and write valid index
+	block.MockStorageBlock(t, baseBkt, userID, 10, 20)
+	block.MockStorageBlock(t, baseBkt, userID, 20, 30)
+
+	u := NewUpdater(baseBkt, userID, nil, 16, 16, logger)
+	expectedIdx, _, err := u.UpdateIndex(ctx, nil)
+	require.NoError(t, err)
+	require.NoError(t, WriteIndex(ctx, baseBkt, userID, nil, expectedIdx))
+
+	// Wrap bucket to simulate corruption on first attempt, then success
+	bkt := &corruptingBucket{
+		Bucket:               baseBkt,
+		remainingCorruptions: 1, // Corrupt once, then return valid data
+	}
+
+	// Should succeed on retry
+	actualIdx, err := ReadIndex(ctx, bkt, userID, nil, logger)
+	require.NoError(t, err)
+	assert.Equal(t, expectedIdx, actualIdx)
+
+	// Verify it made 2 attempts (1 failed + 1 success)
+	assert.Equal(t, 2, bkt.getAttemptCount, "expected 2 attempts: 1 corruption + 1 success")
+}
+
+// corruptingBucket simulates transient corruption
+type corruptingBucket struct {
+	objstore.Bucket
+	remainingCorruptions int
+	getAttemptCount      int
+	mu                   sync.Mutex
+}
+
+func (c *corruptingBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	c.mu.Lock()
+	c.getAttemptCount++
+	shouldCorrupt := c.remainingCorruptions > 0
+	if shouldCorrupt {
+		c.remainingCorruptions--
+	}
+	c.mu.Unlock()
+
+	// Simulate corrupted bucket index file
+	if shouldCorrupt && strings.HasSuffix(name, IndexCompressedFilename) {
+		return io.NopCloser(strings.NewReader("corrupted-gzip-data!")), nil
+	}
+
+	return c.Bucket.Get(ctx, name)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds retry logic with exponential backoff to `ReadIndex()` to handle transient bucket index corruption during concurrent reads/writes.

**Problem:**
During store-gateway restarts, the store-gateway's `ReadIndex()` call can receive mixed content from both the old and new versions of the file. This could result in corrupted gzip streams or invalid JSON, causing `ErrIndexCorrupted`. When this happens, the store-gateway proceeds with empty metadata, which leads to incorrect block cleanup where valid blocks (and their index headers) are deleted, requiring hours to rebuild.

**Solution:**
- Implements retry logic (up to 5 attempts) specifically for `ErrIndexCorrupted`
- Uses exponential backoff with jitter (500ms, 1s, 2s, 4s, 8s) 
- Only retries on corruption errors; other errors (e.g., `ErrIndexNotFound`) fail immediately
- Respects context cancellation during retry delays
- Refactored read logic into `readIndexAttempt()` for clean separation

**Impact:**
This prevents the critical bug where store-gateways delete index headers during rolling restarts, eliminating multi-hour recovery times for large tenants.

#### Which issue(s) this PR fixes or relates to

Fixes #10649

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds retry with exponential backoff/jitter to `ReadIndex()` for `ErrIndexCorrupted`, with logging and tests, refactoring read logic into `readIndexAttempt()`.
> 
> - **Bucket Index Read**:
>   - Retries `ReadIndex()` up to 5 times on `ErrIndexCorrupted` with exponential backoff and jitter; respects context cancellation.
>   - Adds structured logging for retry attempts and final failure/success.
>   - Refactors single read flow into `readIndexAttempt()`.
> - **Tests**:
>   - Adds `TestReadIndex_ShouldRetryIfIndexIsCorrupted` using a `corruptingBucket` to simulate transient corruption and verify retry success.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec317778076b9afca17373e5e253cf8066cd172a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->