### PR TITLE
distributor, ruler: rename "organization" span attribute to be consistent with logs

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1983,7 +1983,7 @@ func (d *Distributor) push(ctx context.Context, pushReq *Request) error {
 	}
 
 	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(attribute.String("organization", userID))
+	span.SetAttributes(attribute.String("user", userID))
 
 	if d.cfg.WriteRequestsBufferPoolingEnabled {
 		slabPool := pool.NewFastReleasingSlabPool[byte](&d.writeRequestBytePool, writeRequestSlabPoolSize)

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -309,7 +309,7 @@ func (r *DefaultMultiTenantManager) getOrCreateNotifier(userID string) (*notifie
 				return nil, err
 			}
 
-			ctx, sp := tracer.Start(ctx, "notify", trace.WithAttributes(attribute.String("organization", userID)))
+			ctx, sp := tracer.Start(ctx, "notify", trace.WithAttributes(attribute.String("user", userID)))
 			defer sp.End()
 
 			otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))


### PR DESCRIPTION
#### What this PR does

The PR updates two instances, where we add the `organization=<userID>` attributes to the spans. Mimir tends to use the term `user` across the code base, when the `userID` is logged. I don't see why we should be doing it differently in the traces.

Note (1): I looked across the git history, and both instances, the PR touches, were added 4-5 years ago.

Note (2): This is a minor change, that I don't want to bother adding to the changelog.