### PR TITLE
compactor:fix correct spelling from "initialised" to "initialized"

### DIFF
--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -947,7 +947,7 @@ func (c *BucketCompactor) Compact(ctx context.Context, maxCompactionTime time.Du
 	}()
 
 	// Keep this channel outside the compaction loop, because we want the "max compaction time"
-	// to apply on compactions across multiple consecutive loops. This channel is initialised
+	// to apply on compactions across multiple consecutive loops. This channel is initialized
 	// after the first planning.
 	var maxCompactionTimeChan <-chan time.Time
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Fix typo in `bucket_compactor.go` comment: "initialised" → "initialized"


#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a comment typo in `pkg/compactor/bucket_compactor.go` (“initialised” → “initialized”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 069a632d47b5e3c5d18503144fdd378047c505bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->