### PR TITLE
compactor: fix potential goroutine leak on early returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,7 @@
 * [BUGFIX] MQE: Fix internal error when executing a subquery with delayed name removal enabled. #14946
 * [BUGFIX] Alertmanager: Fix deadlock when trying to broadcast after stopping a tenant #14922
 * [BUGFIX] Query-frontend: Fix max total query length limit (`-query-frontend.max-total-query-length`) not being enforced on instant queries with subqueries or range selectors. #14985
+* [BUGFIX] Compactor: Fix potential goroutine leak when compaction iteration exits early due to errors. #13420
 
 ### Mixin
 

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -997,8 +997,8 @@ func (c *BucketCompactor) compactOnce(ctx context.Context, syncer *metaSyncer, m
 		mtx                    sync.Mutex
 	)
 
-	defer workCtxCancel(errCompactionIterationCancelled)
 	defer func() {
+		workCtxCancel(errCompactionIterationCancelled)
 		if !jobChanClosed {
 			close(jobChan)
 			wg.Wait()

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -991,12 +991,19 @@ func (c *BucketCompactor) compactOnce(ctx context.Context, syncer *metaSyncer, m
 		wg                     sync.WaitGroup
 		workCtx, workCtxCancel = context.WithCancelCause(ctx)
 		jobChan                = make(chan *Job)
+		jobChanClosed          = false
 		errChan                = make(chan error, c.concurrency)
 		finishedAllJobs        = true
 		mtx                    sync.Mutex
 	)
 
 	defer workCtxCancel(errCompactionIterationCancelled)
+	defer func() {
+		if !jobChanClosed {
+			close(jobChan)
+			wg.Wait()
+		}
+	}()
 
 	// Set up workers which will compact the jobs when the jobs are ready.
 	// They will compact available jobs until they encounter an error, after which they will stop.
@@ -1125,6 +1132,7 @@ jobLoop:
 		}
 	}
 	close(jobChan)
+	jobChanClosed = true
 	wg.Wait()
 
 	// Collect any other error reported by the workers, or any error reported


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR fixes a potential goroutine leak in the bucket compactor's `Compact` method.

When the compaction iteration exits early due to errors (e.g., `SyncMetas`, `GarbageCollect`, or
`filterOwnJobs` failures), the `jobChan` channel was not being closed. This left worker goroutines
blocked indefinitely on `for g := range jobChan`, causing goroutine leaks.


#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.(inline code comments)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the compactor’s concurrent job-dispatch loop; while the change is small, mistakes could cause deadlocks or missed compactions in error paths.
> 
> **Overview**
> Prevents bucket compaction worker goroutines from leaking when a compaction iteration exits early (eg, failures during sync/GC/job filtering) by guaranteeing `jobChan` is closed and workers are `Wait()`ed via a deferred cleanup in `compactOnce`.
> 
> Adds a changelog entry noting the compactor goroutine-leak bugfix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aabf6be3bee3f332a8da98135ea35805f708684e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->