### PR TITLE
helm: add keda fallback support

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Add support for KEDA ScaledObject fallback configuration. This allows configuring fallback behavior when the scaler fails to get metrics from the source. #13467
 * [CHANGE] Set default memory ballast for ruler to 1GiB to reduce GC pressure during startup. #13376
 * [ENHANCEMENT] Add Support to customize gossip ring k8s service annotations. #12718
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -715,3 +715,21 @@ kubectl image reference
 {{- define "mimir.kubectlImage" -}}
 {{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}
 {{- end -}}
+
+{{/*
+Render KEDA ScaledObject fallback configuration block.
+Params:
+  ctx: root context
+  componentFallback: component-specific fallback config (e.g. .Values.distributor.kedaAutoscaling.fallback)
+*/}}
+{{- define "mimir.kedaFallback" -}}
+{{- $fallback := .componentFallback | default .ctx.Values.kedaAutoscaling.fallback -}}
+{{- if and $fallback $fallback.enabled }}
+fallback:
+  failureThreshold: {{ required "kedaAutoscaling.fallback.failureThreshold is required when fallback is enabled" $fallback.failureThreshold }}
+  replicas: {{ required "kedaAutoscaling.fallback.replicas is required when fallback is enabled" $fallback.replicas }}
+  {{- with $fallback.behavior }}
+  behavior: {{ . | quote }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-so.yaml
@@ -18,6 +18,7 @@ spec:
   maxReplicaCount: {{ .Values.distributor.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.distributor.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
+  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.distributor.kedaAutoscaling.fallback) | nindent 2 -}}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "distributor") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-so.yaml
@@ -21,6 +21,7 @@ spec:
   maxReplicaCount: {{ .Values.querier.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.querier.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
+  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.querier.kedaAutoscaling.fallback) | nindent 2 -}}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "querier") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
@@ -18,6 +18,7 @@ spec:
   maxReplicaCount: {{ .Values.query_frontend.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.query_frontend.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
+  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.query_frontend.kedaAutoscaling.fallback) | nindent 2 -}}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "query-frontend") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
@@ -19,6 +19,7 @@ spec:
   maxReplicaCount: {{ .Values.ruler_querier.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.ruler_querier.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
+  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.ruler_querier.kedaAutoscaling.fallback) | nindent 2 -}}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-querier") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
@@ -19,6 +19,7 @@ spec:
   maxReplicaCount: {{ .Values.ruler_query_frontend.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.ruler_query_frontend.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
+  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.ruler_query_frontend.kedaAutoscaling.fallback) | nindent 2 -}}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-query-frontend") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-so.yaml
@@ -18,6 +18,7 @@ spec:
   maxReplicaCount: {{ .Values.ruler.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.ruler.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
+  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.ruler.kedaAutoscaling.fallback) | nindent 2 -}}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -445,6 +445,19 @@ kedaAutoscaling:
   #  - cluster!="eu-west"
   #  - app="foobar"
 
+  # -- KEDA fallback configuration. This section specifies fallback options when the scaler fails to get metrics from the source.
+  # For more information, refer to the [KEDA ScaledObject specification](https://keda.sh/docs/2.18/reference/scaledobject-spec/).
+  fallback:
+    # -- Enable fallback behavior when the scaler fails to get metrics.
+    enabled: false
+    # failureThreshold: 3  # Number of consecutive failures before activating fallback behavior
+    # replicas: 6          # Number of replicas to scale to when fallback is triggered
+    # behavior: "static"   # Fallback behavior type. Options: "static", "currentReplicas", "currentReplicasIfHigher", "currentReplicasIfLower"
+    #                      # static: Use the fallback.replicas value
+    #                      # currentReplicas: Use the current replica count
+    #                      # currentReplicasIfHigher: Use current replicas if higher than fallback.replicas, otherwise use fallback.replicas
+    #                      # currentReplicasIfLower: Use current replicas if lower than fallback.replicas, otherwise use fallback.replicas
+
   # --KEDA trigger authentication settings.
   # ref: https://keda.sh/docs/2.16/scalers/pulsar/#authentication-parameters
   authentication:
@@ -797,6 +810,8 @@ distributor:
           - periodSeconds: 600
             type: Percent
             value: 10
+    # -- Fallback configuration for this component. If not set (null), the global kedaAutoscaling.fallback configuration is used.
+    # fallback: {}
 
   service:
     annotations: {}
@@ -1281,6 +1296,8 @@ ruler:
           - periodSeconds: 600
             type: Percent
             value: 10
+    # -- Fallback configuration for this component. If not set (null), the global kedaAutoscaling.fallback configuration is used.
+    # fallback: {}
 
   service:
     annotations: {}
@@ -1417,6 +1434,8 @@ ruler_querier:
             type: Pods
             value: 15
         stabilizationWindowSeconds: 60
+    # -- Fallback configuration for this component. If not set (null), the global kedaAutoscaling.fallback configuration is used.
+    # fallback: {}
 
   service:
     annotations: {}
@@ -1536,6 +1555,8 @@ ruler_query_frontend:
           - periodSeconds: 60
             type: Percent
             value: 10
+    # -- Fallback configuration for this component. If not set (null), the global kedaAutoscaling.fallback configuration is used.
+    # fallback: {}
 
   service:
     annotations: {}
@@ -1764,6 +1785,8 @@ querier:
             type: Pods
             value: 15
         stabilizationWindowSeconds: 60
+    # -- Fallback configuration for this component. If not set (null), the global kedaAutoscaling.fallback configuration is used.
+    # fallback: {}
 
   service:
     annotations: {}
@@ -1887,6 +1910,8 @@ query_frontend:
           - periodSeconds: 60
             type: Percent
             value: 10
+    # -- Fallback configuration for this component. If not set (null), the global kedaAutoscaling.fallback configuration is used.
+    # fallback: {}
 
   service:
     annotations: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adding support for KEDA fallback mechanism

https://keda.sh/docs/2.18/reference/scaledobject-spec/#fallback

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable KEDA fallback to ScaledObjects (global and per-component) and documents it in values; updates changelog.
> 
> - **Helm templates**:
>   - Add `mimir.kedaFallback` helper in `templates/_helpers.tpl` to render KEDA `fallback` block.
>   - Include fallback rendering in ScaledObjects for `distributor`, `querier`, `query-frontend`, `ruler`, `ruler-querier`, and `ruler-query-frontend` (`templates/*/*-so.yaml`).
> - **Values**:
>   - Add global `kedaAutoscaling.fallback` settings with `enabled`, `failureThreshold`, `replicas`, and optional `behavior` in `values.yaml`.
>   - Add per-component `kedaAutoscaling.fallback` override placeholders for `distributor`, `ruler`, `ruler_querier`, `ruler_query_frontend`, `querier`, and `query_frontend`.
> - **Changelog**:
>   - Note enhancement: support KEDA ScaledObject fallback configuration in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55df71de6bbf1757affdbb9e2ee13c54dcb79548. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->