### PR TITLE
[mimir-distributed-release-6.0] docs: fix indentation in "Continue using classic architecture"

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-helm-chart-5.x-to-6.0.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-helm-chart-5.x-to-6.0.md
@@ -67,8 +67,8 @@ mimir:
   structuredConfig:
     ingest_storage:
       enabled: false
-  ingester:
-    push_grpc_method_enabled: true
+    ingester:
+      push_grpc_method_enabled: true
 kafka:
   enabled: false
 ```


### PR DESCRIPTION
cherry-picks #13380
