### PR TITLE
Jsonnet: Increase ingester_tsdb_head_early_compaction_min_in_memory_series default when Mimir is running with the ingest storage architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 * [CHANGE] Rollout-operator: Vendor jsonnet from rollout-operator repository. #13245 #13317
 * [CHANGE] Ruler: Set default memory ballast to 1GiB to reduce GC pressure during startup. #13376
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
+* [ENHANCEMENT] Ingester: Increase `$._config.ingester_tsdb_head_early_compaction_min_in_memory_series` default when Mimir is running with the ingest storage architecture. #13450
 * [BUGFIX] Ingester: Fix `$._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold` default value, to compute it based on the configured `$._config.ingester_instance_limits.max_series`. #13448
 
 ### Documentation


### PR DESCRIPTION
#### What this PR does

In this PR I'm upstreaming an override we had at Grafana Labs, to increase `ingester_tsdb_head_early_compaction_min_in_memory_series` default when Mimir is running with the ingest storage architecture.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raises the ingester TSDB head early compaction threshold in ingest-storage mode with a new computed default and documents it in the changelog.
> 
> - **Jsonnet**:
>   - Adjusts `$_config.ingester_tsdb_head_early_compaction_min_in_memory_series` logic:
>     - Introduces `max_series_per_ingester` (defaults to `3e6`).
>     - For ingest-storage mode: threshold = max(`ceil(1.2 * ingest_storage_ingester_autoscaling_max_owned_series_threshold)`, `ceil(0.8 * max_series_per_ingester)`).
>     - Otherwise: threshold = `ceil(max_series_per_ingester / 1.5)`.
> - **Changelog**:
>   - Adds enhancement entry reflecting the new default for ingest-storage architecture.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d400b7f4ec3333b9fe8b7be3ca995b657edce0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->