### PR TITLE
fix(parquet store-gateway): include shard index in contraints cache key

### DIFF
--- a/pkg/storage/parquet/block/lazy_reader.go
+++ b/pkg/storage/parquet/block/lazy_reader.go
@@ -338,7 +338,14 @@ func NewLazyBucketReader(
 }
 
 func (r *LazyBucketReader) Name() string {
-	return r.readerLoader.blockID.String()
+	loaded := r.readerLoader.getOrLoadReader(r.ctx)
+	if loaded.err != nil {
+		// TODO: the current interface does not allow to return an error
+		level.Error(r.logger).Log("msg", "failed to get name from lazy reader", "err", loaded.err)
+		return ""
+	}
+	defer loaded.inUse.Done()
+	return loaded.reader.Name()
 }
 
 func (r *LazyBucketReader) BlockID() ulid.ULID {

--- a/pkg/storage/parquet/block/reader.go
+++ b/pkg/storage/parquet/block/reader.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"io"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -96,7 +97,7 @@ func NewBasicReader(
 }
 
 func (r *BasicReader) Name() string {
-	return r.blockID.String()
+	return r.blockID.String() + "/" + strconv.Itoa(r.shardIdx)
 }
 
 func (r *BasicReader) BlockID() ulid.ULID {

--- a/pkg/storegateway/parquet_bucket_block.go
+++ b/pkg/storegateway/parquet_bucket_block.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math"
 	"sort"
-	"strconv"
 	"sync"
 
 	"github.com/grafana/dskit/multierror"
@@ -37,7 +36,7 @@ type parquetBucketShardReader struct {
 }
 
 func (r *parquetBucketShardReader) Name() string {
-	return r.block.meta.ULID.String() + "/" + strconv.Itoa(r.shardIdx)
+	return r.block.shardReaderClosers[r.shardIdx].Name()
 }
 
 func (r *parquetBucketShardReader) ShardIdx() int {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

There are multiple shards per block, and their matchers resolutions are independent, so cache keys should be different.

This was indirectly causing a panic where a row set materialization was getting row ranges outside of the shard's bounds. 

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reader names now include the shard index and shard readers delegate Name() to underlying readers, with lazy reader proxying and error handling.
> 
> - **Storage/parquet/block**:
>   - `BasicReader.Name()` now returns `blockID/shardIdx` (adds shard index).
>   - `LazyBucketReader.Name()` loads underlying reader and proxies its `Name()`, with error logging.
>   - Import added for `strconv` to format shard index.
> - **Storegateway**:
>   - `parquetBucketShardReader.Name()` now delegates to underlying shard reader `Name()` instead of returning block ULID.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1226d91bb48a10d447b6dafb35e3daf0d1f548bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->