### PR TITLE
querymiddleware: extract error message into exported constant

### DIFF
--- a/pkg/frontend/querymiddleware/shard_active_native_histogram_metrics.go
+++ b/pkg/frontend/querymiddleware/shard_active_native_histogram_metrics.go
@@ -144,7 +144,7 @@ func (s *shardActiveNativeHistogramMetricsMiddleware) mergeResponses(ctx context
 
 	if err != nil {
 		merged.Status = "error"
-		merged.Error = fmt.Sprintf("error merging partial responses: %s", err.Error())
+		merged.Error = fmt.Sprintf("%s: %s", ErrMergingPartialResponseStr, err.Error())
 	} else {
 		resp.StatusCode = http.StatusOK
 		slices.SortFunc(metricBucketCount, func(a, b *cardinality.ActiveMetricWithBucketCount) int {

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -284,14 +284,14 @@ func (s *shardActiveSeriesMiddleware) writeMergedResponse(ctx context.Context, c
 	stream.WriteArrayEnd()
 
 	if err := check(); err != nil {
-		level.Error(s.logger).Log("msg", "error merging partial responses", "err", err.Error())
+		level.Error(s.logger).Log("msg", ErrMergingPartialResponseStr, "err", err.Error())
 		span.RecordError(err)
 		stream.WriteMore()
 		stream.WriteObjectField("status")
 		stream.WriteString("error")
 		stream.WriteMore()
 		stream.WriteObjectField("error")
-		stream.WriteString(fmt.Sprintf("error merging partial responses: %s", err.Error()))
+		stream.WriteString(fmt.Sprintf("%s: %s", ErrMergingPartialResponseStr, err.Error()))
 	}
 
 	stream.WriteObjectEnd()
@@ -355,14 +355,14 @@ func (s *shardActiveSeriesMiddleware) writeMergedResponseWithZeroAllocationDecod
 	stream.WriteArrayEnd()
 
 	if err := check(); err != nil {
-		level.Error(s.logger).Log("msg", "error merging partial responses", "err", err.Error())
+		level.Error(s.logger).Log("msg", ErrMergingPartialResponseStr, "err", err.Error())
 		span.RecordError(err)
 		stream.WriteMore()
 		stream.WriteObjectField("status")
 		stream.WriteString("error")
 		stream.WriteMore()
 		stream.WriteObjectField("error")
-		stream.WriteString(fmt.Sprintf("error merging partial responses: %s", err.Error()))
+		stream.WriteString(fmt.Sprintf("%s: %s", ErrMergingPartialResponseStr, err.Error()))
 	}
 
 	stream.WriteObjectEnd()

--- a/pkg/frontend/querymiddleware/shard_by_series_base.go
+++ b/pkg/frontend/querymiddleware/shard_by_series_base.go
@@ -27,6 +27,12 @@ import (
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
+const (
+	// ErrMergingPartialResponseStr is the error message used when merging partial responses from sharded queries fails.
+	// This is used by the recommendations service (backend-enterprise repo) to determine whether to retry requests.
+	ErrMergingPartialResponseStr = "error merging partial responses"
+)
+
 type shardBySeriesBase struct {
 	upstream http.RoundTripper
 	limits   Limits


### PR DESCRIPTION

#### What this PR does
Extract the hardcoded "error merging partial responses" string into an exported constant `ErrMergingPartialResponseStr` in `shard_by_series_base.go`.

#### Which issue(s) this PR fixes or relates to
N/A

Fixes #<issue number>
N/A

#### Checklist

- [N/A ] Tests updated.
- [N/A ] Documentation added.
- [N/A ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `ErrMergingPartialResponseStr` and replaces hardcoded "error merging partial responses" strings in middlewares, unifying log and response error formatting.
> 
> - **Query middleware**:
>   - **Constant**: Add exported `ErrMergingPartialResponseStr` in `pkg/frontend/querymiddleware/shard_by_series_base.go`.
>   - **Error handling**:
>     - Replace hardcoded "error merging partial responses" with the constant in `shard_active_series.go` and `shard_active_native_histogram_metrics.go`.
>     - Standardize error/log output to `"%s: %s"` format using the constant for both logs and JSON responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0939782bb6ec912f5f7454444b76559b93630f5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->