### PR TITLE
Jsonnet: Fix ingest_storage_ingester_autoscaling_max_owned_series_threshold default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 * [CHANGE] Rollout-operator: Vendor jsonnet from rollout-operator repository. #13245 #13317
 * [CHANGE] Ruler: Set default memory ballast to 1GiB to reduce GC pressure during startup. #13376
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
+* [BUGFIX] Ingester: Fix `$._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold` default value, to compute it based on the configured `$._config.ingester_instance_limits.max_series`. #13448
 
 ### Documentation
 

--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -12,7 +12,7 @@
 
     // The target max of owned series across all ingesters.
     // Our ideal max series per ingester is 2/3 of the instance limit, but we target 90% of that to account for scaling delays and the 10% HPA tolerance.
-    ingest_storage_ingester_autoscaling_max_owned_series_threshold: if 'ingester_instance_limits.max_series' in $._config then
+    ingest_storage_ingester_autoscaling_max_owned_series_threshold: if $._config.ingester_instance_limits != null && std.objectHas($._config.ingester_instance_limits, 'max_series') then
       0.9 * $._config.ingester_instance_limits.max_series * (2 / 3)
     else
       1800000,


### PR DESCRIPTION
#### What this PR does

The default `ingest_storage_ingester_autoscaling_max_owned_series_threshold` has always been broken. In this PR I'm fixing it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `ingest_storage_ingester_autoscaling_max_owned_series_threshold` to derive from `$._config.ingester_instance_limits.max_series` when set, with fallback; updates changelog.
> 
> - **Jsonnet**:
>   - Fix `ingest_storage_ingester_autoscaling_max_owned_series_threshold` to check `$._config.ingester_instance_limits` and use `max_series` when present; otherwise fallback to `1800000`.
> - **Changelog**:
>   - Add BUGFIX entry documenting the corrected default value computation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2be2c9bfb5c55c6331f7e0341ffc575c27e23edd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->