### PR TITLE
Filter out 0s from series limit on writes resources dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 * [ENHANCEMENT] Dashboards: Plot OMMKilled events in the workingset memory panels of resources dashboards. #13377
 * [ENHANCEMENT] Dashboards: Add variable to compactor and object store dashboards to switch between classic and native latencies. Use native histogram `thanos_objstore_bucket_operation_duration_seconds`. #12137
 * [BUGFIX] Dashboards: Fix issue where throughput dashboard panels would group all gRPC requests that resulted in a status containing an underscore into one series with no name. #13184
+* [BUGFIX] Dashboards: Filter out 0s from `max_series` limit on Writes Resources > Ingester > In-memory series panel. #13419
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -45594,7 +45594,7 @@ data:
                             "legendLink": null
                          },
                          {
-                            "expr": "min by(namespace) (cortex_ingester_instance_limits{namespace=\"$namespace\", limit=\"max_series\"})",
+                            "expr": "min by(namespace) (cortex_ingester_instance_limits{namespace=\"$namespace\", limit=\"max_series\"} > 0)",
                             "format": "time_series",
                             "legendFormat": "limit",
                             "legendLink": null

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes-resources.json
@@ -546,7 +546,7 @@
                         "legendLink": null
                      },
                      {
-                        "expr": "min by(namespace) (cortex_ingester_instance_limits{namespace=\"$namespace\", limit=\"max_series\"})",
+                        "expr": "min by(namespace) (cortex_ingester_instance_limits{namespace=\"$namespace\", limit=\"max_series\"} > 0)",
                         "format": "time_series",
                         "legendFormat": "limit",
                         "legendLink": null

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes-resources.json
@@ -892,7 +892,7 @@
                         "legendLink": null
                      },
                      {
-                        "expr": "min by(namespace) (cortex_ingester_instance_limits{namespace=\"$namespace\", limit=\"max_series\"})",
+                        "expr": "min by(namespace) (cortex_ingester_instance_limits{namespace=\"$namespace\", limit=\"max_series\"} > 0)",
                         "format": "time_series",
                         "legendFormat": "limit",
                         "legendLink": null

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes-resources.json
@@ -576,7 +576,7 @@
                         "legendLink": null
                      },
                      {
-                        "expr": "min by(namespace) (cortex_ingester_instance_limits{namespace=\"$namespace\", limit=\"max_series\"})",
+                        "expr": "min by(namespace) (cortex_ingester_instance_limits{namespace=\"$namespace\", limit=\"max_series\"} > 0)",
                         "format": "time_series",
                         "legendFormat": "limit",
                         "legendLink": null

--- a/operations/mimir-mixin/dashboards/writes-resources.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes-resources.libsonnet
@@ -56,7 +56,7 @@ local filename = 'mimir-writes-resources.json';
         $.queryPanel(
           [
             'sum by(%s) (cortex_ingester_memory_series{%s})' % [$._config.per_instance_label, $.jobMatcher($._config.job_names.ingester)],
-            'min by(%(label)s) (cortex_ingester_instance_limits{%(label)s="$namespace", limit="max_series"})' % { label: $._config.per_namespace_label },
+            'min by(%(label)s) (cortex_ingester_instance_limits{%(label)s="$namespace", limit="max_series"} > 0)' % { label: $._config.per_namespace_label },
           ],
           [
             '{{%s}}' % $._config.per_instance_label,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Because the query uses `min`, whenever an ingester restarts the graph falls to 0.

Before:
<img width="692" height="263" alt="Screenshot 2025-11-07 at 7 43 32 PM" src="https://github.com/user-attachments/assets/112200e3-8d9f-445c-a382-f653a011be45" />

After:
<img width="688" height="269" alt="Screenshot 2025-11-07 at 7 33 45 PM" src="https://github.com/user-attachments/assets/543b0e57-9b34-4377-840a-460d0997c5e7" />

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters out zero-valued `max_series` limits in the Writes Resources > Ingester > In-memory series panel to avoid drops when an ingester reports 0.
> 
> - **Dashboards**:
>   - Update `In-memory series` panel query to ignore zero `max_series` limits by applying `> 0` in `cortex_ingester_instance_limits` across:
>     - `operations/mimir-mixin/dashboards/writes-resources.libsonnet`
>     - Compiled dashboards: `operations/mimir-mixin-compiled*/dashboards/mimir-writes-resources.json`
>     - Metamonitoring generated dashboards: `metamonitoring/grafana-dashboards.yaml`
> - **Changelog**:
>   - Add BUGFIX entry documenting the dashboard fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28dfb736ad1f7216220017def38a9f4386cfeb2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->