### PR TITLE
add .Values.kafka.address

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -33,6 +33,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add Support to customize gossip ring k8s service annotations. #12718
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Upgrade rollout-operator chart to [0.37.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator). Note required actions for upgrading the rollout-operator chart. #13245
+* [ENHANCEMENT] Add support for `kafka.address" to use an existing Kafka instead of installing an internal one.
 * [BUGFIX] Fix missing newline for custom pod labels. #13325
 * [BUGFIX] Upgrade rollout-operator chart to 0.37.1, which fixes server-tls.self-signed-cert.dns-name to use the full release name instead of always being set to `rollout-operator.NAMESPACE.svc`. If upgrading from 6.0.0 or 6.0.1, delete the `certificate` secret created by the rollout-operator pod and recreate the rollout-operator pod. #13357
 

--- a/operations/helm/charts/mimir-distributed/templates/kafka/kafka-pdb.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/kafka/kafka-pdb.yaml
@@ -1,3 +1,3 @@
-{{- if .Values.kafka.enabled -}}
+{{- if and .Values.kafka.enabled (eq .Values.kafka.address "") -}}
 {{- include "mimir.lib.podDisruptionBudget" (dict "ctx" $ "component" "kafka") }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/kafka/kafka-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/kafka/kafka-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kafka.enabled -}}
+{{- if and .Values.kafka.enabled (eq .Values.kafka.address "") -}}
 {{- with .Values.kafka -}}
 {{- $replicas := .replicas | default 1 -}}
 apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/kafka/kafka-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/kafka/kafka-svc-headless.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kafka.enabled -}}
+{{- if and .Values.kafka.enabled (eq .Values.kafka.address "") -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/operations/helm/charts/mimir-distributed/templates/kafka/kafka-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/kafka/kafka-svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kafka.enabled -}}
+{{- if and .Values.kafka.enabled (eq .Values.kafka.address "") -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -235,7 +235,11 @@ mimir:
       kafka:
         {{- if .Values.kafka.enabled }}
         # Address of Kafka broker to bootstrap the connection.
+        {{- if .Values.kafka.address }}
+        address: {{ .Values.kafka.address }}
+        {{- else }}
         address: {{ template "mimir.fullname" . }}-kafka.{{ .Release.Namespace }}.svc.{{ $.Values.global.clusterDomain }}:{{ $.Values.kafka.service.port }}
+        {{- end }}
         {{- end }}
         # Topic name.
         topic: mimir-ingest
@@ -2986,6 +2990,10 @@ minio:
 kafka:
   # -- Enable Kafka for ingest-storage architecture
   enabled: true
+
+  # address of existing kafka API
+  # kafka won't be installed if you set this
+  address: ""
 
   image:
     # -- The container image registry


### PR DESCRIPTION
#### What this PR does
Adding value kafka.address which can be used to configure existing Kafka instead of deploying Kafka chart.

#### Which issue(s) this PR fixes or relates to

Noop

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `kafka.address` to use an external Kafka; when set, Kafka templates aren’t rendered and the address is used in `ingest_storage.kafka.address`.
> 
> - **Helm (mimir-distributed)**:
>   - Add `values.yaml` option `kafka.address`; use it in `mimir.structuredConfig.ingest_storage.kafka.address`.
>   - Conditionally render internal Kafka resources only if `kafka.address` is empty:
>     - `templates/kafka/kafka-statefulset.yaml`
>     - `templates/kafka/kafka-svc.yaml`
>     - `templates/kafka/kafka-svc-headless.yaml`
>     - `templates/kafka/kafka-pdb.yaml`
> - **Changelog**:
>   - Note enhancement for external Kafka support via `kafka.address`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fac14c35ec54995e3ace279cc956d55275fd76a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->